### PR TITLE
Add an issue template for future-incompatible lints

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue_future.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue_future.md
@@ -1,0 +1,54 @@
+---
+name: Future Incompatibility Tracking Issue
+about: A tracking issue for a future-incompatible lint
+title: Tracking Issue for future-incompatibility lint XXX
+labels: C-tracking-issue C-future-incompatibility T-compiler A-lints
+---
+<!--
+Thank you for creating a future-incompatible tracking issue! 📜 These issues
+are for lints that implement a future-incompatible warning.
+
+Remember to add team labels to the tracking issue.
+For something that affects the language, this would be `T-lang`, and for libs
+it would be `T-libs-api`.
+Also check for any `A-` labels to add.
+-->
+
+This is the **tracking issue** for the `YOUR_LINT_NAME_HERE` future-compatibility warning and other related errors. The goal of this page is describe why this change was made and how you can fix code that is affected by it. It also provides a place to ask questions or register a complaint if you feel the change should not be made. For more information on the policy around future-compatibility warnings, see our [breaking change policy guidelines][guidelines].
+
+[guidelines]: https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html
+
+### What is the warning for?
+
+*Describe the conditions that trigger the warning.*
+
+### Why was this change made?
+
+*Explain why this change was made. If there is additional context, like an MCP, link it here.*
+
+### Example
+
+```rust
+// Include an example here.
+```
+
+### Recommendations
+
+*Give some recommendations on how a user can avoid the lint.*
+
+### When will this warning become a hard error?
+
+*If known, describe the future plans. For example, how long you anticipate this being a warning, or if there are other factors that will influence the anticipated closure.*
+
+### Steps
+
+- [ ] Implement the lint
+- [ ] Raise lint level to deny
+- [ ] Make lint report in dependencies
+- [ ] Switch to a hard error
+
+### Implementation history
+
+<!--
+Include a list of all the PRs that were involved in implementing the lint.
+-->

--- a/src/doc/rustc-dev-guide/src/bug-fix-procedure.md
+++ b/src/doc/rustc-dev-guide/src/bug-fix-procedure.md
@@ -80,41 +80,11 @@ approachable and practical; it may make sense to direct users to an RFC or some
 other issue for the full details. The issue also serves as a place where users
 can comment with questions or other concerns.
 
-A template for these breaking-change tracking issues can be found below. An
-example of how such an issue should look can be [found
+A template for these breaking-change tracking issues can be found
+[here][template]. An example of how such an issue should look can be [found
 here][breaking-change-issue].
 
-The issue should be tagged with (at least) `B-unstable` and `T-compiler`.
-
-### Tracking issue template
-
-This is a template to use for tracking issues:
-
-```
-This is the **summary issue** for the `YOUR_LINT_NAME_HERE`
-future-compatibility warning and other related errors. The goal of
-this page is describe why this change was made and how you can fix
-code that is affected by it. It also provides a place to ask questions
-or register a complaint if you feel the change should not be made. For
-more information on the policy around future-compatibility warnings,
-see our [breaking change policy guidelines][guidelines].
-
-[guidelines]: LINK_TO_THIS_RFC
-
-#### What is the warning for?
-
-*Describe the conditions that trigger the warning and how they can be
-fixed. Also explain why the change was made.**
-
-#### When will this warning become a hard error?
-
-At the beginning of each 6-week release cycle, the Rust compiler team
-will review the set of outstanding future compatibility warnings and
-nominate some of them for **Final Comment Period**. Toward the end of
-the cycle, we will review any comments and make a final determination
-whether to convert the warning into a hard error or remove it
-entirely.
-```
+[template]: https://github.com/rust-lang/rust/issues/new?template=tracking_issue_future.md
 
 ### Issuing future compatibility warnings
 


### PR DESCRIPTION
This adds a GitHub issue template for future-incompatible lints. Most of the existing tracking issues have been using different formats with different information, and I think it would be helpful to make them a little more consistent and to ensure that sufficient information is provided.

Some comments on my choices:
* Added a dedicated section to describe *why* the change is being made. Many existing issues already have this, so let's standardize on it.
* Have a section with a very clear example. Almost all of the existing issues have this in one form or another.
* Added a "Recommendations" section, since this is something I see missing in several of the existing issues, and this is really important information IMHO.
* I reworded the "When" section. The existing template mentioned that these get reviewed every 6 weeks which my understanding is not true. That's also not very helpful information to the user, since it doesn't really answer the question. I'm not sure this section will actually be useful since I suspect most of the time we don't know when it will change (there have been a few exceptions).
* Clearly show the expected progression steps. Several issues already have this.
* Added implementation history, which is useful for linking PRs. (IDK, this could get merged with "Steps".)

