### PR TITLE
Use the fn_span when emitting function calls for better debug info.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1181,6 +1181,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             (_, Some(llfn)) => llfn,
             _ => span_bug!(span, "no instance or llfn for call"),
         };
+        self.set_debug_loc(bx, mir::SourceInfo { span: fn_span, ..source_info });
         helper.do_call(
             self,
             bx,

--- a/tests/debuginfo/multiline-calls.rs
+++ b/tests/debuginfo/multiline-calls.rs
@@ -1,0 +1,35 @@
+//@ compile-flags:-g
+//@ min-gdb-version: 16.0
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command: run
+// gdb-check:[...]#break[...]
+// gdb-command: up
+// gdb-check:[...]zzz[...]
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-check:[...]#break[...]
+// lldb-command: up
+// lldb-check:[...]zzz[...]
+
+struct Foo;
+
+impl Foo {
+    fn bar(self) -> Foo {
+        println!("bar");
+        self
+    }
+    fn baz(self) -> Foo {
+        println!("baz"); // #break
+        self
+    }
+}
+
+fn main() {
+    let f = Foo;
+    f.bar()              // aaa
+        .baz();          // zzz
+}

--- a/tests/ui/panics/location-detail-unwrap-multiline.rs
+++ b/tests/ui/panics/location-detail-unwrap-multiline.rs
@@ -1,8 +1,9 @@
 //@ run-fail
 //@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only -Copt-level=0
 //@ exec-env:RUST_BACKTRACE=1
-//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:10(:10)?\n
+//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:11(:10)?\n
 //@ needs-unwind
+//@ ignore-android FIXME #17520
 
 fn main() {
     let opt: Option<u32> = None;

--- a/tests/ui/panics/location-detail-unwrap-multiline.rs
+++ b/tests/ui/panics/location-detail-unwrap-multiline.rs
@@ -1,0 +1,11 @@
+//@ run-fail
+//@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only -Copt-level=0
+//@ exec-env:RUST_BACKTRACE=1
+//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:10(:10)?\n
+//@ needs-unwind
+
+fn main() {
+    let opt: Option<u32> = None;
+    opt
+        .unwrap();
+}


### PR DESCRIPTION
This especially improves the developer experience for long chains of function calls that span multiple lines, which is common with builder patterns, chains of iterator/future combinators, etc.

try-job: armhf-gnu
try-job: test-various
try-job: x86_64-msvc-1
try-job: arm-android

r? @jieyouxu 
