### PR TITLE
Merge typeck loop with static/const item eval loop

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -223,10 +223,6 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
             }
             _ => (),
         }
-    });
-
-    tcx.par_hir_body_owners(|item_def_id| {
-        let def_kind = tcx.def_kind(item_def_id);
         // Skip `AnonConst`s because we feed their `type_of`.
         if !matches!(def_kind, DefKind::AnonConst) {
             tcx.ensure_ok().typeck(item_def_id);

--- a/tests/ui/closures/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/closure-return-type-mismatch.stderr
@@ -1,12 +1,4 @@
 error[E0308]: mismatched types
-  --> $DIR/closure-return-type-mismatch.rs:20:41
-   |
-LL | static FOO: fn() -> bool = || -> bool { 1 };
-   |                                  ----   ^ expected `bool`, found integer
-   |                                  |
-   |                                  expected `bool` because of return type
-
-error[E0308]: mismatched types
   --> $DIR/closure-return-type-mismatch.rs:7:9
    |
 LL |         a
@@ -26,6 +18,14 @@ LL |     || -> bool {
 LL |         if false {
 LL |             return "hello"
    |                    ^^^^^^^ expected `bool`, found `&str`
+
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:20:41
+   |
+LL | static FOO: fn() -> bool = || -> bool { 1 };
+   |                                  ----   ^ expected `bool`, found integer
+   |                                  |
+   |                                  expected `bool` because of return type
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/coercion/coerce-loop-issue-122561.stderr
+++ b/tests/ui/coercion/coerce-loop-issue-122561.stderr
@@ -25,21 +25,6 @@ LL | fn for_in_arg(a: &[(); for x in 0..2 {} /* `usize` value */]) -> bool {
    |                                         +++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:85:5
-   |
-LL | /     for i in 0.. {
-LL | |
-LL | |     }
-   | |_____^ expected `i32`, found `()`
-   |
-   = note: `for` loops evaluate to unit type `()`
-help: consider returning a value here
-   |
-LL ~     }
-LL +     /* `i32` value */
-   |
-
-error[E0308]: mismatched types
   --> $DIR/coerce-loop-issue-122561.rs:4:5
    |
 LL |   fn for_infinite() -> bool {
@@ -200,6 +185,21 @@ help: consider adding a diverging expression here
    |
 LL ~     }
 LL +     /* `loop {}` or `panic!("...")` */
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/coerce-loop-issue-122561.rs:85:5
+   |
+LL | /     for i in 0.. {
+LL | |
+LL | |     }
+   | |_____^ expected `i32`, found `()`
+   |
+   = note: `for` loops evaluate to unit type `()`
+help: consider returning a value here
+   |
+LL ~     }
+LL +     /* `i32` value */
    |
 
 error[E0308]: mismatched types

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -1,20 +1,4 @@
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/effect_param.rs:11:9
-   |
-LL |     i8::checked_sub::<false>(42, 43);
-   |         ^^^^^^^^^^^--------- help: remove the unnecessary generics
-   |         |
-   |         expected 0 generic arguments
-
-error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/effect_param.rs:13:9
-   |
-LL |     i8::checked_sub::<true>(42, 43);
-   |         ^^^^^^^^^^^-------- help: remove the unnecessary generics
-   |         |
-   |         expected 0 generic arguments
-
-error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:4:9
    |
 LL |     i8::checked_sub::<true>(42, 43);
@@ -27,6 +11,22 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
    |
 LL |     i8::checked_sub::<false>(42, 43);
    |         ^^^^^^^^^^^--------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
+
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:11:9
+   |
+LL |     i8::checked_sub::<false>(42, 43);
+   |         ^^^^^^^^^^^--------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
+
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:13:9
+   |
+LL |     i8::checked_sub::<true>(42, 43);
+   |         ^^^^^^^^^^^-------- help: remove the unnecessary generics
    |         |
    |         expected 0 generic arguments
 

--- a/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
+++ b/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
@@ -1,18 +1,3 @@
-error[E0560]: struct `Crate` has no field named `fiel`
-  --> $DIR/dont-suggest-hygienic-fields.rs:44:34
-   |
-LL | environment!();
-   | -------------- in this macro invocation
-...
-LL |     const CRATE: Crate = Crate { fiel: () };
-   |                                  ^^^^ unknown field
-   |
-   = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: a field with a similar name exists
-   |
-LL |     const CRATE: Crate = Crate { field: () };
-   |                                      +
-
 error[E0609]: no field `field` on type `Compound`
   --> $DIR/dont-suggest-hygienic-fields.rs:24:16
    |
@@ -47,6 +32,21 @@ error[E0609]: no field `0` on type `Component`
    |
 LL |     let _ = ty.0;
    |                ^ unknown field
+
+error[E0560]: struct `Crate` has no field named `fiel`
+  --> $DIR/dont-suggest-hygienic-fields.rs:44:34
+   |
+LL | environment!();
+   | -------------- in this macro invocation
+...
+LL |     const CRATE: Crate = Crate { fiel: () };
+   |                                  ^^^^ unknown field
+   |
+   = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: a field with a similar name exists
+   |
+LL |     const CRATE: Crate = Crate { field: () };
+   |                                      +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -25,14 +25,6 @@ LL |     pub type Alias<'a> = impl T<Item = &'a ()>;
    |
    = note: `Alias` must be used in combination with a concrete type within the same crate
 
-error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/normalize-tait-in-const.rs:28:5
-   |
-LL |     fun(filter_positive());
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-
 error[E0308]: mismatched types
   --> $DIR/normalize-tait-in-const.rs:22:9
    |
@@ -51,6 +43,14 @@ note: this item must have a `#[define_opaque(foo::Alias)]` attribute to be able 
    |
 LL |     pub const fn filter_positive<'a>() -> &'a Alias<'a> {
    |                  ^^^^^^^^^^^^^^^
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/normalize-tait-in-const.rs:28:5
+   |
+LL |     fun(filter_positive());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/parser/pat-lt-bracket-6.stderr
+++ b/tests/ui/parser/pat-lt-bracket-6.stderr
@@ -6,12 +6,6 @@ LL |     let Test(&desc[..]) = x;
    |
    = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
-error[E0308]: mismatched types
-  --> $DIR/pat-lt-bracket-6.rs:10:30
-   |
-LL | const RECOVERY_WITNESS: () = 0;
-   |                              ^ expected `()`, found integer
-
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
   --> $DIR/pat-lt-bracket-6.rs:5:14
    |
@@ -25,6 +19,12 @@ help: use `_` to explicitly ignore each field
    |
 LL |     let Test(&desc[..], _) = x;
    |                       +++
+
+error[E0308]: mismatched types
+  --> $DIR/pat-lt-bracket-6.rs:10:30
+   |
+LL | const RECOVERY_WITNESS: () = 0;
+   |                              ^ expected `()`, found integer
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -10,6 +10,19 @@ help: this trait has no implementations, consider adding one
 LL | trait Project {
    | ^^^^^^^^^^^^^
 
+error[E0277]: the trait bound `(): Project` is not satisfied
+  --> $DIR/bad-projection.rs:14:17
+   |
+LL | pub fn uwu() -> <() as Project>::Assoc {}
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Project` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/bad-projection.rs:9:1
+   |
+LL | trait Project {
+   | ^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0593]: function is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/bad-projection.rs:14:1
    |
@@ -46,19 +59,6 @@ help: this trait has no implementations, consider adding one
    |
 LL | trait Project {
    | ^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `(): Project` is not satisfied
-  --> $DIR/bad-projection.rs:14:17
-   |
-LL | pub fn uwu() -> <() as Project>::Assoc {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Project` is not implemented for `()`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/bad-projection.rs:9:1
-   |
-LL | trait Project {
-   | ^^^^^^^^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/return/dont-suggest-through-inner-const.stderr
+++ b/tests/ui/return/dont-suggest-through-inner-const.stderr
@@ -1,16 +1,16 @@
 error[E0308]: mismatched types
-  --> $DIR/dont-suggest-through-inner-const.rs:4:9
-   |
-LL |         0
-   |         ^ expected `()`, found integer
-
-error[E0308]: mismatched types
   --> $DIR/dont-suggest-through-inner-const.rs:1:17
    |
 LL | const fn f() -> usize {
    |          -      ^^^^^ expected `usize`, found `()`
    |          |
    |          implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-through-inner-const.rs:4:9
+   |
+LL |         0
+   |         ^ expected `()`, found integer
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/no-explicit-const-params.stderr
+++ b/tests/ui/traits/const-traits/no-explicit-const-params.stderr
@@ -1,4 +1,32 @@
 error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/no-explicit-const-params.rs:15:5
+   |
+LL |     foo::<true>();
+   |     ^^^-------- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
+   |
+note: function defined here, with 0 generic parameters
+  --> $DIR/no-explicit-const-params.rs:3:10
+   |
+LL | const fn foo() {}
+   |          ^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/no-explicit-const-params.rs:17:12
+   |
+LL |     <() as Bar<true>>::bar();
+   |            ^^^------ help: remove the unnecessary generics
+   |            |
+   |            expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/no-explicit-const-params.rs:6:7
+   |
+LL | trait Bar {
+   |       ^^^
+
+error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:22:5
    |
 LL |     foo::<false>();
@@ -31,34 +59,6 @@ error[E0277]: the trait bound `(): const Bar` is not satisfied
    |
 LL |     <() as Bar<false>>::bar();
    |      ^^
-
-error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/no-explicit-const-params.rs:15:5
-   |
-LL |     foo::<true>();
-   |     ^^^-------- help: remove the unnecessary generics
-   |     |
-   |     expected 0 generic arguments
-   |
-note: function defined here, with 0 generic parameters
-  --> $DIR/no-explicit-const-params.rs:3:10
-   |
-LL | const fn foo() {}
-   |          ^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/no-explicit-const-params.rs:17:12
-   |
-LL |     <() as Bar<true>>::bar();
-   |            ^^^------ help: remove the unnecessary generics
-   |            |
-   |            expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/no-explicit-const-params.rs:6:7
-   |
-LL | trait Bar {
-   |       ^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -1,21 +1,3 @@
-error[E0080]: evaluation of constant value failed
-  --> $DIR/uninhabited.rs:41:9
-   |
-LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/uninhabited.rs:63:9
-   |
-LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/uninhabited.rs:87:9
-   |
-LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-
 error[E0277]: `()` cannot be safely transmuted into `void::Void`
   --> $DIR/uninhabited.rs:29:41
    |
@@ -58,6 +40,12 @@ LL | |                 lifetimes: true,
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
+error[E0080]: evaluation of constant value failed
+  --> $DIR/uninhabited.rs:41:9
+   |
+LL |         assert!(false);
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
+
 error[E0277]: `()` cannot be safely transmuted into `yawning_void_enum::Void`
   --> $DIR/uninhabited.rs:71:41
    |
@@ -79,6 +67,12 @@ LL | |                 lifetimes: true,
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
 
+error[E0080]: evaluation of constant value failed
+  --> $DIR/uninhabited.rs:63:9
+   |
+LL |         assert!(false);
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
+
 error[E0277]: `u128` cannot be safely transmuted into `DistantVoid`
   --> $DIR/uninhabited.rs:92:43
    |
@@ -99,6 +93,12 @@ LL | |                 lifetimes: true,
 ...  |
 LL | |         }>
    | |__________^ required by this bound in `is_maybe_transmutable`
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/uninhabited.rs:87:9
+   |
+LL |         assert!(false);
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
 
 error[E0277]: `Src` cannot be safely transmuted into `issue_126267::Error`
   --> $DIR/uninhabited.rs:108:42


### PR DESCRIPTION
r? @ghost

Let's try a small one first. Doing this in general has some bad cache coherence issues because the query caches are laid out in `Vec<QueryResult>` lists per query where each index refers to a `DefId` in the same order as we're iterating. Iterating two or more lists at the same time does have cache issues, so I want to poke a bit at it to see if we can't merge just a few of them at a time.