### PR TITLE
Resolved issue with mismatched types triggering ICE in certain scenarios

### DIFF
--- a/tests/crashes/140823.rs
+++ b/tests/crashes/140823.rs
@@ -1,9 +1,0 @@
-//@ known-bug: #140823
-
-struct Container<T> {
-    data: T,
-}
-
-fn ice(callback: Box<dyn Fn(Container<&u8>)>) {
-    let fails: Box<dyn Fn(&Container<&u8>)> = callback;
-}

--- a/tests/ui/fn/coerce-suggestion-infer-region.rs
+++ b/tests/ui/fn/coerce-suggestion-infer-region.rs
@@ -1,0 +1,26 @@
+//! Functions with a mismatch between the expected and found type where the difference is a
+//! reference may trigger analysis for additional help. In this test the expected type will be
+//! &'a Container<&'a u8> and the found type will be Container<&'?0 u8>.
+//!
+//! This test exercises a scenario where the found type being analyzed contains an inference region
+//! variable ('?0). This cannot be used in comparisons because the variable no longer exists by the
+//! time the later analysis is performed.
+//!
+//! This is a regression test of #140823
+
+trait MyFn<P> {}
+
+struct Container<T> {
+    data: T,
+}
+
+struct Desugared {
+    callback: Box<dyn for<'a> MyFn<&'a Container<&'a u8>>>,
+}
+
+fn test(callback: Box<dyn for<'a> MyFn<Container<&'a u8>>>) -> Desugared {
+    Desugared { callback }
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/fn/coerce-suggestion-infer-region.stderr
+++ b/tests/ui/fn/coerce-suggestion-infer-region.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/coerce-suggestion-infer-region.rs:22:17
+   |
+LL |     Desugared { callback }
+   |                 ^^^^^^^^ expected `Box<dyn MyFn<&Container<&u8>>>`, found `Box<dyn MyFn<Container<&u8>>>`
+   |
+   = note: expected struct `Box<(dyn for<'a> MyFn<&'a Container<&'a u8>> + 'static)>`
+              found struct `Box<(dyn for<'a> MyFn<Container<&'a u8>> + 'static)>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

## Background

The function `annotate_mut_binding_to_immutable_binding` called in `emit_coerce_suggestions` performs a type comparison between the `expected` and `found` types from `ExpectedFound` in the `TypeError`. This can fail if the `found` type contains a region variable that's been rolled back.

## What is being changed?

This updates `annotate_mut_binding_to_immutable_binding` to use `expr_ty` and `expected` from the parent function instead of the types from the `TypeError`. This sidesteps the issue of using `found` from `TypeError` which may leak lingering inference region variables.

This does change the diagnostic behavior to _only_ support cases where the expected outermost type is `&T`, but that seems to be the intended functionality.

Also fixed the example in the `annotate_mut_binding_to_immutable_binding` rustdocs.

r? rust-lang/types

Fixes #140823 