### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
@@ -155,6 +155,20 @@ pub(crate) struct Regions {
 impl Regions {
     /// Returns true if none of this structure's tables contain any regions.
     pub(crate) fn has_no_regions(&self) -> bool {
+        // Every region has a span, so if there are no spans then there are no regions.
+        self.all_cov_spans().next().is_none()
+    }
+
+    pub(crate) fn all_cov_spans(&self) -> impl Iterator<Item = &CoverageSpan> {
+        macro_rules! iter_cov_spans {
+            ( $( $regions:expr ),* $(,)? ) => {
+                std::iter::empty()
+                $(
+                    .chain( $regions.iter().map(|region| &region.cov_span) )
+                )*
+            }
+        }
+
         let Self {
             code_regions,
             expansion_regions,
@@ -163,11 +177,13 @@ impl Regions {
             mcdc_decision_regions,
         } = self;
 
-        code_regions.is_empty()
-            && expansion_regions.is_empty()
-            && branch_regions.is_empty()
-            && mcdc_branch_regions.is_empty()
-            && mcdc_decision_regions.is_empty()
+        iter_cov_spans!(
+            code_regions,
+            expansion_regions,
+            branch_regions,
+            mcdc_branch_regions,
+            mcdc_decision_regions,
+        )
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -104,6 +104,16 @@ fn fill_region_tables<'tcx>(
     ids_info: &'tcx CoverageIdsInfo,
     covfun: &mut CovfunRecord<'tcx>,
 ) {
+    // If this function is unused, replace all counters with zero.
+    let counter_for_bcb = |bcb: BasicCoverageBlock| -> ffi::Counter {
+        let term = if covfun.is_used {
+            ids_info.term_for_bcb[bcb].expect("every BCB in a mapping was given a term")
+        } else {
+            CovTerm::Zero
+        };
+        ffi::Counter::from_term(term)
+    };
+
     // Currently a function's mappings must all be in the same file, so use the
     // first mapping's span to determine the file.
     let source_map = tcx.sess.source_map();
@@ -135,16 +145,6 @@ fn fill_region_tables<'tcx>(
     // For each counter/region pair in this function+file, convert it to a
     // form suitable for FFI.
     for &Mapping { ref kind, span } in &fn_cov_info.mappings {
-        // If this function is unused, replace all counters with zero.
-        let counter_for_bcb = |bcb: BasicCoverageBlock| -> ffi::Counter {
-            let term = if covfun.is_used {
-                ids_info.term_for_bcb[bcb].expect("every BCB in a mapping was given a term")
-            } else {
-                CovTerm::Zero
-            };
-            ffi::Counter::from_term(term)
-        };
-
         let Some(coords) = make_coords(span) else { continue };
         let cov_span = coords.make_coverage_span(local_file_id);
 

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -11,6 +11,7 @@ use rustc_abi::Align;
 use rustc_codegen_ssa::traits::{
     BaseTypeCodegenMethods as _, ConstCodegenMethods, StaticCodegenMethods,
 };
+use rustc_index::IndexVec;
 use rustc_middle::mir::coverage::{
     BasicCoverageBlock, CovTerm, CoverageIdsInfo, Expression, FunctionCoverageInfo, Mapping,
     MappingKind, Op,
@@ -125,6 +126,12 @@ fn fill_region_tables<'tcx>(
 
     let local_file_id = covfun.virtual_file_mapping.push_file(&source_file);
 
+    // If this testing flag is set, add an extra unused entry to the local
+    // file table, to help test the code for detecting unused file IDs.
+    if tcx.sess.coverage_inject_unused_local_file() {
+        covfun.virtual_file_mapping.push_file(&source_file);
+    }
+
     // In rare cases, _all_ of a function's spans are discarded, and coverage
     // codegen needs to handle that gracefully to avoid #133606.
     // It's hard for tests to trigger this organically, so instead we set
@@ -177,6 +184,19 @@ fn fill_region_tables<'tcx>(
     }
 }
 
+/// LLVM requires all local file IDs to have at least one mapping region.
+/// If that's not the case, skip this function, to avoid an assertion failure
+/// (or worse) in LLVM.
+fn check_local_file_table(covfun: &CovfunRecord<'_>) -> bool {
+    let mut local_file_id_seen =
+        IndexVec::<u32, _>::from_elem_n(false, covfun.virtual_file_mapping.local_file_table.len());
+    for cov_span in covfun.regions.all_cov_spans() {
+        local_file_id_seen[cov_span.file_id] = true;
+    }
+
+    local_file_id_seen.into_iter().all(|seen| seen)
+}
+
 /// Generates the contents of the covfun record for this function, which
 /// contains the function's coverage mapping data. The record is then stored
 /// as a global variable in the `__llvm_covfun` section.
@@ -185,6 +205,10 @@ pub(crate) fn generate_covfun_record<'tcx>(
     global_file_table: &GlobalFileTable,
     covfun: &CovfunRecord<'tcx>,
 ) {
+    if !check_local_file_table(covfun) {
+        return;
+    }
+
     let &CovfunRecord {
         mangled_function_name,
         source_hash,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -776,7 +776,8 @@ fn test_unstable_options_tracking_hash() {
         CoverageOptions {
             level: CoverageLevel::Mcdc,
             no_mir_spans: true,
-            discard_all_spans_in_codegen: true
+            discard_all_spans_in_codegen: true,
+            inject_unused_local_file: true,
         }
     );
     tracked!(crate_attr, vec!["abc".to_string()]);

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -1,7 +1,8 @@
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::mir;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{DesugaringKind, ExpnKind, MacroKind, Span};
+use rustc_span::source_map::SourceMap;
+use rustc_span::{BytePos, DesugaringKind, ExpnKind, MacroKind, Span};
 use tracing::instrument;
 
 use crate::coverage::graph::{BasicCoverageBlock, CoverageGraph};
@@ -83,8 +84,18 @@ pub(super) fn extract_refined_covspans<'tcx>(
     // Discard any span that overlaps with a hole.
     discard_spans_overlapping_holes(&mut covspans, &holes);
 
-    // Perform more refinement steps after holes have been dealt with.
+    // Discard spans that overlap in unwanted ways.
     let mut covspans = remove_unwanted_overlapping_spans(covspans);
+
+    // For all empty spans, either enlarge them to be non-empty, or discard them.
+    let source_map = tcx.sess.source_map();
+    covspans.retain_mut(|covspan| {
+        let Some(span) = ensure_non_empty_span(source_map, covspan.span) else { return false };
+        covspan.span = span;
+        true
+    });
+
+    // Merge covspans that can be merged.
     covspans.dedup_by(|b, a| a.merge_if_eligible(b));
 
     code_mappings.extend(covspans.into_iter().map(|Covspan { span, bcb }| {
@@ -229,4 +240,27 @@ fn compare_spans(a: Span, b: Span) -> std::cmp::Ordering {
         // - Span A extends further left, or
         // - Both have the same start and span A extends further right
         .then_with(|| Ord::cmp(&a.hi(), &b.hi()).reverse())
+}
+
+fn ensure_non_empty_span(source_map: &SourceMap, span: Span) -> Option<Span> {
+    if !span.is_empty() {
+        return Some(span);
+    }
+
+    // The span is empty, so try to enlarge it to cover an adjacent '{' or '}'.
+    source_map
+        .span_to_source(span, |src, start, end| try {
+            // Adjusting span endpoints by `BytePos(1)` is normally a bug,
+            // but in this case we have specifically checked that the character
+            // we're skipping over is one of two specific ASCII characters, so
+            // adjusting by exactly 1 byte is correct.
+            if src.as_bytes().get(end).copied() == Some(b'{') {
+                Some(span.with_hi(span.hi() + BytePos(1)))
+            } else if start > 0 && src.as_bytes()[start - 1] == b'}' {
+                Some(span.with_lo(span.lo() - BytePos(1)))
+            } else {
+                None
+            }
+        })
+        .ok()?
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -195,6 +195,11 @@ pub struct CoverageOptions {
     /// regression tests for #133606, because we don't have an easy way to
     /// reproduce it from actual source code.
     pub discard_all_spans_in_codegen: bool,
+
+    /// `-Zcoverage-options=inject-unused-local-file`: During codegen, add an
+    /// extra dummy entry to each function's local file table, to exercise the
+    /// code that checks for local file IDs with no mapping regions.
+    pub inject_unused_local_file: bool,
 }
 
 /// Controls whether branch coverage or MC/DC coverage is enabled.

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -82,9 +82,7 @@ fn current_dll_path() -> Result<PathBuf, String> {
                 let fname_ptr = info.dli_fname.as_ptr();
                 #[cfg(not(target_os = "cygwin"))]
                 let fname_ptr = {
-                    if info.dli_fname.is_null() {
-                        return Err("dladdr returned null pointer".into());
-                    }
+                    assert!(!info.dli_fname.is_null(), "the docs do not allow dladdr to be null");
                     info.dli_fname
                 };
                 let bytes = CStr::from_ptr(fname_ptr).to_bytes();

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1413,6 +1413,7 @@ pub mod parse {
                 "mcdc" => slot.level = CoverageLevel::Mcdc,
                 "no-mir-spans" => slot.no_mir_spans = true,
                 "discard-all-spans-in-codegen" => slot.discard_all_spans_in_codegen = true,
+                "inject-unused-local-file" => slot.inject_unused_local_file = true,
                 _ => return false,
             }
         }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -371,6 +371,11 @@ impl Session {
         self.opts.unstable_opts.coverage_options.discard_all_spans_in_codegen
     }
 
+    /// True if testing flag `-Zcoverage-options=inject-unused-local-file` was passed.
+    pub fn coverage_inject_unused_local_file(&self) -> bool {
+        self.opts.unstable_opts.coverage_options.inject_unused_local_file
+    }
+
     pub fn is_sanitizer_cfi_enabled(&self) -> bool {
         self.opts.unstable_opts.sanitizer.contains(SanitizerSet::CFI)
     }

--- a/src/tools/miri/src/shims/native_lib.rs
+++ b/src/tools/miri/src/shims/native_lib.rs
@@ -92,8 +92,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn get_func_ptr_explicitly_from_lib(&mut self, link_name: Symbol) -> Option<CodePtr> {
         let this = self.eval_context_mut();
         // Try getting the function from the shared library.
-        // On windows `_lib_path` will be unused, hence the name starting with `_`.
-        let (lib, _lib_path) = this.machine.native_lib.as_ref().unwrap();
+        let (lib, lib_path) = this.machine.native_lib.as_ref().unwrap();
         let func: libloading::Symbol<'_, unsafe extern "C" fn()> = unsafe {
             match lib.get(link_name.as_str().as_bytes()) {
                 Ok(x) => x,
@@ -114,7 +113,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // This code is a reimplementation of the mechanism for getting `dli_fname` in `libloading`,
         // from: https://docs.rs/libloading/0.7.3/src/libloading/os/unix/mod.rs.html#411
         // using the `libc` crate where this interface is public.
-        let mut info = std::mem::MaybeUninit::<libc::Dl_info>::uninit();
+        let mut info = std::mem::MaybeUninit::<libc::Dl_info>::zeroed();
         unsafe {
             if libc::dladdr(*func.deref() as *const _, info.as_mut_ptr()) != 0 {
                 let info = info.assume_init();
@@ -122,8 +121,9 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let fname_ptr = info.dli_fname.as_ptr();
                 #[cfg(not(target_os = "cygwin"))]
                 let fname_ptr = info.dli_fname;
+                assert!(!fname_ptr.is_null());
                 if std::ffi::CStr::from_ptr(fname_ptr).to_str().unwrap()
-                    != _lib_path.to_str().unwrap()
+                    != lib_path.to_str().unwrap()
                 {
                     return None;
                 }

--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -80,7 +80,7 @@ pub fn bolt_optimize(
         // Move jump tables to a separate section
         .arg("-jump-tables=move")
         // Fold functions with identical code
-        .arg("-icf=1")
+        .arg("-icf=all")
         // The following flag saves about 50 MiB of libLLVM.so size.
         // However, it succeeds very non-deterministically. To avoid frequent artifact size swings,
         // it is kept disabled for now.

--- a/tests/coverage/async_closure.cov-map
+++ b/tests/coverage/async_closure.cov-map
@@ -37,32 +37,29 @@ Number of file 0 mappings: 8
 Highest counter ID seen: c0
 
 Function name: async_closure::main::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0b, 22, 00, 23, 01, 00, 23, 00, 24]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0b, 22, 00, 24]
 Number of files: 1
 - file 0 => $DIR/async_closure.rs
 Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 0, 35) to (start + 0, 36)
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 36)
 Highest counter ID seen: c0
 
 Function name: async_closure::main::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0b, 22, 00, 23, 01, 00, 23, 00, 24]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0b, 22, 00, 24]
 Number of files: 1
 - file 0 => $DIR/async_closure.rs
 Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 0, 35) to (start + 0, 36)
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 36)
 Highest counter ID seen: c0
 
 Function name: async_closure::main::{closure#0}::{closure#0}::<i16>
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0b, 22, 00, 23, 01, 00, 23, 00, 24]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0b, 22, 00, 24]
 Number of files: 1
 - file 0 => $DIR/async_closure.rs
 Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 0, 35) to (start + 0, 36)
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 11, 34) to (start + 0, 36)
 Highest counter ID seen: c0
 

--- a/tests/coverage/unused-local-file.coverage
+++ b/tests/coverage/unused-local-file.coverage
@@ -1,0 +1,7 @@
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |// Force this function to be generated in its home crate, so that it ends up
+   LL|       |// with normal coverage metadata.
+   LL|       |#[inline(never)]
+   LL|      1|pub fn external_function() {}
+

--- a/tests/coverage/unused-local-file.rs
+++ b/tests/coverage/unused-local-file.rs
@@ -1,0 +1,22 @@
+//! If we give LLVM a local file table for a function, but some of the entries
+//! in that table have no associated mapping regions, then an assertion failure
+//! will occur in LLVM. We therefore need to detect and skip any function that
+//! would trigger that assertion.
+//!
+//! To test that this case is handled, even before adding code that could allow
+//! it to happen organically (for expansion region support), we use a special
+//! testing-only flag to force it to occur.
+
+//@ edition: 2024
+//@ compile-flags: -Zcoverage-options=inject-unused-local-file
+
+// The `llvm-cov` tool will complain if the test binary ends up having no
+// coverage metadata at all. To prevent that, we also link to instrumented
+// code in an auxiliary crate that doesn't have the special flag set.
+
+//@ aux-build: discard_all_helper.rs
+extern crate discard_all_helper;
+
+fn main() {
+    discard_all_helper::external_function();
+}

--- a/tests/crashes/139905.rs
+++ b/tests/crashes/139905.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #139905
+trait a<const b: bool> {}
+impl a<{}> for () {}
+trait c {}
+impl<const d: u8> c for () where (): a<d> {}
+impl c for () {}

--- a/tests/crashes/140011.rs
+++ b/tests/crashes/140011.rs
@@ -1,0 +1,11 @@
+//@ known-bug: #140011
+//@compile-flags: -Wrust-2021-incompatible-closure-captures
+enum b {
+    c(d),
+    e(f),
+}
+struct f;
+fn g() {
+    let h;
+    || b::e(a) = h;
+}

--- a/tests/crashes/140099.rs
+++ b/tests/crashes/140099.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #140099
+struct a;
+impl From for a where for<'any> &'any mut (): Clone {}
+fn b() -> Result<(), std::convert::Infallible> {
+    || -> Result<_, a> { b()? }
+}

--- a/tests/crashes/140100.rs
+++ b/tests/crashes/140100.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #140100
+fn a()
+where
+    b: Sized,
+{
+    println!()
+}

--- a/tests/crashes/140123-2.rs
+++ b/tests/crashes/140123-2.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #140123
+//@ compile-flags: --crate-type lib
+
+trait Trait {}
+
+impl Trait for [(); 0] {}
+
+const ICE: [&mut dyn Trait; 2] = [const { empty_mut() }; 2];
+
+const fn empty_mut() -> &'static mut [(); 0] {
+    &mut []
+}

--- a/tests/crashes/140123-3.rs
+++ b/tests/crashes/140123-3.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #140123
+//@ compile-flags: --crate-type lib
+
+const ICE: [&mut [()]; 2] = [const { empty_mut() }; 2];
+
+const fn empty_mut() -> &'static mut [()] {
+    unsafe {
+        std::slice::from_raw_parts_mut(std::ptr::dangling_mut(), 0)
+    }
+}

--- a/tests/crashes/140123-4.rs
+++ b/tests/crashes/140123-4.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #140123
+//@ compile-flags: --crate-type lib
+
+const ICE: [&mut [(); 0]; 2] = [const { empty_mut() }; 2];
+
+const fn empty_mut() -> &'static mut [(); 0] {
+    &mut []
+}
+// https://github.com/rust-lang/rust/issues/140123#issuecomment-2820664450
+const ICE2: [&mut [(); 0]; 2] = [const {
+    let x = &mut [];
+    x
+}; 2];

