### PR TITLE
Do not ICE when reassigning in GatherLocalsVisitor on the bad path

### DIFF
--- a/tests/ui/typeck/gather-locals-twice.rs
+++ b/tests/ui/typeck/gather-locals-twice.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/140785>.
+
+fn main() {
+    () += { let x; };
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `()`
+    //~| ERROR invalid left-hand side of assignment
+}

--- a/tests/ui/typeck/gather-locals-twice.stderr
+++ b/tests/ui/typeck/gather-locals-twice.stderr
@@ -1,0 +1,20 @@
+error[E0368]: binary assignment operation `+=` cannot be applied to type `()`
+  --> $DIR/gather-locals-twice.rs:4:5
+   |
+LL |     () += { let x; };
+   |     --^^^^^^^^^^^^^^
+   |     |
+   |     cannot use `+=` on type `()`
+
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/gather-locals-twice.rs:4:8
+   |
+LL |     () += { let x; };
+   |     -- ^^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0067, E0368.
+For more information about an error, try `rustc --explain E0067`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/140785
Fixes https://github.com/rust-lang/rust/issues/140730

See comment in code.

r? oli-obk