### PR TITLE
document some -Z flags as living in the rustc-dev-guide

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/eagerly-emit-delayed-bugs.md
+++ b/src/doc/unstable-book/src/compiler-flags/eagerly-emit-delayed-bugs.md
@@ -1,0 +1,12 @@
+# `eagerly-emit-delayed-bugs`
+
+This feature is perma-unstable and has no tracking issue.
+
+------------------------
+
+This flag converts all [`span_delayed_bug()`] calls to [`bug!`] calls, exiting the compiler immediately and allowing you to generate a backtrace of where the delayed bug occurred.
+For full documentation, see [the rustc-dev-guide][dev-guide-delayed].
+
+[`bug!`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/macro.bug.html
+[`span_delayed_bug()`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_errors/struct.DiagCtxtHandle.html#method.span_delayed_bug
+[dev-guide-delayed]: https://rustc-dev-guide.rust-lang.org/compiler-debugging.html#debugging-delayed-bugs

--- a/src/doc/unstable-book/src/compiler-flags/track-diagnostics.md
+++ b/src/doc/unstable-book/src/compiler-flags/track-diagnostics.md
@@ -1,0 +1,11 @@
+# `track-diagnostics`
+
+This feature is perma-unstable and has no tracking issue.
+
+------------------------
+
+This flag prints the source code span in the compiler where a diagnostic was generated, respecting [`#[track_caller]`][track_caller]. Note that this may be different from the place it was emitted.
+For full documentation, see [the rustc-dev-guide][dev-guide-track-diagnostics].
+
+[track_caller]: https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute
+[dev-guide-track-diagnostics]: https://rustc-dev-guide.rust-lang.org/compiler-debugging.html#getting-the-error-creation-location

--- a/src/doc/unstable-book/src/compiler-flags/treat-err-as-bug.md
+++ b/src/doc/unstable-book/src/compiler-flags/treat-err-as-bug.md
@@ -1,0 +1,13 @@
+# `treat-err-as-bug`
+
+This feature is perma-unstable and has no tracking issue.
+
+------------------------
+
+This flag converts the selected error to a [`bug!`] call, exiting the compiler immediately and allowing you to generate a backtrace of where the error occurred.
+For full documentation, see [the rustc-dev-guide][dev-guide-backtrace].
+
+Note that the compiler automatically sets `RUST_BACKTRACE=1` for itself, and so you do not need to set it yourself when using this flag.
+
+[`bug!`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/macro.bug.html
+[dev-guide-backtrace]: https://rustc-dev-guide.rust-lang.org/compiler-debugging.html#getting-a-backtrace-for-errors


### PR DESCRIPTION
i was looking for these but didn't find them at first; add a breadcrumb so people know where to look

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
