### PR TITLE
1.87.0 release notes: remove nonsensical `~` operator

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ Version 1.87.0 (2025-05-15)
 Language
 --------
 - [Stabilize `asm_goto` feature](https://github.com/rust-lang/rust/pull/133870)
-- [Allow parsing open beginning ranges (`..EXPR`) after unary operators `!`, `-`, and `*`}](https://github.com/rust-lang/rust/pull/134900).
+- [Allow parsing open beginning ranges (`..EXPR`) after unary operators `!`, `-`, and `*`](https://github.com/rust-lang/rust/pull/134900).
 - [Don't require method impls for methods with `Self: Sized` bounds in `impl`s for unsized types](https://github.com/rust-lang/rust/pull/135480)
 - [Stabilize `feature(precise_capturing_in_traits)` allowing `use<...>` bounds on return position `impl Trait` in `trait`s](https://github.com/rust-lang/rust/pull/138128)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@ Version 1.87.0 (2025-05-15)
 Language
 --------
 - [Stabilize `asm_goto` feature](https://github.com/rust-lang/rust/pull/133870)
-- [Allow parsing open beginning ranges (`..EXPR`) after unary operators `!`, `~`, `-`, and `*`}](https://github.com/rust-lang/rust/pull/134900).
+- [Allow parsing open beginning ranges (`..EXPR`) after unary operators `!`, `-`, and `*`}](https://github.com/rust-lang/rust/pull/134900).
 - [Don't require method impls for methods with `Self: Sized` bounds in `impl`s for unsized types](https://github.com/rust-lang/rust/pull/135480)
 - [Stabilize `feature(precise_capturing_in_traits)` allowing `use<...>` bounds on return position `impl Trait` in `trait`s](https://github.com/rust-lang/rust/pull/138128)
 


### PR DESCRIPTION
There is no `~` unary prefix operator, and it definitely shouldn't be in the release notes for a feature whose introducing PR doesn't test for it (because it doesn't exist).  Also fix an unnecessary `}` on the same line.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @pietroalbini 