### PR TITLE
Add 2nd Solaris target maintainer

### DIFF
--- a/src/doc/rustc/src/platform-support/solaris.md
+++ b/src/doc/rustc/src/platform-support/solaris.md
@@ -8,6 +8,7 @@ Rust for Solaris operating system.
 ## Target maintainers
 
 [@psumbera](https://github.com/psumbera)
+[@kulikjak](https://github.com/kulikjak)
 
 ## Requirements
 


### PR DESCRIPTION
Based on concenr here https://github.com/rust-lang/compiler-team/issues/870#issuecomment-2903825327 I propose my coleague @kulikjak as 2nd Solaris maintainer. He already did some work to Rust in past.