### PR TITLE
[rustdoc] Unify type aliases rendering with other ADT

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -764,7 +764,7 @@ impl Item {
         Some(tcx.visibility(def_id))
     }
 
-    pub(crate) fn attributes_witout_repr(&self, tcx: TyCtxt<'_>, is_json: bool) -> Vec<String> {
+    pub(crate) fn attributes_without_repr(&self, tcx: TyCtxt<'_>, is_json: bool) -> Vec<String> {
         const ALLOWED_ATTRIBUTES: &[Symbol] =
             &[sym::export_name, sym::link_section, sym::no_mangle, sym::non_exhaustive];
 
@@ -805,7 +805,7 @@ impl Item {
         cache: &Cache,
         is_json: bool,
     ) -> Vec<String> {
-        let mut attrs = self.attributes_witout_repr(tcx, is_json);
+        let mut attrs = self.attributes_without_repr(tcx, is_json);
 
         if let Some(repr_attr) = self.repr(tcx, cache) {
             attrs.push(repr_attr);
@@ -813,7 +813,7 @@ impl Item {
         attrs
     }
 
-    /// Returns a `#[repr(...)]` representation.
+    /// Returns a stringified `#[repr(...)]` attribute.
     pub(crate) fn repr(&self, tcx: TyCtxt<'_>, cache: &Cache, is_json: bool) -> Option<String> {
         repr_attributes(tcx, cache, self.def_id()?, self.type_(), is_json)
     }
@@ -2370,8 +2370,9 @@ impl TypeAliasInnerType {
     fn has_stripped_entries(&self) -> Option<bool> {
         Some(match self {
             Self::Enum { variants, .. } => variants.iter().any(|v| v.is_stripped()),
-            Self::Union { fields } => fields.iter().any(|f| f.is_stripped()),
-            Self::Struct { fields, .. } => fields.iter().any(|f| f.is_stripped()),
+            Self::Union { fields } | Self::Struct { fields, .. } => {
+                fields.iter().any(|f| f.is_stripped())
+            }
         })
     }
 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -764,14 +764,11 @@ impl Item {
         Some(tcx.visibility(def_id))
     }
 
-    pub(crate) fn attributes(&self, tcx: TyCtxt<'_>, cache: &Cache, is_json: bool) -> Vec<String> {
+    pub(crate) fn attributes_witout_repr(&self, tcx: TyCtxt<'_>, is_json: bool) -> Vec<String> {
         const ALLOWED_ATTRIBUTES: &[Symbol] =
             &[sym::export_name, sym::link_section, sym::no_mangle, sym::non_exhaustive];
 
-        use rustc_abi::IntegerType;
-
-        let mut attrs: Vec<String> = self
-            .attrs
+        self.attrs
             .other_attrs
             .iter()
             .filter_map(|attr| {
@@ -799,72 +796,86 @@ impl Item {
                     None
                 }
             })
-            .collect();
+            .collect()
+    }
 
-        // Add #[repr(...)]
-        if let Some(def_id) = self.def_id()
-            && let ItemType::Struct | ItemType::Enum | ItemType::Union = self.type_()
-        {
-            let adt = tcx.adt_def(def_id);
-            let repr = adt.repr();
-            let mut out = Vec::new();
-            if repr.c() {
-                out.push("C");
-            }
-            if repr.transparent() {
-                // Render `repr(transparent)` iff the non-1-ZST field is public or at least one
-                // field is public in case all fields are 1-ZST fields.
-                let render_transparent = is_json
-                    || cache.document_private
-                    || adt
-                        .all_fields()
-                        .find(|field| {
-                            let ty =
-                                field.ty(tcx, ty::GenericArgs::identity_for_item(tcx, field.did));
-                            tcx.layout_of(
-                                ty::TypingEnv::post_analysis(tcx, field.did).as_query_input(ty),
-                            )
-                            .is_ok_and(|layout| !layout.is_1zst())
-                        })
-                        .map_or_else(
-                            || adt.all_fields().any(|field| field.vis.is_public()),
-                            |field| field.vis.is_public(),
-                        );
+    pub(crate) fn attributes_and_repr(
+        &self,
+        tcx: TyCtxt<'_>,
+        cache: &Cache,
+        is_json: bool,
+    ) -> Vec<String> {
+        let mut attrs = self.attributes_witout_repr(tcx, is_json);
 
-                if render_transparent {
-                    out.push("transparent");
-                }
-            }
-            if repr.simd() {
-                out.push("simd");
-            }
-            let pack_s;
-            if let Some(pack) = repr.pack {
-                pack_s = format!("packed({})", pack.bytes());
-                out.push(&pack_s);
-            }
-            let align_s;
-            if let Some(align) = repr.align {
-                align_s = format!("align({})", align.bytes());
-                out.push(&align_s);
-            }
-            let int_s;
-            if let Some(int) = repr.int {
-                int_s = match int {
-                    IntegerType::Pointer(is_signed) => {
-                        format!("{}size", if is_signed { 'i' } else { 'u' })
-                    }
-                    IntegerType::Fixed(size, is_signed) => {
-                        format!("{}{}", if is_signed { 'i' } else { 'u' }, size.size().bytes() * 8)
-                    }
-                };
-                out.push(&int_s);
-            }
-            if !out.is_empty() {
-                attrs.push(format!("#[repr({})]", out.join(", ")));
-            }
+        if let Some(repr_attr) = self.repr(tcx, cache) {
+            attrs.push(repr_attr);
         }
         attrs
+    }
+
+    /// Returns a `#[repr(...)]` representation.
+    pub(crate) fn repr(&self, tcx: TyCtxt<'_>, cache: &Cache, is_json: bool) -> Option<String> {
+        use rustc_abi::IntegerType;
+
+        let def_id = self.def_id()?;
+        if !matches!(self.type_(), ItemType::Struct | ItemType::Enum | ItemType::Union) {
+            return None;
+        }
+        let adt = tcx.adt_def(def_id);
+        let repr = adt.repr();
+        let mut out = Vec::new();
+        if repr.c() {
+            out.push("C");
+        }
+        if repr.transparent() {
+            // Render `repr(transparent)` iff the non-1-ZST field is public or at least one
+            // field is public in case all fields are 1-ZST fields.
+            let render_transparent = is_json
+                || cache.document_private
+                || adt
+                    .all_fields()
+                    .find(|field| {
+                        let ty = field.ty(tcx, ty::GenericArgs::identity_for_item(tcx, field.did));
+                        tcx.layout_of(
+                            ty::TypingEnv::post_analysis(tcx, field.did).as_query_input(ty),
+                        )
+                        .is_ok_and(|layout| !layout.is_1zst())
+                    })
+                    .map_or_else(
+                        || adt.all_fields().any(|field| field.vis.is_public()),
+                        |field| field.vis.is_public(),
+                    );
+
+            if render_transparent {
+                out.push("transparent");
+            }
+        }
+        if repr.simd() {
+            out.push("simd");
+        }
+        let pack_s;
+        if let Some(pack) = repr.pack {
+            pack_s = format!("packed({})", pack.bytes());
+            out.push(&pack_s);
+        }
+        let align_s;
+        if let Some(align) = repr.align {
+            align_s = format!("align({})", align.bytes());
+            out.push(&align_s);
+        }
+        let int_s;
+        if let Some(int) = repr.int {
+            int_s = match int {
+                IntegerType::Pointer(is_signed) => {
+                    format!("{}size", if is_signed { 'i' } else { 'u' })
+                }
+                IntegerType::Fixed(size, is_signed) => {
+                    format!("{}{}", if is_signed { 'i' } else { 'u' }, size.size().bytes() * 8)
+                }
+            };
+            out.push(&int_s);
+        }
+        if !out.is_empty() { Some(format!("#[repr({})]", out.join(", "))) } else { None }
     }
 
     pub fn is_doc_hidden(&self) -> bool {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2107,7 +2107,7 @@ impl Enum {
         self.variants.iter().any(|f| f.is_stripped())
     }
 
-    pub(crate) fn variants(&self) -> impl Iterator<Item = &Item> {
+    pub(crate) fn non_stripped_variants(&self) -> impl Iterator<Item = &Item> {
         self.variants.iter().filter(|v| !v.is_stripped())
     }
 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -610,6 +610,9 @@ impl Item {
             UnionItem(ref union_) => Some(union_.has_stripped_entries()),
             EnumItem(ref enum_) => Some(enum_.has_stripped_entries()),
             VariantItem(ref v) => v.has_stripped_entries(),
+            TypeAliasItem(ref type_alias) => {
+                type_alias.inner_type.as_ref().and_then(|t| t.has_stripped_entries())
+            }
             _ => None,
         }
     }
@@ -2343,6 +2346,16 @@ pub(crate) enum TypeAliasInnerType {
     Enum { variants: IndexVec<VariantIdx, Item>, is_non_exhaustive: bool },
     Union { fields: Vec<Item> },
     Struct { ctor_kind: Option<CtorKind>, fields: Vec<Item> },
+}
+
+impl TypeAliasInnerType {
+    fn has_stripped_entries(&self) -> Option<bool> {
+        Some(match self {
+            Self::Enum { variants, .. } => variants.iter().any(|v| v.is_stripped()),
+            Self::Union { fields } => fields.iter().any(|f| f.is_stripped()),
+            Self::Struct { fields, .. } => fields.iter().any(|f| f.is_stripped()),
+        })
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -807,7 +807,7 @@ impl Item {
     ) -> Vec<String> {
         let mut attrs = self.attributes_without_repr(tcx, is_json);
 
-        if let Some(repr_attr) = self.repr(tcx, cache) {
+        if let Some(repr_attr) = self.repr(tcx, cache, is_json) {
             attrs.push(repr_attr);
         }
         attrs

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1203,17 +1203,15 @@ fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) ->
 
 struct CodeAttribute(String);
 
-impl CodeAttribute {
-    fn render_into(self, w: &mut impl fmt::Write) {
-        write!(w, "<div class=\"code-attribute\">{}</div>", self.0).unwrap();
-    }
+fn render_code_attribute(code_attr: CodeAttribute, w: &mut impl fmt::Write) {
+    write!(w, "<div class=\"code-attribute\">{}</div>", code_attr.0).unwrap();
 }
 
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
     for attr in it.attributes_and_repr(cx.tcx(), cx.cache(), false) {
-        CodeAttribute(attr).render_into(w);
+        render_code_attribute(CodeAttribute(attr), w);
     }
 }
 
@@ -1225,7 +1223,7 @@ fn render_repr_attributes_in_code(
     item_type: ItemType,
 ) {
     if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type) {
-        CodeAttribute(repr).render_into(w);
+        render_code_attribute(CodeAttribute(repr), w);
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1201,11 +1201,31 @@ fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) ->
     })
 }
 
+struct CodeAttribute(String);
+
+impl CodeAttribute {
+    fn render_into(self, w: &mut impl fmt::Write) {
+        write!(w, "<div class=\"code-attribute\">{}</div>", self.0).unwrap();
+    }
+}
+
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
     for attr in it.attributes_and_repr(cx.tcx(), cx.cache(), false) {
-        write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
+        CodeAttribute(attr).render_into(w);
+    }
+}
+
+/// used for type aliases to only render their `repr` attribute.
+fn render_repr_attributes_in_code(
+    w: &mut impl fmt::Write,
+    cx: &Context<'_>,
+    def_id: DefId,
+    item_type: ItemType,
+) {
+    if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type) {
+        CodeAttribute(repr).render_into(w);
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1194,7 +1194,7 @@ fn render_assoc_item(
 // a whitespace prefix and newline.
 fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) -> impl fmt::Display {
     fmt::from_fn(move |f| {
-        for a in it.attributes(cx.tcx(), cx.cache(), false) {
+        for a in it.attributes_and_repr(cx.tcx(), cx.cache(), false) {
             writeln!(f, "{prefix}{a}")?;
         }
         Ok(())
@@ -1204,7 +1204,7 @@ fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) ->
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
-    for attr in it.attributes(cx.tcx(), cx.cache(), false) {
+    for attr in it.attributes_and_repr(cx.tcx(), cx.cache(), false) {
         write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
     }
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1222,7 +1222,7 @@ fn render_repr_attributes_in_code(
     def_id: DefId,
     item_type: ItemType,
 ) {
-    if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type) {
+    if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type, false) {
         render_code_attribute(CodeAttribute(repr), w);
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1479,6 +1479,7 @@ impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
                     self.cx.cache(),
                     self.def_id,
                     ItemType::Union,
+                    false,
                 ) {
                     writeln!(f, "{repr}")?;
                 };

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1535,7 +1535,7 @@ fn print_tuple_struct_fields(cx: &Context<'_>, s: &[clean::Item]) -> impl Displa
 
 fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::Display {
     fmt::from_fn(|w| {
-        let count_variants = e.variants().count();
+        let count_variants = e.non_stripped_variants().count();
         wrap_item(w, |w| {
             render_attributes_in_code(w, it, cx);
             write!(

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1278,93 +1278,39 @@ fn item_type_alias(cx: &Context<'_>, it: &clean::Item, t: &clean::TypeAlias) -> 
 
             match inner_type {
                 clean::TypeAliasInnerType::Enum { variants, is_non_exhaustive } => {
-                    let variants_iter = || variants.iter().filter(|i| !i.is_stripped());
                     let ty = cx.tcx().type_of(it.def_id().unwrap()).instantiate_identity();
                     let enum_def_id = ty.ty_adt_def().unwrap().did();
 
-                    wrap_item(w, |w| {
-                        let variants_len = variants.len();
-                        let variants_count = variants_iter().count();
-                        let has_stripped_entries = variants_len != variants_count;
-
-                        write!(
-                            w,
-                            "enum {}{}{}",
-                            it.name.unwrap(),
-                            t.generics.print(cx),
-                            render_enum_fields(
-                                cx,
-                                Some(&t.generics),
-                                variants,
-                                variants_count,
-                                has_stripped_entries,
-                                *is_non_exhaustive,
-                                enum_def_id,
-                            )
-                        )
-                    })?;
-                    write!(w, "{}", item_variants(cx, it, variants, enum_def_id))?;
+                    DisplayEnum {
+                        variants,
+                        generics: &t.generics,
+                        is_non_exhaustive: *is_non_exhaustive,
+                        def_id: enum_def_id,
+                    }
+                    .render_into(cx, it, false, w)?;
                 }
                 clean::TypeAliasInnerType::Union { fields } => {
-                    wrap_item(w, |w| {
-                        let fields_count = fields.iter().filter(|i| !i.is_stripped()).count();
-                        let has_stripped_fields = fields.len() != fields_count;
-
-                        write!(
-                            w,
-                            "union {}{}{}",
-                            it.name.unwrap(),
-                            t.generics.print(cx),
-                            render_struct_fields(
-                                Some(&t.generics),
-                                None,
-                                fields,
-                                "",
-                                true,
-                                has_stripped_fields,
-                                cx,
-                            ),
-                        )
-                    })?;
-                    write!(w, "{}", item_fields(cx, it, fields, None))?;
+                    ItemUnion { cx, it, fields, generics: &t.generics, document_union: false }
+                        .render_into(w)?;
                 }
                 clean::TypeAliasInnerType::Struct { ctor_kind, fields } => {
-                    wrap_item(w, |w| {
-                        let fields_count = fields.iter().filter(|i| !i.is_stripped()).count();
-                        let has_stripped_fields = fields.len() != fields_count;
-
-                        write!(
-                            w,
-                            "struct {}{}{}",
-                            it.name.unwrap(),
-                            t.generics.print(cx),
-                            render_struct_fields(
-                                Some(&t.generics),
-                                *ctor_kind,
-                                fields,
-                                "",
-                                true,
-                                has_stripped_fields,
-                                cx,
-                            ),
-                        )
-                    })?;
-                    write!(w, "{}", item_fields(cx, it, fields, None))?;
+                    DisplayStruct { ctor_kind: *ctor_kind, generics: &t.generics, fields }
+                        .render_into(cx, it, false, w)?;
                 }
             }
+        } else {
+            let def_id = it.item_id.expect_def_id();
+            // Render any items associated directly to this alias, as otherwise they
+            // won't be visible anywhere in the docs. It would be nice to also show
+            // associated items from the aliased type (see discussion in #32077), but
+            // we need #14072 to make sense of the generics.
+            write!(
+                w,
+                "{}{}",
+                render_assoc_items(cx, it, def_id, AssocItemRender::All),
+                document_type_layout(cx, def_id)
+            )?;
         }
-
-        let def_id = it.item_id.expect_def_id();
-        // Render any items associated directly to this alias, as otherwise they
-        // won't be visible anywhere in the docs. It would be nice to also show
-        // associated items from the aliased type (see discussion in #32077), but
-        // we need #14072 to make sense of the generics.
-        write!(
-            w,
-            "{}{}",
-            render_assoc_items(cx, it, def_id, AssocItemRender::All),
-            document_type_layout(cx, def_id)
-        )?;
 
         // [RUSTDOCIMPL] type.impl
         //
@@ -1463,50 +1409,53 @@ fn item_type_alias(cx: &Context<'_>, it: &clean::Item, t: &clean::TypeAlias) -> 
     })
 }
 
-fn item_union(cx: &Context<'_>, it: &clean::Item, s: &clean::Union) -> impl fmt::Display {
-    item_template!(
-        #[template(path = "item_union.html")]
-        struct ItemUnion<'a, 'cx> {
-            cx: &'a Context<'cx>,
-            it: &'a clean::Item,
-            s: &'a clean::Union,
-        },
-        methods = [document, document_type_layout, render_attributes_in_pre, render_assoc_items]
-    );
+item_template!(
+    #[template(path = "item_union.html")]
+    struct ItemUnion<'a, 'cx> {
+        cx: &'a Context<'cx>,
+        it: &'a clean::Item,
+        fields: &'a [clean::Item],
+        generics: &'a clean::Generics,
+        document_union: bool,
+    },
+    methods = [document, document_type_layout, render_attributes_in_pre, render_assoc_items]
+);
 
-    impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
-        fn render_union(&self) -> impl Display {
-            render_union(self.it, Some(&self.s.generics), &self.s.fields, self.cx)
-        }
-
-        fn document_field(&self, field: &'a clean::Item) -> impl Display {
-            document(self.cx, field, Some(self.it), HeadingOffset::H3)
-        }
-
-        fn stability_field(&self, field: &clean::Item) -> Option<String> {
-            field.stability_class(self.cx.tcx())
-        }
-
-        fn print_ty(&self, ty: &'a clean::Type) -> impl Display {
-            ty.print(self.cx)
-        }
-
-        fn fields_iter(
-            &self,
-        ) -> iter::Peekable<impl Iterator<Item = (&'a clean::Item, &'a clean::Type)>> {
-            self.s
-                .fields
-                .iter()
-                .filter_map(|f| match f.kind {
-                    clean::StructFieldItem(ref ty) => Some((f, ty)),
-                    _ => None,
-                })
-                .peekable()
-        }
+impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
+    fn render_union(&self) -> impl Display {
+        render_union(self.it, Some(&self.generics), &self.fields, self.cx)
     }
 
+    fn document_field(&self, field: &'a clean::Item) -> impl Display {
+        document(self.cx, field, Some(self.it), HeadingOffset::H3)
+    }
+
+    fn stability_field(&self, field: &clean::Item) -> Option<String> {
+        field.stability_class(self.cx.tcx())
+    }
+
+    fn print_ty(&self, ty: &'a clean::Type) -> impl Display {
+        ty.print(self.cx)
+    }
+
+    fn fields_iter(
+        &self,
+    ) -> iter::Peekable<impl Iterator<Item = (&'a clean::Item, &'a clean::Type)>> {
+        self.fields
+            .iter()
+            .filter_map(|f| match f.kind {
+                clean::StructFieldItem(ref ty) => Some((f, ty)),
+                _ => None,
+            })
+            .peekable()
+    }
+}
+
+fn item_union(cx: &Context<'_>, it: &clean::Item, s: &clean::Union) -> impl fmt::Display {
     fmt::from_fn(|w| {
-        ItemUnion { cx, it, s }.render_into(w).unwrap();
+        ItemUnion { cx, it, fields: &s.fields, generics: &s.generics, document_union: true }
+            .render_into(w)
+            .unwrap();
         Ok(())
     })
 }
@@ -1533,9 +1482,25 @@ fn print_tuple_struct_fields(cx: &Context<'_>, s: &[clean::Item]) -> impl Displa
     })
 }
 
-fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::Display {
-    fmt::from_fn(|w| {
-        let count_variants = e.non_stripped_variants().count();
+struct DisplayEnum<'a> {
+    variants: &'a IndexVec<VariantIdx, clean::Item>,
+    generics: &'a clean::Generics,
+    is_non_exhaustive: bool,
+    def_id: DefId,
+}
+
+impl<'a> DisplayEnum<'a> {
+    fn render_into<W: fmt::Write>(
+        self,
+        cx: &Context<'_>,
+        it: &clean::Item,
+        document_enum: bool,
+        w: &mut W,
+    ) -> fmt::Result {
+        let variants_count = self.variants.iter().filter(|i| !i.is_stripped()).count();
+        let variants_len = self.variants.len();
+        let has_stripped_entries = variants_len != variants_count;
+
         wrap_item(w, |w| {
             render_attributes_in_code(w, it, cx);
             write!(
@@ -1543,23 +1508,25 @@ fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::D
                 "{}enum {}{}{}",
                 visibility_print_with_space(it, cx),
                 it.name.unwrap(),
-                e.generics.print(cx),
+                self.generics.print(cx),
                 render_enum_fields(
                     cx,
-                    Some(&e.generics),
-                    &e.variants,
-                    count_variants,
-                    e.has_stripped_entries(),
-                    it.is_non_exhaustive(),
-                    it.def_id().unwrap(),
+                    Some(self.generics),
+                    self.variants,
+                    variants_count,
+                    has_stripped_entries,
+                    self.is_non_exhaustive,
+                    self.def_id,
                 ),
             )
         })?;
 
-        write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
+        if document_enum {
+            write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
+        }
 
-        if count_variants != 0 {
-            write!(w, "{}", item_variants(cx, it, &e.variants, it.def_id().unwrap()))?;
+        if variants_count != 0 {
+            write!(w, "{}", item_variants(cx, it, self.variants, self.def_id))?;
         }
         let def_id = it.item_id.expect_def_id();
         write!(
@@ -1568,6 +1535,18 @@ fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::D
             render_assoc_items(cx, it, def_id, AssocItemRender::All),
             document_type_layout(cx, def_id)
         )
+    }
+}
+
+fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::Display {
+    fmt::from_fn(|w| {
+        DisplayEnum {
+            variants: &e.variants,
+            generics: &e.generics,
+            is_non_exhaustive: it.is_non_exhaustive(),
+            def_id: it.def_id().unwrap(),
+        }
+        .render_into(cx, it, true, w)
     })
 }
 
@@ -1955,27 +1934,48 @@ fn item_constant(
     })
 }
 
-fn item_struct(cx: &Context<'_>, it: &clean::Item, s: &clean::Struct) -> impl fmt::Display {
-    fmt::from_fn(|w| {
+struct DisplayStruct<'a> {
+    ctor_kind: Option<CtorKind>,
+    generics: &'a clean::Generics,
+    fields: &'a [clean::Item],
+}
+
+impl<'a> DisplayStruct<'a> {
+    fn render_into<W: fmt::Write>(
+        self,
+        cx: &Context<'_>,
+        it: &clean::Item,
+        document_struct: bool,
+        w: &mut W,
+    ) -> fmt::Result {
         wrap_item(w, |w| {
             render_attributes_in_code(w, it, cx);
             write!(
                 w,
                 "{}",
-                render_struct(it, Some(&s.generics), s.ctor_kind, &s.fields, "", true, cx)
+                render_struct(it, Some(self.generics), self.ctor_kind, self.fields, "", true, cx)
             )
         })?;
 
-        let def_id = it.item_id.expect_def_id();
+        if document_struct {
+            write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
+        }
 
+        let def_id = it.item_id.expect_def_id();
         write!(
             w,
-            "{}{}{}{}",
-            document(cx, it, None, HeadingOffset::H2),
-            item_fields(cx, it, &s.fields, s.ctor_kind),
+            "{}{}{}",
+            item_fields(cx, it, self.fields, self.ctor_kind),
             render_assoc_items(cx, it, def_id, AssocItemRender::All),
             document_type_layout(cx, def_id),
         )
+    }
+}
+
+fn item_struct(cx: &Context<'_>, it: &clean::Item, s: &clean::Struct) -> impl fmt::Display {
+    fmt::from_fn(|w| {
+        DisplayStruct { ctor_kind: s.ctor_kind, generics: &s.generics, fields: s.fields.as_slice() }
+            .render_into(cx, it, true, w)
     })
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1287,15 +1287,15 @@ fn item_type_alias(cx: &Context<'_>, it: &clean::Item, t: &clean::TypeAlias) -> 
                         is_non_exhaustive: *is_non_exhaustive,
                         def_id: enum_def_id,
                     }
-                    .render_into(cx, it, false, w)?;
+                    .render_into(cx, it, true, w)?;
                 }
                 clean::TypeAliasInnerType::Union { fields } => {
-                    ItemUnion { cx, it, fields, generics: &t.generics, document_union: false }
+                    ItemUnion { cx, it, fields, generics: &t.generics, is_type_alias: true }
                         .render_into(w)?;
                 }
                 clean::TypeAliasInnerType::Struct { ctor_kind, fields } => {
                     DisplayStruct { ctor_kind: *ctor_kind, generics: &t.generics, fields }
-                        .render_into(cx, it, false, w)?;
+                        .render_into(cx, it, true, w)?;
                 }
             }
         } else {
@@ -1416,7 +1416,7 @@ item_template!(
         it: &'a clean::Item,
         fields: &'a [clean::Item],
         generics: &'a clean::Generics,
-        document_union: bool,
+        is_type_alias: bool,
     },
     methods = [document, document_type_layout, render_attributes_in_pre, render_assoc_items]
 );
@@ -1453,7 +1453,7 @@ impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
 
 fn item_union(cx: &Context<'_>, it: &clean::Item, s: &clean::Union) -> impl fmt::Display {
     fmt::from_fn(|w| {
-        ItemUnion { cx, it, fields: &s.fields, generics: &s.generics, document_union: true }
+        ItemUnion { cx, it, fields: &s.fields, generics: &s.generics, is_type_alias: false }
             .render_into(w)
             .unwrap();
         Ok(())
@@ -1494,7 +1494,7 @@ impl<'a> DisplayEnum<'a> {
         self,
         cx: &Context<'_>,
         it: &clean::Item,
-        document_enum: bool,
+        is_type_alias: bool,
         w: &mut W,
     ) -> fmt::Result {
         let variants_count = self.variants.iter().filter(|i| !i.is_stripped()).count();
@@ -1521,7 +1521,7 @@ impl<'a> DisplayEnum<'a> {
             )
         })?;
 
-        if document_enum {
+        if !is_type_alias {
             write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
         }
 
@@ -1546,7 +1546,7 @@ fn item_enum(cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) -> impl fmt::D
             is_non_exhaustive: it.is_non_exhaustive(),
             def_id: it.def_id().unwrap(),
         }
-        .render_into(cx, it, true, w)
+        .render_into(cx, it, false, w)
     })
 }
 
@@ -1945,7 +1945,7 @@ impl<'a> DisplayStruct<'a> {
         self,
         cx: &Context<'_>,
         it: &clean::Item,
-        document_struct: bool,
+        is_type_alias: bool,
         w: &mut W,
     ) -> fmt::Result {
         wrap_item(w, |w| {
@@ -1957,7 +1957,7 @@ impl<'a> DisplayStruct<'a> {
             )
         })?;
 
-        if document_struct {
+        if !is_type_alias {
             write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
         }
 
@@ -1975,7 +1975,7 @@ impl<'a> DisplayStruct<'a> {
 fn item_struct(cx: &Context<'_>, it: &clean::Item, s: &clean::Struct) -> impl fmt::Display {
     fmt::from_fn(|w| {
         DisplayStruct { ctor_kind: s.ctor_kind, generics: &s.generics, fields: s.fields.as_slice() }
-            .render_into(cx, it, true, w)
+            .render_into(cx, it, false, w)
     })
 }
 

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -599,7 +599,7 @@ fn sidebar_enum<'a>(
     deref_id_map: &'a DefIdMap<String>,
 ) {
     let mut variants = e
-        .variants()
+        .non_stripped_variants()
         .filter_map(|v| v.name)
         .map(|name| Link::new(format!("variant.{name}"), name.to_string()))
         .collect::<Vec<_>>();

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -5,7 +5,7 @@
 {% if !self.is_type_alias %}
     {{ self.document()|safe }}
 {% endif %}
-{% if self.fields_iter().peek().is_some() %}
+{% if self.fields_iter().next().is_some() %}
     <h2 id="fields" class="fields section-header"> {# #}
         Fields<a href="#fields" class="anchor">§</a> {# #}
     </h2>

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -2,7 +2,7 @@
     {{ self.render_attributes_in_pre()|safe }}
     {{ self.render_union()|safe }}
 </code></pre>
-{% if self.document_union %}
+{% if !self.is_type_alias %}
     {{ self.document()|safe }}
 {% endif %}
 {% if self.fields_iter().peek().is_some() %}

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -2,15 +2,16 @@
     {{ self.render_attributes_in_pre()|safe }}
     {{ self.render_union()|safe }}
 </code></pre>
-{{ self.document()|safe }}
+{% if self.document_union %}
+    {{ self.document()|safe }}
+{% endif %}
 {% if self.fields_iter().peek().is_some() %}
     <h2 id="fields" class="fields section-header"> {# #}
         Fields<a href="#fields" class="anchor">§</a> {# #}
     </h2>
     {% for (field, ty) in self.fields_iter() %}
         {% let name = field.name.expect("union field name") %}
-        <span id="structfield.{{ name }}" {#+ #}
-            class="{{ ItemType::StructField +}} section-header"> {# #}
+        <span id="structfield.{{ name }}" class="{{ ItemType::StructField +}} section-header"> {# #}
             <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
             <code>{{ name }}: {{+ self.print_ty(ty)|safe }}</code> {# #}
         </span>

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -40,7 +40,7 @@ impl JsonRenderer<'_> {
             })
             .collect();
         let docs = item.opt_doc_value();
-        let attrs = item.attributes(self.tcx, self.cache(), true);
+        let attrs = item.attributes_and_repr(self.tcx, self.cache(), true);
         let span = item.span(self.tcx);
         let visibility = item.visibility(self.tcx);
         let clean::ItemInner { name, item_id, .. } = *item.inner;

--- a/tests/rustdoc/type-alias/repr.rs
+++ b/tests/rustdoc/type-alias/repr.rs
@@ -1,0 +1,42 @@
+// This test ensures that the `repr` attribute is displayed in type aliases.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/140739>.
+
+#![crate_name = "foo"]
+
+/// bla
+#[repr(C)]
+pub struct Foo1;
+
+//@ has 'foo/type.Bar1.html'
+//@ has - '//*[@class="rust item-decl"]/code' '#[repr(C)]pub struct Bar1;'
+// Ensures that we see the doc comment of the type alias and not of the aliased type.
+//@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'bar'
+/// bar
+pub type Bar1 = Foo1;
+
+/// bla
+#[repr(C)]
+pub union Foo2 {
+    pub a: u8,
+}
+
+//@ has 'foo/type.Bar2.html'
+//@ matches - '//*[@class="rust item-decl"]' '#\[repr\(C\)\]\npub union Bar2 \{*'
+// Ensures that we see the doc comment of the type alias and not of the aliased type.
+//@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'bar'
+/// bar
+pub type Bar2 = Foo2;
+
+/// bla
+#[repr(C)]
+pub enum Foo3 {
+    A,
+}
+
+//@ has 'foo/type.Bar3.html'
+//@ matches - '//*[@class="rust item-decl"]' '#\[repr\(C\)\]pub enum Bar3 \{*'
+// Ensures that we see the doc comment of the type alias and not of the aliased type.
+//@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]' 'bar'
+/// bar
+pub type Bar3 = Foo3;

--- a/tests/rustdoc/type-layout.rs
+++ b/tests/rustdoc/type-layout.rs
@@ -61,7 +61,7 @@ pub type TypeAlias = X;
 pub type GenericTypeAlias = (Generic<(u32, ())>, Generic<u32>);
 
 // Regression test for the rustdoc equivalent of #85103.
-//@ hasraw type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
+//@ hasraw type_layout/type.Edges.html 'Unable to compute type layout, possibly due to this type having generic parameters. Layout can only be computed for concrete, fully-instantiated types.'
 pub type Edges<'a, E> = std::borrow::Cow<'a, [E]>;
 
 //@ !hasraw type_layout/trait.MyTrait.html 'Size: '


### PR DESCRIPTION
Fixes #140739.

Better reviewed one commit at a time.

Just one thing I'm wondering: should we also render non-`repr` attributes? If so, I wonder if we shouldn't simply change `clean::TypeAlias` to contain the other ADT directly (`Struct`, `Enum` and `Union`) and remove the `TypeAlias::generics` field.

Can be done in a follow-up too.

cc @camelid 
r? @notriddle 