--- a/tests/crashes/140123.rs
+++ b/tests/crashes/140123.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #140123
+//@ compile-flags: --crate-type lib
+
+const OK: [&mut [()]; 2] = [empty_mut(), empty_mut()];
+const ICE: [&mut [()]; 2] = [const { empty_mut() }; 2];
+
+// Any kind of fn call gets around E0764.
+const fn empty_mut() -> &'static mut [()] {
+    &mut []
+}

--- a/tests/crashes/140255.rs
+++ b/tests/crashes/140255.rs
@@ -1,0 +1,3 @@
+//@ known-bug: #140255
+#[unsafe(macro_use::VAR2)]
+fn dead_code() {}

--- a/tests/crashes/140275.rs
+++ b/tests/crashes/140275.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #140275
+#![feature(generic_const_exprs)]
+trait T{}
+trait V{}
+impl<const N: i32> T for [i32; N::<&mut V>] {}

--- a/tests/crashes/140281.rs
+++ b/tests/crashes/140281.rs
@@ -1,0 +1,18 @@
+//@ known-bug: #140281
+
+macro_rules! foo {
+    ($x:expr) => { $x }
+}
+
+fn main() {
+    let t = vec![
+        /// ‮test⁦ RTL in doc in vec!
+        //  ICE (Sadly)
+        1
+    ];
+
+        foo!(
+        /// ‮test⁦ RTL in doc in macro
+        1
+    );
+}

