### PR TITLE
trait_sel: deep reject `match_normalize_trait_ref`

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -52,6 +52,7 @@ pub use rustc_session::lint::RegisteredTools;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::{DUMMY_SP, ExpnId, ExpnKind, Ident, Span, Symbol, kw, sym};
 pub use rustc_type_ir::data_structures::{DelayedMap, DelayedSet};
+pub use rustc_type_ir::fast_reject::DeepRejectCtxt;
 #[allow(
     hidden_glob_reexports,
     rustc::usage_of_type_ir_inherent,

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -232,6 +232,9 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
     }
 
     pub fn types_may_unify(self, lhs: I::Ty, rhs: I::Ty) -> bool {
+        if lhs == rhs {
+            return true;
+        }
         self.types_may_unify_inner(lhs, rhs, Self::STARTING_DEPTH)
     }
 


### PR DESCRIPTION
Spotted during an in-person review of #137944 at RustWeek: `match_normalize_trait_ref` could be using `DeepRejectCtxt` to exit early as an optimisation for projection candidates, like is done with param candidates.

r? @lcnr
cc @oli-obk 