### PR TITLE
in `tests/ui/asm/aarch64/parse-error.rs`, only test cases specific to that target

### DIFF
--- a/tests/ui/asm/aarch64/parse-error.rs
+++ b/tests/ui/asm/aarch64/parse-error.rs
@@ -1,57 +1,11 @@
 //@ only-aarch64
 
-use std::arch::{asm, global_asm};
+use std::arch::asm;
 
 fn main() {
     let mut foo = 0;
     let mut bar = 0;
     unsafe {
-        asm!();
-        //~^ ERROR requires at least a template string argument
-        asm!(foo);
-        //~^ ERROR asm template must be a string literal
-        asm!("{}" foo);
-        //~^ ERROR expected token: `,`
-        asm!("{}", foo);
-        //~^ ERROR expected operand, clobber_abi, options, or additional template string
-        asm!("{}", in foo);
-        //~^ ERROR expected `(`, found `foo`
-        asm!("{}", in(reg foo));
-        //~^ ERROR expected `)`, found `foo`
-        asm!("{}", in(reg));
-        //~^ ERROR expected expression, found end of macro arguments
-        asm!("{}", inout(=) foo => bar);
-        //~^ ERROR expected register class or explicit register
-        asm!("{}", inout(reg) foo =>);
-        //~^ ERROR expected expression, found end of macro arguments
-        asm!("{}", in(reg) foo => bar);
-        //~^ ERROR expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
-        asm!("{}", sym foo + bar);
-        //~^ ERROR expected a path for argument to `sym`
-        asm!("", options(foo));
-        //~^ ERROR expected one of
-        asm!("", options(nomem foo));
-        //~^ ERROR expected one of
-        asm!("", options(nomem, foo));
-        //~^ ERROR expected one of
-        asm!("{}", options(), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("", clobber_abi(foo));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi("C" foo));
-        //~^ ERROR expected one of `)` or `,`, found `foo`
-        asm!("", clobber_abi("C", foo));
-        //~^ ERROR expected string literal
-        asm!("{}", clobber_abi("C"), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("", options(), clobber_abi("C"));
-        asm!("{}", options(), clobber_abi("C"), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("{a}", a = const foo, a = const bar);
-        //~^ ERROR duplicate argument named `a`
-        //~^^ ERROR argument never used
-        //~^^^ ERROR attempt to use a non-constant value in a constant
-        //~^^^^ ERROR attempt to use a non-constant value in a constant
         asm!("", a = in("x0") foo);
         //~^ ERROR explicit register arguments cannot have names
         asm!("{a}", in("x0") foo, a = const bar);
@@ -61,64 +15,5 @@ fn main() {
         asm!("{1}", in("x0") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
         //~^^ ERROR attempt to use a non-constant value in a constant
-        asm!("", options(), "");
-        //~^ ERROR expected one of
-        asm!("{}", in(reg) foo, "{}", out(reg) foo);
-        //~^ ERROR expected one of
-        asm!(format!("{{{}}}", 0), in(reg) foo);
-        //~^ ERROR asm template must be a string literal
-        asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
-        //~^ ERROR asm template must be a string literal
-        asm!("{}", in(reg) _);
-        //~^ ERROR _ cannot be used for input operands
-        asm!("{}", inout(reg) _);
-        //~^ ERROR _ cannot be used for input operands
-        asm!("{}", inlateout(reg) _);
-        //~^ ERROR _ cannot be used for input operands
     }
 }
-
-const FOO: i32 = 1;
-const BAR: i32 = 2;
-global_asm!();
-//~^ ERROR requires at least a template string argument
-global_asm!(FOO);
-//~^ ERROR asm template must be a string literal
-global_asm!("{}" FOO);
-//~^ ERROR expected token: `,`
-global_asm!("{}", FOO);
-//~^ ERROR expected operand, options, or additional template string
-global_asm!("{}", const);
-//~^ ERROR expected expression, found end of macro arguments
-global_asm!("{}", const(reg) FOO);
-//~^ ERROR expected one of
-global_asm!("", options(FOO));
-//~^ ERROR expected one of
-global_asm!("", options(nomem FOO));
-//~^ ERROR expected one of
-global_asm!("", options(nomem, FOO));
-//~^ ERROR expected one of
-global_asm!("{}", options(), const FOO);
-global_asm!("", clobber_abi(FOO));
-//~^ ERROR expected string literal
-global_asm!("", clobber_abi("C" FOO));
-//~^ ERROR expected one of `)` or `,`, found `FOO`
-global_asm!("", clobber_abi("C", FOO));
-//~^ ERROR expected string literal
-global_asm!("{}", clobber_abi("C"), const FOO);
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("", options(), clobber_abi("C"));
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("{}", options(), clobber_abi("C"), const FOO);
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("{a}", a = const FOO, a = const BAR);
-//~^ ERROR duplicate argument named `a`
-//~^^ ERROR argument never used
-global_asm!("", options(), "");
-//~^ ERROR expected one of
-global_asm!("{}", const FOO, "{}", const FOO);
-//~^ ERROR expected one of
-global_asm!(format!("{{{}}}", 0), const FOO);
-//~^ ERROR asm template must be a string literal
-global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
-//~^ ERROR asm template must be a string literal

--- a/tests/ui/asm/aarch64/parse-error.stderr
+++ b/tests/ui/asm/aarch64/parse-error.stderr
@@ -1,377 +1,19 @@
-error: requires at least a template string argument
-  --> $DIR/parse-error.rs:9:9
-   |
-LL |         asm!();
-   |         ^^^^^^
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:11:14
-   |
-LL |         asm!(foo);
-   |              ^^^
-
-error: expected token: `,`
-  --> $DIR/parse-error.rs:13:19
-   |
-LL |         asm!("{}" foo);
-   |                   ^^^ expected `,`
-
-error: expected operand, clobber_abi, options, or additional template string
-  --> $DIR/parse-error.rs:15:20
-   |
-LL |         asm!("{}", foo);
-   |                    ^^^ expected operand, clobber_abi, options, or additional template string
-
-error: expected `(`, found `foo`
-  --> $DIR/parse-error.rs:17:23
-   |
-LL |         asm!("{}", in foo);
-   |                       ^^^ expected `(`
-
-error: expected `)`, found `foo`
-  --> $DIR/parse-error.rs:19:27
-   |
-LL |         asm!("{}", in(reg foo));
-   |                           ^^^ expected `)`
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:21:27
-   |
-LL |         asm!("{}", in(reg));
-   |                           ^ expected expression
-
-error: expected register class or explicit register
-  --> $DIR/parse-error.rs:23:26
-   |
-LL |         asm!("{}", inout(=) foo => bar);
-   |                          ^
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:25:37
-   |
-LL |         asm!("{}", inout(reg) foo =>);
-   |                                     ^ expected expression
-
-error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
-  --> $DIR/parse-error.rs:27:32
-   |
-LL |         asm!("{}", in(reg) foo => bar);
-   |                                ^^ expected one of 7 possible tokens
-
-error: expected a path for argument to `sym`
-  --> $DIR/parse-error.rs:29:24
-   |
-LL |         asm!("{}", sym foo + bar);
-   |                        ^^^^^^^^^
-
-error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `nostack`, `preserves_flags`, `pure`, `raw`, or `readonly`, found `foo`
-  --> $DIR/parse-error.rs:31:26
-   |
-LL |         asm!("", options(foo));
-   |                          ^^^ expected one of 10 possible tokens
-
-error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:33:32
-   |
-LL |         asm!("", options(nomem foo));
-   |                                ^^^ expected one of `)` or `,`
-
-error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `nostack`, `preserves_flags`, `pure`, `raw`, or `readonly`, found `foo`
-  --> $DIR/parse-error.rs:35:33
-   |
-LL |         asm!("", options(nomem, foo));
-   |                                 ^^^ expected one of 10 possible tokens
-
-error: expected string literal
-  --> $DIR/parse-error.rs:39:30
-   |
-LL |         asm!("", clobber_abi(foo));
-   |                              ^^^ not a string literal
-
-error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:41:34
-   |
-LL |         asm!("", clobber_abi("C" foo));
-   |                                  ^^^ expected one of `)` or `,`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:43:35
-   |
-LL |         asm!("", clobber_abi("C", foo));
-   |                                   ^^^ not a string literal
-
-error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:50:36
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                     -------------  ^^^^^^^^^^^^^ duplicate argument
-   |                     |
-   |                     previously here
-
-error: argument never used
-  --> $DIR/parse-error.rs:50:36
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                                    ^^^^^^^^^^^^^ argument never used
-   |
-   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
-
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:55:18
+  --> $DIR/parse-error.rs:9:18
    |
 LL |         asm!("", a = in("x0") foo);
    |                  ^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:61:35
+  --> $DIR/parse-error.rs:15:35
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                     ------------  ^^^^^^^^^ positional argument
    |                     |
    |                     explicit register argument
 
-error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `label`, `lateout`, `options`, `out`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:64:29
-   |
-LL |         asm!("", options(), "");
-   |                             ^^ expected one of 10 possible tokens
-
-error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `label`, `lateout`, `options`, `out`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:66:33
-   |
-LL |         asm!("{}", in(reg) foo, "{}", out(reg) foo);
-   |                                 ^^^^ expected one of 10 possible tokens
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:68:14
-   |
-LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
-   |              ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:70:21
-   |
-LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:72:28
-   |
-LL |         asm!("{}", in(reg) _);
-   |                            ^
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:74:31
-   |
-LL |         asm!("{}", inout(reg) _);
-   |                               ^
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:76:35
-   |
-LL |         asm!("{}", inlateout(reg) _);
-   |                                   ^
-
-error: requires at least a template string argument
-  --> $DIR/parse-error.rs:83:1
-   |
-LL | global_asm!();
-   | ^^^^^^^^^^^^^
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:85:13
-   |
-LL | global_asm!(FOO);
-   |             ^^^
-
-error: expected token: `,`
-  --> $DIR/parse-error.rs:87:18
-   |
-LL | global_asm!("{}" FOO);
-   |                  ^^^ expected `,`
-
-error: expected operand, options, or additional template string
-  --> $DIR/parse-error.rs:89:19
-   |
-LL | global_asm!("{}", FOO);
-   |                   ^^^ expected operand, options, or additional template string
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:91:24
-   |
-LL | global_asm!("{}", const);
-   |                        ^ expected expression
-
-error: expected one of `,`, `.`, `?`, or an operator, found `FOO`
-  --> $DIR/parse-error.rs:93:30
-   |
-LL | global_asm!("{}", const(reg) FOO);
-   |                              ^^^ expected one of `,`, `.`, `?`, or an operator
-
-error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:95:25
-   |
-LL | global_asm!("", options(FOO));
-   |                         ^^^ expected one of `)`, `att_syntax`, or `raw`
-
-error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:97:31
-   |
-LL | global_asm!("", options(nomem FOO));
-   |                               ^^^ expected one of `)` or `,`
-
-error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:99:32
-   |
-LL | global_asm!("", options(nomem, FOO));
-   |                                ^^^ expected one of `)`, `att_syntax`, or `raw`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:102:29
-   |
-LL | global_asm!("", clobber_abi(FOO));
-   |                             ^^^ not a string literal
-
-error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:104:33
-   |
-LL | global_asm!("", clobber_abi("C" FOO));
-   |                                 ^^^ expected one of `)` or `,`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:106:34
-   |
-LL | global_asm!("", clobber_abi("C", FOO));
-   |                                  ^^^ not a string literal
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:108:19
-   |
-LL | global_asm!("{}", clobber_abi("C"), const FOO);
-   |                   ^^^^^^^^^^^^^^^^
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:110:28
-   |
-LL | global_asm!("", options(), clobber_abi("C"));
-   |                            ^^^^^^^^^^^^^^^^
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:112:30
-   |
-LL | global_asm!("{}", options(), clobber_abi("C"), const FOO);
-   |                              ^^^^^^^^^^^^^^^^
-
-error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:114:35
-   |
-LL | global_asm!("{a}", a = const FOO, a = const BAR);
-   |                    -------------  ^^^^^^^^^^^^^ duplicate argument
-   |                    |
-   |                    previously here
-
-error: argument never used
-  --> $DIR/parse-error.rs:114:35
-   |
-LL | global_asm!("{a}", a = const FOO, a = const BAR);
-   |                                   ^^^^^^^^^^^^^ argument never used
-   |
-   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
-
-error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:117:28
-   |
-LL | global_asm!("", options(), "");
-   |                            ^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
-
-error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:119:30
-   |
-LL | global_asm!("{}", const FOO, "{}", const FOO);
-   |                              ^^^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:121:13
-   |
-LL | global_asm!(format!("{{{}}}", 0), const FOO);
-   |             ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:123:20
-   |
-LL | global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
-   |                    ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:37:37
-   |
-LL |         asm!("{}", options(), const foo);
-   |                                     ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:45:44
-   |
-LL |         asm!("{}", clobber_abi("C"), const foo);
-   |                                            ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:48:55
-   |
-LL |         asm!("{}", options(), clobber_abi("C"), const foo);
-   |                                                       ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:50:31
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                               ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:50:46
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                                              ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut bar = 0;
-LL +     const bar: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:57:45
+  --> $DIR/parse-error.rs:11:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -383,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:59:45
+  --> $DIR/parse-error.rs:13:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -395,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:61:41
+  --> $DIR/parse-error.rs:15:41
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                                         ^^^ non-constant value
@@ -406,6 +48,6 @@ LL -     let mut bar = 0;
 LL +     const bar: /* Type */ = 0;
    |
 
-error: aborting due to 57 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
this is more in line with the x86 parse error tests at https://github.com/rust-lang/rust/blob/master/tests/ui/asm/x86_64/x86_64_parse_error.rs. We could at this point use minicore so that these tests run no matter the host target?

`tests/ui/asm/aarch64/parse-error.rs` was mostly a copy of https://github.com/rust-lang/rust/blob/master/tests/ui/asm/parse-error.rs, though a bit out of date. The only aarch64-specific tests are those that talk about register names. Here is a diff between those two files:

```diff
--- <unnamed>
+++ <unnamed>
@@ -1,4 +1,4 @@
-//@ needs-asm-support
+//@ only-aarch64
 
 use std::arch::{asm, global_asm};
 
@@ -36,36 +36,12 @@
         //~^ ERROR expected one of
         asm!("{}", options(), const foo);
         //~^ ERROR attempt to use a non-constant value in a constant
-
-        // test that asm!'s clobber_abi doesn't accept non-string literals
-        // see also https://github.com/rust-lang/rust/issues/112635
-        asm!("", clobber_abi());
-        //~^ ERROR at least one abi must be provided
         asm!("", clobber_abi(foo));
         //~^ ERROR expected string literal
         asm!("", clobber_abi("C" foo));
         //~^ ERROR expected one of `)` or `,`, found `foo`
         asm!("", clobber_abi("C", foo));
         //~^ ERROR expected string literal
-        asm!("", clobber_abi(1));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(()));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(uwu));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi({}));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(loop {}));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(if));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(do));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(<));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi(.));
-        //~^ ERROR expected string literal
-
         asm!("{}", clobber_abi("C"), const foo);
         //~^ ERROR attempt to use a non-constant value in a constant
         asm!("", options(), clobber_abi("C"));
@@ -76,7 +52,15 @@
         //~^^ ERROR argument never used
         //~^^^ ERROR attempt to use a non-constant value in a constant
         //~^^^^ ERROR attempt to use a non-constant value in a constant
-
+        asm!("", a = in("x0") foo);
+        //~^ ERROR explicit register arguments cannot have names
+        asm!("{a}", in("x0") foo, a = const bar);
+        //~^ ERROR attempt to use a non-constant value in a constant
+        asm!("{a}", in("x0") foo, a = const bar);
+        //~^ ERROR attempt to use a non-constant value in a constant
+        asm!("{1}", in("x0") foo, const bar);
+        //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
+        //~^^ ERROR attempt to use a non-constant value in a constant
         asm!("", options(), "");
         //~^ ERROR expected one of
         asm!("{}", in(reg) foo, "{}", out(reg) foo);
@@ -109,13 +93,11 @@
 global_asm!("{}", const(reg) FOO);
 //~^ ERROR expected one of
 global_asm!("", options(FOO));
-//~^ ERROR expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-global_asm!("", options(FOO,));
-//~^ ERROR expected one of `)`, `att_syntax`, or `raw`, found `FOO`
+//~^ ERROR expected one of
 global_asm!("", options(nomem FOO));
-//~^ ERROR expected one of `)` or `,`, found `FOO`
+//~^ ERROR expected one of
 global_asm!("", options(nomem, FOO));
-//~^ ERROR expected one of `)`, `att_syntax`, or `raw`, found `FOO`
+//~^ ERROR expected one of
 global_asm!("{}", options(), const FOO);
 global_asm!("", clobber_abi(FOO));
 //~^ ERROR expected string literal
@@ -129,8 +111,6 @@
 //~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{}", options(), clobber_abi("C"), const FOO);
 //~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("", clobber_abi("C"), clobber_abi("C"));
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
 global_asm!("{a}", a = const FOO, a = const BAR);
 //~^ ERROR duplicate argument named `a`
 //~^^ ERROR argument never used
@@ -142,16 +122,3 @@
 //~^ ERROR asm template must be a string literal
 global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
 //~^ ERROR asm template must be a string literal
-
-global_asm!("{}", in(reg));
-//~^ ERROR the `in` operand cannot be used with `global_asm!`
-global_asm!("{}", out(reg));
-//~^ ERROR the `out` operand cannot be used with `global_asm!`
-global_asm!("{}", lateout(reg));
-//~^ ERROR the `lateout` operand cannot be used with `global_asm!`
-global_asm!("{}", inout(reg));
-//~^ ERROR the `inout` operand cannot be used with `global_asm!`
-global_asm!("{}", inlateout(reg));
-//~^ ERROR the `inlateout` operand cannot be used with `global_asm!`
-global_asm!("{}", label(reg));
-//~^ ERROR the `label` operand cannot be used with `global_asm!`
```

