### PR TITLE
Make the assertion in `Ident::new` debug-only.

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2352,7 +2352,7 @@ impl Ident {
     #[inline]
     /// Constructs a new identifier from a symbol and a span.
     pub fn new(name: Symbol, span: Span) -> Ident {
-        assert_ne!(name, kw::Empty);
+        debug_assert_ne!(name, kw::Empty);
         Ident { name, span }
     }
 


### PR DESCRIPTION
This fixes a perf regression introduced in #140252.

r? @oli-obk