### PR TITLE
[win] Use a dash instead of slash for linker to avoid breaking lld

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_pc_windows_msvc.rs
@@ -14,7 +14,7 @@ pub(crate) fn target() -> Target {
     // MSVC emits a warning about code that may trip "Cortex-A53 MPCore processor bug #843419" (see
     // https://developer.arm.com/documentation/epm048406/latest) which is sometimes emitted by LLVM.
     // Since Arm64 Windows 10+ isn't supported on that processor, it's safe to disable the warning.
-    base.add_pre_link_args(LinkerFlavor::Msvc(Lld::No), &["/arm64hazardfree"]);
+    base.add_pre_link_args(LinkerFlavor::Msvc(Lld::No), &["-arm64hazardfree"]);
 
     Target {
         llvm_target: "aarch64-pc-windows-msvc".into(),


### PR DESCRIPTION
#140758 added the `/arm64hazardfree` linker arg for aarch64-pc-windows-msvc, unfortunately this breaks linking with `lld` as it 1) doesn't understand the arguments and 2) assumes that unknown args that start with `/` are input files.

Fix is to use a dash for the arg: `-arm64hazardfree`

r? @wesleywiser 