### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -621,13 +621,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
                         &ocx, op, span,
                     ) {
                         Ok(_) => ocx.select_all_or_error(),
-                        Err(e) => {
-                            if e.is_empty() {
-                                ocx.select_all_or_error()
-                            } else {
-                                e
-                            }
-                        }
+                        Err(e) => e,
                     };
 
                     // Could have no errors if a type lowering error, say, caused the query

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -362,6 +362,10 @@ lint_impl_trait_redundant_captures = all possible in-scope parameters are alread
 
 lint_implicit_unsafe_autorefs = implicit autoref creates a reference to the dereference of a raw pointer
     .note = creating a reference requires the pointer target to be valid and imposes aliasing requirements
+    .raw_ptr = this raw pointer has type `{$raw_ptr_ty}`
+    .autoref = autoref is being applied to this expression, resulting in: `{$autoref_ty}`
+    .through_overloaded_deref = reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+    .method_def = method calls to `{$method_name}` require a reference
     .suggestion = try using a raw pointer method instead; or if this reference is intentional, make it explicit
 
 lint_improper_ctypes = `extern` {$desc} uses type `{$ty}`, which is not FFI-safe

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -364,7 +364,7 @@ lint_implicit_unsafe_autorefs = implicit autoref creates a reference to the dere
     .note = creating a reference requires the pointer target to be valid and imposes aliasing requirements
     .raw_ptr = this raw pointer has type `{$raw_ptr_ty}`
     .autoref = autoref is being applied to this expression, resulting in: `{$autoref_ty}`
-    .through_overloaded_deref = reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+    .overloaded_deref = references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
     .method_def = method calls to `{$method_name}` require a reference
     .suggestion = try using a raw pointer method instead; or if this reference is intentional, make it explicit
 

--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -2,9 +2,12 @@ use rustc_ast::{BorrowKind, UnOp};
 use rustc_hir::{Expr, ExprKind, Mutability};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, OverloadedDeref};
 use rustc_session::{declare_lint, declare_lint_pass};
-use rustc_span::{kw, sym};
+use rustc_span::sym;
 
