### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
@@ -1,9 +1,14 @@
-use crate::spec::{Target, TargetMetadata, base};
+use crate::spec::{LinkerFlavor, Lld, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.max_atomic_width = Some(128);
     base.features = "+v8a,+neon,+fp-armv8".into();
+
+    // MSVC emits a warning about code that may trip "Cortex-A53 MPCore processor bug #843419" (see
+    // https://developer.arm.com/documentation/epm048406/latest) which is sometimes emitted by LLVM.
+    // Since Arm64 Windows 10+ isn't supported on that processor, it's safe to disable the warning.
+    base.add_pre_link_args(LinkerFlavor::Msvc(Lld::No), &["/arm64hazardfree"]);
 
     Target {
         llvm_target: "aarch64-pc-windows-msvc".into(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1516,6 +1516,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 } else {
                     expr.span.with_hi(expr.span.lo() + BytePos(1))
                 };
+
+                match self.tcx.sess.source_map().span_to_snippet(span) {
+                    Ok(snippet) if snippet.starts_with("&") => {}
+                    _ => break 'outer,
+                }
+
                 suggestions.push((span, String::new()));
 
                 let ty::Ref(_, inner_ty, _) = suggested_ty.kind() else {

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -730,6 +730,10 @@ fn recursive_mkdir_empty() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn recursive_rmdir() {
     let tmpdir = tmpdir();
     let d1 = tmpdir.join("d1");
@@ -749,6 +753,10 @@ fn recursive_rmdir() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn recursive_rmdir_of_symlink() {
     // test we do not recursively delete a symlink but only dirs.
     let tmpdir = tmpdir();
@@ -1533,6 +1541,10 @@ fn file_open_not_found() {
 }
 
 #[test]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn create_dir_all_with_junctions() {
     let tmpdir = tmpdir();
     let target = tmpdir.join("target");
@@ -2011,6 +2023,10 @@ fn test_rename_symlink() {
 
 #[test]
 #[cfg(windows)]
+#[cfg_attr(
+    all(windows, target_arch = "aarch64"),
+    ignore = "SymLinks not enabled on Arm64 Windows runners https://github.com/actions/partner-runner-images/issues/94"
+)]
 fn test_rename_junction() {
     let tmpdir = tmpdir();
     let original = tmpdir.join("original");

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -35,6 +35,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-32bit",
     "ignore-64bit",
     "ignore-aarch64",
+    "ignore-aarch64-pc-windows-msvc",
     "ignore-aarch64-unknown-linux-gnu",
     "ignore-aix",
     "ignore-android",

--- a/tests/debuginfo/step-into-match.rs
+++ b/tests/debuginfo/step-into-match.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -g
 //@ ignore-android: FIXME(#10381)
 
+// On Arm64 Windows, stepping at the end of a function on goes to the callsite, not the instruction
+// after it.
+//@ ignore-aarch64-pc-windows-msvc: Stepping out of functions behaves differently.
+
 // === GDB TESTS ==============================================================
 
 // gdb-command: r

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -1,5 +1,7 @@
 //@ ignore-lldb
 
+//@ ignore-aarch64-pc-windows-msvc: Arm64 Windows cdb doesn't support JavaScript extensions.
+
 // GDB changed the way that it formatted Foreign types
 //@ min-gdb-version: 9.2
 

--- a/tests/run-make/pointer-auth-link-with-c/test.rs
+++ b/tests/run-make/pointer-auth-link-with-c/test.rs
@@ -1,4 +1,4 @@
-#[link(name = "test")]
+#[link(name = "test", kind = "static")]
 extern "C" {
     fn foo() -> i32;
 }

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -42,9 +42,13 @@ macro_rules! dump_and_die {
         // there, even on i686-pc-windows-msvc. We do the best we can in
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
+        //
+        // aarch64-msvc is broken as its backtraces are truncated.
+        // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
+                    all(target_env = "msvc", target_arch = "aarch64"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.rs
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.rs
@@ -1,0 +1,18 @@
+trait Trait {}
+
+struct Chars;
+impl Trait for Chars {}
+
+struct FlatMap<T>(T);
+impl<T: Trait> std::fmt::Debug for FlatMap<T> {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+fn lol() {
+    format_args!("{:?}", FlatMap(&Chars));
+    //~^ ERROR the trait bound `&Chars: Trait` is not satisfied [E0277]
+}
+
+fn main() {}

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
@@ -6,6 +6,7 @@ LL |     format_args!("{:?}", FlatMap(&Chars));
    |                   |
    |                   required by a bound introduced by this call
    |
+   = help: the trait `Trait` is implemented for `Chars`
 note: required for `FlatMap<&Chars>` to implement `Debug`
   --> $DIR/suggest-remove-deref-issue-140166.rs:7:16
    |
@@ -15,11 +16,6 @@ LL | impl<T: Trait> std::fmt::Debug for FlatMap<T> {
    |         unsatisfied trait bound introduced here
 note: required by a bound in `core::fmt::rt::Argument::<'_>::new_debug`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
-help: consider removing the leading `&`-reference
-   |
-LL -     format_args!("{:?}", FlatMap(&Chars));
-LL +     format_args!("{:?}", latMap(&Chars));
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
+++ b/tests/ui/traits/suggest-remove-deref-issue-140166.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `&Chars: Trait` is not satisfied
+  --> $DIR/suggest-remove-deref-issue-140166.rs:14:26
+   |
+LL |     format_args!("{:?}", FlatMap(&Chars));
+   |                   ----   ^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `&Chars`
+   |                   |
+   |                   required by a bound introduced by this call
+   |
+note: required for `FlatMap<&Chars>` to implement `Debug`
+  --> $DIR/suggest-remove-deref-issue-140166.rs:7:16
+   |
+LL | impl<T: Trait> std::fmt::Debug for FlatMap<T> {
+   |         -----  ^^^^^^^^^^^^^^^     ^^^^^^^^^^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required by a bound in `core::fmt::rt::Argument::<'_>::new_debug`
+  --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
+help: consider removing the leading `&`-reference
+   |
+LL -     format_args!("{:?}", FlatMap(&Chars));
+LL +     format_args!("{:?}", latMap(&Chars));
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #140736 (trait selection: check `&` before suggest remove deref)
 - #140755 ([win][arm64] Disable various DebugInfo tests that don't work on Arm64 Windows)
 - #140756 ([arm64] Pointer auth test should link with C static library statically)
 - #140758 ([win][arm64] Disable MSVC Linker 'Arm Hazard' warning)
 - #140759 ([win][arm64] Disable std::fs tests that require symlinks)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140736,140755,140756,140758,140759)
<!-- homu-ignore:end -->