### PR TITLE
GetUserProfileDirectoryW is now documented to always store the size

### DIFF
--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -202,8 +202,6 @@ fn home_dir_crt() -> Option<PathBuf> {
             |buf, mut sz| {
                 // GetUserProfileDirectoryW does not quite use the usual protocol for
                 // negotiating the buffer size, so we have to translate.
-                // FIXME(#141254): We rely on the *undocumented* property that this function will
-                // always set the size, not just on failure.
                 match c::GetUserProfileDirectoryW(
                     ptr::without_provenance_mut(CURRENT_PROCESS_TOKEN),
                     buf,


### PR DESCRIPTION
Update to match https://github.com/MicrosoftDocs/sdk-api/pull/1810

Also fix a bug in the Miri implementation while I am starting at that code...

r? @ChrisDenton 
Fixes #141254