### PR TITLE
mir-opt: Do not create storage marks in EarlyOtherwiseBranch

### DIFF
--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -128,15 +128,10 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
 
             let mut patch = MirPatch::new(body);
 
-            let (second_discriminant_temp, second_operand) = if opt_data.need_hoist_discriminant {
+            let second_operand = if opt_data.need_hoist_discriminant {
                 // create temp to store second discriminant in, `_s` in example above
                 let second_discriminant_temp =
                     patch.new_temp(opt_data.child_ty, opt_data.child_source.span);
-
-                patch.add_statement(
-                    parent_end,
-                    StatementKind::StorageLive(second_discriminant_temp),
-                );
 
                 // create assignment of discriminant
                 patch.add_assign(
@@ -144,12 +139,9 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
                     Place::from(second_discriminant_temp),
                     Rvalue::Discriminant(opt_data.child_place),
                 );
-                (
-                    Some(second_discriminant_temp),
-                    Operand::Move(Place::from(second_discriminant_temp)),
-                )
+                Operand::Move(Place::from(second_discriminant_temp))
             } else {
-                (None, Operand::Copy(opt_data.child_place))
+                Operand::Copy(opt_data.child_place)
             };
 
             // create temp to store inequality comparison between the two discriminants, `_t` in
@@ -157,7 +149,6 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
             let nequal = BinOp::Ne;
             let comp_res_type = nequal.ty(tcx, parent_ty, opt_data.child_ty);
             let comp_temp = patch.new_temp(comp_res_type, opt_data.child_source.span);
-            patch.add_statement(parent_end, StatementKind::StorageLive(comp_temp));
 
             // create inequality comparison
             let comp_rvalue =
@@ -193,41 +184,12 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
             let eq_bb = patch.new_block(eq_switch);
 
             // Jump to it on the basis of the inequality comparison
-            let mut true_case = opt_data.destination;
-            let mut false_case = eq_bb;
-            // Create an indirect BB to add `StorageDead` If the jump target is itself.
-            for bb in [&mut false_case, &mut true_case].into_iter() {
-                if *bb == parent {
-                    *bb = patch.new_block(BasicBlockData::new(
-                        Some(Terminator {
-                            kind: TerminatorKind::Goto { target: parent },
-                            source_info: bbs[parent].terminator().source_info,
-                        }),
-                        bbs[parent].is_cleanup,
-                    ));
-                }
-            }
+            let true_case = opt_data.destination;
+            let false_case = eq_bb;
             patch.patch_terminator(
                 parent,
                 TerminatorKind::if_(Operand::Move(Place::from(comp_temp)), true_case, false_case),
             );
-
-            if let Some(second_discriminant_temp) = second_discriminant_temp {
-                // generate StorageDead for the second_discriminant_temp not in use anymore
-                patch.add_statement(
-                    parent_end,
-                    StatementKind::StorageDead(second_discriminant_temp),
-                );
-            }
-
-            // Generate a StorageDead for comp_temp in each of the targets, since we moved it into
-            // the switch
-            for bb in [false_case, true_case].into_iter() {
-                patch.add_statement(
-                    Location { block: bb, statement_index: 0 },
-                    StatementKind::StorageDead(comp_temp),
-                );
-            }
 
             patch.apply(body);
         }

--- a/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -32,16 +32,12 @@
           StorageDead(_4);
           _9 = discriminant((_3.0: Option2<u32>));
 -         switchInt(move _9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
-+         StorageLive(_12);
 +         _12 = discriminant((_3.1: Option2<bool>));
-+         StorageLive(_13);
 +         _13 = Ne(copy _9, move _12);
-+         StorageDead(_12);
 +         switchInt(move _13) -> [0: bb7, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_13);
           _0 = const 1_u32;
 -         goto -> bb8;
 +         goto -> bb5;
@@ -100,7 +96,6 @@
 +     }
 + 
 +     bb7: {
-+         StorageDead(_13);
 +         switchInt(copy _9) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb6];
       }
   }

--- a/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
@@ -32,16 +32,12 @@
           StorageDead(_4);
           _9 = discriminant((_3.0: Option2<u32>));
 -         switchInt(move _9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
-+         StorageLive(_12);
 +         _12 = discriminant((_3.1: Option2<u32>));
-+         StorageLive(_13);
 +         _13 = Ne(copy _9, move _12);
-+         StorageDead(_12);
 +         switchInt(move _13) -> [0: bb7, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_13);
           _0 = const 1_u32;
 -         goto -> bb8;
 +         goto -> bb5;
@@ -100,7 +96,6 @@
 +     }
 + 
 +     bb7: {
-+         StorageDead(_13);
 +         switchInt(copy _9) -> [0: bb4, 1: bb3, 2: bb2, otherwise: bb6];
       }
   }

