### PR TITLE
Fix the issue of typo of comma in arm parsing

### DIFF
--- a/tests/ui/parser/match-arm-comma-typo-issue-140991.fixed
+++ b/tests/ui/parser/match-arm-comma-typo-issue-140991.fixed
@@ -1,0 +1,24 @@
+//@ run-rustfix
+
+pub enum Foo {
+    X, Y
+}
+
+pub fn typo1(foo: Foo) -> Foo {
+    use Foo::*;
+    match foo {
+        X => Y,
+        Y => X, //~ ERROR expected one of
+    }
+}
+
+pub fn typo2(foo: Foo) -> Foo {
+    use Foo::*;
+    match foo {
+        X => Y,
+        Y => X, //~ ERROR expected one of
+    }
+}
+
+
+fn main() { }

--- a/tests/ui/parser/match-arm-comma-typo-issue-140991.rs
+++ b/tests/ui/parser/match-arm-comma-typo-issue-140991.rs
@@ -1,0 +1,24 @@
+//@ run-rustfix
+
+pub enum Foo {
+    X, Y
+}
+
+pub fn typo1(foo: Foo) -> Foo {
+    use Foo::*;
+    match foo {
+        X => Y.
+        Y => X, //~ ERROR expected one of
+    }
+}
+
+pub fn typo2(foo: Foo) -> Foo {
+    use Foo::*;
+    match foo {
+        X => Y/
+        Y => X, //~ ERROR expected one of
+    }
+}
+
+
+fn main() { }

--- a/tests/ui/parser/match-arm-comma-typo-issue-140991.stderr
+++ b/tests/ui/parser/match-arm-comma-typo-issue-140991.stderr
@@ -1,0 +1,26 @@
+error: expected one of `(`, `,`, `.`, `::`, `?`, `}`, or an operator, found `=>`
+  --> $DIR/match-arm-comma-typo-issue-140991.rs:11:11
+   |
+LL |         Y => X,
+   |           ^^ expected one of 7 possible tokens
+   |
+help: you might have meant to write a `,` to end this `match` arm
+   |
+LL -         X => Y.
+LL +         X => Y,
+   |
+
+error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, `}`, or an operator, found `=>`
+  --> $DIR/match-arm-comma-typo-issue-140991.rs:19:11
+   |
+LL |         Y => X,
+   |           ^^ expected one of 8 possible tokens
+   |
+help: you might have meant to write a `,` to end this `match` arm
+   |
+LL -         X => Y/
+LL +         X => Y,
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #140991 

I also checked is it a '/', since it's near from ',' from keyboard.
