### PR TITLE
Fix pagetoc inactive color in rustc book

### DIFF
--- a/src/doc/rustc/theme/pagetoc.css
+++ b/src/doc/rustc/theme/pagetoc.css
@@ -49,7 +49,7 @@
     }
     #pagetoc a {
         border-left: 1px solid var(--sidebar-bg);
-        color: var(--sidebar-fg) !important;
+        color: var(--fg);
         display: block;
         padding-bottom: 5px;
         padding-top: 5px;


### PR DESCRIPTION
This PR fixes the color of inactive entry in rustc pagetoc, particularly with the "Rust" theme.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/c6c8fe9a-0016-46cb-a638-71a62787b629) | ![image](https://github.com/user-attachments/assets/7146be5b-6ac3-4c9b-8e5a-eedd6ce61314) |

Live preview at: http://urgau.rf.gd/book

Related to https://github.com/rust-lang/rust/pull/140113#issuecomment-2888615781
r? @ehuss