### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
@@ -1,9 +1,14 @@
-use crate::spec::{Target, TargetMetadata, base};
+use crate::spec::{LinkerFlavor, Lld, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.max_atomic_width = Some(128);
     base.features = "+v8a,+neon,+fp-armv8".into();
+
+    // MSVC emits a warning about code that may trip "Cortex-A53 MPCore processor bug #843419" (see
+    // https://developer.arm.com/documentation/epm048406/latest) which is sometimes emitted by LLVM.
+    // Since Arm64 Windows 10+ isn't supported on that processor, it's safe to disable the warning.
+    base.add_pre_link_args(LinkerFlavor::Msvc(Lld::No), &["/arm64hazardfree"]);
 
     Target {
         llvm_target: "aarch64-pc-windows-msvc".into(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1516,6 +1516,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 } else {
                     expr.span.with_hi(expr.span.lo() + BytePos(1))
                 };
+
+                match self.tcx.sess.source_map().span_to_snippet(span) {
+                    Ok(snippet) if snippet.starts_with("&") => {}
+                    _ => break 'outer,
+                }
+
                 suggestions.push((span, String::new()));
 
                 let ty::Ref(_, inner_ty, _) = suggested_ty.kind() else {

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -730,6 +730,10 @@ fn recursive_mkdir_empty() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn recursive_rmdir() {
     let tmpdir = tmpdir();
     let d1 = tmpdir.join("d1");
@@ -749,6 +753,10 @@ fn recursive_rmdir() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn recursive_rmdir_of_symlink() {
     // test we do not recursively delete a symlink but only dirs.
     let tmpdir = tmpdir();
@@ -1533,6 +1541,10 @@ fn file_open_not_found() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn create_dir_all_with_junctions() {
     let tmpdir = tmpdir();
     let target = tmpdir.join("target");
@@ -2011,6 +2023,10 @@ fn test_rename_symlink() {
 
 #[test]
 #[cfg(windows)]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn test_rename_junction() {
     let tmpdir = tmpdir();
     let original = tmpdir.join("original");

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc::SyncSender;
 use build_helper::git::get_git_modified_files;
 use ignore::WalkBuilder;
 
-use crate::core::builder::Builder;
+use crate::core::builder::{Builder, Kind};
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::exec::command;
 use crate::utils::helpers::{self, t};
@@ -122,6 +122,11 @@ fn print_paths(verb: &str, adjective: Option<&str>, paths: &[String]) {
 }
 
 pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {
+    if build.kind == Kind::Format && build.top_stage != 0 {
+        eprintln!("ERROR: `x fmt` only supports stage 0.");
+        crate::exit!(1);
+    }
+
     if !paths.is_empty() {
         eprintln!(
             "fmt error: path arguments are no longer accepted; use `--all` to format everything"

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -124,6 +124,7 @@ fn print_paths(verb: &str, adjective: Option<&str>, paths: &[String]) {
 pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {
     if build.kind == Kind::Format && build.top_stage != 0 {
         eprintln!("ERROR: `x fmt` only supports stage 0.");
+        eprintln!("HELP: Use `x run rustfmt` to run in-tree rustfmt.");
         crate::exit!(1);
     }
 

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -420,3 +420,56 @@ impl Step for CoverageDump {
         cmd.run(builder);
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Rustfmt;
+
+impl Step for Rustfmt {
+    type Output = ();
+    const ONLY_HOSTS: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.path("src/tools/rustfmt")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(Rustfmt);
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let host = builder.build.build;
+
+        // `x run` uses stage 0 by default but rustfmt does not work well with stage 0.
+        // Change the stage to 1 if it's not set explicitly.
+        let stage = if builder.config.is_explicit_stage() || builder.top_stage >= 1 {
+            builder.top_stage
+        } else {
+            1
+        };
+
+        if stage == 0 {
+            eprintln!("rustfmt cannot be run at stage 0");
+            eprintln!("HELP: Use `x fmt` to use stage 0 rustfmt.");
+            std::process::exit(1);
+        }
+
+        let compiler = builder.compiler(stage, host);
+        let rustfmt_build = builder.ensure(tool::Rustfmt { compiler, target: host });
+
+        let mut rustfmt = tool::prepare_tool_cargo(
+            builder,
+            rustfmt_build.build_compiler,
+            Mode::ToolRustc,
+            host,
+            Kind::Run,
+            "src/tools/rustfmt",
+            SourceType::InTree,
+            &[],
+        );
+
+        rustfmt.args(["--bin", "rustfmt", "--"]);
+        rustfmt.args(builder.config.args());
+
+        rustfmt.into_cmd().run(builder);
+    }
+}

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1116,6 +1116,7 @@ impl<'a> Builder<'a> {
                 run::FeaturesStatusDump,
                 run::CyclicStep,
                 run::CoverageDump,
+                run::Rustfmt,
             ),
             Kind::Setup => {
                 describe!(setup::Profile, setup::Hook, setup::Link, setup::Editor)

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -406,4 +406,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Added a new option `rust.debug-assertions-tools` to control debug asssertions for tools.",
     },
+    ChangeInfo {
+        change_id: 140732,
+        severity: ChangeSeverity::Info,
+        summary: "`./x run` now supports running in-tree `rustfmt`, e.g., `./x run rustfmt -- --check /path/to/file.rs`.",
+    },
 ];

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -35,6 +35,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-32bit",
     "ignore-64bit",
     "ignore-aarch64",
+    "ignore-aarch64-pc-windows-msvc",
     "ignore-aarch64-unknown-linux-gnu",
     "ignore-aix",
     "ignore-android",

--- a/tests/debuginfo/step-into-match.rs
+++ b/tests/debuginfo/step-into-match.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -g
 //@ ignore-android: FIXME(#10381)
 
+// On Arm64 Windows, stepping at the end of a function on goes to the callsite, not the instruction
+// after it.
+//@ ignore-aarch64-pc-windows-msvc: Stepping out of functions behaves differently.
+
 // === GDB TESTS ==============================================================
 
 // gdb-command: r

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -1,5 +1,7 @@
 //@ ignore-lldb
 
+//@ ignore-aarch64-pc-windows-msvc: Arm64 Windows cdb doesn't support JavaScript extensions.
+
 // GDB changed the way that it formatted Foreign types
 //@ min-gdb-version: 9.2
 

--- a/tests/run-make/pointer-auth-link-with-c/test.rs
+++ b/tests/run-make/pointer-auth-link-with-c/test.rs
@@ -1,4 +1,4 @@
-#[link(name = "test")]
+#[link(name = "test", kind = "static")]
 extern "C" {
     fn foo() -> i32;
 }

--- a/tests/ui/errors/auxiliary/file-debuginfo.rs
+++ b/tests/ui/errors/auxiliary/file-debuginfo.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=debuginfo
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file-diag.rs
+++ b/tests/ui/errors/auxiliary/file-diag.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=diagnostics
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file-macro.rs
+++ b/tests/ui/errors/auxiliary/file-macro.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=macro
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file.rs
+++ b/tests/ui/errors/auxiliary/file.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/trait-debuginfo.rs
+++ b/tests/ui/errors/auxiliary/trait-debuginfo.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=debuginfo
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait-diag.rs
+++ b/tests/ui/errors/auxiliary/trait-diag.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=diagnostics
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait-macro.rs
+++ b/tests/ui/errors/auxiliary/trait-macro.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=macro
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait.rs
+++ b/tests/ui/errors/auxiliary/trait.rs
@@ -1,0 +1,1 @@
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-diag.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-macro.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.rs
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.rs
@@ -1,0 +1,57 @@
+// This test exercises `-Zremap-path-scope`, diagnostics printing paths and dependency.
+//
+// We test different combinations with/without remap in deps, with/without remap in this
+// crate but always in deps and always here but never in deps.
+
+//@ revisions: with-diag-in-deps with-macro-in-deps with-debuginfo-in-deps
+//@ revisions: only-diag-in-deps only-macro-in-deps only-debuginfo-in-deps
+//@ revisions: not-diag-in-deps
+
+//@[with-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-debuginfo-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[not-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+
+//@[with-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+//@[with-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+//@[with-debuginfo-in-deps] compile-flags: -Zremap-path-scope=debuginfo
+//@[not-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+
+//@[with-diag-in-deps] aux-build:trait-diag.rs
+//@[with-macro-in-deps] aux-build:trait-macro.rs
+//@[with-debuginfo-in-deps] aux-build:trait-debuginfo.rs
+//@[only-diag-in-deps] aux-build:trait-diag.rs
+//@[only-macro-in-deps] aux-build:trait-macro.rs
+//@[only-debuginfo-in-deps] aux-build:trait-debuginfo.rs
+//@[not-diag-in-deps] aux-build:trait.rs
+
+// The $SRC_DIR*.rs:LL:COL normalisation doesn't kick in automatically
+// as the remapped revision will not begin with $SRC_DIR_REAL,
+// so we have to do it ourselves.
+//@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:COL"
+
+#[cfg(any(with_diag_in_deps, only_diag_in_deps))]
+extern crate trait_diag as r#trait;
+
+#[cfg(any(with_macro_in_deps, only_macro_in_deps))]
+extern crate trait_macro as r#trait;
+
+#[cfg(any(with_debuginfo_in_deps, only_debuginfo_in_deps))]
+extern crate trait_debuginfo as r#trait;
+
+#[cfg(not_diag_in_deps)]
+extern crate r#trait as r#trait;
+
+struct A;
+
+impl r#trait::Trait for A {}
+//[with-macro-in-deps]~^ ERROR `A` doesn't implement `std::fmt::Display`
+//[with-debuginfo-in-deps]~^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-diag-in-deps]~^^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-macro-in-deps]~^^^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-debuginfo-in-deps]~^^^^^ ERROR `A` doesn't implement `std::fmt::Display`
+
+//[with-diag-in-deps]~? ERROR `A` doesn't implement `std::fmt::Display`
+//[not-diag-in-deps]~? ERROR `A` doesn't implement `std::fmt::Display`
+
+fn main() {}

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> remapped/errors/auxiliary/trait-diag.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-macro.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-macro.normal.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.normal.run.stdout
@@ -1,1 +1,0 @@
-remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.not-macro-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.not-macro-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "remapped/errors/remap-path-prefix-macro.rs"
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file::file() = "$DIR/auxiliary/file.rs"
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file!() = "remapped/errors/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.only-debuginfo-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.only-debuginfo-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "$DIR/remap-path-prefix-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::file() = "$DIR/auxiliary/file-debuginfo.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file!() = "$DIR/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.only-diag-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.only-diag-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "$DIR/remap-path-prefix-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::file() = "$DIR/auxiliary/file-diag.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file!() = "$DIR/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.only-macro-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.only-macro-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "$DIR/remap-path-prefix-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::file() = "remapped/errors/auxiliary/file-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file!() = "$DIR/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.rs
+++ b/tests/ui/errors/remap-path-prefix-macro.rs
@@ -1,12 +1,52 @@
+// This test exercises `-Zremap-path-scope`, macros (like file!()) and dependency.
+//
+// We test different combinations with/without remap in deps, with/without remap in
+// this crate but always in deps and always here but never in deps.
+
 //@ run-pass
 //@ check-run-results
 
-//@ revisions: normal with-macro-scope without-macro-scope
-//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
-//@ [with-macro-scope]compile-flags: -Zremap-path-scope=macro,diagnostics
-//@ [without-macro-scope]compile-flags: -Zremap-path-scope=diagnostics
-// no-remap-src-base: Manually remap, so the remapped path remains in .stderr file.
+//@ revisions: with-diag-in-deps with-macro-in-deps with-debuginfo-in-deps
+//@ revisions: only-diag-in-deps only-macro-in-deps only-debuginfo-in-deps
+//@ revisions: not-macro-in-deps
+
+//@[with-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-debuginfo-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[not-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+
+//@[with-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+//@[with-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+//@[with-debuginfo-in-deps] compile-flags: -Zremap-path-scope=debuginfo
+//@[not-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+
+//@[with-diag-in-deps] aux-build:file-diag.rs
+//@[with-macro-in-deps] aux-build:file-macro.rs
+//@[with-debuginfo-in-deps] aux-build:file-debuginfo.rs
+//@[only-diag-in-deps] aux-build:file-diag.rs
+//@[only-macro-in-deps] aux-build:file-macro.rs
+//@[only-debuginfo-in-deps] aux-build:file-debuginfo.rs
+//@[not-macro-in-deps] aux-build:file.rs
+
+// The $SRC_DIR*.rs:LL:COL normalisation doesn't kick in automatically
+// as the remapped revision will not begin with $SRC_DIR_REAL,
+// so we have to do it ourselves.
+//@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:COL"
+
+#[cfg(any(with_diag_in_deps, only_diag_in_deps))]
+extern crate file_diag as file;
+
+#[cfg(any(with_macro_in_deps, only_macro_in_deps))]
+extern crate file_macro as file;
+
+#[cfg(any(with_debuginfo_in_deps, only_debuginfo_in_deps))]
+extern crate file_debuginfo as file;
+
+#[cfg(not_macro_in_deps)]
+extern crate file;
 
 fn main() {
-    println!("{}", file!());
+    dbg!(file::my_file!());
+    dbg!(file::file());
+    dbg!(file!());
 }

--- a/tests/ui/errors/remap-path-prefix-macro.with-debuginfo-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.with-debuginfo-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "$DIR/remap-path-prefix-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::file() = "$DIR/auxiliary/file-debuginfo.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file!() = "$DIR/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.with-diag-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.with-diag-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "$DIR/remap-path-prefix-macro.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file::file() = "$DIR/auxiliary/file-diag.rs"
+[$DIR/remap-path-prefix-macro.rs:LL:COL] file!() = "$DIR/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.with-macro-in-deps.run.stderr
+++ b/tests/ui/errors/remap-path-prefix-macro.with-macro-in-deps.run.stderr
@@ -1,0 +1,3 @@
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file::my_file!() = "remapped/errors/remap-path-prefix-macro.rs"
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file::file() = "remapped/errors/auxiliary/file-macro.rs"
+[remapped/errors/remap-path-prefix-macro.rs:LL:COL] file!() = "remapped/errors/remap-path-prefix-macro.rs"

--- a/tests/ui/errors/remap-path-prefix-macro.with-macro-scope.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.with-macro-scope.run.stdout
@@ -1,1 +1,0 @@
-remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.without-macro-scope.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.without-macro-scope.run.stdout
@@ -1,1 +1,0 @@
-$DIR/remap-path-prefix-macro.rs

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -42,9 +42,13 @@ macro_rules! dump_and_die {
         // there, even on i686-pc-windows-msvc. We do the best we can in
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
+        //
+        // aarch64-msvc is broken as its backtraces are truncated.
+        // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
+                    all(target_env = "msvc", target_arch = "aarch64"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.rs
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.rs
@@ -1,0 +1,18 @@
+trait Trait {}
+
+struct Chars;
+impl Trait for Chars {}
+
+struct FlatMap<T>(T);
+impl<T: Trait> std::fmt::Debug for FlatMap<T> {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+fn lol() {
+    format_args!("{:?}", FlatMap(&Chars));
+    //~^ ERROR the trait bound `&Chars: Trait` is not satisfied [E0277]
+}
+
+fn main() {}

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
@@ -6,6 +6,7 @@ LL |     format_args!("{:?}", FlatMap(&Chars));
    |                   |
    |                   required by a bound introduced by this call
    |
+   = help: the trait `Trait` is implemented for `Chars`
 note: required for `FlatMap<&Chars>` to implement `Debug`
   --> $DIR/suggest-remove-deref-issue-140166.rs:7:16
    |
@@ -15,11 +16,6 @@ LL | impl<T: Trait> std::fmt::Debug for FlatMap<T> {
    |         unsatisfied trait bound introduced here
 note: required by a bound in `core::fmt::rt::Argument::<'_>::new_debug`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-help: consider removing the leading `&`-reference
-   |
-LL -     format_args!("{:?}", FlatMap(&Chars));
-LL +     format_args!("{:?}", latMap(&Chars));
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `&Chars: Trait` is not satisfied
+  --> $DIR/suggest-remove-deref-issue-140166.rs:14:26
+   |
+LL |     format_args!("{:?}", FlatMap(&Chars));
+   |                   ----   ^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `&Chars`
+   |                   |
+   |                   required by a bound introduced by this call
+   |
+note: required for `FlatMap<&Chars>` to implement `Debug`
+  --> $DIR/suggest-remove-deref-issue-140166.rs:7:16
+   |
+LL | impl<T: Trait> std::fmt::Debug for FlatMap<T> {
+   |         -----  ^^^^^^^^^^^^^^^     ^^^^^^^^^^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required by a bound in `core::fmt::rt::Argument::<'_>::new_debug`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
+help: consider removing the leading `&`-reference
+   |
+LL -     format_args!("{:?}", FlatMap(&Chars));
+LL +     format_args!("{:?}", latMap(&Chars));
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #140716 (Improve `-Zremap-path-scope` tests with dependency)
 - #140732 (make it possible to run in-tree rustfmt with `x run rustfmt`)
 - #140736 (trait selection: check `&` before suggest remove deref)
 - #140755 ([win][arm64] Disable various DebugInfo tests that don't work on Arm64 Windows)
 - #140756 ([arm64] Pointer auth test should link with C static library statically)
 - #140758 ([win][arm64] Disable MSVC Linker 'Arm Hazard' warning)
 - #140759 ([win][arm64] Disable std::fs tests that require symlinks)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140716,140732,140736,140755,140756,140758,140759)
<!-- homu-ignore:end -->