### PR TITLE
Split duration_constructors to get non-controversial constructors out

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -373,7 +373,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_constructors)]
+    /// #![feature(duration_constructors_lite)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::from_hours(6);
@@ -381,7 +381,7 @@ impl Duration {
     /// assert_eq!(6 * 60 * 60, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_constructors", issue = "120301")]
+    #[unstable(feature = "duration_constructors_lite", issue = "140881")]
     #[must_use]
     #[inline]
     pub const fn from_hours(hours: u64) -> Duration {
@@ -401,7 +401,7 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_constructors)]
+    /// #![feature(duration_constructors_lite)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::from_mins(10);
@@ -409,7 +409,7 @@ impl Duration {
     /// assert_eq!(10 * 60, duration.as_secs());
     /// assert_eq!(0, duration.subsec_nanos());
     /// ```
-    #[unstable(feature = "duration_constructors", issue = "120301")]
+    #[unstable(feature = "duration_constructors_lite", issue = "140881")]
     #[must_use]
     #[inline]
     pub const fn from_mins(mins: u64) -> Duration {

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -24,6 +24,7 @@
 #![feature(dec2flt)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]
+#![feature(duration_constructors_lite)]
 #![feature(error_generic_member_access)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]

--- a/library/coretests/tests/time.rs
+++ b/library/coretests/tests/time.rs
@@ -46,16 +46,25 @@ fn from_weeks_overflow() {
 }
 
 #[test]
-fn constructors() {
+fn constructor_weeks() {
     assert_eq!(Duration::from_weeks(1), Duration::from_secs(7 * 24 * 60 * 60));
     assert_eq!(Duration::from_weeks(0), Duration::ZERO);
+}
 
+#[test]
+fn constructor_days() {
     assert_eq!(Duration::from_days(1), Duration::from_secs(86_400));
     assert_eq!(Duration::from_days(0), Duration::ZERO);
+}
 
+#[test]
+fn constructor_hours() {
     assert_eq!(Duration::from_hours(1), Duration::from_secs(3_600));
     assert_eq!(Duration::from_hours(0), Duration::ZERO);
+}
 
+#[test]
+fn constructor_minutes() {
     assert_eq!(Duration::from_mins(1), Duration::from_secs(60));
     assert_eq!(Duration::from_mins(0), Duration::ZERO);
 }

--- a/src/doc/unstable-book/src/library-features/duration-constructors-lite.md
+++ b/src/doc/unstable-book/src/library-features/duration-constructors-lite.md
@@ -1,0 +1,11 @@
+# `duration_constructors_lite`
+
+The tracking issue for this feature is: [#140881]
+
+[#140881]: https://github.com/rust-lang/rust/issues/140881
+
+------------------------
+
+Add the methods `from_mins`, `from_hours` to `Duration`.
+
+For `from_days` and `from_weeks` see [`duration_constructors`](https://github.com/rust-lang/rust/issues/120301).

--- a/src/doc/unstable-book/src/library-features/duration-constructors.md
+++ b/src/doc/unstable-book/src/library-features/duration-constructors.md
@@ -6,4 +6,5 @@ The tracking issue for this feature is: [#120301]
 
 ------------------------
 
-Add the methods `from_mins`, `from_hours` and `from_days` to `Duration`.
+Add the methods `from_days` and `from_weeks` to `Duration`.
+For `from_mins` and `from_hours` see [duration-constructors-lite.md](./duration-constructors-lite.md)

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -5789,7 +5789,7 @@ The tracking issue for this feature is: [#120301]
 
 ------------------------
 
-Add the methods `from_mins`, `from_hours` and `from_days` to `Duration`.
+Add the methods `from_days` and `from_weeks` to `Duration`.
 "##,
         default_severity: Severity::Allow,
         warn_since: None,


### PR DESCRIPTION
This implements #140881  

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
