### PR TITLE
Don't lint against named labels in `naked_asm!`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2849,7 +2849,7 @@ impl InlineAsmOperand {
     }
 }
 
-#[derive(Clone, Copy, Encodable, Decodable, Debug, HashStable_Generic, Walkable)]
+#[derive(Clone, Copy, Encodable, Decodable, Debug, HashStable_Generic, Walkable, PartialEq, Eq)]
 pub enum AsmMacro {
     /// The `asm!` macro
     Asm,

--- a/tests/ui/asm/named-asm-labels.stderr
+++ b/tests/ui/asm/named-asm-labels.stderr
@@ -475,16 +475,7 @@ LL |         #[warn(named_asm_labels)]
    |                ^^^^^^^^^^^^^^^^
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:178:17
-   |
-LL |     naked_asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1)
-   |                 ^^^^^
-   |
-   = help: only local labels of the form `<number>:` should be used in inline asm
-   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
-
-error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:185:20
+  --> $DIR/named-asm-labels.rs:183:20
    |
 LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
    |                    ^^^^^
@@ -493,25 +484,16 @@ LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noret
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:193:17
+  --> $DIR/named-asm-labels.rs:201:17
    |
-LL |     naked_asm!(".Laaa: nop; ret;")
+LL |     naked_asm!(".Lccc: nop; ret;")
    |                 ^^^^^
    |
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:203:21
-   |
-LL |         naked_asm!(".Lbbb: nop; ret;")
-   |                     ^^^^^
-   |
-   = help: only local labels of the form `<number>:` should be used in inline asm
-   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
-
-error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:212:15
+  --> $DIR/named-asm-labels.rs:221:15
    |
 LL |         asm!("closure1: nop");
    |               ^^^^^^^^
@@ -520,7 +502,7 @@ LL |         asm!("closure1: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:216:15
+  --> $DIR/named-asm-labels.rs:225:15
    |
 LL |         asm!("closure2: nop");
    |               ^^^^^^^^
@@ -529,7 +511,7 @@ LL |         asm!("closure2: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:226:19
+  --> $DIR/named-asm-labels.rs:235:19
    |
 LL |             asm!("closure3: nop");
    |                   ^^^^^^^^
@@ -537,5 +519,14 @@ LL |             asm!("closure3: nop");
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
-error: aborting due to 56 previous errors; 1 warning emitted
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:246:21
+   |
+LL |         naked_asm!(".Lbbb: nop; ret;")
+   |                     ^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: aborting due to 55 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Naked functions are allowed to define global labels, just like `global_asm!`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
