### PR TITLE
Improved error message for top-level or-patterns

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -690,8 +690,8 @@ parse_nul_in_c_str = null characters in C string literals are not supported
 
 parse_or_in_let_chain = `||` operators are not supported in let chain conditions
 
-parse_or_pattern_not_allowed_in_fn_parameters = top-level or-patterns are not allowed in function parameters
-parse_or_pattern_not_allowed_in_let_binding = top-level or-patterns are not allowed in `let` bindings
+parse_or_pattern_not_allowed_in_fn_parameters = function parameters require top-level or-patterns in parentheses
+parse_or_pattern_not_allowed_in_let_binding = `let` bindings require top-level or-patterns in parentheses
 parse_out_of_range_hex_escape = out of range hex escape
     .label = must be a character in the range [\x00-\x7f]
 

--- a/tests/ui/or-patterns/fn-param-wrap-parens.fixed
+++ b/tests/ui/or-patterns/fn-param-wrap-parens.fixed
@@ -10,4 +10,4 @@ enum E { A, B }
 use E::*;
 
 #[cfg(false)]
-fn fun1((A | B): E) {} //~ ERROR top-level or-patterns are not allowed
+fn fun1((A | B): E) {} //~ ERROR function parameters require top-level or-patterns in parentheses

--- a/tests/ui/or-patterns/fn-param-wrap-parens.rs
+++ b/tests/ui/or-patterns/fn-param-wrap-parens.rs
@@ -10,4 +10,4 @@ enum E { A, B }
 use E::*;
 
 #[cfg(false)]
-fn fun1(A | B: E) {} //~ ERROR top-level or-patterns are not allowed
+fn fun1(A | B: E) {} //~ ERROR function parameters require top-level or-patterns in parentheses

--- a/tests/ui/or-patterns/fn-param-wrap-parens.stderr
+++ b/tests/ui/or-patterns/fn-param-wrap-parens.stderr
@@ -1,4 +1,4 @@
-error: top-level or-patterns are not allowed in function parameters
+error: function parameters require top-level or-patterns in parentheses
   --> $DIR/fn-param-wrap-parens.rs:13:9
    |
 LL | fn fun1(A | B: E) {}

