### PR TITLE
turn lld warning on old gccs into info log

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -768,7 +768,7 @@ fn link_natively(
             && cmd.get_args().iter().any(|e| e.to_string_lossy() == "-fuse-ld=lld")
         {
             info!("linker output: {:?}", out);
-            warn!("The linker driver does not support `-fuse-ld=lld`. Retrying without it.");
+            info!("The linker driver does not support `-fuse-ld=lld`. Retrying without it.");
             for arg in cmd.take_args() {
                 if arg.to_string_lossy() != "-fuse-ld=lld" {
                     cmd.arg(arg);


### PR DESCRIPTION
As discussed in #140964 and IRL, this PR switches the spammy warning shown unconditionally when an old gcc doesn't support `-fuse-ld=lld` and we retry linking without it, to an info debug log so we don't lose it.

r? @Mark-Simulacrum 

Fixes #140964