### PR TITLE
clean up old rintf leftovers

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2296,12 +2296,6 @@ pub fn round_ties_even_f16(x: f16) -> f16;
 #[rustc_nounwind]
 pub fn round_ties_even_f32(x: f32) -> f32;
 
-/// Provided for compatibility with stdarch. DO NOT USE.
-#[inline(always)]
-pub unsafe fn rintf32(x: f32) -> f32 {
-    round_ties_even_f32(x)
-}
-
 /// Returns the nearest integer to an `f64`. Rounds half-way cases to the number with an even
 /// least significant digit.
 ///
@@ -2310,12 +2304,6 @@ pub unsafe fn rintf32(x: f32) -> f32 {
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub fn round_ties_even_f64(x: f64) -> f64;
-
-/// Provided for compatibility with stdarch. DO NOT USE.
-#[inline(always)]
-pub unsafe fn rintf64(x: f64) -> f64 {
-    round_ties_even_f64(x)
-}
 
 /// Returns the nearest integer to an `f128`. Rounds half-way cases to the number with an even
 /// least significant digit.


### PR DESCRIPTION
As usual stdarch needed special treatment due to https://github.com/rust-lang/stdarch/issues/1655, and apparently I forgot to clean up these leftovers here. They can be removed now.