### PR TITLE
Async drop fix for 'broken mir, place has deref as later projection'

### DIFF
--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -318,15 +318,20 @@ where
                 bug!();
             };
             let obj_ptr_ty = Ty::new_mut_ptr(tcx, drop_ty);
-            let obj_ptr_place = Place::from(self.new_temp(obj_ptr_ty));
             let unwrap_ty = adt_def.non_enum_variant().fields[FieldIdx::ZERO].ty(tcx, adt_args);
-            let addr = Rvalue::RawPtr(
-                RawPtrKind::Mut,
-                pin_obj_place.project_deeper(
-                    &[ProjectionElem::Field(FieldIdx::ZERO, unwrap_ty), ProjectionElem::Deref],
-                    tcx,
-                ),
-            );
+            let obj_ref_place = Place::from(self.new_temp(unwrap_ty));
+            call_statements.push(self.assign(
+                obj_ref_place,
+                Rvalue::Use(Operand::Copy(tcx.mk_place_field(
+                    pin_obj_place,
+                    FieldIdx::ZERO,
+                    unwrap_ty,
+                ))),
+            ));
+
+            let obj_ptr_place = Place::from(self.new_temp(obj_ptr_ty));
+
+            let addr = Rvalue::RawPtr(RawPtrKind::Mut, tcx.mk_place_deref(obj_ref_place));
             call_statements.push(self.assign(obj_ptr_place, addr));
             obj_ptr_place
         };

--- a/tests/ui/async-await/async-drop/deref-later-projection.rs
+++ b/tests/ui/async-await/async-drop/deref-later-projection.rs
@@ -1,7 +1,11 @@
-//@ known-bug: #140975
-//@ compile-flags: --crate-type lib -Zvalidate-mir
-//@ edition: 2021
+// Ex-ICE: #140975
+//@ compile-flags: -Zvalidate-mir
+//@ build-pass
+//@ edition:2021
+#![crate_type = "lib"]
 #![feature(async_drop)]
+#![allow(incomplete_features)]
+
 use std::{future::AsyncDrop, pin::Pin};
 
 struct HasAsyncDrop ;


### PR DESCRIPTION
fixes #140975

<!-- homu-ignore:start -->
<!--
https://github.com/rust-lang/rust/issues/126482

    r? oli-obk
-->
<!-- homu-ignore:end -->

Problem in codegen fixed with an additional temporary local.