### PR TITLE
Fix `broken-pipe-no-ice` run-make test for rpath-less builds

### DIFF
--- a/src/tools/run-make-support/src/command.rs
+++ b/src/tools/run-make-support/src/command.rs
@@ -63,6 +63,12 @@ impl Command {
         }
     }
 
+    // Internal-only.
+    pub(crate) fn into_raw_command(mut self) -> std::process::Command {
+        self.drop_bomb.defuse();
+        self.cmd
+    }
+
     /// Specify a stdin input buffer. This is a convenience helper,
     pub fn stdin_buf<I: AsRef<[u8]>>(&mut self, input: I) -> &mut Self {
         self.stdin_buf = Some(input.as_ref().to_vec().into_boxed_slice());

--- a/src/tools/run-make-support/src/external_deps/rustdoc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustdoc.rs
@@ -5,7 +5,7 @@ use crate::command::Command;
 use crate::env::env_var;
 use crate::util::set_host_compiler_dylib_path;
 
-/// Construct a new `rustdoc` invocation.
+/// Construct a new `rustdoc` invocation. This will configure the host compiler runtime libs.
 #[track_caller]
 pub fn rustdoc() -> Rustdoc {
     Rustdoc::new()
@@ -28,7 +28,7 @@ fn setup_common() -> Command {
 }
 
 impl Rustdoc {
-    /// Construct a bare `rustdoc` invocation.
+    /// Construct a bare `rustdoc` invocation. This will configure the host compiler runtime libs.
     #[track_caller]
     pub fn new() -> Self {
         let cmd = setup_common();

--- a/src/tools/run-make-support/src/macros.rs
+++ b/src/tools/run-make-support/src/macros.rs
@@ -28,6 +28,18 @@
 macro_rules! impl_common_helpers {
     ($wrapper: ident) => {
         impl $wrapper {
+            /// In very rare circumstances, you may need a e.g. `bare_rustc()` or `bare_rustdoc()`
+            /// with host runtime libs configured, but want the underlying raw
+            /// [`std::process::Command`] (e.g. for manipulating pipes or whatever). This function
+            /// will consume the command wrapper and extract the underlying
+            /// [`std::process::Command`].
+            ///
+            /// Caution: this will mean that you can no longer use the convenience methods on the
+            /// command wrapper. Use as a last resort.
+            pub fn into_raw_command(self) -> ::std::process::Command {
+                self.cmd.into_raw_command()
+            }
+
             /// Specify an environment variable.
             pub fn env<K, V>(&mut self, key: K, value: V) -> &mut Self
             where

--- a/tests/run-make/broken-pipe-no-ice/rmake.rs
+++ b/tests/run-make/broken-pipe-no-ice/rmake.rs
@@ -14,7 +14,7 @@
 use std::io::Read;
 use std::process::{Command, Stdio};
 
-use run_make_support::env_var;
+use run_make_support::{bare_rustc, rustdoc};
 
 #[derive(Debug, PartialEq)]
 enum Binary {
@@ -67,11 +67,13 @@ fn check_broken_pipe_handled_gracefully(bin: Binary, mut cmd: Command) {
 }
 
 fn main() {
-    let mut rustc = Command::new(env_var("RUSTC"));
+    let mut rustc = bare_rustc();
     rustc.arg("--print=sysroot");
+    let rustc = rustc.into_raw_command();
     check_broken_pipe_handled_gracefully(Binary::Rustc, rustc);
 
-    let mut rustdoc = Command::new(env_var("RUSTDOC"));
+    let mut rustdoc = rustdoc();
     rustdoc.arg("--version");
+    let rustdoc = rustdoc.into_raw_command();
     check_broken_pipe_handled_gracefully(Binary::Rustdoc, rustdoc);
 }


### PR DESCRIPTION
The `broken-pipe-no-ice` run-make test currently fails on rpath-less builds, because host compiler runtime libs are not configured for raw std command usages.

This PR is an alternative approach to #140744. However, instead of duplicating `run_make_support::util::set_host_compiler_dylib_path` logic, we instead support "ejecting" the "configured" underlying std `Command` from `bare_rustc()` and `rustdoc()`, where host compiler runtime libs are already set.

cc @jchecahi
r? @Kobzol