### PR TITLE
More option optimization tests

### DIFF
--- a/tests/codegen/option-niche-eq.rs
+++ b/tests/codegen/option-niche-eq.rs
@@ -24,6 +24,18 @@ pub fn non_zero_signed_eq(l: Option<NonZero<i64>>, r: Option<NonZero<i64>>) -> b
     l == r
 }
 
+// Test for #49892
+// This currently relies on a manual implementation of `PartialOrd`/`Ord` for `Option`
+// Once LLVM is better able to optimize this pattern, we can return to using a derive.
+// CHECK-LABEL: @non_zero_ord
+#[no_mangle]
+pub fn non_zero_ord(a: Option<NonZero<u32>>, b: Option<NonZero<u32>>) -> bool {
+    // CHECK: start:
+    // CHECK-NEXT: icmp ult i32
+    // CHECK-NEXT: ret i1
+    a < b
+}
+
 // CHECK-LABEL: @non_null_eq
 #[no_mangle]
 pub fn non_null_eq(l: Option<NonNull<u8>>, r: Option<NonNull<u8>>) -> bool {

--- a/tests/codegen/option-niche-eq.rs
+++ b/tests/codegen/option-niche-eq.rs
@@ -1,3 +1,4 @@
+//@ min-llvm-version: 20
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 #![crate_type = "lib"]
 
@@ -24,7 +25,7 @@ pub fn non_zero_signed_eq(l: Option<NonZero<i64>>, r: Option<NonZero<i64>>) -> b
     l == r
 }
 
-// Test for #49892
+// FIXME(#49892)
 // This currently relies on a manual implementation of `PartialOrd`/`Ord` for `Option`
 // Once LLVM is better able to optimize this pattern, we can return to using a derive.
 // CHECK-LABEL: @non_zero_ord
@@ -73,13 +74,3 @@ pub fn niche_eq(l: Option<EnumWithNiche>, r: Option<EnumWithNiche>) -> bool {
     // CHECK-NEXT: ret i1
     l == r
 }
-
-// FIXME: This should work too
-// // FIXME-CHECK-LABEL: @bool_eq
-// #[no_mangle]
-// pub fn bool_eq(l: Option<bool>, r: Option<bool>) -> bool {
-//     // FIXME-CHECK: start:
-//     // FIXME-CHECK-NEXT: icmp eq i8
-//     // FIXME-CHECK-NEXT: ret i1
-//     l == r
-// }

--- a/tests/codegen/option-niche-unfixed/option-bool-eq.rs
+++ b/tests/codegen/option-niche-unfixed/option-bool-eq.rs
@@ -1,0 +1,15 @@
+//@ should-fail
+//@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
+//! FIXME(#49892)
+//! Tests that LLVM does not fully optimize comparisons of `Option<bool>`.
+//! If this starts passing, it can be moved to `tests/codegen/option-niche-eq.rs`
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @bool_eq
+#[no_mangle]
+pub fn bool_eq(l: Option<bool>, r: Option<bool>) -> bool {
+    // CHECK: start:
+    // CHECK-NEXT: icmp eq i8
+    // CHECK-NEXT: ret i1
+    l == r
+}

--- a/tests/codegen/option-niche-unfixed/option-nonzero-eq.rs
+++ b/tests/codegen/option-niche-unfixed/option-nonzero-eq.rs
@@ -1,0 +1,24 @@
+//@ should-fail
+//@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
+//! FIXME(#49892)
+//! Test that the derived implementation of `PartialEq` for `Option` is not fully
+//! optimized by LLVM. If this starts passing, the test and manual impl should
+//! be removed.
+#![crate_type = "lib"]
+
+use std::num::NonZero;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Option<T> {
+    None,
+    Some(T),
+}
+
+// CHECK-LABEL: @non_zero_eq
+#[no_mangle]
+pub fn non_zero_eq(l: Option<NonZero<u32>>, r: Option<NonZero<u32>>) -> bool {
+    // CHECK: start:
+    // CHECK-NEXT: icmp eq i32
+    // CHECK-NEXT: ret i1
+    l == r
+}


### PR DESCRIPTION
I noticed that although adding a manual implementation for PartialOrd on Option in #122024, I didn't add a test so that we can easily check if this behavior has improved.

This also adds a couple of `should-fail` tests - this will allow us to remove these hacky implementations if upstream LLVM improves.