### PR TITLE
Properly remove Noratrieb from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1171,7 +1171,6 @@ contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "fmease",
     "jyn514",
-    "Noratrieb",
     "spastorino",
 ]
 
@@ -1198,7 +1197,6 @@ compiler = [
     "@lcnr",
     "@Nadrieril",
     "@nnethercote",
-    "@Noratrieb",
     "@oli-obk",
     "@petrochenkov",
     "@SparrowLii",
@@ -1206,7 +1204,6 @@ compiler = [
 ]
 libs = [
     "@Mark-Simulacrum",
-    "@Noratrieb",
     "@workingjubilee",
     "@joboet",
     "@jhpratt",


### PR DESCRIPTION
I've put myself on vacation a while ago, but really I just want to remove myself from the queue because I couldn't get around to reviewing all the PRs, I'm still here and available :3.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
