### PR TITLE
Avoid creating an empty identifer in `Symbol::to_ident_string`.

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2592,7 +2592,8 @@ impl Symbol {
     /// (`token_to_string`, `Ident::to_string`), except that symbols don't keep the rawness flag
     /// or edition, so we have to guess the rawness using the global edition.
     pub fn to_ident_string(self) -> String {
-        Ident::with_dummy_span(self).to_string()
+        // Avoid creating an empty identifier, because that asserts in debug builds.
+        if self == kw::Empty { String::new() } else { Ident::with_dummy_span(self).to_string() }
     }
 }
 

--- a/tests/crashes/140884.rs
+++ b/tests/crashes/140884.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #140884
-//@ needs-rustc-debug-assertions
-
-fn a() {
-    extern "" {}
-}

--- a/tests/ui/extern/extern-empty-string-issue-140884.rs
+++ b/tests/ui/extern/extern-empty-string-issue-140884.rs
@@ -1,0 +1,3 @@
+extern "" {} //~ ERROR invalid ABI: found ``
+
+fn main() {}

--- a/tests/ui/extern/extern-empty-string-issue-140884.stderr
+++ b/tests/ui/extern/extern-empty-string-issue-140884.stderr
@@ -1,0 +1,15 @@
+error[E0703]: invalid ABI: found ``
+  --> $DIR/extern-empty-string-issue-140884.rs:1:8
+   |
+LL | extern "" {}
+   |        ^^ invalid ABI
+   |
+   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `C`
+   |
+LL | extern "C" {}
+   |         +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0703`.


### PR DESCRIPTION
Because that causes an assertion failure in debug builds.

Fixes #140884.

r? @oli-obk