### PR TITLE
mention lint group in default level lint note

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -24,7 +24,7 @@ use rustc_middle::ty::layout::{LayoutError, LayoutOfHelpers, TyAndLayout};
 use rustc_middle::ty::print::{PrintError, PrintTraitRefExt as _, Printer, with_no_trimmed_paths};
 use rustc_middle::ty::{self, GenericArg, RegisteredTools, Ty, TyCtxt, TypingEnv, TypingMode};
 use rustc_session::lint::{FutureIncompatibleInfo, Lint, LintBuffer, LintExpectationId, LintId};
-use rustc_session::{LintStoreMarker, Session};
+use rustc_session::{DynLintStore, Session};
 use rustc_span::edit_distance::find_best_match_for_names;
 use rustc_span::{Ident, Span, Symbol, sym};
 use tracing::debug;
@@ -62,7 +62,13 @@ pub struct LintStore {
     lint_groups: FxIndexMap<&'static str, LintGroup>,
 }
 
-impl LintStoreMarker for LintStore {}
+impl DynLintStore for LintStore {
+    fn lint_groups_iter(&self) -> Box<dyn Iterator<Item = rustc_session::LintGroup> + '_> {
+        Box::new(self.get_lint_groups().map(|(name, lints, is_externally_loaded)| {
+            rustc_session::LintGroup { name, lints, is_externally_loaded }
+        }))
+    }
+}
 
 /// The target of the `by_name` map, which accounts for renaming/deprecation.
 #[derive(Debug)]

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -211,11 +211,28 @@ impl LintExpectation {
 }
 
 fn explain_lint_level_source(
+    sess: &Session,
     lint: &'static Lint,
     level: Level,
     src: LintLevelSource,
     err: &mut Diag<'_, ()>,
 ) {
+    // Find the name of the lint group that contains the given lint.
+    // Assumes the lint only belongs to one group.
+    let lint_group_name = |lint| {
+        let lint_groups_iter = sess.lint_groups_iter();
+        let lint_id = LintId::of(lint);
+        lint_groups_iter
+            .filter(|lint_group| !lint_group.is_externally_loaded)
+            .find(|lint_group| {
+                lint_group
+                    .lints
+                    .iter()
+                    .find(|lint_group_lint| **lint_group_lint == lint_id)
+                    .is_some()
+            })
+            .map(|lint_group| lint_group.name)
+    };
     let name = lint.name_lower();
     if let Level::Allow = level {
         // Do not point at `#[allow(compat_lint)]` as the reason for a compatibility lint
@@ -224,7 +241,15 @@ fn explain_lint_level_source(
     }
     match src {
         LintLevelSource::Default => {
-            err.note_once(format!("`#[{}({})]` on by default", level.as_str(), name));
+            let level_str = level.as_str();
+            match lint_group_name(lint) {
+                Some(group_name) => {
+                    err.note_once(format!("`#[{level_str}({name})]` (part of `#[{level_str}({group_name})]`) on by default"));
+                }
+                None => {
+                    err.note_once(format!("`#[{level_str}({name})]` on by default"));
+                }
+            }
         }
         LintLevelSource::CommandLine(lint_flag_val, orig_level) => {
             let flag = orig_level.to_cmd_flag();
@@ -427,7 +452,7 @@ pub fn lint_level(
             decorate(&mut err);
         }
 
-        explain_lint_level_source(lint, level, src, &mut err);
+        explain_lint_level_source(sess, lint, level, src, &mut err);
         err.emit()
     }
     lint_level_impl(sess, lint, level, span, Box::new(decorate))

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -330,7 +330,7 @@ LL |         if X.is_some() {
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[deny(static_mut_refs)]` on by default
+   = note: `#[deny(static_mut_refs)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
 error: aborting due to 36 previous errors
 

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -165,7 +165,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: use `extern "C"` instead
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:104:1

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -147,7 +147,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: use `extern "C"` instead
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:104:1

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -159,7 +159,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: use `extern "C"` instead
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:104:1

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -159,7 +159,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: use `extern "C"` instead
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:104:1

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -141,7 +141,7 @@ LL | fn cdecl_ptr(f: extern "cdecl" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: use `extern "C"` instead
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "cdecl" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:104:1

--- a/tests/ui/abi/unsupported.x64_win.stderr
+++ b/tests/ui/abi/unsupported.x64_win.stderr
@@ -109,7 +109,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: "stdcall" is not a supported ABI for the current target
   --> $DIR/unsupported.rs:87:1

--- a/tests/ui/associated-consts/associated-const-type-parameters.stderr
+++ b/tests/ui/associated-consts/associated-const-type-parameters.stderr
@@ -4,7 +4,7 @@ warning: trait `Bar` is never used
 LL | trait Bar: Foo {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/rpit.stderr
+++ b/tests/ui/associated-type-bounds/rpit.stderr
@@ -6,7 +6,7 @@ LL | trait Tr2<'a> { fn tr2(self) -> &'a Self; }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/associated-types-issue-20220.stderr
+++ b/tests/ui/associated-types/associated-types-issue-20220.stderr
@@ -4,7 +4,7 @@ warning: trait `IntoIteratorX` is never used
 LL | trait IntoIteratorX {
    |       ^^^^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/associated-types-nested-projections.stderr
+++ b/tests/ui/associated-types/associated-types-nested-projections.stderr
@@ -7,7 +7,7 @@ LL | trait IntoIterator {
 LL |     fn into_iter(self) -> Self::Iter;
    |        ^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.stderr
+++ b/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.stderr
@@ -7,7 +7,7 @@ LL | trait Int
 LL |     fn dummy(&self) { }
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/attributes/key-value-expansion-scope.stderr
+++ b/tests/ui/attributes/key-value-expansion-scope.stderr
@@ -135,7 +135,7 @@ LL | #![doc = in_root!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
   --> $DIR/key-value-expansion-scope.rs:4:10
@@ -199,7 +199,7 @@ LL | #![doc = in_root!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
@@ -211,7 +211,7 @@ LL | #![doc = in_mod_escape!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
@@ -223,7 +223,7 @@ LL | #[doc = in_mod!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
@@ -235,7 +235,7 @@ LL |     #![doc = in_mod!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
@@ -247,7 +247,7 @@ LL | #[doc = in_mod_escape!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
@@ -259,5 +259,5 @@ LL |     #![doc = in_mod_escape!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/attributes/lint_on_root.stderr
+++ b/tests/ui/attributes/lint_on_root.stderr
@@ -14,7 +14,7 @@ LL | #![inline = ""]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 2 previous errors
 
@@ -27,5 +27,5 @@ LL | #![inline = ""]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -256,7 +256,7 @@ LL | #[doc]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[doc(hidden)]`, `#[doc(inline)]`, and `#[doc = "string"]`
   --> $DIR/malformed-attrs.rs:76:1
@@ -766,7 +766,7 @@ warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: missing options for `on_unimplemented` attribute
   --> $DIR/malformed-attrs.rs:138:1
@@ -836,7 +836,7 @@ LL | #[doc]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[doc(hidden)]`, `#[doc(inline)]`, and `#[doc = "string"]`
@@ -848,7 +848,7 @@ LL | #[doc]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
@@ -860,7 +860,7 @@ LL | #[link]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
@@ -871,7 +871,7 @@ LL | #[inline = 5]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
@@ -882,7 +882,7 @@ LL | #[ignore()]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
@@ -893,5 +893,5 @@ LL | #[ignore = 1]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/auto-traits/auto-traits.stderr
+++ b/tests/ui/auto-traits/auto-traits.stderr
@@ -4,7 +4,7 @@ warning: trait `AutoInner` is never used
 LL |     auto trait AutoInner {}
    |                ^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: trait `AutoUnsafeInner` is never used
   --> $DIR/auto-traits.rs:23:23

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -6,7 +6,7 @@ LL |         let sfoo: *mut Foo = &mut SFOO;
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw mut` instead to create a raw pointer
    |
 LL |         let sfoo: *mut Foo = &raw mut SFOO;

--- a/tests/ui/borrowck/ice-mutability-error-slicing-121807.stderr
+++ b/tests/ui/borrowck/ice-mutability-error-slicing-121807.stderr
@@ -21,7 +21,7 @@ LL |     extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 error[E0185]: method `read_dword` has a `&self` declaration in the impl, but not in the trait
   --> $DIR/ice-mutability-error-slicing-121807.rs:17:5

--- a/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
+++ b/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
@@ -6,7 +6,7 @@ LL |     extern "C" fn read_dword(Self::Assoc<'_>) -> u16;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 error[E0185]: method `read_dword` has a `&self` declaration in the impl, but not in the trait
   --> $DIR/trait-impl-argument-difference-ice.rs:14:5

--- a/tests/ui/cast/cast-rfc0401-vtable-kinds.stderr
+++ b/tests/ui/cast/cast-rfc0401-vtable-kinds.stderr
@@ -4,7 +4,7 @@ warning: trait `Bar` is never used
 LL | trait Bar {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/cast/coercion-as-explicit-cast.stderr
+++ b/tests/ui/cast/coercion-as-explicit-cast.stderr
@@ -6,7 +6,7 @@ LL | trait Foo {
 LL |     fn foo(&self) {}
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/cast/fat-ptr-cast-rpass.stderr
+++ b/tests/ui/cast/fat-ptr-cast-rpass.stderr
@@ -6,7 +6,7 @@ LL | trait Foo {
 LL |     fn foo(&self) {}
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/closures/2229_closure_analysis/match/issue-87097.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/issue-87097.stderr
@@ -7,7 +7,7 @@ LL |     A,
 LL |     B,
    |     ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused closure that must be used
   --> $DIR/issue-87097.rs:17:5
@@ -19,7 +19,7 @@ LL | |     };
    | |_____^
    |
    = note: closures are lazy and do nothing unless called
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused closure that must be used
   --> $DIR/issue-87097.rs:26:5

--- a/tests/ui/closures/issue-1460.stderr
+++ b/tests/ui/closures/issue-1460.stderr
@@ -5,7 +5,7 @@ LL |     {|i: u32| if 1 == i { }};
    |      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: closures are lazy and do nothing unless called
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/closures/moved-upvar-mut-rebind-11958.stderr
+++ b/tests/ui/closures/moved-upvar-mut-rebind-11958.stderr
@@ -5,7 +5,7 @@ LL |     let _thunk = Box::new(move|| { x = 2; });
    |                                    ^
    |
    = help: maybe it is overwritten before being read?
-   = note: `#[warn(unused_assignments)]` on by default
+   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `x`
   --> $DIR/moved-upvar-mut-rebind-11958.rs:10:36
@@ -14,7 +14,7 @@ LL |     let _thunk = Box::new(move|| { x = 2; });
    |                                    ^
    |
    = help: did you mean to capture by reference instead?
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: 2 warnings emitted
 

--- a/tests/ui/closures/old-closure-expr-precedence.stderr
+++ b/tests/ui/closures/old-closure-expr-precedence.stderr
@@ -4,7 +4,7 @@ warning: unnecessary trailing semicolons
 LL |   if (true) { 12; };;; -num;
    |                     ^^ help: remove these semicolons
    |
-   = note: `#[warn(redundant_semicolons)]` on by default
+   = note: `#[warn(redundant_semicolons)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/closures/unused-closure-ice-16256.stderr
+++ b/tests/ui/closures/unused-closure-ice-16256.stderr
@@ -5,7 +5,7 @@ LL |     |c: u8| buf.push(c);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: closures are lazy and do nothing unless called
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coercion/issue-14589.stderr
+++ b/tests/ui/coercion/issue-14589.stderr
@@ -6,7 +6,7 @@ LL | trait Foo { fn dummy(&self) { }}
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coercion/method-return-trait-object-14399.stderr
+++ b/tests/ui/coercion/method-return-trait-object-14399.stderr
@@ -6,7 +6,7 @@ LL | trait A { fn foo(&self) {} }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coercion/mut-trait-coercion-8248.stderr
+++ b/tests/ui/coercion/mut-trait-coercion-8248.stderr
@@ -6,7 +6,7 @@ LL | trait A {
 LL |     fn dummy(&self) { }
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coercion/trait-object-coercion-distribution-9951.stderr
+++ b/tests/ui/coercion/trait-object-coercion-distribution-9951.stderr
@@ -6,7 +6,7 @@ LL | trait Bar {
 LL |   fn noop(&self);
    |      ^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/coherence-fn-covariant-bound-vs-static.stderr
+++ b/tests/ui/coherence/coherence-fn-covariant-bound-vs-static.stderr
@@ -9,7 +9,7 @@ LL | impl<'a> Trait for fn(fn(&'a ())) {}
    = warning: the behavior may change in a future release
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
-   = note: `#[warn(coherence_leak_check)]` on by default
+   = note: `#[warn(coherence_leak_check)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/coherence-fn-inputs.stderr
+++ b/tests/ui/coherence/coherence-fn-inputs.stderr
@@ -9,7 +9,7 @@ LL | impl Trait for for<'c> fn(&'c u32, &'c u32) {
    = warning: the behavior may change in a future release
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
-   = note: `#[warn(coherence_leak_check)]` on by default
+   = note: `#[warn(coherence_leak_check)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/coherence-subtyping.stderr
+++ b/tests/ui/coherence/coherence-subtyping.stderr
@@ -10,7 +10,7 @@ LL | impl TheTrait for for<'a> fn(&'a u8, &'a u8) -> &'a u8 {
    = warning: the behavior may change in a future release
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
-   = note: `#[warn(coherence_leak_check)]` on by default
+   = note: `#[warn(coherence_leak_check)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-alias.classic.stderr
+++ b/tests/ui/coherence/orphan-check-alias.classic.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-alias.next.stderr
+++ b/tests/ui/coherence/orphan-check-alias.next.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.classic.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-ambiguity.next.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait1<Local, T> for <T as Project>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.classic.stderr
@@ -8,7 +8,7 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning[E0210]: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9

--- a/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering-multiple-params.next.stderr
@@ -8,7 +8,7 @@ LL | impl<T, U> foreign::Trait0<LocalTy, T, U> for <() as Trait<T, U>>::Assoc {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning[E0210]: type parameter `U` must be covered by another type when it appears before the first local type (`LocalTy`)
   --> $DIR/orphan-check-projections-not-covering-multiple-params.rs:17:9

--- a/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.classic.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:27:6

--- a/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-not-covering.next.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait0<Local, T, ()> for <T as Identity>::Output {}
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/orphan-check-projections-not-covering.rs:27:6

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.classic.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
+++ b/tests/ui/coherence/orphan-check-projections-unsat-bounds.next.stderr
@@ -8,7 +8,7 @@ LL | impl<T> foreign::Trait1<LocalTy, T> for <Wrapper<T> as Discard>::Output
    = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
    = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
-   = note: `#[warn(uncovered_param_in_projection)]` on by default
+   = note: `#[warn(uncovered_param_in_projection)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/const-generics/dyn-supertraits.stderr
+++ b/tests/ui/const-generics/dyn-supertraits.stderr
@@ -4,7 +4,7 @@ warning: trait `Baz` is never used
 LL | trait Baz: Foo<3> {}
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: trait `Boz` is never used
   --> $DIR/dyn-supertraits.rs:26:7

--- a/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
@@ -24,7 +24,7 @@ LL |     [0; size_of::<*mut T>()]; // lint on stable, error with `generic_const_
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
-   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = note: `#[warn(const_evaluatable_unchecked)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/dependence_lint.rs:18:9

--- a/tests/ui/const-generics/generic_const_exprs/function-call.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/function-call.stderr
@@ -6,7 +6,7 @@ LL |     let _ = [0; foo::<T>()];
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
-   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = note: `#[warn(const_evaluatable_unchecked)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -46,7 +46,7 @@ warning: type `v11` should have an upper camel case name
 LL |     pub type v11 = [[usize; v4]; v4];
    |              ^^^ help: convert the identifier to upper camel case (notice the capitalization): `V11`
    |
-   = note: `#[warn(non_camel_case_types)]` on by default
+   = note: `#[warn(non_camel_case_types)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: type `v17` should have an upper camel case name
   --> $DIR/unevaluated-const-ice-119731.rs:16:16

--- a/tests/ui/const-generics/invariant.stderr
+++ b/tests/ui/const-generics/invariant.stderr
@@ -10,7 +10,7 @@ LL | impl SadBee for fn(&'static ()) {
    = warning: the behavior may change in a future release
    = note: for more information, see issue #56105 <https://github.com/rust-lang/rust/issues/56105>
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
-   = note: `#[warn(coherence_leak_check)]` on by default
+   = note: `#[warn(coherence_leak_check)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error[E0308]: mismatched types
   --> $DIR/invariant.rs:25:5

--- a/tests/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/tests/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -4,7 +4,7 @@ warning: trait `Bar` is never used
 LL | trait Bar<T> {}
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/const-generics/issues/issue-83466.stderr
+++ b/tests/ui/const-generics/issues/issue-83466.stderr
@@ -9,7 +9,7 @@ LL |     S.func::<'a, 10_u32>()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = note: `#[warn(late_bound_lifetime_arguments)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/issue-83466.rs:11:18

--- a/tests/ui/const-generics/issues/issue-86535-2.stderr
+++ b/tests/ui/const-generics/issues/issue-86535-2.stderr
@@ -4,7 +4,7 @@ warning: struct `Bar` is never constructed
 LL | struct Bar<const N: &'static ()>;
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/const-generics/issues/issue-86535.stderr
+++ b/tests/ui/const-generics/issues/issue-86535.stderr
@@ -4,7 +4,7 @@ warning: struct `F` is never constructed
 LL | struct F<const S: &'static str>;
    |        ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -69,7 +69,7 @@ LL |     let _ = [0; size_of::<*mut T>() + 1];
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
-   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = note: `#[warn(const_evaluatable_unchecked)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: aborting due to 7 previous errors; 1 warning emitted
 

--- a/tests/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
+++ b/tests/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
@@ -6,7 +6,7 @@ LL |     [0; std::mem::size_of::<*mut T>()];
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
-   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = note: `#[warn(const_evaluatable_unchecked)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/const-evaluatable-unchecked.rs:17:21

--- a/tests/ui/consts/const-block-item.stderr
+++ b/tests/ui/consts/const-block-item.stderr
@@ -4,7 +4,7 @@ warning: trait `Value` is never used
 LL |     pub trait Value {
    |               ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
+++ b/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
@@ -6,7 +6,7 @@ LL |     panic!({ "foo" });
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
-   = note: `#[warn(non_fmt_panics)]` on by default
+   = note: `#[warn(non_fmt_panics)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", { "foo" });

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -6,7 +6,7 @@ LL |     let ptr = unsafe { &mut BB };
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw mut` instead to create a raw pointer
    |
 LL |     let ptr = unsafe { &raw mut BB };

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -17,7 +17,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     static FOO: dyn Sync = AtomicUsize::new(0);

--- a/tests/ui/consts/packed_pattern.stderr
+++ b/tests/ui/consts/packed_pattern.stderr
@@ -6,7 +6,7 @@ LL |         Foo { field: (5, 6, 7, 8) } => {},
 LL |         FOO => unreachable!(),
    |         ^^^ no value can reach this
    |
-   = note: `#[warn(unreachable_patterns)]` on by default
+   = note: `#[warn(unreachable_patterns)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/consts/packed_pattern2.stderr
+++ b/tests/ui/consts/packed_pattern2.stderr
@@ -6,7 +6,7 @@ LL |         Bar { a: Foo { field: (5, 6) } } => {},
 LL |         FOO => unreachable!(),
    |         ^^^ no value can reach this
    |
-   = note: `#[warn(unreachable_patterns)]` on by default
+   = note: `#[warn(unreachable_patterns)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/gen_block_panic.stderr
+++ b/tests/ui/coroutine/gen_block_panic.stderr
@@ -6,7 +6,7 @@ LL |         panic!("foo");
 LL |         yield 69;
    |         ^^^^^^^^^ unreachable statement
    |
-   = note: `#[warn(unreachable_code)]` on by default
+   = note: `#[warn(unreachable_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/issue-52398.stderr
+++ b/tests/ui/coroutine/issue-52398.stderr
@@ -8,7 +8,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused coroutine that must be used
   --> $DIR/issue-52398.rs:24:18

--- a/tests/ui/coroutine/issue-57084.stderr
+++ b/tests/ui/coroutine/issue-57084.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/match-bindings.stderr
+++ b/tests/ui/coroutine/match-bindings.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/reborrow-mut-upvar.stderr
+++ b/tests/ui/coroutine/reborrow-mut-upvar.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/too-live-local-in-immovable-gen.stderr
+++ b/tests/ui/coroutine/too-live-local-in-immovable-gen.stderr
@@ -9,7 +9,7 @@ LL | |         };
    | |_________^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/yield-in-args-rev.stderr
+++ b/tests/ui/coroutine/yield-in-args-rev.stderr
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/yield-in-initializer.stderr
+++ b/tests/ui/coroutine/yield-in-initializer.stderr
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/yield-subtype.stderr
+++ b/tests/ui/coroutine/yield-subtype.stderr
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/delegation/target-expr-pass.stderr
+++ b/tests/ui/delegation/target-expr-pass.stderr
@@ -4,7 +4,7 @@ warning: trait `Trait` is never used
 LL | trait Trait {
    |       ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: struct `F` is never constructed
   --> $DIR/target-expr-pass.rs:21:8

--- a/tests/ui/diagnostic_namespace/do_not_recommend/does_not_acccept_args.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/does_not_acccept_args.current.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
 LL | #[diagnostic::do_not_recommend(not_accepted)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
   --> $DIR/does_not_acccept_args.rs:15:1

--- a/tests/ui/diagnostic_namespace/do_not_recommend/does_not_acccept_args.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/does_not_acccept_args.next.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
 LL | #[diagnostic::do_not_recommend(not_accepted)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
   --> $DIR/does_not_acccept_args.rs:15:1

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` on by default
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:11:1

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` on by default
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:11:1

--- a/tests/ui/diagnostic_namespace/non_existing_attributes_accepted.stderr
+++ b/tests/ui/diagnostic_namespace/non_existing_attributes_accepted.stderr
@@ -4,7 +4,7 @@ warning: unknown diagnostic attribute
 LL | #[diagnostic::non_existing_attribute]
    |               ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(unknown_diagnostic_attributes)]` on by default
+   = note: `#[warn(unknown_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: unknown diagnostic attribute
   --> $DIR/non_existing_attributes_accepted.rs:8:15

--- a/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
@@ -4,7 +4,7 @@ warning: unmatched `}` found
 LL | #[diagnostic::on_unimplemented(message = "{{Test } thing")]
    |                                          ^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(malformed_diagnostic_format_literals)]` on by default
+   = note: `#[warn(malformed_diagnostic_format_literals)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: positional format arguments are not allowed here
   --> $DIR/broken_format.rs:7:49

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definiti
 LL | #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` on by default
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:6:5
@@ -13,7 +13,7 @@ LL |     on(Self = "&str"),
    |     ^^^^^^^^^^^^^^^^^ invalid option found here
    |
    = help: only `message`, `note` and `label` are allowed as options
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:12:5
@@ -46,7 +46,7 @@ LL |     message = "{from_desugaring}{direct}{cause}{integral}{integer}",
    |                 ^^^^^^^^^^^^^^^
    |
    = help: expect either a generic argument name or `{Self}` as format argument
-   = note: `#[warn(malformed_diagnostic_format_literals)]` on by default
+   = note: `#[warn(malformed_diagnostic_format_literals)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: there is no parameter `direct` on trait `Baz`
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:33:34

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definiti
 LL | #[diagnostic::on_unimplemented(message = "Baz")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` on by default
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:3:32
@@ -13,7 +13,7 @@ LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    |                                ^^^^^^^^^^^^^^^^^^^ invalid option found here
    |
    = help: only `message`, `note` and `label` are allowed as options
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:12:50
@@ -62,7 +62,7 @@ LL | #[diagnostic::on_unimplemented(message = "{DoesNotExist}")]
    |                                            ^^^^^^^^^^^^
    |
    = help: expect either a generic argument name or `{Self}` as format argument
-   = note: `#[warn(malformed_diagnostic_format_literals)]` on by default
+   = note: `#[warn(malformed_diagnostic_format_literals)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:3:32

--- a/tests/ui/diagnostic_namespace/on_unimplemented/ignore_unsupported_options_and_continue_to_use_fallback.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/ignore_unsupported_options_and_continue_to_use_fallback.stderr
@@ -5,7 +5,7 @@ LL |     if(Self = "()"),
    |     ^^^^^^^^^^^^^^^ invalid option found here
    |
    = help: only `message`, `note` and `label` are allowed as options
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `message` is ignored due to previous definition of `message`
   --> $DIR/ignore_unsupported_options_and_continue_to_use_fallback.rs:10:32

--- a/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/on_impl_trait.stderr
@@ -4,7 +4,7 @@ warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definiti
 LL | #[diagnostic::on_unimplemented(message = "blah", label = "blah", note = "blah")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` on by default
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0277]: the trait bound `{integer}: Alias` is not satisfied
   --> $DIR/on_impl_trait.rs:16:9

--- a/tests/ui/diagnostic_namespace/on_unimplemented/report_warning_on_duplicated_options.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/report_warning_on_duplicated_options.stderr
@@ -7,7 +7,7 @@ LL |     message = "first message",
 LL |     message = "second message",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `message` is already declared here
    |
-   = note: `#[warn(malformed_diagnostic_attributes)]` on by default
+   = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: `label` is ignored due to previous definition of `label`
   --> $DIR/report_warning_on_duplicated_options.rs:11:5

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -187,7 +187,7 @@ LL | type H = Fn(u8) -> (u8)::Output;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | type H = <dyn Fn(u8) -> (u8)>::Output;

--- a/tests/ui/drop/drop-struct-as-object.stderr
+++ b/tests/ui/drop/drop-struct-as-object.stderr
@@ -6,7 +6,7 @@ LL | trait Dummy {
 LL |     fn get(&self) -> usize;
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/drop/generic-drop-trait-bound-15858.stderr
+++ b/tests/ui/drop/generic-drop-trait-bound-15858.stderr
@@ -6,7 +6,7 @@ LL | trait Bar {
 LL |     fn do_something(&mut self);
    |        ^^^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
@@ -6,7 +6,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn id<F>(f: dyn Copy) -> usize {

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
@@ -6,7 +6,7 @@ LL | trait B { fn f(a: A) -> A; }
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: dyn A) -> A; }

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
@@ -24,7 +24,7 @@ LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn call_this<F>(f: F) : dyn Fn(&str) + call_that {}

--- a/tests/ui/dynamically-sized-types/dst-coercions.stderr
+++ b/tests/ui/dynamically-sized-types/dst-coercions.stderr
@@ -6,7 +6,7 @@ LL | trait T { fn dummy(&self) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: () = match true {
@@ -111,7 +111,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: () = match true {
@@ -132,7 +132,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     deserialize::<()>()?;
@@ -153,7 +153,7 @@ note: in edition 2024, the requirement `(): From<!>` will fail
    |
 LL |     help(1)?;
    |     ^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     help::<(), _>(1)?;
@@ -174,7 +174,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     takes_apit(|| Default::default())?;
    |                   ^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     takes_apit::<()>(|| Default::default())?;
@@ -195,7 +195,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     takes_apit2(mk()?);
    |                 ^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     takes_apit2(mk::<()>()?);

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -6,7 +6,7 @@ LL |     let _ = MyIterator::next;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _ = <dyn MyIterator>::next;

--- a/tests/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
+++ b/tests/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
@@ -9,7 +9,7 @@ LL | |     )) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 help: try naming the parameter or explicitly ignoring it
    |
 LL |     fn test(x: u32, _: (

--- a/tests/ui/expr/if/if-ret.stderr
+++ b/tests/ui/expr/if/if-ret.stderr
@@ -6,7 +6,7 @@ LL | fn foo() { if (return) { } }
    |               |
    |               any code following this expression is unreachable
    |
-   = note: `#[warn(unreachable_code)]` on by default
+   = note: `#[warn(unreachable_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/extern/no-mangle-associated-fn.stderr
+++ b/tests/ui/extern/no-mangle-associated-fn.stderr
@@ -4,7 +4,7 @@ warning: trait `Bar` is never used
 LL | trait Bar {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -49,7 +49,7 @@ LL | #[repr(simd)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0517]: attribute should be applied to a struct
   --> $DIR/feature-gate-repr-simd.rs:9:8
@@ -85,5 +85,5 @@ LL | #[repr(simd)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -40,7 +40,7 @@ mod inline {
     #[inline = "2100"] fn f() { }
     //~^ ERROR valid forms for the attribute are
     //~| WARN this was previously accepted
-    //~| NOTE #[deny(ill_formed_attribute_input)]` on by default
+    //~| NOTE `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
     //~| NOTE for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
     #[inline] struct S;

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -305,7 +305,7 @@ LL |     #[inline = "2100"] fn f() { }
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 37 previous errors
 
@@ -320,5 +320,5 @@ LL |     #[inline = "2100"] fn f() { }
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/fn/error-recovery-mismatch.stderr
+++ b/tests/ui/fn/error-recovery-mismatch.stderr
@@ -27,7 +27,7 @@ LL |     fn fold<T>(&self, _: T, &self._) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/error-recovery-mismatch.rs:11:35

--- a/tests/ui/generics/duplicate-generic-parameter-error-86756.stderr
+++ b/tests/ui/generics/duplicate-generic-parameter-error-86756.stderr
@@ -20,7 +20,7 @@ LL |     eq::<dyn, Foo>
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     eq::<dyn, dyn Foo>

--- a/tests/ui/generics/empty-generic-brackets-equiv.stderr
+++ b/tests/ui/generics/empty-generic-brackets-equiv.stderr
@@ -4,7 +4,7 @@ warning: trait `T` is never used
 LL | trait T<> {}
    |       ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/generics/invalid-type-param-default.stderr
+++ b/tests/ui/generics/invalid-type-param-default.stderr
@@ -12,7 +12,7 @@ LL | fn avg<T = i32>(_: T) {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: defaults for generic parameters are not allowed here
   --> $DIR/invalid-type-param-default.rs:12:8
@@ -44,7 +44,7 @@ LL | fn avg<T = i32>(_: T) {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: defaults for generic parameters are not allowed here
@@ -55,7 +55,7 @@ LL | fn mdn<T = T::Item>(_: T) {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: defaults for generic parameters are not allowed here
@@ -66,5 +66,5 @@ LL | impl<T = i32> S<T> {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
+++ b/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
@@ -23,7 +23,7 @@ LL | fn mainIterator<_ = _> {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/overlapping-errors-span-issue-123861.rs:1:21
@@ -43,5 +43,5 @@ LL | fn mainIterator<_ = _> {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/impl-trait/example-st.stderr
+++ b/tests/ui/impl-trait/example-st.stderr
@@ -4,7 +4,7 @@ warning: trait `Bind` is never used
 LL | trait Bind<F> {
    |       ^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -6,7 +6,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {

--- a/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
+++ b/tests/ui/impl-trait/in-trait/bad-item-bound-within-rpitit.stderr
@@ -25,7 +25,7 @@ LL |     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {
    |
    = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
-   = note: `#[warn(refining_impl_trait_reachable)]` on by default
+   = note: `#[warn(refining_impl_trait_reachable)]` (part of `#[warn(refining_impl_trait)]`) on by default
 help: replace the return type so that it matches the trait
    |
 LL -     fn iter(&self) -> impl 'a + Iterator<Item = I::Item<'a>> {

--- a/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
+++ b/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
@@ -9,7 +9,7 @@ LL |     fn bar(&self) -> impl Iterator + '_ {
    |
    = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
-   = note: `#[warn(refining_impl_trait_internal)]` on by default
+   = note: `#[warn(refining_impl_trait_internal)]` (part of `#[warn(refining_impl_trait)]`) on by default
 help: replace the return type so that it matches the trait
    |
 LL |     fn bar(&self) -> impl Iterator<Item = impl Sized> + '_ {

--- a/tests/ui/impl-trait/in-trait/refine-captures.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-captures.stderr
@@ -6,7 +6,7 @@ LL |     fn test() -> impl Sized + use<> {}
    |
    = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
-   = note: `#[warn(refining_impl_trait_internal)]` on by default
+   = note: `#[warn(refining_impl_trait_internal)]` (part of `#[warn(refining_impl_trait)]`) on by default
 help: modify the `use<..>` bound to capture the same lifetimes that the trait does
    |
 LL |     fn test() -> impl Sized + use<'a> {}

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
@@ -9,7 +9,7 @@ LL |     fn test() -> &'a () {
    |
    = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
-   = note: `#[warn(refining_impl_trait_internal)]` on by default
+   = note: `#[warn(refining_impl_trait_internal)]` (part of `#[warn(refining_impl_trait)]`) on by default
 help: replace the return type so that it matches the trait
    |
 LL -     fn test() -> &'a () {

--- a/tests/ui/impl-trait/type-alias-generic-param.stderr
+++ b/tests/ui/impl-trait/type-alias-generic-param.stderr
@@ -4,7 +4,7 @@ warning: trait `Meow` is never used
 LL | trait Meow {
    |       ^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/imports/ambiguous-10.stderr
+++ b/tests/ui/imports/ambiguous-10.stderr
@@ -19,7 +19,7 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `Token` could also refer to the enum imported here
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-12.stderr
+++ b/tests/ui/imports/ambiguous-12.stderr
@@ -19,7 +19,7 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `b` could also refer to the function imported here
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-13.stderr
+++ b/tests/ui/imports/ambiguous-13.stderr
@@ -19,7 +19,7 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `Rect` could also refer to the struct imported here
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -19,7 +19,7 @@ note: `foo` could also refer to the function imported here
 LL |     pub use b::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use b::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-15.stderr
+++ b/tests/ui/imports/ambiguous-15.stderr
@@ -19,7 +19,7 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `Error` could also refer to the enum imported here
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-16.stderr
+++ b/tests/ui/imports/ambiguous-16.stderr
@@ -19,7 +19,7 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `ConfirmedTranscriptHashInput` could also refer to the struct imported her
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-17.stderr
+++ b/tests/ui/imports/ambiguous-17.stderr
@@ -29,7 +29,7 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 
@@ -55,5 +55,5 @@ note: `id` could also refer to the function imported here
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-3.stderr
+++ b/tests/ui/imports/ambiguous-3.stderr
@@ -19,7 +19,7 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `x` could also refer to the function imported here
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-5.stderr
+++ b/tests/ui/imports/ambiguous-5.stderr
@@ -19,7 +19,7 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `Class` could also refer to the struct imported here
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-6.stderr
+++ b/tests/ui/imports/ambiguous-6.stderr
@@ -19,7 +19,7 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 
@@ -45,5 +45,5 @@ note: `C` could also refer to the constant imported here
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -29,7 +29,7 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: ambiguous glob re-exports
   --> $DIR/ambiguous-9.rs:15:13
@@ -85,7 +85,7 @@ note: `date_range` could also refer to the function imported here
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: `date_range` is ambiguous
@@ -109,5 +109,5 @@ note: `date_range` could also refer to the function imported here
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -89,7 +89,7 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::b::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 5 previous errors
 
@@ -117,5 +117,5 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::b::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -16,7 +16,7 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
-   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
@@ -60,7 +60,7 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
-   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
@@ -82,6 +82,6 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------ in this macro invocation
-   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -25,7 +25,7 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 2 previous errors
 
@@ -52,5 +52,5 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/inference/inference-variable-behind-raw-pointer.stderr
+++ b/tests/ui/inference/inference-variable-behind-raw-pointer.stderr
@@ -6,7 +6,7 @@ LL |     if data.is_null() {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
-   = note: `#[warn(tyvar_behind_raw_pointer)]` on by default
+   = note: `#[warn(tyvar_behind_raw_pointer)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/inference/inference_unstable.stderr
+++ b/tests/ui/inference/inference_unstable.stderr
@@ -7,7 +7,7 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
-   = note: `#[warn(unstable_name_collisions)]` on by default
+   = note: `#[warn(unstable_name_collisions)]` (part of `#[warn(future_incompatible)]`) on by default
 help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
    |
 LL + #![feature(ipu_flatten)]

--- a/tests/ui/issues/issue-17351.stderr
+++ b/tests/ui/issues/issue-17351.stderr
@@ -6,7 +6,7 @@ LL | trait Str { fn foo(&self) {} }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-20055-box-trait.stderr
+++ b/tests/ui/issues/issue-20055-box-trait.stderr
@@ -6,7 +6,7 @@ LL | trait Boo {
 LL |     fn dummy(&self) { }
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-23485.stderr
+++ b/tests/ui/issues/issue-23485.stderr
@@ -7,7 +7,7 @@ LL | trait Iterator {
 LL |     fn clone_first(mut self) -> Option<<Self::Item as Deref>::Target> where
    |        ^^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -6,7 +6,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let x: u8 = <dyn BitXor>::bitor(0 as u8, 0 as u8);

--- a/tests/ui/issues/issue-2989.stderr
+++ b/tests/ui/issues/issue-2989.stderr
@@ -4,7 +4,7 @@ warning: trait `methods` is never used
 LL | trait methods {
    |       ^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-34503.stderr
+++ b/tests/ui/issues/issue-34503.stderr
@@ -8,7 +8,7 @@ LL |         fn foo(&self) where (T, Option<T>): Ord {}
 LL |         fn bar(&self, x: &Option<T>) -> bool
    |            ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-39367.stderr
+++ b/tests/ui/issues/issue-39367.stderr
@@ -11,7 +11,7 @@ LL | |             });
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/issues/issue-47094.stderr
+++ b/tests/ui/issues/issue-47094.stderr
@@ -6,7 +6,7 @@ LL | #[repr(C, u8)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0566]: conflicting representation hints
   --> $DIR/issue-47094.rs:8:8
@@ -32,7 +32,7 @@ LL | #[repr(C, u8)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error[E0566]: conflicting representation hints
@@ -46,5 +46,5 @@ LL | #[repr(u8)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -6,7 +6,7 @@ LL |     Trait::nonexistent(());
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Trait>::nonexistent(());

--- a/tests/ui/issues/issue-72278.stderr
+++ b/tests/ui/issues/issue-72278.stderr
@@ -9,7 +9,7 @@ LL |     S.func::<'a, U>()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = note: `#[warn(late_bound_lifetime_arguments)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/iterators/into-iter-on-arrays-2018.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-2018.stderr
@@ -6,7 +6,7 @@ LL |     let _: Iter<'_, i32> = array.into_iter();
    |
    = warning: this changes meaning in Rust 2021
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
-   = note: `#[warn(array_into_iter)]` on by default
+   = note: `#[warn(array_into_iter)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     let _: Iter<'_, i32> = array.into_iter();

--- a/tests/ui/iterators/into-iter-on-arrays-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-lint.stderr
@@ -6,7 +6,7 @@ LL |     small.into_iter();
    |
    = warning: this changes meaning in Rust 2021
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
-   = note: `#[warn(array_into_iter)]` on by default
+   = note: `#[warn(array_into_iter)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     small.into_iter();

--- a/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
@@ -6,7 +6,7 @@ LL |     let _: Iter<'_, i32> = boxed_slice.into_iter();
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
-   = note: `#[warn(boxed_slice_into_iter)]` on by default
+   = note: `#[warn(boxed_slice_into_iter)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     let _: Iter<'_, i32> = boxed_slice.into_iter();

--- a/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
@@ -6,7 +6,7 @@ LL |     boxed.into_iter();
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
-   = note: `#[warn(boxed_slice_into_iter)]` on by default
+   = note: `#[warn(boxed_slice_into_iter)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     boxed.into_iter();

--- a/tests/ui/lang-items/issue-83471.stderr
+++ b/tests/ui/lang-items/issue-83471.stderr
@@ -48,7 +48,7 @@ LL |     fn call(export_name);
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 error[E0718]: `fn` lang item must be applied to a trait with 1 generic argument
   --> $DIR/issue-83471.rs:19:1

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -30,7 +30,7 @@ LL | fn c<T = u8()>() {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0308]: mismatched types
   --> $DIR/unusual-rib-combinations.rs:5:16
@@ -51,5 +51,5 @@ LL | fn c<T = u8()>() {}
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
+   = note: `#[deny(invalid_type_param_default)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/link-native-libs/link-attr-validation-early.stderr
+++ b/tests/ui/link-native-libs/link-attr-validation-early.stderr
@@ -7,7 +7,7 @@ LL | #[link]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
   --> $DIR/link-attr-validation-early.rs:4:1
@@ -31,7 +31,7 @@ LL | #[link]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
@@ -43,5 +43,5 @@ LL | #[link = "foo"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/unsupported-abi.stderr
@@ -12,7 +12,7 @@ LL | | }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #137018 <https://github.com/rust-lang/rust/issues/137018>
    = help: if you need `extern "stdcall"` on win32 and `extern "C"` everywhere else, use `extern "system"`
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
+   = note: `#[warn(unsupported_calling_conventions)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: ABI not supported by `#[link(kind = "raw-dylib")]` on this architecture
   --> $DIR/unsupported-abi.rs:16:5

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -6,7 +6,7 @@ LL |     Dyn::func();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Dyn>::func();

--- a/tests/ui/lint/forbid-group-member.stderr
+++ b/tests/ui/lint/forbid-group-member.stderr
@@ -9,7 +9,7 @@ LL | #[allow(unused_variables)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
-   = note: `#[warn(forbidden_lint_groups)]` on by default
+   = note: `#[warn(forbidden_lint_groups)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: 1 warning emitted
 
@@ -25,5 +25,5 @@ LL | #[allow(unused_variables)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
-   = note: `#[warn(forbidden_lint_groups)]` on by default
+   = note: `#[warn(forbidden_lint_groups)]` (part of `#[warn(future_incompatible)]`) on by default
 

--- a/tests/ui/lint/future-incompatible-lint-group.stderr
+++ b/tests/ui/lint/future-incompatible-lint-group.stderr
@@ -6,7 +6,7 @@ LL |     fn f(u8) {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
-   = note: `#[warn(anonymous_parameters)]` on by default
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 error: ambiguous associated item
   --> $DIR/future-incompatible-lint-group.rs:18:17

--- a/tests/ui/lint/let_underscore/let_underscore_lock.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_lock.stderr
@@ -4,7 +4,7 @@ error: non-binding let on a synchronization lock
 LL |     let _ = data.lock().unwrap();
    |         ^ this lock is not assigned to a binding and is immediately dropped
    |
-   = note: `#[deny(let_underscore_lock)]` on by default
+   = note: `#[deny(let_underscore_lock)]` (part of `#[deny(let_underscore)]`) on by default
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = data.lock().unwrap();

--- a/tests/ui/lint/lint-non-uppercase-usages.stderr
+++ b/tests/ui/lint/lint-non-uppercase-usages.stderr
@@ -4,7 +4,7 @@ warning: constant `my_static` should have an upper case name
 LL | const my_static: u32 = 0;
    |       ^^^^^^^^^
    |
-   = note: `#[warn(non_upper_case_globals)]` on by default
+   = note: `#[warn(non_upper_case_globals)]` (part of `#[warn(nonstandard_style)]`) on by default
 help: convert the identifier to upper case
    |
 LL - const my_static: u32 = 0;

--- a/tests/ui/lint/mention-lint-group-in-default-level-lint-note-issue-65464.rs
+++ b/tests/ui/lint/mention-lint-group-in-default-level-lint-note-issue-65464.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+// Verify information about membership to builtin lint group is included in the lint message when
+// explaining lint level and source for builtin lints with default settings.
+//
+// Ideally, we'd like to use lints that are part of `unused` group as shown in the issue.
+// This is not possible in a ui test, because `unused` lints are enabled with `-A unused`
+// in such tests, and the we're testing a scenario with no modification to the default settings.
+
+fn main() {
+    // additional context is provided only if the level is not explicitly set
+    let WrongCase = 1;
+    //~^ WARN [non_snake_case]
+    //~| NOTE `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+    // unchanged message if the level is explicitly set
+    // even if the level is the same as the default
+    #[warn(nonstandard_style)] //~ NOTE the lint level is defined here
+    let WrongCase = 2;
+    //~^ WARN [non_snake_case]
+    //~| NOTE `#[warn(non_snake_case)]` implied by `#[warn(nonstandard_style)]`
+}

--- a/tests/ui/lint/mention-lint-group-in-default-level-lint-note-issue-65464.stderr
+++ b/tests/ui/lint/mention-lint-group-in-default-level-lint-note-issue-65464.stderr
@@ -1,0 +1,23 @@
+warning: variable `WrongCase` should have a snake case name
+  --> $DIR/mention-lint-group-in-default-level-lint-note-issue-65464.rs:12:9
+   |
+LL |     let WrongCase = 1;
+   |         ^^^^^^^^^ help: convert the identifier to snake case: `wrong_case`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: variable `WrongCase` should have a snake case name
+  --> $DIR/mention-lint-group-in-default-level-lint-note-issue-65464.rs:19:9
+   |
+LL |     let WrongCase = 2;
+   |         ^^^^^^^^^ help: convert the identifier to snake case: `wrong_case`
+   |
+note: the lint level is defined here
+  --> $DIR/mention-lint-group-in-default-level-lint-note-issue-65464.rs:18:12
+   |
+LL |     #[warn(nonstandard_style)]
+   |            ^^^^^^^^^^^^^^^^^
+   = note: `#[warn(non_snake_case)]` implied by `#[warn(nonstandard_style)]`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
+++ b/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
@@ -33,7 +33,7 @@ warning: constant `µ` should have an upper case name
 LL | const µ: f64 = 0.000001;
    |       ^ help: convert the identifier to upper case: `Μ`
    |
-   = note: `#[warn(non_upper_case_globals)]` on by default
+   = note: `#[warn(non_upper_case_globals)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.stderr
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.stderr
@@ -9,7 +9,7 @@ LL |         _ => foo!()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
@@ -26,6 +26,6 @@ LL |         _ => foo!()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/lint/special-upper-lower-cases.stderr
+++ b/tests/ui/lint/special-upper-lower-cases.stderr
@@ -4,7 +4,7 @@ warning: type `𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝` should have an upper camel 
 LL | struct 𝕟𝕠𝕥𝕒𝕔𝕒𝕞𝕖𝕝;
    |        ^^^^^^^^^ should have an UpperCamelCase name
    |
-   = note: `#[warn(non_camel_case_types)]` on by default
+   = note: `#[warn(non_camel_case_types)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: type `𝕟𝕠𝕥_𝕒_𝕔𝕒𝕞𝕖𝕝` should have an upper camel case name
   --> $DIR/special-upper-lower-cases.rs:14:8
@@ -18,7 +18,7 @@ warning: static variable `𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲` shou
 LL | static 𝗻𝗼𝗻𝘂𝗽𝗽𝗲𝗿𝗰𝗮𝘀𝗲: i32 = 1;
    |        ^^^^^^^^^^^^ should have an UPPER_CASE name
    |
-   = note: `#[warn(non_upper_case_globals)]` on by default
+   = note: `#[warn(non_upper_case_globals)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: variable `𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢` should have a snake case name
   --> $DIR/special-upper-lower-cases.rs:21:9
@@ -26,7 +26,7 @@ warning: variable `𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢` should have a snake cas
 LL |     let 𝓢𝓝𝓐𝓐𝓐𝓐𝓚𝓔𝓢 = 1;
    |         ^^^^^^^^^ should have a snake_case name
    |
-   = note: `#[warn(non_snake_case)]` on by default
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: 4 warnings emitted
 

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -6,7 +6,7 @@ LL |         let _y = &X;
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _y = &raw const X;

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -6,7 +6,7 @@ LL |         let _y = &X;
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[deny(static_mut_refs)]` on by default
+   = note: `#[deny(static_mut_refs)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _y = &raw const X;

--- a/tests/ui/lint/unused/issue-70041.stderr
+++ b/tests/ui/lint/unused/issue-70041.stderr
@@ -4,7 +4,7 @@ warning: unused macro definition: `regex`
 LL | macro_rules! regex {
    |              ^^^^^
    |
-   = note: `#[warn(unused_macros)]` on by default
+   = note: `#[warn(unused_macros)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused import: `regex`
   --> $DIR/issue-70041.rs:10:5
@@ -12,7 +12,7 @@ warning: unused import: `regex`
 LL | use regex;
    |     ^^^^^
    |
-   = note: `#[warn(unused_imports)]` on by default
+   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
 
 warning: 2 warnings emitted
 

--- a/tests/ui/macros/issue-111749.stderr
+++ b/tests/ui/macros/issue-111749.stderr
@@ -12,7 +12,7 @@ LL |     cbor_map! { #[test(test)] 4};
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 2 previous errors
 
@@ -25,5 +25,5 @@ LL |     cbor_map! { #[test(test)] 4};
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/macros/lint-trailing-macro-call.stderr
+++ b/tests/ui/macros/lint-trailing-macro-call.stderr
@@ -11,7 +11,7 @@ LL |     expand_it!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
@@ -30,6 +30,6 @@ LL |     expand_it!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -75,7 +75,7 @@ LL |     let i = m!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
@@ -94,6 +94,6 @@ LL |     let i = m!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-in-expression-context.fixed
+++ b/tests/ui/macros/macro-in-expression-context.fixed
@@ -8,7 +8,7 @@ macro_rules! foo {
         //~| NOTE macro invocations at the end of a block
         //~| NOTE to ignore the value produced by the macro
         //~| NOTE for more information
-        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` on by default
+        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
         assert_eq!("B", "B");
     }
     //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following

--- a/tests/ui/macros/macro-in-expression-context.rs
+++ b/tests/ui/macros/macro-in-expression-context.rs
@@ -8,7 +8,7 @@ macro_rules! foo {
         //~| NOTE macro invocations at the end of a block
         //~| NOTE to ignore the value produced by the macro
         //~| NOTE for more information
-        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` on by default
+        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
         assert_eq!("B", "B");
     }
     //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following

--- a/tests/ui/macros/macro-in-expression-context.stderr
+++ b/tests/ui/macros/macro-in-expression-context.stderr
@@ -26,7 +26,7 @@ LL |     foo!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
@@ -45,6 +45,6 @@ LL |     foo!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
-   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-self-mutability-7911.stderr
+++ b/tests/ui/macros/macro-self-mutability-7911.stderr
@@ -6,7 +6,7 @@ LL | trait FooBar {
 LL |     fn dummy(&self) { }
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/macros/non-fmt-panic.stderr
+++ b/tests/ui/macros/non-fmt-panic.stderr
@@ -5,7 +5,7 @@ LL |     panic!("here's a brace: {");
    |                             ^
    |
    = note: this message is not used as a format string, but will be in Rust 2021
-   = note: `#[warn(non_fmt_panics)]` on by default
+   = note: `#[warn(non_fmt_panics)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: add a "{}" format string to use the message literally
    |
 LL |     panic!("{}", "here's a brace: {");

--- a/tests/ui/malformed/malformed-regressions.stderr
+++ b/tests/ui/malformed/malformed-regressions.stderr
@@ -7,7 +7,7 @@ LL | #[doc]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
   --> $DIR/malformed-regressions.rs:7:1
@@ -59,7 +59,7 @@ LL | #[doc]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
@@ -71,7 +71,7 @@ LL | #[link]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[link(name = "...")]`, `#[link(name = "...", kind = "dylib|static|...")]`, `#[link(name = "...", wasm_import_module = "...")]`, `#[link(name = "...", import_name_type = "decorated|noprefix|undecorated")]`, and `#[link(name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated")]`
@@ -83,7 +83,7 @@ LL | #[link = ""]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
@@ -94,7 +94,7 @@ LL | #[ignore()]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[inline(always)]`, `#[inline(never)]`, and `#[inline]`
@@ -105,5 +105,5 @@ LL | #[inline = ""]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
-   = note: `#[deny(ill_formed_attribute_input)]` on by default
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
@@ -20,7 +20,7 @@ LL |     0.clone::<'a>();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
-   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = note: `#[warn(late_bound_lifetime_arguments)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/methods/method-recursive-blanket-impl.stderr
+++ b/tests/ui/methods/method-recursive-blanket-impl.stderr
@@ -4,7 +4,7 @@ warning: trait `Foo` is never used
 LL | trait Foo<A> {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/methods/method-two-trait-defer-resolution-2.stderr
+++ b/tests/ui/methods/method-two-trait-defer-resolution-2.stderr
@@ -6,7 +6,7 @@ LL | trait MyCopy { fn foo(&self) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/methods/method-two-traits-distinguished-via-where-clause.stderr
+++ b/tests/ui/methods/method-two-traits-distinguished-via-where-clause.stderr
@@ -4,7 +4,7 @@ warning: trait `A` is never used
 LL | trait A {
    |       ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/methods/trait-method-self-param-error-7575.stderr
+++ b/tests/ui/methods/trait-method-self-param-error-7575.stderr
@@ -4,7 +4,7 @@ warning: trait `Foo` is never used
 LL | trait Foo {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/mir/mir_raw_fat_ptr.stderr
+++ b/tests/ui/mir/mir_raw_fat_ptr.stderr
@@ -6,7 +6,7 @@ LL | trait Foo { fn foo(&self) -> usize; }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/moves/issue-22536-copy-mustnt-zero.stderr
+++ b/tests/ui/moves/issue-22536-copy-mustnt-zero.stderr
@@ -7,7 +7,7 @@ LL |     type Buffer: Copy;
 LL |     fn foo(&self) {}
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will f
    |
 LL |     foo(_x);
    |         ^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _x: () = return;
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will f
    |
 LL |     foo(_x);
    |         ^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _x: () = return;

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |         false => <_>::default(),
    |                   ^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL -         false => <_>::default(),
@@ -55,7 +55,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |         false => <_>::default(),
    |                   ^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL -         false => <_>::default(),
@@ -77,7 +77,7 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     deserialize::<()>()?;

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();
@@ -54,7 +54,7 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();
@@ -75,7 +75,7 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let x: ();

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: Test` will fail
    |
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     unconstrained_arg::<()>(return);
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: Test` will fail
    |
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     unconstrained_arg::<()>(return);

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: UnitReturn` will fail
    |
 LL |     let _ = if true { unconstrained_return() } else { panic!() };
    |                       ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _: () = if true { unconstrained_return() } else { panic!() };
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: UnitReturn` will fail
    |
 LL |     let _ = if true { unconstrained_return() } else { panic!() };
    |                       ^^^^^^^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     let _: () = if true { unconstrained_return() } else { panic!() };

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: Bar` will fail
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     foo::<()>(|| panic!());
@@ -35,7 +35,7 @@ note: in edition 2024, the requirement `!: Bar` will fail
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |     foo::<()>(|| panic!());

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -12,7 +12,7 @@ note: in edition 2024, the requirement `!: T` will fail
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 warning: 1 warning emitted
 
@@ -31,5 +31,5 @@ note: in edition 2024, the requirement `!: T` will fail
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -7,7 +7,7 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
@@ -143,7 +143,7 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
@@ -159,7 +159,7 @@ LL |             core::mem::transmute(Zst)
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |             core::mem::transmute::<_, ()>(Zst)
@@ -175,7 +175,7 @@ LL |         unsafe { Union { a: () }.b }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
 warning: never type fallback affects this raw pointer dereference
@@ -187,7 +187,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
@@ -203,7 +203,7 @@ LL |         unsafe { internally_create(x) }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { internally_create::<()>(x) }
@@ -219,7 +219,7 @@ LL |         unsafe { zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
@@ -235,7 +235,7 @@ LL |         let zeroed = mem::zeroed;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
@@ -251,7 +251,7 @@ LL |         let f = internally_create;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let f = internally_create::<()>;
@@ -267,7 +267,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
 warning: never type fallback affects this call to an `unsafe` function
@@ -282,6 +282,6 @@ LL |         msg_send!();
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -7,7 +7,7 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
@@ -152,7 +152,7 @@ LL |         unsafe { mem::zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { mem::zeroed::<()>() }
@@ -168,7 +168,7 @@ LL |             core::mem::transmute(Zst)
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |             core::mem::transmute::<_, ()>(Zst)
@@ -184,7 +184,7 @@ LL |         unsafe { Union { a: () }.b }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
 error: never type fallback affects this raw pointer dereference
@@ -196,7 +196,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
@@ -212,7 +212,7 @@ LL |         unsafe { internally_create(x) }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         unsafe { internally_create::<()>(x) }
@@ -228,7 +228,7 @@ LL |         unsafe { zeroed() }
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
@@ -244,7 +244,7 @@ LL |         let zeroed = mem::zeroed;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let zeroed = mem::zeroed::<()>;
@@ -260,7 +260,7 @@ LL |         let f = internally_create;
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 help: use `()` annotations to avoid fallback changes
    |
 LL |         let f = internally_create::<()>;
@@ -276,7 +276,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
 
 Future breakage diagnostic:
 error: never type fallback affects this call to an `unsafe` function
@@ -291,6 +291,6 @@ LL |         msg_send!();
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
-   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+   = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -6,7 +6,7 @@ LL |         S1 { a: unsafe { &mut X1 } }
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw mut` instead to create a raw pointer
    |
 LL |         S1 { a: unsafe { &raw mut X1 } }

--- a/tests/ui/nll/issue-48623-coroutine.stderr
+++ b/tests/ui/nll/issue-48623-coroutine.stderr
@@ -5,7 +5,7 @@ LL |     #[coroutine] move || { d; yield; &mut *r };
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: coroutines are lazy and do nothing unless resumed
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/overloaded/issue-14958.stderr
+++ b/tests/ui/overloaded/issue-14958.stderr
@@ -6,7 +6,7 @@ LL | trait Foo { fn dummy(&self) { }}
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/overloaded/overloaded-index-in-field.stderr
+++ b/tests/ui/overloaded/overloaded-index-in-field.stderr
@@ -9,7 +9,7 @@ LL |     fn get_from_ref(&self) -> isize;
 LL |     fn inc(&mut self);
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/parser/recover/recover-pat-ranges.stderr
+++ b/tests/ui/parser/recover/recover-pat-ranges.stderr
@@ -192,7 +192,7 @@ LL |         (1 + 4)...1 * 2 => (),
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default
+   = note: `#[warn(ellipsis_inclusive_range_patterns)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 
 error: aborting due to 13 previous errors; 1 warning emitted
 

--- a/tests/ui/parser/removed-syntax/removed-syntax-fixed-vec.stderr
+++ b/tests/ui/parser/removed-syntax/removed-syntax-fixed-vec.stderr
@@ -17,7 +17,7 @@ warning: type `v` should have an upper camel case name
 LL | type v = [isize * 3];
    |      ^ help: convert the identifier to upper camel case (notice the capitalization): `V`
    |
-   = note: `#[warn(non_camel_case_types)]` on by default
+   = note: `#[warn(non_camel_case_types)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/parser/trait-object-trait-parens.stderr
+++ b/tests/ui/parser/trait-object-trait-parens.stderr
@@ -24,7 +24,7 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;

--- a/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
+++ b/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
@@ -4,7 +4,7 @@ warning: struct `Foo` is never constructed
 LL | struct Foo;
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused closure that must be used
   --> $DIR/skipped-ref-pats-issue-125058.rs:11:5
@@ -18,7 +18,7 @@ LL | |     };
    | |_____^
    |
    = note: closures are lazy and do nothing unless called
-   = note: `#[warn(unused_must_use)]` on by default
+   = note: `#[warn(unused_must_use)]` (part of `#[warn(unused)]`) on by default
 
 warning: 2 warnings emitted
 

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -69,7 +69,7 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 5 previous errors
 
@@ -86,5 +86,5 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/proc-macro/generate-mod.stderr
+++ b/tests/ui/proc-macro/generate-mod.stderr
@@ -46,7 +46,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: `#[deny(proc_macro_derive_resolution_fallback)]` on by default
+   = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find type `OuterDerive` in this scope
@@ -91,7 +91,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: `#[deny(proc_macro_derive_resolution_fallback)]` on by default
+   = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
@@ -103,7 +103,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: `#[deny(proc_macro_derive_resolution_fallback)]` on by default
+   = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
@@ -115,7 +115,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: `#[deny(proc_macro_derive_resolution_fallback)]` on by default
+   = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:
@@ -127,7 +127,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: `#[deny(proc_macro_derive_resolution_fallback)]` on by default
+   = note: `#[deny(proc_macro_derive_resolution_fallback)]` (part of `#[deny(future_incompatible)]`) on by default
    = note: this error originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage diagnostic:

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
@@ -28,7 +28,7 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 2 previous errors
 
@@ -45,5 +45,5 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/proc-macro/proc-macro-attributes.stderr
+++ b/tests/ui/proc-macro/proc-macro-attributes.stderr
@@ -93,7 +93,7 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:10:3
@@ -146,7 +146,7 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: derive helper attribute is used before it is introduced
@@ -160,7 +160,7 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: derive helper attribute is used before it is introduced
@@ -174,7 +174,7 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error: derive helper attribute is used before it is introduced
@@ -188,5 +188,5 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[deny(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
+++ b/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
@@ -30,7 +30,7 @@ LL | pub use core as reexported_core;
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
-   = note: `#[deny(pub_use_of_private_extern_crate)]` on by default
+   = note: `#[deny(pub_use_of_private_extern_crate)]` (part of `#[deny(future_incompatible)]`) on by default
 help: consider making the `extern crate` item publicly accessible
    |
 LL | pub extern crate core;
@@ -49,7 +49,7 @@ LL | pub use core as reexported_core;
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
-   = note: `#[deny(pub_use_of_private_extern_crate)]` on by default
+   = note: `#[deny(pub_use_of_private_extern_crate)]` (part of `#[deny(future_incompatible)]`) on by default
 help: consider making the `extern crate` item publicly accessible
    |
 LL | pub extern crate core;

--- a/tests/ui/repr/conflicting-repr-hints.stderr
+++ b/tests/ui/repr/conflicting-repr-hints.stderr
@@ -6,7 +6,7 @@ LL | #[repr(C, u64)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0566]: conflicting representation hints
   --> $DIR/conflicting-repr-hints.rs:19:8
@@ -90,7 +90,7 @@ LL | #[repr(C, u64)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 Future breakage diagnostic:
 error[E0566]: conflicting representation hints
@@ -101,5 +101,5 @@ LL | #[repr(u32, u64)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
-   = note: `#[deny(conflicting_repr_hints)]` on by default
+   = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/protect-precedences.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/protect-precedences.stderr
@@ -6,7 +6,7 @@ LL |         if let _ = return true && false {};
    |                    |
    |                    any code following this expression is unreachable
    |
-   = note: `#[warn(unreachable_code)]` on by default
+   = note: `#[warn(unreachable_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/self/self-ctor-nongeneric.stderr
+++ b/tests/ui/self/self-ctor-nongeneric.stderr
@@ -9,7 +9,7 @@ LL |         const C: S0 = Self(0);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124186 <https://github.com/rust-lang/rust/issues/124186>
-   = note: `#[warn(self_constructor_from_outer_item)]` on by default
+   = note: `#[warn(self_constructor_from_outer_item)]` (part of `#[warn(future_incompatible)]`) on by default
 
 warning: can't reference `Self` constructor from outer item
   --> $DIR/self-ctor-nongeneric.rs:12:13

--- a/tests/ui/sized/coinductive-2.stderr
+++ b/tests/ui/sized/coinductive-2.stderr
@@ -4,7 +4,7 @@ warning: trait `Collection` is never used
 LL | trait Collection<T>: Sized {
    |       ^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/span/issue-24690.stderr
+++ b/tests/ui/span/issue-24690.stderr
@@ -17,7 +17,7 @@ warning: variable `theTwo` should have a snake case name
 LL |     let theTwo = 2;
    |         ^^^^^^ help: convert the identifier to snake case: `the_two`
    |
-   = note: `#[warn(non_snake_case)]` on by default
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: variable `theOtherTwo` should have a snake case name
   --> $DIR/issue-24690.rs:13:9

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -6,7 +6,7 @@ LL | static n: &'static usize = unsafe { &n_mut };
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw const` instead to create a raw pointer
    |
 LL | static n: &'static usize = unsafe { &raw const n_mut };

--- a/tests/ui/statics/static-impl.stderr
+++ b/tests/ui/statics/static-impl.stderr
@@ -7,7 +7,7 @@ LL |     fn length_(&self, ) -> usize;
 LL |     fn iter_<F>(&self, f: F) where F: FnMut(&T);
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -6,7 +6,7 @@ LL |     let _ = unsafe { (&TEST) as *const usize };
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw const` instead to create a raw pointer
    |
 LL |     let _ = unsafe { (&raw const TEST) as *const usize };

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -6,7 +6,7 @@ LL |     assert_eq!(static_mut_xc::a, 3);
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 warning: creating a shared reference to mutable static
   --> $DIR/static-mut-xc.rs:22:16

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -6,7 +6,7 @@ LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
    |
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
-   = note: `#[warn(static_mut_refs)]` on by default
+   = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 help: use `&raw const` instead to create a raw pointer
    |
 LL | static mut S: *const u8 = unsafe { &raw const S as *const *const u8 as *const u8 };

--- a/tests/ui/std/issue-3563-3.stderr
+++ b/tests/ui/std/issue-3563-3.stderr
@@ -7,7 +7,7 @@ LL | trait Canvas {
 LL |     fn add_points(&mut self, shapes: &[Point]) {
    |        ^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/stdlib-unit-tests/raw-fat-ptr.stderr
+++ b/tests/ui/stdlib-unit-tests/raw-fat-ptr.stderr
@@ -6,7 +6,7 @@ LL | trait Foo { fn foo(&self) -> usize; }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/structs-enums/enum-null-pointer-opt.stderr
+++ b/tests/ui/structs-enums/enum-null-pointer-opt.stderr
@@ -6,7 +6,7 @@ LL | trait Trait { fn dummy(&self) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/suggestions/dont-try-removing-the-field.stderr
+++ b/tests/ui/suggestions/dont-try-removing-the-field.stderr
@@ -4,7 +4,7 @@ warning: unused variable: `baz`
 LL |     let Foo { foo, bar, baz } = x;
    |                         ^^^ help: try ignoring the field: `baz: _`
    |
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/suggestions/ice-unwrap-probe-many-result-125876.stderr
+++ b/tests/ui/suggestions/ice-unwrap-probe-many-result-125876.stderr
@@ -12,7 +12,7 @@ LL |     std::ptr::from_ref(num).cast_mut().as_deref();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
-   = note: `#[warn(tyvar_behind_raw_pointer)]` on by default
+   = note: `#[warn(tyvar_behind_raw_pointer)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
 
 warning: type annotations needed
   --> $DIR/ice-unwrap-probe-many-result-125876.rs:5:40

--- a/tests/ui/suggestions/issue-116434-2015.stderr
+++ b/tests/ui/suggestions/issue-116434-2015.stderr
@@ -6,7 +6,7 @@ LL |     fn foo() -> Clone;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn foo() -> dyn Clone;

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -69,7 +69,7 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}

--- a/tests/ui/suggestions/try-removing-the-field.stderr
+++ b/tests/ui/suggestions/try-removing-the-field.stderr
@@ -6,7 +6,7 @@ LL |     let Foo { foo, bar, .. } = x;
    |                    |
    |                    help: try removing the field
    |
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `unused`
   --> $DIR/try-removing-the-field.rs:20:20

--- a/tests/ui/traits/alias/bounds.stderr
+++ b/tests/ui/traits/alias/bounds.stderr
@@ -4,7 +4,7 @@ warning: trait `Empty` is never used
 LL | trait Empty {}
    |       ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/alias/style_lint.stderr
+++ b/tests/ui/traits/alias/style_lint.stderr
@@ -4,7 +4,7 @@ warning: trait alias `bar` should have an upper camel case name
 LL | trait bar = std::fmt::Display + std::fmt::Debug;
    |       ^^^ help: convert the identifier to upper camel case: `Bar`
    |
-   = note: `#[warn(non_camel_case_types)]` on by default
+   = note: `#[warn(non_camel_case_types)]` (part of `#[warn(nonstandard_style)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -6,7 +6,7 @@ LL | fn foo(_x: Foo + Send) {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn foo(_x: dyn Foo + Send) {

--- a/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.stderr
+++ b/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.stderr
@@ -45,7 +45,7 @@ LL | demo! { impl const Trait }
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
    = note: this warning originates in the macro `demo` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might have intended to implement this trait for a given type
    |

--- a/tests/ui/traits/default-method/bound-subst4.stderr
+++ b/tests/ui/traits/default-method/bound-subst4.stderr
@@ -7,7 +7,7 @@ LL |     fn g(&self, x: usize) -> usize { x }
 LL |     fn h(&self, x: T) { }
    |        ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/impl-inherent-prefer-over-trait.stderr
+++ b/tests/ui/traits/impl-inherent-prefer-over-trait.stderr
@@ -6,7 +6,7 @@ LL | trait Trait {
 LL |     fn bar(&self);
    |        ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/impl-object-overlap-issue-23853.stderr
+++ b/tests/ui/traits/impl-object-overlap-issue-23853.stderr
@@ -6,7 +6,7 @@ LL | trait Foo { fn dummy(&self) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/impl.stderr
+++ b/tests/ui/traits/impl.stderr
@@ -6,7 +6,7 @@ LL | trait T {
 LL |     fn t(&self) {}
    |        ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/issue-38033.stderr
+++ b/tests/ui/traits/issue-38033.stderr
@@ -7,7 +7,7 @@ LL | trait IntoFuture {
 LL |     fn into_future(self) -> Self::Future;
    |        ^^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/issue-6128.stderr
+++ b/tests/ui/traits/issue-6128.stderr
@@ -8,7 +8,7 @@ LL |     fn f(&self, _: Edge);
 LL |     fn g(&self, _: Node);
    |        ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
@@ -6,7 +6,7 @@ LL | impl Foo<i64> {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl dyn Foo<i64> {

--- a/tests/ui/traits/multidispatch-conditional-impl-not-considered.stderr
+++ b/tests/ui/traits/multidispatch-conditional-impl-not-considered.stderr
@@ -4,7 +4,7 @@ warning: trait `Foo` is never used
 LL | trait Foo {
    |       ^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/multidispatch-infer-convert-target.stderr
+++ b/tests/ui/traits/multidispatch-infer-convert-target.stderr
@@ -6,7 +6,7 @@ LL | trait Convert<Target> {
 LL |     fn convert(&self) -> Target;
    |        ^^^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/traits/trait-upcasting/lifetime.stderr
+++ b/tests/ui/traits/trait-upcasting/lifetime.stderr
@@ -10,7 +10,7 @@ LL |     fn z(&self) -> i32 {
 LL |     fn y(&self) -> i32 {
    |        ^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: method `w` is never used
   --> $DIR/lifetime.rs:22:8

--- a/tests/ui/traits/trait-upcasting/replace-vptr.stderr
+++ b/tests/ui/traits/trait-upcasting/replace-vptr.stderr
@@ -6,7 +6,7 @@ LL | trait A {
 LL |     fn foo_a(&self);
    |        ^^^^^
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: method `foo_c` is never used
   --> $DIR/replace-vptr.rs:12:8

--- a/tests/ui/traits/unspecified-self-in-trait-ref.stderr
+++ b/tests/ui/traits/unspecified-self-in-trait-ref.stderr
@@ -6,7 +6,7 @@ LL |     let a = Foo::lol();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let a = <dyn Foo>::lol();

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
@@ -16,7 +16,7 @@ note: `V` could also refer to the associated type defined here
    |
 LL |     type V;
    |     ^^^^^^
-   = note: `#[deny(ambiguous_associated_items)]` on by default
+   = note: `#[deny(ambiguous_associated_items)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closures-counter-not-moved.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-counter-not-moved.stderr
@@ -4,7 +4,7 @@ warning: unused variable: `item`
 LL |         for item in y {
    |             ^^^^ help: if this is intentional, prefix it with an underscore: `_item`
    |
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: value assigned to `counter` is never read
   --> $DIR/unboxed-closures-counter-not-moved.rs:24:9
@@ -13,7 +13,7 @@ LL |         counter += 1;
    |         ^^^^^^^
    |
    = help: maybe it is overwritten before being read?
-   = note: `#[warn(unused_assignments)]` on by default
+   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `counter`
   --> $DIR/unboxed-closures-counter-not-moved.rs:24:9

--- a/tests/ui/unboxed-closures/unboxed-closures-move-mutable.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-move-mutable.stderr
@@ -5,7 +5,7 @@ LL |         move || x += 1;
    |                 ^
    |
    = help: did you mean to capture by reference instead?
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `x`
   --> $DIR/unboxed-closures-move-mutable.rs:20:17

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
@@ -11,7 +11,7 @@ note: an unsafe function restricts its caller, but its body is safe by default
    |
 LL | unsafe fn foo() {
    | ^^^^^^^^^^^^^^^
-   = note: `#[warn(unsafe_op_in_unsafe_fn)]` on by default
+   = note: `#[warn(unsafe_op_in_unsafe_fn)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
@@ -11,7 +11,7 @@ note: an unsafe function restricts its caller, but its body is safe by default
    |
 LL | unsafe fn foo() {
    | ^^^^^^^^^^^^^^^
-   = note: `#[warn(unsafe_op_in_unsafe_fn)]` on by default
+   = note: `#[warn(unsafe_op_in_unsafe_fn)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -6,7 +6,7 @@ LL | trait Foo<const N: Bar<2>> {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: `#[warn(bare_trait_objects)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Foo<const N: dyn Bar<2>> {

--- a/tests/ui/where-clauses/where-clause-early-bound-lifetimes.stderr
+++ b/tests/ui/where-clauses/where-clause-early-bound-lifetimes.stderr
@@ -6,7 +6,7 @@ LL | trait TheTrait { fn dummy(&self) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 

--- a/tests/ui/where-clauses/where-clause-method-substituion-rpass.stderr
+++ b/tests/ui/where-clauses/where-clause-method-substituion-rpass.stderr
@@ -6,7 +6,7 @@ LL | trait Foo<T> { fn dummy(&self, arg: T) { } }
    |       |
    |       method in this trait
    |
-   = note: `#[warn(dead_code)]` on by default
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
### Summary

This PR updates lint diagnostics so that default-level notes now mention the lint group they belong to, if any.
Fixes: rust-lang/rust#65464.

### Example

```rust
fn main() {
    let x = 5;
}
```

Before:

```
= note: `#[warn(unused_variables)]` on by default
```

After:

```
= note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
```

### Unchanged Cases

Messages remain the same when the lint level is explicitly set, e.g.:

* Attribute on the lint `#[warn(unused_variables)]`:

  ```
  note: the lint level is defined here
  LL | #[warn(unused_variables)]
     |        ^^^^^^^^^^^^^^^^
  ```
* Attribute on the group `#[warn(unused)]:`:

  ```
  = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
  ```
* CLI option `-W unused`:

  ```
  = note: `-W unused-variables` implied by `-W unused`
  = help: to override `-W unused` add `#[allow(unused_variables)]`
  ```
* CLI option `-W unused-variables`:

  ```
  = note: requested on the command line with `-W unused-variables`
  ```