### PR TITLE
opt-dist: fix deprecated BOLT -icf=1 option

### DIFF
--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -80,7 +80,7 @@ pub fn bolt_optimize(
         // Move jump tables to a separate section
         .arg("-jump-tables=move")
         // Fold functions with identical code
-        .arg("-icf=1")
+        .arg("-icf=all")
         // The following flag saves about 50 MiB of libLLVM.so size.
         // However, it succeeds very non-deterministically. To avoid frequent artifact size swings,
         // it is kept disabled for now.


### PR DESCRIPTION
Replaced deprecated `-icf=1` BOLT option.

Spotted in recent CI run (https://github.com/rust-lang-ci/rust/actions/runs/15080898417/job/42397253162):
```
BOLT-WARNING: specifying numeric value "1" for option -icf is deprecated
```

Change was added in https://github.com/llvm/llvm-project/pull/116275

Btw, now there also exist new option `-icf=safe`, will be nice to try it too.