### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
     needs: [ calculate_matrix ]
     runs-on: "${{ matrix.os }}"
     timeout-minutes: 360
+    # The bors environment contains secrets required for elevated workflows (try and auto builds),
+    # which need to access e.g. S3 and upload artifacts. We want to provide access to that
+    # environment only on the try/auto branches, which are only accessible to bors.
+    # This also ensures that PR CI (which doesn't get write access to S3) works, as it cannot
+    # access the environment.
+    #
+    # We only enable the environment for the rust-lang/rust repository, so that rust-lang-ci/rust
+    # CI works until we migrate off it (since that repository doesn't contain the environment).
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try' || github.ref == 'refs/heads/auto')) && 'bors') || '' }}
     env:
       CI_JOB_NAME: ${{ matrix.name }}
       CI_JOB_DOC_URL: ${{ matrix.doc_url }}

--- a/compiler/rustc_mir_transform/src/check_unnecessary_transmutes.rs
+++ b/compiler/rustc_mir_transform/src/check_unnecessary_transmutes.rs
@@ -9,6 +9,7 @@ use crate::errors::UnnecessaryTransmute as Error;
 
 /// Check for transmutes that overlap with stdlib methods.
 /// For example, transmuting `[u8; 4]` to `u32`.
+/// We chose not to lint u8 -> bool transmutes, see #140431
 pub(super) struct CheckUnnecessaryTransmutes;
 
 impl<'tcx> crate::MirLint<'tcx> for CheckUnnecessaryTransmutes {
@@ -98,8 +99,6 @@ impl<'a, 'tcx> UnnecessaryTransmuteChecker<'a, 'tcx> {
             (Uint(_), Float(ty)) => err(format!("{}::from_bits({arg})", ty.name_str())),
             // bool → { x8 }
             (Bool, Int(..) | Uint(..)) => err(format!("({arg}) as {}", fn_sig.output())),
-            // u8 → bool
-            (Uint(_), Bool) => err(format!("({arg} == 1)")),
             _ => return None,
         })
     }

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -320,6 +320,7 @@ impl str {
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "replace_first")]
     #[must_use = "this returns the replaced string as a new allocation, \
                   without modifying the original"]
     #[stable(feature = "str_replacen", since = "1.16.0")]

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1179,8 +1179,10 @@ function preLoadCss(cssUrl) {
 
     onEachLazy(document.querySelectorAll(".toggle > summary:not(.hideme)"), el => {
         // @ts-expect-error
+        // Clicking on the summary's contents should not collapse it,
+        // but links within should still fire.
         el.addEventListener("click", e => {
-            if (e.target.tagName !== "SUMMARY" && e.target.tagName !== "A") {
+            if (!e.target.matches("summary, a, a *")) {
                 e.preventDefault();
             }
         });

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -180,19 +180,13 @@ pub struct Item {
     ///
     /// Does not include `#[deprecated]` attributes: see the [`Self::deprecation`] field instead.
     ///
-    /// Some attributes appear in pretty-printed Rust form, regardless of their formatting
+    /// Attributes appear in pretty-printed Rust form, regardless of their formatting
     /// in the original source code. For example:
     /// - `#[non_exhaustive]` and `#[must_use]` are represented as themselves.
     /// - `#[no_mangle]` and `#[export_name]` are also represented as themselves.
     /// - `#[repr(C)]` and other reprs also appear as themselves,
     ///   though potentially with a different order: e.g. `repr(i8, C)` may become `repr(C, i8)`.
     ///   Multiple repr attributes on the same item may be combined into an equivalent single attr.
-    ///
-    /// Other attributes may appear debug-printed. For example:
-    /// - `#[inline]` becomes something similar to `#[attr="Inline(Hint)"]`.
-    ///
-    /// As an internal implementation detail subject to change, this debug-printing format
-    /// is currently equivalent to the HIR pretty-printing of parsed attributes.
     pub attrs: Vec<String>,
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -1,5 +1,4 @@
 // Checks that individual trait impls can only be collapsed via clicking directly on the summary element
-include: "utils.goml"
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -13,7 +13,7 @@ click: "summary:has(#trait-impl-link-in-summary) > .impl"
 assert-window-property: ({"pageYOffset": "0"})
 
 // But links should still work
-click: "#trait-impl-link-in-summary"
+click: "summary:has(#trait-impl-link-in-summary) a:has(#trait-impl-link-in-summary)"
 assert-window-property-false: ({"pageYOffset": "0"})
 
 // As well as clicks on elements within links

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -6,17 +6,21 @@ assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 // Collapse the trait impl doc. The actual clickable area is outside the element, hence offset.
 click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
 assert-attribute-false: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // Clicks on the text should be ignored
 click: "summary:has(#trait-impl-link-in-summary) > .impl"
-assert-window-property: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // But links should still work
 click: "summary:has(#trait-impl-link-in-summary) a:has(#trait-impl-link-in-summary)"
 assert-window-property-false: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
 
 // As well as clicks on elements within links
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
 assert-window-property: ({"pageYOffset": "0"})
 click: "#trait-impl-link-in-summary"
 assert-window-property-false: ({"pageYOffset": "0"})
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})

--- a/tests/rustdoc-gui/collapse-trait-impl.goml
+++ b/tests/rustdoc-gui/collapse-trait-impl.goml
@@ -1,0 +1,23 @@
+// Checks that individual trait impls can only be collapsed via clicking directly on the summary element
+include: "utils.goml"
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+assert-attribute: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+
+// Collapse the trait impl doc. The actual clickable area is outside the element, hence offset.
+click-with-offset: ("summary:has(#trait-impl-link-in-summary)", {"x": -15, "y": 5})
+assert-attribute-false: ("details:has(#trait-impl-link-in-summary)", {"open": ""})
+
+// Clicks on the text should be ignored
+click: "summary:has(#trait-impl-link-in-summary) > .impl"
+assert-window-property: ({"pageYOffset": "0"})
+
+// But links should still work
+click: "#trait-impl-link-in-summary"
+assert-window-property-false: ({"pageYOffset": "0"})
+
+// As well as clicks on elements within links
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+assert-window-property: ({"pageYOffset": "0"})
+click: "#trait-impl-link-in-summary"
+assert-window-property-false: ({"pageYOffset": "0"})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -79,6 +79,7 @@ impl Foo {
     pub fn warning2() {}
 }
 
+/// <a href="#implementations"><code id="trait-impl-link-in-summary">A collapsible trait impl with a link</code></a>
 impl AsRef<str> for Foo {
     fn as_ref(&self) -> &str {
         "hello"

--- a/tests/rustdoc-json/attrs/inline.rs
+++ b/tests/rustdoc-json/attrs/inline.rs
@@ -1,0 +1,11 @@
+//@ is "$.index[?(@.name=='just_inline')].attrs" '["#[inline]"]'
+#[inline]
+pub fn just_inline() {}
+
+//@ is "$.index[?(@.name=='inline_always')].attrs" '["#[inline(always)]"]'
+#[inline(always)]
+pub fn inline_always() {}
+
+//@ is "$.index[?(@.name=='inline_never')].attrs" '["#[inline(never)]"]'
+#[inline(never)]
+pub fn inline_never() {}

--- a/tests/ui/transmute/unnecessary-transmutation.fixed
+++ b/tests/ui/transmute/unnecessary-transmutation.fixed
@@ -81,13 +81,13 @@ fn main() {
         let y: i64 = f64::to_bits(1f64).cast_signed();
         //~^ ERROR
 
-        let z: bool = (1u8 == 1);
-        //~^ ERROR
+        let z: bool = transmute(1u8);
+        // clippy
         let z: u8 = (z) as u8;
         //~^ ERROR
 
         let z: bool = transmute(1i8);
-        // no error!
+        // clippy
         let z: i8 = (z) as i8;
         //~^ ERROR
     }

--- a/tests/ui/transmute/unnecessary-transmutation.rs
+++ b/tests/ui/transmute/unnecessary-transmutation.rs
@@ -82,12 +82,12 @@ fn main() {
         //~^ ERROR
 
         let z: bool = transmute(1u8);
-        //~^ ERROR
+        // clippy
         let z: u8 = transmute(z);
         //~^ ERROR
 
         let z: bool = transmute(1i8);
-        // no error!
+        // clippy
         let z: i8 = transmute(z);
         //~^ ERROR
     }

--- a/tests/ui/transmute/unnecessary-transmutation.stderr
+++ b/tests/ui/transmute/unnecessary-transmutation.stderr
@@ -240,12 +240,6 @@ LL |         let y: i64 = transmute(1f64);
    |                      ^^^^^^^^^^^^^^^ help: replace this with: `f64::to_bits(1f64).cast_signed()`
 
 error: unnecessary transmute
-  --> $DIR/unnecessary-transmutation.rs:84:23
-   |
-LL |         let z: bool = transmute(1u8);
-   |                       ^^^^^^^^^^^^^^ help: replace this with: `(1u8 == 1)`
-
-error: unnecessary transmute
   --> $DIR/unnecessary-transmutation.rs:86:21
    |
 LL |         let z: u8 = transmute(z);
@@ -257,5 +251,5 @@ error: unnecessary transmute
 LL |         let z: i8 = transmute(z);
    |                     ^^^^^^^^^^^^ help: replace this with: `(z) as i8`
 
-error: aborting due to 36 previous errors
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #140431 (dont handle bool transmute)
 - #140868 (rustdoc: Fix links with inline code in trait impl docs)
 - #141323 (Add bors environment to CI)
 - #141337 (bump stdarch)
 - #141364 (rustdoc-json: Remove false docs and add test for inline attribute)
 - #141370 (add doc alias `replace_first` for `str::replacen`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140431,140868,141323,141337,141364,141370)
<!-- homu-ignore:end -->