### PR TITLE
Move `dist-x86_64-linux` CI job to GitHub temporarily

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -228,7 +228,7 @@ auto:
   - name: dist-x86_64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-linux-36c-codebuild
+    <<: *job-linux-16c
 
   - name: dist-x86_64-linux-alt
     env:


### PR DESCRIPTION
To make it easier to migrate off the `rust-lang-ci/rust` repository.

r? @marcoieni