### PR TITLE
{aarch64,x86_64}-pc-windows-gnullvm: build host tools

### DIFF
--- a/src/ci/docker/host-x86_64/dist-aarch64-windows-gnullvm/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-aarch64-windows-gnullvm/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:24.04
+
+WORKDIR /build
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    curl \
+    g++ \
+    git \
+    make \
+    ninja-build \
+    python3 \
+    xz-utils
+
+ENV ARCH=aarch64
+COPY host-x86_64/dist-x86_64-windows-gnullvm/install-llvm-mingw.sh /build
+RUN ./install-llvm-mingw.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV CC_aarch64_pc_windows_gnullvm=aarch64-w64-mingw32-clang \
+    CXX_aarch64_pc_windows_gnullvm=aarch64-w64-mingw32-clang++
+
+ENV HOST=aarch64-pc-windows-gnullvm
+
+# We are bootstrapping this target and cannot use previously built artifacts.
+# Without this option Clang is given `"-I/checkout/obj/build/aarch64-pc-windows-gnullvm/ci-llvm/include"`
+# despite no such directory existing:
+# $ ls obj/dist-windows-gnullvm/build/aarch64-pc-windows-gnullvm/ -1
+# llvm
+# stage2
+ENV NO_DOWNLOAD_CI_LLVM 1
+
+ENV RUST_CONFIGURE_ARGS \
+    --enable-extended \
+    --enable-profiler \
+    --enable-sanitizers \
+    --disable-docs \
+    --set llvm.download-ci-llvm=false \
+    --set rust.llvm-tools=false
+# LLVM cross tools are not installed into expected location so copying fails.
+# Probably will solve itself once this target can host itself on Windows.
+# --enable-full-tools \
+
+ENV SCRIPT python3 ../x.py dist --host $HOST --target $HOST

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -55,9 +55,6 @@ RUN ./install-riscv64-none-elf.sh
 COPY host-x86_64/dist-various-1/install-riscv32-none-elf.sh /build
 RUN ./install-riscv32-none-elf.sh
 
-COPY host-x86_64/dist-various-1/install-llvm-mingw.sh /build
-RUN ./install-llvm-mingw.sh
-
 # Suppress some warnings in the openwrt toolchains we downloaded
 ENV STAGING_DIR=/tmp
 
@@ -114,9 +111,6 @@ ENV TARGETS=$TARGETS,armv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
-ENV TARGETS=$TARGETS,aarch64-pc-windows-gnullvm
-ENV TARGETS=$TARGETS,i686-pc-windows-gnullvm
-ENV TARGETS=$TARGETS,x86_64-pc-windows-gnullvm
 
 ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
     CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \
@@ -148,10 +142,7 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_riscv64imac_unknown_none_elf=riscv64-unknown-elf-gcc \
     CFLAGS_riscv64imac_unknown_none_elf=-march=rv64imac -mabi=lp64 \
     CC_riscv64gc_unknown_none_elf=riscv64-unknown-elf-gcc \
-    CFLAGS_riscv64gc_unknown_none_elf=-march=rv64gc -mabi=lp64 \
-    CC_aarch64_pc_windows_gnullvm=aarch64-w64-mingw32-clang \
-    CC_i686_pc_windows_gnullvm=i686-w64-mingw32-clang \
-    CC_x86_64_pc_windows_gnullvm=x86_64-w64-mingw32-clang
+    CFLAGS_riscv64gc_unknown_none_elf=-march=rv64gc -mabi=lp64
 
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-armv5te=/musl-armv5te \

--- a/src/ci/docker/host-x86_64/dist-various-1/install-llvm-mingw.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/install-llvm-mingw.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-release_date=20240404
-archive=llvm-mingw-${release_date}-ucrt-ubuntu-20.04-x86_64.tar.xz
-curl -L https://github.com/mstorsjo/llvm-mingw/releases/download/${release_date}/${archive} | \
-tar --extract --lzma --strip 1 --directory /usr/local

--- a/src/ci/docker/host-x86_64/dist-x86_64-windows-gnullvm/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-windows-gnullvm/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:24.04
+
+WORKDIR /build
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    curl \
+    g++ \
+    git \
+    make \
+    ninja-build \
+    python3 \
+    xz-utils
+
+ENV ARCH='i686 x86_64'
+COPY host-x86_64/dist-x86_64-windows-gnullvm/install-llvm-mingw.sh /build
+RUN ./install-llvm-mingw.sh
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV CC_i686_pc_windows_gnullvm=i686-w64-mingw32-clang \
+    CC_x86_64_pc_windows_gnullvm=x86_64-w64-mingw32-clang \
+    CXX_x86_64_pc_windows_gnullvm=x86_64-w64-mingw32-clang++
+
+ENV HOST=x86_64-pc-windows-gnullvm
+ENV TARGETS=i686-pc-windows-gnullvm,x86_64-pc-windows-gnullvm
+
+# We are bootstrapping this target and cannot use previously built artifacts.
+# Without this option Clang is given `"-I/checkout/obj/build/aarch64-pc-windows-gnullvm/ci-llvm/include"`
+# despite no such directory existing:
+# $ ls obj/dist-windows-gnullvm/build/aarch64-pc-windows-gnullvm/ -1
+# llvm
+# stage2
+ENV NO_DOWNLOAD_CI_LLVM 1
+
+ENV RUST_CONFIGURE_ARGS \
+    --enable-extended \
+    --enable-profiler \
+    --enable-sanitizers \
+    --disable-docs \
+    --set llvm.download-ci-llvm=false \
+    --set rust.llvm-tools=false
+# LLVM cross tools are not installed into expected location so copying fails.
+# Probably will solve itself once these targets can host themselves on Windows.
+# --enable-full-tools \
+
+ENV SCRIPT python3 ../x.py dist --host $HOST --target $TARGETS

