### PR TITLE
Use C-string literals to reduce boilerplate

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -511,13 +511,8 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
-    ///
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").unwrap();
-    /// assert_eq!(cstr.count_bytes(), 3);
-    ///
-    /// let cstr = CStr::from_bytes_with_nul(b"\0").unwrap();
-    /// assert_eq!(cstr.count_bytes(), 0);
+    /// assert_eq!(c"foo".count_bytes(), 3);
+    /// assert_eq!(c"".count_bytes(), 0);
     /// ```
     #[inline]
     #[must_use]
@@ -533,19 +528,8 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
-    /// # use std::ffi::FromBytesWithNulError;
-    ///
-    /// # fn main() { test().unwrap(); }
-    /// # fn test() -> Result<(), FromBytesWithNulError> {
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0")?;
-    /// assert!(!cstr.is_empty());
-    ///
-    /// let empty_cstr = CStr::from_bytes_with_nul(b"\0")?;
-    /// assert!(empty_cstr.is_empty());
+    /// assert!(!c"foo".is_empty());
     /// assert!(c"".is_empty());
-    /// # Ok(())
-    /// # }
     /// ```
     #[inline]
     #[stable(feature = "cstr_is_empty", since = "1.71.0")]
@@ -569,10 +553,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
-    ///
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
-    /// assert_eq!(cstr.to_bytes(), b"foo");
+    /// assert_eq!(c"foo".to_bytes(), b"foo");
     /// ```
     #[inline]
     #[must_use = "this returns the result of the operation, \
@@ -598,10 +579,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
-    ///
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
-    /// assert_eq!(cstr.to_bytes_with_nul(), b"foo\0");
+    /// assert_eq!(c"foo".to_bytes_with_nul(), b"foo\0");
     /// ```
     #[inline]
     #[must_use = "this returns the result of the operation, \
@@ -623,10 +601,8 @@ impl CStr {
     ///
     /// ```
     /// #![feature(cstr_bytes)]
-    /// use std::ffi::CStr;
     ///
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
-    /// assert!(cstr.bytes().eq(*b"foo"));
+    /// assert!(c"foo".bytes().eq(*b"foo"));
     /// ```
     #[inline]
     #[unstable(feature = "cstr_bytes", issue = "112115")]
@@ -645,10 +621,7 @@ impl CStr {
     /// # Examples
     ///
     /// ```
-    /// use std::ffi::CStr;
-    ///
-    /// let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
-    /// assert_eq!(cstr.to_str(), Ok("foo"));
+    /// assert_eq!(c"foo".to_str(), Ok("foo"));
     /// ```
     #[stable(feature = "cstr_to_str", since = "1.4.0")]
     #[rustc_const_stable(feature = "const_cstr_methods", since = "1.72.0")]


### PR DESCRIPTION
Reduce boilerplate in doctests by replacing fallible function calls with
literals.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
