### PR TITLE
`core_float_math`: Move functions to `math` module

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -12,7 +12,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::convert::FloatToInt;
-use crate::num::{FpCategory, libm};
+use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{cfg_match, intrinsics, mem};
 
@@ -1557,413 +1557,441 @@ impl f32 {
     }
 }
 
-/// Experimental version of `floor` in `core`. See [`f32::floor`] for details.
+/// Experimental implementations of floating point functions in `core`.
 ///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let f = 3.7_f32;
-/// let g = 3.0_f32;
-/// let h = -3.7_f32;
-///
-/// assert_eq!(f32::floor(f), 3.0);
-/// assert_eq!(f32::floor(g), 3.0);
-/// assert_eq!(f32::floor(h), -4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::floor`]: ../../std/primitive.f32.html#method.floor
-#[inline]
+/// _The standalone functions in this module are for testing only.
+/// They will be stabilized as inherent methods._
 #[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn floor(x: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::floorf32(x) }
-}
+pub mod math {
+    use crate::intrinsics;
+    use crate::num::libm;
 
-/// Experimental version of `ceil` in `core`. See [`f32::ceil`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let f = 3.01_f32;
-/// let g = 4.0_f32;
-///
-/// assert_eq!(f32::ceil(f), 4.0);
-/// assert_eq!(f32::ceil(g), 4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::ceil`]: ../../std/primitive.f32.html#method.ceil
-#[inline]
-#[doc(alias = "ceiling")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-#[unstable(feature = "core_float_math", issue = "137578")]
-pub fn ceil(x: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::ceilf32(x) }
-}
-
-/// Experimental version of `round` in `core`. See [`f32::round`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let f = 3.3_f32;
-/// let g = -3.3_f32;
-/// let h = -3.7_f32;
-/// let i = 3.5_f32;
-/// let j = 4.5_f32;
-///
-/// assert_eq!(f32::round(f), 3.0);
-/// assert_eq!(f32::round(g), -3.0);
-/// assert_eq!(f32::round(h), -4.0);
-/// assert_eq!(f32::round(i), 4.0);
-/// assert_eq!(f32::round(j), 5.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::round`]: ../../std/primitive.f32.html#method.round
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn round(x: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::roundf32(x) }
-}
-
-/// Experimental version of `round_ties_even` in `core`. See [`f32::round_ties_even`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let f = 3.3_f32;
-/// let g = -3.3_f32;
-/// let h = 3.5_f32;
-/// let i = 4.5_f32;
-///
-/// assert_eq!(f32::round_ties_even(f), 3.0);
-/// assert_eq!(f32::round_ties_even(g), -3.0);
-/// assert_eq!(f32::round_ties_even(h), 4.0);
-/// assert_eq!(f32::round_ties_even(i), 4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::round_ties_even`]: ../../std/primitive.f32.html#method.round_ties_even
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn round_ties_even(x: f32) -> f32 {
-    intrinsics::round_ties_even_f32(x)
-}
-
-/// Experimental version of `trunc` in `core`. See [`f32::trunc`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let f = 3.7_f32;
-/// let g = 3.0_f32;
-/// let h = -3.7_f32;
-///
-/// assert_eq!(f32::trunc(f), 3.0);
-/// assert_eq!(f32::trunc(g), 3.0);
-/// assert_eq!(f32::trunc(h), -3.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::trunc`]: ../../std/primitive.f32.html#method.trunc
-#[inline]
-#[doc(alias = "truncate")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-#[unstable(feature = "core_float_math", issue = "137578")]
-pub fn trunc(x: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::truncf32(x) }
-}
-
-/// Experimental version of `fract` in `core`. See [`f32::fract`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let x = 3.6_f32;
-/// let y = -3.6_f32;
-/// let abs_difference_x = (f32::fract(x) - 0.6).abs();
-/// let abs_difference_y = (f32::fract(y) - (-0.6)).abs();
-///
-/// assert!(abs_difference_x <= f32::EPSILON);
-/// assert!(abs_difference_y <= f32::EPSILON);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::fract`]: ../../std/primitive.f32.html#method.fract
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn fract(x: f32) -> f32 {
-    x - trunc(x)
-}
-
-/// Experimental version of `mul_add` in `core`. See [`f32::mul_add`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// # // FIXME(#140515): mingw has an incorrect fma https://sourceforge.net/p/mingw-w64/bugs/848/
-/// # #[cfg(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")))] {
-/// use core::f32;
-///
-/// let m = 10.0_f32;
-/// let x = 4.0_f32;
-/// let b = 60.0_f32;
-///
-/// assert_eq!(f32::mul_add(m, x, b), 100.0);
-/// assert_eq!(m * x + b, 100.0);
-///
-/// let one_plus_eps = 1.0_f32 + f32::EPSILON;
-/// let one_minus_eps = 1.0_f32 - f32::EPSILON;
-/// let minus_one = -1.0_f32;
-///
-/// // The exact result (1 + eps) * (1 - eps) = 1 - eps * eps.
-/// assert_eq!(f32::mul_add(one_plus_eps, one_minus_eps, minus_one), -f32::EPSILON * f32::EPSILON);
-/// // Different rounding with the non-fused multiply and add.
-/// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
-/// # }
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::mul_add`]: ../../std/primitive.f32.html#method.mul_add
-#[inline]
-#[doc(alias = "fmaf", alias = "fusedMultiplyAdd")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-#[unstable(feature = "core_float_math", issue = "137578")]
-pub fn mul_add(x: f32, y: f32, z: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::fmaf32(x, y, z) }
-}
-
-/// Experimental version of `div_euclid` in `core`. See [`f32::div_euclid`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let a: f32 = 7.0;
-/// let b = 4.0;
-/// assert_eq!(f32::div_euclid(a, b), 1.0); // 7.0 > 4.0 * 1.0
-/// assert_eq!(f32::div_euclid(-a, b), -2.0); // -7.0 >= 4.0 * -2.0
-/// assert_eq!(f32::div_euclid(a, -b), -1.0); // 7.0 >= -4.0 * -1.0
-/// assert_eq!(f32::div_euclid(-a, -b), 2.0); // -7.0 >= -4.0 * 2.0
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::div_euclid`]: ../../std/primitive.f32.html#method.div_euclid
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn div_euclid(x: f32, rhs: f32) -> f32 {
-    let q = trunc(x / rhs);
-    if x % rhs < 0.0 {
-        return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+    /// Experimental version of `floor` in `core`. See [`f32::floor`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let f = 3.7_f32;
+    /// let g = 3.0_f32;
+    /// let h = -3.7_f32;
+    ///
+    /// assert_eq!(f32::math::floor(f), 3.0);
+    /// assert_eq!(f32::math::floor(g), 3.0);
+    /// assert_eq!(f32::math::floor(h), -4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::floor`]: ../../../std/primitive.f32.html#method.floor
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn floor(x: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::floorf32(x) }
     }
-    q
-}
 
-/// Experimental version of `rem_euclid` in `core`. See [`f32::rem_euclid`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let a: f32 = 7.0;
-/// let b = 4.0;
-/// assert_eq!(f32::rem_euclid(a, b), 3.0);
-/// assert_eq!(f32::rem_euclid(-a, b), 1.0);
-/// assert_eq!(f32::rem_euclid(a, -b), 3.0);
-/// assert_eq!(f32::rem_euclid(-a, -b), 1.0);
-/// // limitation due to round-off error
-/// assert!(f32::rem_euclid(-f32::EPSILON, 3.0) != 0.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::rem_euclid`]: ../../std/primitive.f32.html#method.rem_euclid
-#[inline]
-#[doc(alias = "modulo", alias = "mod")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn rem_euclid(x: f32, rhs: f32) -> f32 {
-    let r = x % rhs;
-    if r < 0.0 { r + rhs.abs() } else { r }
-}
+    /// Experimental version of `ceil` in `core`. See [`f32::ceil`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let f = 3.01_f32;
+    /// let g = 4.0_f32;
+    ///
+    /// assert_eq!(f32::math::ceil(f), 4.0);
+    /// assert_eq!(f32::math::ceil(g), 4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::ceil`]: ../../../std/primitive.f32.html#method.ceil
+    #[inline]
+    #[doc(alias = "ceiling")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    pub fn ceil(x: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::ceilf32(x) }
+    }
 
