### PR TITLE
compiletest: add option for automatically adding annotations

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -422,6 +422,23 @@ the different revisions.
 >
 > By convention, the `FALSE` cfg is used to have an always-false config.
 
+### Automatic error annotations
+
+`compiletest` provides the `--try-annotate` flag to add missing annotations.
+
+Note that this flag is an experimental and crude tool. If you use it, you should carefully review
+and modify its changes:
+- trim down the annotation so it tests what you want to test, for example some particular wording
+ of a diagnostic or just the error code/lint name.
+- delete or normalize parts of the annotations that refer to line numbers, like
+ `{async block@src/main.rs:8:13: 8:18}`, so that they don't cause churn later when the UI test
+ itself changes.
+
+You have to pass this flag to `compiletest` like so:
+```text
+./x test tests/ui -- --try-annotate 
+```
+
 ## Controlling pass/fail expectations
 
 By default, a UI test is expected to **generate a compile error** because most

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -177,6 +177,10 @@ pub struct Config {
     /// `true` to overwrite stderr/stdout files instead of complaining about changes in output.
     pub bless: bool,
 
+    /// `true` to attempt to add annotations to the test file.
+    // This only adds annotations, it does not delete ones that were not found.
+    pub try_annotate: bool,
+
     /// Stop as soon as possible after any test fails.
     /// May run a few more tests before stopping, due to threading.
     pub fail_fast: bool,
@@ -913,4 +917,12 @@ pub fn incremental_dir(
     revision: Option<&str>,
 ) -> Utf8PathBuf {
     output_base_name(config, testpaths, revision).with_extension("inc")
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Location {
+    pub line_start: usize,
+    pub line_end: usize,
+    pub column_start: usize,
+    pub column_end: usize,
 }

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -135,6 +135,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "bless",
             "overwrite stderr/stdout files instead of complaining about a mismatch",
         )
+        .optflag("", "try-annotate", "attempt to fix up error annotations in ui tests")
         .optflag("", "fail-fast", "stop as soon as possible after any test fails")
         .optflag("", "quiet", "print one character per test instead of one line")
         .optopt("", "color", "coloring: auto, always, never", "WHEN")
@@ -330,6 +331,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
 
     Config {
         bless: matches.opt_present("bless"),
+        try_annotate: matches.opt_present("try-annotate"),
         fail_fast: matches.opt_present("fail-fast")
             || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
 

--- a/src/tools/compiletest/src/runtest/codegen_units.rs
+++ b/src/tools/compiletest/src/runtest/codegen_units.rs
@@ -32,7 +32,7 @@ impl TestCx<'_> {
 
         let expected: Vec<MonoItem> = errors::load_errors(&self.testpaths.file, None)
             .iter()
-            .map(|e| str_to_mono_item(&e.msg[..], false))
+            .map(|e| str_to_mono_item(&e.msg.text[..], false))
             .collect();
 
         let mut missing = Vec::new();


### PR DESCRIPTION
This PR adds the option `--try-annotate` to have compiletest write annotations like `//~ERROR found Foo, expected Bar`.

I need this to automatically generate tests for https://github.com/rust-lang/rust/pull/140948#issuecomment-2876116891 but I realized this is quite useful generally so I have split this up into its own PR.

I have tested this on our test suite by removing all targeted annotations (skipping revision tests and `//~?`  and `//~v`), which results in 10k failing tests. By then running 
```
python x.py test tests/ui -- --try-annotate 
python x.py test tests/ui -- --bless
```

all but 24 tests will pass again. Most of these tests either have opaque types (see the instability comment in the PR), involve syntax errors spread over multiple lines (again, see instability) or they are weird and should use a  `//~v` annotation.

<details>
<summary><b>Failing tests</b></summary>

    [ui] tests\ui\attributes\export\crate-type-2.rs
    [ui] tests\ui\coroutine\clone-impl.rs
    [ui] tests\ui\feature-gates\feature-gate-frontmatter.rs
    [ui] tests\ui\fmt\format-string-error-2.rs
    [ui] tests\ui\frontmatter\multifrontmatter-2.rs
    [ui] tests\ui\frontmatter\frontmatter-whitespace-1.rs
    [ui] tests\ui\frontmatter\mismatch-2.rs
    [ui] tests\ui\frontmatter\mismatch-1.rs
    [ui] tests\ui\frontmatter\unclosed-3.rs
    [ui] tests\ui\frontmatter\unclosed-1.rs
    [ui] tests\ui\frontmatter\unclosed-2.rs
    [ui] tests\ui\frontmatter\unclosed-4.rs
    [ui] tests\ui\frontmatter\unclosed-5.rs
    [ui] tests\ui\impl-trait\issue-55872-3.rs
    [ui] tests\ui\lexer\lexer-crlf-line-endings-string-literal-doc-comment.rs
    [ui] tests\ui\macros\issue-83344.rs
    [ui] tests\ui\methods\filter-relevant-fn-bounds.rs
    [ui] tests\ui\parser\bad-char-literals.rs
    [ui] tests\ui\parser\doc-before-identifier.rs
    [ui] tests\ui\parser\doc-comment-in-stmt.rs
    [ui] tests\ui\rustdoc\check-doc-alias-attr.rs
    [ui] tests\ui\str\str-escape.rs
    [ui] tests\ui\type-alias-impl-trait\mututally-recursive-overflow.rs
    [ui] tests\ui\typeck\typeck_type_placeholder_item.rs


</details>


<details>
<summary><b>Script for deleting annotations, in case you want to try it out</b></summary>

```rust
use std::ffi::OsStr;
use std::fs::OpenOptions;
use std::io;
use std::io::BufRead;
use std::io::BufReader;
use std::io::Seek;
use std::io::Write;
use std::path::Path;
use walkdir::WalkDir;

const ROOT: &str = "C:/Users/bruno/Rust/rust/tests/ui";

fn main() -> io::Result<()> {
    for entry in WalkDir::new(ROOT) {
        let entry = entry?;
        if entry.path().extension() == Some(OsStr::new("rs")) {
            delete_annotations(entry.path())?;
            println!(" cleaned {}", entry.path().display());
        }
    }

    Ok(())
}

fn delete_annotations(path: &Path) -> io::Result<()> {
    let mut file = OpenOptions::new().write(true).read(true).open(path)?;
    let br = BufReader::new(&file);
    let mut lines = br.lines().collect::<Result<Vec<_>, _>>()?;
    for line in &lines {
        if line.contains("//@ revisions") || line.contains("//@revisions") {
            return Ok(());
        }
    }

    file.set_len(0).unwrap();
    file.rewind().unwrap();

    for line in lines {
        if line.contains("//~?") || line.contains("//~v") {
            writeln!(file, "{line}")?;
        } else if let Some(bye_annotation) = line.split_terminator("//~").next() {
            writeln!(file, "{}", bye_annotation.trim_end())?;
        } else {
            writeln!(file, "{line}")?;
        }
    }
    file.flush()?;
    Ok(())
}
```
</details>

Also, this PR stops immediately formatting the error messages. It proved quite painful to extract the original error again, so instead I implemented this type which is just formatted when needed.
```rust
pub struct ErrorMessage {
    pub span: Option<Location>,
    pub code: Option<DiagnosticCode>,
    pub text: String,
}
``` 


r? @jieyouxu 

