### PR TITLE
Avoid extra path trimming in method not found error

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -599,7 +599,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let tcx = self.tcx;
         let rcvr_ty = self.resolve_vars_if_possible(rcvr_ty);
         let mut ty_file = None;
-        let (mut ty_str, short_ty_str) =
+        let (ty_str, short_ty_str) =
             if trait_missing_method && let ty::Dynamic(predicates, _, _) = rcvr_ty.kind() {
                 (predicates.to_string(), with_forced_trimmed_paths!(predicates.to_string()))
             } else {
@@ -736,10 +736,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         if let Some(within_macro_span) = within_macro_span {
             err.span_label(within_macro_span, "due to this macro variable");
-        }
-
-        if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {
-            ty_str = short_ty_str;
         }
 
         if rcvr_ty.references_error() {

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -39,7 +39,7 @@ error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in t
   --> replaced
    |
 LL |     Type.foo();
-   |          ^^^ method not found in `Type`
+   |          ^^^ method not found in `dep_2_reexport::Type`
    |
 note: there are multiple different versions of crate `dependency` in the dependency graph
   --> replaced
@@ -63,7 +63,7 @@ error[E0599]: no function or associated item named `bar` found for struct `dep_2
   --> replaced
    |
 LL |     Type::bar();
-   |           ^^^ function or associated item not found in `Type`
+   |           ^^^ function or associated item not found in `dep_2_reexport::Type`
    |
 note: there are multiple different versions of crate `dependency` in the dependency graph
   --> replaced

--- a/tests/ui/associated-types/issue-43924.stderr
+++ b/tests/ui/associated-types/issue-43924.stderr
@@ -14,7 +14,7 @@ error[E0599]: no function or associated item named `default` found for trait obj
   --> $DIR/issue-43924.rs:14:39
    |
 LL |     assert_eq!(<() as Foo<u32>>::Out::default().to_string(), "false");
-   |                                       ^^^^^^^ function or associated item not found in `dyn ToString`
+   |                                       ^^^^^^^ function or associated item not found in `(dyn ToString + 'static)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -42,13 +42,13 @@ error[E0599]: no method named `foo` found for struct `rustc_confusables_across_c
   --> $DIR/rustc_confusables.rs:15:7
    |
 LL |     x.foo();
-   |       ^^^ method not found in `BTreeSet`
+   |       ^^^ method not found in `rustc_confusables_across_crate::BTreeSet`
 
 error[E0599]: no method named `push` found for struct `rustc_confusables_across_crate::BTreeSet` in the current scope
   --> $DIR/rustc_confusables.rs:17:7
    |
 LL |     x.push();
-   |       ^^^^ method not found in `BTreeSet`
+   |       ^^^^ method not found in `rustc_confusables_across_crate::BTreeSet`
    |
 help: you might have meant to use `insert`
    |
@@ -60,7 +60,7 @@ error[E0599]: no method named `test` found for struct `rustc_confusables_across_
   --> $DIR/rustc_confusables.rs:20:7
    |
 LL |     x.test();
-   |       ^^^^ method not found in `BTreeSet`
+   |       ^^^^ method not found in `rustc_confusables_across_crate::BTreeSet`
 
 error[E0599]: no method named `pulled` found for struct `rustc_confusables_across_crate::BTreeSet` in the current scope
   --> $DIR/rustc_confusables.rs:22:7

--- a/tests/ui/empty/empty-struct-braces-expr.stderr
+++ b/tests/ui/empty/empty-struct-braces-expr.stderr
@@ -121,7 +121,7 @@ error[E0599]: no variant or associated item named `Empty3` found for enum `empty
   --> $DIR/empty-struct-braces-expr.rs:25:19
    |
 LL |     let xe3 = XE::Empty3;
-   |                   ^^^^^^ variant or associated item not found in `XE`
+   |                   ^^^^^^ variant or associated item not found in `empty_struct::XE`
    |
 help: there is a variant with a similar name
    |
@@ -132,7 +132,7 @@ error[E0599]: no variant or associated item named `Empty3` found for enum `empty
   --> $DIR/empty-struct-braces-expr.rs:26:19
    |
 LL |     let xe3 = XE::Empty3();
-   |                   ^^^^^^ variant or associated item not found in `XE`
+   |                   ^^^^^^ variant or associated item not found in `empty_struct::XE`
    |
 help: there is a variant with a similar name
    |

--- a/tests/ui/error-emitter/multiline-removal-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.svg
@@ -1,4 +1,4 @@
-<svg width="1902px" height="4322px" xmlns="http://www.w3.org/2000/svg">
+<svg width="2322px" height="4322px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -99,7 +99,7 @@
 </tspan>
     <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:14:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:24:4</tspan>
 </tspan>
@@ -213,7 +213,7 @@
 </tspan>
     <tspan x="10px" y="1738px">
 </tspan>
-    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:29:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:35:4</tspan>
 </tspan>
@@ -329,7 +329,7 @@
 </tspan>
     <tspan x="10px" y="2782px">
 </tspan>
-    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:40:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="2818px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:46:4</tspan>
 </tspan>
@@ -441,7 +441,7 @@
 </tspan>
     <tspan x="10px" y="3790px">
 </tspan>
-    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:51:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="3826px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:56:4</tspan>
 </tspan>

--- a/tests/ui/functions-closures/fn-help-with-err.stderr
+++ b/tests/ui/functions-closures/fn-help-with-err.stderr
@@ -8,7 +8,7 @@ error[E0599]: no method named `bar` found for struct `Arc<{closure@$DIR/fn-help-
   --> $DIR/fn-help-with-err.rs:19:10
    |
 LL |     arc2.bar();
-   |          ^^^ method not found in `Arc<{closure@fn-help-with-err.rs:18:36}>`
+   |          ^^^ method not found in `Arc<{closure@$DIR/fn-help-with-err.rs:18:36: 18:38}>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `bar`, perhaps you need to implement it

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-1.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-1.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `filterx` exists for struct `Map<Repeat, {closure@hrtb-doesnt-borrow-self-1.rs:113:27}>`, but its trait bounds were not satisfied
+error[E0599]: the method `filterx` exists for struct `Map<Repeat, {closure@$DIR/hrtb-doesnt-borrow-self-1.rs:113:27: 113:34}>`, but its trait bounds were not satisfied
   --> $DIR/hrtb-doesnt-borrow-self-1.rs:114:22
    |
 LL | pub struct Map<S, F> {

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-2.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-2.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, fn(&u64) -> &u64 {identity::<u64>}>, {closure@hrtb-doesnt-borrow-self-2.rs:109:30}>`, but its trait bounds were not satisfied
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/hrtb-doesnt-borrow-self-2.rs:109:30: 109:37}>`, but its trait bounds were not satisfied
   --> $DIR/hrtb-doesnt-borrow-self-2.rs:110:24
    |
 LL | pub struct Filter<S, F> {

--- a/tests/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/tests/ui/impl-trait/no-method-suggested-traits.stderr
@@ -173,7 +173,7 @@ error[E0599]: no method named `method2` found for struct `no_method_suggested_tr
   --> $DIR/no-method-suggested-traits.rs:52:37
    |
 LL |     no_method_suggested_traits::Foo.method2();
-   |                                     ^^^^^^^ method not found in `Foo`
+   |                                     ^^^^^^^ method not found in `no_method_suggested_traits::Foo`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
@@ -186,7 +186,7 @@ error[E0599]: no method named `method2` found for struct `Rc<&mut Box<&no_method
   --> $DIR/no-method-suggested-traits.rs:54:71
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method2();
-   |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
+   |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&no_method_suggested_traits::Foo>>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
@@ -199,7 +199,7 @@ error[E0599]: no method named `method2` found for enum `no_method_suggested_trai
   --> $DIR/no-method-suggested-traits.rs:56:40
    |
 LL |     no_method_suggested_traits::Bar::X.method2();
-   |                                        ^^^^^^^ method not found in `Bar`
+   |                                        ^^^^^^^ method not found in `no_method_suggested_traits::Bar`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
@@ -212,7 +212,7 @@ error[E0599]: no method named `method2` found for struct `Rc<&mut Box<&no_method
   --> $DIR/no-method-suggested-traits.rs:58:74
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method2();
-   |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&Bar>>`
+   |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&no_method_suggested_traits::Bar>>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
@@ -283,25 +283,25 @@ error[E0599]: no method named `method3` found for struct `no_method_suggested_tr
   --> $DIR/no-method-suggested-traits.rs:73:37
    |
 LL |     no_method_suggested_traits::Foo.method3();
-   |                                     ^^^^^^^ method not found in `Foo`
+   |                                     ^^^^^^^ method not found in `no_method_suggested_traits::Foo`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&no_method_suggested_traits::Foo>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:74:71
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method3();
-   |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
+   |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&no_method_suggested_traits::Foo>>`
 
 error[E0599]: no method named `method3` found for enum `no_method_suggested_traits::Bar` in the current scope
   --> $DIR/no-method-suggested-traits.rs:76:40
    |
 LL |     no_method_suggested_traits::Bar::X.method3();
-   |                                        ^^^^^^^ method not found in `Bar`
+   |                                        ^^^^^^^ method not found in `no_method_suggested_traits::Bar`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&no_method_suggested_traits::Bar>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:77:74
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method3();
-   |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&Bar>>`
+   |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&no_method_suggested_traits::Bar>>`
 
 error: aborting due to 24 previous errors
 

--- a/tests/ui/issues/issue-30123.stderr
+++ b/tests/ui/issues/issue-30123.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `new_undirected` found for st
   --> $DIR/issue-30123.rs:7:33
    |
 LL |     let ug = Graph::<i32, i32>::new_undirected();
-   |                                 ^^^^^^^^^^^^^^ function or associated item not found in `Graph<i32, i32>`
+   |                                 ^^^^^^^^^^^^^^ function or associated item not found in `issue_30123_aux::Graph<i32, i32>`
    |
 note: if you're trying to build a new `issue_30123_aux::Graph<i32, i32>`, consider using `issue_30123_aux::Graph::<N, E>::new` which returns `issue_30123_aux::Graph<_, _>`
   --> $DIR/auxiliary/issue-30123-aux.rs:14:5

--- a/tests/ui/issues/issue-41880.stderr
+++ b/tests/ui/issues/issue-41880.stderr
@@ -5,7 +5,7 @@ LL | pub struct Iterate<T, F> {
    | ------------------------ method `iter` not found for this struct
 ...
 LL |     println!("{:?}", a.iter().take(10).collect::<Vec<usize>>());
-   |                        ^^^^ method not found in `Iterate<{integer}, {closure@issue-41880.rs:26:24}>`
+   |                        ^^^^ method not found in `Iterate<{integer}, {closure@$DIR/issue-41880.rs:26:24: 26:27}>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/missing-writer.stderr
+++ b/tests/ui/macros/missing-writer.stderr
@@ -24,7 +24,7 @@ error[E0599]: cannot write into `&'static str`
   --> $DIR/missing-writer.rs:5:12
    |
 LL |     write!("{}_{}", x, y);
-   |     -------^^^^^^^------- method not found in `&str`
+   |     -------^^^^^^^------- method not found in `&'static str`
    |
 note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
   --> $DIR/missing-writer.rs:5:12
@@ -41,7 +41,7 @@ error[E0599]: cannot write into `&'static str`
   --> $DIR/missing-writer.rs:11:14
    |
 LL |     writeln!("{}_{}", x, y);
-   |     ---------^^^^^^^------- method not found in `&str`
+   |     ---------^^^^^^^------- method not found in `&'static str`
    |
 note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
   --> $DIR/missing-writer.rs:11:14

--- a/tests/ui/methods/issue-19521.stderr
+++ b/tests/ui/methods/issue-19521.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `homura` found for reference `&'static str` in the
   --> $DIR/issue-19521.rs:2:8
    |
 LL |     "".homura()();
-   |        ^^^^^^ method not found in `&str`
+   |        ^^^^^^ method not found in `&'static str`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/tests/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -23,7 +23,7 @@ error[E0599]: no method named `extend` found for struct `Map` in the current sco
   --> $DIR/method-not-found-generic-arg-elision.rs:87:67
    |
 LL |     v.iter().map(Box::new(|x| x * x) as Box<dyn Fn(&i32) -> i32>).extend(std::iter::once(100));
-   |                                                                   ^^^^^^ method not found in `Map<Iter<'_, i32>, Box<dyn Fn(&i32) -> i32>>`
+   |                                                                   ^^^^^^ method not found in `Map<std::slice::Iter<'_, i32>, Box<dyn for<'a> Fn(&'a i32) -> i32>>`
 
 error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the current scope
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13

--- a/tests/ui/methods/receiver-equality.stderr
+++ b/tests/ui/methods/receiver-equality.stderr
@@ -5,7 +5,7 @@ LL | struct B<T>(T);
    | ----------- function or associated item `method` not found for this struct
 ...
 LL |     B::<for<'a> fn(&'a ())>::method(y);
-   |                              ^^^^^^ function or associated item not found in `B<fn(&())>`
+   |                              ^^^^^^ function or associated item not found in `B<for<'a> fn(&'a ())>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/methods/untrimmed-path-type.rs
+++ b/tests/ui/methods/untrimmed-path-type.rs
@@ -1,0 +1,11 @@
+// Ensures that the path of the `Error` type is not trimmed
+// to make it clear which Error type is meant.
+
+fn main() {
+   meow().unknown(); //~ ERROR no method named `unknown` found
+   //~^ NOTE method not found in `Result<(), std::io::Error>`
+}
+
+fn meow() -> Result<(), std::io::Error> {
+    Ok(())
+}

--- a/tests/ui/methods/untrimmed-path-type.stderr
+++ b/tests/ui/methods/untrimmed-path-type.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no method named `unknown` found for enum `Result` in the current scope
+  --> $DIR/untrimmed-path-type.rs:5:11
+   |
+LL |    meow().unknown();
+   |           ^^^^^^^ method not found in `Result<(), std::io::Error>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -15,7 +15,7 @@ help: consider adjusting the signature so it borrows its argument
 LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
    |                                           +
 
-error[E0599]: the method `count` exists for struct `Filter<Fuse<Once<&str>>, {closure@issue-36053-2.rs:7:39}>`, but its trait bounds were not satisfied
+error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>`, but its trait bounds were not satisfied
   --> $DIR/issue-36053-2.rs:7:55
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();

--- a/tests/ui/nll/issue-57362-2.stderr
+++ b/tests/ui/nll/issue-57362-2.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `make_g` found for fn pointer
   --> $DIR/issue-57362-2.rs:23:25
    |
 LL |     let x = <fn (&())>::make_g();
-   |                         ^^^^^^ function or associated item not found in `fn(&())`
+   |                         ^^^^^^ function or associated item not found in `for<'a> fn(&'a ())`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `X` defines an item `make_g`, perhaps you need to implement it

--- a/tests/ui/nll/issue-57642-higher-ranked-subtype.stderr
+++ b/tests/ui/nll/issue-57642-higher-ranked-subtype.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `make_g` found for fn pointer
   --> $DIR/issue-57642-higher-ranked-subtype.rs:31:25
    |
 LL |     let x = <fn (&())>::make_g();
-   |                         ^^^^^^ function or associated item not found in `fn(&())`
+   |                         ^^^^^^ function or associated item not found in `for<'a> fn(&'a ())`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `X` defines an item `make_g`, perhaps you need to implement it
@@ -15,7 +15,7 @@ error[E0599]: no function or associated item named `make_f` found for fn pointer
   --> $DIR/issue-57642-higher-ranked-subtype.rs:36:25
    |
 LL |     let x = <fn (&())>::make_f();
-   |                         ^^^^^^ function or associated item not found in `fn(&())`
+   |                         ^^^^^^ function or associated item not found in `for<'a> fn(&'a ())`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Y` defines an item `make_f`, perhaps you need to implement it

