### PR TITLE
rustdoc: add private items toggle

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -479,9 +479,9 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
                         Some(ty::Visibility::Restricted(_)) => {
                             if myitem.is_doc_hidden() {
                                 // Don't separate with a space when there are two of them
-                                "<span title=\"Restricted Visibility\">&nbsp;🔒</span><span title=\"Hidden item\">👻</span> "
+                                "<span class=\"priv-item\" title=\"Restricted Visibility\">&nbsp;🔒</span><span title=\"Hidden item\">👻</span> "
                             } else {
-                                "<span title=\"Restricted Visibility\">&nbsp;🔒</span> "
+                                "<span class=\"priv-item\" title=\"Restricted Visibility\">&nbsp;🔒</span> "
                             }
                         }
                         _ if myitem.is_doc_hidden() => {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2891,6 +2891,11 @@ in src-script.js and main.js
 	margin-bottom: 0;
 }
 
+.hide-priv dt:has(.priv-item),
+.hide-priv dt:has(.priv-item) + dd {
+	display: none;
+}
+
 /* End: styles for --scrape-examples feature */
 
 /* Begin: styles for themes

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -90,6 +90,8 @@
                     removeClass(document.documentElement, "word-wrap-source-code");
                 }
                 break;
+            case "show-private-items":
+                showPrivateItems(value === true);
         }
     }
 
@@ -286,6 +288,11 @@
                 "js_name": "word-wrap-source-code",
                 "default": false,
             },
+            {
+                "name": "Show private items",
+                "js_name": "show-private-items",
+                "default": false,
+            },
         ];
 
         // Then we build the DOM.
@@ -340,6 +347,19 @@
                !elemContainsTarget(settingsBtn, event.relatedTarget));
         if (helpUnfocused && settingsUnfocused) {
             window.hidePopoverMenus();
+        }
+    }
+
+    /**
+     * @param {boolean} value
+     */
+    function showPrivateItems(value) {
+        /*document.querySelectorAll("dt:has([title='Restricted Visibility'])").forEach(x => x.hidden = !value);
+         */
+        if (value) {
+            removeClass(document.documentElement, "hide-priv");
+        } else {
+            addClass(document.documentElement, "hide-priv");
         }
     }
 

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -333,6 +333,9 @@ if (getSettingValue("sans-serif-fonts") === "true") {
 if (getSettingValue("word-wrap-source-code") === "true") {
     addClass(document.documentElement, "word-wrap-source-code");
 }
+if (getSettingValue("show-private-items") !== "true") {
+    addClass(document.documentElement, "hide-priv");
+}
 function updateSidebarWidth() {
     const desktopSidebarWidth = getSettingValue("desktop-sidebar-width");
     if (desktopSidebarWidth && desktopSidebarWidth !== "null") {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @ghost 

@ojeda here's a MVP implementation of the feature you were talking about.

currently the search isn't affected at all, and additionally, there's no way to toggle the feature at the command line.

(DO NOT MERGE: the feature would be insta-stable)