### PR TITLE
Suggest replace f with f: Box<f> when expr field is short hand

### DIFF
--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -680,6 +680,18 @@ pub(crate) enum SuggestBoxing {
         hir_typeck_suggest_boxing_when_appropriate,
         applicability = "machine-applicable"
     )]
+    ExprFieldShorthand {
+        #[suggestion_part(code = "{ident}: Box::new(")]
+        start: Span,
+        #[suggestion_part(code = ")")]
+        end: Span,
+        ident: Ident,
+    },
+    #[note(hir_typeck_suggest_boxing_note)]
+    #[multipart_suggestion(
+        hir_typeck_suggest_boxing_when_appropriate,
+        applicability = "machine-applicable"
+    )]
     Other {
         #[suggestion_part(code = "Box::new(")]
         start: Span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -585,6 +585,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 {
                     errors::SuggestBoxing::AsyncBody
                 }
+                _ if let Node::ExprField(expr_field) = self.tcx.parent_hir_node(hir_id)
+                    && expr_field.is_shorthand =>
+                {
+                    errors::SuggestBoxing::ExprFieldShorthand {
+                        start: span.shrink_to_lo(),
+                        end: span.shrink_to_hi(),
+                        ident: expr_field.ident,
+                    }
+                }
                 _ => errors::SuggestBoxing::Other {
                     start: span.shrink_to_lo(),
                     end: span.shrink_to_hi(),

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.rs
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.rs
@@ -1,0 +1,14 @@
+struct X {
+    a: Box<u32>,
+}
+
+struct Y {
+    y: Box<u32>,
+}
+
+fn main() {
+    let a = 8;
+    let v2 = X { a }; //~ ERROR mismatched types [E0308]
+    let v3 = Y { y: a }; //~ ERROR mismatched types [E0308]
+    let v4 = Y { a }; //~ ERROR struct `Y` has no field named `a` [E0560]
+}

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
@@ -9,8 +9,8 @@ LL |     let v2 = X { a };
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
    |
-LL |     let v2 = X { Box::new(a) };
-   |                  +++++++++ +
+LL |     let v2 = X { a: Box::new(a) };
+   |                  ++++++++++++ +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-box-for-expr-field-issue-139631.rs:12:21

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
@@ -1,0 +1,44 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:11:18
+   |
+LL |     let v2 = X { a };
+   |                  ^ expected `Box<u32>`, found integer
+   |
+   = note: expected struct `Box<u32>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     let v2 = X { Box::new(a) };
+   |                  +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:12:21
+   |
+LL |     let v3 = Y { y: a };
+   |                     ^ expected `Box<u32>`, found integer
+   |
+   = note: expected struct `Box<u32>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     let v3 = Y { y: Box::new(a) };
+   |                     +++++++++ +
+
+error[E0560]: struct `Y` has no field named `a`
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:13:18
+   |
+LL |     let v4 = Y { a };
+   |                  ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     let v4 = Y { a };
+LL +     let v4 = Y { y };
+   |
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0560.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #139631 

r? compiler