-/// Experimental version of `powi` in `core`. See [`f32::powi`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let x = 2.0_f32;
-/// let abs_difference = (f32::powi(x, 2) - (x * x)).abs();
-/// assert!(abs_difference <= f32::EPSILON);
-///
-/// assert_eq!(f32::powi(f32::NAN, 0), 1.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::powi`]: ../../std/primitive.f32.html#method.powi
-#[inline]
-#[must_use = "method returns a new number and does not mutate the original value"]
-#[unstable(feature = "core_float_math", issue = "137578")]
-pub fn powi(x: f32, n: i32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::powif32(x, n) }
-}
+    /// Experimental version of `round` in `core`. See [`f32::round`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let f = 3.3_f32;
+    /// let g = -3.3_f32;
+    /// let h = -3.7_f32;
+    /// let i = 3.5_f32;
+    /// let j = 4.5_f32;
+    ///
+    /// assert_eq!(f32::math::round(f), 3.0);
+    /// assert_eq!(f32::math::round(g), -3.0);
+    /// assert_eq!(f32::math::round(h), -4.0);
+    /// assert_eq!(f32::math::round(i), 4.0);
+    /// assert_eq!(f32::math::round(j), 5.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::round`]: ../../../std/primitive.f32.html#method.round
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn round(x: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::roundf32(x) }
+    }
 
-/// Experimental version of `sqrt` in `core`. See [`f32::sqrt`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let positive = 4.0_f32;
-/// let negative = -4.0_f32;
-/// let negative_zero = -0.0_f32;
-///
-/// assert_eq!(f32::sqrt(positive), 2.0);
-/// assert!(f32::sqrt(negative).is_nan());
-/// assert_eq!(f32::sqrt(negative_zero), negative_zero);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::sqrt`]: ../../std/primitive.f32.html#method.sqrt
-#[inline]
-#[doc(alias = "squareRoot")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn sqrt(x: f32) -> f32 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::sqrtf32(x) }
-}
+    /// Experimental version of `round_ties_even` in `core`. See [`f32::round_ties_even`] for
+    /// details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let f = 3.3_f32;
+    /// let g = -3.3_f32;
+    /// let h = 3.5_f32;
+    /// let i = 4.5_f32;
+    ///
+    /// assert_eq!(f32::math::round_ties_even(f), 3.0);
+    /// assert_eq!(f32::math::round_ties_even(g), -3.0);
+    /// assert_eq!(f32::math::round_ties_even(h), 4.0);
+    /// assert_eq!(f32::math::round_ties_even(i), 4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::round_ties_even`]: ../../../std/primitive.f32.html#method.round_ties_even
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn round_ties_even(x: f32) -> f32 {
+        intrinsics::round_ties_even_f32(x)
+    }
 
-/// Experimental version of `abs_sub` in `core`. See [`f32::abs_sub`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let x = 3.0f32;
-/// let y = -3.0f32;
-///
-/// let abs_difference_x = (f32::abs_sub(x, 1.0) - 2.0).abs();
-/// let abs_difference_y = (f32::abs_sub(y, 1.0) - 0.0).abs();
-///
-/// assert!(abs_difference_x <= f32::EPSILON);
-/// assert!(abs_difference_y <= f32::EPSILON);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::abs_sub`]: ../../std/primitive.f32.html#method.abs_sub
-#[inline]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[deprecated(
-    since = "1.10.0",
-    note = "you probably meant `(self - other).abs()`: \
+    /// Experimental version of `trunc` in `core`. See [`f32::trunc`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let f = 3.7_f32;
+    /// let g = 3.0_f32;
+    /// let h = -3.7_f32;
+    ///
+    /// assert_eq!(f32::math::trunc(f), 3.0);
+    /// assert_eq!(f32::math::trunc(g), 3.0);
+    /// assert_eq!(f32::math::trunc(h), -3.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::trunc`]: ../../../std/primitive.f32.html#method.trunc
+    #[inline]
+    #[doc(alias = "truncate")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    pub fn trunc(x: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::truncf32(x) }
+    }
+
+    /// Experimental version of `fract` in `core`. See [`f32::fract`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let x = 3.6_f32;
+    /// let y = -3.6_f32;
+    /// let abs_difference_x = (f32::math::fract(x) - 0.6).abs();
+    /// let abs_difference_y = (f32::math::fract(y) - (-0.6)).abs();
+    ///
+    /// assert!(abs_difference_x <= f32::EPSILON);
+    /// assert!(abs_difference_y <= f32::EPSILON);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::fract`]: ../../../std/primitive.f32.html#method.fract
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn fract(x: f32) -> f32 {
+        x - trunc(x)
+    }
+
+    /// Experimental version of `mul_add` in `core`. See [`f32::mul_add`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// # // FIXME(#140515): mingw has an incorrect fma
+    /// # // https://sourceforge.net/p/mingw-w64/bugs/848/
+    /// # #[cfg(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")))] {
+    /// use core::f32;
+    ///
+    /// let m = 10.0_f32;
+    /// let x = 4.0_f32;
+    /// let b = 60.0_f32;
+    ///
+    /// assert_eq!(f32::math::mul_add(m, x, b), 100.0);
+    /// assert_eq!(m * x + b, 100.0);
+    ///
+    /// let one_plus_eps = 1.0_f32 + f32::EPSILON;
+    /// let one_minus_eps = 1.0_f32 - f32::EPSILON;
+    /// let minus_one = -1.0_f32;
+    ///
+    /// // The exact result (1 + eps) * (1 - eps) = 1 - eps * eps.
+    /// assert_eq!(
+    ///     f32::math::mul_add(one_plus_eps, one_minus_eps, minus_one),
+    ///     -f32::EPSILON * f32::EPSILON
+    /// );
+    /// // Different rounding with the non-fused multiply and add.
+    /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
+    /// # }
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::mul_add`]: ../../../std/primitive.f32.html#method.mul_add
+    #[inline]
+    #[doc(alias = "fmaf", alias = "fusedMultiplyAdd")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    pub fn mul_add(x: f32, y: f32, z: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::fmaf32(x, y, z) }
+    }
+
+    /// Experimental version of `div_euclid` in `core`. See [`f32::div_euclid`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let a: f32 = 7.0;
+    /// let b = 4.0;
+    /// assert_eq!(f32::math::div_euclid(a, b), 1.0); // 7.0 > 4.0 * 1.0
+    /// assert_eq!(f32::math::div_euclid(-a, b), -2.0); // -7.0 >= 4.0 * -2.0
+    /// assert_eq!(f32::math::div_euclid(a, -b), -1.0); // 7.0 >= -4.0 * -1.0
+    /// assert_eq!(f32::math::div_euclid(-a, -b), 2.0); // -7.0 >= -4.0 * 2.0
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::div_euclid`]: ../../../std/primitive.f32.html#method.div_euclid
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn div_euclid(x: f32, rhs: f32) -> f32 {
+        let q = trunc(x / rhs);
+        if x % rhs < 0.0 {
+            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        }
+        q
+    }
+
+    /// Experimental version of `rem_euclid` in `core`. See [`f32::rem_euclid`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let a: f32 = 7.0;
+    /// let b = 4.0;
+    /// assert_eq!(f32::math::rem_euclid(a, b), 3.0);
+    /// assert_eq!(f32::math::rem_euclid(-a, b), 1.0);
+    /// assert_eq!(f32::math::rem_euclid(a, -b), 3.0);
+    /// assert_eq!(f32::math::rem_euclid(-a, -b), 1.0);
+    /// // limitation due to round-off error
+    /// assert!(f32::math::rem_euclid(-f32::EPSILON, 3.0) != 0.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::rem_euclid`]: ../../../std/primitive.f32.html#method.rem_euclid
+    #[inline]
+    #[doc(alias = "modulo", alias = "mod")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn rem_euclid(x: f32, rhs: f32) -> f32 {
+        let r = x % rhs;
+        if r < 0.0 { r + rhs.abs() } else { r }
+    }
+
+    /// Experimental version of `powi` in `core`. See [`f32::powi`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let x = 2.0_f32;
+    /// let abs_difference = (f32::math::powi(x, 2) - (x * x)).abs();
+    /// assert!(abs_difference <= f32::EPSILON);
+    ///
+    /// assert_eq!(f32::math::powi(f32::NAN, 0), 1.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::powi`]: ../../../std/primitive.f32.html#method.powi
+    #[inline]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    pub fn powi(x: f32, n: i32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::powif32(x, n) }
+    }
+
+    /// Experimental version of `sqrt` in `core`. See [`f32::sqrt`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let positive = 4.0_f32;
+    /// let negative = -4.0_f32;
+    /// let negative_zero = -0.0_f32;
+    ///
+    /// assert_eq!(f32::math::sqrt(positive), 2.0);
+    /// assert!(f32::math::sqrt(negative).is_nan());
+    /// assert_eq!(f32::math::sqrt(negative_zero), negative_zero);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::sqrt`]: ../../../std/primitive.f32.html#method.sqrt
+    #[inline]
+    #[doc(alias = "squareRoot")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn sqrt(x: f32) -> f32 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::sqrtf32(x) }
+    }
+
+    /// Experimental version of `abs_sub` in `core`. See [`f32::abs_sub`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let x = 3.0f32;
+    /// let y = -3.0f32;
+    ///
+    /// let abs_difference_x = (f32::math::abs_sub(x, 1.0) - 2.0).abs();
+    /// let abs_difference_y = (f32::math::abs_sub(y, 1.0) - 0.0).abs();
+    ///
+    /// assert!(abs_difference_x <= f32::EPSILON);
+    /// assert!(abs_difference_y <= f32::EPSILON);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::abs_sub`]: ../../../std/primitive.f32.html#method.abs_sub
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(
+        since = "1.10.0",
+        note = "you probably meant `(self - other).abs()`: \
             this operation is `(self - other).max(0.0)` \
             except that `abs_sub` also propagates NaNs (also \
             known as `fdimf` in C). If you truly need the positive \
             difference, consider using that expression or the C function \
             `fdimf`, depending on how you wish to handle NaN (please consider \
             filing an issue describing your use-case too)."
-)]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn abs_sub(x: f32, other: f32) -> f32 {
-    libm::fdimf(x, other)
-}
+    )]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn abs_sub(x: f32, other: f32) -> f32 {
+        libm::fdimf(x, other)
+    }
 
