### PR TITLE
use `if matches!` instead of `match` for simplicity

### DIFF
--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -139,7 +139,7 @@ fn parse_assert<'a>(cx: &ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PResult<
     //
     // Emit an error and suggest inserting a comma.
     let custom_message =
-        if let token::Literal(token::Lit { kind: token::Str, .. }) = parser.token.kind {
+        if matches!(parser.token.kind, token::Literal(token::Lit { kind: token::Str, .. })) {
             let comma = parser.prev_token.span.shrink_to_hi();
             cx.dcx().emit_err(errors::AssertMissingComma { span: parser.token.span, comma });
 


### PR DESCRIPTION
This pull request updates the `check.rs` + `assert.rs` files to use `matches!` instead of `match` for simplicity. This change makes it a bit easier to read without changing any core functionality.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
