### PR TITLE
Remove #![feature(let_chains)] from libcore

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -158,7 +158,6 @@
 #![feature(intra_doc_pointers)]
 #![feature(intrinsics)]
 #![feature(lang_items)]
-#![feature(let_chains)]
 #![feature(link_llvm_intrinsics)]
 #![feature(macro_metavar_expr)]
 #![feature(marker_trait_attr)]

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-LINUX_VERSION=v6.15-rc4
+# https://github.com/Rust-for-Linux/linux/issues/1163
+LINUX_VERSION=3ca02fc80cc4fdac63aaa6796642f1e07be591d6
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/132833 has stabilized the let_chains feature. This PR removes the last occurrence from the library.

Split out of #140966 as it caused breakage. Now we have a patch to the linux tree that fixes the build, so we update the linux tree to it.

cc https://github.com/Rust-for-Linux/linux/issues/1163
cc https://github.com/rust-lang/rust/issues/140722