### PR TITLE
typeck: catch `continue`s pointing to blocks

### DIFF
--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -66,8 +66,7 @@ pub fn build_mir<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> Body<'tcx> {
                 }
             };
 
-            // this must run before MIR dump, because
-            // "not all control paths return a value" is reported here.
+            // Checking liveness after building the THIR ensures there were no typeck errors.
             //
             // maybe move the check to a MIR pass?
             tcx.ensure_ok().check_liveness(def);

--- a/tests/crashes/113379.rs
+++ b/tests/crashes/113379.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #113379
-
-async fn f999() -> Vec<usize> {
-    'b: {
-        continue 'b;
-    }
-}

--- a/tests/crashes/121623.rs
+++ b/tests/crashes/121623.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #121623
-fn main() {
-    match () {
-        _ => 'b: {
-            continue 'b;
-        }
-    }
-}

--- a/tests/ui/label/continue-pointing-to-block-ice-113379.rs
+++ b/tests/ui/label/continue-pointing-to-block-ice-113379.rs
@@ -1,0 +1,12 @@
+//! Regression test for ICE #113379. Liveness linting assumes that `continue`s all point to loops.
+//! This tests that if a `continue` points to a block, we don't run liveness lints.
+
+async fn f999() -> Vec<usize> {
+    //~^ ERROR `async fn` is not permitted in Rust 2015
+    'b: {
+        //~^ ERROR mismatched types
+        continue 'b;
+        //~^ ERROR `continue` pointing to a labeled block
+    }
+}
+//~^ ERROR `main` function not found

--- a/tests/ui/label/continue-pointing-to-block-ice-113379.stderr
+++ b/tests/ui/label/continue-pointing-to-block-ice-113379.stderr
@@ -1,0 +1,43 @@
+error[E0670]: `async fn` is not permitted in Rust 2015
+  --> $DIR/continue-pointing-to-block-ice-113379.rs:4:1
+   |
+LL | async fn f999() -> Vec<usize> {
+   | ^^^^^ to use `async fn`, switch to Rust 2018 or later
+   |
+   = help: pass `--edition 2024` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0601]: `main` function not found in crate `continue_pointing_to_block_ice_113379`
+  --> $DIR/continue-pointing-to-block-ice-113379.rs:11:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/continue-pointing-to-block-ice-113379.rs`
+
+error[E0696]: `continue` pointing to a labeled block
+  --> $DIR/continue-pointing-to-block-ice-113379.rs:8:9
+   |
+LL | /     'b: {
+LL | |
+LL | |         continue 'b;
+   | |         ^^^^^^^^^^^ labeled blocks cannot be `continue`'d
+LL | |
+LL | |     }
+   | |_____- labeled block the `continue` points to
+
+error[E0308]: mismatched types
+  --> $DIR/continue-pointing-to-block-ice-113379.rs:6:5
+   |
+LL | /     'b: {
+LL | |
+LL | |         continue 'b;
+LL | |
+LL | |     }
+   | |_____^ expected `Vec<usize>`, found `()`
+   |
+   = note: expected struct `Vec<usize>`
+           found unit type `()`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0601, E0670, E0696.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/label/continue-pointing-to-block-ice-121623.rs
+++ b/tests/ui/label/continue-pointing-to-block-ice-121623.rs
@@ -1,0 +1,11 @@
+//! Regression test for ICE #121623. Liveness linting assumes that `continue`s all point to loops.
+//! This tests that if a `continue` points to a block, we don't run liveness lints.
+
+fn main() {
+    match () {
+        _ => 'b: {
+            continue 'b;
+            //~^ ERROR `continue` pointing to a labeled block
+        }
+    }
+}

--- a/tests/ui/label/continue-pointing-to-block-ice-121623.stderr
+++ b/tests/ui/label/continue-pointing-to-block-ice-121623.stderr
@@ -1,0 +1,14 @@
+error[E0696]: `continue` pointing to a labeled block
+  --> $DIR/continue-pointing-to-block-ice-121623.rs:7:13
+   |
+LL |           _ => 'b: {
+   |  ______________-
+LL | |             continue 'b;
+   | |             ^^^^^^^^^^^ labeled blocks cannot be `continue`'d
+LL | |
+LL | |         }
+   | |_________- labeled block the `continue` points to
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0696`.


### PR DESCRIPTION
This taints the typeck results with errors if a `continue` is found not pointing to a loop.

A few things were going wrong here. First, since this wasn't caught in typeck, we'd end up building the THIR and then running liveness lints on ill-formed HIR. Since liveness assumes all `continue`s point to loops, it wasn't setting a live node for the `continue`'s destination. There was a fallback for if it couldn't retrieve that live node, but it was faulty; it would create a new live node to represent an erroneous state after the analysis's RWU table had already been built. This would ICE if the new live node was used in operations, such as merging results from the arms of a match. I've removed this error-recovery since it was buggy, and we should really catch bad labels before liveness.

I've also replaced an outdated comment about when liveness lints are run. At this point, I think the call to `check_liveness` could be moved elsewhere, but if it can be run when the typeck results are tainted by errors, it'll need some slight refactoring so it can bail out in that case. In lieu of that, I've added an assert.

Fixes #113379
Fixes #121623
