### PR TITLE
Lowercase git url for rust-lang/enzyme.git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	shallow = true
 [submodule "src/tools/enzyme"]
 	path = src/tools/enzyme
-	url = https://github.com/rust-lang/Enzyme.git
+	url = https://github.com/rust-lang/enzyme.git
 	shallow = true
 [submodule "src/gcc"]
 	path = src/gcc


### PR DESCRIPTION
On Fuchsia, we have an internal Gerrit mirrors of the rust repositories to avoid excess load on the public github servers. Since rust uses submodules, we need to then use git's `url.<base>.insteadOf` to point our checkouts at our mirrors.

We'd prefer to be able to point all repositories under `https://github.com/rust-lang` to
`https://rust.googlesource.com/rust-lang`, but unfortunately it seems that when Rust mirrored Enzyme, the repository name was lower cased to `https://github.com/rust-lang/enzyme`, but kept the name capitalized in the .gitmodules file. This didn't cause a problem for Github, which seems to handle repository names in a case insensitive way, Gerrit is case sensitive, so we can't use a glob rule. Instead we have to setup `insteadOf` rules for each repository.

This renames the URL to match the case of the repository name, which should avoid the issue.