### PR TITLE
Implement Default for &Option

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2094,6 +2094,15 @@ impl<T> Default for Option<T> {
     }
 }
 
+#[stable(feature = "option_ref_default", since = "CURRENT_RUSTC_VERSION")]
+impl<'a, T> Default for &'a Option<T> {
+    /// Returns `&None`
+    #[inline]
+    fn default() -> &'a Option<T> {
+        &None
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for Option<T> {
     type Item = T;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/140808)*
<!-- homu-ignore:end -->

Pretty straightforward, but here is some justification:

I wasn't able to derive Default for my struct containing a `&Option<MyType>` because I can't implement `Default` for `&Option<MyType>` because of the orphan rule. I suppose this is an unusual case because `Option<&T>` is generally preferred over `&Option<T>`. But I think adding this is justified for a couple reasons. 1) It removes an unnecessary speed bump. 2) I think there are times when `&Option<T>` is preferable. In my project I am creating and passing around `&Option<MyType>` in a lot of places, but only actually using `MyType` in one place. So it's not worth the ergonomic cost of having to write `build_mytype(...).as_ref()` instead of `&build_mytype(...)` in many places.

r? libs
