### PR TITLE
Improve `dangerous_implicit_aurorefs` diagnostic output

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -362,6 +362,10 @@ lint_impl_trait_redundant_captures = all possible in-scope parameters are alread
 
 lint_implicit_unsafe_autorefs = implicit autoref creates a reference to the dereference of a raw pointer
     .note = creating a reference requires the pointer target to be valid and imposes aliasing requirements
+    .raw_ptr = this raw pointer has type `{$raw_ptr_ty}`
+    .autoref = autoref is being applied to this expression, resulting in: `{$autoref_ty}`
+    .through_overloaded_deref = reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+    .method_def = method calls to `{$method_name}` require a reference
     .suggestion = try using a raw pointer method instead; or if this reference is intentional, make it explicit
 
 lint_improper_ctypes = `extern` {$desc} uses type `{$ty}`, which is not FFI-safe

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -364,7 +364,7 @@ lint_implicit_unsafe_autorefs = implicit autoref creates a reference to the dere
     .note = creating a reference requires the pointer target to be valid and imposes aliasing requirements
     .raw_ptr = this raw pointer has type `{$raw_ptr_ty}`
     .autoref = autoref is being applied to this expression, resulting in: `{$autoref_ty}`
-    .through_overloaded_deref = reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+    .overloaded_deref = references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
     .method_def = method calls to `{$method_name}` require a reference
     .suggestion = try using a raw pointer method instead; or if this reference is intentional, make it explicit
 

--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -2,9 +2,12 @@ use rustc_ast::{BorrowKind, UnOp};
 use rustc_hir::{Expr, ExprKind, Mutability};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, OverloadedDeref};
 use rustc_session::{declare_lint, declare_lint_pass};
-use rustc_span::{kw, sym};
+use rustc_span::sym;
 
