### PR TITLE
Async drop fix for async_drop_in_place<T> layout for unspecified T

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1924,6 +1924,9 @@ impl<'tcx> TyCtxt<'tcx> {
         def_id: DefId,
         args: GenericArgsRef<'tcx>,
     ) -> Option<&'tcx CoroutineLayout<'tcx>> {
+        if args[0].has_placeholders() || args[0].has_non_region_param() {
+            return None;
+        }
         let instance = InstanceKind::AsyncDropGlue(def_id, Ty::new_coroutine(self, def_id, args));
         self.mir_shims(instance).coroutine_layout_raw()
     }

--- a/tests/ui/async-await/async-drop/open-drop-error.rs
+++ b/tests/ui/async-await/async-drop/open-drop-error.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Zmir-enable-passes=+DataflowConstProp
+//@ edition: 2021
+//@ build-pass
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+use std::mem::ManuallyDrop;
+use std::{
+    future::async_drop_in_place,
+    pin::{pin, Pin},
+};
+fn main() {
+    a(b)
+}
+fn b() {}
+fn a<C>(d: C) {
+    let e = pin!(ManuallyDrop::new(d));
+    let f = unsafe { Pin::map_unchecked_mut(e, |g| &mut **g) };
+    let h = unsafe { async_drop_in_place(f.get_unchecked_mut()) };
+    h;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
https://github.com/rust-lang/rust/issues/126482
https://github.com/rust-lang/rust/issues/140423

    r? oli-obk
-->
<!-- homu-ignore:end -->

Fix for https://github.com/rust-lang/rust/issues/140423.
Layout of `async_drop_in_place<T>::{closure}` is calculated for unspecified T from dataflow_const_prop `try_make_constant`.

@oli-obk, do you think, it may be a better solution to add check like `if !args[0].is_fully_specialized() { return None; }` in `fn async_drop_coroutine_layout`?
And could you, pls, recommend, how to implement `is_fully_specialized()` in a most simple way?