### PR TITLE
add regression test for rust-lang#101650

### DIFF
--- a/tests/ui/async-await/format-await-send.rs
+++ b/tests/ui/async-await/format-await-send.rs
@@ -1,0 +1,24 @@
+// regression test for <https://github.com/rust-lang/rust/issues/101650>
+// assert that Future which has format!() with an async function is Send
+
+#![allow(unused)]
+
+//@ check-pass
+//@ edition: 2018
+
+use core::future::Future;
+use core::pin::Pin;
+
+fn build_string() -> Pin<Box<dyn Future<Output = String> + Send>> {
+    Box::pin(async move {
+        let mut string_builder = String::new();
+        string_builder += &format!("Hello {}", helper().await);
+        string_builder
+    })
+}
+
+async fn helper() -> String {
+    "World".to_string()
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

closes #101650, which was already fixed.
