### PR TITLE
Dont walk into unsafe binders when emiting error for non-structural type match

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -382,6 +382,9 @@ fn extend_type_not_partial_eq<'tcx>(
         fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
             match ty.kind() {
                 ty::Dynamic(..) => return ControlFlow::Break(()),
+                // Unsafe binders never implement `PartialEq`, so avoid walking into them
+                // which would require instantiating its binder with placeholders too.
+                ty::UnsafeBinder(..) => return ControlFlow::Break(()),
                 ty::FnPtr(..) => return ControlFlow::Continue(()),
                 ty::Adt(def, _args) => {
                     let ty_def_id = def.did();

--- a/tests/ui/unsafe-binders/non-strucutral-type-diag.rs
+++ b/tests/ui/unsafe-binders/non-strucutral-type-diag.rs
@@ -1,0 +1,17 @@
+// regression test for <https://github.com/rust-lang/rust/issues/141422>.
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+#[derive(Copy, Clone)]
+struct Adt<'a>(&'a ());
+
+const C: Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)> = None;
+
+fn main() {
+    match None {
+        C => {}
+        //~^ ERROR constant of non-structural type
+        _ => {}
+    }
+}

--- a/tests/ui/unsafe-binders/non-strucutral-type-diag.stderr
+++ b/tests/ui/unsafe-binders/non-strucutral-type-diag.stderr
@@ -1,0 +1,13 @@
+error: constant of non-structural type `Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)>` in a pattern
+  --> $DIR/non-strucutral-type-diag.rs:13:9
+   |
+LL | const C: Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)> = None;
+   | ---------------------------------------------------- constant defined here
+...
+LL |         C => {}
+   |         ^ constant of non-structural type
+   |
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #141422.

The other two binder-having types are also special cased here, unsurprisingly.

r? oli-obk