### PR TITLE
Async drop poll shim for error dropee generates noop body

### DIFF
--- a/tests/ui/async-await/async-drop/open-drop-error2.rs
+++ b/tests/ui/async-await/async-drop/open-drop-error2.rs
@@ -1,0 +1,21 @@
+//@compile-flags: -Zvalidate-mir -Zinline-mir=yes --crate-type=lib
+
+#![feature(async_drop)]
+#![allow(incomplete_features)]
+
+use std::{
+    future::{Future, async_drop_in_place},
+    pin::pin,
+    task::Context,
+};
+
+fn wrong() -> impl Sized {
+    //~^ ERROR: the size for values of type `str` cannot be known at compilation time
+    *"abc" // Doesn't implement Sized
+}
+fn weird(context: &mut Context<'_>) {
+    let mut e = wrong();
+    let h = unsafe { async_drop_in_place(&raw mut e) };
+    let i = pin!(h);
+    i.poll(context);
+}

--- a/tests/ui/async-await/async-drop/open-drop-error2.stderr
+++ b/tests/ui/async-await/async-drop/open-drop-error2.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/open-drop-error2.rs:12:15
+   |
+LL | fn wrong() -> impl Sized {
+   |               ^^^^^^^^^^ doesn't have a size known at compile-time
+LL |
+LL |     *"abc" // Doesn't implement Sized
+   |     ------ return type was inferred to be `str` here
+   |
+   = help: the trait `Sized` is not implemented for `str`
+help: references are always `Sized`, even if they point to unsized data; consider not dereferencing the expression
+   |
+LL -     *"abc" // Doesn't implement Sized
+LL +     "abc" // Doesn't implement Sized
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/140930.

<!-- homu-ignore:start -->
<!--
    https://github.com/rust-lang/rust/issues/126482

    r? oli-obk
-->
<!-- homu-ignore:end -->

When dropee type for async drop poll shim is `ty::Error(_)`, the generated poll function will be noop body. To avoid ICE in `elaborate_drop`.