### PR TITLE
Draft: Make into_parts methods on Vec associated functions

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -3140,7 +3140,7 @@ impl<T, A: Allocator> From<Vec<T, A>> for VecDeque<T, A> {
     /// any additional memory.
     #[inline]
     fn from(other: Vec<T, A>) -> Self {
-        let (ptr, len, cap, alloc) = other.into_raw_parts_with_alloc();
+        let (ptr, len, cap, alloc) = Vec::into_raw_parts_with_alloc(other);
         Self { head: 0, len, buf: unsafe { RawVec::from_raw_parts_in(ptr, cap, alloc) } }
     }
 }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -156,6 +156,7 @@
 #![feature(try_trait_v2)]
 #![feature(try_with_capacity)]
 #![feature(tuple_trait)]
+#![feature(ub_checks)]
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(unwrap_infallible)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2811,7 +2811,7 @@ impl<T, A: Allocator> From<Vec<T, A>> for Rc<[T], A> {
     #[inline]
     fn from(v: Vec<T, A>) -> Rc<[T], A> {
         unsafe {
-            let (vec_ptr, len, cap, alloc) = v.into_raw_parts_with_alloc();
+            let (vec_ptr, len, cap, alloc) = Vec::into_raw_parts_with_alloc(v);
 
             let rc_ptr = Self::allocate_for_slice_in(len, &alloc);
             ptr::copy_nonoverlapping(vec_ptr, (&raw mut (*rc_ptr).value) as *mut T, len);

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -935,15 +935,15 @@ impl String {
     /// #![feature(vec_into_raw_parts)]
     /// let s = String::from("hello");
     ///
-    /// let (ptr, len, cap) = s.into_raw_parts();
+    /// let (ptr, len, cap) = String::into_raw_parts(s);
     ///
     /// let rebuilt = unsafe { String::from_raw_parts(ptr, len, cap) };
     /// assert_eq!(rebuilt, "hello");
     /// ```
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
-    pub fn into_raw_parts(self) -> (*mut u8, usize, usize) {
-        self.vec.into_raw_parts()
+    pub fn into_raw_parts(string: Self) -> (*mut u8, usize, usize) {
+        Vec::into_raw_parts(string.vec)
     }
 
     /// Creates a new `String` from a pointer, a length and a capacity.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3837,7 +3837,7 @@ impl<T, A: Allocator + Clone> From<Vec<T, A>> for Arc<[T], A> {
     #[inline]
     fn from(v: Vec<T, A>) -> Arc<[T], A> {
         unsafe {
-            let (vec_ptr, len, cap, alloc) = v.into_raw_parts_with_alloc();
+            let (vec_ptr, len, cap, alloc) = Vec::into_raw_parts_with_alloc(v);
 
             let rc_ptr = Self::allocate_for_slice_in(len, &alloc);
             ptr::copy_nonoverlapping(vec_ptr, (&raw mut (*rc_ptr).data) as *mut T, len);

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -944,6 +944,14 @@ impl<T, A: Allocator> Vec<T, A> {
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub unsafe fn from_raw_parts_in(ptr: *mut T, length: usize, capacity: usize, alloc: A) -> Self {
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "Vec::from_raw_parts requires that length is less than or equal to capacity",
+            (
+                length: usize = length,
+                capacity: usize = capacity,
+            ) => length <= capacity,
+        );
         unsafe { Vec { buf: RawVec::from_raw_parts_in(ptr, capacity, alloc), len: length } }
     }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1,4 +1,4 @@
-//! A contiguous growable array type with heap-allocated contents, written
+//! A contiguous growable array type with heap-allocated contents, writtenalloc/vec/
 //! `Vec<T>`.
 //!
 //! Vectors have *O*(1) indexing, amortized *O*(1) push (to the end) and
@@ -1092,7 +1092,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// #![feature(vec_into_raw_parts)]
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
-    /// let (ptr, len, cap) = v.into_raw_parts();
+    /// let (ptr, len, cap) = Vec::into_raw_parts(v);
     ///
     /// let rebuilt = unsafe {
     ///     // We can now make changes to the components, such as
@@ -1105,8 +1105,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
-    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
-        let mut me = ManuallyDrop::new(self);
+    pub fn into_raw_parts(vec: Self) -> (*mut T, usize, usize) {
+        let mut me = ManuallyDrop::new(vec);
         (me.as_mut_ptr(), me.len(), me.capacity())
     }
 
@@ -1133,7 +1133,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
-    /// let (ptr, len, cap) = v.into_parts();
+    /// let (ptr, len, cap) = Vec::into_parts(v);
     ///
     /// let rebuilt = unsafe {
     ///     // We can now make changes to the components, such as
@@ -1147,8 +1147,8 @@ impl<T, A: Allocator> Vec<T, A> {
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
     // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
-    pub fn into_parts(self) -> (NonNull<T>, usize, usize) {
-        let (ptr, len, capacity) = self.into_raw_parts();
+    pub fn into_parts(vec: Self) -> (NonNull<T>, usize, usize) {
+        let (ptr, len, capacity) = Self::into_raw_parts(vec);
         // SAFETY: A `Vec` always has a non-null pointer.
         (unsafe { NonNull::new_unchecked(ptr) }, len, capacity)
     }
@@ -1179,7 +1179,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// v.push(0);
     /// v.push(1);
     ///
-    /// let (ptr, len, cap, alloc) = v.into_raw_parts_with_alloc();
+    /// let (ptr, len, cap, alloc) = Vec::into_raw_parts_with_alloc(v);
     ///
     /// let rebuilt = unsafe {
     ///     // We can now make changes to the components, such as
@@ -1193,8 +1193,8 @@ impl<T, A: Allocator> Vec<T, A> {
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
-    pub fn into_raw_parts_with_alloc(self) -> (*mut T, usize, usize, A) {
-        let mut me = ManuallyDrop::new(self);
+    pub fn into_raw_parts_with_alloc(vec: Self) -> (*mut T, usize, usize, A) {
+        let mut me = ManuallyDrop::new(vec);
         let len = me.len();
         let capacity = me.capacity();
         let ptr = me.as_mut_ptr();
@@ -1229,7 +1229,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// v.push(0);
     /// v.push(1);
     ///
-    /// let (ptr, len, cap, alloc) = v.into_parts_with_alloc();
+    /// let (ptr, len, cap, alloc) = Vec::into_parts_with_alloc(v);
     ///
     /// let rebuilt = unsafe {
     ///     // We can now make changes to the components, such as
@@ -1244,8 +1244,8 @@ impl<T, A: Allocator> Vec<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "box_vec_non_null", reason = "new API", issue = "130364")]
     // #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
-    pub fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) {
-        let (ptr, len, capacity, alloc) = self.into_raw_parts_with_alloc();
+    pub fn into_parts_with_alloc(vec: Self) -> (NonNull<T>, usize, usize, A) {
+        let (ptr, len, capacity, alloc) = Vec::into_raw_parts_with_alloc(vec);
         // SAFETY: A `Vec` always has a non-null pointer.
         (unsafe { NonNull::new_unchecked(ptr) }, len, capacity, alloc)
     }
@@ -3139,7 +3139,7 @@ impl<T, A: Allocator, const N: usize> Vec<[T; N], A> {
     /// ```
     #[stable(feature = "slice_flatten", since = "1.80.0")]
     pub fn into_flattened(self) -> Vec<T, A> {
-        let (ptr, len, cap, alloc) = self.into_raw_parts_with_alloc();
+        let (ptr, len, cap, alloc) = Vec::into_raw_parts_with_alloc(self);
         let (new_len, new_cap) = if T::IS_ZST {
             (len.checked_mul(N).expect("vec len overflow"), usize::MAX)
         } else {


### PR DESCRIPTION
(doesn’t need review for now, posted to accompany stabilization report)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
