### PR TITLE
Use `DeepRejectCtxt` in `assemble_inherent_candidates_from_param`

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(array_windows)]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]

--- a/tests/ui/traits/next-solver/method/param-method-from-unnormalized-param-env-2.rs
+++ b/tests/ui/traits/next-solver/method/param-method-from-unnormalized-param-env-2.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/214>.
+// See comment below.
+
+trait A {
+    fn hello(&self) {}
+}
+
+trait B {
+    fn hello(&self) {}
+}
+
+impl<T> A for T {}
+impl<T> B for T {}
+
+fn test<F, R>(q: F::Item)
+where
+    F: Iterator<Item = R>,
+    // We want to prefer `A` for `R.hello()`
+    F::Item: A,
+{
+    q.hello();
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/method/param-method-from-unnormalized-param-env.rs
+++ b/tests/ui/traits/next-solver/method/param-method-from-unnormalized-param-env.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/214>.
+
+fn execute<K, F, R>(q: F::Item) -> R
+where
+    F: Iterator<Item = R>,
+    // Both of the below bounds should be considered for `.into()`, and then be combined
+    // into a single `R: Into<?0>` bound which can be inferred to `?0 = R`.
+    F::Item: Into<K>,
+    R: Into<String>,
+{
+    q.into()
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/214

We were not properly considering unnormalized param-env candidates in `assemble_inherent_candidates_from_param`.

r? lcnr