### PR TITLE
Add match guard let chain drop order and scoping tests

### DIFF
--- a/tests/ui/drop/drop-order-comparisons.e2021.fixed
+++ b/tests/ui/drop/drop-order-comparisons.e2021.fixed
@@ -24,6 +24,7 @@
 //@ [e2024] edition: 2024
 //@ run-pass
 
+#![feature(if_let_guard)]
 #![cfg_attr(e2021, feature(let_chains))]
 #![cfg_attr(e2021, warn(rust_2024_compatibility))]
 
@@ -344,6 +345,25 @@ fn t_if_let_chains_then() {
     e.assert(9);
 }
 
+#[rustfmt::skip]
+fn t_guard_if_let_chains_then() {
+    let e = Events::new();
+    _ = match () {
+        () if e.ok(1).is_ok()
+            && let true = e.ok(9).is_ok()
+            && let Ok(_v) = e.ok(8)
+            && let Ok(_) = e.ok(7)
+            && let Ok(_) = e.ok(6).as_ref()
+            && e.ok(2).is_ok()
+            && let Ok(_v) = e.ok(5)
+            && let Ok(_) = e.ok(4).as_ref() => {
+                e.mark(3);
+            }
+        _ => {}
+    };
+    e.assert(9);
+}
+
 #[cfg(e2021)]
 #[rustfmt::skip]
 fn t_if_let_nested_else() {
@@ -484,6 +504,25 @@ fn t_if_let_chains_then_else() {
     e.assert(9);
 }
 
+#[rustfmt::skip]
+fn t_guard_if_let_chains_then_else() {
+    let e = Events::new();
+    _ = match () {
+       () if e.ok(1).is_ok()
+            && let true = e.ok(8).is_ok()
+            && let Ok(_v) = e.ok(7)
+            && let Ok(_) = e.ok(6)
+            && let Ok(_) = e.ok(5).as_ref()
+            && e.ok(2).is_ok()
+            && let Ok(_v) = e.ok(4)
+            && let Ok(_) = e.err(3) => {}
+        _ => {
+            e.mark(9);
+        }
+    };
+    e.assert(9);
+}
+
 fn main() {
     t_bindings();
     t_tuples();
@@ -502,10 +541,12 @@ fn main() {
     t_if_let_nested_then();
     t_let_else_chained_then();
     t_if_let_chains_then();
+    t_guard_if_let_chains_then();
     t_if_let_nested_else();
     t_if_let_nested_then_else();
     t_let_else_chained_then_else();
     t_if_let_chains_then_else();
+    t_guard_if_let_chains_then_else();
 }
 
 // # Test scaffolding

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -1,5 +1,5 @@
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:76:9
+  --> $DIR/drop-order-comparisons.rs:77:9
    |
 LL |       _ = ({
    |  _________-
@@ -29,35 +29,35 @@ LL | |     }, e.mark(3), e.ok(4));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#3` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_v` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
-  --> $DIR/drop-order-comparisons.rs:28:25
+  --> $DIR/drop-order-comparisons.rs:29:25
    |
 LL | #![cfg_attr(e2021, warn(rust_2024_compatibility))]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(tail_expr_drop_order)]` implied by `#[warn(rust_2024_compatibility)]`
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:100:45
+  --> $DIR/drop-order-comparisons.rs:101:45
    |
 LL |       _ = ({
    |  _________-
@@ -77,19 +77,19 @@ LL | |     }, e.mark(1), e.ok(4));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:100:19
+  --> $DIR/drop-order-comparisons.rs:101:19
    |
 LL |       _ = ({
    |  _________-
@@ -109,19 +109,19 @@ LL | |     }, e.mark(1), e.ok(4));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:221:24
+  --> $DIR/drop-order-comparisons.rs:222:24
    |
 LL |       _ = ({
    |  _________-
@@ -141,19 +141,19 @@ LL | |     }, e.mark(2), e.ok(3));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:247:24
+  --> $DIR/drop-order-comparisons.rs:248:24
    |
 LL |       _ = ({
    |  _________-
@@ -173,19 +173,19 @@ LL | |     }, e.mark(2), e.ok(3));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:123:13
+  --> $DIR/drop-order-comparisons.rs:124:13
    |
 LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |             ^^^^^^^^^^^^-------^^^^^^^^^
@@ -195,12 +195,12 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:127:5
+  --> $DIR/drop-order-comparisons.rs:128:5
    |
 LL |     }, e.mark(2), e.ok(3));
    |     ^