--- a/tests/crashes/140303.rs
+++ b/tests/crashes/140303.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #140303
+//@compile-flags: -Zvalidate-mir
+use std::future::Future;
+async fn a() -> impl Sized {
+    b(c)
+}
+async fn c(); // kaboom
+fn b<d>(e: d) -> impl Sized
+where
+    d: f,
+{
+    || -> <d>::h { panic!() }
+}
+trait f {
+    type h;
+}
+impl<d, g> f for d
+where
+    d: Fn() -> g,
+    g: Future,
+{
+}

--- a/tests/crashes/140333.rs
+++ b/tests/crashes/140333.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #140333
+fn a() -> impl b<
+    [c; {
+        struct d {
+            #[a]
+            bar: e,
+        }
+    }],
+>;

--- a/tests/crashes/140365.rs
+++ b/tests/crashes/140365.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #140365
+//@compile-flags: -C opt-level=1 -Zvalidate-mir
+fn f() -> &'static str
+where
+    Self: Sized,
+{
+    ""
+}

--- a/tests/crashes/140381.rs
+++ b/tests/crashes/140381.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #140381
+pub trait Foo<T> {}
+pub trait Lend {
+    type From<'a>
+    where
+        Self: 'a;
+    fn lend(from: Self::From<'_>) -> impl Foo<Self::From<'_>>;
+}
+
+impl<T, F> Lend for (T, F) {
+    type From<'a> = ();
+
+    fn lend(from: Self::From<'_>) -> impl Foo<Self::From<'_>> {
+        from
+    }
+}

--- a/tests/crashes/140429.rs
+++ b/tests/crashes/140429.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #140429
+//@ compile-flags: -Zlint-mir --crate-type lib
+//@ edition:2024
+
+#![feature(async_drop)]
+async fn a<T>(x: T) {}

--- a/tests/crashes/140479.rs
+++ b/tests/crashes/140479.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #140479
+macro_rules! a { ( $( { $ [ $b:c ] } )) => ( $(${ concat(d, $b)} ))}
+fn e() {
+    a!({})
+}

--- a/tests/crashes/140484.rs
+++ b/tests/crashes/140484.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #140484
+//@edition:2024
+#![feature(async_drop)]
+use std::future::AsyncDrop;
+struct a;
+impl Drop for a {
+    fn b() {}
+}
+impl AsyncDrop for a {
+    type c;
+}
+async fn bar() {
+    a;
+}

--- a/tests/crashes/140500.rs
+++ b/tests/crashes/140500.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #140500
+
+#![feature(async_drop)]
+use std::future::AsyncDrop;
+struct a;
+impl Drop for a {
+    fn b() {}
+}
+impl AsyncDrop for a {
+    fn c(d: impl Sized) {}
+}
+async fn bar() {
+    a;
+}

--- a/tests/crashes/140530.rs
+++ b/tests/crashes/140530.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #140530
+//@ edition: 2024
+
+#![feature(async_drop, gen_blocks)]
+async gen fn a() {
+  _ = async {}
+}
+fn main() {}

--- a/tests/crashes/140531.rs
+++ b/tests/crashes/140531.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #140531
+//@compile-flags: -Zlint-mir --crate-type lib
+//@ edition:2024
+#![feature(async_drop)]
+async fn call_once(f: impl AsyncFnOnce()) {
+    let fut = Box::pin(f());
+}

--- a/tests/crashes/140571.rs
+++ b/tests/crashes/140571.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #140571
+pub trait IsVoid {
+    const IS_VOID: bool;
+}
+impl<T> IsVoid for T {
+    default const IS_VOID: bool = false;
+}
+impl<T> Maybe<T> for () where T: NotVoid + ?Sized {}
+
+pub trait NotVoid {}
+impl<T> NotVoid for T where T: IsVoid<IS_VOID = false> + ?Sized {}
+
+pub trait Maybe<T> {}
+impl<T> Maybe<T> for T {}

--- a/tests/crashes/140577.rs
+++ b/tests/crashes/140577.rs
@@ -1,0 +1,32 @@
+//@ known-bug: #140577
+//@ compile-flags: -Znext-solver=globally
+//@ edition:2021
+
+use std::future::Future;
+use std::pin::Pin;
+trait Acquire {
+    type Connection;
+}
+impl Acquire for &'static () {
+    type Connection = ();
+}
+fn b<T: Acquire>() -> impl Future + Send {
+    let x: Pin<Box<dyn Future<Output = T::Connection> + Send>> = todo!();
+    x
+}
+fn main() {
+    async {
+        b::<&()>().await;
+    }
+    .aa();
+}
+
+impl<F> Filter for F where F: Send {}
+
+trait Filter {
+    fn aa(self)
+    where
+        Self: Sized,
+    {
+    }
+}

--- a/tests/crashes/140609.rs
+++ b/tests/crashes/140609.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #140609
+#![feature(with_negative_coherence)]
+#![feature(generic_const_exprs)]
+#![crate_type = "lib"]
+trait Trait {}
+struct A<const B: bool>;
+
+trait C {}
+
+impl<const D: u32> Trait for E<D> where A<{ D <= 2 }>: FnOnce(&isize) {}
+struct E<const D: u32>;
+
+impl<const D: u32> Trait for E<D> where A<{ D <= 2 }>: C {}

--- a/tests/crashes/140642.rs
+++ b/tests/crashes/140642.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #140642
+#![feature(min_generic_const_args)]
+
+pub trait Tr<A> {
+    const SIZE: usize;
+}
+
+fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}

