### PR TITLE
rustc_const_eval: Expose APIs for signalling foreign accesses to memory

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -799,7 +799,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
     /// Initialize all previously uninitialized bytes in the entire allocation, and set
     /// provenance of everything to `Wildcard`. Before calling this, make sure all
     /// provenance in this allocation is exposed!
-    pub fn prepare_for_native_write(&mut self) {
+    pub fn prepare_for_native_write(&mut self, paranoid: bool) {
         let full_range = AllocRange { start: Size::ZERO, size: Size::from_bytes(self.len()) };
         // Overwrite uninitialized bytes with 0, to ensure we don't leak whatever their value happens to be.
         for chunk in self.init_mask.range_as_init_chunks(full_range) {
@@ -809,7 +809,9 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
                 uninit_bytes.fill(0);
             }
         }
-        self.mark_foreign_write(full_range);
+        if paranoid {
+            self.mark_foreign_write(full_range);
+        }
     }
 
     /// Initialise previously uninitialised bytes in the given range, and set provenance of

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -799,7 +799,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
     /// Initialize all previously uninitialized bytes in the entire allocation, and set
     /// provenance of everything to `Wildcard`. Before calling this, make sure all
     /// provenance in this allocation is exposed!
-    pub fn prepare_for_native_write(&mut self) -> AllocResult {
+    pub fn prepare_for_native_write(&mut self) {
         let full_range = AllocRange { start: Size::ZERO, size: Size::from_bytes(self.len()) };
         // Overwrite uninitialized bytes with 0, to ensure we don't leak whatever their value happens to be.
         for chunk in self.init_mask.range_as_init_chunks(full_range) {
@@ -809,18 +809,23 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
                 uninit_bytes.fill(0);
             }
         }
-        // Mark everything as initialized now.
-        self.mark_init(full_range, true);
+        self.mark_foreign_write(full_range);
+    }
 
-        // Set provenance of all bytes to wildcard.
-        self.provenance.write_wildcards(self.len());
+    /// Initialise previously uninitialised bytes in the given range, and set provenance of
+    /// everything in it to `Wildcard`. Before calling this, make sure all provenance in this
+    /// range is exposed!
+    pub fn mark_foreign_write(&mut self, range: AllocRange) {
+        // Mark everything as initialized now.
+        self.mark_init(range, true);
+
+        // Set provenance of affected bytes to wildcard.
+        self.provenance.write_wildcards(range);
 
         // Also expose the provenance of the interpreter-level allocation, so it can
         // be written by FFI. The `black_box` is defensive programming as LLVM likes
         // to (incorrectly) optimize away ptr2int casts whose result is unused.
         std::hint::black_box(self.get_bytes_unchecked_raw_mut().expose_provenance());
-
-        Ok(())
     }
 
     /// Remove all provenance in the given memory range.

--- a/compiler/rustc_middle/src/mir/interpret/allocation/provenance_map.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation/provenance_map.rs
@@ -213,10 +213,11 @@ impl<Prov: Provenance> ProvenanceMap<Prov> {
         Ok(())
     }
 
-    /// Overwrites all provenance in the allocation with wildcard provenance.
+    /// Overwrites all provenance in the specified range within the allocation
+    /// with wildcard provenance.
     ///
     /// Provided for usage in Miri and panics otherwise.
-    pub fn write_wildcards(&mut self, alloc_size: usize) {
+    pub fn write_wildcards(&mut self, range: AllocRange) {
         assert!(
             Prov::OFFSET_IS_ADDR,
             "writing wildcard provenance is not supported when `OFFSET_IS_ADDR` is false"
@@ -225,9 +226,8 @@ impl<Prov: Provenance> ProvenanceMap<Prov> {
 
         // Remove all pointer provenances, then write wildcards into the whole byte range.
         self.ptrs.clear();
-        let last = Size::from_bytes(alloc_size);
         let bytes = self.bytes.get_or_insert_with(Box::default);
-        for offset in Size::ZERO..last {
+        for offset in range.start..range.start + range.size {
             bytes.insert(offset, wildcard);
         }
     }

--- a/src/tools/miri/src/alloc_addresses/mod.rs
+++ b/src/tools/miri/src/alloc_addresses/mod.rs
@@ -476,7 +476,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // for the search within `prepare_for_native_call`.
         let exposed: Vec<AllocId> =
             this.machine.alloc_addresses.get_mut().exposed.iter().copied().collect();
-        this.prepare_for_native_call(exposed)
+        this.prepare_for_native_call(exposed, true)
     }
 }
 


### PR DESCRIPTION
This PR will allow Miri to internally update its state based on information about foreign accesses performed on its memory during FFI. Necessary as part of [rust-lang/miri#4326](https://github.com/rust-lang/miri/pull/4326) to make use of the extra information we gain; currently pending review of the design (see design document in the linked PR), so marked as draft for now.

r? @RalfJung