### PR TITLE
Enable [behind-upstream] triagebot option for rust-lang/rust

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1424,3 +1424,6 @@ compiletest = [
 # Enable `@rustbot note` functionality
 # Documentation at: https://forge.rust-lang.org/triagebot/note.html
 [note]
+
+[behind-upstream]
+days-threshold = 7

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1426,4 +1426,4 @@ compiletest = [
 [note]
 
 [behind-upstream]
-days-threshold = 7
+days-threshold = 14


### PR DESCRIPTION
After testing in [rustc-develop-guide](https://github.com/rust-lang/rustc-dev-guide/pull/2384#issuecomment-2876631306), we can turn on `behind-upstream` here.

Doc: https://forge.rust-lang.org/triagebot/behind-upstream.html

r? @Urgau 
