### PR TITLE
Attempt to improve the `std::fs::create_dir_all` docs related to atomicity

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2803,8 +2803,8 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// Recursively create a directory and all of its parent components if they
 /// are missing.
 ///
-/// If this function returns an error, some of the parent components might have
-/// been created already.
+/// This function is not atomic. If it returns an error, any parent components it was able to create
+/// will remain.
 ///
 /// If the empty path is passed to this function, it always succeeds without
 /// creating any directories.


### PR DESCRIPTION
The original paragraph was added in rust-lang/rust#124520. It doesn't match the actual code logic. It says "function returns an error" if "the parent components" _(which also implies directories)_ "have been created already". The code is as follows:

https://github.com/rust-lang/rust/blob/e88e85463468ce5d5ce468414eb69e3b15fa8d42/library/std/src/fs.rs#L3146
https://github.com/rust-lang/rust/blob/e88e85463468ce5d5ce468414eb69e3b15fa8d42/library/std/src/fs.rs#L3160

These lines suppress all errors if any path component is a directory. I've updated the paragraph to mirror this.