### PR TITLE
Update miniz_oxide dependency of coverage_dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,7 +234,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.8",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -780,7 +774,7 @@ dependencies = [
  "itertools",
  "leb128",
  "md-5",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "regex",
  "rustc-demangle",
 ]
@@ -1220,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.8",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2256,15 +2250,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"

--- a/src/tools/coverage-dump/Cargo.toml
+++ b/src/tools/coverage-dump/Cargo.toml
@@ -10,6 +10,6 @@ anyhow = "1.0.71"
 itertools = "0.12"
 leb128 = "0.2.5"
 md5 = { package = "md-5" , version = "0.10.5" }
-miniz_oxide = "0.7.1"
+miniz_oxide = "0.8.8"
 regex = "1.8.4"
 rustc-demangle = "0.1.23"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This was the final subproject that depended on ```miniz_oxide``` 0.7.x after the rest were when updating the ```backtrace-rs``` dependency in in #140705. Older versions of ```miniz_oxide``` got hit by a [serious](https://github.com/rust-lang/rust/issues/132636) performance regression in rust 1.82 (which has been worked around in more recent versions of the library) so should really be avoided if possible (granted it only affects compression so not sure if it had much impact in practice here, though there have also been some other performance improvements since .)

This also means no longer having to build two versions of miniz_oxide as everything can now use the same version, and no longer needing to build both ```adler``` and ```adler2```