--- a/tests/ui/object-pointer-types.stderr
+++ b/tests/ui/object-pointer-types.stderr
@@ -25,7 +25,7 @@ error[E0599]: no method named `managed` found for struct `Box<(dyn Foo + 'static
   --> $DIR/object-pointer-types.rs:23:7
    |
 LL |     x.managed();
-   |       ^^^^^^^ method not found in `Box<dyn Foo>`
+   |       ^^^^^^^ method not found in `Box<(dyn Foo + 'static)>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -20,11 +20,11 @@ LL |     let fp = BufWriter::new(fp);
 note: required by a bound in `BufWriter`
   --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
 
-error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn Write>`, but its trait bounds were not satisfied
+error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn std::io::Write>`, but its trait bounds were not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:21:14
    |
 LL |     writeln!(fp, "hello world").unwrap();
-   |     ---------^^---------------- method cannot be called on `BufWriter<&dyn Write>` due to unsatisfied trait bounds
+   |     ---------^^---------------- method cannot be called on `BufWriter<&dyn std::io::Write>` due to unsatisfied trait bounds
    |
 note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
   --> $DIR/mut-borrow-needed-by-trait.rs:21:14

--- a/tests/ui/suggestions/suggest-using-chars.stderr
+++ b/tests/ui/suggestions/suggest-using-chars.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `iter` found for reference `&'static str` in the c
   --> $DIR/suggest-using-chars.rs:2:19
    |
 LL |     let _ = "foo".iter();
-   |                   ^^^^ method not found in `&str`
+   |                   ^^^^ method not found in `&'static str`
    |
 help: because of the in-memory representation of `&str`, to obtain an `Iterator` over each of its codepoint use method `chars`
    |
@@ -14,7 +14,7 @@ error[E0599]: no method named `foo` found for reference `&'static str` in the cu
   --> $DIR/suggest-using-chars.rs:3:19
    |
 LL |     let _ = "foo".foo();
-   |                   ^^^ method not found in `&str`
+   |                   ^^^ method not found in `&'static str`
 
 error[E0599]: no method named `iter` found for struct `String` in the current scope
   --> $DIR/suggest-using-chars.rs:4:33

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -21,7 +21,7 @@ LL | |         })
 note: required by a bound in `cloned`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut IntoIter<u8>, {closure@issue-31173.rs:7:21}>>`, but its trait bounds were not satisfied
+error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}>>`, but its trait bounds were not satisfied
   --> $DIR/issue-31173.rs:12:10
    |
 LL |       let temp: Vec<u8> = it

--- a/tests/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `call` found for closure `{closure@$DIR/unboxed-cl
   --> $DIR/unboxed-closures-static-call-wrong-trait.rs:7:10
    |
 LL |     mut_.call((0, ));
-   |          ^^^^ method not found in `{closure@unboxed-closures-static-call-wrong-trait.rs:6:26}`
+   |          ^^^^ method not found in `{closure@$DIR/unboxed-closures-static-call-wrong-trait.rs:6:26: 6:29}`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Method errors have an extra check that force trim paths whenever the normal string is longer than 10 characters, which can be quite unhelpful when multiple items have the same name (for example an `Error`).

A user reported this force trimming as being quite unhelpful when they had a method error where the precise path of the `Error` mattered.

The code uses `tcx.short_string` already to get the normal path, which tries to be clever around trimming paths if necessary, so there is no reason for this extra force trimming.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
