### PR TITLE
Expand free alias types when computing implied outlives-bounds

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -160,6 +160,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         // See trait-system-refactor-initiative#234.
     }
 
+    fn expand_free_alias_tys<T: TypeFoldable<TyCtxt<'tcx>>>(self, t: T) -> T {
+        self.expand_free_alias_tys(t)
+    }
+
     fn expand_abstract_consts<T: TypeFoldable<TyCtxt<'tcx>>>(self, t: T) -> T {
         self.expand_abstract_consts(t)
     }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -879,7 +879,7 @@ impl<'tcx> TyCtxt<'tcx> {
         value.fold_with(&mut FreeAliasTypeExpander { tcx: self, depth: 0 })
     }
 
-    /// Peel off all [free alias types] in this type until there are none left.
+    /// Peel off all [free alias types][free] in this type until there are none left.
     ///
     /// This only expands free alias types in “head” / outermost positions. It can
     /// be used over [expand_free_alias_tys] as an optimization in situations where

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -217,6 +217,7 @@ pub trait Interner:
     /// (in theory) only happen when concurrent.
     fn assert_evaluation_is_concurrent(&self);
 
+    fn expand_free_alias_tys<T: TypeFoldable<Self>>(self, t: T) -> T;
     fn expand_abstract_consts<T: TypeFoldable<Self>>(self, t: T) -> T;
 
     type GenericsOf: GenericsOf<Self>;

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -58,6 +58,7 @@ pub fn push_outlives_components<I: Interner>(
     ty: I::Ty,
     out: &mut SmallVec<[Component<I>; 4]>,
 ) {
+    let ty = cx.expand_free_alias_tys(ty);
     ty.visit_with(&mut OutlivesCollector { cx, out, visited: Default::default() });
 }
 
@@ -138,6 +139,11 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
 
             ty::Placeholder(p) => {
                 self.out.push(Component::Placeholder(p));
+            }
+
+            // All free alias types should've been expanded beforehand.
+            ty::Alias(ty::AliasTy { kind: ty::Free { .. }, .. }) => {
+                panic!("unexpected free alias type")
             }
 
             // For projections, we prefer to generate an obligation like

--- a/tests/ui/lazy-type-alias/implied-outlives-bounds-1.print.stderr
+++ b/tests/ui/lazy-type-alias/implied-outlives-bounds-1.print.stderr
@@ -1,0 +1,11 @@
+error: rustc_dump_inferred_outlives
+  --> $DIR/implied-outlives-bounds-1.rs:13:1
+   |
+LL | struct Type<'a, K, V>(&'a mut Alias<K, V>);
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: K: 'a
+   = note: V: 'a
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lazy-type-alias/implied-outlives-bounds-1.rs
+++ b/tests/ui/lazy-type-alias/implied-outlives-bounds-1.rs
@@ -1,0 +1,17 @@
+// Check that we infer the outlives-predicates `K: 'a`, `V: 'a` for `Type`
+// from the free alias `Alias`.
+// FIXME(fmease): Proper explainer.
+
+//@ revisions: default print
+//@[default] check-pass
+
+#![feature(lazy_type_alias)]
+#![cfg_attr(print, feature(rustc_attrs))]
+#![allow(incomplete_features)]
+
+#[cfg_attr(print, rustc_dump_inferred_outlives)]
+struct Type<'a, K, V>(&'a mut Alias<K, V>); //[print]~ ERROR rustc_dump_inferred_outlives
+
+type Alias<K, V> = (K, V);
+
+fn main() {}


### PR DESCRIPTION
Supersedes rust-lang/rust#122340 (see lengthy discussions in comments).
Follow-up to rust-lang/rust#119350.

Draft status: Need to add more tests, will do later — am at conf. Also: Needs better PR descr.

r? oli-obk