### PR TITLE
Migrate to modern datetime API

### DIFF
--- a/src/ci/cpu-usage-over-time.py
+++ b/src/ci/cpu-usage-over-time.py
@@ -170,7 +170,7 @@ print("Time,Idle")
 while True:
     time.sleep(1)
     next_state = State()
-    now = datetime.datetime.utcnow().isoformat()
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
     idle = next_state.idle_since(cur_state)
     print("%s,%s" % (now, idle))
     sys.stdout.flush()


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```
Note that `.replace(tzinfo=None)` allows to keep the original behavior where the time appears as a naive UTC timestamp (i.e., without any timezone offset). Comparision:
```python
# With .utcnow() or .now(datetime.timezone.utc).replace(tzinfo=None)
Time,Idle
2025-05-14T15:40:25.013414,98.73417721518987

# With .now(datetime.timezone.utc)
Time,Idle
2025-05-14T15:40:25.013414+00:00,98.73417721518987
```

