### PR TITLE
builtin dyn impl no guide inference

### DIFF
--- a/tests/ui/traits/object/no-incomplete-inference.current.stderr
+++ b/tests/ui/traits/object/no-incomplete-inference.current.stderr
@@ -1,0 +1,16 @@
+error[E0283]: type annotations needed
+  --> $DIR/no-incomplete-inference.rs:16:5
+   |
+LL |     impls_equals::<dyn Equals<u32>, _>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `impls_equals`
+   |
+   = note: cannot satisfy `dyn Equals<u32>: Equals<_>`
+note: required by a bound in `impls_equals`
+  --> $DIR/no-incomplete-inference.rs:13:20
+   |
+LL | fn impls_equals<T: Equals<U> + ?Sized, U: ?Sized>() {}
+   |                    ^^^^^^^^^ required by this bound in `impls_equals`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/object/no-incomplete-inference.next.stderr
+++ b/tests/ui/traits/object/no-incomplete-inference.next.stderr
@@ -1,0 +1,16 @@
+error[E0283]: type annotations needed
+  --> $DIR/no-incomplete-inference.rs:16:5
+   |
+LL |     impls_equals::<dyn Equals<u32>, _>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `impls_equals`
+   |
+   = note: cannot satisfy `dyn Equals<u32>: Equals<_>`
+note: required by a bound in `impls_equals`
+  --> $DIR/no-incomplete-inference.rs:13:20
+   |
+LL | fn impls_equals<T: Equals<U> + ?Sized, U: ?Sized>() {}
+   |                    ^^^^^^^^^ required by this bound in `impls_equals`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/object/no-incomplete-inference.rs
+++ b/tests/ui/traits/object/no-incomplete-inference.rs
@@ -1,0 +1,18 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+
+// Make sure that having an applicable user-written
+// and builtin impl is ambiguous.
+
+trait Equals<T: ?Sized> {}
+
+impl<T: ?Sized> Equals<T> for T {}
+
+fn impls_equals<T: Equals<U> + ?Sized, U: ?Sized>() {}
+
+fn main() {
+    impls_equals::<dyn Equals<u32>, _>();
+    //~^ ERROR type annotations needed
+}


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/141347

we can already slightly restrict this behavior in the old solver, so why not do so. Needs crater and an FCP.

r? @compiler-errors 