### PR TITLE
Make check-cfg diagnostics work in `#[doc(cfg(..))]`

### DIFF
--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 use crate::context::{EarlyContext, LintContext, LintStore};
 use crate::passes::{EarlyLintPass, EarlyLintPassObject};
 
-mod diagnostics;
+pub(super) mod diagnostics;
 
 macro_rules! lint_callback { ($cx:expr, $f:ident, $($args:expr),*) => ({
     $cx.pass.$f(&$cx.context, $($args),*);
@@ -40,7 +40,7 @@ impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
         for early_lint in self.context.buffered.take(id) {
             let BufferedEarlyLint { span, node_id: _, lint_id, diagnostic } = early_lint;
             self.context.opt_span_lint(lint_id.lint, span, |diag| {
-                diagnostics::decorate_lint(self.context.sess(), self.tcx, diagnostic, diag);
+                diagnostics::decorate_builtin_lint(self.context.sess(), self.tcx, diagnostic, diag);
             });
         }
     }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -18,7 +18,7 @@ use crate::lints::{self, ElidedNamedLifetime};
 
 mod check_cfg;
 
-pub(super) fn decorate_lint(
+pub fn decorate_builtin_lint(
     sess: &Session,
     tcx: Option<TyCtxt<'_>>,
     diagnostic: BuiltinLintDiag,

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -126,6 +126,7 @@ use unused::*;
 #[rustfmt::skip]
 pub use builtin::{MissingDoc, SoftLints};
 pub use context::{CheckLintNameResult, EarlyContext, LateContext, LintContext, LintStore};
+pub use early::diagnostics::decorate_builtin_lint;
 pub use early::{EarlyCheckNode, check_ast_node};
 pub use late::{check_crate, late_lint_mod, unerased_lint_store};
 pub use levels::LintLevelsBuilder;

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -409,12 +409,12 @@ pub(crate) fn merge_attrs(
             } else {
                 Attributes::from_hir(&both)
             },
-            extract_cfg_from_attrs(both.iter(), cx.tcx, &cx.cache.hidden_cfg),
+            extract_cfg_from_attrs(both.iter(), cx.tcx, None, &cx.cache.hidden_cfg),
         )
     } else {
         (
             Attributes::from_hir(old_attrs),
-            extract_cfg_from_attrs(old_attrs.iter(), cx.tcx, &cx.cache.hidden_cfg),
+            extract_cfg_from_attrs(old_attrs.iter(), cx.tcx, None, &cx.cache.hidden_cfg),
         )
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -210,6 +210,7 @@ fn generate_item_with_correct_attrs(
             Cow::Owned(attr) => attr,
         }),
         cx.tcx,
+        def_id.as_local().map(|did| cx.tcx.local_def_id_to_hir_id(did)),
         &cx.cache.hidden_cfg,
     );
     let attrs = Attributes::from_hir_iter(attrs.iter().map(|(attr, did)| (&**attr, *did)), false);

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -12,8 +12,9 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::{BodyId, Mutability};
+use rustc_hir::{BodyId, HirId, Mutability};
 use rustc_index::IndexVec;
+use rustc_lint_defs::{BuiltinLintDiag, Lint};
 use rustc_metadata::rendered_const;
 use rustc_middle::span_bug;
 use rustc_middle::ty::fast_reject::SimplifiedType;
@@ -477,7 +478,12 @@ impl Item {
             name,
             kind,
             Attributes::from_hir(hir_attrs),
-            extract_cfg_from_attrs(hir_attrs.iter(), cx.tcx, &cx.cache.hidden_cfg),
+            extract_cfg_from_attrs(
+                hir_attrs.iter(),
+                cx.tcx,
+                def_id.as_local().map(|did| cx.tcx.local_def_id_to_hir_id(did)),
+                &cx.cache.hidden_cfg,
+            ),
         )
     }
 
