### PR TITLE
expand: Use `Option` instead of `SmallVec<1>` where possible.

### DIFF
--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -172,12 +172,9 @@ impl MutVisitor for CfgEval<'_> {
         Some(expr)
     }
 
-    fn flat_map_generic_param(
-        &mut self,
-        param: ast::GenericParam,
-    ) -> SmallVec<[ast::GenericParam; 1]> {
+    fn filter_map_generic_param(&mut self, param: ast::GenericParam) -> Option<ast::GenericParam> {
         let param = configure!(self, param);
-        mut_visit::walk_flat_map_generic_param(self, param)
+        mut_visit::walk_filter_map_generic_param(self, param)
     }
 
     fn flat_map_stmt(&mut self, stmt: ast::Stmt) -> SmallVec<[ast::Stmt; 1]> {
@@ -207,33 +204,33 @@ impl MutVisitor for CfgEval<'_> {
         mut_visit::walk_flat_map_foreign_item(self, foreign_item)
     }
 
-    fn flat_map_arm(&mut self, arm: ast::Arm) -> SmallVec<[ast::Arm; 1]> {
+    fn filter_map_arm(&mut self, arm: ast::Arm) -> Option<ast::Arm> {
         let arm = configure!(self, arm);
-        mut_visit::walk_flat_map_arm(self, arm)
+        mut_visit::walk_filter_map_arm(self, arm)
     }
 
-    fn flat_map_expr_field(&mut self, field: ast::ExprField) -> SmallVec<[ast::ExprField; 1]> {
+    fn filter_map_expr_field(&mut self, field: ast::ExprField) -> Option<ast::ExprField> {
         let field = configure!(self, field);
-        mut_visit::walk_flat_map_expr_field(self, field)
+        mut_visit::walk_filter_map_expr_field(self, field)
     }
 
-    fn flat_map_pat_field(&mut self, fp: ast::PatField) -> SmallVec<[ast::PatField; 1]> {
+    fn filter_map_pat_field(&mut self, fp: ast::PatField) -> Option<ast::PatField> {
         let fp = configure!(self, fp);
-        mut_visit::walk_flat_map_pat_field(self, fp)
+        mut_visit::walk_filter_map_pat_field(self, fp)
     }
 
-    fn flat_map_param(&mut self, p: ast::Param) -> SmallVec<[ast::Param; 1]> {
+    fn filter_map_param(&mut self, p: ast::Param) -> Option<ast::Param> {
         let p = configure!(self, p);
-        mut_visit::walk_flat_map_param(self, p)
+        mut_visit::walk_filter_map_param(self, p)
     }
 
-    fn flat_map_field_def(&mut self, sf: ast::FieldDef) -> SmallVec<[ast::FieldDef; 1]> {
+    fn filter_map_field_def(&mut self, sf: ast::FieldDef) -> Option<ast::FieldDef> {
         let sf = configure!(self, sf);
-        mut_visit::walk_flat_map_field_def(self, sf)
+        mut_visit::walk_filter_map_field_def(self, sf)
     }
 
-    fn flat_map_variant(&mut self, variant: ast::Variant) -> SmallVec<[ast::Variant; 1]> {
+    fn filter_map_variant(&mut self, variant: ast::Variant) -> Option<ast::Variant> {
         let variant = configure!(self, variant);
-        mut_visit::walk_flat_map_variant(self, variant)
+        mut_visit::walk_filter_map_variant(self, variant)
     }
 }

--- a/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
@@ -394,7 +394,7 @@ impl<'a> ast::mut_visit::MutVisitor for TypeSubstitution<'a> {
             rustc_ast::WherePredicateKind::BoundPredicate(bound) => {
                 bound
                     .bound_generic_params
-                    .flat_map_in_place(|param| self.flat_map_generic_param(param));
+                    .flat_map_in_place(|param| self.filter_map_generic_param(param));
                 self.visit_ty(&mut bound.bounded_ty);
                 for bound in &mut bound.bounds {
                     self.visit_param_bound(bound, BoundKind::Bound)

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -435,35 +435,35 @@ pub trait MacResult {
         None
     }
 
-    fn make_arms(self: Box<Self>) -> Option<SmallVec<[ast::Arm; 1]>> {
+    fn make_arm(self: Box<Self>) -> Option<Option<ast::Arm>> {
         None
     }
 
-    fn make_expr_fields(self: Box<Self>) -> Option<SmallVec<[ast::ExprField; 1]>> {
+    fn make_expr_field(self: Box<Self>) -> Option<Option<ast::ExprField>> {
         None
     }
 
-    fn make_pat_fields(self: Box<Self>) -> Option<SmallVec<[ast::PatField; 1]>> {
+    fn make_pat_field(self: Box<Self>) -> Option<Option<ast::PatField>> {
         None
     }
 
-    fn make_generic_params(self: Box<Self>) -> Option<SmallVec<[ast::GenericParam; 1]>> {
+    fn make_generic_param(self: Box<Self>) -> Option<Option<ast::GenericParam>> {
         None
     }
 
-    fn make_params(self: Box<Self>) -> Option<SmallVec<[ast::Param; 1]>> {
+    fn make_param(self: Box<Self>) -> Option<Option<ast::Param>> {
         None
     }
 
-    fn make_field_defs(self: Box<Self>) -> Option<SmallVec<[ast::FieldDef; 1]>> {
+    fn make_field_def(self: Box<Self>) -> Option<Option<ast::FieldDef>> {
         None
     }
 
-    fn make_variants(self: Box<Self>) -> Option<SmallVec<[ast::Variant; 1]>> {
+    fn make_variant(self: Box<Self>) -> Option<Option<ast::Variant>> {
         None
     }
 
-    fn make_where_predicates(self: Box<Self>) -> Option<SmallVec<[ast::WherePredicate; 1]>> {
+    fn make_where_predicate(self: Box<Self>) -> Option<Option<ast::WherePredicate>> {
         None
     }
 
@@ -654,32 +654,32 @@ impl MacResult for DummyResult {
         }))
     }
 
-    fn make_arms(self: Box<DummyResult>) -> Option<SmallVec<[ast::Arm; 1]>> {
-        Some(SmallVec::new())
+    fn make_arm(self: Box<DummyResult>) -> Option<Option<ast::Arm>> {
+        Some(None)
     }
 
-    fn make_expr_fields(self: Box<DummyResult>) -> Option<SmallVec<[ast::ExprField; 1]>> {
-        Some(SmallVec::new())
+    fn make_expr_field(self: Box<DummyResult>) -> Option<Option<ast::ExprField>> {
+        Some(None)
     }
 
-    fn make_pat_fields(self: Box<DummyResult>) -> Option<SmallVec<[ast::PatField; 1]>> {
-        Some(SmallVec::new())
+    fn make_pat_field(self: Box<DummyResult>) -> Option<Option<ast::PatField>> {
+        Some(None)
     }
 
-    fn make_generic_params(self: Box<DummyResult>) -> Option<SmallVec<[ast::GenericParam; 1]>> {
-        Some(SmallVec::new())
+    fn make_generic_param(self: Box<DummyResult>) -> Option<Option<ast::GenericParam>> {
+        Some(None)
     }
 
-    fn make_params(self: Box<DummyResult>) -> Option<SmallVec<[ast::Param; 1]>> {
-        Some(SmallVec::new())
+    fn make_param(self: Box<DummyResult>) -> Option<Option<ast::Param>> {
+        Some(None)
     }
 
-    fn make_field_defs(self: Box<DummyResult>) -> Option<SmallVec<[ast::FieldDef; 1]>> {
-        Some(SmallVec::new())
+    fn make_field_def(self: Box<DummyResult>) -> Option<Option<ast::FieldDef>> {
+        Some(None)
     }
 
-    fn make_variants(self: Box<DummyResult>) -> Option<SmallVec<[ast::Variant; 1]>> {
-        Some(SmallVec::new())
+    fn make_variant(self: Box<DummyResult>) -> Option<Option<ast::Variant>> {
+        Some(None)
     }
 
     fn make_crate(self: Box<DummyResult>) -> Option<ast::Crate> {

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -342,7 +342,7 @@ impl MutVisitor for PlaceholderExpander {
     fn filter_map_expr(&mut self, expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
         match expr.kind {
             ast::ExprKind::MacCall(_) => self.remove(expr.id).make_opt_expr(),
-            _ => noop_filter_map_expr(self, expr),
+            _ => walk_filter_map_expr(self, expr),
         }
     }
 


### PR DESCRIPTION
Currently we use `SmallVec` in various places in expansion where an `Option` would suffice.

r? @petrochenkov