### PR TITLE
Clarify WTF-8 safety docs

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -594,9 +594,9 @@ impl OsString {
     /// The slice must be valid for the platform encoding (as described in
     /// [`OsStr::from_encoded_bytes_unchecked`]).
     ///
-    /// This bypasses the encoding-dependent surrogate joining, so `self` must
-    /// not end with a leading surrogate half and `other` must not start with
-    /// with a trailing surrogate half.
+    /// This bypasses the encoding-dependent surrogate joining, so either
+    /// `self` must not end with a leading surrogate half, or `other` must not
+    /// start with a trailing surrogate half.
     #[inline]
     pub(crate) unsafe fn extend_from_slice_unchecked(&mut self, other: &[u8]) {
         // SAFETY: Guaranteed by caller.

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -215,9 +215,9 @@ impl Buf {
     /// The slice must be valid for the platform encoding (as described in
     /// [`Slice::from_encoded_bytes_unchecked`]).
     ///
-    /// This bypasses the WTF-8 surrogate joining, so `self` must not end with a
-    /// leading surrogate half and `other` must not start with with a trailing
-    /// surrogate half.
+    /// This bypasses the WTF-8 surrogate joining, so either `self` must not
+    /// end with a leading surrogate half, or `other` must not start with a
+    /// trailing surrogate half.
     #[inline]
     pub unsafe fn extend_from_slice_unchecked(&mut self, other: &[u8]) {
         self.inner.extend_from_slice(other);


### PR DESCRIPTION
This PR is a follow-up to PR #140159, which clarifies ~~two things~~:
- the WTF-8 safety comment [was confusing](https://github.com/rust-lang/rust/pull/140159#discussion_r2082766965), either surrogate condition is actually sufficient for safety, both are not required
- ~~the private `os_str::Slice` type name is easily confused with `std::slice`~~

~~Happy to bikeshed the `OsSlice` name, other alternatives are `OsStrSlice` and `StrSlice`. Now it's got a distinct name from `std::slice`, it's easy to search and replace.~~

cc @thaliaarchi @workingjubilee 