-/// Experimental version of `cbrt` in `core`. See [`f32::cbrt`] for details.
-///
-/// # Unspecified precision
-///
-/// The precision of this function is non-deterministic. This means it varies by platform, Rust version, and
-/// can even differ within the same execution from one invocation to the next.
-/// This function currently corresponds to the `cbrtf` from libc on Unix
-/// and Windows. Note that this might change in the future.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f32;
-///
-/// let x = 8.0f32;
-///
-/// // x^(1/3) - 2 == 0
-/// let abs_difference = (f32::cbrt(x) - 2.0).abs();
-///
-/// assert!(abs_difference <= f32::EPSILON);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f32::cbrt`]: ../../std/primitive.f32.html#method.cbrt
-#[inline]
-#[must_use = "method returns a new number and does not mutate the original value"]
-#[unstable(feature = "core_float_math", issue = "137578")]
-pub fn cbrt(x: f32) -> f32 {
-    libm::cbrtf(x)
+    /// Experimental version of `cbrt` in `core`. See [`f32::cbrt`] for details.
+    ///
+    /// # Unspecified precision
+    ///
+    /// The precision of this function is non-deterministic. This means it varies by platform, Rust version, and
+    /// can even differ within the same execution from one invocation to the next.
+    /// This function currently corresponds to the `cbrtf` from libc on Unix
+    /// and Windows. Note that this might change in the future.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f32;
+    ///
+    /// let x = 8.0f32;
+    ///
+    /// // x^(1/3) - 2 == 0
+    /// let abs_difference = (f32::math::cbrt(x) - 2.0).abs();
+    ///
+    /// assert!(abs_difference <= f32::EPSILON);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f32::cbrt`]: ../../../std/primitive.f32.html#method.cbrt
+    #[inline]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    pub fn cbrt(x: f32) -> f32 {
+        libm::cbrtf(x)
+    }
 }

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -12,7 +12,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::convert::FloatToInt;
-use crate::num::{FpCategory, libm};
+use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
 
@@ -1556,406 +1556,434 @@ impl f64 {
     }
 }
 
-/// Experimental version of `floor` in `core`. See [`f64::floor`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let f = 3.7_f64;
-/// let g = 3.0_f64;
-/// let h = -3.7_f64;
-///
-/// assert_eq!(f64::floor(f), 3.0);
-/// assert_eq!(f64::floor(g), 3.0);
-/// assert_eq!(f64::floor(h), -4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::floor`]: ../../std/primitive.f64.html#method.floor
-#[inline]
 #[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn floor(x: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::floorf64(x) }
-}
+/// Experimental implementations of floating point functions in `core`.
+///
+/// _The standalone functions in this module are for testing only.
+/// They will be stabilized as inherent methods._
+pub mod math {
+    use crate::intrinsics;
+    use crate::num::libm;
 
-/// Experimental version of `ceil` in `core`. See [`f64::ceil`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let f = 3.01_f64;
-/// let g = 4.0_f64;
-///
-/// assert_eq!(f64::ceil(f), 4.0);
-/// assert_eq!(f64::ceil(g), 4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::ceil`]: ../../std/primitive.f64.html#method.ceil
-#[inline]
-#[doc(alias = "ceiling")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn ceil(x: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::ceilf64(x) }
-}
-
-/// Experimental version of `round` in `core`. See [`f64::round`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let f = 3.3_f64;
-/// let g = -3.3_f64;
-/// let h = -3.7_f64;
-/// let i = 3.5_f64;
-/// let j = 4.5_f64;
-///
-/// assert_eq!(f64::round(f), 3.0);
-/// assert_eq!(f64::round(g), -3.0);
-/// assert_eq!(f64::round(h), -4.0);
-/// assert_eq!(f64::round(i), 4.0);
-/// assert_eq!(f64::round(j), 5.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::round`]: ../../std/primitive.f64.html#method.round
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn round(x: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::roundf64(x) }
-}
-
-/// Experimental version of `round_ties_even` in `core`. See [`f64::round_ties_even`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let f = 3.3_f64;
-/// let g = -3.3_f64;
-/// let h = 3.5_f64;
-/// let i = 4.5_f64;
-///
-/// assert_eq!(f64::round_ties_even(f), 3.0);
-/// assert_eq!(f64::round_ties_even(g), -3.0);
-/// assert_eq!(f64::round_ties_even(h), 4.0);
-/// assert_eq!(f64::round_ties_even(i), 4.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::round_ties_even`]: ../../std/primitive.f64.html#method.round_ties_even
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn round_ties_even(x: f64) -> f64 {
-    intrinsics::round_ties_even_f64(x)
-}
-
-/// Experimental version of `trunc` in `core`. See [`f64::trunc`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let f = 3.7_f64;
-/// let g = 3.0_f64;
-/// let h = -3.7_f64;
-///
-/// assert_eq!(f64::trunc(f), 3.0);
-/// assert_eq!(f64::trunc(g), 3.0);
-/// assert_eq!(f64::trunc(h), -3.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::trunc`]: ../../std/primitive.f64.html#method.trunc
-#[inline]
-#[doc(alias = "truncate")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn trunc(x: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::truncf64(x) }
-}
-
-/// Experimental version of `fract` in `core`. See [`f64::fract`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let x = 3.6_f64;
-/// let y = -3.6_f64;
-/// let abs_difference_x = (f64::fract(x) - 0.6).abs();
-/// let abs_difference_y = (f64::fract(y) - (-0.6)).abs();
-///
-/// assert!(abs_difference_x < 1e-10);
-/// assert!(abs_difference_y < 1e-10);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::fract`]: ../../std/primitive.f64.html#method.fract
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn fract(x: f64) -> f64 {
-    x - trunc(x)
-}
-
-/// Experimental version of `mul_add` in `core`. See [`f64::mul_add`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// # // FIXME(#140515): mingw has an incorrect fma https://sourceforge.net/p/mingw-w64/bugs/848/
-/// # #[cfg(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")))] {
-/// use core::f64;
-///
-/// let m = 10.0_f64;
-/// let x = 4.0_f64;
-/// let b = 60.0_f64;
-///
-/// assert_eq!(f64::mul_add(m, x, b), 100.0);
-/// assert_eq!(m * x + b, 100.0);
-///
-/// let one_plus_eps = 1.0_f64 + f64::EPSILON;
-/// let one_minus_eps = 1.0_f64 - f64::EPSILON;
-/// let minus_one = -1.0_f64;
-///
-/// // The exact result (1 + eps) * (1 - eps) = 1 - eps * eps.
-/// assert_eq!(f64::mul_add(one_plus_eps, one_minus_eps, minus_one), -f64::EPSILON * f64::EPSILON);
-/// // Different rounding with the non-fused multiply and add.
-/// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
-/// # }
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::mul_add`]: ../../std/primitive.f64.html#method.mul_add
-#[inline]
-#[doc(alias = "fma", alias = "fusedMultiplyAdd")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn mul_add(x: f64, a: f64, b: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::fmaf64(x, a, b) }
-}
-
-/// Experimental version of `div_euclid` in `core`. See [`f64::div_euclid`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let a: f64 = 7.0;
-/// let b = 4.0;
-/// assert_eq!(f64::div_euclid(a, b), 1.0); // 7.0 > 4.0 * 1.0
-/// assert_eq!(f64::div_euclid(-a, b), -2.0); // -7.0 >= 4.0 * -2.0
-/// assert_eq!(f64::div_euclid(a, -b), -1.0); // 7.0 >= -4.0 * -1.0
-/// assert_eq!(f64::div_euclid(-a, -b), 2.0); // -7.0 >= -4.0 * 2.0
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::div_euclid`]: ../../std/primitive.f64.html#method.div_euclid
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn div_euclid(x: f64, rhs: f64) -> f64 {
-    let q = trunc(x / rhs);
-    if x % rhs < 0.0 {
-        return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+    /// Experimental version of `floor` in `core`. See [`f64::floor`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let f = 3.7_f64;
+    /// let g = 3.0_f64;
+    /// let h = -3.7_f64;
+    ///
+    /// assert_eq!(f64::math::floor(f), 3.0);
+    /// assert_eq!(f64::math::floor(g), 3.0);
+    /// assert_eq!(f64::math::floor(h), -4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::floor`]: ../../../std/primitive.f64.html#method.floor
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn floor(x: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::floorf64(x) }
     }
-    q
-}
 
