### PR TITLE
HIR: explain in comment why `ExprKind::If` "then" is an `Expr`

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2744,6 +2744,8 @@ pub enum ExprKind<'hir> {
     ///
     /// The "then" expr is always `ExprKind::Block`. If present, the "else" expr is always
     /// `ExprKind::Block` (for `else`) or `ExprKind::If` (for `else if`).
+    /// Note that using an `Expr` instead of a `Block` for the "then" part is intentional,
+    /// as it simplifies the type coercion machinery.
     If(&'hir Expr<'hir>, &'hir Expr<'hir>, Option<&'hir Expr<'hir>>),
     /// A conditionless loop (can be exited with `break`, `continue`, or `return`).
     ///


### PR DESCRIPTION
One could be tempted to replace the "then" `hir::Expr` with kind `hir::ExprKind::Block` by a `hir::Block`. Explain why this would not be a good idea.

I've been there.

r? @compiler-errors 