### PR TITLE
rustdoc: Fix links with inline code in trait impl docs

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1179,8 +1179,10 @@ function preLoadCss(cssUrl) {
 
     onEachLazy(document.querySelectorAll(".toggle > summary:not(.hideme)"), el => {
         // @ts-expect-error
+        // Clicking on the summary's contents should not collapse it,
+        // but links within should still fire.
         el.addEventListener("click", e => {
-            if (e.target.tagName !== "SUMMARY" && e.target.tagName !== "A") {
+            if (!e.target.matches("summary, a, a *")) {
                 e.preventDefault();
             }
         });

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -1,5 +1,4 @@
 // Checks that individual trait impls can only be collapsed via clicking directly on the summary element
-include: "utils.goml"
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -13,7 +13,7 @@ click: "summary:has(#trait-impl-link-in-summary) > .impl"
 assert-window-property: ({"pageYOffset": "0"})
 
 // But links should still work
-click: "#trait-impl-link-in-summary"
+click: "summary:has(#trait-impl-link-in-summary) a:has(#trait-impl-link-in-summary)"
 assert-window-property-false: ({"pageYOffset": "0"})
 
 // As well as clicks on elements within links

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -6,17 +6,21 @@ assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 // Collapse the trait impl doc. The actual clickable area is outside the element, hence offset.
 click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
 assert-attribute-false: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // Clicks on the text should be ignored
 click: "summary:has(#trait-impl-link-in-summary) > .impl"
-assert-window-property: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // But links should still work
 click: "summary:has(#trait-impl-link-in-summary) a:has(#trait-impl-link-in-summary)"
 assert-window-property-false: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // As well as clicks on elements within links
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 assert-window-property: ({"pageYOffset": "0"})
 click: "#trait-impl-link-in-summary"
 assert-window-property-false: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -1,0 +1,23 @@
+// Checks that individual trait impls can only be collapsed via clicking directly on the summary element
+include: "utils.goml"
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+
+// Collapse the trait impl doc. The actual clickable area is outside the element, hence offset.
+click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
+assert-attribute-false: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+
+// Clicks on the text should be ignored
+click: "summary:has(#trait-impl-link-in-summary) > .impl"
+assert-window-property: ({"pageYOffset": "0"})
+
+// But links should still work
+click: "#trait-impl-link-in-summary"
+assert-window-property-false: ({"pageYOffset": "0"})
+
+// As well as clicks on elements within links
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+assert-window-property: ({"pageYOffset": "0"})
+click: "#trait-impl-link-in-summary"
+assert-window-property-false: ({"pageYOffset": "0"})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -79,6 +79,7 @@ impl Foo {
     pub fn warning2() {}
 }
 
+/// <a href="#implementations"><code id="trait-impl-link-in-summary">A collapsible trait impl with a link</code></a>
 impl AsRef<str> for Foo {
     fn as_ref(&self) -> &str {
         "hello"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes #140857