### PR TITLE
Replace `try_reserve_exact` with `try_with_capacity` in `std::fs::read`

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -285,8 +285,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     fn inner(path: &Path) -> io::Result<Vec<u8>> {
         let mut file = File::open(path)?;
         let size = file.metadata().map(|m| m.len() as usize).ok();
-        let mut bytes = Vec::new();
-        bytes.try_reserve_exact(size.unwrap_or(0))?;
+        let mut bytes = Vec::try_with_capacity(size.unwrap_or(0))?;
         io::default_read_to_end(&mut file, &mut bytes, size)?;
         Ok(bytes)
     }


### PR DESCRIPTION
This change restores the previous behavior prior to #117925. That PR was made to handle OOM errors that turn into a panic with `Vec::with_capacity`. `try_reserve_exact` was used for that since there was no `try_with_capacity` method at the time. It was added later in #120504. I think it'd a better fit here.