### PR TITLE
Note expr being cast when encounter NonScalar cast error

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -408,6 +408,16 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     self.expr_ty,
                     fcx.ty_to_string(self.cast_ty)
                 );
+
+                if let Ok(snippet) = fcx.tcx.sess.source_map().span_to_snippet(self.expr_span)
+                    && matches!(self.expr.kind, ExprKind::AddrOf(..))
+                {
+                    err.note(format!(
+                        "casting reference expression `{}` because `&` binds tighter than `as`",
+                        snippet
+                    ));
+                }
+
                 let mut sugg = None;
                 let mut sugg_mutref = false;
                 if let ty::Ref(reg, cast_ty, mutbl) = *self.cast_ty.kind() {

--- a/tests/ui/cast/func-pointer-issue-140491.rs
+++ b/tests/ui/cast/func-pointer-issue-140491.rs
@@ -1,0 +1,7 @@
+fn my_fn(event: &Event<'_>) {}
+
+struct Event<'a>(&'a ());
+
+fn main() {
+    const ptr: &fn(&Event<'_>) = &my_fn as _; //~ ERROR non-primitive cast: `&for<'a, 'b> fn(&'a Event<'b>) {my_fn}` as `&for<'a, 'b> fn(&'a Event<'b>)` [E0605]
+}

--- a/tests/ui/cast/func-pointer-issue-140491.stderr
+++ b/tests/ui/cast/func-pointer-issue-140491.stderr
@@ -1,0 +1,9 @@
+error[E0605]: non-primitive cast: `&for<'a, 'b> fn(&'a Event<'b>) {my_fn}` as `&for<'a, 'b> fn(&'a Event<'b>)`
+  --> $DIR/func-pointer-issue-140491.rs:6:34
+   |
+LL | ..._>) = &my_fn as _;
+   |          ^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0605`.

--- a/tests/ui/cast/func-pointer-issue-140491.stderr
+++ b/tests/ui/cast/func-pointer-issue-140491.stderr
@@ -3,6 +3,8 @@ error[E0605]: non-primitive cast: `&for<'a, 'b> fn(&'a Event<'b>) {my_fn}` as `&
    |
 LL | ..._>) = &my_fn as _;
    |          ^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+   |
+   = note: casting reference expression `&my_fn` because `&` binds tighter than `as`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coercion/issue-73886.stderr
+++ b/tests/ui/coercion/issue-73886.stderr
@@ -3,6 +3,8 @@ error[E0605]: non-primitive cast: `&&[i32; 1]` as `&[_]`
    |
 LL |     let _ = &&[0] as &[_];
    |             ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+   |
+   = note: casting reference expression `&&[0]` because `&` binds tighter than `as`
 
 error[E0605]: non-primitive cast: `u32` as `Option<_>`
   --> $DIR/issue-73886.rs:4:13


### PR DESCRIPTION
Fixes #140491 

I added note for `expr` so that it doesn't treat `&x as T` as `&(x as T)` but `(&x) as T`. But I'm not sure if I want to add note for all NonScalar, maybe for specific `expr_ty`?


r? compiler