### PR TITLE
std: note that `std::str::from_utf8*` functions are aliases to `<str>::from_utf8*` methods

### DIFF
--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -6,6 +6,8 @@ use crate::{mem, ptr};
 
 /// Converts a slice of bytes to a string slice.
 ///
+/// This is an alias to [`str::from_utf8`].
+///
 /// A string slice ([`&str`]) is made of bytes ([`u8`]), and a byte slice
 /// ([`&[u8]`][byteslice]) is made of bytes, so this function converts between
 /// the two. Not all byte slices are valid string slices, however: [`&str`] requires
@@ -97,6 +99,8 @@ pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 
 /// Converts a mutable slice of bytes to a mutable string slice.
 ///
+/// This is an alias to [`str::from_utf8_mut`].
+///
 /// # Examples
 ///
 /// Basic usage:
@@ -142,6 +146,8 @@ pub const fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
 ///
+/// This is an alias to [`str::from_utf8_unchecked`].
+///
 /// See the safe version, [`from_utf8`], for more information.
 ///
 /// # Safety
@@ -177,6 +183,8 @@ pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
 
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8; mutable version.
+///
+/// This is an alias to [`str::from_utf8_unchecked_mut`].
 ///
 /// See the immutable version, [`from_utf8_unchecked()`] for documentation and safety requirements.
 ///


### PR DESCRIPTION
Closes #141079

r? libs
