### PR TITLE
Fix path resolution of `rustfmt` in `cargo-fmt`

### DIFF
--- a/src/tools/rustfmt/src/cargo-fmt/main.rs
+++ b/src/tools/rustfmt/src/cargo-fmt/main.rs
@@ -6,7 +6,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
-use std::ffi::OsStr;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
@@ -151,11 +150,10 @@ fn execute() -> i32 {
 }
 
 fn rustfmt_command() -> Command {
-    let rustfmt_var = env::var_os("RUSTFMT");
-    let rustfmt = match &rustfmt_var {
-        Some(rustfmt) => rustfmt,
-        None => OsStr::new("rustfmt"),
-    };
+    let rustfmt = env::current_exe()
+        .expect("current executable path invalid")
+        .with_file_name("rustfmt");
+
     Command::new(rustfmt)
 }
 


### PR DESCRIPTION
Instead of resolving `rustfmt` path from RUSTFMT or PATH envs, use the one located in the same directory as `cargo-fmt`. So that `cargo-fmt` uses the expected version of `rustfmt` to avoid accidental use of unrelated versions.

Fixes #137666