--- a/src/ci/docker/host-x86_64/dist-x86_64-windows-gnullvm/install-llvm-mingw.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-windows-gnullvm/install-llvm-mingw.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+release_date=20250613
+archive=llvm-mingw-${release_date}-ucrt-ubuntu-22.04-x86_64.tar.xz
+curl -L https://github.com/mstorsjo/llvm-mingw/releases/download/${release_date}/${archive} | \
+tar --extract --xz --strip 1 --directory /usr/local
+
+# https://github.com/mstorsjo/llvm-mingw/issues/493
+for arch in $ARCH; do
+    ln -s $arch-w64-windows-gnu.cfg /usr/local/bin/$arch-pc-windows-gnu.cfg
+done

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -237,6 +237,12 @@ auto:
   - name: dist-s390x-linux
     <<: *job-linux-4c
 
+  - name: dist-aarch64-windows-gnullvm
+    <<: *job-linux-4c
+
+  - name: dist-x86_64-windows-gnullvm
+    <<: *job-linux-4c
+
   - name: dist-various-1
     <<: *job-linux-4c
 

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -88,6 +88,7 @@ so Rustup may install the documentation for a similar tier 1 target instead.
 
 target | notes
 -------|-------
+[`aarch64-pc-windows-gnullvm`](platform-support/windows-gnullvm.md) | ARM64 MinGW (Windows 10+), LLVM ABI
 [`aarch64-pc-windows-msvc`](platform-support/windows-msvc.md) | ARM64 Windows MSVC
 `aarch64-unknown-linux-musl` | ARM64 Linux with musl 1.2.3
 [`aarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ARM64 OpenHarmony
@@ -105,6 +106,7 @@ target | notes
 [`riscv64gc-unknown-linux-gnu`](platform-support/riscv64gc-unknown-linux-gnu.md) | RISC-V Linux (kernel 4.20+, glibc 2.29)
 [`riscv64gc-unknown-linux-musl`](platform-support/riscv64gc-unknown-linux-musl.md) | RISC-V Linux (kernel 4.20+, musl 1.2.3)
 [`s390x-unknown-linux-gnu`](platform-support/s390x-unknown-linux-gnu.md) | S390x Linux (kernel 3.2+, glibc 2.17)
+[`x86_64-pc-windows-gnullvm`](platform-support/windows-gnullvm.md) | 64-bit x86 MinGW (Windows 10+), LLVM ABI
 [`x86_64-unknown-freebsd`](platform-support/freebsd.md) | 64-bit x86 FreeBSD
 [`x86_64-unknown-illumos`](platform-support/illumos.md) | illumos
 `x86_64-unknown-linux-musl` | 64-bit Linux with musl 1.2.3
@@ -147,7 +149,6 @@ target | std | notes
 [`aarch64-apple-ios-macabi`](platform-support/apple-ios-macabi.md) | ✓ | Mac Catalyst on ARM64
 [`aarch64-apple-ios-sim`](platform-support/apple-ios.md) | ✓ | Apple iOS Simulator on ARM64
 [`aarch64-linux-android`](platform-support/android.md) | ✓ | ARM64 Android
-[`aarch64-pc-windows-gnullvm`](platform-support/windows-gnullvm.md) | ✓ | ARM64 MinGW (Windows 10+), LLVM ABI
 [`aarch64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | ARM64 Fuchsia
 `aarch64-unknown-none` | * | Bare ARM64, hardfloat
 `aarch64-unknown-none-softfloat` | * | Bare ARM64, softfloat
@@ -204,7 +205,6 @@ target | std | notes
 [`x86_64-apple-ios-macabi`](platform-support/apple-ios-macabi.md) | ✓ | Mac Catalyst on x86_64
 [`x86_64-fortanix-unknown-sgx`](platform-support/x86_64-fortanix-unknown-sgx.md) | ✓ | [Fortanix ABI] for 64-bit Intel SGX
 [`x86_64-linux-android`](platform-support/android.md) | ✓ | 64-bit x86 Android
-[`x86_64-pc-windows-gnullvm`](platform-support/windows-gnullvm.md) | ✓ | 64-bit x86 MinGW (Windows 10+), LLVM ABI
 [`x86_64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | 64-bit x86 Fuchsia
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15+, glibc 2.27)
 [`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat

--- a/src/doc/rustc/src/platform-support/windows-gnullvm.md
+++ b/src/doc/rustc/src/platform-support/windows-gnullvm.md
@@ -1,6 +1,6 @@
 # \*-windows-gnullvm
 
-**Tier: 2 (without host tools)**
+**Tier: 2 (with host tools)**
 
 Windows targets similar to `*-windows-gnu` but using UCRT as the runtime and various LLVM tools/libraries instead of GCC/Binutils.
 


### PR DESCRIPTION
This is a temporary single-release workflow to create stage0 for these targets.

I opted for bootstrapping from Linux because that's the easiest host system to work with, but once this hits beta, having dedicated Windows runners would be sensible and probably preferable.

`--enable-full-tools` for whatever reason doesn't seem to work when cross-compiling, because LLVM tools for the new hosts are not copied into the expected directory.

https://github.com/rust-lang/compiler-team/issues/877