### PR TITLE
check coroutines with `TypingMode::Borrowck` to avoid cyclic reasoning

### DIFF
--- a/tests/ui/coroutine/delayed-obligations-emit.next.stderr
+++ b/tests/ui/coroutine/delayed-obligations-emit.next.stderr
@@ -1,0 +1,15 @@
+error[E0275]: overflow evaluating the requirement `{async block@$DIR/delayed-obligations-emit.rs:17:11: 17:16}: Send`
+  --> $DIR/delayed-obligations-emit.rs:17:5
+   |
+LL |     spawn(async { build_dependencies().await });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `spawn`
+  --> $DIR/delayed-obligations-emit.rs:31:13
+   |
+LL | fn spawn<F: Send>(_: F) {}
+   |             ^^^^ required by this bound in `spawn`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/coroutine/delayed-obligations-emit.rs
+++ b/tests/ui/coroutine/delayed-obligations-emit.rs
@@ -1,0 +1,33 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ edition: 2024
+//@[current] check-pass
+
+// This previously caused an ICE with the new solver.
+// The delayed coroutine obligations were checked with the
+// opaque types inferred by borrowck.
+//
+// One of these delayed obligations failed with overflow in
+// borrowck, causing us to taint `type_of` for the opaque. This
+// then caused us to also not emit an error when checking the
+// coroutine obligations.
+
+fn build_multiple<'a>() -> impl Sized {
+    spawn(async { build_dependencies().await });
+    //[next]~^ ERROR overflow evaluating the requirement
+}
+
+// Adding an explicit `Send` bound fixes it.
+// Proving `build_dependencies(): Send` in `build_multiple` adds
+// addiitional defining uses/placeholders.
+fn build_dependencies() -> impl Future<Output = ()> /* + Send */ {
+    async {
+        Box::pin(build_dependencies()).await;
+        async { build_multiple() }.await;
+    }
+}
+
+fn spawn<F: Send>(_: F) {}
+
+fn main() {}


### PR DESCRIPTION
MIR borrowck taints its output if an obligation fails. This could then cause `check_coroutine_obligations` to silence its error, causing us to not emit and actual error and ICE.

Fixes the ICE in https://github.com/rust-lang/trait-system-refactor-initiative/issues/199. It is unfortunately still a regression.

r? compiler-errors