### PR TITLE
Enable `[issue-links]` and `[no-mentions]` in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1425,3 +1425,12 @@ compiletest = [
 
 [behind-upstream]
 days-threshold = 14
+
+# Canonicalize issue numbers to avoid closing the wrong issue
+# when commits are included in subtrees, as well as warning links in commits.
+# Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
+[issue-links]
+
+# Prevents mentions in commits to avoid users being spammed
+# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
+[no-mentions]


### PR DESCRIPTION
This PR enables the [`[issue-links]`](https://forge.rust-lang.org/triagebot/issue-links.html) and [`[no-mentions]`](https://forge.rust-lang.org/triagebot/no-mentions.html) handlers of triagebot.

Most of our subtrees have already adopted them:
 - https://github.com/rust-lang/rust-analyzer/pull/19555
 - https://github.com/rust-lang/rust-clippy/pull/14563 & https://github.com/rust-lang/rust-clippy/pull/14576
 - https://github.com/rust-lang/rustc-dev-guide/pull/2335
 - https://github.com/rust-lang/miri/pull/4259
 - https://github.com/rust-lang/reference/pull/1788

r? @Kobzol 
