### PR TITLE
Do not eagerly fold consts in `normalize_param_env_or_error` if new solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -340,7 +340,7 @@ pub fn normalize_param_env_or_error<'tcx>(
     let mut predicates: Vec<_> = util::elaborate(
         tcx,
         unnormalized_env.caller_bounds().into_iter().map(|predicate| {
-            if tcx.features().generic_const_exprs() {
+            if tcx.features().generic_const_exprs() || tcx.next_trait_solver_globally() {
                 return predicate;
             }
 
@@ -405,8 +405,6 @@ pub fn normalize_param_env_or_error<'tcx>(
             // compatibility. Eventually when lazy norm is implemented this can just be removed.
             // We do not normalize types here as there is no backwards compatibility requirement
             // for us to do so.
-            //
-            // FIXME(-Znext-solver): remove this hack since we have deferred projection equality
             predicate.fold_with(&mut ConstNormalizer(tcx))
         }),
     )

--- a/tests/ui/traits/next-solver/no-param-env-const-fold.rs
+++ b/tests/ui/traits/next-solver/no-param-env-const-fold.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/213>.
+
+use std::ops::Deref;
+
+trait Trait: Deref<Target = [u8; { 1 + 1 }]> {}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/213

Given:

```
trait Trait: Deref<Target = [u8; { 1 + 1 }]> {}
```

when elaborating param env for `Trait`, we have `Self: Trait`, `Self: Deref<Target = [u8; {anon const}]>`. 

Before this PR, we would fold the anon consts away *before* elaborating. However, we end up getting another *un-folded* copy of the anon const from elaborating `Self: Trait`. This leads to normalization ambiguity.

r? lcnr