--- a/tests/crashes/140683.rs
+++ b/tests/crashes/140683.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #140683
+impl T {
+#[core::contracts::ensures]
+  fn b() { (loop) }
+}

--- a/tests/crashes/140729.rs
+++ b/tests/crashes/140729.rs
@@ -1,0 +1,11 @@
+//@ known-bug: #140729
+#![feature(min_generic_const_args)]
+
+const C: usize = 0;
+pub struct A<const M: usize> {}
+impl A<C> {
+    fn fun1() {}
+}
+impl A {
+    fn fun1() {}
+}

--- a/tests/crashes/140823.rs
+++ b/tests/crashes/140823.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #140823
+
+struct Container<T> {
+    data: T,
+}
+
+fn ice(callback: Box<dyn Fn(Container<&u8>)>) {
+    let fails: Box<dyn Fn(&Container<&u8>)> = callback;
+}

--- a/tests/crashes/140850.rs
+++ b/tests/crashes/140850.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #140850
+//@ compile-flags: -Zvalidate-mir
+fn A() -> impl {
+    while A() {}
+    loop {}
+}
+fn main() {}

--- a/tests/crashes/140860.rs
+++ b/tests/crashes/140860.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #140860
+#![feature(min_generic_const_args)]
+#![feature(unsized_const_params)]
+#![feature(with_negative_coherence, negative_impls)]
+trait a < const b : &'static str> {} trait c {} struct d< e >(e);
+impl<e> c for e where e: a<""> {}
+impl<e> c for d<e> {}
+impl<e> !a<f> for e {}
+const f : &str = "";
+fn main() {}