-/// Experimental version of `rem_euclid` in `core`. See [`f64::rem_euclid`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let a: f64 = 7.0;
-/// let b = 4.0;
-/// assert_eq!(f64::rem_euclid(a, b), 3.0);
-/// assert_eq!(f64::rem_euclid(-a, b), 1.0);
-/// assert_eq!(f64::rem_euclid(a, -b), 3.0);
-/// assert_eq!(f64::rem_euclid(-a, -b), 1.0);
-/// // limitation due to round-off error
-/// assert!(f64::rem_euclid(-f64::EPSILON, 3.0) != 0.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::rem_euclid`]: ../../std/primitive.f64.html#method.rem_euclid
-#[inline]
-#[doc(alias = "modulo", alias = "mod")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn rem_euclid(x: f64, rhs: f64) -> f64 {
-    let r = x % rhs;
-    if r < 0.0 { r + rhs.abs() } else { r }
-}
+    /// Experimental version of `ceil` in `core`. See [`f64::ceil`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let f = 3.01_f64;
+    /// let g = 4.0_f64;
+    ///
+    /// assert_eq!(f64::math::ceil(f), 4.0);
+    /// assert_eq!(f64::math::ceil(g), 4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::ceil`]: ../../../std/primitive.f64.html#method.ceil
+    #[inline]
+    #[doc(alias = "ceiling")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn ceil(x: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::ceilf64(x) }
+    }
 
-/// Experimental version of `powi` in `core`. See [`f64::powi`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let x = 2.0_f64;
-/// let abs_difference = (f64::powi(x, 2) - (x * x)).abs();
-/// assert!(abs_difference <= f64::EPSILON);
-///
-/// assert_eq!(f64::powi(f64::NAN, 0), 1.0);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::powi`]: ../../std/primitive.f64.html#method.powi
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn powi(x: f64, n: i32) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::powif64(x, n) }
-}
+    /// Experimental version of `round` in `core`. See [`f64::round`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let f = 3.3_f64;
+    /// let g = -3.3_f64;
+    /// let h = -3.7_f64;
+    /// let i = 3.5_f64;
+    /// let j = 4.5_f64;
+    ///
+    /// assert_eq!(f64::math::round(f), 3.0);
+    /// assert_eq!(f64::math::round(g), -3.0);
+    /// assert_eq!(f64::math::round(h), -4.0);
+    /// assert_eq!(f64::math::round(i), 4.0);
+    /// assert_eq!(f64::math::round(j), 5.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::round`]: ../../../std/primitive.f64.html#method.round
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn round(x: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::roundf64(x) }
+    }
 
-/// Experimental version of `sqrt` in `core`. See [`f64::sqrt`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let positive = 4.0_f64;
-/// let negative = -4.0_f64;
-/// let negative_zero = -0.0_f64;
-///
-/// assert_eq!(f64::sqrt(positive), 2.0);
-/// assert!(f64::sqrt(negative).is_nan());
-/// assert_eq!(f64::sqrt(negative_zero), negative_zero);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::sqrt`]: ../../std/primitive.f64.html#method.sqrt
-#[inline]
-#[doc(alias = "squareRoot")]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn sqrt(x: f64) -> f64 {
-    // SAFETY: intrinsic with no preconditions
-    unsafe { intrinsics::sqrtf64(x) }
-}
+    /// Experimental version of `round_ties_even` in `core`. See [`f64::round_ties_even`] for
+    /// details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let f = 3.3_f64;
+    /// let g = -3.3_f64;
+    /// let h = 3.5_f64;
+    /// let i = 4.5_f64;
+    ///
+    /// assert_eq!(f64::math::round_ties_even(f), 3.0);
+    /// assert_eq!(f64::math::round_ties_even(g), -3.0);
+    /// assert_eq!(f64::math::round_ties_even(h), 4.0);
+    /// assert_eq!(f64::math::round_ties_even(i), 4.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::round_ties_even`]: ../../../std/primitive.f64.html#method.round_ties_even
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn round_ties_even(x: f64) -> f64 {
+        intrinsics::round_ties_even_f64(x)
+    }
 
