### PR TITLE
Add negative test coverage for `-Clink-self-contained` and `-Zlinker-features`

### DIFF
--- a/tests/ui/linking/link-self-contained-malformed.invalid_modifier.stderr
+++ b/tests/ui/linking/link-self-contained-malformed.invalid_modifier.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `*lld` for codegen option `link-self-contained` - one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw` was expected
+

--- a/tests/ui/linking/link-self-contained-malformed.no_value.stderr
+++ b/tests/ui/linking/link-self-contained-malformed.no_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `` for codegen option `link-self-contained` - one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw` was expected
+

--- a/tests/ui/linking/link-self-contained-malformed.rs
+++ b/tests/ui/linking/link-self-contained-malformed.rs
@@ -1,0 +1,23 @@
+//! Check that malformed `-Clink-self-contained` invocations are properly rejected.
+
+//@ revisions: no_value
+//@[no_value] compile-flags: -Clink-self-contained=
+//[no_value]~? ERROR incorrect value `` for codegen option `link-self-contained`
+
+//@ revisions: invalid_modifier
+//@[invalid_modifier] compile-flags: -Clink-self-contained=*lld
+//[invalid_modifier]~? ERROR incorrect value `*lld` for codegen option `link-self-contained`
+
+//@ revisions: unknown_value
+//@[unknown_value] compile-flags: -Clink-self-contained=unknown
+//[unknown_value]~? ERROR incorrect value `unknown` for codegen option `link-self-contained`
+
+//@ revisions: unknown_modifier_value
+//@[unknown_modifier_value] compile-flags: -Clink-self-contained=-unknown
+//[unknown_modifier_value]~? ERROR incorrect value `-unknown` for codegen option `link-self-contained`
+
+//@ revisions: unknown_boolean
+//@[unknown_boolean] compile-flags: -Clink-self-contained=maybe
+//[unknown_boolean]~? ERROR incorrect value `maybe` for codegen option `link-self-contained`
+
+fn main() {}

--- a/tests/ui/linking/link-self-contained-malformed.unknown_boolean.stderr
+++ b/tests/ui/linking/link-self-contained-malformed.unknown_boolean.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `maybe` for codegen option `link-self-contained` - one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw` was expected
+

--- a/tests/ui/linking/link-self-contained-malformed.unknown_modifier_value.stderr
+++ b/tests/ui/linking/link-self-contained-malformed.unknown_modifier_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `-unknown` for codegen option `link-self-contained` - one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw` was expected
+

--- a/tests/ui/linking/link-self-contained-malformed.unknown_value.stderr
+++ b/tests/ui/linking/link-self-contained-malformed.unknown_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `unknown` for codegen option `link-self-contained` - one of: `y`, `yes`, `on`, `n`, `no`, `off`, or a list of enabled (`+` prefix) and disabled (`-` prefix) components: `crto`, `libc`, `unwind`, `linker`, `sanitizers`, `mingw` was expected
+

--- a/tests/ui/linking/linker-features-malformed.invalid_modifier.stderr
+++ b/tests/ui/linking/linker-features-malformed.invalid_modifier.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `*lld` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+

--- a/tests/ui/linking/linker-features-malformed.invalid_separator.stderr
+++ b/tests/ui/linking/linker-features-malformed.invalid_separator.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `-lld@+lld` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+

--- a/tests/ui/linking/linker-features-malformed.no_value.stderr
+++ b/tests/ui/linking/linker-features-malformed.no_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+

--- a/tests/ui/linking/linker-features-malformed.rs
+++ b/tests/ui/linking/linker-features-malformed.rs
@@ -1,0 +1,27 @@
+//! Check that malformed `-Zlinker-features` flags are properly rejected.
+
+//@ revisions: no_value
+//@[no_value] compile-flags: -Zlinker-features=
+//[no_value]~? ERROR incorrect value `` for unstable option `linker-features`
+
+//@ revisions: invalid_modifier
+//@[invalid_modifier] compile-flags: -Zlinker-features=*lld
+//[invalid_modifier]~? ERROR incorrect value `*lld` for unstable option `linker-features`
+
+//@ revisions: unknown_value
+//@[unknown_value] compile-flags: -Zlinker-features=unknown
+//[unknown_value]~? ERROR incorrect value `unknown` for unstable option `linker-features`
+
+//@ revisions: unknown_modifier_value
+//@[unknown_modifier_value] compile-flags: -Zlinker-features=-unknown
+//[unknown_modifier_value]~? ERROR incorrect value `-unknown` for unstable option `linker-features`
+
+//@ revisions: unknown_boolean
+//@[unknown_boolean] compile-flags: -Zlinker-features=maybe
+//[unknown_boolean]~? ERROR incorrect value `maybe` for unstable option `linker-features`
+
+//@ revisions: invalid_separator
+//@[invalid_separator] compile-flags: -Zlinker-features=-lld@+lld
+//[invalid_separator]~? ERROR incorrect value `-lld@+lld` for unstable option `linker-features`
+
+fn main() {}

--- a/tests/ui/linking/linker-features-malformed.unknown_boolean.stderr
+++ b/tests/ui/linking/linker-features-malformed.unknown_boolean.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `maybe` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+

--- a/tests/ui/linking/linker-features-malformed.unknown_modifier_value.stderr
+++ b/tests/ui/linking/linker-features-malformed.unknown_modifier_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `-unknown` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+

--- a/tests/ui/linking/linker-features-malformed.unknown_value.stderr
+++ b/tests/ui/linking/linker-features-malformed.unknown_value.stderr
@@ -1,0 +1,2 @@
+error: incorrect value `unknown` for unstable option `linker-features` - a list of enabled (`+` prefix) and disabled (`-` prefix) features: `lld` was expected
+


### PR DESCRIPTION
Noticed while reviewing stabilization #140525 that we don't have any negative test coverage for these flags. Feel free to cherry-pick these tests into the stabilization PR, or we can land these before separately.

r? @lqd