-use crate::lints::{ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsSuggestion};
+use crate::lints::{
+    ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsMethodNote, ImplicitUnsafeAutorefsOrigin,
+    ImplicitUnsafeAutorefsSuggestion,
+};
 use crate::{LateContext, LateLintPass, LintContext};
 
 declare_lint! {
@@ -98,8 +101,8 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
                 peel_place_mappers(inner).kind
             // 1. Deref of a raw pointer.
             && typeck.expr_ty(dereferenced).is_raw_ptr()
-            // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
             && let method_did = match expr.kind {
+                // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
                 ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
                 _ => None,
             }
@@ -111,11 +114,18 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
                 ImplicitUnsafeAutorefsDiag {
                     raw_ptr_span: dereferenced.span,
                     raw_ptr_ty: typeck.expr_ty(dereferenced),
-                    autoref_span: inner.span,
-                    autoref_ty: typeck.expr_ty_adjusted(inner),
-                    method_def_span: method_did.map(|did| cx.tcx.def_span(did)),
-                    method_name: method_did.map(|did| cx.tcx.item_name(did)).unwrap_or(kw::Empty),
-                    through_overloaded_deref,
+                    origin: if through_overloaded_deref {
+                        ImplicitUnsafeAutorefsOrigin::OverloadedDeref
+                    } else {
+                        ImplicitUnsafeAutorefsOrigin::Autoref {
+                            autoref_span: inner.span,
+                            autoref_ty: typeck.expr_ty_adjusted(inner),
+                        }
+                    },
+                    method: method_did.map(|did| ImplicitUnsafeAutorefsMethodNote {
+                        def_span: cx.tcx.def_span(did),
+                        method_name: cx.tcx.item_name(did),
+                    }),
                     suggestion: ImplicitUnsafeAutorefsSuggestion {
                         mutbl: borrow_mutbl.ref_prefix_str(),
                         deref: if is_coming_from_deref { "*" } else { "" },
@@ -151,7 +161,8 @@ fn peel_derefs_adjustments<'a>(mut adjs: &'a [Adjustment<'a>]) -> &'a [Adjustmen
 
 /// Test if some adjustment has some implicit borrow.
 ///
-/// Returns `Some(mutability)` if the argument adjustment has implicit borrow in it.
+/// Returns `Some((mutability, was_an_overloaded_deref))` if the argument adjustment is
+/// an implicit borrow (or has an implicit borrow via an overloaded deref).
 fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<(Mutability, bool)> {
     match kind {
         &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some((mutbl, true)),

--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -2,7 +2,7 @@ use rustc_ast::{BorrowKind, UnOp};
 use rustc_hir::{Expr, ExprKind, Mutability};
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, OverloadedDeref};
 use rustc_session::{declare_lint, declare_lint_pass};
-use rustc_span::sym;
+use rustc_span::{kw, sym};
 
 use crate::lints::{ImplicitUnsafeAutorefsDiag, ImplicitUnsafeAutorefsSuggestion};
 use crate::{LateContext, LateLintPass, LintContext};
@@ -92,25 +92,30 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitAutorefs {
             && let adjustments = peel_derefs_adjustments(&**adjustments)
             // 3. An automatically inserted reference (might come from a deref).
             && let [adjustment] = adjustments
-            && let Some(borrow_mutbl) = has_implicit_borrow(adjustment)
+            && let Some((borrow_mutbl, through_overloaded_deref)) = has_implicit_borrow(adjustment)
             && let ExprKind::Unary(UnOp::Deref, dereferenced) =
                 // 2. Any number of place projections.
                 peel_place_mappers(inner).kind
             // 1. Deref of a raw pointer.
             && typeck.expr_ty(dereferenced).is_raw_ptr()
             // PERF: 5. b. A method call annotated with `#[rustc_no_implicit_refs]`
-            && match expr.kind {
-                ExprKind::MethodCall(..) => matches!(
-                    cx.typeck_results().type_dependent_def_id(expr.hir_id),
-                    Some(def_id) if cx.tcx.has_attr(def_id, sym::rustc_no_implicit_autorefs)
-                ),
-                _ => true,
+            && let method_did = match expr.kind {
+                ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+                _ => None,
             }
+            && method_did.map(|did| cx.tcx.has_attr(did, sym::rustc_no_implicit_autorefs)).unwrap_or(true)
         {
             cx.emit_span_lint(
                 DANGEROUS_IMPLICIT_AUTOREFS,
                 expr.span.source_callsite(),
                 ImplicitUnsafeAutorefsDiag {
+                    raw_ptr_span: dereferenced.span,
+                    raw_ptr_ty: typeck.expr_ty(dereferenced),
+                    autoref_span: inner.span,
+                    autoref_ty: typeck.expr_ty_adjusted(inner),
+                    method_def_span: method_did.map(|did| cx.tcx.def_span(did)),
+                    method_name: method_did.map(|did| cx.tcx.item_name(did)).unwrap_or(kw::Empty),
+                    through_overloaded_deref,
                     suggestion: ImplicitUnsafeAutorefsSuggestion {
                         mutbl: borrow_mutbl.ref_prefix_str(),
                         deref: if is_coming_from_deref { "*" } else { "" },
@@ -147,10 +152,10 @@ fn peel_derefs_adjustments<'a>(mut adjs: &'a [Adjustment<'a>]) -> &'a [Adjustmen
 /// Test if some adjustment has some implicit borrow.
 ///
 /// Returns `Some(mutability)` if the argument adjustment has implicit borrow in it.
-fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<Mutability> {
+fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<(Mutability, bool)> {
     match kind {
-        &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some(mutbl),
-        &Adjust::Borrow(AutoBorrow::Ref(mutbl)) => Some(mutbl.into()),
+        &Adjust::Deref(Some(OverloadedDeref { mutbl, .. })) => Some((mutbl, true)),
+        &Adjust::Borrow(AutoBorrow::Ref(mutbl)) => Some((mutbl.into(), false)),
         Adjust::NeverToAny
         | Adjust::Pointer(..)
         | Adjust::ReborrowPin(..)

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -59,7 +59,18 @@ pub(crate) enum ShadowedIntoIterDiagSub {
 #[derive(LintDiagnostic)]
 #[diag(lint_implicit_unsafe_autorefs)]
 #[note]
-pub(crate) struct ImplicitUnsafeAutorefsDiag {
+pub(crate) struct ImplicitUnsafeAutorefsDiag<'a> {
+    #[label(lint_raw_ptr)]
+    pub raw_ptr_span: Span,
+    pub raw_ptr_ty: Ty<'a>,
+    #[note(lint_autoref)]
+    pub autoref_span: Span,
+    pub autoref_ty: Ty<'a>,
+    #[note(lint_method_def)]
+    pub method_def_span: Option<Span>,
+    pub method_name: Symbol,
+    #[note(lint_through_overloaded_deref)]
+    pub through_overloaded_deref: bool,
     #[subdiagnostic]
     pub suggestion: ImplicitUnsafeAutorefsSuggestion,
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -63,16 +63,32 @@ pub(crate) struct ImplicitUnsafeAutorefsDiag<'a> {
     #[label(lint_raw_ptr)]
     pub raw_ptr_span: Span,
     pub raw_ptr_ty: Ty<'a>,
-    #[note(lint_autoref)]
-    pub autoref_span: Span,
-    pub autoref_ty: Ty<'a>,
-    #[note(lint_method_def)]
-    pub method_def_span: Option<Span>,
-    pub method_name: Symbol,
-    #[note(lint_through_overloaded_deref)]
-    pub through_overloaded_deref: bool,
+    #[subdiagnostic]
+    pub origin: ImplicitUnsafeAutorefsOrigin<'a>,
+    #[subdiagnostic]
+    pub method: Option<ImplicitUnsafeAutorefsMethodNote>,
     #[subdiagnostic]
     pub suggestion: ImplicitUnsafeAutorefsSuggestion,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum ImplicitUnsafeAutorefsOrigin<'a> {
+    #[note(lint_autoref)]
+    Autoref {
+        #[primary_span]
+        autoref_span: Span,
+        autoref_ty: Ty<'a>,
+    },
+    #[note(lint_overloaded_deref)]
+    OverloadedDeref,
+}
+
+#[derive(Subdiagnostic)]
+#[note(lint_method_def)]
+pub(crate) struct ImplicitUnsafeAutorefsMethodNote {
+    #[primary_span]
+    pub def_span: Span,
+    pub method_name: Symbol,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -61,13 +61,14 @@ where
         ecx: &mut EvalCtxt<'_, D>,
         goal: Goal<I, Self>,
         assumption: I::Clause,
-    ) -> Result<(), NoSolution> {
+        then: impl FnOnce(&mut EvalCtxt<'_, D>) -> QueryResult<I>,
+    ) -> QueryResult<I> {
         let host_clause = assumption.as_host_effect_clause().unwrap();
 
         let assumption_trait_pred = ecx.instantiate_binder_with_infer(host_clause);
         ecx.eq(goal.param_env, goal.predicate.trait_ref, assumption_trait_pred.trait_ref)?;
 
-        Ok(())
+        then(ecx)
     }
 
     /// Register additional assumptions for aliases corresponding to `~const` item bounds.

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -196,6 +196,14 @@ where
                 debug!("dropck_outlives: ty from dtorck_types = {:?}", ty);
                 ty
             } else {
+                // Flush errors b/c `deeply_normalize` doesn't expect pending
+                // obligations, and we may have pending obligations from the
+                // branch above (from other types).
+                let errors = ocx.select_all_or_error();
+                if !errors.is_empty() {
+                    return Err(errors);
+                }
+
                 ocx.deeply_normalize(&cause, param_env, ty)?;
 
                 let errors = ocx.select_where_possible();

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1760,12 +1760,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         if is_match {
             let generics = self.tcx().generics_of(obligation.predicate.def_id);
-            // FIXME(generic-associated-types): Addresses aggressive inference in #92917.
+            // FIXME(generic_associated_types): Addresses aggressive inference in #92917.
             // If this type is a GAT, and of the GAT args resolve to something new,
             // that means that we must have newly inferred something about the GAT.
             // We should give up in that case.
-            // FIXME(generic-associated-types): This only detects one layer of inference,
-            // which is probably not what we actually want, but fixing it causes some ambiguity:
+            //
+            // This only detects one layer of inference, which is probably not what we actually
+            // want, but fixing it causes some ambiguity:
             // <https://github.com/rust-lang/rust/issues/125196>.
             if !generics.is_own_empty()
                 && obligation.predicate.args[generics.parent_count..].iter().any(|&p| {

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -298,6 +298,14 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
     + From<I::Region>
     + From<I::Const>
 {
+    fn as_term(&self) -> Option<I::Term> {
+        match self.kind() {
+            ty::GenericArgKind::Lifetime(_) => None,
+            ty::GenericArgKind::Type(ty) => Some(ty.into()),
+            ty::GenericArgKind::Const(ct) => Some(ct.into()),
+        }
+    }
+
     fn as_type(&self) -> Option<I::Ty> {
         if let ty::GenericArgKind::Type(ty) = self.kind() { Some(ty) } else { None }
     }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -682,6 +682,13 @@ impl<I: Interner> AliasTerm<I> {
     pub fn trait_ref(self, interner: I) -> TraitRef<I> {
         self.trait_ref_and_own_args(interner).0
     }
+
+    /// Extract the own args from this projection.
+    /// For example, if this is a projection of `<T as StreamingIterator>::Item<'a>`,
+    /// then this function would return the slice `['a]` as the own args.
+    pub fn own_args(self, interner: I) -> I::GenericArgsSlice {
+        self.trait_ref_and_own_args(interner).1
+    }
 }
 
 /// The following methods work only with inherent associated term projections.

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -287,7 +287,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     }
 
     #[inline]
-    pub(crate) fn non_null(&self) -> NonNull<T> {
+    pub(crate) const fn non_null(&self) -> NonNull<T> {
         self.inner.non_null()
     }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1816,10 +1816,10 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_ptr`]: Vec::as_ptr
     /// [`as_non_null`]: Vec::as_non_null
     #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
+    #[rustc_const_unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
     #[inline]
-    pub fn as_non_null(&mut self) -> NonNull<T> {
-        // SAFETY: A `Vec` always has a non-null pointer.
-        unsafe { NonNull::new_unchecked(self.as_mut_ptr()) }
+    pub const fn as_non_null(&mut self) -> NonNull<T> {
+        self.buf.non_null()
     }
 
     /// Returns a reference to the underlying allocator.

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -12,11 +12,11 @@
 //! "pinned," in that it has been permanently (until the end of its lifespan) attached to its
 //! location in memory, as though pinned to a pinboard. Pinning a value is an incredibly useful
 //! building block for [`unsafe`] code to be able to reason about whether a raw pointer to the
-//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessary from the
-//! time the value is first pinned until the end of its lifespan. This concept of "pinning" is
-//! necessary to implement safe interfaces on top of things like self-referential types and
-//! intrusive data structures which cannot currently be modeled in fully safe Rust using only
-//! borrow-checked [references][reference].
+//! pinned value is still valid. [As we'll see later][drop-guarantee], once a value is pinned,
+//! it is necessarily valid at its memory location until the end of its lifespan. This concept
+//! of "pinning" is necessary to implement safe interfaces on top of things like self-referential
+//! types and intrusive data structures which cannot currently be modeled in fully safe Rust using
+//! only borrow-checked [references][reference].
 //!
 //! "Pinning" allows us to put a *value* which exists at some location in memory into a state where
 //! safe code cannot *move* that value to a different location in memory or otherwise invalidate it

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -12,7 +12,7 @@
 //! "pinned," in that it has been permanently (until the end of its lifespan) attached to its
 //! location in memory, as though pinned to a pinboard. Pinning a value is an incredibly useful
 //! building block for [`unsafe`] code to be able to reason about whether a raw pointer to the
-//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessarily from the
+//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessary from the
 //! time the value is first pinned until the end of its lifespan. This concept of "pinning" is
 //! necessary to implement safe interfaces on top of things like self-referential types and
 //! intrusive data structures which cannot currently be modeled in fully safe Rust using only

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1498,11 +1498,10 @@ impl File {
             None => Ok(libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT as _ }),
         };
         cfg_if::cfg_if! {
-            if #[cfg(any(target_os = "redox", target_os = "espidf", target_os = "horizon", target_os = "vxworks", target_os = "nuttx"))] {
+            if #[cfg(any(target_os = "redox", target_os = "espidf", target_os = "horizon", target_os = "nuttx"))] {
                 // Redox doesn't appear to support `UTIME_OMIT`.
                 // ESP-IDF and HorizonOS do not support `futimens` at all and the behavior for those OS is therefore
                 // the same as for Redox.
-                // `futimens` and `UTIME_OMIT` are a work in progress for vxworks.
                 let _ = times;
                 Err(io::const_error!(
                     io::ErrorKind::Unsupported,

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -222,16 +222,8 @@ impl Thread {
 
     #[cfg(target_os = "vxworks")]
     pub fn set_name(name: &CStr) {
-        // FIXME(libc): adding real STATUS, ERROR type eventually.
-        unsafe extern "C" {
-            fn taskNameSet(task_id: libc::TASK_ID, task_name: *mut libc::c_char) -> libc::c_int;
-        }
-
-        //  VX_TASK_NAME_LEN is 31 in VxWorks 7.
-        const VX_TASK_NAME_LEN: usize = 31;
-
-        let mut name = truncate_cstr::<{ VX_TASK_NAME_LEN }>(name);
-        let res = unsafe { taskNameSet(libc::taskIdSelf(), name.as_mut_ptr()) };
+        let mut name = truncate_cstr::<{ libc::VX_TASK_RENAME_LENGTH - 1 }>(name);
+        let res = unsafe { libc::taskNameSet(libc::taskIdSelf(), name.as_mut_ptr()) };
         debug_assert_eq!(res, libc::OK);
     }
 

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -58,7 +58,7 @@ fn rustfmt(
 fn get_rustfmt_version(build: &Builder<'_>) -> Option<(String, BuildStamp)> {
     let stamp_file = BuildStamp::new(&build.out).with_prefix("rustfmt");
 
-    let mut cmd = command(build.initial_rustfmt()?);
+    let mut cmd = command(build.config.initial_rustfmt.as_ref()?);
     cmd.arg("--version");
 
     let output = cmd.allow_failure().run_capture(build);
@@ -243,7 +243,7 @@ pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {
 
     let override_ = override_builder.build().unwrap(); // `override` is a reserved keyword
 
-    let rustfmt_path = build.initial_rustfmt().unwrap_or_else(|| {
+    let rustfmt_path = build.config.initial_rustfmt.clone().unwrap_or_else(|| {
         eprintln!("fmt error: `x fmt` is not supported on this channel");
         crate::exit!(1);
     });

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1102,7 +1102,7 @@ impl Step for Tidy {
         if builder.config.channel == "dev" || builder.config.channel == "nightly" {
             if !builder.config.json_output {
                 builder.info("fmt check");
-                if builder.initial_rustfmt().is_none() {
+                if builder.config.initial_rustfmt.is_none() {
                     let inferred_rustfmt_dir = builder.initial_sysroot.join("bin");
                     eprintln!(
                         "\

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -446,7 +446,7 @@ impl Config {
 
     #[cfg(test)]
     pub(crate) fn maybe_download_rustfmt(&self) -> Option<PathBuf> {
-        None
+        Some(PathBuf::new())
     }
 
     /// NOTE: rustfmt is a completely different toolchain than the bootstrap compiler, so it can't
@@ -454,6 +454,10 @@ impl Config {
     #[cfg(not(test))]
     pub(crate) fn maybe_download_rustfmt(&self) -> Option<PathBuf> {
         use build_helper::stage0_parser::VersionMetadata;
+
+        if self.dry_run() {
+            return Some(PathBuf::new());
+        }
 
         let VersionMetadata { date, version } = self.stage0_metadata.rustfmt.as_ref()?;
         let channel = format!("{version}-{date}");

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -325,7 +325,6 @@ forward! {
     tempdir() -> PathBuf,
     llvm_link_shared() -> bool,
     download_rustc() -> bool,
-    initial_rustfmt() -> Option<PathBuf>,
 }
 
 impl Build {
@@ -613,10 +612,6 @@ impl Build {
         unsafe {
             crate::utils::job::setup(self);
         }
-
-        // Download rustfmt early so that it can be used in rust-analyzer configs.
-        trace!("downloading rustfmt early");
-        let _ = &builder::Builder::new(self).initial_rustfmt();
 
         // Handle hard-coded subcommands.
         {

--- a/tests/ui/drop/dropck-normalize-errors.rs
+++ b/tests/ui/drop/dropck-normalize-errors.rs
@@ -1,0 +1,31 @@
+// Test that we don't ICE when computing the drop types for
+
+trait Decode<'a> {
+    type Decoder;
+}
+
+trait NonImplementedTrait {
+    type Assoc;
+}
+struct NonImplementedStruct;
+
+pub struct ADecoder<'a> {
+    b: <B as Decode<'a>>::Decoder,
+}
+fn make_a_decoder<'a>() -> ADecoder<'a> {
+    //~^ ERROR the trait bound
+    //~| ERROR the trait bound
+    panic!()
+}
+
+struct B;
+impl<'a> Decode<'a> for B {
+    type Decoder = BDecoder;
+    //~^ ERROR the trait bound
+}
+pub struct BDecoder {
+    non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
+    //~^ ERROR the trait bound
+}
+
+fn main() {}

--- a/tests/ui/drop/dropck-normalize-errors.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.stderr
@@ -1,0 +1,76 @@
+error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `ADecoder<'a>`
+  --> $DIR/dropck-normalize-errors.rs:15:28
+   |
+LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
+   |                            ^^^^^^^^^^^^ within `ADecoder<'a>`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dropck-normalize-errors.rs:7:1
+   |
+LL | trait NonImplementedTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required because it appears within the type `BDecoder`
+  --> $DIR/dropck-normalize-errors.rs:26:12
+   |
+LL | pub struct BDecoder {
+   |            ^^^^^^^^
+note: required because it appears within the type `ADecoder<'a>`
+  --> $DIR/dropck-normalize-errors.rs:12:12
+   |
+LL | pub struct ADecoder<'a> {
+   |            ^^^^^^^^
+   = note: the return type of a function must have a statically known size
+
+error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied in `BDecoder`
+  --> $DIR/dropck-normalize-errors.rs:23:20
+   |
+LL |     type Decoder = BDecoder;
+   |                    ^^^^^^^^ within `BDecoder`, the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dropck-normalize-errors.rs:7:1
+   |
+LL | trait NonImplementedTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required because it appears within the type `BDecoder`
+  --> $DIR/dropck-normalize-errors.rs:26:12
+   |
+LL | pub struct BDecoder {
+   |            ^^^^^^^^
+note: required by a bound in `Decode::Decoder`
+  --> $DIR/dropck-normalize-errors.rs:4:5
+   |
+LL |     type Decoder;
+   |     ^^^^^^^^^^^^^ required by this bound in `Decode::Decoder`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Decoder: ?Sized;
+   |                 ++++++++
+
+error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
+  --> $DIR/dropck-normalize-errors.rs:27:22
+   |
+LL |     non_implemented: <NonImplementedStruct as NonImplementedTrait>::Assoc,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dropck-normalize-errors.rs:7:1
+   |
+LL | trait NonImplementedTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
+  --> $DIR/dropck-normalize-errors.rs:15:28
+   |
+LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
+   |                            ^^^^^^^^^^^^ the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dropck-normalize-errors.rs:7:1
+   |
+LL | trait NonImplementedTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/guide-inference-in-gat-arg-deeper.rs
+++ b/tests/ui/generic-associated-types/guide-inference-in-gat-arg-deeper.rs
@@ -1,5 +1,9 @@
-// Fix for <https://github.com/rust-lang/rust/issues/125196>.
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Fix for <https://github.com/rust-lang/rust/issues/125196>.
 
 trait Tr {
     type Gat<T>;

--- a/tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs
+++ b/tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs
@@ -1,0 +1,33 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Regression test for trait-system-refactor-initiative#202. We have
+// to make sure we don't constrain ambiguous GAT args when normalizing
+// via where bounds or item bounds.
+
+trait Trait {
+    type Assoc<U>;
+}
+
+fn ret<T: Trait, U>(x: U) -> <T as Trait>::Assoc<U> {
+    loop {}
+}
+
+fn where_bound<T: Trait<Assoc<u32> = u32>>() {
+    let inf = Default::default();
+    let x = ret::<T, _>(inf);
+    let _: i32 = inf;
+}
+
+trait ItemBound {
+    type Bound: Trait<Assoc<u32> = u32>;
+}
+fn item_bound<T: ItemBound>() {
+    let inf = Default::default();
+    let x = ret::<T::Bound, _>(inf);
+    let _: i32 = inf;
+}
+
+fn main() {}

--- a/tests/ui/lint/implicit_autorefs.fixed
+++ b/tests/ui/lint/implicit_autorefs.fixed
@@ -96,4 +96,10 @@ unsafe fn test_string(ptr: *mut String) {
     //~^ WARN implicit autoref
 }
 
+unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
+    let _ = (&(&(*slice))[..]).len();
+    //~^ WARN implicit autoref
+    //~^^ WARN implicit autoref
+}
+
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.rs
+++ b/tests/ui/lint/implicit_autorefs.rs
@@ -96,4 +96,10 @@ unsafe fn test_string(ptr: *mut String) {
     //~^ WARN implicit autoref
 }
 
+unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
+    let _ = (*slice)[..].len();
+    //~^ WARN implicit autoref
+    //~^^ WARN implicit autoref
+}
+
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.stderr
+++ b/tests/ui/lint/implicit_autorefs.stderr
@@ -2,9 +2,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:10:13
    |
 LL |     let _ = (*ptr)[..16];
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const [u8]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:10:13
+   |
+LL |     let _ = (*ptr)[..16];
+   |             ^^^^^^
    = note: `#[warn(dangerous_implicit_autorefs)]` on by default
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
@@ -15,9 +22,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:19:13
    |
 LL |     let l = (*ptr).field.len();
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*const Test`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:19:13
+   |
+LL |     let l = (*ptr).field.len();
+   |             ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let l = (&(*ptr).field).len();
@@ -27,9 +43,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:22:16
    |
 LL |     &raw const (*ptr).field[..l - 1]
-   |                ^^^^^^^^^^^^^^^^^^^^^
+   |                ^^---^^^^^^^^^^^^^^^^
+   |                  |
+   |                  this raw pointer has type `*const Test`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:22:16
+   |
+LL |     &raw const (*ptr).field[..l - 1]
+   |                ^^^^^^^^^^^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     &raw const (&(*ptr).field)[..l - 1]
@@ -39,9 +62,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:27:9
    |
 LL |     _ = (*a)[0].len();
-   |         ^^^^^^^^^^^^^
+   |         ^^-^^^^^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:27:9
+   |
+LL |     _ = (*a)[0].len();
+   |         ^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a)[0]).len();
@@ -51,9 +83,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
-   |         ^^^^^^^^^^^^^^^^^^
+   |         ^^-^^^^^^^^^^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:30:9
+   |
+LL |     _ = (*a)[..1][0].len();
+   |         ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a)[..1][0]).len();
@@ -63,9 +104,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
-   |         ^^^^^^^^^
+   |         ^^-^^^^^^
+   |           |
+   |           this raw pointer has type `*mut [String]`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[String]`
+  --> $DIR/implicit_autorefs.rs:30:9
+   |
+LL |     _ = (*a)[..1][0].len();
+   |         ^^^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     _ = (&(*a))[..1][0].len();
@@ -75,9 +123,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:36:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:36:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -87,9 +143,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:38:24
    |
 LL |     let _ = &raw const (*ptr).field;
-   |                        ^^^^^^^^^^^^
+   |                        ^^---^^^^^^^
+   |                          |
+   |                          this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:38:24
+   |
+LL |     let _ = &raw const (*ptr).field;
+   |                        ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = &raw const (&(*ptr)).field;
@@ -99,9 +163,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:43:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:43:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -111,9 +183,17 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:48:13
    |
 LL |     let _ = (*ptr).field;
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*const ManuallyDrop<ManuallyDrop<Test>>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `Test`
+  --> $DIR/implicit_autorefs.rs:48:13
+   |
+LL |     let _ = (*ptr).field;
+   |             ^^^^^^
+   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -123,9 +203,16 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:62:26
    |
 LL |     let _p: *const i32 = &raw const **w;
-   |                          ^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^-
+   |                                       |
+   |                                       this raw pointer has type `*const W<i32>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&W<i32>`
+  --> $DIR/implicit_autorefs.rs:62:38
+   |
+LL |     let _p: *const i32 = &raw const **w;
+   |                                      ^^
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _p: *const i32 = &raw const *(&**w);
@@ -135,9 +222,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:72:14
    |
 LL |     unsafe { (*ptr).field.len() }
-   |              ^^^^^^^^^^^^^^^^^^
+   |              ^^---^^^^^^^^^^^^^
+   |                |
+   |                this raw pointer has type `*const Test2`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:72:14
+   |
+LL |     unsafe { (*ptr).field.len() }
+   |              ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     unsafe { (&(*ptr).field).len() }
@@ -147,9 +243,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:82:13
    |
 LL |     let _ = (*ptr).get(0);
-   |             ^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:82:13
+   |
+LL |     let _ = (*ptr).get(0);
+   |             ^^^^^^
+note: method calls to `get` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).get(0);
@@ -159,9 +264,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:84:13
    |
 LL |     let _ = (*ptr).get_unchecked(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[u8]`
+  --> $DIR/implicit_autorefs.rs:84:13
+   |
+LL |     let _ = (*ptr).get_unchecked(0);
+   |             ^^^^^^
+note: method calls to `get_unchecked` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).get_unchecked(0);
@@ -171,9 +285,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:86:13
    |
 LL |     let _ = (*ptr).get_mut(0);
-   |             ^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&mut [u8]`
+  --> $DIR/implicit_autorefs.rs:86:13
+   |
+LL |     let _ = (*ptr).get_mut(0);
+   |             ^^^^^^
+note: method calls to `get_mut` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&mut (*ptr)).get_mut(0);
@@ -183,9 +306,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:88:13
    |
 LL |     let _ = (*ptr).get_unchecked_mut(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut Vec<u8>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&mut [u8]`
+  --> $DIR/implicit_autorefs.rs:88:13
+   |
+LL |     let _ = (*ptr).get_unchecked_mut(0);
+   |             ^^^^^^
+note: method calls to `get_unchecked_mut` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&mut (*ptr)).get_unchecked_mut(0);
@@ -195,9 +327,18 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:93:13
    |
 LL |     let _ = (*ptr).len();
-   |             ^^^^^^^^^^^^
+   |             ^^---^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut String`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:93:13
+   |
+LL |     let _ = (*ptr).len();
+   |             ^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).len();
@@ -207,13 +348,62 @@ warning: implicit autoref creates a reference to the dereference of a raw pointe
   --> $DIR/implicit_autorefs.rs:95:13
    |
 LL |     let _ = (*ptr).is_empty();
-   |             ^^^^^^^^^^^^^^^^^
+   |             ^^---^^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*mut String`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&String`
+  --> $DIR/implicit_autorefs.rs:95:13
+   |
+LL |     let _ = (*ptr).is_empty();
+   |             ^^^^^^
+note: method calls to `is_empty` require a reference
+  --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).is_empty();
    |             ++      +
 
-warning: 18 warnings emitted
+warning: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^-----^^^^^^^^^^^
+   |               |
+   |               this raw pointer has type `*const [T]`
+   |
+   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[T]`
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^^^^^^^^^^^
+note: method calls to `len` require a reference
+  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
+   |
+LL |     let _ = (&(*slice)[..]).len();
+   |             ++            +
+
+warning: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^-----^^^^^
+   |               |
+   |               this raw pointer has type `*const [T]`
+   |
+   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
+note: autoref is being applied to this expression, resulting in: `&[T]`
+  --> $DIR/implicit_autorefs.rs:100:13
+   |
+LL |     let _ = (*slice)[..].len();
+   |             ^^^^^^^^
+help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
+   |
+LL |     let _ = (&(*slice))[..].len();
+   |             ++        +
+
+warning: 20 warnings emitted
 

--- a/tests/ui/lint/implicit_autorefs.stderr
+++ b/tests/ui/lint/implicit_autorefs.stderr
@@ -128,12 +128,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:36:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -148,12 +143,7 @@ LL |     let _ = &raw const (*ptr).field;
    |                          this raw pointer has type `*const ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:38:24
-   |
-LL |     let _ = &raw const (*ptr).field;
-   |                        ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = &raw const (&(*ptr)).field;
@@ -168,12 +158,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*mut ManuallyDrop<Test>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:43:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;
@@ -188,12 +173,7 @@ LL |     let _ = (*ptr).field;
    |               this raw pointer has type `*const ManuallyDrop<ManuallyDrop<Test>>`
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
-note: autoref is being applied to this expression, resulting in: `Test`
-  --> $DIR/implicit_autorefs.rs:48:13
-   |
-LL |     let _ = (*ptr).field;
-   |             ^^^^^^
-   = note: reference(s) created through call(s) to overloaded `Deref(Mut)::deref(_mut)` implementation
+   = note: references are created through calls to explicit `Deref(Mut)::deref(_mut)` implementations
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr)).field;


### PR DESCRIPTION
Successful merges:

 - #139749 (docs(library/core/src/pin): fix typo "necessarily" -> "necessary")
 - #140685 (Simplify `Vec::as_non_null` implementation and make it `const`)
 - #140712 (normalization: avoid incompletely constraining GAT args)
 - #140768 (Improve `dangerous_implicit_aurorefs` diagnostic output)
 - #140947 (Flush errors before deep normalize in `dropck_outlives`)
 - #140990 (VxWorks: updates from recent libc versions)
 - #141027 (remove `RustfmtState` to reduce `initial_rustfmt` complexity)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139749,140685,140712,140768,140947,140990,141027)
<!-- homu-ignore:end -->