-/// Experimental version of `abs_sub` in `core`. See [`f64::abs_sub`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let x = 3.0_f64;
-/// let y = -3.0_f64;
-///
-/// let abs_difference_x = (f64::abs_sub(x, 1.0) - 2.0).abs();
-/// let abs_difference_y = (f64::abs_sub(y, 1.0) - 0.0).abs();
-///
-/// assert!(abs_difference_x < 1e-10);
-/// assert!(abs_difference_y < 1e-10);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::abs_sub`]: ../../std/primitive.f64.html#method.abs_sub
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[deprecated(
-    since = "1.10.0",
-    note = "you probably meant `(self - other).abs()`: \
+    /// Experimental version of `trunc` in `core`. See [`f64::trunc`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let f = 3.7_f64;
+    /// let g = 3.0_f64;
+    /// let h = -3.7_f64;
+    ///
+    /// assert_eq!(f64::math::trunc(f), 3.0);
+    /// assert_eq!(f64::math::trunc(g), 3.0);
+    /// assert_eq!(f64::math::trunc(h), -3.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::trunc`]: ../../../std/primitive.f64.html#method.trunc
+    #[inline]
+    #[doc(alias = "truncate")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn trunc(x: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::truncf64(x) }
+    }
+
+    /// Experimental version of `fract` in `core`. See [`f64::fract`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let x = 3.6_f64;
+    /// let y = -3.6_f64;
+    /// let abs_difference_x = (f64::math::fract(x) - 0.6).abs();
+    /// let abs_difference_y = (f64::math::fract(y) - (-0.6)).abs();
+    ///
+    /// assert!(abs_difference_x < 1e-10);
+    /// assert!(abs_difference_y < 1e-10);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::fract`]: ../../../std/primitive.f64.html#method.fract
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn fract(x: f64) -> f64 {
+        x - trunc(x)
+    }
+
+    /// Experimental version of `mul_add` in `core`. See [`f64::mul_add`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// # // FIXME(#140515): mingw has an incorrect fma
+    /// # // https://sourceforge.net/p/mingw-w64/bugs/848/
+    /// # #[cfg(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")))] {
+    /// use core::f64;
+    ///
+    /// let m = 10.0_f64;
+    /// let x = 4.0_f64;
+    /// let b = 60.0_f64;
+    ///
+    /// assert_eq!(f64::math::mul_add(m, x, b), 100.0);
+    /// assert_eq!(m * x + b, 100.0);
+    ///
+    /// let one_plus_eps = 1.0_f64 + f64::EPSILON;
+    /// let one_minus_eps = 1.0_f64 - f64::EPSILON;
+    /// let minus_one = -1.0_f64;
+    ///
+    /// // The exact result (1 + eps) * (1 - eps) = 1 - eps * eps.
+    /// assert_eq!(
+    ///     f64::math::mul_add(one_plus_eps, one_minus_eps, minus_one),
+    ///     -f64::EPSILON * f64::EPSILON
+    /// );
+    /// // Different rounding with the non-fused multiply and add.
+    /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
+    /// # }
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::mul_add`]: ../../../std/primitive.f64.html#method.mul_add
+    #[inline]
+    #[doc(alias = "fma", alias = "fusedMultiplyAdd")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn mul_add(x: f64, a: f64, b: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::fmaf64(x, a, b) }
+    }
+
+    /// Experimental version of `div_euclid` in `core`. See [`f64::div_euclid`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let a: f64 = 7.0;
+    /// let b = 4.0;
+    /// assert_eq!(f64::math::div_euclid(a, b), 1.0); // 7.0 > 4.0 * 1.0
+    /// assert_eq!(f64::math::div_euclid(-a, b), -2.0); // -7.0 >= 4.0 * -2.0
+    /// assert_eq!(f64::math::div_euclid(a, -b), -1.0); // 7.0 >= -4.0 * -1.0
+    /// assert_eq!(f64::math::div_euclid(-a, -b), 2.0); // -7.0 >= -4.0 * 2.0
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::div_euclid`]: ../../../std/primitive.f64.html#method.div_euclid
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn div_euclid(x: f64, rhs: f64) -> f64 {
+        let q = trunc(x / rhs);
+        if x % rhs < 0.0 {
+            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        }
+        q
+    }
+
+    /// Experimental version of `rem_euclid` in `core`. See [`f64::rem_euclid`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let a: f64 = 7.0;
+    /// let b = 4.0;
+    /// assert_eq!(f64::math::rem_euclid(a, b), 3.0);
+    /// assert_eq!(f64::math::rem_euclid(-a, b), 1.0);
+    /// assert_eq!(f64::math::rem_euclid(a, -b), 3.0);
+    /// assert_eq!(f64::math::rem_euclid(-a, -b), 1.0);
+    /// // limitation due to round-off error
+    /// assert!(f64::math::rem_euclid(-f64::EPSILON, 3.0) != 0.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::rem_euclid`]: ../../../std/primitive.f64.html#method.rem_euclid
+    #[inline]
+    #[doc(alias = "modulo", alias = "mod")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn rem_euclid(x: f64, rhs: f64) -> f64 {
+        let r = x % rhs;
+        if r < 0.0 { r + rhs.abs() } else { r }
+    }
+
+    /// Experimental version of `powi` in `core`. See [`f64::powi`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let x = 2.0_f64;
+    /// let abs_difference = (f64::math::powi(x, 2) - (x * x)).abs();
+    /// assert!(abs_difference <= f64::EPSILON);
+    ///
+    /// assert_eq!(f64::math::powi(f64::NAN, 0), 1.0);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::powi`]: ../../../std/primitive.f64.html#method.powi
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn powi(x: f64, n: i32) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::powif64(x, n) }
+    }
+
+    /// Experimental version of `sqrt` in `core`. See [`f64::sqrt`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let positive = 4.0_f64;
+    /// let negative = -4.0_f64;
+    /// let negative_zero = -0.0_f64;
+    ///
+    /// assert_eq!(f64::math::sqrt(positive), 2.0);
+    /// assert!(f64::math::sqrt(negative).is_nan());
+    /// assert_eq!(f64::math::sqrt(negative_zero), negative_zero);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::sqrt`]: ../../../std/primitive.f64.html#method.sqrt
+    #[inline]
+    #[doc(alias = "squareRoot")]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn sqrt(x: f64) -> f64 {
+        // SAFETY: intrinsic with no preconditions
+        unsafe { intrinsics::sqrtf64(x) }
+    }
+
+    /// Experimental version of `abs_sub` in `core`. See [`f64::abs_sub`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let x = 3.0_f64;
+    /// let y = -3.0_f64;
+    ///
+    /// let abs_difference_x = (f64::math::abs_sub(x, 1.0) - 2.0).abs();
+    /// let abs_difference_y = (f64::math::abs_sub(y, 1.0) - 0.0).abs();
+    ///
+    /// assert!(abs_difference_x < 1e-10);
+    /// assert!(abs_difference_y < 1e-10);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::abs_sub`]: ../../../std/primitive.f64.html#method.abs_sub
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[deprecated(
+        since = "1.10.0",
+        note = "you probably meant `(self - other).abs()`: \
                 this operation is `(self - other).max(0.0)` \
                 except that `abs_sub` also propagates NaNs (also \
                 known as `fdim` in C). If you truly need the positive \
                 difference, consider using that expression or the C function \
                 `fdim`, depending on how you wish to handle NaN (please consider \
                 filing an issue describing your use-case too)."
-)]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn abs_sub(x: f64, other: f64) -> f64 {
-    libm::fdim(x, other)
-}
+    )]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn abs_sub(x: f64, other: f64) -> f64 {
+        libm::fdim(x, other)
+    }
 
-/// Experimental version of `cbrt` in `core`. See [`f64::cbrt`] for details.
-///
-/// # Examples
-///
-/// ```
-/// #![feature(core_float_math)]
-///
-/// use core::f64;
-///
-/// let x = 8.0_f64;
-///
-/// // x^(1/3) - 2 == 0
-/// let abs_difference = (f64::cbrt(x) - 2.0).abs();
-///
-/// assert!(abs_difference < 1e-10);
-/// ```
-///
-/// _This standalone function is for testing only. It will be stabilized as an inherent method._
-///
-/// [`f64::cbrt`]: ../../std/primitive.f64.html#method.cbrt
-#[inline]
-#[unstable(feature = "core_float_math", issue = "137578")]
-#[must_use = "method returns a new number and does not mutate the original value"]
-pub fn cbrt(x: f64) -> f64 {
-    libm::cbrt(x)
+    /// Experimental version of `cbrt` in `core`. See [`f64::cbrt`] for details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(core_float_math)]
+    ///
+    /// use core::f64;
+    ///
+    /// let x = 8.0_f64;
+    ///
+    /// // x^(1/3) - 2 == 0
+    /// let abs_difference = (f64::math::cbrt(x) - 2.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// ```
+    ///
+    /// _This standalone function is for testing only.
+    /// It will be stabilized as an inherent method._
+    ///
+    /// [`f64::cbrt`]: ../../../std/primitive.f64.html#method.cbrt
+    #[inline]
+    #[unstable(feature = "core_float_math", issue = "137578")]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    pub fn cbrt(x: f64) -> f64 {
+        libm::cbrt(x)
+    }
 }

