### PR TITLE
speed up charsearcher for ascii chars

### DIFF
--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -656,7 +656,7 @@ impl<'a, P: Pattern> SplitInternal<'a, P> {
         None
     }
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<&'a str> {
         if self.finished {
             return None;

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -429,8 +429,23 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
             SearchStep::Done
         }
     }
-    #[inline]
+    #[inline(always)]
     fn next_match(&mut self) -> Option<(usize, usize)> {
+        if self.utf8_size == 1 {
+            return match self
+                .haystack
+                .as_bytes()
+                .get(self.finger..self.finger_back)?
+                .iter()
+                .position(|x| *x == self.utf8_encoded[0])
+            {
+                Some(x) => {
+                    self.finger += x + 1;
+                    Some((self.finger - 1, self.finger))
+                }
+                None => None,
+            };
+        }
         loop {
             // get the haystack after the last character found
             let bytes = self.haystack.as_bytes().get(self.finger..self.finger_back)?;
@@ -498,6 +513,21 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
     }
     #[inline]
     fn next_match_back(&mut self) -> Option<(usize, usize)> {
+        if self.utf8_size == 1 {
+            return match self
+                .haystack
+                .get(self.finger..self.finger_back)?
+                .as_bytes()
+                .iter()
+                .rposition(|&x| x == self.utf8_encoded[0])
+            {
+                Some(x) => {
+                    self.finger_back = self.finger + x;
+                    Some((self.finger_back, self.finger_back + 1))
+                }
+                None => None,
+            };
+        }
         let haystack = self.haystack.as_bytes();
         loop {
             // get the haystack up to but not including the last character searched


### PR DESCRIPTION
attempt at fixing rust-lang/rust#82471

this implementation should be valid because ascii characters are always one byte and there are no continuation bytes that overlap with ascii characters

im not completely sure that this is _always_ an improvement but it seems to be an improvement for this case and i dont think it can significantly regress any cases