### PR TITLE
Don't reload proc macros on fork

### DIFF
--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -31,7 +31,7 @@ tempfile = "3.7.1"
 tracing = "0.1"
 # tidy-alphabetical-end
 
-[target.'cfg(target_os = "aix")'.dependencies]
+[target.'cfg(any(target_os = "aix", target_os = "cygwin"))'.dependencies]
 # tidy-alphabetical-start
 libc = "0.2"
 # tidy-alphabetical-end

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1442,6 +1442,11 @@ fn load_dylib(path: &Path, max_attempts: usize) -> Result<libloading::Library, S
                         attempt + 1
                     );
                 }
+                #[cfg(target_os = "cygwin")]
+                unsafe {
+                    // We don't need to reload proc macros in child processes.
+                    libc::dlfork(libc::FORK_NO_RELOAD);
+                }
                 return Ok(lib);
             }
             Err(err) => {


### PR DESCRIPTION
I come across this problem recently, and see the mailing list of cygwin: https://inbox.sourceware.org/cygwin/TYCPR01MB10926F334CDC9344A89527583F89CA@TYCPR01MB10926.jpnprd01.prod.outlook.com/

TL;DR: rustc fails to execute the linker when proc macro DLLs are too many.

As we don't need to reload these them when executing the linker, I think it's OK to set `FORK_NO_RELOAD` for the loaded proc macro DLLs. It's a little hacky though. `dlfork` is a cygwin extension without documents, and it cannot set whether to reload a specific DLL on fork. If available, I prefer such an option for `dlopen`.

Not sure what does the rustc maintainers think about this workaround. I'll also ask for advice from the cygwin maintainers.