### PR TITLE
Refactor the two-phase check for impls and impl items

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1137,7 +1137,7 @@ rustc_queries! {
     /// their respective impl (i.e., part of the derive macro)
     query live_symbols_and_ignored_derived_traits(_: ()) -> &'tcx (
         LocalDefIdSet,
-        LocalDefIdMap<Vec<(DefId, DefId)>>
+        LocalDefIdMap<FxIndexSet<(DefId, DefId)>>
     ) {
         arena_cache
         desc { "finding live symbols in crate" }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -332,16 +332,19 @@ impl Default for CommandOutput {
 
 /// Helper trait to format both Command and BootstrapCommand as a short execution line,
 /// without all the other details (e.g. environment variables).
+#[cfg(feature = "tracing")]
 pub trait FormatShortCmd {
     fn format_short_cmd(&self) -> String;
 }
 
+#[cfg(feature = "tracing")]
 impl FormatShortCmd for BootstrapCommand {
     fn format_short_cmd(&self) -> String {
         self.command.format_short_cmd()
     }
 }
 
+#[cfg(feature = "tracing")]
 impl FormatShortCmd for Command {
     fn format_short_cmd(&self) -> String {
         let program = Path::new(self.get_program());

--- a/tests/ui/derives/clone-debug-dead-code.stderr
+++ b/tests/ui/derives/clone-debug-dead-code.stderr
@@ -40,7 +40,7 @@ LL | struct D { f: () }
    |        |
    |        field in this struct
    |
-   = note: `D` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
+   = note: `D` has derived impls for the traits `Debug` and `Clone`, but these are intentionally ignored during dead code analysis
 
 error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:21:12

--- a/tests/ui/deriving/deriving-in-macro.rs
+++ b/tests/ui/deriving/deriving-in-macro.rs
@@ -1,5 +1,6 @@
-//@ run-pass
+//@ check-pass
 #![allow(non_camel_case_types)]
+#![allow(dead_code)]
 
 macro_rules! define_vec {
     () => (

--- a/tests/ui/lint/dead-code/alias-type-used-as-generic-arg-in-impl.rs
+++ b/tests/ui/lint/dead-code/alias-type-used-as-generic-arg-in-impl.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+struct T<X>(X);
+
+type A<X> = T<X>;
+
+trait Tr {
+    fn foo();
+}
+
+impl<X> Tr for T<A<X>> {
+    fn foo() {}
+}
+
+fn main() {
+   T::<T<()>>::foo();
+}

--- a/tests/ui/lint/dead-code/issue-41883.stderr
+++ b/tests/ui/lint/dead-code/issue-41883.stderr
@@ -29,6 +29,8 @@ error: struct `UnusedStruct` is never constructed
    |
 LL |     struct UnusedStruct;
    |            ^^^^^^^^^^^^
+   |
+   = note: `UnusedStruct` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
@@ -56,6 +56,8 @@ warning: struct `Foo` is never constructed
    |
 LL | struct Foo(usize, #[allow(unused)] usize);
    |        ^^^
+   |
+   = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/lint/dead-code/trait-only-used-as-type-bound.rs
+++ b/tests/ui/lint/dead-code/trait-only-used-as-type-bound.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+trait UInt: Copy + From<u8> {}
+
+impl UInt for u16 {}
+
+trait Int: Copy {
+    type Unsigned: UInt;
+
+    fn as_unsigned(self) -> Self::Unsigned;
+}
+
+impl Int for i16 {
+    type Unsigned = u16;
+
+    fn as_unsigned(self) -> u16 {
+        self as _
+    }
+}
+
+fn priv_func<T: Int>(x: u8, y: T) -> (T::Unsigned, T::Unsigned) {
+    (T::Unsigned::from(x), y.as_unsigned())
+}
+
+pub fn pub_func(x: u8, y: i16) -> (u16, u16) {
+    priv_func(x, y)
+}
+
+fn main() {}


### PR DESCRIPTION
Refactor the two-phase dead code check to make the logic clearer and simpler:
1. adding assoc fn and impl into `unsolved_items` directly during the initial construction of the worklist
2. converge the logic of checking whether assoc fn and impl are used to `item_should_be_checked`, and the item is considered used only when its corresponding trait and Self adt are used

This PR only refactors as much as possible to avoid affecting the original functions. However, due to the adjustment of the order of checks, the test results are slightly different, but overall, there is no regression problem

Fixes rust-lang/rust#127911
Fixes rust-lang/rust#128839

Extracted from https://github.com/rust-lang/rust/pull/128637.
r? petrochenkov

try-job: dist-aarch64-linux