### PR TITLE
Only assemble impl candidates if there are no candidates that would have shadowed it

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -394,9 +394,24 @@ where
 
         match assemble_from {
             AssembleCandidatesFrom::All => {
-                self.assemble_impl_candidates(goal, &mut candidates);
                 self.assemble_builtin_impl_candidates(goal, &mut candidates);
+
+                // UwU
+                if !matches!(self.typing_mode(), TypingMode::Coherence) {
+                    if candidates.iter().any(|cand| {
+                        matches!(
+                            cand.source,
+                            CandidateSource::ParamEnv(ParamEnvSource::NonGlobal)
+                                | CandidateSource::AliasBound
+                                | CandidateSource::BuiltinImpl(BuiltinImplSource::Trivial)
+                        )
+                    }) {
+                        return candidates;
+                    }
+                }
+
                 self.assemble_object_bound_candidates(goal, &mut candidates);
+                self.assemble_impl_candidates(goal, &mut candidates);
             }
             AssembleCandidatesFrom::EnvAndBounds => {}
         }

--- a/tests/ui/traits/unconstrained-projection-normalization-2.next.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization-2.next.stderr
@@ -1,9 +1,3 @@
-error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/unconstrained-projection-normalization-2.rs:14:6
-   |
-LL | impl<T: ?Sized> Every for Thing {
-   |      ^ unconstrained type parameter
-
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization-2.rs:16:18
    |
@@ -27,6 +21,12 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Assoc: ?Sized;
    |               ++++++++
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-projection-normalization-2.rs:14:6
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      ^ unconstrained type parameter
 
 error[E0282]: type annotations needed
   --> $DIR/unconstrained-projection-normalization-2.rs:20:11

--- a/tests/ui/traits/unconstrained-projection-normalization.next.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization.next.stderr
@@ -1,9 +1,3 @@
-error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/unconstrained-projection-normalization.rs:13:6
-   |
-LL | impl<T: ?Sized> Every for Thing {
-   |      ^ unconstrained type parameter
-
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization.rs:15:18
    |
@@ -27,6 +21,12 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Assoc: ?Sized;
    |               ++++++++
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-projection-normalization.rs:13:6
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      ^ unconstrained type parameter
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
 We don't need to assemble impl candidates since we know they are always shadowed by a param-env candidate, so it avoid doing possibly exponential unnecessary work.

This "optimization" is also a fix for a perf regression in rayon.