### PR TITLE
Improve ternary operator recovery

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -815,7 +815,6 @@ parse_switch_ref_box_order = switch the order of `ref` and `box`
     .suggestion = swap them
 
 parse_ternary_operator = Rust has no ternary operator
-    .help = use an `if-else` expression instead
 
 parse_tilde_is_not_unary_operator = `~` cannot be used as a unary operator
     .suggestion = use `!` to perform bitwise not
@@ -962,6 +961,8 @@ parse_use_empty_block_not_semi = expected { "`{}`" }, found `;`
 
 parse_use_eq_instead = unexpected `==`
     .suggestion = try using `=` instead
+
+parse_use_if_else = use an `if-else` expression instead
 
 parse_use_let_not_auto = write `let` instead of `auto` to introduce a new variable
 parse_use_let_not_var = write `let` instead of `var` to introduce a new variable

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -436,10 +436,28 @@ pub(crate) enum IfExpressionMissingThenBlockSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_ternary_operator)]
-#[help]
 pub(crate) struct TernaryOperator {
     #[primary_span]
     pub span: Span,
+    /// If we have a span for the condition expression, suggest the if/else
+    #[subdiagnostic]
+    pub sugg: Option<TernaryOperatorSuggestion>,
+    /// Otherwise, just print the suggestion message
+    #[help(parse_use_if_else)]
+    pub no_sugg: bool,
+}
+
+#[derive(Subdiagnostic, Copy, Clone)]
+#[multipart_suggestion(parse_use_if_else, applicability = "maybe-incorrect", style = "verbose")]
+pub(crate) struct TernaryOperatorSuggestion {
+    #[suggestion_part(code = "if ")]
+    pub before_cond: Span,
+    #[suggestion_part(code = "{{")]
+    pub question: Span,
+    #[suggestion_part(code = "}} else {{")]
+    pub colon: Span,
+    #[suggestion_part(code = " }}")]
+    pub end: Span,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -879,7 +879,12 @@ impl<'a> Parser<'a> {
             {
                 // Just check for errors and recover; do not eat semicolon yet.
 
-                let expect_result = self.expect_one_of(&[], &[exp!(Semi), exp!(CloseBrace)]);
+                let expect_result =
+                    if let Err(e) = self.maybe_recover_from_ternary_operator(Some(expr.span)) {
+                        Err(e)
+                    } else {
+                        self.expect_one_of(&[], &[exp!(Semi), exp!(CloseBrace)])
+                    };
 
                 // Try to both emit a better diagnostic, and avoid further errors by replacing
                 // the `expr` with `ExprKind::Err`.

--- a/tests/ui/parser/ternary_operator.rs
+++ b/tests/ui/parser/ternary_operator.rs
@@ -28,3 +28,9 @@ fn main() {
     //~| HELP use an `if-else` expression instead
     //~| ERROR expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
 }
+
+fn expr(a: u64, b: u64) -> u64 {
+    a > b ? a : b
+    //~^ ERROR Rust has no ternary operator
+    //~| HELP use an `if-else` expression instead
+}

--- a/tests/ui/parser/ternary_operator.stderr
+++ b/tests/ui/parser/ternary_operator.stderr
@@ -2,7 +2,7 @@ error: Rust has no ternary operator
   --> $DIR/ternary_operator.rs:2:19
    |
 LL |     let x = 5 > 2 ? true : false;
-   |                   ^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^
    |
    = help: use an `if-else` expression instead
 
@@ -10,7 +10,7 @@ error: Rust has no ternary operator
   --> $DIR/ternary_operator.rs:8:19
    |
 LL |     let x = 5 > 2 ? { true } : { false };
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use an `if-else` expression instead
 
@@ -18,7 +18,7 @@ error: Rust has no ternary operator
   --> $DIR/ternary_operator.rs:14:19
    |
 LL |     let x = 5 > 2 ? f32::MAX : f32::MIN;
-   |                   ^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use an `if-else` expression instead
 
@@ -38,9 +38,21 @@ error: Rust has no ternary operator
   --> $DIR/ternary_operator.rs:26:19
    |
 LL |     let x = 5 > 2 ? { let x = vec![]: Vec<u16>; x } : { false };
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use an `if-else` expression instead
 
-error: aborting due to 6 previous errors
+error: Rust has no ternary operator
+  --> $DIR/ternary_operator.rs:33:5
+   |
+LL |     a > b ? a : b
+   |     ^^^^^^^^^^^^^
+   |
+help: use an `if-else` expression instead
+   |
+LL -     a > b ? a : b
+LL +     if a > b { a } else { b }
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This 
- Improves the span of the error to not point at the next token
- Where possible, we use the span of the condition to further improve the span of the error to include the cond, and suggest a maybe-incorrect fix

Currently this works on free expressions, not let statements; some more refactoring would be needed to pass the span down, which I'm not sure is worth doing.

### Old
![image](https://github.com/user-attachments/assets/5688cefc-e4ef-4135-a5ba-340ce05ae6f3)

### New
![image](https://github.com/user-attachments/assets/154f5380-e0c8-42c7-9bf8-0adb3d0433fa)
