### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue_future.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue_future.md
@@ -1,0 +1,54 @@
+---
+name: Future Incompatibility Tracking Issue
+about: A tracking issue for a future-incompatible lint
+title: Tracking Issue for future-incompatibility lint XXX
+labels: C-tracking-issue C-future-incompatibility T-compiler A-lints
+---
+<!--
+Thank you for creating a future-incompatible tracking issue! 📜 These issues
+are for lints that implement a future-incompatible warning.
+
+Remember to add team labels to the tracking issue.
+For something that affects the language, this would be `T-lang`, and for libs
+it would be `T-libs-api`.
+Also check for any `A-` labels to add.
+-->
+
+This is the **tracking issue** for the `YOUR_LINT_NAME_HERE` future-compatibility warning and other related errors. The goal of this page is describe why this change was made and how you can fix code that is affected by it. It also provides a place to ask questions or register a complaint if you feel the change should not be made. For more information on the policy around future-compatibility warnings, see our [breaking change policy guidelines][guidelines].
+
+[guidelines]: https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html
+
+### What is the warning for?
+
+*Describe the conditions that trigger the warning.*
+
+### Why was this change made?
+
+*Explain why this change was made. If there is additional context, like an MCP, link it here.*
+
+### Example
+
+```rust
+// Include an example here.
+```
+
+### Recommendations
+
+*Give some recommendations on how a user can avoid the lint.*
+
+### When will this warning become a hard error?
+
+*If known, describe the future plans. For example, how long you anticipate this being a warning, or if there are other factors that will influence the anticipated closure.*
+
+### Steps
+
+- [ ] Implement the lint
+- [ ] Raise lint level to deny
+- [ ] Make lint report in dependencies
+- [ ] Switch to a hard error
+
+### Implementation history
+
+<!--
+Include a list of all the PRs that were involved in implementing the lint.
+-->

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -680,6 +680,18 @@ pub(crate) enum SuggestBoxing {
         hir_typeck_suggest_boxing_when_appropriate,
         applicability = "machine-applicable"
     )]
