### PR TITLE
Remove `stable` attribute from wasi fs (read_exact|write_all)_at

### DIFF
--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -72,7 +72,6 @@ pub trait FileExt {
     /// If this function returns an error, it is unspecified how many bytes it
     /// has read, but it will never read more than would be necessary to
     /// completely fill the buffer.
-    #[stable(feature = "rw_exact_all_at", since = "1.33.0")]
     fn read_exact_at(&self, mut buf: &mut [u8], mut offset: u64) -> io::Result<()> {
         while !buf.is_empty() {
             match self.read_at(buf, offset) {
@@ -144,7 +143,6 @@ pub trait FileExt {
     /// non-[`io::ErrorKind::Interrupted`] kind that [`write_at`] returns.
     ///
     /// [`write_at`]: FileExt::write_at
-    #[stable(feature = "rw_exact_all_at", since = "1.33.0")]
     fn write_all_at(&self, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
         while !buf.is_empty() {
             match self.write_at(buf, offset) {


### PR DESCRIPTION
The docs for [`std::os::wasi::fs::FileExt::read_exact_at`](https://doc.rust-lang.org/1.86.0/std/os/wasi/fs/trait.FileExt.html#method.read_exact_at) and [`std::os::wasi::fs::FileExt::write_all_at`](https://doc.rust-lang.org/1.86.0/std/os/wasi/fs/trait.FileExt.html#method.write_all_at) show the methods to be stable since v1.33, which is not correct and was a mistake made when the methods were added in (https://github.com/rust-lang/rust/pull/74076#pullrequestreview-443124667). The reviewer seemed to think this was an insta-stabilization, but the entire file is marked as unstable so that was not right. The stabilization version would also have been wrong either way.