@@ -1033,6 +1039,7 @@ pub(crate) fn hir_attr_lists<'a, I: IntoIterator<Item = &'a hir::Attribute>>(
 pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> + Clone>(
     attrs: I,
     tcx: TyCtxt<'_>,
+    hir_id: Option<HirId>,
     hidden_cfg: &FxHashSet<Cfg>,
 ) -> Option<Arc<Cfg>> {
     let doc_cfg_active = tcx.features().doc_cfg();
@@ -1056,6 +1063,32 @@ pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> 
             .peekable();
         if doc_cfg.peek().is_some() && doc_cfg_active {
             let sess = tcx.sess;
+
+            struct RustdocCfgMatchesLintEmitter<'a>(TyCtxt<'a>, Option<HirId>);
+
+            impl<'a> rustc_attr_parsing::CfgMatchesLintEmitter for RustdocCfgMatchesLintEmitter<'a> {
+                fn emit_span_lint(
+                    &self,
+                    sess: &Session,
+                    lint: &'static Lint,
+                    sp: rustc_span::Span,
+                    builtin_diag: BuiltinLintDiag,
+                ) {
+                    if let Some(hir_id) = self.1 {
+                        self.0.node_span_lint(lint, hir_id, sp, |diag| {
+                            rustc_lint::decorate_builtin_lint(
+                                sess,
+                                Some(self.0),
+                                builtin_diag,
+                                diag,
+                            )
+                        });
+                    } else {
+                        // No HIR id. Probably in another crate. Don't lint.
+                    }
+                }
+            }
+
             doc_cfg.fold(Cfg::True, |mut cfg, item| {
                 if let Some(cfg_mi) =
                     item.meta_item().and_then(|item| rustc_expand::config::parse_cfg(item, sess))
@@ -1064,7 +1097,7 @@ pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> 
                     rustc_attr_parsing::cfg_matches(
                         cfg_mi,
                         tcx.sess,
-                        rustc_ast::CRATE_NODE_ID,
+                        RustdocCfgMatchesLintEmitter(tcx, hir_id),
                         Some(tcx.features()),
                     );
                     match Cfg::parse(cfg_mi) {

--- a/src/librustdoc/doctest/rust.rs
+++ b/src/librustdoc/doctest/rust.rs
@@ -116,9 +116,12 @@ impl HirCollector<'_> {
         nested: F,
     ) {
         let ast_attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id(def_id));
-        if let Some(ref cfg) =
-            extract_cfg_from_attrs(ast_attrs.iter(), self.tcx, &FxHashSet::default())
-            && !cfg.matches(&self.tcx.sess.psess)
+        if let Some(ref cfg) = extract_cfg_from_attrs(
+            ast_attrs.iter(),
+            self.tcx,
+            Some(self.tcx.local_def_id_to_hir_id(def_id)),
+            &FxHashSet::default(),
+        ) && !cfg.matches(&self.tcx.sess.psess)
         {
             return;
         }

--- a/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
+++ b/tests/rustdoc-ui/doc-cfg-check-cfg.cfg_empty.stderr
@@ -1,0 +1,12 @@
+warning: unexpected `cfg` condition name: `foo`
+  --> $DIR/doc-cfg-check-cfg.rs:13:11
+   |
+LL | #[doc(cfg(foo))]
+   |           ^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(foo)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/rustdoc-ui/doc-cfg-check-cfg.rs
+++ b/tests/rustdoc-ui/doc-cfg-check-cfg.rs
@@ -1,16 +1,21 @@
 // Ensure that `doc(cfg())` respects `check-cfg`
 // Currently not properly working
-#![feature(doc_cfg)]
-#![deny(unexpected_cfgs)]
 
-//@revisions: no_check cfg_empty cfg_foo
+//@ check-pass
+//@ no-auto-check-cfg
+
+//@ revisions: no_check cfg_empty cfg_foo
 //@[cfg_empty] compile-flags: --check-cfg cfg()
 //@[cfg_foo] compile-flags: --check-cfg cfg(foo)
 
-//@[no_check] check-pass
-//@[cfg_empty] check-pass
-//@[cfg_empty] known-bug: #138358
-//@[cfg_foo] check-pass
+#![feature(doc_cfg)]
 
 #[doc(cfg(foo))]
+//[cfg_empty]~^ WARN unexpected `cfg` condition name: `foo`
 pub fn foo() {}
+
+pub mod module {
+    #[allow(unexpected_cfgs)]
+    #[doc(cfg(bar))]
+    pub fn bar() {}
+}

--- a/tests/rustdoc-ui/doc-cfg.rs
+++ b/tests/rustdoc-ui/doc-cfg.rs
@@ -3,7 +3,9 @@
 #[doc(cfg(), cfg(foo, bar))]
 //~^ ERROR
 //~^^ ERROR
-#[doc(cfg(foo), cfg(bar))] // ok!
+#[doc(cfg(foo), cfg(bar))]
+//~^ WARN unexpected `cfg` condition name: `foo`
+//~^^ WARN unexpected `cfg` condition name: `bar`
 #[doc(cfg())] //~ ERROR
 #[doc(cfg(foo, bar))] //~ ERROR
 pub fn foo() {}

--- a/tests/rustdoc-ui/doc-cfg.stderr
+++ b/tests/rustdoc-ui/doc-cfg.stderr
@@ -10,17 +10,37 @@ error: multiple `cfg` predicates are specified
 LL | #[doc(cfg(), cfg(foo, bar))]
    |                       ^^^
 
+warning: unexpected `cfg` condition name: `foo`
+  --> $DIR/doc-cfg.rs:6:11
+   |
+LL | #[doc(cfg(foo), cfg(bar))]
+   |           ^^^
+   |
+   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: to expect this configuration use `--check-cfg=cfg(foo)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `bar`
+  --> $DIR/doc-cfg.rs:6:21
+   |
+LL | #[doc(cfg(foo), cfg(bar))]
+   |                     ^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(bar)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
 error: `cfg` predicate is not specified
-  --> $DIR/doc-cfg.rs:7:7
+  --> $DIR/doc-cfg.rs:9:7
    |
 LL | #[doc(cfg())]
    |       ^^^^^ help: expected syntax is: `cfg(/* predicate */)`
 
 error: multiple `cfg` predicates are specified
-  --> $DIR/doc-cfg.rs:8:16
+  --> $DIR/doc-cfg.rs:10:16
    |
 LL | #[doc(cfg(foo, bar))]
    |                ^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 2 warnings emitted
 


### PR DESCRIPTION
This PR makes it so that the check-cfg `unexpected_cfgs` lint, is correctly emitted in `rustdoc`'s `#[doc(cfg(..))]`.

This is achieved by adding a custom trait to `cfg_matches` (the method that emits the lint) which permits `rustc` and `rustdoc` to each have their way to emitting lints (via buffered lints/AST for `rustc` and via `TyCtxt`/HIR for `rustdoc`).

The reason this is required is because buffered lints operates on the AST but `rustdoc` uses the HIR and by the time `rustdoc` calls `cfg_matches` we are way passed the point where buffered lints have been drain and emitted.

Best reviewed commit by commit.

r? @jieyouxu (for the compiler part)
r? @GuillaumeGomez (for the rustdoc part)