--- a/tests/crashes/140884.rs
+++ b/tests/crashes/140884.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #140884
+//@ needs-rustc-debug-assertions
+
+fn a() {
+    extern "" {}
+}

--- a/tests/crashes/140891.rs
+++ b/tests/crashes/140891.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #140891
+struct A<const N: usize> {}
+impl<const N: usize> Iterator for A<N> {
+    fn next() -> [(); std::mem::size_of::<Option<Self::Item>>] {}
+}
+fn main() {}

--- a/tests/crashes/140974.rs
+++ b/tests/crashes/140974.rs
@@ -1,0 +1,14 @@
+//@ known-bug: #140974
+//@edition:2021
+#![feature(async_drop)]
+use core::future::AsyncDrop;
+
+async fn fun(_: HasIncompleteAsyncDrop) {}
+
+struct HasIncompleteAsyncDrop;
+impl Drop for HasIncompleteAsyncDrop {
+    fn drop(&mut self) {}
+}
+impl AsyncDrop for HasIncompleteAsyncDrop {
+    // not implemented yet..
+}

--- a/tests/crashes/140975.rs
+++ b/tests/crashes/140975.rs
@@ -1,0 +1,22 @@
+//@ known-bug: #140975
+//@ compile-flags: --crate-type lib -Zvalidate-mir
+//@ edition: 2021
+#![feature(async_drop)]
+use std::{future::AsyncDrop, pin::Pin};
+
+struct HasAsyncDrop ;
+impl Drop for HasAsyncDrop {
+    fn drop(&mut self) {}
+}
+impl AsyncDrop for HasAsyncDrop {
+    async fn drop(self: Pin<&mut Self>) {}
+}
+
+struct Holder {
+    inner: HasAsyncDrop,
+}
+async fn bar() {
+    Holder {
+        inner: HasAsyncDrop
+   };
+}

--- a/tests/crashes/141124.rs
+++ b/tests/crashes/141124.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #141124
+struct S;
+trait SimpleTrait {}
+trait TraitAssoc {
+    type Assoc;
+}
+
+impl<T> TraitAssoc for T
+where
+    T: SimpleTrait,
+{
+    type Assoc = <(T,) as TraitAssoc>::Assoc;
+}
+impl SimpleTrait for <S as TraitAssoc>::Assoc {}
+
+pub fn main() {}

--- a/tests/crashes/141143.rs
+++ b/tests/crashes/141143.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #141143
+trait TypedClient {
+    fn publish_typed<F>(&self) -> impl Sized
+    where
+        F: Clone;
+}
+impl TypedClient for () {
+    fn publish_typed<F>(&self) -> impl Sized {}
+}
+
+fn main() {
+    ().publish_typed();
+}

