### PR TITLE
Implement `ptr::is_aligned_for` and `NonNull::is_aligned_for`.

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1438,6 +1438,37 @@ impl<T: ?Sized> *const T {
         self.is_aligned_to(align_of::<T>())
     }
 
+    /// Returns whether the pointer is properly aligned for `U`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(pointer_is_aligned_for)]
+    /// 
+    /// // On some platforms, the alignment of i32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedI32(i32);
+    /// 
+    /// // On some platforms, the alignment of u32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedU32(u32);
+    ///
+    /// let data = AlignedI32(42);
+    /// let ptr = &data as *const AlignedI32;
+    ///
+    /// assert!(ptr.is_aligned_for::<AlignedU32>());
+    /// assert!(!ptr.wrapping_byte_add(1).is_aligned_for::<AlignedU32>());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
+    pub fn is_aligned_for<U: Sized>(self) -> bool
+    where
+        T: Sized,
+    {
+        self.is_aligned_to(align_of::<U>())
+    }
+
     /// Returns whether the pointer is aligned to `align`.
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1444,11 +1444,11 @@ impl<T: ?Sized> *const T {
     ///
     /// ```
     /// #![feature(pointer_is_aligned_for)]
-    /// 
+    ///
     /// // On some platforms, the alignment of i32 is less than 4.
     /// #[repr(align(4))]
     /// struct AlignedI32(i32);
-    /// 
+    ///
     /// // On some platforms, the alignment of u32 is less than 4.
     /// #[repr(align(4))]
     /// struct AlignedU32(u32);
@@ -1462,9 +1462,9 @@ impl<T: ?Sized> *const T {
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
-    pub fn is_aligned_for<U: Sized>(self) -> bool
+    pub fn is_aligned_for<U>(self) -> bool
     where
-        T: Sized,
+        U: Sized,
     {
         self.is_aligned_to(align_of::<U>())
     }

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1693,6 +1693,37 @@ impl<T: ?Sized> *mut T {
         self.is_aligned_to(align_of::<T>())
     }
 
+    /// Returns whether the pointer is properly aligned for `U`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(pointer_is_aligned_for)]
+    /// 
+    /// // On some platforms, the alignment of i32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedI32(i32);
+    /// 
+    /// // On some platforms, the alignment of u32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedU32(u32);
+    ///
+    /// let mut data = AlignedI32(42);
+    /// let ptr = &mut data as *mut AlignedI32;
+    ///
+    /// assert!(ptr.is_aligned_for::<AlignedU32>());
+    /// assert!(!ptr.wrapping_byte_add(1).is_aligned_for::<AlignedU32>());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
+    pub fn is_aligned_for<U: Sized>(self) -> bool
+    where
+        T: Sized,
+    {
+        self.is_aligned_to(align_of::<U>())
+    }
+
     /// Returns whether the pointer is aligned to `align`.
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1699,11 +1699,11 @@ impl<T: ?Sized> *mut T {
     ///
     /// ```
     /// #![feature(pointer_is_aligned_for)]
-    /// 
+    ///
     /// // On some platforms, the alignment of i32 is less than 4.
     /// #[repr(align(4))]
     /// struct AlignedI32(i32);
-    /// 
+    ///
     /// // On some platforms, the alignment of u32 is less than 4.
     /// #[repr(align(4))]
     /// struct AlignedU32(u32);
@@ -1717,9 +1717,9 @@ impl<T: ?Sized> *mut T {
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
-    pub fn is_aligned_for<U: Sized>(self) -> bool
+    pub fn is_aligned_for<U>(self) -> bool
     where
-        T: Sized,
+        U: Sized,
     {
         self.is_aligned_to(align_of::<U>())
     }

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1290,6 +1290,7 @@ impl<T: ?Sized> NonNull<T> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(pointer_is_aligned_for)]
     /// use std::ptr::NonNull;
     ///
     /// // On some platforms, the alignment of i32 is less than 4.

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1285,6 +1285,37 @@ impl<T: ?Sized> NonNull<T> {
         self.as_ptr().is_aligned()
     }
 
+    /// Returns whether the pointer is properly aligned for `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ptr::NonNull;
+    ///
+    /// // On some platforms, the alignment of i32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedI32(i32);
+    ///
+    /// // On some platforms, the alignment of u32 is less than 4.
+    /// #[repr(align(4))]
+    /// struct AlignedU32(u32);
+    ///
+    /// let data = AlignedI32(42);
+    /// let ptr = NonNull::<AlignedI32>::from(&data);
+    ///
+    /// assert!(ptr.is_aligned_for::<AlignedU32>());
+    /// assert!(!NonNull::new(ptr.as_ptr().wrapping_byte_add(1)).unwrap().is_aligned_for::<AlignedU32>());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
+    pub fn is_aligned_for<U: Sized>(self) -> bool
+    where
+        T: Sized,
+    {
+        self.as_ptr().is_aligned_for::<U>()
+    }
+
     /// Returns whether the pointer is aligned to `align`.
     ///
     /// For non-`Sized` pointees this operation considers only the data pointer,

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1309,9 +1309,9 @@ impl<T: ?Sized> NonNull<T> {
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned_for", issue = "140980")]
-    pub fn is_aligned_for<U: Sized>(self) -> bool
+    pub fn is_aligned_for<U>(self) -> bool
     where
-        T: Sized,
+        U: Sized,
     {
         self.as_ptr().is_aligned_for::<U>()
     }


### PR DESCRIPTION
Implement three related methods on pointers: `is_aligned_for`.

- Tracking issue: https://github.com/rust-lang/rust/issues/140980

# Warning

The ACP has not yet been accepted.