### PR TITLE
Add bors environment to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
     needs: [ calculate_matrix ]
     runs-on: "${{ matrix.os }}"
     timeout-minutes: 360
+    # The bors environment contains secrets required for elevated workflows (try and auto builds),
+    # which need to access e.g. S3 and upload artifacts. We want to provide access to that
+    # environment only on the try/auto branches, which are only accessible to bors.
+    # This also ensures that PR CI (which doesn't get write access to S3) works, as it cannot
+    # access the environment.
+    #
+    # We only enable the environment for the rust-lang/rust repository, so that rust-lang-ci/rust
+    # CI works until we migrate off it (since that repository doesn't contain the environment).
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/auto')) && 'bors') || '' }}
     env:
       CI_JOB_NAME: ${{ matrix.name }}
       CI_JOB_DOC_URL: ${{ matrix.doc_url }}


### PR DESCRIPTION
This will be used to access secrets once we move off rust-lang-ci. The PR configures the environment:
- Only for `rust-lang/rust`, so that it doesn't affect `rust-lang-ci/rust` before we switch (we can remove this condition later, but the environment likely won't work for forks anyway, so we might as well just keep it to make fork CI work)
- Only for the `try`/`auto` branches, so that PR CI still works.

Context: https://github.com/rust-lang/infra-team/issues/188

r? @marcoieni