### PR TITLE
ci: run distcheck on arm

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-distcheck/Dockerfile
@@ -24,6 +24,6 @@ RUN sh /scripts/sccache.sh
 # We are disabling CI LLVM since distcheck is an offline build.
 ENV NO_DOWNLOAD_CI_LLVM 1
 
-ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --set rust.omit-git-hash=false
+ENV RUST_CONFIGURE_ARGS --build=aarch64-unknown-linux-gnu --set rust.omit-git-hash=false
 ENV SCRIPT python3 ../x.py --stage 2 test distcheck
 ENV DIST_SRC 1

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -323,8 +323,8 @@ auto:
   - name: x86_64-gnu-debug
     <<: *job-linux-4c
 
-  - name: x86_64-gnu-distcheck
-    <<: *job-linux-8c
+  - name: aarch64-gnu-distcheck
+    <<: *job-aarch64-linux
 
   # The x86_64-gnu-llvm-20 job is split into multiple jobs to run tests in parallel.
   # x86_64-gnu-llvm-20-1 skips tests that run in x86_64-gnu-llvm-20-{2,3}.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Change the distcheck job to run on arm instead of x86 to remove the large runner.
`aarch64-unknown-linux-gnu` is a tier 1 target, so it should be equivalent to `x86_64-unknown-linux-gnu`.

This change was discussed in [zulip](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Speed.20up.20distcheck/with/519631765)[#t-infra/bootstrap > Speed up distcheck](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Speed.20up.20distcheck/with/519631765).
r? @ghost
<!-- homu-ignore:end -->
try-job: aarch64-gnu-distcheck