### PR TITLE
Suggest correct `version("..")` predicate syntax in check-cfg

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -835,6 +835,7 @@ lint_unexpected_cfg_name_similar_name = there is a config with a similar name
 lint_unexpected_cfg_name_similar_name_different_values = there is a config with a similar name and different values
 lint_unexpected_cfg_name_similar_name_no_value = there is a config with a similar name and no value
 lint_unexpected_cfg_name_similar_name_value = there is a config with a similar name and value
+lint_unexpected_cfg_name_version_syntax = there is a similar config predicate: `version("..")`
 lint_unexpected_cfg_name_with_similar_value = found config with similar value
 
 lint_unexpected_cfg_value = unexpected `cfg` condition value: {$has_value ->

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -140,6 +140,14 @@ pub(super) fn unexpected_cfg_name(
 
     let code_sugg = if is_feature_cfg && is_from_cargo {
         lints::unexpected_cfg_name::CodeSuggestion::DefineFeatures
+    // Suggest correct `version("..")` predicate syntax
+    } else if let Some((_value, value_span)) = value
+        && name == sym::version
+    {
+        lints::unexpected_cfg_name::CodeSuggestion::VersionSyntax {
+            between_name_and_value: name_span.between(value_span),
+            after_value: value_span.shrink_to_hi(),
+        }
     // Suggest the most probable if we found one
     } else if let Some(best_match) = find_best_match_for_name(&possibilities, name, None) {
         is_feature_cfg |= best_match == sym::feature;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2273,6 +2273,16 @@ pub(crate) mod unexpected_cfg_name {
     pub(crate) enum CodeSuggestion {
         #[help(lint_unexpected_cfg_define_features)]
         DefineFeatures,
+        #[multipart_suggestion(
+            lint_unexpected_cfg_name_version_syntax,
+            applicability = "machine-applicable"
+        )]
+        VersionSyntax {
+            #[suggestion_part(code = "(")]
+            between_name_and_value: Span,
+            #[suggestion_part(code = ")")]
+            after_value: Span,
+        },
         #[suggestion(
             lint_unexpected_cfg_name_similar_name_value,
             applicability = "maybe-incorrect",

--- a/tests/ui/check-cfg/wrong-version-syntax.fixed
+++ b/tests/ui/check-cfg/wrong-version-syntax.fixed
@@ -1,0 +1,14 @@
+// Check warning for wrong `cfg(version("1.27"))` syntax
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+//@ run-rustfix
+
+#![feature(cfg_version)]
+
+#[cfg(not(version("1.48.0")))]
+//~^ WARNING unexpected `cfg` condition name: `version`
+pub fn g() {}
+
+pub fn main() {}

--- a/tests/ui/check-cfg/wrong-version-syntax.rs
+++ b/tests/ui/check-cfg/wrong-version-syntax.rs
@@ -1,0 +1,14 @@
+// Check warning for wrong `cfg(version("1.27"))` syntax
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+//@ run-rustfix
+
+#![feature(cfg_version)]
+
+#[cfg(not(version = "1.48.0"))]
+//~^ WARNING unexpected `cfg` condition name: `version`
+pub fn g() {}
+
+pub fn main() {}

--- a/tests/ui/check-cfg/wrong-version-syntax.stderr
+++ b/tests/ui/check-cfg/wrong-version-syntax.stderr
@@ -1,0 +1,17 @@
+warning: unexpected `cfg` condition name: `version`
+  --> $DIR/wrong-version-syntax.rs:10:11
+   |
+LL | #[cfg(not(version = "1.48.0"))]
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(version, values("1.48.0"))`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+help: there is a similar config predicate: `version("..")`
+   |
+LL - #[cfg(not(version = "1.48.0"))]
+LL + #[cfg(not(version("1.48.0")))]
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This PR specialize the `unexpected_cfgs` lint diagnostic to suggest correct `version("..")` predicate syntax when providing the key-value one, eg. `version = "1.27"`.

Fixes https://github.com/rust-lang/rust/issues/141440
r? @jieyouxu