-use crate::lints::{ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsSuggestion};
+use crate::lints::{
+    ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsMethodNote, ImplicitUnsafeAutorefsOrigin,
+    ImplicitUnsafeAutorefsSuggestion,
+};
 use crate::{LateContext, LateLintPass, LintContext};
 
 declare_lint! {
@@ -98,8 +101,8 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
                 peel_place_mappers(inner).kind
             // 1. Deref of a raw pointer.
             && typeck.expr_ty(dereferenced).is_raw_ptr()
-            // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
             && let method_did = match expr.kind {
+                // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
                 ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
                 _ => None,
             }
@@ -111,11 +114,18 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
                 ImplicitUnsafeAutorefsDiag {
                     raw_ptr_span: dereferenced.span,
                     raw_ptr_ty: typeck.expr_ty(dereferenced),
-                    autoref_span: inner.span,
-                    autoref_ty: typeck.expr_ty_adjusted(inner),
-                    method_def_span: method_did.map(|did| cx.tcx.def_span(did)),
-                    method_name: method_did.map(|did| cx.tcx.item_name(did)).unwrap_or(kw::Empty),
-                    through_overloaded_deref,
+                    origin: if through_overloaded_deref {
+                        ImplicitUnsafeAutorefsOrigin::OverloadedDeref
+                    } else {
+                        ImplicitUnsafeAutorefsOrigin::Autoref {
+                            autoref_span: inner.span,
+                            autoref_ty: typeck.expr_ty_adjusted(inner),
+                        }
+                    },
+                    method: method_did.map(|did| ImplicitUnsafeAutorefsMethodNote {
+                        def_span: cx.tcx.def_span(did),
+                        method_name: cx.tcx.item_name(did),
+                    }),
                     suggestion: ImplicitUnsafeAutorefsSuggestion {
                         mutbl: borrow_mutbl.ref_prefix_str(),
                         deref: if is_coming_from_deref { "*" } else { "" },
@@ -151,7 +161,8 @@ fn peel_derefs_adjustments<'a>(mut adjs: &'a [Adjustment<'a>]) -> &'a [Adjustmen
 
 /// Test if some adjustment has some implicit borrow.
 ///
-/// Returns `Some(mutability)` if the argument adjustment has implicit borrow in it.
+/// Returns `Some((mutability, was_an_overloaded_deref))` if the argument adjustment is
+/// an implicit borrow (or has an implicit borrow via an overloaded deref).
 fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<(Mutability, bool)> {
     match kind {
         &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some((mutbl, true)),

--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -2,7 +2,7 @@ use rustc_ast::{BorrowKind, UnOp};
 use rustc_hir::{Expr, ExprKind, Mutability};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, OverloadedDeref};
 use rustc_session::{declare_lint, declare_lint_pass};
-use rustc_span::sym;
+use rustc_span::{kw, sym};
 
 use crate::lints::{ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsSuggestion};
 use crate::{LateContext, LateLintPass, LintContext};
@@ -92,25 +92,30 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
             && let adjustments = peel_derefs_adjustments(&**adjustments)
             // 3. An automatically inserted reference (might come from a deref).
             && let [adjustment] = adjustments
-            && let Some(borrow_mutbl) = has_implicit_borrow(adjustment)
+            && let Some((borrow_mutbl, through_overloaded_deref)) = has_implicit_borrow(adjustment)
             && let ExprKind::Unary(UnOp::Deref, dereferenced) =
                 // 2. Any number of place projections.
                 peel_place_mappers(inner).kind
             // 1. Deref of a raw pointer.
             && typeck.expr_ty(dereferenced).is_raw_ptr()
             // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
-            && match expr.kind {
-                ExprKind::MethodCall(..) => matches!(
-                    cx.typeck_results().type_dependent_def_id(expr.hir_id),
-                    Some(def_id) if cx.tcx.has_attr(def_id, sym::rustc_no_implicit_autorefs)
-                ),
-                _ => true,
+            && let method_did = match expr.kind {
+                ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+                _ => None,
             }
+            && method_did.map(|did| cx.tcx.has_attr(did, sym::rustc_no_implicit_autorefs)).unwrap_or(true)
         {
             cx.emit_span_lint(
                 DANGEROUS_IMPLICIT_AUTOREFS,
                 expr.span.source_callsite(),
                 ImplicitUnsafeAutorefsDiag {
+                    raw_ptr_span: dereferenced.span,
+                    raw_ptr_ty: typeck.expr_ty(dereferenced),
+                    autoref_span: inner.span,
+                    autoref_ty: typeck.expr_ty_adjusted(inner),
+                    method_def_span: method_did.map(|did| cx.tcx.def_span(did)),
+                    method_name: method_did.map(|did| cx.tcx.item_name(did)).unwrap_or(kw::Empty),
+                    through_overloaded_deref,
                     suggestion: ImplicitUnsafeAutorefsSuggestion {
                         mutbl: borrow_mutbl.ref_prefix_str(),
                         deref: if is_coming_from_deref { "*" } else { "" },
@@ -147,10 +152,10 @@ fn peel_derefs_adjustments<'a>(mut adjs: &'a [Adjustment<'a>]) -> &'a [Adjustmen
 /// Test if some adjustment has some implicit borrow.
 ///
 /// Returns `Some(mutability)` if the argument adjustment has implicit borrow in it.
-fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<Mutability> {
+fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<(Mutability, bool)> {
     match kind {
-        &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some(mutbl),
-        &Adjust::Borrow(AutoBorrow::Ref(mutbl)) => Some(mutbl.into()),
+        &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some((mutbl, true)),
+        &Adjust::Borrow(AutoBorrow::Ref(mutbl)) => Some((mutbl.into(), false)),
         Adjust::NeverToAny
         | Adjust::Pointer(..)
         | Adjust::ReborrowPin(..)

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -59,7 +59,18 @@ pub(crate) enum ShadowedIntoIterDiagSub {
 #[derive(LintDiagnostic)]
 #[diag(lint_implicit_unsafe_autorefs)]
 #[note]
-pub(crate) struct ImplicitUnsafeAutorefsDiag {
+pub(crate) struct ImplicitUnsafeAutorefsDiag<'a> {
+    #[label(lint_raw_ptr)]
+    pub raw_ptr_span: Span,
+    pub raw_ptr_ty: Ty<'a>,
+    #[note(lint_autoref)]
+    pub autoref_span: Span,
+    pub autoref_ty: Ty<'a>,
+    #[note(lint_method_def)]
+    pub method_def_span: Option<Span>,
+    pub method_name: Symbol,
+    #[note(lint_through_overloaded_deref)]
+    pub through_overloaded_deref: bool,
     #[subdiagnostic]
     pub suggestion: ImplicitUnsafeAutorefsSuggestion,
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -63,16 +63,32 @@ pub(crate) struct ImplicitUnsafeAutorefsDiag<'a> {
     #[label(lint_raw_ptr)]
     pub raw_ptr_span: Span,
     pub raw_ptr_ty: Ty<'a>,
-    #[note(lint_autoref)]
-    pub autoref_span: Span,
-    pub autoref_ty: Ty<'a>,
-    #[note(lint_method_def)]
-    pub method_def_span: Option<Span>,
-    pub method_name: Symbol,
-    #[note(lint_through_overloaded_deref)]
-    pub through_overloaded_deref: bool,
+    #[subdiagnostic]
+    pub origin: ImplicitUnsafeAutorefsOrigin<'a>,
+    #[subdiagnostic]
+    pub method: Option<ImplicitUnsafeAutorefsMethodNote>,
     #[subdiagnostic]
     pub suggestion: ImplicitUnsafeAutorefsSuggestion,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum ImplicitUnsafeAutorefsOrigin<'a> {
+    #[note(lint_autoref)]
+    Autoref {
+        #[primary_span]
+        autoref_span: Span,
+        autoref_ty: Ty<'a>,
+    },
+    #[note(lint_overloaded_deref)]
+    OverloadedDeref,
+}
+
+#[derive(Subdiagnostic)]
+#[note(lint_method_def)]
+pub(crate) struct ImplicitUnsafeAutorefsMethodNote {
+    #[primary_span]
+    pub def_span: Span,
+    pub method_name: Symbol,
 }
 
 #[derive(Subdiagnostic)]

--- a/tests/ui/lint/implicit_autorefs.fixed
+++ b/tests/ui/lint/implicit_autorefs.fixed
@@ -96,4 +96,10 @@ unsafe fn test_string(ptr: *mut String) {
     //~^ WARN implicit autoref
 }
 
+unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
+    let _ = (&(&(*slice))[..]).len();
+    //~^ WARN implicit autoref
+    //~^^ WARN implicit autoref
+}
+
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.rs
+++ b/tests/ui/lint/implicit_autorefs.rs
@@ -96,4 +96,10 @@ unsafe fn test_string(ptr: *mut String) {
     //~^ WARN implicit autoref
 }
 
+unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
+    let _ = (*slice)[..].len();
+    //~^ WARN implicit autoref
+    //~^^ WARN implicit autoref
+}
+
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.stderr
+++ b/tests/ui/lint/implicit_autorefs.stderr
@@ -2,9 +2,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:10:13
    |
 LL |     let _ = (*ptr)[..16];
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const [u8]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:10:13
+   |
+LL |     let _ = (*ptr)[..16];
+   |             ^^^^^^
    = note: `#[warn(dangerous_implicit_autorefs)]` on by default
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
@@ -15,9 +22,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:19:13
    |
 LL |     let l = (*ptr).field.len();
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*const Test`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:19:13
+   |
+LL |     let l = (*ptr).field.len();
+   |             ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let l = (&(*ptr).field).len();
@@ -27,9 +43,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:22:16
    |
 LL |     &raw const (*ptr).field[..l - 1]
-   |                ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^---^^^^^^^^^^^^^^^^
+   |                  |
+   |                  this raw pointer has type `*const Test`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:22:16
+   |
+LL |     &raw const (*ptr).field[..l - 1]
+   |                ^^^^^^^^^^^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     &raw const (&(*ptr).field)[..l - 1]
@@ -39,9 +62,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:27:9
    |
 LL |     _ = (*a)[0].len();
-   |         ^^^^^^^^^^^^^
+   |         ^^-^^^^^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:27:9
+   |
+LL |     _ = (*a)[0].len();
+   |         ^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a)[0]).len();
@@ -51,9 +83,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
-   |         ^^^^^^^^^^^^^^^^^^
+   |         ^^-^^^^^^^^^^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:30:9
+   |
+LL |     _ = (*a)[..1][0].len();
+   |         ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a)[..1][0]).len();
@@ -63,9 +104,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
-   |         ^^^^^^^^^
+   |         ^^-^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[String]`
+  --> $DIR/implicit_autorefs.rs:30:9
+   |
+LL |     _ = (*a)[..1][0].len();
+   |         ^^^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a))[..1][0].len();
@@ -75,9 +123,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:36:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:36:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -87,9 +143,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:38:24
    |
 LL |     let _ = &raw const (*ptr).field;
-   |                        ^^^^^^^^^^^^
+   |                        ^^---^^^^^^^
+   |                          |
+   |                          this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:38:24
+   |
+LL |     let _ = &raw const (*ptr).field;
+   |                        ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = &raw const (&(*ptr)).field;
@@ -99,9 +163,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:43:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:43:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -111,9 +183,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:48:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const ManuallyDrop<ManuallyDrop<Test>>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:48:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -123,9 +203,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:62:26
    |
 LL |     let _p: *const i32 = &raw const **w;
-   |                          ^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^-
+   |                                       |
+   |                                       this raw pointer has type `*const W<i32>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&W<i32>`
+  --> $DIR/implicit_autorefs.rs:62:38
+   |
+LL |     let _p: *const i32 = &raw const **w;
+   |                                      ^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _p: *const i32 = &raw const *(&**w);
@@ -135,9 +222,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:72:14
    |
 LL |     unsafe { (*ptr).field.len() }
-   |              ^^^^^^^^^^^^^^^^^^
+   |              ^^---^^^^^^^^^^^^^
+   |                |
+   |                this raw pointer has type `*const Test2`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:72:14
+   |
+LL |     unsafe { (*ptr).field.len() }
+   |              ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     unsafe { (&(*ptr).field).len() }
@@ -147,9 +243,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:82:13
    |
 LL |     let _ = (*ptr).get(0);
-   |             ^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:82:13
+   |
+LL |     let _ = (*ptr).get(0);
+   |             ^^^^^^
+note: method calls to `get` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).get(0);
@@ -159,9 +264,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:84:13
    |
 LL |     let _ = (*ptr).get_unchecked(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:84:13
+   |
+LL |     let _ = (*ptr).get_unchecked(0);
+   |             ^^^^^^
+note: method calls to `get_unchecked` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).get_unchecked(0);
@@ -171,9 +285,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:86:13
    |
 LL |     let _ = (*ptr).get_mut(0);
-   |             ^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&mut [u8]`
+  --> $DIR/implicit_autorefs.rs:86:13
+   |
+LL |     let _ = (*ptr).get_mut(0);
+   |             ^^^^^^
+note: method calls to `get_mut` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&mut (*ptr)).get_mut(0);
@@ -183,9 +306,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:88:13
    |
 LL |     let _ = (*ptr).get_unchecked_mut(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&mut [u8]`
+  --> $DIR/implicit_autorefs.rs:88:13
+   |
+LL |     let _ = (*ptr).get_unchecked_mut(0);
+   |             ^^^^^^
+note: method calls to `get_unchecked_mut` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&mut (*ptr)).get_unchecked_mut(0);
@@ -195,9 +327,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:93:13
    |
 LL |     let _ = (*ptr).len();
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut String`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:93:13
+   |
+LL |     let _ = (*ptr).len();
+   |             ^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).len();
@@ -207,13 +348,62 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:95:13
    |
 LL |     let _ = (*ptr).is_empty();
-   |             ^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut String`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:95:13
+   |
+LL |     let _ = (*ptr).is_empty();
+   |             ^^^^^^
+note: method calls to `is_empty` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).is_empty();
    |             ++      +
 
-warning: 18 warnings emitted
+warning: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^-----^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*const [T]`
+   |
+   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[T]`
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
+   |
+LL |     let _ = (&(*slice)[..]).len();
+   |             ++            +
+
+warning: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^-----^^^^^
+   |               |
+   |               this raw pointer has type `*const [T]`
+   |
+   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[T]`
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^^^^^^^
+help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
+   |
+LL |     let _ = (&(*slice))[..].len();
+   |             ++        +
+
+warning: 20 warnings emitted
 

--- a/tests/ui/lint/implicit_autorefs.stderr
+++ b/tests/ui/lint/implicit_autorefs.stderr
@@ -128,12 +128,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:36:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -148,12 +143,7 @@ LL |     let _ = &raw const (*ptr).field;
    |                          this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:38:24
-   |
-LL |     let _ = &raw const (*ptr).field;
-   |                        ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = &raw const (&(*ptr)).field;
@@ -168,12 +158,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*mut ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:43:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -188,12 +173,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*const ManuallyDrop<ManuallyDrop<Test>>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:48:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;


### PR DESCRIPTION
This PR *greatly* improves the `dangerous_implicit_aurorefs` lint diagnostic output.

Kind of related to #140721.

r? @jieyouxu (maybe)
