### PR TITLE
Update hermit-abi to 0.5.1

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",


### PR DESCRIPTION
This updates hermit-abi to version 0.5.1, bringing the [recent `AF_*`](https://github.com/rust-lang/libc/pull/4344) changes to std.