### PR TITLE
try_cast_aligned: avoid bare int-to-ptr casts

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -76,15 +76,13 @@ impl<T: ?Sized> *const T {
     /// ```rust
     /// #![feature(pointer_try_cast_aligned)]
     ///
-    /// let aligned: *const u8 = 0x1000 as _;
+    /// let x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned: *const u64 = &x;
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: *const u8 = 0x1001 as _;
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -58,15 +58,13 @@ impl<T: ?Sized> *mut T {
     /// ```rust
     /// #![feature(pointer_try_cast_aligned)]
     ///
-    /// let aligned: *mut u8 = 0x1000 as _;
+    /// let mut x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned: *mut u64 = &mut x;
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: *mut u8 = 0x1001 as _;
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -501,15 +501,13 @@ impl<T: ?Sized> NonNull<T> {
     /// #![feature(pointer_try_cast_aligned)]
     /// use std::ptr::NonNull;
     ///
-    /// let aligned: NonNull<u8> = NonNull::new(0x1000 as _).unwrap();
+    /// let mut x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned = NonNull::from_mut(&mut x);
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: NonNull<u8> = NonNull::new(0x1001 as _).unwrap();
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \


### PR DESCRIPTION
This fixes a CI failure in https://github.com/rust-lang/miri-test-libstd caused by strict provenance violations in doctests added in https://github.com/rust-lang/rust/pull/141222.

r? @tgross35 
Cc @mathisbot 