--- a/library/coretests/tests/floats/f32.rs
+++ b/library/coretests/tests/floats/f32.rs
@@ -215,88 +215,88 @@ fn test_classify() {
 
 #[test]
 fn test_floor() {
-    assert_approx_eq!(f32::floor(1.0f32), 1.0f32);
-    assert_approx_eq!(f32::floor(1.3f32), 1.0f32);
-    assert_approx_eq!(f32::floor(1.5f32), 1.0f32);
-    assert_approx_eq!(f32::floor(1.7f32), 1.0f32);
-    assert_approx_eq!(f32::floor(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::floor(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::floor(-1.0f32), -1.0f32);
-    assert_approx_eq!(f32::floor(-1.3f32), -2.0f32);
-    assert_approx_eq!(f32::floor(-1.5f32), -2.0f32);
-    assert_approx_eq!(f32::floor(-1.7f32), -2.0f32);
+    assert_approx_eq!(f32::math::floor(1.0f32), 1.0f32);
+    assert_approx_eq!(f32::math::floor(1.3f32), 1.0f32);
+    assert_approx_eq!(f32::math::floor(1.5f32), 1.0f32);
+    assert_approx_eq!(f32::math::floor(1.7f32), 1.0f32);
+    assert_approx_eq!(f32::math::floor(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::floor(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::floor(-1.0f32), -1.0f32);
+    assert_approx_eq!(f32::math::floor(-1.3f32), -2.0f32);
+    assert_approx_eq!(f32::math::floor(-1.5f32), -2.0f32);
+    assert_approx_eq!(f32::math::floor(-1.7f32), -2.0f32);
 }
 
 #[test]
 fn test_ceil() {
-    assert_approx_eq!(f32::ceil(1.0f32), 1.0f32);
-    assert_approx_eq!(f32::ceil(1.3f32), 2.0f32);
-    assert_approx_eq!(f32::ceil(1.5f32), 2.0f32);
-    assert_approx_eq!(f32::ceil(1.7f32), 2.0f32);
-    assert_approx_eq!(f32::ceil(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::ceil(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::ceil(-1.0f32), -1.0f32);
-    assert_approx_eq!(f32::ceil(-1.3f32), -1.0f32);
-    assert_approx_eq!(f32::ceil(-1.5f32), -1.0f32);
-    assert_approx_eq!(f32::ceil(-1.7f32), -1.0f32);
+    assert_approx_eq!(f32::math::ceil(1.0f32), 1.0f32);
+    assert_approx_eq!(f32::math::ceil(1.3f32), 2.0f32);
+    assert_approx_eq!(f32::math::ceil(1.5f32), 2.0f32);
+    assert_approx_eq!(f32::math::ceil(1.7f32), 2.0f32);
+    assert_approx_eq!(f32::math::ceil(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::ceil(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::ceil(-1.0f32), -1.0f32);
+    assert_approx_eq!(f32::math::ceil(-1.3f32), -1.0f32);
+    assert_approx_eq!(f32::math::ceil(-1.5f32), -1.0f32);
+    assert_approx_eq!(f32::math::ceil(-1.7f32), -1.0f32);
 }
 
 #[test]
 fn test_round() {
-    assert_approx_eq!(f32::round(2.5f32), 3.0f32);
-    assert_approx_eq!(f32::round(1.0f32), 1.0f32);
-    assert_approx_eq!(f32::round(1.3f32), 1.0f32);
-    assert_approx_eq!(f32::round(1.5f32), 2.0f32);
-    assert_approx_eq!(f32::round(1.7f32), 2.0f32);
-    assert_approx_eq!(f32::round(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::round(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::round(-1.0f32), -1.0f32);
-    assert_approx_eq!(f32::round(-1.3f32), -1.0f32);
-    assert_approx_eq!(f32::round(-1.5f32), -2.0f32);
-    assert_approx_eq!(f32::round(-1.7f32), -2.0f32);
+    assert_approx_eq!(f32::math::round(2.5f32), 3.0f32);
+    assert_approx_eq!(f32::math::round(1.0f32), 1.0f32);
+    assert_approx_eq!(f32::math::round(1.3f32), 1.0f32);
+    assert_approx_eq!(f32::math::round(1.5f32), 2.0f32);
+    assert_approx_eq!(f32::math::round(1.7f32), 2.0f32);
+    assert_approx_eq!(f32::math::round(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::round(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::round(-1.0f32), -1.0f32);
+    assert_approx_eq!(f32::math::round(-1.3f32), -1.0f32);
+    assert_approx_eq!(f32::math::round(-1.5f32), -2.0f32);
+    assert_approx_eq!(f32::math::round(-1.7f32), -2.0f32);
 }
 
 #[test]
 fn test_round_ties_even() {
-    assert_approx_eq!(f32::round_ties_even(2.5f32), 2.0f32);
-    assert_approx_eq!(f32::round_ties_even(1.0f32), 1.0f32);
-    assert_approx_eq!(f32::round_ties_even(1.3f32), 1.0f32);
-    assert_approx_eq!(f32::round_ties_even(1.5f32), 2.0f32);
-    assert_approx_eq!(f32::round_ties_even(1.7f32), 2.0f32);
-    assert_approx_eq!(f32::round_ties_even(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::round_ties_even(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::round_ties_even(-1.0f32), -1.0f32);
-    assert_approx_eq!(f32::round_ties_even(-1.3f32), -1.0f32);
-    assert_approx_eq!(f32::round_ties_even(-1.5f32), -2.0f32);
-    assert_approx_eq!(f32::round_ties_even(-1.7f32), -2.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(2.5f32), 2.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(1.0f32), 1.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(1.3f32), 1.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(1.5f32), 2.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(1.7f32), 2.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(-1.0f32), -1.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(-1.3f32), -1.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(-1.5f32), -2.0f32);
+    assert_approx_eq!(f32::math::round_ties_even(-1.7f32), -2.0f32);
 }
 
 #[test]
 fn test_trunc() {
-    assert_approx_eq!(f32::trunc(1.0f32), 1.0f32);
-    assert_approx_eq!(f32::trunc(1.3f32), 1.0f32);
-    assert_approx_eq!(f32::trunc(1.5f32), 1.0f32);
-    assert_approx_eq!(f32::trunc(1.7f32), 1.0f32);
-    assert_approx_eq!(f32::trunc(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::trunc(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::trunc(-1.0f32), -1.0f32);
-    assert_approx_eq!(f32::trunc(-1.3f32), -1.0f32);
-    assert_approx_eq!(f32::trunc(-1.5f32), -1.0f32);
-    assert_approx_eq!(f32::trunc(-1.7f32), -1.0f32);
+    assert_approx_eq!(f32::math::trunc(1.0f32), 1.0f32);
+    assert_approx_eq!(f32::math::trunc(1.3f32), 1.0f32);
+    assert_approx_eq!(f32::math::trunc(1.5f32), 1.0f32);
+    assert_approx_eq!(f32::math::trunc(1.7f32), 1.0f32);
+    assert_approx_eq!(f32::math::trunc(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::trunc(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::trunc(-1.0f32), -1.0f32);
+    assert_approx_eq!(f32::math::trunc(-1.3f32), -1.0f32);
+    assert_approx_eq!(f32::math::trunc(-1.5f32), -1.0f32);
+    assert_approx_eq!(f32::math::trunc(-1.7f32), -1.0f32);
 }
 
 #[test]
 fn test_fract() {
-    assert_approx_eq!(f32::fract(1.0f32), 0.0f32);
-    assert_approx_eq!(f32::fract(1.3f32), 0.3f32);
-    assert_approx_eq!(f32::fract(1.5f32), 0.5f32);
-    assert_approx_eq!(f32::fract(1.7f32), 0.7f32);
-    assert_approx_eq!(f32::fract(0.0f32), 0.0f32);
-    assert_approx_eq!(f32::fract(-0.0f32), -0.0f32);
-    assert_approx_eq!(f32::fract(-1.0f32), -0.0f32);
-    assert_approx_eq!(f32::fract(-1.3f32), -0.3f32);
-    assert_approx_eq!(f32::fract(-1.5f32), -0.5f32);
-    assert_approx_eq!(f32::fract(-1.7f32), -0.7f32);
+    assert_approx_eq!(f32::math::fract(1.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::fract(1.3f32), 0.3f32);
+    assert_approx_eq!(f32::math::fract(1.5f32), 0.5f32);
+    assert_approx_eq!(f32::math::fract(1.7f32), 0.7f32);
+    assert_approx_eq!(f32::math::fract(0.0f32), 0.0f32);
+    assert_approx_eq!(f32::math::fract(-0.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::fract(-1.0f32), -0.0f32);
+    assert_approx_eq!(f32::math::fract(-1.3f32), -0.3f32);
+    assert_approx_eq!(f32::math::fract(-1.5f32), -0.5f32);
+    assert_approx_eq!(f32::math::fract(-1.7f32), -0.7f32);
 }
 
 #[test]
@@ -417,15 +417,15 @@ fn test_mul_add() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_approx_eq!(f32::mul_add(12.3f32, 4.5, 6.7), 62.05);
-    assert_approx_eq!(f32::mul_add(-12.3f32, -4.5, -6.7), 48.65);
-    assert_approx_eq!(f32::mul_add(0.0f32, 8.9, 1.2), 1.2);
-    assert_approx_eq!(f32::mul_add(3.4f32, -0.0, 5.6), 5.6);
-    assert!(f32::mul_add(nan, 7.8, 9.0).is_nan());
-    assert_eq!(f32::mul_add(inf, 7.8, 9.0), inf);
-    assert_eq!(f32::mul_add(neg_inf, 7.8, 9.0), neg_inf);
-    assert_eq!(f32::mul_add(8.9f32, inf, 3.2), inf);
-    assert_eq!(f32::mul_add(-3.2f32, 2.4, neg_inf), neg_inf);
+    assert_approx_eq!(f32::math::mul_add(12.3f32, 4.5, 6.7), 62.05);
+    assert_approx_eq!(f32::math::mul_add(-12.3f32, -4.5, -6.7), 48.65);
+    assert_approx_eq!(f32::math::mul_add(0.0f32, 8.9, 1.2), 1.2);
+    assert_approx_eq!(f32::math::mul_add(3.4f32, -0.0, 5.6), 5.6);
+    assert!(f32::math::mul_add(nan, 7.8, 9.0).is_nan());
+    assert_eq!(f32::math::mul_add(inf, 7.8, 9.0), inf);
+    assert_eq!(f32::math::mul_add(neg_inf, 7.8, 9.0), neg_inf);
+    assert_eq!(f32::math::mul_add(8.9f32, inf, 3.2), inf);
+    assert_eq!(f32::math::mul_add(-3.2f32, 2.4, neg_inf), neg_inf);
 }
 
 #[test]

--- a/library/coretests/tests/floats/f64.rs
+++ b/library/coretests/tests/floats/f64.rs
@@ -1,5 +1,6 @@
-use std::f64::consts;
-use std::num::FpCategory as Fp;
+use core::f64;
+use core::f64::consts;
+use core::num::FpCategory as Fp;
 
 /// Smallest number
 const TINY_BITS: u64 = 0x1;
@@ -201,88 +202,88 @@ fn test_classify() {
 
 #[test]
 fn test_floor() {
-    assert_approx_eq!(f64::floor(1.0f64), 1.0f64);
-    assert_approx_eq!(f64::floor(1.3f64), 1.0f64);
-    assert_approx_eq!(f64::floor(1.5f64), 1.0f64);
-    assert_approx_eq!(f64::floor(1.7f64), 1.0f64);
-    assert_approx_eq!(f64::floor(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::floor(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::floor(-1.0f64), -1.0f64);
-    assert_approx_eq!(f64::floor(-1.3f64), -2.0f64);
-    assert_approx_eq!(f64::floor(-1.5f64), -2.0f64);
-    assert_approx_eq!(f64::floor(-1.7f64), -2.0f64);
+    assert_approx_eq!(f64::math::floor(1.0f64), 1.0f64);
+    assert_approx_eq!(f64::math::floor(1.3f64), 1.0f64);
+    assert_approx_eq!(f64::math::floor(1.5f64), 1.0f64);
+    assert_approx_eq!(f64::math::floor(1.7f64), 1.0f64);
+    assert_approx_eq!(f64::math::floor(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::floor(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::floor(-1.0f64), -1.0f64);
+    assert_approx_eq!(f64::math::floor(-1.3f64), -2.0f64);
+    assert_approx_eq!(f64::math::floor(-1.5f64), -2.0f64);
+    assert_approx_eq!(f64::math::floor(-1.7f64), -2.0f64);
 }
 
 #[test]
 fn test_ceil() {
-    assert_approx_eq!(f64::ceil(1.0f64), 1.0f64);
-    assert_approx_eq!(f64::ceil(1.3f64), 2.0f64);
-    assert_approx_eq!(f64::ceil(1.5f64), 2.0f64);
-    assert_approx_eq!(f64::ceil(1.7f64), 2.0f64);
-    assert_approx_eq!(f64::ceil(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::ceil(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::ceil(-1.0f64), -1.0f64);
-    assert_approx_eq!(f64::ceil(-1.3f64), -1.0f64);
-    assert_approx_eq!(f64::ceil(-1.5f64), -1.0f64);
-    assert_approx_eq!(f64::ceil(-1.7f64), -1.0f64);
+    assert_approx_eq!(f64::math::ceil(1.0f64), 1.0f64);
+    assert_approx_eq!(f64::math::ceil(1.3f64), 2.0f64);
+    assert_approx_eq!(f64::math::ceil(1.5f64), 2.0f64);
+    assert_approx_eq!(f64::math::ceil(1.7f64), 2.0f64);
+    assert_approx_eq!(f64::math::ceil(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::ceil(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::ceil(-1.0f64), -1.0f64);
+    assert_approx_eq!(f64::math::ceil(-1.3f64), -1.0f64);
+    assert_approx_eq!(f64::math::ceil(-1.5f64), -1.0f64);
+    assert_approx_eq!(f64::math::ceil(-1.7f64), -1.0f64);
 }
 
 #[test]
 fn test_round() {
-    assert_approx_eq!(f64::round(2.5f64), 3.0f64);
-    assert_approx_eq!(f64::round(1.0f64), 1.0f64);
-    assert_approx_eq!(f64::round(1.3f64), 1.0f64);
-    assert_approx_eq!(f64::round(1.5f64), 2.0f64);
-    assert_approx_eq!(f64::round(1.7f64), 2.0f64);
-    assert_approx_eq!(f64::round(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::round(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::round(-1.0f64), -1.0f64);
-    assert_approx_eq!(f64::round(-1.3f64), -1.0f64);
-    assert_approx_eq!(f64::round(-1.5f64), -2.0f64);
-    assert_approx_eq!(f64::round(-1.7f64), -2.0f64);
+    assert_approx_eq!(f64::math::round(2.5f64), 3.0f64);
+    assert_approx_eq!(f64::math::round(1.0f64), 1.0f64);
+    assert_approx_eq!(f64::math::round(1.3f64), 1.0f64);
+    assert_approx_eq!(f64::math::round(1.5f64), 2.0f64);
+    assert_approx_eq!(f64::math::round(1.7f64), 2.0f64);
+    assert_approx_eq!(f64::math::round(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::round(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::round(-1.0f64), -1.0f64);
+    assert_approx_eq!(f64::math::round(-1.3f64), -1.0f64);
+    assert_approx_eq!(f64::math::round(-1.5f64), -2.0f64);
+    assert_approx_eq!(f64::math::round(-1.7f64), -2.0f64);
 }
 
 #[test]
 fn test_round_ties_even() {
-    assert_approx_eq!(f64::round_ties_even(2.5f64), 2.0f64);
-    assert_approx_eq!(f64::round_ties_even(1.0f64), 1.0f64);
-    assert_approx_eq!(f64::round_ties_even(1.3f64), 1.0f64);
-    assert_approx_eq!(f64::round_ties_even(1.5f64), 2.0f64);
-    assert_approx_eq!(f64::round_ties_even(1.7f64), 2.0f64);
-    assert_approx_eq!(f64::round_ties_even(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::round_ties_even(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::round_ties_even(-1.0f64), -1.0f64);
-    assert_approx_eq!(f64::round_ties_even(-1.3f64), -1.0f64);
-    assert_approx_eq!(f64::round_ties_even(-1.5f64), -2.0f64);
-    assert_approx_eq!(f64::round_ties_even(-1.7f64), -2.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(2.5f64), 2.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(1.0f64), 1.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(1.3f64), 1.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(1.5f64), 2.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(1.7f64), 2.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(-1.0f64), -1.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(-1.3f64), -1.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(-1.5f64), -2.0f64);
+    assert_approx_eq!(f64::math::round_ties_even(-1.7f64), -2.0f64);
 }
 
 #[test]
 fn test_trunc() {
-    assert_approx_eq!(f64::trunc(1.0f64), 1.0f64);
-    assert_approx_eq!(f64::trunc(1.3f64), 1.0f64);
-    assert_approx_eq!(f64::trunc(1.5f64), 1.0f64);
-    assert_approx_eq!(f64::trunc(1.7f64), 1.0f64);
-    assert_approx_eq!(f64::trunc(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::trunc(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::trunc(-1.0f64), -1.0f64);
-    assert_approx_eq!(f64::trunc(-1.3f64), -1.0f64);
-    assert_approx_eq!(f64::trunc(-1.5f64), -1.0f64);
-    assert_approx_eq!(f64::trunc(-1.7f64), -1.0f64);
+    assert_approx_eq!(f64::math::trunc(1.0f64), 1.0f64);
+    assert_approx_eq!(f64::math::trunc(1.3f64), 1.0f64);
+    assert_approx_eq!(f64::math::trunc(1.5f64), 1.0f64);
+    assert_approx_eq!(f64::math::trunc(1.7f64), 1.0f64);
+    assert_approx_eq!(f64::math::trunc(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::trunc(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::trunc(-1.0f64), -1.0f64);
+    assert_approx_eq!(f64::math::trunc(-1.3f64), -1.0f64);
+    assert_approx_eq!(f64::math::trunc(-1.5f64), -1.0f64);
+    assert_approx_eq!(f64::math::trunc(-1.7f64), -1.0f64);
 }
 
 #[test]
 fn test_fract() {
-    assert_approx_eq!(f64::fract(1.0f64), 0.0f64);
-    assert_approx_eq!(f64::fract(1.3f64), 0.3f64);
-    assert_approx_eq!(f64::fract(1.5f64), 0.5f64);
-    assert_approx_eq!(f64::fract(1.7f64), 0.7f64);
-    assert_approx_eq!(f64::fract(0.0f64), 0.0f64);
-    assert_approx_eq!(f64::fract(-0.0f64), -0.0f64);
-    assert_approx_eq!(f64::fract(-1.0f64), -0.0f64);
-    assert_approx_eq!(f64::fract(-1.3f64), -0.3f64);
-    assert_approx_eq!(f64::fract(-1.5f64), -0.5f64);
-    assert_approx_eq!(f64::fract(-1.7f64), -0.7f64);
+    assert_approx_eq!(f64::math::fract(1.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::fract(1.3f64), 0.3f64);
+    assert_approx_eq!(f64::math::fract(1.5f64), 0.5f64);
+    assert_approx_eq!(f64::math::fract(1.7f64), 0.7f64);
+    assert_approx_eq!(f64::math::fract(0.0f64), 0.0f64);
+    assert_approx_eq!(f64::math::fract(-0.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::fract(-1.0f64), -0.0f64);
+    assert_approx_eq!(f64::math::fract(-1.3f64), -0.3f64);
+    assert_approx_eq!(f64::math::fract(-1.5f64), -0.5f64);
+    assert_approx_eq!(f64::math::fract(-1.7f64), -0.7f64);
 }
 
 #[test]

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -46,7 +46,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f32 {
-        core::f32::floor(self)
+        core::f32::math::floor(self)
     }
 
     /// Returns the smallest integer greater than or equal to `self`.
@@ -68,7 +68,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f32 {
-        core::f32::ceil(self)
+        core::f32::math::ceil(self)
     }
 
     /// Returns the nearest integer to `self`. If a value is half-way between two
@@ -96,7 +96,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f32 {
-        core::f32::round(self)
+        core::f32::math::round(self)
     }
 
     /// Returns the nearest integer to a number. Rounds half-way cases to the number
@@ -122,7 +122,7 @@ impl f32 {
     #[stable(feature = "round_ties_even", since = "1.77.0")]
     #[inline]
     pub fn round_ties_even(self) -> f32 {
-        core::f32::round_ties_even(self)
+        core::f32::math::round_ties_even(self)
     }
 
     /// Returns the integer part of `self`.
@@ -147,7 +147,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f32 {
-        core::f32::trunc(self)
+        core::f32::math::trunc(self)
     }
 
     /// Returns the fractional part of `self`.
@@ -170,7 +170,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f32 {
-        core::f32::fract(self)
+        core::f32::math::fract(self)
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
@@ -212,7 +212,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f32, b: f32) -> f32 {
-        core::f32::mul_add(self, a, b)
+        core::f32::math::mul_add(self, a, b)
     }
 
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
@@ -242,7 +242,7 @@ impl f32 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn div_euclid(self, rhs: f32) -> f32 {
-        core::f32::div_euclid(self, rhs)
+        core::f32::math::div_euclid(self, rhs)
     }
 
     /// Calculates the least nonnegative remainder of `self (mod rhs)`.
@@ -279,7 +279,7 @@ impl f32 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f32) -> f32 {
-        core::f32::rem_euclid(self, rhs)
+        core::f32::math::rem_euclid(self, rhs)
     }
 
     /// Raises a number to an integer power.
@@ -307,7 +307,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powi(self, n: i32) -> f32 {
-        core::f32::powi(self, n)
+        core::f32::math::powi(self, n)
     }
 
     /// Raises a number to a floating point power.
@@ -362,7 +362,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f32 {
-        core::f32::sqrt(self)
+        core::f32::math::sqrt(self)
     }
 
     /// Returns `e^(self)`, (the exponential function).
@@ -595,7 +595,7 @@ impl f32 {
     )]
     pub fn abs_sub(self, other: f32) -> f32 {
         #[allow(deprecated)]
-        core::f32::abs_sub(self, other)
+        core::f32::math::abs_sub(self, other)
     }
 
     /// Returns the cube root of a number.
@@ -622,7 +622,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f32 {
-        core::f32::cbrt(self)
+        core::f32::math::cbrt(self)
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -46,7 +46,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f64 {
-        core::f64::floor(self)
+        core::f64::math::floor(self)
     }
 
     /// Returns the smallest integer greater than or equal to `self`.
@@ -68,7 +68,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f64 {
-        core::f64::ceil(self)
+        core::f64::math::ceil(self)
     }
 
     /// Returns the nearest integer to `self`. If a value is half-way between two
@@ -96,7 +96,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f64 {
-        core::f64::round(self)
+        core::f64::math::round(self)
     }
 
     /// Returns the nearest integer to a number. Rounds half-way cases to the number
@@ -122,7 +122,7 @@ impl f64 {
     #[stable(feature = "round_ties_even", since = "1.77.0")]
     #[inline]
     pub fn round_ties_even(self) -> f64 {
-        core::f64::round_ties_even(self)
+        core::f64::math::round_ties_even(self)
     }
 
     /// Returns the integer part of `self`.
@@ -147,7 +147,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f64 {
-        core::f64::trunc(self)
+        core::f64::math::trunc(self)
     }
 
     /// Returns the fractional part of `self`.
@@ -170,7 +170,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f64 {
-        core::f64::fract(self)
+        core::f64::math::fract(self)
     }
 
     /// Fused multiply-add. Computes `(self * a) + b` with only one rounding
@@ -212,7 +212,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f64, b: f64) -> f64 {
-        core::f64::mul_add(self, a, b)
+        core::f64::math::mul_add(self, a, b)
     }
 
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
@@ -242,7 +242,7 @@ impl f64 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn div_euclid(self, rhs: f64) -> f64 {
-        core::f64::div_euclid(self, rhs)
+        core::f64::math::div_euclid(self, rhs)
     }
 
     /// Calculates the least nonnegative remainder of `self (mod rhs)`.
@@ -279,7 +279,7 @@ impl f64 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f64) -> f64 {
-        core::f64::rem_euclid(self, rhs)
+        core::f64::math::rem_euclid(self, rhs)
     }
 
     /// Raises a number to an integer power.
@@ -307,7 +307,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powi(self, n: i32) -> f64 {
-        core::f64::powi(self, n)
+        core::f64::math::powi(self, n)
     }
 
     /// Raises a number to a floating point power.
@@ -362,7 +362,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f64 {
-        core::f64::sqrt(self)
+        core::f64::math::sqrt(self)
     }
 
     /// Returns `e^(self)`, (the exponential function).
@@ -595,7 +595,7 @@ impl f64 {
     )]
     pub fn abs_sub(self, other: f64) -> f64 {
         #[allow(deprecated)]
-        core::f64::abs_sub(self, other)
+        core::f64::math::abs_sub(self, other)
     }
 
     /// Returns the cube root of a number.
@@ -622,7 +622,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f64 {
-        core::f64::cbrt(self)
+        core::f64::math::cbrt(self)
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the


### PR DESCRIPTION
When these functions were added in https://github.com/rust-lang/rust/pull/138087 It made a relatively common pattern for emulating these functions using an extension trait (which internally uses `libm`) much more fragile. If `core::f32` happened to be imported by the user (to access a constant, say), then that import in the module namespace would take precedence over the `f32` in the type namespace for resolving these functions, running headfirst into the stability attribute.

We ran into this in [Color](https://github.com/linebender/color) and chose to release the remedial 0.3.1 and 0.2.4, to allow downstream crates to build on `docs.rs`.

As these methods are perma-unstable, moving them into a new module should not have any long-term concerns, and ensures that this "breakage" doesn't adversely impact anyone else.

I believe that I've made the module unstable correctly. I presume that this does not require a test to make sure stable code can't depend on the module existing?

I've left the stability attribute on each function - happy to tweak this if a different pattern is more correct.

Tracking issue for `core_float_math`: https://github.com/rust-lang/rust/issues/137578.
This PR is as requested in https://github.com/rust-lang/rust/pull/138087.

r? @tgross35

Recommended reviewing with whitespace hidden.

(This is my first PR to `std/core`/this repository, as far as I can remember)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->