### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
@@ -1,9 +1,15 @@
-use crate::spec::{LinkerFlavor, Lld, Target, TargetMetadata, base};
+use crate::spec::{FramePointer, LinkerFlavor, Lld, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.max_atomic_width = Some(128);
     base.features = "+v8a,+neon,+fp-armv8".into();
+
+    // Microsoft recommends enabling frame pointers on Arm64 Windows.
+    // From https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170#integer-registers
+    // "The frame pointer (x29) is required for compatibility with fast stack walking used by ETW
+    // and other services. It must point to the previous {x29, x30} pair on the stack."
+    base.frame_pointer = FramePointer::NonLeaf;
 
     // MSVC emits a warning about code that may trip "Cortex-A53 MPCore processor bug #843419" (see
     // https://developer.arm.com/documentation/epm048406/latest) which is sometimes emitted by LLVM.

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -163,7 +163,7 @@ fn check_version(config: &Config) -> Option<String> {
             msg.push_str("WARNING: The `change-id` is missing in the `bootstrap.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.\n");
             msg.push_str("NOTE: to silence this warning, ");
             msg.push_str(&format!(
-                "add `change-id = {latest_change_id}` or change-id = \"ignore\" at the top of `bootstrap.toml`"
+                "add `change-id = {latest_change_id}` or `change-id = \"ignore\"` at the top of `bootstrap.toml`"
             ));
             return Some(msg);
         }
@@ -195,7 +195,7 @@ fn check_version(config: &Config) -> Option<String> {
 
     msg.push_str("NOTE: to silence this warning, ");
     msg.push_str(&format!(
-        "update `bootstrap.toml` to use `change-id = {latest_change_id}` or change-id = \"ignore\" instead"
+        "update `bootstrap.toml` to use `change-id = {latest_change_id}` or `change-id = \"ignore\"` instead"
     ));
 
     if io::stdout().is_terminal() {

--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse2.rs
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse2.rs
@@ -1,5 +1,6 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
+#![allow(unnecessary_transmutes)]
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
@@ -3,8 +3,8 @@
 fn main() {
     macro_rules! x {
         () => {
-            None::<i32> //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
+            None::<i32>
         };
     }
-    for _ in x! {} {}
+    for _ in x! {} {} //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
 }

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.rs
@@ -1,0 +1,10 @@
+#![forbid(for_loops_over_fallibles)]
+
+fn main() {
+    macro_rules! x {
+        () => {
+            None::<i32> //~ ERROR for loop over an `Option`. This is more readably written as an `if let` statement [for_loops_over_fallibles]
+        };
+    }
+    for _ in x! {} {}
+}

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
@@ -1,0 +1,32 @@
+error: for loop over an `Option`. This is more readably written as an `if let` statement
+  --> $DIR/macro-issue-140747.rs:6:13
+   |
+LL |             None::<i32>
+   |             ^^^^^^^^^^^
+...
+LL |     for _ in x! {} {}
+   |              ----- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/macro-issue-140747.rs:1:11
+   |
+LL | #![forbid(for_loops_over_fallibles)]
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to check pattern in a loop use `while let`
+   |
+LL ~             ) =
+LL |         };
+LL |     }
+LL ~     while let Some(_ in x! {} {}
+   |
+help: consider using `if let` to clear intent
+   |
+LL ~             ) =
+LL |         };
+LL |     }
+LL ~     if let Some(_ in x! {} {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
+++ b/tests/ui/lint/for-loops-over-falibles/macro-issue-140747.stderr
@@ -1,31 +1,23 @@
 error: for loop over an `Option`. This is more readably written as an `if let` statement
-  --> $DIR/macro-issue-140747.rs:6:13
+  --> $DIR/macro-issue-140747.rs:9:14
    |
-LL |             None::<i32>
-   |             ^^^^^^^^^^^
-...
 LL |     for _ in x! {} {}
-   |              ----- in this macro invocation
+   |              ^^^^^
    |
 note: the lint level is defined here
   --> $DIR/macro-issue-140747.rs:1:11
    |
 LL | #![forbid(for_loops_over_fallibles)]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: to check pattern in a loop use `while let`
    |
-LL ~             ) =
-LL |         };
-LL |     }
-LL ~     while let Some(_ in x! {} {}
+LL -     for _ in x! {} {}
+LL +     while let Some(_) = x! {} {}
    |
 help: consider using `if let` to clear intent
    |
-LL ~             ) =
-LL |         };
-LL |     }
-LL ~     if let Some(_ in x! {} {}
+LL -     for _ in x! {} {}
+LL +     if let Some(_) = x! {} {}
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmute/unnecessary-transmutation.fixed
+++ b/tests/ui/transmute/unnecessary-transmutation.fixed
@@ -49,6 +49,10 @@ fn main() {
         //~^ ERROR
         let y: char = char::from_u32_unchecked(y);
         //~^ ERROR
+        let y: i32 = u32::from('🐱').cast_signed();
+        //~^ ERROR
+        let y: char = char::from_u32_unchecked(i32::cast_unsigned(y));
+        //~^ ERROR
 
         let x: u16 = i16::cast_unsigned(8i16);
         //~^ ERROR
@@ -70,6 +74,11 @@ fn main() {
         let y: f64 = f64::from_bits(3u64);
         //~^ ERROR
         let y: u64 = f64::to_bits(2.0);
+        //~^ ERROR
+
+        let y: f64 = f64::from_bits(i64::cast_unsigned(1i64));
+        //~^ ERROR
+        let y: i64 = f64::to_bits(1f64).cast_signed();
         //~^ ERROR
 
         let z: bool = (1u8 == 1);

--- a/tests/ui/transmute/unnecessary-transmutation.rs
+++ b/tests/ui/transmute/unnecessary-transmutation.rs
@@ -49,6 +49,10 @@ fn main() {
         //~^ ERROR
         let y: char = transmute(y);
         //~^ ERROR
+        let y: i32 = transmute('🐱');
+        //~^ ERROR
+        let y: char = transmute(y);
+        //~^ ERROR
 
         let x: u16 = transmute(8i16);
         //~^ ERROR
@@ -70,6 +74,11 @@ fn main() {
         let y: f64 = transmute(3u64);
         //~^ ERROR
         let y: u64 = transmute(2.0);
+        //~^ ERROR
+
+        let y: f64 = transmute(1i64);
+        //~^ ERROR
+        let y: i64 = transmute(1f64);
         //~^ ERROR
 
         let z: bool = transmute(1u8);

--- a/tests/ui/transmute/unnecessary-transmutation.stderr
+++ b/tests/ui/transmute/unnecessary-transmutation.stderr
@@ -154,82 +154,108 @@ LL |         let y: char = transmute(y);
    = help: consider `char::from_u32(…).unwrap()`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:53:22
+  --> $DIR/unnecessary-transmutation.rs:52:22
+   |
+LL |         let y: i32 = transmute('🐱');
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `u32::from('🐱').cast_signed()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:54:23
+   |
+LL |         let y: char = transmute(y);
+   |                       ^^^^^^^^^^^^ help: replace this with: `char::from_u32_unchecked(i32::cast_unsigned(y))`
+   |
+   = help: consider `char::from_u32(i32::cast_unsigned(…)).unwrap()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:57:22
    |
 LL |         let x: u16 = transmute(8i16);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i16::cast_unsigned(8i16)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:55:22
+  --> $DIR/unnecessary-transmutation.rs:59:22
    |
 LL |         let x: i16 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u16::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:57:22
+  --> $DIR/unnecessary-transmutation.rs:61:22
    |
 LL |         let x: u32 = transmute(4i32);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i32::cast_unsigned(4i32)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:59:22
+  --> $DIR/unnecessary-transmutation.rs:63:22
    |
 LL |         let x: i32 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u32::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:61:22
+  --> $DIR/unnecessary-transmutation.rs:65:22
    |
 LL |         let x: u64 = transmute(7i64);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `i64::cast_unsigned(7i64)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:63:22
+  --> $DIR/unnecessary-transmutation.rs:67:22
    |
 LL |         let x: i64 = transmute(x);
    |                      ^^^^^^^^^^^^ help: replace this with: `u64::cast_signed(x)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:66:22
+  --> $DIR/unnecessary-transmutation.rs:70:22
    |
 LL |         let y: f32 = transmute(1u32);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `f32::from_bits(1u32)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:68:22
+  --> $DIR/unnecessary-transmutation.rs:72:22
    |
 LL |         let y: u32 = transmute(y);
    |                      ^^^^^^^^^^^^ help: replace this with: `f32::to_bits(y)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:70:22
+  --> $DIR/unnecessary-transmutation.rs:74:22
    |
 LL |         let y: f64 = transmute(3u64);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::from_bits(3u64)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:72:22
+  --> $DIR/unnecessary-transmutation.rs:76:22
    |
 LL |         let y: u64 = transmute(2.0);
    |                      ^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(2.0)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:75:23
+  --> $DIR/unnecessary-transmutation.rs:79:22
+   |
+LL |         let y: f64 = transmute(1i64);
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::from_bits(i64::cast_unsigned(1i64))`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:81:22
+   |
+LL |         let y: i64 = transmute(1f64);
+   |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(1f64).cast_signed()`
+
+error: unnecessary transmute
+  --> $DIR/unnecessary-transmutation.rs:84:23
    |
 LL |         let z: bool = transmute(1u8);
    |                       ^^^^^^^^^^^^^^ help: replace this with: `(1u8 == 1)`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:77:21
+  --> $DIR/unnecessary-transmutation.rs:86:21
    |
 LL |         let z: u8 = transmute(z);
    |                     ^^^^^^^^^^^^ help: replace this with: `(z) as u8`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:82:21
+  --> $DIR/unnecessary-transmutation.rs:91:21
    |
 LL |         let z: i8 = transmute(z);
    |                     ^^^^^^^^^^^^ help: replace this with: `(z) as i8`
 
-error: aborting due to 32 previous errors
+error: aborting due to 36 previous errors
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1002,7 +1002,7 @@ message = "This PR changes a file inside `tests/crashes`. If a crash was fixed, 
 
 [mentions."tests/rustdoc-json"]
 message = """
-These commits modify `test/rustdoc-json`.
+These commits modify `tests/rustdoc-json`.
 rustdoc-json is a **public** (but unstable) interface.
 
 Please ensure that if you've changed the output:


### PR DESCRIPTION
Successful merges:

 - #140801 (Use span before macro expansion in lint for-loops-over-falibles)
 - #140804 (add signed ints to unn- transmutes to ensure feature parity)
 - #140812 (Fix `tests/rustdoc-json` triagebot message path)
 - #140817 (bootstrap: more consistent use of `...` when citing configuration snippets)
 - #140828 (Enable non-leaf Frame Pointers for Arm64 Windows)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140801,140804,140812,140817,140828)
<!-- homu-ignore:end -->