--- a/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
@@ -20,13 +20,11 @@
           StorageDead(_5);
           StorageDead(_4);
 -         switchInt(copy (_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
-+         StorageLive(_6);
 +         _6 = Ne(copy (_3.0: u32), copy (_3.1: u32));
 +         switchInt(move _6) -> [0: bb6, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_6);
           _0 = const 0_u32;
 -         goto -> bb8;
 +         goto -> bb5;
@@ -70,7 +68,6 @@
 -     bb8: {
 -         StorageDead(_3);
 -         return;
-+         StorageDead(_6);
 +         switchInt(copy (_3.0: u32)) -> [1: bb4, 2: bb3, 3: bb2, otherwise: bb1];
       }
   }

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -1,6 +1,10 @@
 //@ test-mir-pass: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UnreachableEnumBranching
 
+#![feature(custom_mir, core_intrinsics)]
+
+use std::intrinsics::mir::*;
+
 enum Option2<T> {
     Some(T),
     None,
@@ -124,6 +128,32 @@ fn opt5_failed_type(x: u32, y: u64) -> u32 {
     }
 }
 
+// EMIT_MIR early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
+#[custom_mir(dialect = "runtime")]
+fn target_self(val: i32) {
+    // CHECK-LABEL: fn target_self(
+    mir! {
+        {
+            Goto(bb1)
+        }
+        bb1 = {
+            match val {
+                0 => bb2,
+                _ => bb1,
+            }
+        }
+        bb2 = {
+            match val {
+                0 => bb3,
+                _ => bb1,
+            }
+        }
+        bb3 = {
+            Return()
+        }
+    }
+}
+
 fn main() {
     opt1(None, Some(0));
     opt2(None, Some(0));
@@ -131,4 +161,5 @@ fn main() {
     opt4(Option2::None, Option2::Some(0));
     opt5(0, 0);
     opt5_failed(0, 0);
+    target_self(1);
 }

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -132,6 +132,8 @@ fn opt5_failed_type(x: u32, y: u64) -> u32 {
 #[custom_mir(dialect = "runtime")]
 fn target_self(val: i32) {
     // CHECK-LABEL: fn target_self(
+    // CHECK: Ne(
+    // CHECK-NEXT: switchInt
     mir! {
         {
             Goto(bb1)

--- a/tests/mir-opt/early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
@@ -1,0 +1,35 @@
+- // MIR for `target_self` before EarlyOtherwiseBranch
++ // MIR for `target_self` after EarlyOtherwiseBranch
+  
+  fn target_self(_1: i32) -> () {
+      let mut _0: ();
++     let mut _2: bool;
+  
+      bb0: {
+          goto -> bb1;
+      }
+  
+      bb1: {
+-         switchInt(copy _1) -> [0: bb2, otherwise: bb1];
++         StorageLive(_2);
++         _2 = Ne(copy _1, copy _1);
++         switchInt(move _2) -> [0: bb3, otherwise: bb4];
+      }
+  
+      bb2: {
+-         switchInt(copy _1) -> [0: bb3, otherwise: bb1];
++         return;
+      }
+  
+      bb3: {
+-         return;
++         StorageDead(_2);
++         switchInt(copy _1) -> [0: bb2, otherwise: bb1];
++     }
++ 
++     bb4: {
++         StorageDead(_2);
++         goto -> bb1;
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
@@ -11,9 +11,8 @@
   
       bb1: {
 -         switchInt(copy _1) -> [0: bb2, otherwise: bb1];
-+         StorageLive(_2);
 +         _2 = Ne(copy _1, copy _1);
-+         switchInt(move _2) -> [0: bb3, otherwise: bb4];
++         switchInt(move _2) -> [0: bb3, otherwise: bb1];
       }
   
       bb2: {
@@ -23,13 +22,7 @@
   
       bb3: {
 -         return;
-+         StorageDead(_2);
 +         switchInt(copy _1) -> [0: bb2, otherwise: bb1];
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_2);
-+         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt2.EarlyOtherwiseBranch.diff
@@ -42,16 +42,12 @@
           StorageDead(_5);
           _14 = discriminant((_4.0: Option2<u32>));
 -         switchInt(move _14) -> [0: bb2, 1: bb4, 2: bb6, otherwise: bb12];
-+         StorageLive(_18);
 +         _18 = discriminant((_4.1: Option2<u32>));
-+         StorageLive(_19);
 +         _19 = Ne(copy _14, move _18);
-+         StorageDead(_18);
 +         switchInt(move _19) -> [0: bb10, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_19);
           _0 = const 1_u32;
 -         goto -> bb11;
 +         goto -> bb8;
@@ -134,7 +130,6 @@
 +     }
 + 
 +     bb10: {
-+         StorageDead(_19);
 +         switchInt(copy _14) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
       }
   }


### PR DESCRIPTION
Fixes #141212.

The first commit add `StorageDead` by creating new indirect BB that makes CFG more complicated, but I think it's better to just not create storage marks.

r? mir-opt