### PR TITLE
ui/async-drop-initial: factor in panic strategy in destructor size check

### DIFF
--- a/tests/ui/async-await/async-drop/async-drop-initial.rs
+++ b/tests/ui/async-await/async-drop/async-drop-initial.rs
@@ -60,7 +60,10 @@ fn main() {
         let j = 42;
         test_async_drop(&i, 16).await;
         test_async_drop(&j, 16).await;
-        test_async_drop(AsyncStruct { b: AsyncInt(8), a: AsyncInt(7), i: 6 }, 168).await;
+        test_async_drop(
+            AsyncStruct { b: AsyncInt(8), a: AsyncInt(7), i: 6 },
+            if cfg!(panic = "unwind") { 168 } else { 136 },
+        ).await;
         test_async_drop(ManuallyDrop::new(AsyncInt(9)), 16).await;
 
         let foo = AsyncInt(10);


### PR DESCRIPTION
the size of `AsyncStruct`'s destructor depends on whether the configured panic strategy is 'unwind' or 'abort' so factor that into the test using conditional compilation

fixes rust-lang/rust#140939
fixes rust-lang/rust#140493

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
