### PR TITLE
make path_statements lint machine applicable for statements with no effect

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -675,6 +675,7 @@ lint_path_statement_drop = path statement drops value
     .suggestion = use `drop` to clarify the intent
 
 lint_path_statement_no_effect = path statement with no effect
+    .suggestion = remove this statement
 
 lint_pattern_in_bodiless = patterns aren't allowed in functions without bodies
     .label = pattern not allowed in function without body

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2077,7 +2077,10 @@ pub(crate) enum PathStatementDropSub {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_path_statement_no_effect)]
-pub(crate) struct PathStatementNoEffect;
+pub(crate) struct PathStatementNoEffect {
+    #[suggestion(lint_suggestion, code = "", applicability = "machine-applicable")]
+    pub suggestion: Span,
+}
 
 #[derive(LintDiagnostic)]
 #[diag(lint_unused_delim)]

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -568,7 +568,11 @@ impl<'tcx> LateLintPass<'tcx> for PathStatements {
                     };
                     cx.emit_span_lint(PATH_STATEMENTS, s.span, PathStatementDrop { sub })
                 } else {
-                    cx.emit_span_lint(PATH_STATEMENTS, s.span, PathStatementNoEffect);
+                    cx.emit_span_lint(
+                        PATH_STATEMENTS,
+                        s.span,
+                        PathStatementNoEffect { suggestion: s.span },
+                    );
                 }
             }
         }

--- a/tests/ui/lint/warn-path-statement.rs
+++ b/tests/ui/lint/warn-path-statement.rs
@@ -14,4 +14,12 @@ fn main() {
 
     let z = (Droppy,);
     z; //~ ERROR path statement drops value
+
+    macro_rules! foo {
+        ($e:expr) => {
+            $e;
+        };
+    }
+
+    foo!(x);
 }

--- a/tests/ui/lint/warn-path-statement.stderr
+++ b/tests/ui/lint/warn-path-statement.stderr
@@ -2,7 +2,7 @@ error: path statement with no effect
   --> $DIR/warn-path-statement.rs:10:5
    |
 LL |     x;
-   |     ^^
+   |     ^^ help: remove this statement
    |
    = note: requested on the command line with `-D path-statements`
 
@@ -18,5 +18,16 @@ error: path statement drops value
 LL |     z;
    |     ^^ help: use `drop` to clarify the intent: `drop(z);`
 
-error: aborting due to 3 previous errors
+error: path statement with no effect
+  --> $DIR/warn-path-statement.rs:20:13
+   |
+LL |             $e;
+   |             ^^^ help: remove this statement
+...
+LL |     foo!(x);
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
The motivation for this change is to make it easier to clean up code generated by c2rust, which tends to include a lot of unnecessary path statements.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
