### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,8 @@ jobs:
           fi
           exit ${STATUS}
         env:
-          AWS_ACCESS_KEY_ID: ${{ env.CACHES_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}
+          AWS_ACCESS_KEY_ID: ${{ (github.repository == 'rust-lang/rust' && secrets.CACHES_AWS_ACCESS_KEY_ID) || env.CACHES_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ (github.repository == 'rust-lang/rust' && secrets.CACHES_AWS_SECRET_ACCESS_KEY) || secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.CACHES_AWS_ACCESS_KEY_ID)] }}
 
       - name: create github artifacts
         run: src/ci/scripts/create-doc-artifacts.sh
@@ -257,8 +257,8 @@ jobs:
       - name: upload artifacts to S3
         run: src/ci/scripts/upload-artifacts.sh
         env:
-          AWS_ACCESS_KEY_ID: ${{ env.ARTIFACTS_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}
+          AWS_ACCESS_KEY_ID: ${{ (github.repository == 'rust-lang/rust' && secrets.ARTIFACTS_AWS_ACCESS_KEY_ID) || env.ARTIFACTS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ (github.repository == 'rust-lang/rust' && secrets.ARTIFACTS_AWS_SECRET_ACCESS_KEY) || secrets[format('AWS_SECRET_ACCESS_KEY_{0}', env.ARTIFACTS_AWS_ACCESS_KEY_ID)] }}
         # Adding a condition on DEPLOY=1 or DEPLOY_ALT=1 is not needed as all deploy
         # builders *should* have the AWS credentials available. Still, explicitly
         # adding the condition is helpful as this way CI will not silently skip

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -327,7 +327,7 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<I: Intern
                 // always be called once. It additionally implements `Fn`/`FnMut`
                 // only if it has no upvars referencing the closure-env lifetime,
                 // and if the closure kind permits it.
-                if closure_kind != ty::ClosureKind::FnOnce && args.has_self_borrows() {
+                if goal_kind != ty::ClosureKind::FnOnce && args.has_self_borrows() {
                     return Err(NoSolution);
                 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2823,7 +2823,7 @@ impl Ident {
     /// Whether this would be the identifier for a tuple field like `self.0`, as
     /// opposed to a named field like `self.thing`.
     pub fn is_numeric(self) -> bool {
-        !self.name.is_empty() && self.as_str().bytes().all(|b| b.is_ascii_digit())
+        self.as_str().bytes().all(|b| b.is_ascii_digit())
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -841,16 +841,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 return None;
             };
 
-        let (closure_def_id, found_args, by_ref_captures) = match *self_ty.kind() {
+        let (closure_def_id, found_args, has_self_borrows) = match *self_ty.kind() {
             ty::Closure(def_id, args) => {
-                (def_id, args.as_closure().sig().map_bound(|sig| sig.inputs()[0]), None)
+                (def_id, args.as_closure().sig().map_bound(|sig| sig.inputs()[0]), false)
             }
             ty::CoroutineClosure(def_id, args) => (
                 def_id,
                 args.as_coroutine_closure()
                     .coroutine_closure_sig()
                     .map_bound(|sig| sig.tupled_inputs_ty),
-                Some(args.as_coroutine_closure().coroutine_captures_by_ref_ty()),
+                !args.as_coroutine_closure().tupled_upvars_ty().is_ty_var()
+                    && args.as_coroutine_closure().has_self_borrows(),
             ),
             _ => return None,
         };
@@ -884,10 +885,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // If the closure has captures, then perhaps the reason that the trait
         // is unimplemented is because async closures don't implement `Fn`/`FnMut`
         // if they have captures.
-        if let Some(by_ref_captures) = by_ref_captures
-            && let ty::FnPtr(sig_tys, _) = by_ref_captures.kind()
-            && !sig_tys.skip_binder().output().is_unit()
-        {
+        if has_self_borrows && expected_kind != ty::ClosureKind::FnOnce {
             let mut err = self.dcx().create_err(AsyncClosureNotFn {
                 span: self.tcx.def_span(closure_def_id),
                 kind: expected_kind.as_str(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1503,11 +1503,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     return None;
                 };
 
-                let Ok(Some(ImplSource::UserDefined(impl_data))) = SelectionContext::new(self)
-                    .poly_select(&obligation.with(
-                        self.tcx,
-                        predicate.kind().rebind(proj.projection_term.trait_ref(self.tcx)),
-                    ))
+                let trait_ref = self.enter_forall_and_leak_universe(
+                    predicate.kind().rebind(proj.projection_term.trait_ref(self.tcx)),
+                );
+                let Ok(Some(ImplSource::UserDefined(impl_data))) =
+                    SelectionContext::new(self).select(&obligation.with(self.tcx, trait_ref))
                 else {
                     return None;
                 };

--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -5,7 +5,7 @@ use rustc_infer::traits::solve::inspect::ProbeKind;
 use rustc_infer::traits::solve::{CandidateSource, Certainty, Goal};
 use rustc_infer::traits::{
     BuiltinImplSource, ImplSource, ImplSourceUserDefinedData, Obligation, ObligationCause,
-    PolyTraitObligation, Selection, SelectionError, SelectionResult,
+    Selection, SelectionError, SelectionResult, TraitObligation,
 };
 use rustc_macros::extension;
 use rustc_middle::{bug, span_bug};
@@ -17,7 +17,7 @@ use crate::solve::inspect::{self, ProofTreeInferCtxtExt};
 impl<'tcx> InferCtxt<'tcx> {
     fn select_in_new_trait_solver(
         &self,
-        obligation: &PolyTraitObligation<'tcx>,
+        obligation: &TraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
         assert!(self.next_trait_solver());
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -265,9 +265,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         &mut self,
         obligation: &PolyTraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
-        if self.infcx.next_trait_solver() {
-            return self.infcx.select_in_new_trait_solver(obligation);
-        }
+        assert!(!self.infcx.next_trait_solver());
 
         let candidate = match self.select_from_obligation(obligation) {
             Err(SelectionError::Overflow(OverflowError::Canonical)) => {
@@ -299,6 +297,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         &mut self,
         obligation: &TraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
+        if self.infcx.next_trait_solver() {
+            return self.infcx.select_in_new_trait_solver(obligation);
+        }
+
         self.poly_select(&Obligation {
             cause: obligation.cause.clone(),
             param_env: obligation.param_env,

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -76,15 +76,13 @@ impl<T: ?Sized> *const T {
     /// ```rust
     /// #![feature(pointer_try_cast_aligned)]
     ///
-    /// let aligned: *const u8 = 0x1000 as _;
+    /// let x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned: *const u64 = &x;
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: *const u8 = 0x1001 as _;
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -58,15 +58,13 @@ impl<T: ?Sized> *mut T {
     /// ```rust
     /// #![feature(pointer_try_cast_aligned)]
     ///
-    /// let aligned: *mut u8 = 0x1000 as _;
+    /// let mut x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned: *mut u64 = &mut x;
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: *mut u8 = 0x1001 as _;
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -501,15 +501,13 @@ impl<T: ?Sized> NonNull<T> {
     /// #![feature(pointer_try_cast_aligned)]
     /// use std::ptr::NonNull;
     ///
-    /// let aligned: NonNull<u8> = NonNull::new(0x1000 as _).unwrap();
+    /// let mut x = 0u64;
     ///
-    /// // i32 has at most 4-byte alignment, so this will succeed
-    /// assert!(aligned.try_cast_aligned::<i32>().is_some());
+    /// let aligned = NonNull::from_mut(&mut x);
+    /// let unaligned = unsafe { aligned.byte_add(1) };
     ///
-    /// let unaligned: NonNull<u8> = NonNull::new(0x1001 as _).unwrap();
-    ///
-    /// // i32 has at least 2-byte alignment, so this will fail
-    /// assert!(unaligned.try_cast_aligned::<i32>().is_none());
+    /// assert!(aligned.try_cast_aligned::<u32>().is_some());
+    /// assert!(unaligned.try_cast_aligned::<u32>().is_none());
     /// ```
     #[unstable(feature = "pointer_try_cast_aligned", issue = "141221")]
     #[must_use = "this returns the result of the operation, \

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -324,7 +324,7 @@ auto:
     <<: *job-linux-4c
 
   - name: x86_64-gnu-distcheck
-    <<: *job-linux-8c
+    <<: *job-linux-4c
 
   # The x86_64-gnu-llvm-20 job is split into multiple jobs to run tests in parallel.
   # x86_64-gnu-llvm-20-1 skips tests that run in x86_64-gnu-llvm-20-{2,3}.

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -59,12 +59,7 @@ fn filter_assoc_items_by_name_and_namespace(
     ident: Ident,
     ns: Namespace,
 ) -> impl Iterator<Item = &ty::AssocItem> {
-    let iter: Box<dyn Iterator<Item = &ty::AssocItem>> = if !ident.name.is_empty() {
-        Box::new(tcx.associated_items(assoc_items_of).filter_by_name_unhygienic(ident.name))
-    } else {
-        Box::new([].iter())
-    };
-    iter.filter(move |item| {
+    tcx.associated_items(assoc_items_of).filter_by_name_unhygienic(ident.name).filter(move |item| {
         item.namespace() == ns && tcx.hygienic_eq(ident, item.ident(tcx), assoc_items_of)
     })
 }

--- a/tests/crashes/140642.rs
+++ b/tests/crashes/140642.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #140642
-#![feature(min_generic_const_args)]
-
-pub trait Tr<A> {
-    const SIZE: usize;
-}
-
-fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}

--- a/tests/ui/async-await/async-closures/async-fn-mut-impl-fn-once.rs
+++ b/tests/ui/async-await/async-closures/async-fn-mut-impl-fn-once.rs
@@ -1,0 +1,15 @@
+//@ edition:2021
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+fn call_once<F>(_: impl FnOnce() -> F) {}
+
+fn main() {
+    let mut i = 0;
+    let c = async || {
+        i += 1;
+    };
+    call_once(c);
+}

--- a/tests/ui/const-generics/mgca/projection-error.rs
+++ b/tests/ui/const-generics/mgca/projection-error.rs
@@ -1,0 +1,17 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+// Regression test for #140642. Test that normalizing const aliases
+// containing erroneous types normalizes to a const error instead of
+// a type error.
+
+
+pub trait Tr<A> {
+    const SIZE: usize;
+}
+
+fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+//~^ ERROR: cannot find type `T` in this scope
+//~| ERROR: cannot find type `T` in this scope
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/projection-error.stderr
+++ b/tests/ui/const-generics/mgca/projection-error.stderr
@@ -1,0 +1,39 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/projection-error.rs:13:17
+   |
+LL | pub trait Tr<A> {
+   | --------------- similarly named trait `Tr` defined here
+...
+LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                 ^
+   |
+help: a trait with a similar name exists
+   |
+LL | fn mk_array(_x: Tr) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                  +
+help: you might be missing a type parameter
+   |
+LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |            +++
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/projection-error.rs:13:29
+   |
+LL | pub trait Tr<A> {
+   | --------------- similarly named trait `Tr` defined here
+...
+LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |                             ^
+   |
+help: a trait with a similar name exists
+   |
+LL | fn mk_array(_x: T) -> [(); <Tr as Tr<bool>>::SIZE] {}
+   |                              +
+help: you might be missing a type parameter
+   |
+LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
+   |            +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/mismatched_types/hr-projection-mismatch.current.stderr
+++ b/tests/ui/mismatched_types/hr-projection-mismatch.current.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/hr-projection-mismatch.rs:20:5
+   |
+LL |     wrap::<_, Thing>();
+   |     ^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected reference `&'a _`
+              found reference `&_`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/mismatched_types/hr-projection-mismatch.next.stderr
+++ b/tests/ui/mismatched_types/hr-projection-mismatch.next.stderr
@@ -1,0 +1,20 @@
+error[E0271]: type mismatch resolving `<Thing as Trait<'a>>::Assoc == &i32`
+  --> $DIR/hr-projection-mismatch.rs:20:15
+   |
+LL |     wrap::<_, Thing>();
+   |               ^^^^^ type mismatch resolving `<Thing as Trait<'a>>::Assoc == &i32`
+   |
+note: types differ
+  --> $DIR/hr-projection-mismatch.rs:14:18
+   |
+LL |     type Assoc = &'a i32;
+   |                  ^^^^^^^
+note: required by a bound in `wrap`
+  --> $DIR/hr-projection-mismatch.rs:17:33
+   |
+LL | fn wrap<T, U: for<'a> Trait<'a, Assoc = T>>() {}
+   |                                 ^^^^^^^^^ required by this bound in `wrap`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/mismatched_types/hr-projection-mismatch.rs
+++ b/tests/ui/mismatched_types/hr-projection-mismatch.rs
@@ -1,0 +1,25 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/rust/issues/141322>.
+
+trait Trait<'a> {
+    type Assoc;
+}
+
+struct Thing;
+
+impl<'a> Trait<'a> for Thing {
+    type Assoc = &'a i32;
+}
+
+fn wrap<T, U: for<'a> Trait<'a, Assoc = T>>() {}
+
+fn foo() {
+    wrap::<_, Thing>();
+    //[next]~^ ERROR type mismatch resolving `<Thing as Trait<'a>>::Assoc == &i32
+    //[current]~^^ ERROR mismatched types
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #141355 (ci: improve citool job db errors)
 - #141359 (Fix `FnOnce` impl for `AsyncFn`/`AsyncFnMut` self-borrowing closures in new solver)
 - #141362 (Normalize aliases to correct kind of error term)
 - #141377 (Remove unnecessary `is_empty` checks)
 - #141381 (try_cast_aligned: avoid bare int-to-ptr casts)
 - #141382 (ci: convert distcheck to free runner)
 - #141389 (ci: prepare aws access keys for migration)
 - #141390 (Don't allow `poly_select` in new solver)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141355,141359,141362,141377,141381,141382,141389,141390)
<!-- homu-ignore:end -->