--- a/tests/mir-opt/coverage/branch_match_arms.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/coverage/branch_match_arms.main.InstrumentCoverage.diff
@@ -40,7 +40,7 @@
 +     coverage Code { bcb: bcb5 } => $DIR/branch_match_arms.rs:19:17: 19:18 (#0);
 +     coverage Code { bcb: bcb5 } => $DIR/branch_match_arms.rs:19:23: 19:30 (#0);
 +     coverage Code { bcb: bcb5 } => $DIR/branch_match_arms.rs:19:31: 19:32 (#0);
-+     coverage Code { bcb: bcb2 } => $DIR/branch_match_arms.rs:21:2: 21:2 (#0);
++     coverage Code { bcb: bcb2 } => $DIR/branch_match_arms.rs:21:1: 21:2 (#0);
 + 
       bb0: {
 +         Coverage::VirtualCounter(bcb0);

--- a/tests/mir-opt/coverage/instrument_coverage.bar.InstrumentCoverage.diff
+++ b/tests/mir-opt/coverage/instrument_coverage.bar.InstrumentCoverage.diff
@@ -6,7 +6,7 @@
   
 +     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage.rs:27:1: 27:17 (#0);
 +     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage.rs:28:5: 28:9 (#0);
-+     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage.rs:29:2: 29:2 (#0);
++     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage.rs:29:1: 29:2 (#0);
 + 
       bb0: {
 +         Coverage::VirtualCounter(bcb0);

--- a/tests/mir-opt/coverage/instrument_coverage.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/coverage/instrument_coverage.main.InstrumentCoverage.diff
@@ -10,8 +10,8 @@
 +     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage.rs:13:1: 13:10 (#0);
 +     coverage Code { bcb: bcb1 } => $DIR/instrument_coverage.rs:15:12: 15:15 (#0);
 +     coverage Code { bcb: bcb2 } => $DIR/instrument_coverage.rs:16:13: 16:18 (#0);
-+     coverage Code { bcb: bcb3 } => $DIR/instrument_coverage.rs:17:10: 17:10 (#0);
-+     coverage Code { bcb: bcb2 } => $DIR/instrument_coverage.rs:19:2: 19:2 (#0);
++     coverage Code { bcb: bcb3 } => $DIR/instrument_coverage.rs:17:9: 17:10 (#0);
++     coverage Code { bcb: bcb2 } => $DIR/instrument_coverage.rs:19:1: 19:2 (#0);
 + 
       bb0: {
 +         Coverage::VirtualCounter(bcb0);

--- a/tests/mir-opt/coverage/instrument_coverage_cleanup.main.CleanupPostBorrowck.diff
+++ b/tests/mir-opt/coverage/instrument_coverage_cleanup.main.CleanupPostBorrowck.diff
@@ -10,8 +10,8 @@
       coverage Code { bcb: bcb0 } => $DIR/instrument_coverage_cleanup.rs:13:1: 13:10 (#0);
       coverage Code { bcb: bcb0 } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0);
       coverage Code { bcb: bcb3 } => $DIR/instrument_coverage_cleanup.rs:14:37: 14:39 (#0);
-      coverage Code { bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:39: 14:39 (#0);
-      coverage Code { bcb: bcb2 } => $DIR/instrument_coverage_cleanup.rs:15:2: 15:2 (#0);
+      coverage Code { bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:38: 14:39 (#0);
+      coverage Code { bcb: bcb2 } => $DIR/instrument_coverage_cleanup.rs:15:1: 15:2 (#0);
       coverage Branch { true_bcb: bcb3, false_bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0);
   
       bb0: {

--- a/tests/mir-opt/coverage/instrument_coverage_cleanup.main.InstrumentCoverage.diff
+++ b/tests/mir-opt/coverage/instrument_coverage_cleanup.main.InstrumentCoverage.diff
@@ -10,8 +10,8 @@
 +     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage_cleanup.rs:13:1: 13:10 (#0);
 +     coverage Code { bcb: bcb0 } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0);
 +     coverage Code { bcb: bcb3 } => $DIR/instrument_coverage_cleanup.rs:14:37: 14:39 (#0);
-+     coverage Code { bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:39: 14:39 (#0);
-+     coverage Code { bcb: bcb2 } => $DIR/instrument_coverage_cleanup.rs:15:2: 15:2 (#0);
++     coverage Code { bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:38: 14:39 (#0);
++     coverage Code { bcb: bcb2 } => $DIR/instrument_coverage_cleanup.rs:15:1: 15:2 (#0);
 +     coverage Branch { true_bcb: bcb3, false_bcb: bcb1 } => $DIR/instrument_coverage_cleanup.rs:14:8: 14:36 (#0);
 + 
       bb0: {

--- a/tests/ui/asm/aarch64/parse-error.rs
+++ b/tests/ui/asm/aarch64/parse-error.rs
@@ -1,57 +1,11 @@
 //@ only-aarch64
 
-use std::arch::{asm, global_asm};
+use std::arch::asm;
 
 fn main() {
     let mut foo = 0;
     let mut bar = 0;
     unsafe {
-        asm!();
-        //~^ ERROR requires at least a template string argument
-        asm!(foo);
-        //~^ ERROR asm template must be a string literal
-        asm!("{}" foo);
-        //~^ ERROR expected token: `,`
-        asm!("{}", foo);
-        //~^ ERROR expected operand, clobber_abi, options, or additional template string
-        asm!("{}", in foo);
-        //~^ ERROR expected `(`, found `foo`
-        asm!("{}", in(reg foo));
-        //~^ ERROR expected `)`, found `foo`
-        asm!("{}", in(reg));
-        //~^ ERROR expected expression, found end of macro arguments
-        asm!("{}", inout(=) foo => bar);
-        //~^ ERROR expected register class or explicit register
-        asm!("{}", inout(reg) foo =>);
-        //~^ ERROR expected expression, found end of macro arguments
-        asm!("{}", in(reg) foo => bar);
-        //~^ ERROR expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
-        asm!("{}", sym foo + bar);
-        //~^ ERROR expected a path for argument to `sym`
-        asm!("", options(foo));
-        //~^ ERROR expected one of
-        asm!("", options(nomem foo));
-        //~^ ERROR expected one of
-        asm!("", options(nomem, foo));
-        //~^ ERROR expected one of
-        asm!("{}", options(), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("", clobber_abi(foo));
-        //~^ ERROR expected string literal
-        asm!("", clobber_abi("C" foo));
-        //~^ ERROR expected one of `)` or `,`, found `foo`
-        asm!("", clobber_abi("C", foo));
-        //~^ ERROR expected string literal
-        asm!("{}", clobber_abi("C"), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("", options(), clobber_abi("C"));
-        asm!("{}", options(), clobber_abi("C"), const foo);
-        //~^ ERROR attempt to use a non-constant value in a constant
-        asm!("{a}", a = const foo, a = const bar);
-        //~^ ERROR duplicate argument named `a`
-        //~^^ ERROR argument never used
-        //~^^^ ERROR attempt to use a non-constant value in a constant
-        //~^^^^ ERROR attempt to use a non-constant value in a constant
         asm!("", a = in("x0") foo);
         //~^ ERROR explicit register arguments cannot have names
         asm!("{a}", in("x0") foo, a = const bar);
@@ -61,64 +15,5 @@ fn main() {
         asm!("{1}", in("x0") foo, const bar);
         //~^ ERROR positional arguments cannot follow named arguments or explicit register arguments
         //~^^ ERROR attempt to use a non-constant value in a constant
-        asm!("", options(), "");
-        //~^ ERROR expected one of
-        asm!("{}", in(reg) foo, "{}", out(reg) foo);
-        //~^ ERROR expected one of
-        asm!(format!("{{{}}}", 0), in(reg) foo);
-        //~^ ERROR asm template must be a string literal
-        asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
-        //~^ ERROR asm template must be a string literal
-        asm!("{}", in(reg) _);
-        //~^ ERROR _ cannot be used for input operands
-        asm!("{}", inout(reg) _);
-        //~^ ERROR _ cannot be used for input operands
-        asm!("{}", inlateout(reg) _);
-        //~^ ERROR _ cannot be used for input operands
     }
 }
-
-const FOO: i32 = 1;
-const BAR: i32 = 2;
-global_asm!();
-//~^ ERROR requires at least a template string argument
-global_asm!(FOO);
-//~^ ERROR asm template must be a string literal
-global_asm!("{}" FOO);
-//~^ ERROR expected token: `,`
-global_asm!("{}", FOO);
-//~^ ERROR expected operand, options, or additional template string
-global_asm!("{}", const);
-//~^ ERROR expected expression, found end of macro arguments
-global_asm!("{}", const(reg) FOO);
-//~^ ERROR expected one of
-global_asm!("", options(FOO));
-//~^ ERROR expected one of
-global_asm!("", options(nomem FOO));
-//~^ ERROR expected one of
-global_asm!("", options(nomem, FOO));
-//~^ ERROR expected one of
-global_asm!("{}", options(), const FOO);
-global_asm!("", clobber_abi(FOO));
-//~^ ERROR expected string literal
-global_asm!("", clobber_abi("C" FOO));
-//~^ ERROR expected one of `)` or `,`, found `FOO`
-global_asm!("", clobber_abi("C", FOO));
-//~^ ERROR expected string literal
-global_asm!("{}", clobber_abi("C"), const FOO);
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("", options(), clobber_abi("C"));
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("{}", options(), clobber_abi("C"), const FOO);
-//~^ ERROR `clobber_abi` cannot be used with `global_asm!`
-global_asm!("{a}", a = const FOO, a = const BAR);
-//~^ ERROR duplicate argument named `a`
-//~^^ ERROR argument never used
-global_asm!("", options(), "");
-//~^ ERROR expected one of
-global_asm!("{}", const FOO, "{}", const FOO);
-//~^ ERROR expected one of
-global_asm!(format!("{{{}}}", 0), const FOO);
-//~^ ERROR asm template must be a string literal
-global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
-//~^ ERROR asm template must be a string literal

--- a/tests/ui/asm/aarch64/parse-error.stderr
+++ b/tests/ui/asm/aarch64/parse-error.stderr
@@ -1,377 +1,19 @@
-error: requires at least a template string argument
-  --> $DIR/parse-error.rs:9:9
-   |
-LL |         asm!();
-   |         ^^^^^^
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:11:14
-   |
-LL |         asm!(foo);
-   |              ^^^
-
-error: expected token: `,`
-  --> $DIR/parse-error.rs:13:19
-   |
-LL |         asm!("{}" foo);
-   |                   ^^^ expected `,`
-
-error: expected operand, clobber_abi, options, or additional template string
-  --> $DIR/parse-error.rs:15:20
-   |
-LL |         asm!("{}", foo);
-   |                    ^^^ expected operand, clobber_abi, options, or additional template string
-
-error: expected `(`, found `foo`
-  --> $DIR/parse-error.rs:17:23
-   |
-LL |         asm!("{}", in foo);
-   |                       ^^^ expected `(`
-
-error: expected `)`, found `foo`
-  --> $DIR/parse-error.rs:19:27
-   |
-LL |         asm!("{}", in(reg foo));
-   |                           ^^^ expected `)`
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:21:27
-   |
-LL |         asm!("{}", in(reg));
-   |                           ^ expected expression
-
-error: expected register class or explicit register
-  --> $DIR/parse-error.rs:23:26
-   |
-LL |         asm!("{}", inout(=) foo => bar);
-   |                          ^
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:25:37
-   |
-LL |         asm!("{}", inout(reg) foo =>);
-   |                                     ^ expected expression
-
-error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
-  --> $DIR/parse-error.rs:27:32
-   |
-LL |         asm!("{}", in(reg) foo => bar);
-   |                                ^^ expected one of 7 possible tokens
-
-error: expected a path for argument to `sym`
-  --> $DIR/parse-error.rs:29:24
-   |
-LL |         asm!("{}", sym foo + bar);
-   |                        ^^^^^^^^^
-
-error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `nostack`, `preserves_flags`, `pure`, `raw`, or `readonly`, found `foo`
-  --> $DIR/parse-error.rs:31:26
-   |
-LL |         asm!("", options(foo));
-   |                          ^^^ expected one of 10 possible tokens
-
-error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:33:32
-   |
-LL |         asm!("", options(nomem foo));
-   |                                ^^^ expected one of `)` or `,`
-
-error: expected one of `)`, `att_syntax`, `may_unwind`, `nomem`, `noreturn`, `nostack`, `preserves_flags`, `pure`, `raw`, or `readonly`, found `foo`
-  --> $DIR/parse-error.rs:35:33
-   |
-LL |         asm!("", options(nomem, foo));
-   |                                 ^^^ expected one of 10 possible tokens
-
-error: expected string literal
-  --> $DIR/parse-error.rs:39:30
-   |
-LL |         asm!("", clobber_abi(foo));
-   |                              ^^^ not a string literal
-
-error: expected one of `)` or `,`, found `foo`
-  --> $DIR/parse-error.rs:41:34
-   |
-LL |         asm!("", clobber_abi("C" foo));
-   |                                  ^^^ expected one of `)` or `,`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:43:35
-   |
-LL |         asm!("", clobber_abi("C", foo));
-   |                                   ^^^ not a string literal
-
-error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:50:36
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                     -------------  ^^^^^^^^^^^^^ duplicate argument
-   |                     |
-   |                     previously here
-
-error: argument never used
-  --> $DIR/parse-error.rs:50:36
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                                    ^^^^^^^^^^^^^ argument never used
-   |
-   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
-
 error: explicit register arguments cannot have names
-  --> $DIR/parse-error.rs:55:18
+  --> $DIR/parse-error.rs:9:18
    |
 LL |         asm!("", a = in("x0") foo);
    |                  ^^^^^^^^^^^^^^^^
 
 error: positional arguments cannot follow named arguments or explicit register arguments
-  --> $DIR/parse-error.rs:61:35
+  --> $DIR/parse-error.rs:15:35
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                     ------------  ^^^^^^^^^ positional argument
    |                     |
    |                     explicit register argument
 
-error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `label`, `lateout`, `options`, `out`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:64:29
-   |
-LL |         asm!("", options(), "");
-   |                             ^^ expected one of 10 possible tokens
-
-error: expected one of `clobber_abi`, `const`, `in`, `inlateout`, `inout`, `label`, `lateout`, `options`, `out`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:66:33
-   |
-LL |         asm!("{}", in(reg) foo, "{}", out(reg) foo);
-   |                                 ^^^^ expected one of 10 possible tokens
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:68:14
-   |
-LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
-   |              ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:70:21
-   |
-LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:72:28
-   |
-LL |         asm!("{}", in(reg) _);
-   |                            ^
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:74:31
-   |
-LL |         asm!("{}", inout(reg) _);
-   |                               ^
-
-error: _ cannot be used for input operands
-  --> $DIR/parse-error.rs:76:35
-   |
-LL |         asm!("{}", inlateout(reg) _);
-   |                                   ^
-
-error: requires at least a template string argument
-  --> $DIR/parse-error.rs:83:1
-   |
-LL | global_asm!();
-   | ^^^^^^^^^^^^^
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:85:13
-   |
-LL | global_asm!(FOO);
-   |             ^^^
-
-error: expected token: `,`
-  --> $DIR/parse-error.rs:87:18
-   |
-LL | global_asm!("{}" FOO);
-   |                  ^^^ expected `,`
-
-error: expected operand, options, or additional template string
-  --> $DIR/parse-error.rs:89:19
-   |
-LL | global_asm!("{}", FOO);
-   |                   ^^^ expected operand, options, or additional template string
-
-error: expected expression, found end of macro arguments
-  --> $DIR/parse-error.rs:91:24
-   |
-LL | global_asm!("{}", const);
-   |                        ^ expected expression
-
-error: expected one of `,`, `.`, `?`, or an operator, found `FOO`
-  --> $DIR/parse-error.rs:93:30
-   |
-LL | global_asm!("{}", const(reg) FOO);
-   |                              ^^^ expected one of `,`, `.`, `?`, or an operator
-
-error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:95:25
-   |
-LL | global_asm!("", options(FOO));
-   |                         ^^^ expected one of `)`, `att_syntax`, or `raw`
-
-error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:97:31
-   |
-LL | global_asm!("", options(nomem FOO));
-   |                               ^^^ expected one of `)` or `,`
-
-error: expected one of `)`, `att_syntax`, or `raw`, found `FOO`
-  --> $DIR/parse-error.rs:99:32
-   |
-LL | global_asm!("", options(nomem, FOO));
-   |                                ^^^ expected one of `)`, `att_syntax`, or `raw`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:102:29
-   |
-LL | global_asm!("", clobber_abi(FOO));
-   |                             ^^^ not a string literal
-
-error: expected one of `)` or `,`, found `FOO`
-  --> $DIR/parse-error.rs:104:33
-   |
-LL | global_asm!("", clobber_abi("C" FOO));
-   |                                 ^^^ expected one of `)` or `,`
-
-error: expected string literal
-  --> $DIR/parse-error.rs:106:34
-   |
-LL | global_asm!("", clobber_abi("C", FOO));
-   |                                  ^^^ not a string literal
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:108:19
-   |
-LL | global_asm!("{}", clobber_abi("C"), const FOO);
-   |                   ^^^^^^^^^^^^^^^^
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:110:28
-   |
-LL | global_asm!("", options(), clobber_abi("C"));
-   |                            ^^^^^^^^^^^^^^^^
-
-error: `clobber_abi` cannot be used with `global_asm!`
-  --> $DIR/parse-error.rs:112:30
-   |
-LL | global_asm!("{}", options(), clobber_abi("C"), const FOO);
-   |                              ^^^^^^^^^^^^^^^^
-
-error: duplicate argument named `a`
-  --> $DIR/parse-error.rs:114:35
-   |
-LL | global_asm!("{a}", a = const FOO, a = const BAR);
-   |                    -------------  ^^^^^^^^^^^^^ duplicate argument
-   |                    |
-   |                    previously here
-
-error: argument never used
-  --> $DIR/parse-error.rs:114:35
-   |
-LL | global_asm!("{a}", a = const FOO, a = const BAR);
-   |                                   ^^^^^^^^^^^^^ argument never used
-   |
-   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {1} */"`
-
-error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `""`
-  --> $DIR/parse-error.rs:117:28
-   |
-LL | global_asm!("", options(), "");
-   |                            ^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
-
-error: expected one of `clobber_abi`, `const`, `options`, or `sym`, found `"{}"`
-  --> $DIR/parse-error.rs:119:30
-   |
-LL | global_asm!("{}", const FOO, "{}", const FOO);
-   |                              ^^^^ expected one of `clobber_abi`, `const`, `options`, or `sym`
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:121:13
-   |
-LL | global_asm!(format!("{{{}}}", 0), const FOO);
-   |             ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: asm template must be a string literal
-  --> $DIR/parse-error.rs:123:20
-   |
-LL | global_asm!("{1}", format!("{{{}}}", 0), const FOO, const BAR);
-   |                    ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:37:37
-   |
-LL |         asm!("{}", options(), const foo);
-   |                                     ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:45:44
-   |
-LL |         asm!("{}", clobber_abi("C"), const foo);
-   |                                            ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:48:55
-   |
-LL |         asm!("{}", options(), clobber_abi("C"), const foo);
-   |                                                       ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:50:31
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                               ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut foo = 0;
-LL +     const foo: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:50:46
-   |
-LL |         asm!("{a}", a = const foo, a = const bar);
-   |                                              ^^^ non-constant value
-   |
-help: consider using `const` instead of `let`
-   |
-LL -     let mut bar = 0;
-LL +     const bar: /* Type */ = 0;
-   |
-
-error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:57:45
+  --> $DIR/parse-error.rs:11:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -383,7 +25,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:59:45
+  --> $DIR/parse-error.rs:13:45
    |
 LL |         asm!("{a}", in("x0") foo, a = const bar);
    |                                             ^^^ non-constant value
@@ -395,7 +37,7 @@ LL +     const bar: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/parse-error.rs:61:41
+  --> $DIR/parse-error.rs:15:41
    |
 LL |         asm!("{1}", in("x0") foo, const bar);
    |                                         ^^^ non-constant value
@@ -406,6 +48,6 @@ LL -     let mut bar = 0;
 LL +     const bar: /* Type */ = 0;
    |
 
-error: aborting due to 57 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
Successful merges:

 - #140847 (coverage: Detect unused local file IDs to avoid an LLVM assertion)
 - #141117 (opt-dist: fix deprecated BOLT -icf=1 option)
 - #141225 (more ice tests)
 - #141239 (dladdr cannot leave dli_fname to be null)
 - #141242 (in `tests/ui/asm/aarch64/parse-error.rs`, only test cases specific to that target)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140847,141117,141225,141239,141242)
<!-- homu-ignore:end -->