### PR TITLE
Normalize aliases to correct kind of error term

### DIFF
--- a/tests/crashes/140642.rs
+++ b/tests/crashes/140642.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #140642
-#![feature(min_generic_const_args)]
-
-pub trait Tr<A> {
-    const SIZE: usize;
-}
-
-fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}

--- a/tests/ui/const-generics/mgca/projection-error.rs
+++ b/tests/ui/const-generics/mgca/projection-error.rs
@@ -1,0 +1,17 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+// Regression test for #140642. Test that normalizing const aliases
+// containing erroneous types normalizes to a const error instead of
+// a type error.
+
+
+pub trait Tr<A> {
+    const SIZE: usize;
+}
+
+fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+//~^ ERROR: cannot find type `T` in this scope
+//~| ERROR: cannot find type `T` in this scope
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/projection-error.stderr
+++ b/tests/ui/const-generics/mgca/projection-error.stderr
@@ -1,0 +1,39 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/projection-error.rs:13:17
+   |
+LL | pub trait Tr<A> {
+   | --------------- similarly named trait `Tr` defined here
+...
+LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                 ^
+   |
+help: a trait with a similar name exists
+   |
+LL | fn mk_array(_x: Tr) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                  +
+help: you might be missing a type parameter
+   |
+LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |            +++
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/projection-error.rs:13:29
+   |
+LL | pub trait Tr<A> {
+   | --------------- similarly named trait `Tr` defined here
+...
+LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                             ^
+   |
+help: a trait with a similar name exists
+   |
+LL | fn mk_array(_x: T) -> [(); <Tr as Tr<bool>>::SIZE] {}
+   |                              +
+help: you might be missing a type parameter
+   |
+LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |            +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #140642

When normalizing an alias to an error in the old solver, normalize to the same term kind as the alias being normalized instead of always to a type error.

r? lcnr