### PR TITLE
trim cache module in utils bootstrap

### DIFF
--- a/src/bootstrap/src/utils/cache.rs
+++ b/src/bootstrap/src/utils/cache.rs
@@ -20,7 +20,6 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::Deref;
-use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 use std::{fmt, mem};
 
@@ -51,24 +50,9 @@ impl<T> PartialEq for Interned<T> {
 }
 impl<T> Eq for Interned<T> {}
 
-impl PartialEq<str> for Interned<String> {
-    fn eq(&self, other: &str) -> bool {
-        *self == other
-    }
-}
 impl PartialEq<&str> for Interned<String> {
     fn eq(&self, other: &&str) -> bool {
         **self == **other
-    }
-}
-impl<T> PartialEq<&Interned<T>> for Interned<T> {
-    fn eq(&self, other: &&Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl<T> PartialEq<Interned<T>> for &Interned<T> {
-    fn eq(&self, other: &Interned<T>) -> bool {
-        self.0 == other.0
     }
 }
 
@@ -188,8 +172,6 @@ impl<T: Hash + Clone + Eq> TyIntern<T> {
 #[derive(Default)]
 pub struct Interner {
     strs: Mutex<TyIntern<String>>,
-    paths: Mutex<TyIntern<PathBuf>>,
-    lists: Mutex<TyIntern<Vec<String>>>,
 }
 
 /// Defines the behavior required for a type to be internable.
@@ -207,18 +189,6 @@ trait Internable: Clone + Eq + Hash + 'static {
 impl Internable for String {
     fn intern_cache() -> &'static Mutex<TyIntern<Self>> {
         &INTERNER.strs
-    }
-}
-
-impl Internable for PathBuf {
-    fn intern_cache() -> &'static Mutex<TyIntern<Self>> {
-        &INTERNER.paths
-    }
-}
-
-impl Internable for Vec<String> {
-    fn intern_cache() -> &'static Mutex<TyIntern<Self>> {
-        &INTERNER.lists
     }
 }
 

--- a/src/bootstrap/src/utils/cache/tests.rs
+++ b/src/bootstrap/src/utils/cache/tests.rs
@@ -13,26 +13,6 @@ fn test_string_interning() {
 }
 
 #[test]
-fn test_path_interning() {
-    let p1 = PathBuf::from("/tmp/file").intern();
-    let p2 = PathBuf::from("/tmp/file").intern();
-    let p3 = PathBuf::from("/tmp/other").intern();
-
-    assert_eq!(p1, p2);
-    assert_ne!(p1, p3);
-}
-
-#[test]
-fn test_vec_interning() {
-    let v1 = vec!["a".to_string(), "b".to_string()].intern();
-    let v2 = vec!["a".to_string(), "b".to_string()].intern();
-    let v3 = vec!["c".to_string()].intern();
-
-    assert_eq!(v1, v2);
-    assert_ne!(v1, v3);
-}
-
-#[test]
 fn test_interned_equality() {
     let s1 = INTERNER.intern_str("test");
     let s2 = INTERNER.intern_str("test");


### PR DESCRIPTION
We don't use other variants of Interner in bootstrap, so this PR streamlines the bootstrap cache utils module.

r? @onur-ozkan 