### PR TITLE
Do not remove `super` keyword from `super let`

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -63,6 +63,11 @@ impl Rewrite for ast::Local {
             return Err(RewriteError::SkipFormatting);
         }
 
+        // FIXME(super_let): Implement formatting
+        if self.super_.is_some() {
+            return Err(RewriteError::SkipFormatting);
+        }
+
         let attrs_str = self.attrs.rewrite_result(context, shape)?;
         let mut result = if attrs_str.is_empty() {
             "let ".to_owned()


### PR DESCRIPTION
This is affecting a macro in the standard library:

https://github.com/rust-lang/rust/blob/bc7512ee6309ee7e8cacf87b94aa6d1f550c9d99/library/core/src/pin.rs#L1945

I added an exception in 6f6a9a585891d0a2d1114a7a621f35f28f39c0d9, but I'd like to remove it eventually, so opening this in-tree to not block this on the next rustfmt sync.

r? @calebcartwright or @ytmimi

