### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -178,7 +178,7 @@ pub(crate) struct Options {
     pub(crate) expanded_args: Vec<String>,
 
     /// Arguments to be used when compiling doctests.
-    pub(crate) doctest_compilation_args: Vec<String>,
+    pub(crate) doctest_build_args: Vec<String>,
 }
 
 impl fmt::Debug for Options {
@@ -808,7 +808,7 @@ impl Options {
         let scrape_examples_options = ScrapeExamplesOptions::new(matches, dcx);
         let with_examples = matches.opt_strs("with-examples");
         let call_locations = crate::scrape_examples::load_call_locations(with_examples, dcx);
-        let doctest_compilation_args = matches.opt_strs("doctest-compilation-args");
+        let doctest_build_args = matches.opt_strs("doctest-build-arg");
 
         let unstable_features =
             rustc_feature::UnstableFeatures::from_environment(crate_name.as_deref());
@@ -858,7 +858,7 @@ impl Options {
             scrape_examples_options,
             unstable_features,
             expanded_args: args,
-            doctest_compilation_args,
+            doctest_build_args,
         };
         let render_options = RenderOptions {
             output,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -51,46 +51,6 @@ pub(crate) struct GlobalTestOptions {
     pub(crate) args_file: PathBuf,
 }
 
-/// Function used to split command line arguments just like a shell would.
-fn split_args(args: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut iter = args.chars();
-    let mut current = String::new();
-
-    while let Some(c) = iter.next() {
-        if c == '\\' {
-            if let Some(c) = iter.next() {
-                // If it's escaped, even a quote or a whitespace will be ignored.
-                current.push(c);
-            }
-        } else if c == '"' || c == '\'' {
-            while let Some(new_c) = iter.next() {
-                if new_c == c {
-                    break;
-                } else if new_c == '\\' {
-                    if let Some(c) = iter.next() {
-                        // If it's escaped, even a quote will be ignored.
-                        current.push(c);
-                    }
-                } else {
-                    current.push(new_c);
-                }
-            }
-        } else if " \n\t\r".contains(c) {
-            if !current.is_empty() {
-                out.push(current.clone());
-                current.clear();
-            }
-        } else {
-            current.push(c);
-        }
-    }
-    if !current.is_empty() {
-        out.push(current);
-    }
-    out
-}
-
 pub(crate) fn generate_args_file(file_path: &Path, options: &RustdocOptions) -> Result<(), String> {
     let mut file = File::create(file_path)
         .map_err(|error| format!("failed to create args file: {error:?}"))?;
@@ -119,9 +79,7 @@ pub(crate) fn generate_args_file(file_path: &Path, options: &RustdocOptions) -> 
         content.push(format!("-Z{unstable_option_str}"));
     }
 
-    for compilation_args in &options.doctest_compilation_args {
-        content.extend(split_args(compilation_args));
-    }
+    content.extend(options.doctest_build_args.clone());
 
     let content = content.join("\n");
 

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -382,28 +382,6 @@ fn main() {
 }
 
 #[test]
-fn check_split_args() {
-    fn compare(input: &str, expected: &[&str]) {
-        let output = super::split_args(input);
-        let expected = expected.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-        assert_eq!(expected, output, "test failed for {input:?}");
-    }
-
-    compare("'a' \"b\"c", &["a", "bc"]);
-    compare("'a' \"b \"c d", &["a", "b c", "d"]);
-    compare("'a' \"b\\\"c\"", &["a", "b\"c"]);
-    compare("'a\"'", &["a\""]);
-    compare("\"a'\"", &["a'"]);
-    compare("\\ a", &[" a"]);
-    compare("\\\\", &["\\"]);
-    compare("a'", &["a"]);
-    compare("a          ", &["a"]);
-    compare("a          b", &["a", "b"]);
-    compare("a\n\t \rb", &["a", "b"]);
-    compare("a\n\t1 \rb", &["a", "1", "b"]);
-}
-
-#[test]
 fn comment_in_attrs() {
     // If there is an inline code comment after attributes, we need to ensure that
     // a backline will be added to prevent generating code "inside" it (and thus generating)

--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -136,8 +136,7 @@ nav.sub {
 	--scrape-example-code-wrapper-background-end: rgba(255, 255, 255, 0);
 	--sidebar-resizer-hover: hsl(207, 90%, 66%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
-	--sidebar-resizer-img-filter: opacity(66%);
-	--sidebar-resizer-img-hover-filter: none;
+	--sidebar-resizer-shadow: #ccc;
 }
 /* End theme: light */
 
@@ -248,8 +247,7 @@ nav.sub {
 		--scrape-example-code-wrapper-background-end: rgba(53, 53, 53, 0);
 		--sidebar-resizer-hover: hsl(207, 30%, 54%);
 		--sidebar-resizer-active: hsl(207, 90%, 54%);
-		--sidebar-resizer-img-filter: opacity(66%);
-		--sidebar-resizer-img-hover-filter: none;
+		--sidebar-resizer-shadow: #000;
 	}
 /* End theme: dark */
 }

--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -43,6 +43,7 @@ nav.sub {
 	--settings-button-border-focus: #717171;
 	--sidebar-background-color: #f5f5f5;
 	--sidebar-background-color-hover: #e0e0e0;
+	--sidebar-border-color: #ddd;
 	--code-block-background-color: #f5f5f5;
 	--scrollbar-track-background-color: #dcdcdc;
 	--scrollbar-thumb-background-color: rgba(36, 37, 39, 0.6);
@@ -135,6 +136,8 @@ nav.sub {
 	--scrape-example-code-wrapper-background-end: rgba(255, 255, 255, 0);
 	--sidebar-resizer-hover: hsl(207, 90%, 66%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
+	--sidebar-resizer-img-filter: opacity(66%);
+	--sidebar-resizer-img-hover-filter: none;
 }
 /* End theme: light */
 
@@ -149,6 +152,7 @@ nav.sub {
 		--settings-button-border-focus: #ffb900;
 		--sidebar-background-color: #505050;
 		--sidebar-background-color-hover: #676767;
+		--sidebar-border-color: #2A2A2A;
 		--code-block-background-color: #2A2A2A;
 		--scrollbar-track-background-color: #717171;
 		--scrollbar-thumb-background-color: rgba(32, 34, 37, .6);
@@ -244,6 +248,8 @@ nav.sub {
 		--scrape-example-code-wrapper-background-end: rgba(53, 53, 53, 0);
 		--sidebar-resizer-hover: hsl(207, 30%, 54%);
 		--sidebar-resizer-active: hsl(207, 90%, 54%);
+		--sidebar-resizer-img-filter: opacity(66%);
+		--sidebar-resizer-img-hover-filter: none;
 	}
 /* End theme: dark */
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1,4 +1,6 @@
-/* When static files are updated, their suffixes need to be updated.
+/*
+// ignore-tidy-filelength
+	When static files are updated, their suffixes need to be updated.
 	1. In the top directory run:
 		./x.py doc --stage 1 library/core
 	2. Find the directory containing files named with updated suffixes:
@@ -493,12 +495,13 @@ img {
 	top: 0;
 	left: 0;
 	z-index: var(--desktop-sidebar-z-index);
+	/* resize indicator: hide this when on touch or mobile */
+	border-right: solid 1px var(--sidebar-border-color);
 }
 
 .rustdoc.src .sidebar {
 	flex-basis: 50px;
 	width: 50px;
-	border-right: 1px solid;
 	overflow-x: hidden;
 	/* The sidebar is by default hidden  */
 	overflow-y: hidden;
@@ -512,12 +515,32 @@ img {
 .sidebar-resizer {
 	touch-action: none;
 	width: 9px;
-	cursor: col-resize;
+	cursor: ew-resize;
 	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 	position: fixed;
 	height: 100%;
-	/* make sure there's a 1px gap between the scrollbar and resize handle */
-	left: calc(var(--desktop-sidebar-width) + 1px);
+	left: var(--desktop-sidebar-width);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.sidebar-resizer::after {
+	content: url('data:image/svg+xml,\
+		<svg xmlns="http://www.w3.org/2000/svg" width="8" height="24" viewBox="0 0 8 24"> \
+		<linearGradient id="x" x1="0" x2="0" y1="0" y2="1"> \
+		<stop offset="0.5" stop-color="%23666"/><stop offset="0.5" stop-color="%23ccc"/> \
+		</linearGradient> \
+		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="21" cx="3"/> \
+		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="15" cx="3"/> \
+		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="9" cx="3"/> \
+		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="3" cx="3"/></svg>');
+	width: 8px;
+	height: 24px;
+	filter: var(--sidebar-resizer-img-filter);
+}
+.sidebar-resizer:hover::after {
+	filter: var(--sidebar-resizer-img-hover-filter);
 }
 
 .rustdoc.src .sidebar-resizer {
@@ -540,7 +563,7 @@ img {
 }
 
 .sidebar-resizing * {
-	cursor: col-resize !important;
+	cursor: ew-resize !important;
 }
 
 .sidebar-resizing .sidebar {
@@ -558,7 +581,7 @@ img {
 	margin: 0;
 	/* when active or hovered, place resizer glow on top of the sidebar (right next to, or even
 	   on top of, the scrollbar) */
-	left: var(--desktop-sidebar-width);
+	left: calc(var(--desktop-sidebar-width) - 1px);
 	border-left: solid 1px var(--sidebar-resizer-hover);
 }
 
@@ -575,6 +598,10 @@ img {
 		/* too easy to hit the resizer while trying to hit the [-] toggle */
 		display: none !important;
 	}
+	.sidebar {
+		/* resize indicator: hide this when on touch or mobile */
+		border-right: none;
+	}
 }
 
 .sidebar-resizer.active {
@@ -585,8 +612,10 @@ img {
 	margin-left: -140px;
 	border-left: none;
 }
-.sidebar-resizer.active:before {
+.sidebar-resizer.active::before {
 	border-left: solid 2px var(--sidebar-resizer-active);
+	margin-left: 8px;
+	padding-left: 1px;
 	display: block;
 	height: 100%;
 	content: "";
@@ -2510,6 +2539,8 @@ in src-script.js and main.js
 		/* Reduce height slightly to account for mobile topbar. */
 		height: calc(100vh - 45px);
 		width: 200px;
+		/* resize indicator: hide this when on touch or mobile */
+		border-right: none;
 	}
 
 	/* The source view uses a different design for the sidebar toggle, and doesn't have a topbar,
@@ -2893,6 +2924,7 @@ by default.
 	--settings-button-border-focus: #717171;
 	--sidebar-background-color: #f5f5f5;
 	--sidebar-background-color-hover: #e0e0e0;
+	--sidebar-border-color: #ddd;
 	--code-block-background-color: #f5f5f5;
 	--scrollbar-track-background-color: #dcdcdc;
 	--scrollbar-thumb-background-color: rgba(36, 37, 39, 0.6);
@@ -2985,6 +3017,8 @@ by default.
 	--scrape-example-code-wrapper-background-end: rgba(255, 255, 255, 0);
 	--sidebar-resizer-hover: hsl(207, 90%, 66%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
+	--sidebar-resizer-img-filter: opacity(66%);
+	--sidebar-resizer-img-hover-filter: none;
 }
 /* End theme: light */
 
@@ -2998,6 +3032,7 @@ by default.
 	--settings-button-border-focus: #ffb900;
 	--sidebar-background-color: #505050;
 	--sidebar-background-color-hover: #676767;
+	--sidebar-border-color: #2A2A2A;
 	--code-block-background-color: #2A2A2A;
 	--scrollbar-track-background-color: #717171;
 	--scrollbar-thumb-background-color: rgba(32, 34, 37, .6);
@@ -3093,6 +3128,8 @@ by default.
 	--scrape-example-code-wrapper-background-end: rgba(53, 53, 53, 0);
 	--sidebar-resizer-hover: hsl(207, 30%, 54%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
+	--sidebar-resizer-img-filter: opacity(66%);
+	--sidebar-resizer-img-hover-filter: none;
 }
 /* End theme: dark */
 
@@ -3110,6 +3147,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--settings-button-border-focus: #e0e0e0;
 	--sidebar-background-color: #14191f;
 	--sidebar-background-color-hover: rgba(70, 70, 70, 0.33);
+	--sidebar-border-color: #000;
 	--code-block-background-color: #191f26;
 	--scrollbar-track-background-color: transparent;
 	--scrollbar-thumb-background-color: #5c6773;
@@ -3205,6 +3243,8 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--scrape-example-code-wrapper-background-end: rgba(15, 20, 25, 0);
 	--sidebar-resizer-hover: hsl(34, 50%, 33%);
 	--sidebar-resizer-active: hsl(34, 100%, 66%);
+	--sidebar-resizer-img-filter: opacity(66%);
+	--sidebar-resizer-img-hover-filter: none;
 }
 
 :root[data-theme="ayu"] h1,

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1,5 +1,5 @@
+/* ignore-tidy-filelength */
 /*
-// ignore-tidy-filelength
 	When static files are updated, their suffixes need to be updated.
 	1. In the top directory run:
 		./x.py doc --stage 1 library/core
@@ -522,25 +522,33 @@ img {
 	left: var(--desktop-sidebar-width);
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-start;
 }
-
 .sidebar-resizer::after {
-	content: url('data:image/svg+xml,\
-		<svg xmlns="http://www.w3.org/2000/svg" width="8" height="24" viewBox="0 0 8 24"> \
-		<linearGradient id="x" x1="0" x2="0" y1="0" y2="1"> \
-		<stop offset="0.5" stop-color="%23666"/><stop offset="0.5" stop-color="%23ccc"/> \
-		</linearGradient> \
-		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="21" cx="3"/> \
-		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="15" cx="3"/> \
-		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="9" cx="3"/> \
-		<circle r="2" fill="none" stroke-width="2" stroke="url(%23x)" cy="3" cx="3"/></svg>');
+	content: "";
+	background: linear-gradient(
+		0.25turn,
+		transparent 0px,
+		transparent 2px,
+		var(--sidebar-border-color) 2px,
+		var(--sidebar-border-color) 3px,
+		var(--sidebar-resizer-shadow) 3px,
+		var(--sidebar-resizer-shadow) 4px,
+		transparent 4px,
+		transparent 6px,
+		var(--sidebar-border-color) 6px,
+		var(--sidebar-border-color) 7px,
+		var(--sidebar-resizer-shadow) 7px,
+		var(--sidebar-resizer-shadow) 8px,
+		transparent 8px
+	);
+	border: solid 1px var(--sidebar-border-color);
+	border-left: none;
+	border-right: solid 1px var(--sidebar-resizer-shadow);
+	border-bottom: solid 1px var(--sidebar-resizer-shadow);
 	width: 8px;
 	height: 24px;
-	filter: var(--sidebar-resizer-img-filter);
-}
-.sidebar-resizer:hover::after {
-	filter: var(--sidebar-resizer-img-hover-filter);
+	image-rendering: crisp-edges;
 }
 
 .rustdoc.src .sidebar-resizer {
@@ -614,8 +622,6 @@ img {
 }
 .sidebar-resizer.active::before {
 	border-left: solid 2px var(--sidebar-resizer-active);
-	margin-left: 8px;
-	padding-left: 1px;
 	display: block;
 	height: 100%;
 	content: "";
@@ -3017,8 +3023,7 @@ by default.
 	--scrape-example-code-wrapper-background-end: rgba(255, 255, 255, 0);
 	--sidebar-resizer-hover: hsl(207, 90%, 66%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
-	--sidebar-resizer-img-filter: opacity(66%);
-	--sidebar-resizer-img-hover-filter: none;
+	--sidebar-resizer-shadow: #ccc;
 }
 /* End theme: light */
 
@@ -3032,7 +3037,7 @@ by default.
 	--settings-button-border-focus: #ffb900;
 	--sidebar-background-color: #505050;
 	--sidebar-background-color-hover: #676767;
-	--sidebar-border-color: #2A2A2A;
+	--sidebar-border-color: #999;
 	--code-block-background-color: #2A2A2A;
 	--scrollbar-track-background-color: #717171;
 	--scrollbar-thumb-background-color: rgba(32, 34, 37, .6);
@@ -3128,8 +3133,7 @@ by default.
 	--scrape-example-code-wrapper-background-end: rgba(53, 53, 53, 0);
 	--sidebar-resizer-hover: hsl(207, 30%, 54%);
 	--sidebar-resizer-active: hsl(207, 90%, 54%);
-	--sidebar-resizer-img-filter: opacity(66%);
-	--sidebar-resizer-img-hover-filter: none;
+	--sidebar-resizer-shadow: #000;
 }
 /* End theme: dark */
 
@@ -3147,7 +3151,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--settings-button-border-focus: #e0e0e0;
 	--sidebar-background-color: #14191f;
 	--sidebar-background-color-hover: rgba(70, 70, 70, 0.33);
-	--sidebar-border-color: #000;
+	--sidebar-border-color: #5c6773;
 	--code-block-background-color: #191f26;
 	--scrollbar-track-background-color: transparent;
 	--scrollbar-thumb-background-color: #5c6773;
@@ -3243,8 +3247,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--scrape-example-code-wrapper-background-end: rgba(15, 20, 25, 0);
 	--sidebar-resizer-hover: hsl(34, 50%, 33%);
 	--sidebar-resizer-active: hsl(34, 100%, 66%);
-	--sidebar-resizer-img-filter: opacity(66%);
-	--sidebar-resizer-img-hover-filter: none;
+	--sidebar-resizer-shadow: #000;
 }
 
 :root[data-theme="ayu"] h1,

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -114,7 +114,7 @@
         {% endif %}
         {{ sidebar|safe }}
     </nav> {# #}
-    <div class="sidebar-resizer"></div> {# #}
+    <div class="sidebar-resizer" title="Drag to resize sidebar"></div> {# #}
     <main>
         {% if page.css_class != "src" %}<div class="width-limiter">{% endif %}
             {# defined in storage.js to avoid duplicating complex UI across every page #}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -646,9 +646,9 @@ fn opts() -> Vec<RustcOptGroup> {
             Unstable,
             Multi,
             "",
-            "doctest-compilation-args",
-            "",
-            "add arguments to be used when compiling doctests",
+            "doctest-build-arg",
+            "One argument (of possibly many) to be used when compiling doctests",
+            "ARG",
         ),
         opt(
             Unstable,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -73,9 +73,11 @@ extern crate tikv_jemalloc_sys as jemalloc_sys;
 
 use std::env::{self, VarError};
 use std::io::{self, IsTerminal};
+use std::path::Path;
 use std::process;
 
 use rustc_errors::DiagCtxtHandle;
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_interface::interface;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::{ErrorOutputType, RustcOptGroup, make_crate_type_option};
@@ -904,6 +906,10 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
                 rustc_interface::passes::write_dep_info(tcx);
             }
 
+            if let Some(metrics_dir) = &sess.opts.unstable_opts.metrics_dir {
+                dump_feature_usage_metrics(tcx, metrics_dir);
+            }
+
             if run_check {
                 // Since we're in "check" mode, no need to generate anything beyond this point.
                 return;
@@ -922,4 +928,17 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
             }
         })
     })
+}
+
+fn dump_feature_usage_metrics(tcxt: TyCtxt<'_>, metrics_dir: &Path) {
+    let hash = tcxt.crate_hash(LOCAL_CRATE);
+    let crate_name = tcxt.crate_name(LOCAL_CRATE);
+    let metrics_file_name = format!("unstable_feature_usage_metrics-{crate_name}-{hash}.json");
+    let metrics_path = metrics_dir.join(metrics_file_name);
+    if let Err(error) = tcxt.features().dump_feature_usage_metrics(metrics_path) {
+        // FIXME(yaahc): once metrics can be enabled by default we will want "failure to emit
+        // default metrics" to only produce a warning when metrics are enabled by default and emit
+        // an error only when the user manually enables metrics
+        tcxt.dcx().err(format!("cannot emit feature usage metrics: {error}"));
+    }
 }

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -191,8 +191,9 @@ Options:
                         from provided path. Only use with --merge=finalize
         --html-no-source 
                         Disable HTML source code pages generation
-        --doctest-compilation-args add arguments to be used when compiling doctests
-                        
+        --doctest-build-arg ARG
+                        One argument (of possibly many) to be used when
+                        compiling doctests
         --disable-minification 
                         disable the minification of CSS/JS files
                         (perma-unstable, do not use with cached files)

--- a/tests/rustdoc-gui/sidebar-resize-close-popover.goml
+++ b/tests/rustdoc-gui/sidebar-resize-close-popover.goml
@@ -1,13 +1,13 @@
 // Checks sidebar resizing close the Settings popover
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 click: "#settings-menu"
 wait-for: "#settings"
 assert-css: ("#settings", {"display": "block"})
 // normal resizing
 drag-and-drop: ((205, 100), (185, 100))
-assert-property: (".sidebar", {"clientWidth": "182"})
+assert-property: (".sidebar", {"clientWidth": "181"})
 assert-css: ("#settings", {"display": "none"})
 
 // Now same thing, but for source code

--- a/tests/rustdoc-gui/sidebar-resize-setting.goml
+++ b/tests/rustdoc-gui/sidebar-resize-setting.goml
@@ -1,6 +1,6 @@
 // Checks sidebar resizing stays synced with the setting
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 
 // Verify that the "hide" option is unchecked

--- a/tests/rustdoc-gui/sidebar-resize.goml
+++ b/tests/rustdoc-gui/sidebar-resize.goml
@@ -1,13 +1,13 @@
 // Checks sidebar resizing
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 // normal resizing
 drag-and-drop: ((205, 100), (185, 100))
-assert-property: (".sidebar", {"clientWidth": "182"})
+assert-property: (".sidebar", {"clientWidth": "181"})
 // resize past maximum (don't grow past 500)
 drag-and-drop: ((185, 100), (600, 100))
-assert-property: (".sidebar", {"clientWidth": "500"})
+assert-property: (".sidebar", {"clientWidth": "499"})
 // resize past minimum (hide sidebar)
 drag-and-drop: ((501, 100), (5, 100))
 assert-property: (".sidebar", {"clientWidth": "0"})

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -1,7 +1,7 @@
 // Checks multiple things on the sidebar display (width of its elements, colors, etc).
 include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 show-text: true
 
 // First, check the sidebar colors.
@@ -84,13 +84,13 @@ assert-property: ("html", {"scrollTop": "0"})
 
 // We now go back to the crate page to click on the "lib2" crate link.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 assert-css: (".sidebar-elems ul.crate > li:first-child > a", {"color": "#356da4"})
 click: ".sidebar-elems ul.crate > li:first-child > a"
 
 // PAGE: lib2/index.html
 go-to: "file://" + |DOC_PATH| + "/lib2/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 assert-text: (".sidebar > .sidebar-crate > h2 > a", "lib2")
 assert-count: (".sidebar .location", 0)
 // We check that we have the crates list and that the "current" on is now "lib2".
@@ -116,7 +116,7 @@ assert-text: (".sidebar-elems ul.block > li.current > a", "foobar")
 assert-false: ".sidebar-elems > .crate"
 
 go-to: "./module/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 assert-text: (".sidebar > .sidebar-crate > h2 > a", "lib2")
 assert-text: (".sidebar .location", "Module module")
 assert-count: (".sidebar .location", 1)
@@ -134,7 +134,7 @@ assert-property: (".sidebar > .sidebar-elems > #rustdoc-modnav > h2 > a", {
 assert-false: ".sidebar-elems > .crate"
 
 go-to: "./sub_module/sub_sub_module/index.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 assert-text: (".sidebar > .sidebar-crate > h2 > a", "lib2")
 assert-text: (".sidebar .location", "Module sub_sub_module")
 assert-text: (".sidebar > .sidebar-elems > #rustdoc-modnav > h2", "In lib2::module::sub_module")
@@ -149,13 +149,13 @@ assert-text: ("#functions + .item-table dt > a", "foo")
 
 // Links to trait implementations in the sidebar should not wrap even if they are long.
 go-to: "file://" + |DOC_PATH| + "/lib2/struct.HasALongTraitWithParams.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 assert-property: (".sidebar-elems section .block li > a", {"offsetHeight": 29})
 
 // Test that clicking on of the "In <module>" headings in the sidebar links to the
 // appropriate anchor in index.html.
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 click: "//ul[@class='block mod']/preceding-sibling::h3/a"
 // PAGE: index.html
 assert-css: ("#modules", {"background-color": "#fdffd3"})
@@ -163,10 +163,10 @@ assert-css: ("#modules", {"background-color": "#fdffd3"})
 // Finally, assert that the Summary toggle doesn't affect sidebar width.
 click: "#toggle-all-docs"
 assert-text: ("#toggle-all-docs", "Show all")
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 click: "#toggle-all-docs"
 assert-text: ("#toggle-all-docs", "Summary")
-assert-property: (".sidebar", {"clientWidth": "200"})
+assert-property: (".sidebar", {"clientWidth": "199"})
 
 // Checks that all.html and index.html have their sidebar link in the same place.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"

--- a/tests/rustdoc-ui/doctest/rustflags-multiple-args.rs
+++ b/tests/rustdoc-ui/doctest/rustflags-multiple-args.rs
@@ -1,9 +1,8 @@
-// This test checks that the test behave when `--doctest-compilation-args` is passed
-// multiple times.
+// This test checks that the test behave when `--doctest-build-arg` is passed multiple times.
 
 //@ check-pass
-//@ compile-flags: --test -Zunstable-options --doctest-compilation-args=--cfg=testcase_must_be_present
-//@ compile-flags: --doctest-compilation-args=--cfg=another
+//@ compile-flags: --test -Zunstable-options --doctest-build-arg=--cfg=testcase_must_be_present
+//@ compile-flags: --doctest-build-arg=--cfg=another
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
+++ b/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
@@ -1,6 +1,6 @@
 
 running 1 test
-test $DIR/rustflags-multiple-args.rs - Bar (line 10) ... ok
+test $DIR/rustflags-multiple-args.rs - Bar (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/rustflags.rs
+++ b/tests/rustdoc-ui/doctest/rustflags.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: --test -Zunstable-options --doctest-compilation-args=--cfg=testcase_must_be_present
+//@ compile-flags: --test -Zunstable-options --doctest-build-arg=--cfg=testcase_must_be_present
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/ui/typeck/gather-locals-twice.rs
+++ b/tests/ui/typeck/gather-locals-twice.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/140785>.
+
+fn main() {
+    () += { let x; };
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `()`
+    //~| ERROR invalid left-hand side of assignment
+}

--- a/tests/ui/typeck/gather-locals-twice.stderr
+++ b/tests/ui/typeck/gather-locals-twice.stderr
@@ -1,0 +1,20 @@
+error[E0368]: binary assignment operation `+=` cannot be applied to type `()`
+  --> $DIR/gather-locals-twice.rs:2:5
+   |
+LL |     () += { let x; };
+   |     --^^^^^^^^^^^^^^
+   |     |
+   |     cannot use `+=` on type `()`
+
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/gather-locals-twice.rs:2:8
+   |
+LL |     () += { let x; };
+   |     -- ^^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0067, E0368.
+For more information about an error, try `rustc --explain E0067`.


### PR DESCRIPTION
Successful merges:

 - #139562 (rustdoc: add a handle that makes sidebar resizing more obvious)
 - #139863 (rustdoc: Replace unstable flag `--doctest-compilation-args` with a simpler one: `--doctest-build-arg`)
 - #140815 (also export metrics from librustdoc)
 - #140827 (Do not ICE when reassigning in GatherLocalsVisitor on the bad path)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139562,139863,140815,140827)
<!-- homu-ignore:end -->