### PR TITLE
Disallow `export_name` starting with "llvm."

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -52,8 +52,8 @@ codegen_ssa_expected_one_argument = expected one argument
 
 codegen_ssa_expected_used_symbol = expected `used`, `used(compiler)` or `used(linker)`
 
-codegen_ssa_export_name_llvm_intrinsic = exported symbol name must not start with "llvm."
-    .note = symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+codegen_ssa_export_name_llvm_intrinsic = exported symbol name must not start with `llvm.`
+    .note = symbols starting with `llvm.` are reserved for LLVM intrinsics
 
 codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
 

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -52,6 +52,9 @@ codegen_ssa_expected_one_argument = expected one argument
 
 codegen_ssa_expected_used_symbol = expected `used`, `used(compiler)` or `used(linker)`
 
+codegen_ssa_export_name_llvm_intrinsic = exported symbol name must not start with "llvm."
+    .note = symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+
 codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
 
 codegen_ssa_extract_bundled_libs_archive_member = failed to get data from archive member '{$rlib}': {$error}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -148,6 +148,14 @@ pub(crate) struct NullOnExport {
 }
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_export_name_llvm_intrinsic)]
+#[note]
+pub(crate) struct ExportNameLLVMIntrinsic {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_unsupported_instruction_set, code = E0779)]
 pub(crate) struct UnsuportedInstructionSet {
     #[primary_span]

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1304,7 +1304,6 @@ impl<'a> DiagCtxtHandle<'a> {
         self.create_almost_fatal(fatal).emit()
     }
 
-    // FIXME: This method should be removed (every error should have an associated error code).
     #[rustc_lint_diagnostics]
     #[track_caller]
     pub fn struct_err(self, msg: impl Into<DiagMessage>) -> Diag<'a> {

--- a/tests/ui/attributes/export_name-checks.rs
+++ b/tests/ui/attributes/export_name-checks.rs
@@ -2,14 +2,14 @@
 
 // rdtsc is an existing LLVM intrinsic
 #[export_name = "llvm.x86.rdtsc"]
-//~^ ERROR: exported symbol name must not start with "llvm."
+//~^ ERROR: exported symbol name must not start with `llvm.`
 pub unsafe fn foo(a: u8) -> u8 {
     2 * a
 }
 
 // qwerty is not a real llvm intrinsic
 #[export_name = "llvm.x86.qwerty"]
-//~^ ERROR: exported symbol name must not start with "llvm."
+//~^ ERROR: exported symbol name must not start with `llvm.`
 pub unsafe fn bar(a: u8) -> u8 {
     2 * a
 }

--- a/tests/ui/attributes/export_name-checks.rs
+++ b/tests/ui/attributes/export_name-checks.rs
@@ -1,0 +1,18 @@
+#![crate_type = "lib"]
+
+// rdtsc is an existing LLVM intrinsic
+#[export_name = "llvm.x86.rdtsc"]
+//~^ ERROR: exported symbol name must not start with "llvm."
+pub unsafe fn foo(a: u8) -> u8 {
+    2 * a
+}
+
+// qwerty is not a real llvm intrinsic
+#[export_name = "llvm.x86.qwerty"]
+//~^ ERROR: exported symbol name must not start with "llvm."
+pub unsafe fn bar(a: u8) -> u8 {
+    2 * a
+}
+
+#[export_name="ab\0cd"] //~ ERROR `export_name` may not contain null characters
+pub fn qux() {}

--- a/tests/ui/attributes/export_name-checks.stderr
+++ b/tests/ui/attributes/export_name-checks.stderr
@@ -1,0 +1,25 @@
+error: exported symbol name must not start with "llvm."
+  --> $DIR/export_name-checks.rs:4:17
+   |
+LL | #[export_name = "llvm.x86.rdtsc"]
+   |                 ^^^^^^^^^^^^^^^^
+   |
+   = note: symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+
+error: exported symbol name must not start with "llvm."
+  --> $DIR/export_name-checks.rs:11:17
+   |
+LL | #[export_name = "llvm.x86.qwerty"]
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+
+error[E0648]: `export_name` may not contain null characters
+  --> $DIR/export_name-checks.rs:17:1
+   |
+LL | #[export_name="ab\0cd"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0648`.

--- a/tests/ui/attributes/export_name-checks.stderr
+++ b/tests/ui/attributes/export_name-checks.stderr
@@ -15,10 +15,10 @@ LL | #[export_name = "llvm.x86.qwerty"]
    = note: symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
 
 error[E0648]: `export_name` may not contain null characters
-  --> $DIR/export_name-checks.rs:17:1
+  --> $DIR/export_name-checks.rs:17:15
    |
 LL | #[export_name="ab\0cd"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/export_name-checks.stderr
+++ b/tests/ui/attributes/export_name-checks.stderr
@@ -1,18 +1,18 @@
-error: exported symbol name must not start with "llvm."
+error: exported symbol name must not start with `llvm.`
   --> $DIR/export_name-checks.rs:4:17
    |
 LL | #[export_name = "llvm.x86.rdtsc"]
    |                 ^^^^^^^^^^^^^^^^
    |
-   = note: symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+   = note: symbols starting with `llvm.` are reserved for LLVM intrinsics
 
-error: exported symbol name must not start with "llvm."
+error: exported symbol name must not start with `llvm.`
   --> $DIR/export_name-checks.rs:11:17
    |
 LL | #[export_name = "llvm.x86.qwerty"]
    |                 ^^^^^^^^^^^^^^^^^
    |
-   = note: symbols starting with "llvm." are reserved for LLVM intrinsics and cannot be defined in user code
+   = note: symbols starting with `llvm.` are reserved for LLVM intrinsics
 
 error[E0648]: `export_name` may not contain null characters
   --> $DIR/export_name-checks.rs:17:15

--- a/tests/ui/error-codes/E0648.stderr
+++ b/tests/ui/error-codes/E0648.stderr
@@ -1,8 +1,8 @@
 error[E0648]: `export_name` may not contain null characters
-  --> $DIR/E0648.rs:1:1
+  --> $DIR/E0648.rs:1:15
    |
 LL | #[export_name="\0foo"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Tags #140822  , but maybe(?) does not fix it
Motivation in the issue, and in code comments.

This implementation adds the check to right to `#[export_name]` parsing code. I considered moving it closer to the place where the new name gets emitted to llvm, but that looked harder to get right, and easier to accidentally break going forward.

I don't believe any other attributes need this handling. The only one that comes close is `link_name` but that one *uses* the name, and does not *define* it, and in fact `#[link_name = "llvm.stuff"]` is entirely justified and actively used in real code.

Two small drive-by changes in separate commits (removed an obsolete and misleading `//FIXME` comment, and tighten the diagnostics span for the null-byte-in-`export_name` check). Happy to split them into dedicated PR(s) if this is deemed valuable.