### PR TITLE
triagebot: Better message for changes to `tests/rustdoc-json`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1001,7 +1001,15 @@ message = "This PR changes how GCC is built. Consider updating src/bootstrap/dow
 message = "This PR changes a file inside `tests/crashes`. If a crash was fixed, please move into the corresponding `ui` subdir and add 'Fixes #<issueNr>' to the PR description to autoclose the issue upon merge."
 
 [mentions."tests/rustdoc-json"]
-cc = ["@aDotInTheVoid"]
+message = """
+These commits modify `test/rustdoc-json`.
+rustdoc-json is a **public** (but unstable) interface.
+
+Please ensure that if you've changed the output:
+- It's intentional.
+- The `FORMAT_VERSION` in `src/librustdoc-json-types` is bumped if necessary.
+"""
+cc = ["@aDotInTheVoid", "@obi1kenobi"]
 
 [mentions."tests/ui/deriving/deriving-all-codegen.stdout"]
 message = "Changes to the code generated for builtin derived traits."


### PR DESCRIPTION
Followup to #140689 / #140606

Adds a message to changes to `tests/rustdoc-json`, instead of just pinging me. Hopefully this makes the significance of these tests clearer to people who otherwise wouldn't have context, so hopefully we can avoid that happening again. It's annoyingly hard to know how well this works, because the real test is seeing if it doesn't get ignored.

Predrag has [kindly offered](https://github.com/rust-lang/rust/issues/140689#issuecomment-2855602664) to also get pinged here.

cc @jyn514 @obi1kenobi 

r? @GuillaumeGomez 
