### PR TITLE
Use `Arena::alloc_from_iter` to avoid redundant vec allocations

### DIFF
--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -203,9 +203,8 @@ pub(super) fn trait_impls_of_provider(tcx: TyCtxt<'_>, trait_id: DefId) -> Trait
     // Traits defined in the current crate can't have impls in upstream
     // crates, so we don't bother querying the cstore.
     if !trait_id.is_local() {
-        for &cnum in tcx.crates(()).iter() {
-            for &(impl_def_id, simplified_self_ty) in
-                tcx.implementations_of_trait((cnum, trait_id)).iter()
+        for &cnum in tcx.crates(()) {
+            for &(impl_def_id, simplified_self_ty) in tcx.implementations_of_trait((cnum, trait_id))
             {
                 if let Some(simplified_self_ty) = simplified_self_ty {
                     impls

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -34,13 +34,10 @@ fn assumed_wf_types<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx [(Ty<'
         DefKind::AssocFn => {
             let sig = tcx.fn_sig(def_id).instantiate_identity();
             let liberated_sig = tcx.liberate_late_bound_regions(def_id.to_def_id(), sig);
-            let mut assumed_wf_types: Vec<_> =
-                tcx.assumed_wf_types(tcx.local_parent(def_id)).into();
-            assumed_wf_types.extend(itertools::zip_eq(
-                liberated_sig.inputs_and_output,
-                fn_sig_spans(tcx, def_id),
-            ));
-            tcx.arena.alloc_slice(&assumed_wf_types)
+            tcx.arena.alloc_from_iter(iter::chain(
+                tcx.assumed_wf_types(tcx.local_parent(def_id)).iter().copied(),
+                itertools::zip_eq(liberated_sig.inputs_and_output, fn_sig_spans(tcx, def_id)),
+            ))
         }
         DefKind::Impl { .. } => {
             // Trait arguments and the self type for trait impls or only the self type for

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
+#![feature(iter_chain)]
 #![feature(iterator_try_collect)]
 #![feature(never_type)]
 #![feature(rustdoc_internals)]


### PR DESCRIPTION
Doesn't show up on my local perf run, but might improve performance by a bit in certain cases.
(second commit is a small drive-by cleanup)
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
