### PR TITLE
Warning added when dependency crate has async drop types, and the feature is disabled

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -2,7 +2,7 @@ metadata_as_needed_compatibility =
     linking modifier `as-needed` is only compatible with `dylib` and `framework` linking kinds
 
 metadata_async_drop_types_in_dependency =
-    found async drop types in dependecy `{$extern_crate}`, but async_drop feature is disabled for `{$local_crate}`
+    found async drop types in dependency `{$extern_crate}`, but async_drop feature is disabled for `{$local_crate}`
     .help = if async drop type will be dropped in a crate without `feature(async_drop)`, sync Drop will be used
 
 metadata_bad_panic_strategy =

--- a/tests/ui/async-await/async-drop/dependency-dropped.rs
+++ b/tests/ui/async-await/async-drop/dependency-dropped.rs
@@ -5,7 +5,7 @@
 //@ edition:2021
 
 #![cfg_attr(with_feature, feature(async_drop))]
-//[without_feature]~^ WARN found async drop types in dependecy `async_drop_dep`, but async_drop feature is disabled for `dependency_dropped`
+//[without_feature]~^ WARN found async drop types in dependency `async_drop_dep`, but async_drop feature is disabled for `dependency_dropped`
 
 #![allow(incomplete_features)]
 

--- a/tests/ui/async-await/async-drop/dependency-dropped.without_feature.stderr
+++ b/tests/ui/async-await/async-drop/dependency-dropped.without_feature.stderr
@@ -1,4 +1,4 @@
-warning: found async drop types in dependecy `async_drop_dep`, but async_drop feature is disabled for `dependency_dropped`
+warning: found async drop types in dependency `async_drop_dep`, but async_drop feature is disabled for `dependency_dropped`
   --> $DIR/dependency-dropped.rs:7:1
    |
 LL | #![cfg_attr(with_feature, feature(async_drop))]


### PR DESCRIPTION
In continue of https://github.com/rust-lang/rust/pull/141031.

<!-- homu-ignore:start -->
<!--
    https://github.com/rust-lang/rust/issues/126482

    r? oli-obk
-->
<!-- homu-ignore:end -->

When dependency crate has non-empty `adt_async_destructor` table in metadata, and `async_drop` feature is disabled for local crate, warning will be emitted.

Test `dependency-dropped` has two revisions - with and without feature enabled. With feature enabled, async drop for dropee is executed ("Async drop" printed). Without the feature enabled, sync drop is executed ("Sync drop" printed) and warning is emitted.

Warning example:
```
warning: found async drop types in dependecy `async_drop_dep`, but async_drop feature is disabled for `dependency_dropped`
  --> $DIR/dependency-dropped.rs:7:1
   |
LL | #![cfg_attr(with_feature, feature(async_drop))]
   | ^
   |
   = help: if async drop type will be dropped in a crate without `feature(async_drop)`, sync Drop will be used
```