@@ -215,7 +215,7 @@ LL ~     } _ => {}}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:145:13
+  --> $DIR/drop-order-comparisons.rs:146:13
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |             ^^^^^^^^^^^^--------^^^^^^^^^
@@ -225,12 +225,12 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:145:44
+  --> $DIR/drop-order-comparisons.rs:146:44
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                                            ^
@@ -244,7 +244,7 @@ LL ~     }}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:247:12
+  --> $DIR/drop-order-comparisons.rs:248:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -254,12 +254,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:247:43
+  --> $DIR/drop-order-comparisons.rs:248:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^
@@ -273,7 +273,7 @@ LL ~         }}
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:352:12
+  --> $DIR/drop-order-comparisons.rs:372:12
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |            ^^^^^^^^^^^--------^^^^^^^^
@@ -283,12 +283,12 @@ LL |         if let true = e.err(9).is_ok() {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:352:41
+  --> $DIR/drop-order-comparisons.rs:372:41
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |                                         ^
@@ -302,7 +302,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:355:12
+  --> $DIR/drop-order-comparisons.rs:375:12
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -312,12 +312,12 @@ LL |         if let Ok(_v) = e.err(8) {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:355:35
+  --> $DIR/drop-order-comparisons.rs:375:35
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |                                   ^
@@ -331,7 +331,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:358:12
+  --> $DIR/drop-order-comparisons.rs:378:12
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |            ^^^^^^^^^^^^--------
@@ -341,12 +341,12 @@ LL |         if let Ok(_) = e.err(7) {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:358:34
+  --> $DIR/drop-order-comparisons.rs:378:34
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |                                  ^
@@ -360,7 +360,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:361:12
+  --> $DIR/drop-order-comparisons.rs:381:12
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -370,12 +370,12 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:361:43
+  --> $DIR/drop-order-comparisons.rs:381:43
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                                           ^
@@ -389,7 +389,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:365:12
+  --> $DIR/drop-order-comparisons.rs:385:12
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -399,12 +399,12 @@ LL |         if let Ok(_v) = e.err(5) {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:365:35
+  --> $DIR/drop-order-comparisons.rs:385:35
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |                                   ^
@@ -418,7 +418,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:368:12
+  --> $DIR/drop-order-comparisons.rs:388:12
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |            ^^^^^^^^^^^^--------
@@ -428,12 +428,12 @@ LL |         if let Ok(_) = e.err(4) {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:368:34
+  --> $DIR/drop-order-comparisons.rs:388:34
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |                                  ^
@@ -447,7 +447,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:404:12
+  --> $DIR/drop-order-comparisons.rs:424:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -457,12 +457,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:571:1
+  --> $DIR/drop-order-comparisons.rs:612:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:404:43
+  --> $DIR/drop-order-comparisons.rs:424:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^

--- a/tests/ui/drop/drop-order-comparisons.rs
+++ b/tests/ui/drop/drop-order-comparisons.rs
@@ -24,6 +24,7 @@
 //@ [e2024] edition: 2024
 //@ run-pass
 
+#![feature(if_let_guard)]
 #![cfg_attr(e2021, feature(let_chains))]
 #![cfg_attr(e2021, warn(rust_2024_compatibility))]
 
@@ -344,6 +345,25 @@ fn t_if_let_chains_then() {
     e.assert(9);
 }
 
+#[rustfmt::skip]
+fn t_guard_if_let_chains_then() {
+    let e = Events::new();
+    _ = match () {
+        () if e.ok(1).is_ok()
+            && let true = e.ok(9).is_ok()
+            && let Ok(_v) = e.ok(8)
+            && let Ok(_) = e.ok(7)
+            && let Ok(_) = e.ok(6).as_ref()
+            && e.ok(2).is_ok()
+            && let Ok(_v) = e.ok(5)
+            && let Ok(_) = e.ok(4).as_ref() => {
+                e.mark(3);
+            }
+        _ => {}
+    };
+    e.assert(9);
+}
+
 #[cfg(e2021)]
 #[rustfmt::skip]
 fn t_if_let_nested_else() {
@@ -484,6 +504,25 @@ fn t_if_let_chains_then_else() {
     e.assert(9);
 }
 
+#[rustfmt::skip]
+fn t_guard_if_let_chains_then_else() {
+    let e = Events::new();
+    _ = match () {
+       () if e.ok(1).is_ok()
+            && let true = e.ok(8).is_ok()
+            && let Ok(_v) = e.ok(7)
+            && let Ok(_) = e.ok(6)
+            && let Ok(_) = e.ok(5).as_ref()
+            && e.ok(2).is_ok()
+            && let Ok(_v) = e.ok(4)
+            && let Ok(_) = e.err(3) => {}
+        _ => {
+            e.mark(9);
+        }
+    };
+    e.assert(9);
+}
+
 fn main() {
     t_bindings();
     t_tuples();
@@ -502,10 +541,12 @@ fn main() {
     t_if_let_nested_then();
     t_let_else_chained_then();
     t_if_let_chains_then();
+    t_guard_if_let_chains_then();
     t_if_let_nested_else();
     t_if_let_nested_then_else();
     t_let_else_chained_then_else();
     t_if_let_chains_then_else();
+    t_guard_if_let_chains_then_else();
 }
 
 // # Test scaffolding

--- a/tests/ui/mir/mir_match_guard_let_chains_drop_order.rs
+++ b/tests/ui/mir/mir_match_guard_let_chains_drop_order.rs
@@ -1,0 +1,110 @@
+//@ run-pass
+//@ needs-unwind
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+
+// See `mir_drop_order.rs` for more information
+
+#![feature(if_let_guard)]
+#![allow(irrefutable_let_patterns)]
+
+use std::cell::RefCell;
+use std::panic;
+
+pub struct DropLogger<'a, T> {
+    extra: T,
+    id: usize,
+    log: &'a panic::AssertUnwindSafe<RefCell<Vec<usize>>>,
+}
+
+impl<'a, T> Drop for DropLogger<'a, T> {
+    fn drop(&mut self) {
+        self.log.0.borrow_mut().push(self.id);
+    }
+}
+
+struct InjectedFailure;
+
+#[allow(unreachable_code)]
+fn main() {
+    let log = panic::AssertUnwindSafe(RefCell::new(vec![]));
+    let d = |id, extra| DropLogger { extra, id: id, log: &log };
+    let get = || -> Vec<_> {
+        let mut m = log.0.borrow_mut();
+        let n = m.drain(..);
+        n.collect()
+    };
+
+    {
+        let _x = (
+            d(
+                0,
+                d(
+                    1,
+                    match () { () if let Some(_) = d(2, Some(true)).extra
+                        && let DropLogger { .. } = d(3, None) => {
+                            None
+                        }
+                        _ => {
+                            Some(true)
+                        }
+                    }
+                )
+                .extra,
+            ),
+            d(4, None),
+            &d(5, None),
+            d(6, None),
+            match () {
+                () if let DropLogger { .. } = d(7, None)
+                && let DropLogger { .. } = d(8, None) => {
+                    d(9, None)
+                }
+                _ => {
+                    // 10 is not constructed
+                    d(10, None)
+                }
+            },
+        );
+        assert_eq!(get(), vec![3, 2, 8, 7, 1]);
+    }
+    assert_eq!(get(), vec![0, 4, 6, 9, 5]);
+
+    let _ = std::panic::catch_unwind(|| {
+        (
+            d(
+                11,
+                d(
+                    12,
+                    match () {
+                        () if let Some(_) = d(13, Some(true)).extra
+                                && let DropLogger { .. } = d(14, None) => {
+                            None
+                        }
+                        _ => {
+                            Some(true)
+                        }
+                    }
+                )
+                .extra,
+            ),
+            d(15, None),
+            &d(16, None),
+            d(17, None),
+            match () {
+                () if let DropLogger { .. } = d(18, None)
+                    && let DropLogger { .. } = d(19, None)
+                => {
+                    d(20, None)
+                }
+                _ => {
+                    // 10 is not constructed
+                    d(21, None)
+                }
+            },
+            panic::panic_any(InjectedFailure),
+        );
+    });
+    assert_eq!(get(), vec![14, 13, 19, 18, 20, 17, 15, 11, 16, 12]);
+}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/temporary-early-drop.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/temporary-early-drop.rs
@@ -1,0 +1,29 @@
+// issue-103476
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+//@ check-pass
+
+#![feature(if_let_guard)]
+#![allow(irrefutable_let_patterns)]
+
+struct Pd;
+
+impl Pd {
+    fn it(&self) -> It {
+        todo!()
+    }
+}
+
+pub struct It<'a>(Box<dyn Tr<'a>>);
+
+trait Tr<'a> {}
+
+fn f(m: Option<Pd>) {
+    match () {
+        () if let Some(n) = m && let it = n.it() => {}
+        _ => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
We have a bunch of tests for if let chain drop order, but those tests don't cover match guard chains to the same depth. This PR adds the following tests:

* match guard equivalents of the if let chains tests in the `drop-order-comparisons.rs` test, added by  #133605.
* match guard equivalent of the `mir_let_chains_drop_order.rs` test, added by #107251
* match guard equivalent of `temporary-early-drop.rs`, added by #133093

The added tests all have variants for 2021 and 2024, showing that the behavior on both editions matches that of if let chains on 2024.

tracking issue: https://github.com/rust-lang/rust/issues/51114