### PR TITLE
When AsyncDrop impl is empty, sync drop generated in elaborator

### DIFF
--- a/tests/ui/async-await/async-drop/elaborate-index-out-of-bounds.rs
+++ b/tests/ui/async-await/async-drop/elaborate-index-out-of-bounds.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #140974
-//@edition:2021
+//@ edition: 2024
+// Ex-ICE: #140974
+#![crate_type = "lib"]
+#![allow(incomplete_features)]
 #![feature(async_drop)]
 use core::future::AsyncDrop;
 
@@ -10,5 +12,6 @@ impl Drop for HasIncompleteAsyncDrop {
     fn drop(&mut self) {}
 }
 impl AsyncDrop for HasIncompleteAsyncDrop {
+    //~^ ERROR: not all trait items implemented, missing: `drop` [E0046]
     // not implemented yet..
 }

--- a/tests/ui/async-await/async-drop/elaborate-index-out-of-bounds.stderr
+++ b/tests/ui/async-await/async-drop/elaborate-index-out-of-bounds.stderr
@@ -1,0 +1,11 @@
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/elaborate-index-out-of-bounds.rs:14:1
+   |
+LL | impl AsyncDrop for HasIncompleteAsyncDrop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `async fn drop(self: Pin<&mut Self>) { todo!() }`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0046`.


### PR DESCRIPTION
Fixes #140974.

<!-- homu-ignore:start -->
<!--
https://github.com/rust-lang/rust/issues/126482

    r? oli-obk
-->
<!-- homu-ignore:end -->
