### PR TITLE
rustdoc: use descriptive tooltip if doctest is conditionally ignored

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -81,51 +81,29 @@ fn write_header(
     );
 
     if tooltip != Tooltip::None {
-        // variable for extending lifetimes of temporaries
-        let tmp;
-        write_str(
-            out,
-            format_args!(
-                "<a href=\"#\" class=\"tooltip\" title=\"{}\">ⓘ</a>",
-                match tooltip {
-                    Tooltip::IgnoreAll => "This example is not tested",
-                    Tooltip::IgnoreSome(platforms) => {
-                        tmp = format!(
-                            "This example is not tested on {}",
-                            fmt::from_fn(|f| {
-                                match platforms.len() {
-                                    0 => unreachable!(),
-                                    1 => f.write_str(&platforms[0]),
-                                    2 => write!(f, "{} or {}", &platforms[0], &platforms[1]),
-                                    _ => {
-                                        for (i, plat) in platforms.iter().enumerate() {
-                                            match (platforms.len() - 2).cmp(&i) {
-                                                std::cmp::Ordering::Greater => {
-                                                    write!(f, "{}, ", plat)?
-                                                }
-                                                std::cmp::Ordering::Equal => {
-                                                    write!(f, "{}, or ", plat)?
-                                                }
-                                                std::cmp::Ordering::Less => f.write_str(&plat)?,
-                                            }
-                                        }
-                                        Ok(())
-                                    }
-                                }
-                            })
-                        );
-                        &tmp
+        let tooltip = fmt::from_fn(|f| match &tooltip {
+            Tooltip::IgnoreAll => f.write_str("This example is not tested"),
+            Tooltip::IgnoreSome(platforms) => {
+                f.write_str("This example is not tested on ")?;
+                match &platforms[..] {
+                    [] => unreachable!(),
+                    [platform] => f.write_str(platform)?,
+                    [first, second] => write!(f, "{first} or {second}")?,
+                    [platforms @ .., last] => {
+                        for platform in platforms {
+                            write!(f, "{platform}, ")?;
+                        }
+                        write!(f, "or {last}")?;
                     }
-                    Tooltip::CompileFail => "This example deliberately fails to compile",
-                    Tooltip::ShouldPanic => "This example panics",
-                    Tooltip::Edition(edition) => {
-                        tmp = format!("This example runs with edition {edition}");
-                        &tmp
-                    }
-                    Tooltip::None => unreachable!(),
                 }
-            ),
-        );
+                Ok(())
+            }
+            Tooltip::CompileFail => f.write_str("This example deliberately fails to compile"),
+            Tooltip::ShouldPanic => f.write_str("This example panics"),
+            Tooltip::Edition(edition) => write!(f, "This example runs with edition {edition}"),
+            Tooltip::None => unreachable!(),
+        });
+        write_str(out, format_args!("<a href=\"#\" class=\"tooltip\" title=\"{tooltip}\">ⓘ</a>"));
     }
 
     if let Some(extra) = extra_content {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -320,8 +320,10 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             ))
         });
 
-        let tooltip = if ignore != Ignore::None {
-            highlight::Tooltip::Ignore
+        let tooltip = if ignore == Ignore::All {
+            highlight::Tooltip::IgnoreAll
+        } else if let Ignore::Some(platforms) = ignore {
+            highlight::Tooltip::IgnoreSome(platforms)
         } else if compile_fail {
             highlight::Tooltip::CompileFail
         } else if should_panic {

--- a/tests/rustdoc/doctest/ignore-sometimes.rs
+++ b/tests/rustdoc/doctest/ignore-sometimes.rs
@@ -1,0 +1,23 @@
+#![crate_name = "foo"]
+
+// test for https://github.com/rust-lang/rust/issues/141092
+
+//@ has 'foo/fn.f.html' '//a[@title="This example is not tested on wasm"]' 'ⓘ'
+/// Example
+///
+/// ```ignore-wasm
+/// let x = 1;
+/// ```
+pub fn f() {}
+
+//@ has 'foo/fn.g.html' '//a[@title="This example is not tested on wasm or windows"]' 'ⓘ'
+/// ```ignore-wasm,ignore-windows
+/// let x = 1;
+/// ```
+pub fn g() {}
+
+//@ has 'foo/fn.h.html' '//a[@title="This example is not tested on wasm, windows, or unix"]' 'ⓘ'
+/// ```ignore-wasm,ignore-windows,ignore-unix
+/// let x = 1;
+/// ```
+pub fn h() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/141092

here's what it looks like now: 
![screenshot](https://github.com/user-attachments/assets/71e679fe-8828-439d-a2ce-b9187ad3aeea)


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
