### PR TITLE
Add `#[must_use]` to Array::map

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -531,6 +531,7 @@ impl<T, const N: usize> [T; N] {
     /// let y = x.map(|v| v.len());
     /// assert_eq!(y, [6, 9, 3, 3]);
     /// ```
+    #[must_use]
     #[stable(feature = "array_map", since = "1.55.0")]
     pub fn map<F, U>(self, f: F) -> [U; N]
     where

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -325,7 +325,7 @@ fn array_map_drop_safety() {
     let success = std::panic::catch_unwind(|| {
         let items = [0; 10];
         let mut nth = 0;
-        items.map(|_| {
+        let _ = items.map(|_| {
             assert!(nth < num_to_create);
             nth += 1;
             DropCounter


### PR DESCRIPTION
The output of Array::map is intended to be an array of the same size, and does not modify the original in place nor is it intended for side-effects. Thus, under normal circumstances it should be consumed.

See [discussion](https://internals.rust-lang.org/t/array-map-annotate-with-must-use/22813/26).

Attaching to tracking issue #75243