### PR TITLE
add signed ints to unn- transmutes to ensure feature parity

### DIFF
--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse2.rs
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse2.rs
@@ -1,5 +1,6 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
+#![allow(unnecessary_transmutes)]
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/ui/transmute/unnecessary-transmutation.fixed
+++ b/tests/ui/transmute/unnecessary-transmutation.fixed
@@ -49,6 +49,10 @@ fn main() {
         //~^ ERROR
         let y: char = char::from_u32_unchecked(y);
         //~^ ERROR
+        let y: i32 = u32::from('🐱').cast_signed();
+        //~^ ERROR
+        let y: char = char::from_u32_unchecked(i32::cast_unsigned(y));
+        //~^ ERROR
 
         let x: u16 = i16::cast_unsigned(8i16);
         //~^ ERROR
@@ -70,6 +74,11 @@ fn main() {
         let y: f64 = f64::from_bits(3u64);
         //~^ ERROR
         let y: u64 = f64::to_bits(2.0);
+        //~^ ERROR
+
+        let y: f64 = f64::from_bits(i64::cast_unsigned(1i64));
+        //~^ ERROR
+        let y: i64 = f64::to_bits(1f64).cast_signed();
         //~^ ERROR
 
         let z: bool = (1u8 == 1);

--- a/tests/ui/transmute/unnecessary-transmutation.rs
+++ b/tests/ui/transmute/unnecessary-transmutation.rs
@@ -49,6 +49,10 @@ fn main() {
         //~^ ERROR
         let y: char = transmute(y);
         //~^ ERROR
+        let y: i32 = transmute('🐱');
+        //~^ ERROR
+        let y: char = transmute(y);
+        //~^ ERROR
 
         let x: u16 = transmute(8i16);
         //~^ ERROR
@@ -70,6 +74,11 @@ fn main() {
         let y: f64 = transmute(3u64);
         //~^ ERROR
         let y: u64 = transmute(2.0);
+        //~^ ERROR
+
+        let y: f64 = transmute(1i64);
+        //~^ ERROR
+        let y: i64 = transmute(1f64);
         //~^ ERROR
 
         let z: bool = transmute(1u8);

--- a/tests/ui/transmute/unnecessary-transmutation.stderr
+++ b/tests/ui/transmute/unnecessary-transmutation.stderr
@@ -154,82 +154,108 @@ LL |         let y: char = transmute(y);
    = help: consider `char::from_u32(…).unwrap()`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:53:22
+  --> $DIR/unnecessary-transmutation.rs:52:22
+   |
+LL |         let y: i32 = transmute('🐱');
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `u32::from('🐱').cast_signed()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:54:23
+   |
+LL |         let y: char = transmute(y);
+   |                       ^^^^^^^^^^^^ help: replace this with: `char::from_u32_unchecked(i32::cast_unsigned(y))`
+   |
+   = help: consider `char::from_u32(i32::cast_unsigned(…)).unwrap()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:57:22
    |
 LL |         let x: u16 = transmute(8i16);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i16::cast_unsigned(8i16)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:55:22
+  --> $DIR/unnecessary-transmutation.rs:59:22
    |
 LL |         let x: i16 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u16::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:57:22
+  --> $DIR/unnecessary-transmutation.rs:61:22
    |
 LL |         let x: u32 = transmute(4i32);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(4i32)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:59:22
+  --> $DIR/unnecessary-transmutation.rs:63:22
    |
 LL |         let x: i32 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:61:22
+  --> $DIR/unnecessary-transmutation.rs:65:22
    |
 LL |         let x: u64 = transmute(7i64);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i64::cast_unsigned(7i64)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:63:22
+  --> $DIR/unnecessary-transmutation.rs:67:22
    |
 LL |         let x: i64 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u64::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:66:22
+  --> $DIR/unnecessary-transmutation.rs:70:22
    |
 LL |         let y: f32 = transmute(1u32);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `f32::from_bits(1u32)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:68:22
+  --> $DIR/unnecessary-transmutation.rs:72:22
    |
 LL |         let y: u32 = transmute(y);
    |                      ^^^^^^^^^^^^ help: replace this with: `f32::to_bits(y)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:70:22
+  --> $DIR/unnecessary-transmutation.rs:74:22
    |
 LL |         let y: f64 = transmute(3u64);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::from_bits(3u64)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:72:22
+  --> $DIR/unnecessary-transmutation.rs:76:22
    |
 LL |         let y: u64 = transmute(2.0);
    |                      ^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(2.0)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:75:23
+  --> $DIR/unnecessary-transmutation.rs:79:22
+   |
+LL |         let y: f64 = transmute(1i64);
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::from_bits(i64::cast_unsigned(1i64))`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:81:22
+   |
+LL |         let y: i64 = transmute(1f64);
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(1f64).cast_signed()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:84:23
    |
 LL |         let z: bool = transmute(1u8);
    |                       ^^^^^^^^^^^^^^ help: replace this with: `(1u8 == 1)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:77:21
+  --> $DIR/unnecessary-transmutation.rs:86:21
    |
 LL |         let z: u8 = transmute(z);
    |                     ^^^^^^^^^^^^ help: replace this with: `(z) as u8`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:82:21
+  --> $DIR/unnecessary-transmutation.rs:91:21
    |
 LL |         let z: i8 = transmute(z);
    |                     ^^^^^^^^^^^^ help: replace this with: `(z) as i8`
 
-error: aborting due to 32 previous errors
+error: aborting due to 36 previous errors
 


### PR DESCRIPTION
i forgot a few cases https://github.com/rust-lang/rust-clippy/pull/14703/#pullrequestreview-2824194994

adds

- char -> i32
-  i32 -> char
- float -> size ()
-  size -> float
-   i32 -> float
@rustbot label L-unnecessary_transmutes