--- a/tests/ui/or-patterns/nested-undelimited-precedence.rs
+++ b/tests/ui/or-patterns/nested-undelimited-precedence.rs
@@ -17,7 +17,7 @@ fn foo() {
     let b @ (A | B): E = A;
 
     let b @ A | B: E = A; //~ERROR `b` is not bound in all patterns
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
 }
 
 enum F {
@@ -32,13 +32,13 @@ fn bar() {
     let (A(x) | B(x)): F = A(3);
 
     let &A(_) | B(_): F = A(3); //~ERROR mismatched types
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
     let &&A(_) | B(_): F = A(3); //~ERROR mismatched types
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
     let &mut A(_) | B(_): F = A(3); //~ERROR mismatched types
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
     let &&mut A(_) | B(_): F = A(3); //~ERROR mismatched types
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
 }
 
 fn main() {}

--- a/tests/ui/or-patterns/nested-undelimited-precedence.stderr
+++ b/tests/ui/or-patterns/nested-undelimited-precedence.stderr
@@ -1,4 +1,4 @@
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/nested-undelimited-precedence.rs:19:9
    |
 LL |     let b @ A | B: E = A;
@@ -9,7 +9,7 @@ help: wrap the pattern in parentheses
 LL |     let (b @ A | B): E = A;
    |         +         +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
@@ -20,7 +20,7 @@ help: wrap the pattern in parentheses
 LL |     let (&A(_) | B(_)): F = A(3);
    |         +            +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
@@ -31,7 +31,7 @@ help: wrap the pattern in parentheses
 LL |     let (&&A(_) | B(_)): F = A(3);
    |         +             +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
@@ -42,7 +42,7 @@ help: wrap the pattern in parentheses
 LL |     let (&mut A(_) | B(_)): F = A(3);
    |         +                +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.rs
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.rs
@@ -16,18 +16,18 @@ fn no_top_level_or_patterns() {
 fn no_top_level_or_patterns_2() {
     // ...and for now neither do we allow or-patterns at the top level of functions.
     fn fun1(A | B: E) {}
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR function parameters require top-level or-patterns in parentheses
 
     fn fun2(| A | B: E) {}
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR function parameters require top-level or-patterns in parentheses
 
     // We don't allow top-level or-patterns before type annotation in let-statements because we
     // want to reserve this syntactic space for possible future type ascription.
     let A | B: E = A;
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
 
     let | A | B: E = A;
-    //~^ ERROR top-level or-patterns are not allowed
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
 
     let (A | B): E = A; // ok -- wrapped in parens
 }

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -11,7 +11,7 @@ help: you might have meant to open the body of the closure
 LL |     let _ = |A | { B: E| ();
    |                  +
 
-error: top-level or-patterns are not allowed in function parameters
+error: function parameters require top-level or-patterns in parentheses
   --> $DIR/or-patterns-syntactic-fail.rs:18:13
    |
 LL |     fn fun1(A | B: E) {}
@@ -22,7 +22,7 @@ help: wrap the pattern in parentheses
 LL |     fn fun1((A | B): E) {}
    |             +     +
 
-error: top-level or-patterns are not allowed in function parameters
+error: function parameters require top-level or-patterns in parentheses
   --> $DIR/or-patterns-syntactic-fail.rs:21:13
    |
 LL |     fn fun2(| A | B: E) {}
@@ -33,7 +33,7 @@ help: wrap the pattern in parentheses
 LL |     fn fun2((| A | B): E) {}
    |             +       +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/or-patterns-syntactic-fail.rs:26:9
    |
 LL |     let A | B: E = A;
@@ -44,7 +44,7 @@ help: wrap the pattern in parentheses
 LL |     let (A | B): E = A;
    |         +     +
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/or-patterns-syntactic-fail.rs:29:9
    |
 LL |     let | A | B: E = A;

--- a/tests/ui/or-patterns/remove-leading-vert.fixed
+++ b/tests/ui/or-patterns/remove-leading-vert.fixed
@@ -8,7 +8,7 @@ fn main() {}
 
 #[cfg(false)]
 fn leading() {
-    fn fun1(  A: E) {} //~ ERROR top-level or-patterns are not allowed
+    fn fun1(  A: E) {} //~ ERROR function parameters require top-level or-patterns in parentheses
     fn fun2(  A: E) {} //~ ERROR unexpected `||` before function parameter
     let ( | A): E;
     let ( | A): (E); //~ ERROR unexpected token `||` in pattern

--- a/tests/ui/or-patterns/remove-leading-vert.rs
+++ b/tests/ui/or-patterns/remove-leading-vert.rs
@@ -8,7 +8,7 @@ fn main() {}
 
 #[cfg(false)]
 fn leading() {
-    fn fun1( | A: E) {} //~ ERROR top-level or-patterns are not allowed
+    fn fun1( | A: E) {} //~ ERROR function parameters require top-level or-patterns in parentheses
     fn fun2( || A: E) {} //~ ERROR unexpected `||` before function parameter
     let ( | A): E;
     let ( || A): (E); //~ ERROR unexpected token `||` in pattern

--- a/tests/ui/or-patterns/remove-leading-vert.stderr
+++ b/tests/ui/or-patterns/remove-leading-vert.stderr
@@ -1,4 +1,4 @@
-error: top-level or-patterns are not allowed in function parameters
+error: function parameters require top-level or-patterns in parentheses
   --> $DIR/remove-leading-vert.rs:11:14
    |
 LL |     fn fun1( | A: E) {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
@@ -65,7 +65,7 @@ fn parse(x: Void) {
     let res: Result<bool, Void> = Ok(false);
     let Ok(_) = res;
     let Ok(_) | Err(!) = &res; // Disallowed; see #82048.
-    //~^ ERROR top-level or-patterns are not allowed in `let` bindings
+    //~^ ERROR `let` bindings require top-level or-patterns in parentheses
     let (Ok(_) | Err(!)) = &res;
     let (Ok(_) | Err(&!)) = res.as_ref();
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -26,7 +26,7 @@ error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `<=`
 LL |         Some(!) <=
    |                 ^^ expected one of `,`, `=>`, `if`, `|`, or `}`
 
-error: top-level or-patterns are not allowed in `let` bindings
+error: `let` bindings require top-level or-patterns in parentheses
   --> $DIR/parse.rs:67:9
    |
 LL |     let Ok(_) | Err(!) = &res; // Disallowed; see #82048.


### PR DESCRIPTION
I was confused by "top-level or-patterns are not allowed in `let` bindings" error, because it sounded like or-patterns were completely unsupported.

This error has an auto-fix suggestion that shows otherwise, but the auto-fix isn't always visible in IDEs.

I've changed the wording to be consistent with "`Fn` bounds require arguments in parentheses", and it doesn't sound like a dead-end any more.