### PR TITLE
docs: fix dead link

### DIFF
--- a/src/doc/rustc-dev-guide/src/traits/unsize.md
+++ b/src/doc/rustc-dev-guide/src/traits/unsize.md
@@ -46,7 +46,7 @@ The rules for the latter implementation are slightly complicated, since they
 may allow more than one parameter to be changed (not necessarily unsized) and
 are best stated in terms of the tail field of the struct.
 
-[`unsized_tuple_coercion`]: https://doc.rust-lang.org/beta/unstable-book/language-features/unsized-tuple-coercion.html
+[`unsized_tuple_coercion`]: https://doc.rust-lang.org/stable/unstable-book/language-features/unsized-tuple-coercion.html
 
 ## Upcasting implementations
 


### PR DESCRIPTION
I have fixed the link to the documentation for unsized_tuple_coercion. Now, instead of the broken link https://doc.rust-lang.org/beta/unstable-book/language-features/unsized-tuple-coercion.html, the current link https://doc.rust-lang.org/stable/unstable-book/language-features/unsized-tuple-coercion.html is used.
