### PR TITLE
Use span before macro expansion in lint for-loops-over-falibles

### DIFF
--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
@@ -3,8 +3,8 @@
 fn main() {
     macro_rules! x {
         () => {
-            None::<i32> //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
+            None::<i32>
         };
     }
-    for _ in x! {} {}
+    for _ in x! {} {} //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
 }

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
@@ -1,0 +1,10 @@
+#![forbid(for_loops_over_fallibles)]
+
+fn main() {
+    macro_rules! x {
+        () => {
+            None::<i32> //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
+        };
+    }
+    for _ in x! {} {}
+}

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
@@ -1,0 +1,32 @@
+error: for loop over an `Option`. This is more readably written as an `if let` statement
+  --> $DIR/macro-issue-140747.rs:6:13
+   |
+LL |             None::<i32>
+   |             ^^^^^^^^^^^
+...
+LL |     for _ in x! {} {}
+   |              ----- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/macro-issue-140747.rs:1:11
+   |
+LL | #![forbid(for_loops_over_fallibles)]
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to check pattern in a loop use `while let`
+   |
+LL ~             ) =
+LL |         };
+LL |     }
+LL ~     while let Some(_ in x! {} {}
+   |
+help: consider using `if let` to clear intent
+   |
+LL ~             ) =
+LL |         };
+LL |     }
+LL ~     if let Some(_ in x! {} {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
@@ -1,31 +1,23 @@
 error: for loop over an `Option`. This is more readably written as an `if let` statement
-  --> $DIR/macro-issue-140747.rs:6:13
+  --> $DIR/macro-issue-140747.rs:9:14
    |
-LL |             None::<i32>
-   |             ^^^^^^^^^^^
-...
 LL |     for _ in x! {} {}
-   |              ----- in this macro invocation
+   |              ^^^^^
    |
 note: the lint level is defined here
   --> $DIR/macro-issue-140747.rs:1:11
    |
 LL | #![forbid(for_loops_over_fallibles)]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: to check pattern in a loop use `while let`
    |
-LL ~             ) =
-LL |         };
-LL |     }
-LL ~     while let Some(_ in x! {} {}
+LL -     for _ in x! {} {}
+LL +     while let Some(_) = x! {} {}
    |
 help: consider using `if let` to clear intent
    |
-LL ~             ) =
-LL |         };
-LL |     }
-LL ~     if let Some(_ in x! {} {}
+LL -     for _ in x! {} {}
+LL +     if let Some(_) = x! {} {}
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Fixes #140747

I think there are going to be a lot of cases where macros are expanded in the compiler resulting in span offsets, and I'd like to know how that's typically handled. Does it have to be handled specially every time?