### PR TITLE
Enable review queue tracking

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1411,8 +1411,10 @@ compiletest = [
 "/src/tools/rustdoc-gui-test" =                          ["bootstrap", "@onur-ozkan"]
 "/src/tools/libcxx-version" =                            ["@onur-ozkan"]
 
-# Enable tracking of PR review assignment
-# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment-tracking.html
+# Enable review queue tracking
+# Documentation at: https://forge.rust-lang.org/triagebot/review-queue-tracking.html
+[assign.review_prefs]
+
 [pr-tracking]
 
 # Enable issue transfers within the org


### PR DESCRIPTION
This PR enables the new review queue tracking assignment logic implemented in triagebot. It is documented in https://github.com/rust-lang/rust-forge/pull/853.