### PR TITLE
incorrectly prefer builtin `dyn` impls :3

### DIFF
--- a/tests/ui/traits/next-solver/assembly/better_any-backcompat.rs
+++ b/tests/ui/traits/next-solver/assembly/better_any-backcompat.rs
@@ -1,0 +1,33 @@
+//@ check-pass
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+// A regression test for trait-system-refactor-initiative#183. While
+// this concrete instance is likely not practically unsound, the general
+// pattern is, see #57893.
+
+use std::any::TypeId;
+
+unsafe trait TidAble<'a>: Tid<'a> {}
+trait TidExt<'a>: Tid<'a> {
+    fn downcast_box(self: Box<Self>) {
+        loop {}
+    }
+}
+
+impl<'a, X: ?Sized + Tid<'a>> TidExt<'a> for X {}
+
+unsafe trait Tid<'a>: 'a {}
+
+unsafe impl<'a, T: ?Sized + TidAble<'a>> Tid<'a> for T {}
+
+impl<'a> dyn Tid<'a> + 'a {
+    fn downcast_any_box(self: Box<Self>) {
+        self.downcast_box();
+    }
+}
+
+unsafe impl<'a> TidAble<'a> for dyn Tid<'a> + 'a {}
+
+fn main() {}


### PR DESCRIPTION
This makes #57893 slightly more exploitable with the new solver. It's still strictly better than the old solver and the underlying unsoundness persists in the new one even without this preference.

Properly fixing #57893 is something we've been looking at more deeply recently and discussed at the [Types Meetup during the All-Hands](https://hackmd.io/rz-4ghMzTb2wXOkdLKHaHw#Dyn-traits). Whatever approach we'll end up deciding on will likely require a fairly long transition period and some significant further design work. This should not block `-Znext-solver`.

fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/183

r? @compiler-errors cc @rust-lang/types