### PR TITLE
Emit dummy open drop for unsafe binder

### DIFF
--- a/tests/ui/unsafe/move-out-of-non-copy.rs
+++ b/tests/ui/unsafe/move-out-of-non-copy.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Zvalidate-mir
+
+// Regression test for <https://github.com/rust-lang/rust/issues/141394>.
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+use std::unsafe_binder::unwrap_binder;
+
+fn id<T>(x: unsafe<> T) -> T {
+    //~^ ERROR the trait bound `T: Copy` is not satisfied
+    unsafe { unwrap_binder!(x) }
+}
+
+fn main() {}

--- a/tests/ui/unsafe/move-out-of-non-copy.stderr
+++ b/tests/ui/unsafe/move-out-of-non-copy.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `T: Copy` is not satisfied
+  --> $DIR/move-out-of-non-copy.rs:10:13
+   |
+LL | fn id<T>(x: unsafe<> T) -> T {
+   |             ^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |
+help: consider restricting type parameter `T` with trait `Copy`
+   |
+LL | fn id<T: std::marker::Copy>(x: unsafe<> T) -> T {
+   |        +++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#141394

We can't taint the body in wfcheck when we have a `T: Copy` bound failure, so we end up binding MIR here. Emit a dummy open drop so that drop elaboration doesn't fail.

r? oli-obk