### PR TITLE
Use Docker cache from the current repository

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -97,9 +97,8 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     docker --version
 
     REGISTRY=ghcr.io
-    # Hardcode username to reuse cache between auto and pr jobs
-    # FIXME: should be changed after move from rust-lang-ci
-    REGISTRY_USERNAME=rust-lang-ci
+    # Default to `rust-lang` to allow reusing the cache for local builds
+    REGISTRY_USERNAME=${GITHUB_REPOSITORY_OWNER:-rust-lang}
     # Tag used to push the final Docker image, so that it can be pulled by e.g. rustup
     IMAGE_TAG=${REGISTRY}/${REGISTRY_USERNAME}/rust-ci:${cksum}
     # Tag used to cache the Docker build


### PR DESCRIPTION
This is needed to make the cache work after moving CI from the `rust-lang-ci` org to `rust-lang`. Shouldn't be merged until we actually move bors.

Context: https://github.com/rust-lang/infra-team/issues/188

r? @marcoieni