### PR TITLE
Make NonZero<char> possible

### DIFF
--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -131,6 +131,8 @@ define_valid_range_type! {
     pub struct NonZeroI32Inner(i32 as u32 in 1..=0xffff_ffff);
     pub struct NonZeroI64Inner(i64 as u64 in 1..=0xffffffff_ffffffff);
     pub struct NonZeroI128Inner(i128 as u128 in 1..=0xffffffffffffffff_ffffffffffffffff);
+
+    pub struct NonZeroCharInner(char as u32 in 1..=0x10ffff);
 }
 
 #[cfg(target_pointer_width = "16")]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -79,6 +79,7 @@ impl_zeroable_primitive!(
     NonZeroI64Inner(i64),
     NonZeroI128Inner(i128),
     NonZeroIsizeInner(isize),
+    NonZeroCharInner(char),
 );
 
 /// A value that is known not to equal zero.

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -22,19 +22,18 @@ mod u64;
 mod u8;
 
 mod bignum;
-
 mod const_from;
 mod dec2flt;
+mod float_iter_sum_identity;
 mod flt2dec;
+mod ieee754;
 mod int_log;
 mod int_sqrt;
 mod midpoint;
+mod nan;
+mod niche_types;
 mod ops;
 mod wrapping;
-
-mod float_iter_sum_identity;
-mod ieee754;
-mod nan;
 
 /// Adds the attribute to all items in the block.
 macro_rules! cfg_block {

--- a/library/coretests/tests/num/niche_types.rs
+++ b/library/coretests/tests/num/niche_types.rs
@@ -1,0 +1,12 @@
+use core::num::NonZero;
+
+#[test]
+fn test_new_from_zero_is_none() {
+    assert_eq!(NonZero::<char>::new(0 as char), None);
+}
+
+#[test]
+fn test_new_from_extreme_is_some() {
+    assert!(NonZero::<char>::new(1 as char).is_some());
+    assert!(NonZero::<char>::new(char::MAX).is_some());
+}


### PR DESCRIPTION
I'd like to use `NonZero<char>` for representing units of CStr in https://github.com/rust-lang/literal-escaper