### PR TITLE
rustdoc-json: Remove false docs and add test for inline attribute

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -180,19 +180,13 @@ pub struct Item {
     ///
     /// Does not include `#[deprecated]` attributes: see the [`Self::deprecation`] field instead.
     ///
-    /// Some attributes appear in pretty-printed Rust form, regardless of their formatting
+    /// Attributes appear in pretty-printed Rust form, regardless of their formatting
     /// in the original source code. For example:
     /// - `#[non_exhaustive]` and `#[must_use]` are represented as themselves.
     /// - `#[no_mangle]` and `#[export_name]` are also represented as themselves.
     /// - `#[repr(C)]` and other reprs also appear as themselves,
     ///   though potentially with a different order: e.g. `repr(i8, C)` may become `repr(C, i8)`.
     ///   Multiple repr attributes on the same item may be combined into an equivalent single attr.
-    ///
-    /// Other attributes may appear debug-printed. For example:
-    /// - `#[inline]` becomes something similar to `#[attr="Inline(Hint)"]`.
-    ///
-    /// As an internal implementation detail subject to change, this debug-printing format
-    /// is currently equivalent to the HIR pretty-printing of parsed attributes.
     pub attrs: Vec<String>,
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,

--- a/tests/rustdoc-json/attrs/inline.rs
+++ b/tests/rustdoc-json/attrs/inline.rs
@@ -1,0 +1,11 @@
+//@ is "$.index[?(@.name=='just_inline')].attrs" '["#[inline]"]'
+#[inline]
+pub fn just_inline() {}
+
+//@ is "$.index[?(@.name=='inline_always')].attrs" '["#[inline(always)]"]'
+#[inline(always)]
+pub fn inline_always() {}
+
+//@ is "$.index[?(@.name=='inline_never')].attrs" '["#[inline(never)]"]'
+#[inline(never)]
+pub fn inline_never() {}


### PR DESCRIPTION
The docs about how `#[inline]` was represented isn't true. Updates the comment, and adds a test.

CC #137645

r? @GuillaumeGomez 