+    ExprFieldShorthand {
+        #[suggestion_part(code = "{ident}: Box::new(")]
+        start: Span,
+        #[suggestion_part(code = ")")]
+        end: Span,
+        ident: Ident,
+    },
+    #[note(hir_typeck_suggest_boxing_note)]
+    #[multipart_suggestion(
+        hir_typeck_suggest_boxing_when_appropriate,
+        applicability = "machine-applicable"
+    )]
     Other {
         #[suggestion_part(code = "Box::new(")]
         start: Span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -585,6 +585,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 {
                     errors::SuggestBoxing::AsyncBody
                 }
+                _ if let Node::ExprField(expr_field) = self.tcx.parent_hir_node(hir_id)
+                    && expr_field.is_shorthand =>
+                {
+                    errors::SuggestBoxing::ExprFieldShorthand {
+                        start: span.shrink_to_lo(),
+                        end: span.shrink_to_hi(),
+                        ident: expr_field.ident,
+                    }
+                }
                 _ => errors::SuggestBoxing::Other {
                     start: span.shrink_to_lo(),
                     end: span.shrink_to_hi(),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -280,6 +280,8 @@ symbols! {
         IoSeek,
         IoWrite,
         IpAddr,
+        Ipv4Addr,
+        Ipv6Addr,
         IrTyKind,
         Is,
         Item,

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -391,7 +391,7 @@ impl<T> MaybeUninit<T> {
     /// For your convenience, this also returns a mutable reference to the
     /// (now safely initialized) contents of `self`.
     ///
-    /// As the content is stored inside a `MaybeUninit`, the destructor is not
+    /// As the content is stored inside a `ManuallyDrop`, the destructor is not
     /// run for the inner data if the MaybeUninit leaves scope without a call to
     /// [`assume_init`], [`assume_init_drop`], or similar. Code that receives
     /// the mutable reference returned by this function needs to keep this in

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -68,6 +68,7 @@ pub enum IpAddr {
 /// assert!("0000000.0.0.0".parse::<Ipv4Addr>().is_err()); // first octet is a zero in octal
 /// assert!("0xcb.0x0.0x71.0x00".parse::<Ipv4Addr>().is_err()); // all octets are in hex
 /// ```
+#[rustc_diagnostic_item = "Ipv4Addr"]
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Ipv4Addr {
@@ -160,6 +161,7 @@ impl Hash for Ipv4Addr {
 /// assert_eq!("::1".parse(), Ok(localhost));
 /// assert_eq!(localhost.is_loopback(), true);
 /// ```
+#[rustc_diagnostic_item = "Ipv6Addr"]
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Ipv6Addr {

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -579,9 +579,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",

--- a/src/doc/rustc-dev-guide/src/bug-fix-procedure.md
+++ b/src/doc/rustc-dev-guide/src/bug-fix-procedure.md
@@ -80,41 +80,11 @@ approachable and practical; it may make sense to direct users to an RFC or some
 other issue for the full details. The issue also serves as a place where users
 can comment with questions or other concerns.
 
-A template for these breaking-change tracking issues can be found below. An
-example of how such an issue should look can be [found
+A template for these breaking-change tracking issues can be found
+[here][template]. An example of how such an issue should look can be [found
 here][breaking-change-issue].
 
-The issue should be tagged with (at least) `B-unstable` and `T-compiler`.
-
-### Tracking issue template
-
-This is a template to use for tracking issues:
-
-```
-This is the **summary issue** for the `YOUR_LINT_NAME_HERE`
-future-compatibility warning and other related errors. The goal of
-this page is describe why this change was made and how you can fix
-code that is affected by it. It also provides a place to ask questions
-or register a complaint if you feel the change should not be made. For
-more information on the policy around future-compatibility warnings,
-see our [breaking change policy guidelines][guidelines].
-
-[guidelines]: LINK_TO_THIS_RFC
-
-#### What is the warning for?
-
-*Describe the conditions that trigger the warning and how they can be
-fixed. Also explain why the change was made.**
-
-#### When will this warning become a hard error?
-
-At the beginning of each 6-week release cycle, the Rust compiler team
-will review the set of outstanding future compatibility warnings and
-nominate some of them for **Final Comment Period**. Toward the end of
-the cycle, we will review any comments and make a final determination
-whether to convert the warning into a hard error or remove it
-entirely.
-```
+[template]: https://github.com/rust-lang/rust/issues/new?template=tracking_issue_future.md
 
 ### Issuing future compatibility warnings
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2609,18 +2609,19 @@ impl<'test> TestCx<'test> {
             (expected, actual)
         };
 
-        // Write the actual output to a file in build/
-        let test_name = self.config.compare_mode.as_ref().map_or("", |m| m.to_str());
+        // Write the actual output to a file in build directory.
         let actual_path = self
             .output_base_name()
             .with_extra_extension(self.revision.unwrap_or(""))
-            .with_extra_extension(test_name)
+            .with_extra_extension(
+                self.config.compare_mode.as_ref().map(|cm| cm.to_str()).unwrap_or(""),
+            )
             .with_extra_extension(stream);
 
         if let Err(err) = fs::write(&actual_path, &actual) {
-            self.fatal(&format!("failed to write {stream} to `{actual_path:?}`: {err}",));
+            self.fatal(&format!("failed to write {stream} to `{actual_path}`: {err}",));
         }
-        println!("Saved the actual {stream} to {actual_path:?}");
+        println!("Saved the actual {stream} to `{actual_path}`");
 
         if !self.config.bless {
             if expected.is_empty() {
@@ -2646,13 +2647,16 @@ impl<'test> TestCx<'test> {
 
             if !actual.is_empty() {
                 if let Err(err) = fs::write(&expected_path, &actual) {
-                    self.fatal(&format!("failed to write {stream} to `{expected_path:?}`: {err}"));
+                    self.fatal(&format!("failed to write {stream} to `{expected_path}`: {err}"));
                 }
-                println!("Blessing the {stream} of {test_name} in {expected_path:?}");
+                println!(
+                    "Blessing the {stream} of `{test_name}` as `{expected_path}`",
+                    test_name = self.testpaths.file
+                );
             }
         }
 
-        println!("\nThe actual {0} differed from the expected {0}.", stream);
+        println!("\nThe actual {stream} differed from the expected {stream}");
 
         if self.config.bless { CompareOutcome::Blessed } else { CompareOutcome::Differed }
     }

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.rs
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.rs
@@ -1,0 +1,14 @@
+struct X {
+    a: Box<u32>,
+}
+
+struct Y {
+    y: Box<u32>,
+}
+
+fn main() {
+    let a = 8;
+    let v2 = X { a }; //~ ERROR mismatched types [E0308]
+    let v3 = Y { y: a }; //~ ERROR mismatched types [E0308]
+    let v4 = Y { a }; //~ ERROR struct `Y` has no field named `a` [E0560]
+}

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
@@ -9,8 +9,8 @@ LL |     let v2 = X { a };
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
    |
-LL |     let v2 = X { Box::new(a) };
-   |                  +++++++++ +
+LL |     let v2 = X { a: Box::new(a) };
+   |                  ++++++++++++ +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-box-for-expr-field-issue-139631.rs:12:21

--- a/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
+++ b/tests/ui/box/suggest-box-for-expr-field-issue-139631.stderr
@@ -1,0 +1,44 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:11:18
+   |
+LL |     let v2 = X { a };
+   |                  ^ expected `Box<u32>`, found integer
+   |
+   = note: expected struct `Box<u32>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     let v2 = X { Box::new(a) };
+   |                  +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:12:21
+   |
+LL |     let v3 = Y { y: a };
+   |                     ^ expected `Box<u32>`, found integer
+   |
+   = note: expected struct `Box<u32>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     let v3 = Y { y: Box::new(a) };
+   |                     +++++++++ +
+
+error[E0560]: struct `Y` has no field named `a`
+  --> $DIR/suggest-box-for-expr-field-issue-139631.rs:13:18
+   |
+LL |     let v4 = Y { a };
+   |                  ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     let v4 = Y { a };
+LL +     let v4 = Y { y };
+   |
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0560.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/gather-locals-twice.rs
+++ b/tests/ui/typeck/gather-locals-twice.rs
@@ -1,0 +1,7 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/140785>.
+
+fn main() {
+    () += { let x; };
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `()`
+    //~| ERROR invalid left-hand side of assignment
+}

--- a/tests/ui/typeck/gather-locals-twice.stderr
+++ b/tests/ui/typeck/gather-locals-twice.stderr
@@ -1,0 +1,20 @@
+error[E0368]: binary assignment operation `+=` cannot be applied to type `()`
+  --> $DIR/gather-locals-twice.rs:4:5
+   |
+LL |     () += { let x; };
+   |     --^^^^^^^^^^^^^^
+   |     |
+   |     cannot use `+=` on type `()`
+
+error[E0067]: invalid left-hand side of assignment
+  --> $DIR/gather-locals-twice.rs:4:8
+   |
+LL |     () += { let x; };
+   |     -- ^^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0067, E0368.
+For more information about an error, try `rustc --explain E0067`.


### PR DESCRIPTION
Successful merges:

 - #140827 (Do not ICE when reassigning in GatherLocalsVisitor on the bad path)
 - #140904 (Add an issue template for future-incompatible lints)
 - #140953 (Fix a compiletest blessing message)
 - #140973 (Update rustix to 1.0.7 for bootstrap)
 - #140976 (Add `Ipv4Addr` and `Ipv6Addr` diagnostic items)
 - #140988 (MaybeUninit::write: fix doc)
 - #140989 (Suggest replace f with f: Box<f> when expr field is short hand)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140827,140904,140953,140973,140976,140988,140989)
<!-- homu-ignore:end -->