### PR TITLE
Implement methods to set STARTUPINFO flags for Command API on Windows

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -344,6 +344,27 @@ pub trait CommandExt: Sealed {
         &mut self,
         attribute_list: &ProcThreadAttributeList<'_>,
     ) -> io::Result<process::Child>;
+
+    /// When true, sets the `STARTF_RUNFULLSCREEN` flag on the [STARTUPINFO][1] struct before passing it to `CreateProcess`.
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+    #[unstable(feature = "windows_process_extensions_startupinfo", issue = "141010")]
+    fn startupinfo_fullscreen(&mut self, enabled: bool) -> &mut process::Command;
+
+    /// When true, sets the `STARTF_UNTRUSTEDSOURCE` flag on the [STARTUPINFO][1] struct before passing it to `CreateProcess`.
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+    #[unstable(feature = "windows_process_extensions_startupinfo", issue = "141010")]
+    fn startupinfo_untrusted_source(&mut self, enabled: bool) -> &mut process::Command;
+
+    /// When specified, sets the following flags on the [STARTUPINFO][1] struct before passing it to `CreateProcess`:
+    /// - If `Some(true)`, sets `STARTF_FORCEONFEEDBACK`
+    /// - If `Some(false)`, sets `STARTF_FORCEOFFFEEDBACK`
+    /// - If `None`, does not set any flags
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+    #[unstable(feature = "windows_process_extensions_startupinfo", issue = "141010")]
+    fn startupinfo_force_feedback(&mut self, enabled: Option<bool>) -> &mut process::Command;
 }
 
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
@@ -384,6 +405,21 @@ impl CommandExt for process::Command {
         self.as_inner_mut()
             .spawn_with_attributes(sys::process::Stdio::Inherit, true, Some(attribute_list))
             .map(process::Child::from_inner)
+    }
+
+    fn startupinfo_fullscreen(&mut self, enabled: bool) -> &mut process::Command {
+        self.as_inner_mut().startupinfo_fullscreen(enabled);
+        self
+    }
+
+    fn startupinfo_untrusted_source(&mut self, enabled: bool) -> &mut process::Command {
+        self.as_inner_mut().startupinfo_untrusted_source(enabled);
+        self
+    }
+
+    fn startupinfo_force_feedback(&mut self, enabled: Option<bool>) -> &mut process::Command {
+        self.as_inner_mut().startupinfo_force_feedback(enabled);
+        self
     }
 }
 

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -155,6 +155,9 @@ pub struct Command {
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
     force_quotes_enabled: bool,
+    startupinfo_fullscreen: bool,
+    startupinfo_untrusted_source: bool,
+    startupinfo_force_feedback: Option<bool>,
 }
 
 pub enum Stdio {
@@ -186,6 +189,9 @@ impl Command {
             stdout: None,
             stderr: None,
             force_quotes_enabled: false,
+            startupinfo_fullscreen: false,
+            startupinfo_untrusted_source: false,
+            startupinfo_force_feedback: None,
         }
     }
 
@@ -220,6 +226,18 @@ impl Command {
 
     pub fn raw_arg(&mut self, command_str_to_append: &OsStr) {
         self.args.push(Arg::Raw(command_str_to_append.to_os_string()))
+    }
+
+    pub fn startupinfo_fullscreen(&mut self, enabled: bool) {
+        self.startupinfo_fullscreen = enabled;
+    }
+
+    pub fn startupinfo_untrusted_source(&mut self, enabled: bool) {
+        self.startupinfo_untrusted_source = enabled;
+    }
+
+    pub fn startupinfo_force_feedback(&mut self, enabled: Option<bool>) {
+        self.startupinfo_force_feedback = enabled;
     }
 
     pub fn get_program(&self) -> &OsStr {
@@ -341,6 +359,24 @@ impl Command {
         if let Some(cmd_show) = self.show_window {
             si.dwFlags |= c::STARTF_USESHOWWINDOW;
             si.wShowWindow = cmd_show;
+        }
+
+        if self.startupinfo_fullscreen {
+            si.dwFlags |= c::STARTF_RUNFULLSCREEN;
+        }
+
+        if self.startupinfo_untrusted_source {
+            si.dwFlags |= c::STARTF_UNTRUSTEDSOURCE;
+        }
+
+        match self.startupinfo_force_feedback {
+            Some(true) => {
+                si.dwFlags |= c::STARTF_FORCEONFEEDBACK;
+            }
+            Some(false) => {
+                si.dwFlags |= c::STARTF_FORCEOFFFEEDBACK;
+            }
+            None => {}
         }
 
         let si_ptr: *mut c::STARTUPINFOW;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Implements https://github.com/rust-lang/rust/issues/141010
