### PR TITLE
gvn: bail out unavoidable non-ssa locals in repeat

### DIFF
--- a/tests/mir-opt/gvn_repeat.repeat_local.GVN.diff
+++ b/tests/mir-opt/gvn_repeat.repeat_local.GVN.diff
@@ -1,0 +1,18 @@
+- // MIR for `repeat_local` before GVN
++ // MIR for `repeat_local` after GVN
+  
+  fn repeat_local(_1: usize, _2: usize, _3: i32) -> i32 {
+      let mut _0: i32;
+      let mut _4: [i32; 5];
+      let mut _5: &i32;
+  
+      bb0: {
+          _4 = [copy _3; 5];
+          _5 = &_4[_1];
+          _1 = copy _2;
+-         _0 = copy (*_5);
++         _0 = copy _3;
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn_repeat.repeat_place.GVN.diff
+++ b/tests/mir-opt/gvn_repeat.repeat_place.GVN.diff
@@ -1,0 +1,17 @@
+- // MIR for `repeat_place` before GVN
++ // MIR for `repeat_place` after GVN
+  
+  fn repeat_place(_1: usize, _2: usize, _3: &i32) -> i32 {
+      let mut _0: i32;
+      let mut _4: [i32; 5];
+      let mut _5: &i32;
+  
+      bb0: {
+          _4 = [copy (*_3); 5];
+          _5 = &_4[_1];
+          _1 = copy _2;
+          _0 = copy (*_5);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn_repeat.rs
+++ b/tests/mir-opt/gvn_repeat.rs
@@ -1,0 +1,49 @@
+//@ test-mir-pass: GVN
+
+#![feature(custom_mir, core_intrinsics)]
+
+// Check that we do not introduce out-of-bounds access.
+
+use std::intrinsics::mir::*;
+
+// EMIT_MIR gvn_repeat.repeat_place.GVN.diff
+#[custom_mir(dialect = "runtime")]
+pub fn repeat_place(mut idx1: usize, idx2: usize, val: &i32) -> i32 {
+    // CHECK-LABEL: fn repeat_place(
+    // CHECK: let mut [[ELEM:.*]]: &i32;
+    // CHECK: _0 = copy (*[[ELEM]])
+    mir! {
+        let array;
+        let elem;
+        {
+            array = [*val; 5];
+            elem = &array[idx1];
+            idx1 = idx2;
+            RET = *elem;
+            Return()
+        }
+    }
+}
+
+// EMIT_MIR gvn_repeat.repeat_local.GVN.diff
+#[custom_mir(dialect = "runtime")]
+pub fn repeat_local(mut idx1: usize, idx2: usize, val: i32) -> i32 {
+    // CHECK-LABEL: fn repeat_local(
+    // CHECK: _0 = copy _3
+    mir! {
+        let array;
+        let elem;
+        {
+            array = [val; 5];
+            elem = &array[idx1];
+            idx1 = idx2;
+            RET = *elem;
+            Return()
+        }
+    }
+}
+
+fn main() {
+    assert_eq!(repeat_place(0, 5, &0), 0);
+    assert_eq!(repeat_local(0, 5, 0), 0);
+}


### PR DESCRIPTION
Fixes #141251.

We cannot transform `*elem` to `array[idx1]` in the following code, as `idx1` has already been modified.

```rust
    mir! {
        let array;
        let elem;
        {
            array = [*val; 5];
            elem = &array[idx1];
            idx1 = idx2;
            RET = *elem;
            Return()
        }
    }
```

Perhaps I could transform it to `array[0]`, but I prefer the conservative approach.

r? mir-opt