### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ and we appreciate all of them.
 
 The best way to get started is by asking for help in the [#new
 members](https://rust-lang.zulipchat.com/#narrow/stream/122652-new-members)
-Zulip stream. We have lots of docs below of how to get started on your own, but
+Zulip stream. We have a lot of documentation below on how to get started on your own, but
 the Zulip stream is the best place to *ask* for help.
 
 Documentation for contributing to the compiler or tooling is located in the [Guide to Rustc
@@ -14,7 +14,7 @@ standard library in the [Standard library developers Guide][std-dev-guide], comm
 
 ## Making changes to subtrees and submodules
 
-For submodules, changes need to be made against the repository corresponding the
+For submodules, changes need to be made against the repository corresponding to the
 submodule, and not the main `rust-lang/rust` repository.
 
 For subtrees, prefer sending a PR against the subtree's repository if it does
@@ -25,7 +25,7 @@ rustc-dev-guide change that does not accompany a compiler change).
 
 The [rustc-dev-guide] is meant to help document how rustc –the Rust compiler– works,
 as well as to help new contributors get involved in rustc development. It is recommended
-to read and understand the [rustc-dev-guide] before making a contribution. This guide
+that you read and understand the [rustc-dev-guide] before making a contribution. This guide
 talks about the different bots in the Rust ecosystem, the Rust development tools,
 bootstrapping, the compiler architecture, source code representation, and more.
 
@@ -33,7 +33,7 @@ bootstrapping, the compiler architecture, source code representation, and more.
 
 There are many ways you can get help when you're stuck. Rust has many platforms for this:
 [internals], [rust-zulip], and [rust-discord]. It is recommended to ask for help on
-the [rust-zulip], but any of these platforms are a great way to seek help and even
+the [rust-zulip], but any of these platforms are great ways to seek help and even
 find a mentor! You can learn more about asking questions and getting help in the
 [Asking Questions](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions) chapter of the [rustc-dev-guide].
 

--- a/compiler/rustc_attr_data_structures/src/version.rs
+++ b/compiler/rustc_attr_data_structures/src/version.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display};
+use std::sync::OnceLock;
 
 use rustc_macros::{
     Decodable, Encodable, HashStable_Generic, PrintAttribute, current_rustc_version,
@@ -16,7 +17,28 @@ pub struct RustcVersion {
 
 impl RustcVersion {
     pub const CURRENT: Self = current_rustc_version!();
+    pub fn current_overridable() -> Self {
+        *CURRENT_OVERRIDABLE.get_or_init(|| {
+            if let Ok(override_var) = std::env::var("RUSTC_OVERRIDE_VERSION_STRING")
+                && let Some(override_) = Self::parse_str(&override_var)
+            {
+                override_
+            } else {
+                Self::CURRENT
+            }
+        })
+    }
+    fn parse_str(value: &str) -> Option<Self> {
+        // Ignore any suffixes such as "-dev" or "-nightly".
+        let mut components = value.split('-').next().unwrap().splitn(3, '.');
+        let major = components.next()?.parse().ok()?;
+        let minor = components.next()?.parse().ok()?;
+        let patch = components.next().unwrap_or("0").parse().ok()?;
+        Some(RustcVersion { major, minor, patch })
+    }
 }
+
+static CURRENT_OVERRIDABLE: OnceLock<RustcVersion> = OnceLock::new();
 
 impl Display for RustcVersion {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -129,9 +129,9 @@ pub fn eval_condition(
 
             // See https://github.com/rust-lang/rust/issues/64796#issuecomment-640851454 for details
             if sess.psess.assume_incomplete_release {
-                RustcVersion::CURRENT > min_version
+                RustcVersion::current_overridable() > min_version
             } else {
-                RustcVersion::CURRENT >= min_version
+                RustcVersion::current_overridable() >= min_version
             }
         }
         MetaItemKind::List(mis) => {

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -835,6 +835,7 @@ lint_unexpected_cfg_name_similar_name = there is a config with a similar name
 lint_unexpected_cfg_name_similar_name_different_values = there is a config with a similar name and different values
 lint_unexpected_cfg_name_similar_name_no_value = there is a config with a similar name and no value
 lint_unexpected_cfg_name_similar_name_value = there is a config with a similar name and value
+lint_unexpected_cfg_name_version_syntax = there is a similar config predicate: `version("..")`
 lint_unexpected_cfg_name_with_similar_value = found config with similar value
 
 lint_unexpected_cfg_value = unexpected `cfg` condition value: {$has_value ->

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -140,6 +140,14 @@ pub(super) fn unexpected_cfg_name(
 
     let code_sugg = if is_feature_cfg && is_from_cargo {
         lints::unexpected_cfg_name::CodeSuggestion::DefineFeatures
+    // Suggest correct `version("..")` predicate syntax
+    } else if let Some((_value, value_span)) = value
+        && name == sym::version
+    {
+        lints::unexpected_cfg_name::CodeSuggestion::VersionSyntax {
+            between_name_and_value: name_span.between(value_span),
+            after_value: value_span.shrink_to_hi(),
+        }
     // Suggest the most probable if we found one
     } else if let Some(best_match) = find_best_match_for_name(&possibilities, name, None) {
         is_feature_cfg |= best_match == sym::feature;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2273,6 +2273,16 @@ pub(crate) mod unexpected_cfg_name {
     pub(crate) enum CodeSuggestion {
         #[help(lint_unexpected_cfg_define_features)]
         DefineFeatures,
+        #[multipart_suggestion(
+            lint_unexpected_cfg_name_version_syntax,
+            applicability = "machine-applicable"
+        )]
+        VersionSyntax {
+            #[suggestion_part(code = "(")]
+            between_name_and_value: Span,
+            #[suggestion_part(code = ")")]
+            after_value: Span,
+        },
         #[suggestion(
             lint_unexpected_cfg_name_similar_name_value,
             applicability = "maybe-incorrect",

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -382,6 +382,9 @@ fn extend_type_not_partial_eq<'tcx>(
         fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
             match ty.kind() {
                 ty::Dynamic(..) => return ControlFlow::Break(()),
+                // Unsafe binders never implement `PartialEq`, so avoid walking into them
+                // which would require instantiating its binder with placeholders too.
+                ty::UnsafeBinder(..) => return ControlFlow::Break(()),
                 ty::FnPtr(..) => return ControlFlow::Continue(()),
                 ty::Adt(def, _args) => {
                     let ty_def_id = def.did();

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -202,8 +202,6 @@ fn home_dir_crt() -> Option<PathBuf> {
             |buf, mut sz| {
                 // GetUserProfileDirectoryW does not quite use the usual protocol for
                 // negotiating the buffer size, so we have to translate.
-                // FIXME(#141254): We rely on the *undocumented* property that this function will
-                // always set the size, not just on failure.
                 match c::GetUserProfileDirectoryW(
                     ptr::without_provenance_mut(CURRENT_PROCESS_TOKEN),
                     buf,

--- a/src/doc/rustc/src/platform-support/solaris.md
+++ b/src/doc/rustc/src/platform-support/solaris.md
@@ -8,6 +8,7 @@ Rust for Solaris operating system.
 ## Target maintainers
 
 [@psumbera](https://github.com/psumbera)
+[@kulikjak](https://github.com/kulikjak)
 
 ## Requirements
 

--- a/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
+++ b/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
@@ -42,30 +42,6 @@ LL |     async fn async_dispatch(self: Pin<&mut Self>) -> Self::Output;
    = help: consider moving `async_dispatch` to another trait
    = note: required for the cast from `Pin<&mut {async block@$DIR/mut-is-pointer-like.rs:32:32: 32:37}>` to `Pin<&mut dyn AsyncTrait<Output = ()>>`
 
-error[E0277]: the trait bound `dyn AsyncTrait<Output = ()>: AsyncTrait` is not satisfied
-  --> $DIR/mut-is-pointer-like.rs:36:11
-   |
-LL |         x.async_dispatch().await;
-   |           ^^^^^^^^^^^^^^ the trait `AsyncTrait` is not implemented for `dyn AsyncTrait<Output = ()>`
+error: aborting due to 2 previous errors; 1 warning emitted
 
-error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/mut-is-pointer-like.rs:36:9
-   |
-LL |         x.async_dispatch().await;
-   |         ^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/mut-is-pointer-like.rs:16:14
-   |
-LL | trait AsyncTrait {
-   |       ---------- this trait is not dyn compatible...
-...
-LL |     async fn async_dispatch(self: Pin<&mut Self>) -> Self::Output;
-   |              ^^^^^^^^^^^^^^ ...because method `async_dispatch` is `async`
-   = help: consider moving `async_dispatch` to another trait
-
-error: aborting due to 4 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0038, E0277.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/async-await/dyn/works.stderr
+++ b/tests/ui/async-await/dyn/works.stderr
@@ -42,40 +42,6 @@ LL |     async fn async_dispatch(&self);
    = help: consider moving `async_dispatch` to another trait
    = help: only type `&'static str` implements `AsyncTrait`; consider using it directly instead.
 
-error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/works.rs:28:11
-   |
-LL |         x.async_dispatch().await;
-   |           ^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/works.rs:14:14
-   |
-LL | trait AsyncTrait {
-   |       ---------- this trait is not dyn compatible...
-LL |     async fn async_dispatch(&self);
-   |              ^^^^^^^^^^^^^^ ...because method `async_dispatch` is `async`
-   = help: consider moving `async_dispatch` to another trait
-   = help: only type `&'static str` implements `AsyncTrait`; consider using it directly instead.
-
-error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/works.rs:28:9
-   |
-LL |         x.async_dispatch().await;
-   |         ^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/works.rs:14:14
-   |
-LL | trait AsyncTrait {
-   |       ---------- this trait is not dyn compatible...
-LL |     async fn async_dispatch(&self);
-   |              ^^^^^^^^^^^^^^ ...because method `async_dispatch` is `async`
-   = help: consider moving `async_dispatch` to another trait
-   = help: only type `&'static str` implements `AsyncTrait`; consider using it directly instead.
-
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/check-cfg/wrong-version-syntax.fixed
+++ b/tests/ui/check-cfg/wrong-version-syntax.fixed
@@ -1,0 +1,14 @@
+// Check warning for wrong `cfg(version("1.27"))` syntax
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+//@ run-rustfix
+
+#![feature(cfg_version)]
+
+#[cfg(not(version("1.48.0")))]
+//~^ WARNING unexpected `cfg` condition name: `version`
+pub fn g() {}
+
+pub fn main() {}

--- a/tests/ui/check-cfg/wrong-version-syntax.rs
+++ b/tests/ui/check-cfg/wrong-version-syntax.rs
@@ -1,0 +1,14 @@
+// Check warning for wrong `cfg(version("1.27"))` syntax
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+//@ run-rustfix
+
+#![feature(cfg_version)]
+
+#[cfg(not(version = "1.48.0"))]
+//~^ WARNING unexpected `cfg` condition name: `version`
+pub fn g() {}
+
+pub fn main() {}

--- a/tests/ui/check-cfg/wrong-version-syntax.stderr
+++ b/tests/ui/check-cfg/wrong-version-syntax.stderr
@@ -1,0 +1,17 @@
+warning: unexpected `cfg` condition name: `version`
+  --> $DIR/wrong-version-syntax.rs:10:11
+   |
+LL | #[cfg(not(version = "1.48.0"))]
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(version, values("1.48.0"))`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+help: there is a similar config predicate: `version("..")`
+   |
+LL - #[cfg(not(version = "1.48.0"))]
+LL + #[cfg(not(version("1.48.0")))]
+   |
+
+warning: 1 warning emitted
+

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.rs
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.rs
@@ -15,7 +15,7 @@ impl Foo for () {
 }
 
 fn use_dyn(v: &dyn Foo) { //~ERROR the trait `Foo` is not dyn compatible
-    v.test(); //~ERROR the trait `Foo` is not dyn compatible
+    v.test();
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.stderr
@@ -17,25 +17,6 @@ LL |     fn test(&self) -> [u8; bar::<Self>()];
    = help: consider moving `test` to another trait
    = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility-err-ret.rs:18:5
-   |
-LL |     v.test();
-   |     ^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-compatibility-err-ret.rs:8:8
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     fn test(&self) -> [u8; bar::<Self>()];
-   |        ^^^^           ^^^^^^^^^^^^^^^^^^^ ...because method `test` references the `Self` type in its return type
-   |        |
-   |        ...because method `test` references the `Self` type in its `where` clause
-   = help: consider moving `test` to another trait
-   = help: only type `()` implements `Foo`; consider using it directly instead.
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.rs
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.rs
@@ -15,7 +15,6 @@ impl Foo for () {
 fn use_dyn(v: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     v.test();
-    //~^ ERROR the trait `Foo` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.stderr
@@ -15,23 +15,6 @@ LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
    = help: consider moving `test` to another trait
    = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility-err-where-bounds.rs:17:5
-   |
-LL |     v.test();
-   |     ^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-compatibility-err-where-bounds.rs:8:8
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
-   |        ^^^^ ...because method `test` references the `Self` type in its `where` clause
-   = help: consider moving `test` to another trait
-   = help: only type `()` implements `Foo`; consider using it directly instead.
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.rs
+++ b/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.rs
@@ -25,5 +25,4 @@ pub fn foo() {
     let fetcher = fetcher();
     //~^ ERROR the trait `Fetcher` is not dyn compatible
     let _ = fetcher.get();
-    //~^ ERROR the trait `Fetcher` is not dyn compatible
 }

--- a/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.stderr
+++ b/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.stderr
@@ -34,24 +34,6 @@ LL | pub trait Fetcher: Send + Sync {
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
 
-error[E0038]: the trait `Fetcher` is not dyn compatible
-  --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:27:13
-   |
-LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
-   |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
-...
-LL |     let _ = fetcher.get();
-   |             ^^^^^^^^^^^^^ `Fetcher` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:11:22
-   |
-LL | pub trait Fetcher: Send + Sync {
-   |           ------- this trait is not dyn compatible...
-LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
-   |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/error-codes/E0038.rs
+++ b/tests/ui/error-codes/E0038.rs
@@ -5,8 +5,6 @@ trait Trait {
 fn call_foo(x: Box<dyn Trait>) {
     //~^ ERROR E0038
     let y = x.foo();
-    //~^ ERROR E0038
-    //~| ERROR E0277
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -14,33 +14,6 @@ LL |     fn foo(&self) -> Self;
    |                      ^^^^ ...because method `foo` references the `Self` type in its return type
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/E0038.rs:7:13
-   |
-LL |     let y = x.foo();
-   |             ^^^^^^^ `Trait` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/E0038.rs:2:22
-   |
-LL | trait Trait {
-   |       ----- this trait is not dyn compatible...
-LL |     fn foo(&self) -> Self;
-   |                      ^^^^ ...because method `foo` references the `Self` type in its return type
-   = help: consider moving `foo` to another trait
+error: aborting due to 1 previous error
 
-error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
-  --> $DIR/E0038.rs:7:9
-   |
-LL |     let y = x.foo();
-   |         ^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `dyn Trait`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0038, E0277.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/feature-gates/cfg-version-expand.rs
+++ b/tests/ui/feature-gates/cfg-version-expand.rs
@@ -1,0 +1,30 @@
+//@ run-pass
+//@ rustc-env:RUSTC_OVERRIDE_VERSION_STRING=1.50.3
+
+#![feature(cfg_version)]
+
+#[cfg(version("1.49.0"))]
+const ON_1_49_0: bool = true;
+#[cfg(version("1.50"))]
+const ON_1_50_0: bool = true;
+#[cfg(not(version("1.51")))]
+const ON_1_51_0: bool = false;
+
+// This one uses the wrong syntax, so doesn't eval to true
+#[warn(unexpected_cfgs)]
+#[cfg(not(version = "1.48.0"))] //~ WARN unexpected `cfg` condition name: `version`
+const ON_1_48_0: bool = false;
+
+fn main() {
+    assert!(!ON_1_48_0);
+    assert!(ON_1_49_0);
+    assert!(ON_1_50_0);
+    assert!(!ON_1_51_0);
+    assert!(cfg!(version("1.1")));
+    assert!(cfg!(version("1.49")));
+    assert!(cfg!(version("1.50.0")));
+    assert!(cfg!(version("1.50.3")));
+    assert!(!cfg!(version("1.50.4")));
+    assert!(!cfg!(version("1.51")));
+    assert!(!cfg!(version("1.100")));
+}

--- a/tests/ui/feature-gates/cfg-version-expand.stderr
+++ b/tests/ui/feature-gates/cfg-version-expand.stderr
@@ -1,0 +1,13 @@
+warning: unexpected `cfg` condition name: `version`
+  --> $DIR/cfg-version-expand.rs:15:11
+   |
+LL | #[cfg(not(version = "1.48.0"))]
+   |           ^^^^^^^^^^^^^^^^^^
+   |
+   = help: expected names are: `FALSE` and `test` and 31 more
+   = help: to expect this configuration use `--check-cfg=cfg(version, values("1.48.0"))`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.rs
+++ b/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.rs
@@ -7,8 +7,6 @@ trait Foo {
 async fn takes_dyn_trait(x: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     x.bar().await;
-    //~^ ERROR the trait `Foo` is not dyn compatible
-    //~| ERROR the trait `Foo` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.stderr
+++ b/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.stderr
@@ -14,38 +14,6 @@ LL |     async fn bar(&self);
    |              ^^^ ...because method `bar` is `async`
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:9:7
-   |
-LL |     x.bar().await;
-   |       ^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:4:14
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     async fn bar(&self);
-   |              ^^^ ...because method `bar` is `async`
-   = help: consider moving `bar` to another trait
-
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:9:5
-   |
-LL |     x.bar().await;
-   |     ^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:4:14
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     async fn bar(&self);
-   |              ^^^ ...because method `bar` is `async`
-   = help: consider moving `bar` to another trait
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/trait-objects.rs
+++ b/tests/ui/generic-associated-types/trait-objects.rs
@@ -8,8 +8,6 @@ trait StreamingIterator {
 fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
     //~^ ERROR the trait `StreamingIterator` is not dyn compatible
     x.size_hint().0
-    //~^ ERROR the trait `StreamingIterator` is not dyn compatible
-    //~| ERROR the trait `StreamingIterator` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/trait-objects.stderr
+++ b/tests/ui/generic-associated-types/trait-objects.stderr
@@ -14,38 +14,6 @@ LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error[E0038]: the trait `StreamingIterator` is not dyn compatible
-  --> $DIR/trait-objects.rs:10:7
-   |
-LL |     x.size_hint().0
-   |       ^^^^^^^^^ `StreamingIterator` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/trait-objects.rs:2:10
-   |
-LL | trait StreamingIterator {
-   |       ----------------- this trait is not dyn compatible...
-LL |     type Item<'a> where Self: 'a;
-   |          ^^^^ ...because it contains the generic associated type `Item`
-   = help: consider moving `Item` to another trait
-
-error[E0038]: the trait `StreamingIterator` is not dyn compatible
-  --> $DIR/trait-objects.rs:10:5
-   |
-LL |     x.size_hint().0
-   |     ^^^^^^^^^^^^^ `StreamingIterator` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/trait-objects.rs:2:10
-   |
-LL | trait StreamingIterator {
-   |       ----------------- this trait is not dyn compatible...
-LL |     type Item<'a> where Self: 'a;
-   |          ^^^^ ...because it contains the generic associated type `Item`
-   = help: consider moving `Item` to another trait
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.rs
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.rs
@@ -15,6 +15,4 @@ fn main() {
     //~^ ERROR the trait `Foo` is not dyn compatible
     //~| ERROR the trait `Foo` is not dyn compatible
     let s = i.baz();
-    //~^ ERROR the trait `Foo` is not dyn compatible
-    //~| ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
@@ -16,40 +16,6 @@ LL |     fn baz(&self) -> impl Debug;
    = help: only type `u32` implements `Foo`; consider using it directly instead.
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:17:15
-   |
-LL |     let s = i.baz();
-   |               ^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-compatibility.rs:4:22
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     fn baz(&self) -> impl Debug;
-   |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
-   = help: consider moving `baz` to another trait
-   = help: only type `u32` implements `Foo`; consider using it directly instead.
-
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:17:13
-   |
-LL |     let s = i.baz();
-   |             ^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-compatibility.rs:4:22
-   |
-LL | trait Foo {
-   |       --- this trait is not dyn compatible...
-LL |     fn baz(&self) -> impl Debug;
-   |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
-   = help: consider moving `baz` to another trait
-   = help: only type `u32` implements `Foo`; consider using it directly instead.
-
-error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:14:13
    |
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
@@ -67,6 +33,6 @@ LL |     fn baz(&self) -> impl Debug;
    = help: only type `u32` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Box<u32>` to `Box<dyn Foo>`
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/issues/issue-18959.rs
+++ b/tests/ui/issues/issue-18959.rs
@@ -11,7 +11,6 @@ impl Foo for Thing {
 fn foo(b: &dyn Bar) {
     //~^ ERROR E0038
     b.foo(&0)
-    //~^ ERROR E0038
 }
 
 fn main() {

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -15,23 +15,7 @@ LL | pub trait Bar: Foo { }
    = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-18959.rs:13:5
-   |
-LL |     b.foo(&0)
-   |     ^^^^^^^^^ `Bar` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/issue-18959.rs:1:20
-   |
-LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
-   |                    ^^^ ...because method `foo` has generic type parameters
-LL | pub trait Bar: Foo { }
-   |           --- this trait is not dyn compatible...
-   = help: consider moving `foo` to another trait
-
-error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-18959.rs:19:26
+  --> $DIR/issue-18959.rs:18:26
    |
 LL |     let test: &dyn Bar = &mut thing;
    |                          ^^^^^^^^^^ `Bar` is not dyn compatible
@@ -48,7 +32,7 @@ LL | pub trait Bar: Foo { }
    = note: required for the cast from `&mut Thing` to `&dyn Bar`
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-18959.rs:19:15
+  --> $DIR/issue-18959.rs:18:15
    |
 LL |     let test: &dyn Bar = &mut thing;
    |               ^^^^^^^^ `Bar` is not dyn compatible
@@ -63,6 +47,6 @@ LL | pub trait Bar: Foo { }
    |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -1,0 +1,18 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/141419>.
+
+use std::ops::Deref;
+
+struct W;
+
+trait Foo: Deref<Target = W> {
+    fn method(self: &W) {}
+    //~^ ERROR invalid `self` parameter type: `&W`
+}
+
+fn test(x: &dyn Foo) {
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    x.method();
+    //~^ ERROR the trait `Foo` is not dyn compatible
+}
+
+fn main() {}

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -1,0 +1,49 @@
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:12:13
+   |
+LL |     fn method(self: &W) {}
+   |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
+...
+LL | fn test(x: &dyn Foo) {
+   |             ^^^^^^^ `Foo` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+   |
+LL | trait Foo: Deref<Target = W> {
+   |       --- this trait is not dyn compatible...
+LL |     fn method(self: &W) {}
+   |                     ^^ ...because method `method`'s `self` parameter cannot be dispatched on
+
+error[E0307]: invalid `self` parameter type: `&W`
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+   |
+LL |     fn method(self: &W) {}
+   |                     ^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:5
+   |
+LL |     fn method(self: &W) {}
+   |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
+...
+LL |     x.method();
+   |     ^^^^^^^^^^ `Foo` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
+   |
+LL | trait Foo: Deref<Target = W> {
+   |       --- this trait is not dyn compatible...
+LL |     fn method(self: &W) {}
+   |                     ^^ ...because method `method`'s `self` parameter cannot be dispatched on
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0307.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/test-2.rs
+++ b/tests/ui/traits/test-2.rs
@@ -13,5 +13,4 @@ fn main() {
     (Box::new(10) as Box<dyn bar>).dup();
     //~^ ERROR E0038
     //~| ERROR E0038
-    //~| ERROR E0038
 }

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -50,29 +50,6 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
            implementing `bar` for this new enum and using it instead
 
 error[E0038]: the trait `bar` is not dyn compatible
-  --> $DIR/test-2.rs:13:5
-   |
-LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/test-2.rs:4:30
-   |
-LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
-   |       ---                    ^^^^     ^^^^ ...because method `blah` has generic type parameters
-   |       |                      |
-   |       |                      ...because method `dup` references the `Self` type in its return type
-   |       this trait is not dyn compatible...
-   = help: consider moving `dup` to another trait
-   = help: consider moving `blah` to another trait
-   = help: the following types implement `bar`:
-             i32
-             u32
-           consider defining an enum where each variant holds one of these types,
-           implementing `bar` for this new enum and using it instead
-
-error[E0038]: the trait `bar` is not dyn compatible
   --> $DIR/test-2.rs:13:6
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
@@ -96,7 +73,7 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
            implementing `bar` for this new enum and using it instead
    = note: required for the cast from `Box<{integer}>` to `Box<dyn bar>`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0038, E0107.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/unsafe-binders/non-strucutral-type-diag.rs
+++ b/tests/ui/unsafe-binders/non-strucutral-type-diag.rs
@@ -1,0 +1,17 @@
+// regression test for <https://github.com/rust-lang/rust/issues/141422>.
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+#[derive(Copy, Clone)]
+struct Adt<'a>(&'a ());
+
+const C: Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)> = None;
+
+fn main() {
+    match None {
+        C => {}
+        //~^ ERROR constant of non-structural type
+        _ => {}
+    }
+}

--- a/tests/ui/unsafe-binders/non-strucutral-type-diag.stderr
+++ b/tests/ui/unsafe-binders/non-strucutral-type-diag.stderr
@@ -1,0 +1,13 @@
+error: constant of non-structural type `Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)>` in a pattern
+  --> $DIR/non-strucutral-type-diag.rs:13:9
+   |
+LL | const C: Option<(unsafe<'a> Adt<'a>, Box<dyn Send>)> = None;
+   | ---------------------------------------------------- constant defined here
+...
+LL |         C => {}
+   |         ^ constant of non-structural type
+   |
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
+
+error: aborting due to 1 previous error
+

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -44,8 +44,6 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
-[glacier]
-
 [ping.icebreakers-llvm]
 message = """\
 Hey LLVM ICE-breakers! This bug has been identified as a good


### PR DESCRIPTION
Successful merges:

 - #141405 (GetUserProfileDirectoryW is now documented to always store the size)
 - #141413 (Make #[cfg(version)] respect RUSTC_OVERRIDE_VERSION_STRING)
 - #141427 (Disable `triagebot`'s `glacier` handler)
 - #141429 (Dont walk into unsafe binders when emiting error for non-structural type match)
 - #141438 (Do not try to confirm non-dyn compatible method)
 - #141444 (Improve CONTRIBUTING.md grammar and clarity)
 - #141446 (Add 2nd Solaris target maintainer)
 - #141456 (Suggest correct `version("..")` predicate syntax in check-cfg)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141405,141413,141427,141429,141438,141444,141446,141456)
<!-- homu-ignore:end -->