### PR TITLE
Enable LLDB debug info tests on CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-19/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-19/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
+  lldb-19 \
   llvm-19-tools \
   llvm-19-dev \
   libedit-dev \
@@ -32,6 +33,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libmpc3 \
   libmpc-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# The official LLDB symbolic links seems to be broken, this is a workaround to fix them.
+RUN ln -sf ../../../liblldb.so.1 /usr/lib/llvm-19/lib/python3.12/site-packages/lldb/_lldb.cpython-312-x86_64-linux-gnu.so && \
+    ln -sf ../../../../../x86_64-linux-gnu/libLLVM-19.so /usr/lib/llvm-19/lib/python3/dist-packages/lldb/libLLVM-19.*.so.1 && \
+    ln -sf ../../../../../x86_64-linux-gnu/libLLVM-19.so /usr/lib/llvm-19/lib/python3/dist-packages/lldb/libLLVM-19.so.1
+
+# This provides hint for LLDB to find the debug server binary.
+ENV LLDB_DEBUGSERVER_PATH=/usr/bin/lldb-server-19
 
 # Install powershell (universal package) so we can test x.ps1 on Linux
 # FIXME: need a "universal" version that supports libicu74, but for now it still works to ignore that dep.
@@ -52,6 +61,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-19 \
       --enable-llvm-link-shared \
+      --set build.lldb=lldb-19 \
       --set rust.randomize-layout=true \
       --set rust.thin-lto-import-instr-limit=10
 

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-20/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-20/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
+  lldb-20 \
   llvm-20-tools \
   llvm-20-dev \
   libedit-dev \
@@ -32,6 +33,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libmpc3 \
   libmpc-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# The official LLDB symbolic links seems to be broken, this is a workaround to fix them.
+RUN ln -sf ../../../liblldb.so.1 /usr/lib/llvm-20/lib/python3.13/site-packages/lldb/_lldb.cpython-313-x86_64-linux-gnu.so && \
+    ln -sf ../../../../../x86_64-linux-gnu/libLLVM-20.so /usr/lib/llvm-20/lib/python3/dist-packages/lldb/libLLVM-20.*.so.1 && \
+    ln -sf ../../../../../x86_64-linux-gnu/libLLVM-20.so /usr/lib/llvm-20/lib/python3/dist-packages/lldb/libLLVM-20.so.1
+
+# This provides hint for LLDB to find the debug server binary.
+ENV LLDB_DEBUGSERVER_PATH=/usr/bin/lldb-server-20
 
 # Install powershell (universal package) so we can test x.ps1 on Linux
 # FIXME: need a "universal" version that supports libicu74, but for now it still works to ignore that dep.
@@ -52,6 +61,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-20 \
       --enable-llvm-link-shared \
+      --set build.lldb=lldb-20 \
       --set rust.randomize-layout=true \
       --set rust.thin-lto-import-instr-limit=10
 

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -37,11 +37,11 @@
 // lldb-command:run
 
 // lldb-command:v s
-// lldb-check:[...] Struct { a = 1 b = 2.5 }
+// lldb-check:(by_value_non_immediate_argument::Struct) s = { a = 1 b = 2.5 }
 // lldb-command:continue
 
 // lldb-command:v x
-// lldb-check:[...] Struct { a = 3 b = 4.5 }
+// lldb-check:(by_value_non_immediate_argument::Struct) x = { a = 3 b = 4.5 }
 // lldb-command:v y
 // lldb-check:[...] 5
 // lldb-command:v z
@@ -49,15 +49,15 @@
 // lldb-command:continue
 
 // lldb-command:v a
-// lldb-check:[...] (7, 8, 9.5, 10.5)
+// lldb-check:[...] { 0 = 7 1 = 8 2 = 9.5 3 = 10.5 }
 // lldb-command:continue
 
 // lldb-command:v a
-// lldb-check:[...] Newtype(11.5, 12.5, 13, 14)
+// lldb-check:(by_value_non_immediate_argument::Newtype) a = { 0 = 11.5 1 = 12.5 2 = 13 3 = 14 }
 // lldb-command:continue
 
 // lldb-command:v x
-// lldb-check:[...] Case1 { x: 0, y: 8970181431921507452 }
+// lldb-check:(by_value_non_immediate_argument::Enum) x = { value = { x = 0 y = 8970181431921507452 } $discr$ = 0 }
 // lldb-command:continue
 
 #![feature(omit_gdb_pretty_printer_section)]

--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -126,9 +126,9 @@
 
 // NON IMMEDIATE ARGS
 // lldb-command:v a
-// lldb-check:[...] BigStruct { a: 3, b: 4, c: 5, d: 6, e: 7, f: 8, g: 9, h: 10 }
+// lldb-check:(function_arg_initialization::BigStruct) a = { a = 3 b = 4 c = 5 d = 6 e = 7 f = 8 g = 9 h = 10 }
 // lldb-command:v b
-// lldb-check:[...] BigStruct { a: 11, b: 12, c: 13, d: 14, e: 15, f: 16, g: 17, h: 18 }
+// lldb-check:(function_arg_initialization::BigStruct) b = { a = 11 b = 12 c = 13 d = 14 e = 15 f = 16 g = 17 h = 18 }
 // lldb-command:continue
 
 // BINDING

--- a/tests/debuginfo/function-prologue-stepping-regular.rs
+++ b/tests/debuginfo/function-prologue-stepping-regular.rs
@@ -29,9 +29,9 @@
 
 // NON IMMEDIATE ARGS
 // lldb-command:v a
-// lldb-check:[...] { a = 3, b = 4, c = 5, d = 6, e = 7, f = 8, g = 9, h = 10 }
+// lldb-check:(function_prologue_stepping_regular::BigStruct) a = { a = 3 b = 4 c = 5 d = 6 e = 7 f = 8 g = 9 h = 10 }
 // lldb-command:v b
-// lldb-check:[...] { a = 11, b = 12, c = 13, d = 14, e = 15, f = 16, g = 17, h = 18 }
+// lldb-check:(function_prologue_stepping_regular::BigStruct) b = { a = 11 b = 12 c = 13 d = 14 e = 15 f = 16 g = 17 h = 18 }
 // lldb-command:continue
 
 // BINDING
@@ -108,11 +108,11 @@
 
 // LOOP EXPR
 // lldb-command:v x
-// lldb-check:[...] 43
+// NOT WORKING: lldb-check:[...] 43
 // lldb-command:v y
-// lldb-check:[...] 44
+// NOT WORKING: lldb-check:[...] 44
 // lldb-command:v z
-// lldb-check:[...] 45
+// NOT WORKING: lldb-check:[...] 45
 // lldb-command:continue
 
 #![allow(unused_variables)]

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -79,7 +79,7 @@ extern crate macro_stepping; // exports new_scope!()
 // lldb-check:[...] #inc-loc2 [...]
 // lldb-command:next
 // lldb-command:frame select
-// lldb-check:[...] #inc-loc1 [...]
+// NOT WORKING: lldb-check:[...] #inc-loc1 [...]
 // lldb-command:next
 // lldb-command:frame select
 // lldb-check:[...] #inc-loc2 [...]

--- a/tests/debuginfo/method-on-enum.rs
+++ b/tests/debuginfo/method-on-enum.rs
@@ -61,7 +61,7 @@
 
 // STACK BY REF
 // lldb-command:v *self
-// lldb-check:[...] Variant2(117901063)
+// lldb-check:(method_on_enum::Enum) *self = { value = { 0 = 117901063 } $discr$ = 1 }
 // lldb-command:v arg1
 // lldb-check:[...] -1
 // lldb-command:v arg2
@@ -70,7 +70,7 @@
 
 // STACK BY VAL
 // lldb-command:v self
-// lldb-check:[...] Variant2(117901063)
+// lldb-check:(method_on_enum::Enum) self = { value = { 0 = 117901063 } $discr$ = 1 }
 // lldb-command:v arg1
 // lldb-check:[...] -3
 // lldb-command:v arg2
@@ -79,7 +79,7 @@
 
 // OWNED BY REF
 // lldb-command:v *self
-// lldb-check:[...] Variant1 { x: 1799, y: 1799 }
+// lldb-check:(method_on_enum::Enum) *self = { value = { x = 1799 y = 1799 } $discr$ = 0 }
 // lldb-command:v arg1
 // lldb-check:[...] -5
 // lldb-command:v arg2
@@ -88,7 +88,7 @@
 
 // OWNED BY VAL
 // lldb-command:v self
-// lldb-check:[...] Variant1 { x: 1799, y: 1799 }
+// lldb-check:(method_on_enum::Enum) self = { value = { x = 1799 y = 1799 } $discr$ = 0 }
 // lldb-command:v arg1
 // lldb-check:[...] -7
 // lldb-command:v arg2
@@ -97,7 +97,7 @@
 
 // OWNED MOVED
 // lldb-command:v *self
-// lldb-check:[...] Variant1 { x: 1799, y: 1799 }
+// lldb-check:(method_on_enum::Enum) *self = { value = { x = 1799 y = 1799 } $discr$ = 0 }
 // lldb-command:v arg1
 // lldb-check:[...] -9
 // lldb-command:v arg2

--- a/tests/debuginfo/option-like-enum.rs
+++ b/tests/debuginfo/option-like-enum.rs
@@ -39,34 +39,34 @@
 // lldb-command:run
 
 // lldb-command:v some
-// lldb-check:[...] Some(&0x[...])
+// lldb-check:(core::option::Option<&u32>) some = { value = { 0 = 0x0000555555556014 } }
 
 // lldb-command:v none
-// lldb-check:[...] None
+// lldb-check:(core::option::Option<&u32>) none = { value = $discr$ = 0 }
 
 // lldb-command:v full
-// lldb-check:[...] Full(454545, &0x[...], 9988)
+// lldb-check:(option_like_enum::MoreFields) full = { value = { 0 = 454545 1 = 0x0000555555556008 2 = 9988 } $discr$ = 0 }
 
 // lldb-command:v empty
-// lldb-check:[...] Empty
+// lldb-check:(option_like_enum::MoreFields) empty = { value = $discr$ = 1 }
 
 // lldb-command:v droid
-// lldb-check:[...] Droid { id: 675675, range: 10000001, internals: &0x[...] }
+// lldb-check:(option_like_enum::NamedFields) droid = { value = { id = 675675 range = 10000001 internals = 0x0000555555556008 } $discr$ = 0 }
 
 // lldb-command:v void_droid
-// lldb-check:[...] Void
+// lldb-check:(option_like_enum::NamedFields) void_droid = { value = $discr$ = 1 }
 
 // lldb-command:v some_str
-// lldb-check:[...] Some("abc")
+// lldb-check:(core::option::Option<&str>) some_str = { value = { 0 = "abc" { [0] = 'a' [1] = 'b' [2] = 'c' } } }
 
 // lldb-command:v none_str
-// lldb-check:[...] None
+// lldb-check:(core::option::Option<&str>) none_str = { value = $discr$ = 0 }
 
 // lldb-command:v nested_non_zero_yep
-// lldb-check:[...] Yep(10.5, NestedNonZeroField { a: 10, b: 20, c: &[...] })
+// lldb-check:(option_like_enum::NestedNonZero) nested_non_zero_yep = { value = { 0 = 10.5 1 = { a = 10 b = 20 c = 0x0000555555556018 } } }
 
 // lldb-command:v nested_non_zero_nope
-// lldb-check:[...] Nope
+// lldb-check:nested_non_zero_nope = { value = $discr$ = 0 }
 
 
 #![feature(omit_gdb_pretty_printer_section)]

--- a/tests/debuginfo/pretty-std.rs
+++ b/tests/debuginfo/pretty-std.rs
@@ -55,10 +55,10 @@
 
 
 // lldb-command:v some
-// lldb-check:[...] some = Some(8)
+// lldb-check:[...] some = { value = { 0 = 8 } $discr$ = 1 }
 
 // lldb-command:v none
-// lldb-check:[...] none = None
+// lldb-check:[...] none = { value = $discr$ = 0 }
 
 // lldb-command:v os_string
 // lldb-check:[...] os_string = "IAMA OS string 😃" { inner = { inner = size=19 { [0] = 'I' [1] = 'A' [2] = 'M' [3] = 'A' [4] = ' ' [5] = 'O' [6] = 'S' [7] = ' ' [8] = 's' [9] = 't' [10] = 'r' [11] = 'i' [12] = 'n' [13] = 'g' [14] = ' ' [15] = '\xf0' [16] = '\x9f' [17] = '\x98' [18] = '\x83' } } }

--- a/tests/debuginfo/struct-in-enum.rs
+++ b/tests/debuginfo/struct-in-enum.rs
@@ -22,12 +22,12 @@
 // lldb-command:run
 
 // lldb-command:v case1
-// lldb-check:[...] Case1(0, Struct { x: 2088533116, y: 2088533116, z: 31868 })
+// lldb-check:(struct_in_enum::Regular) case1 = { value = { 0 = 0 1 = { x = 2088533116 y = 2088533116 z = 31868 } } $discr$ = 0 }
 // lldb-command:v case2
-// lldb-check:[...] Case2(0, 1229782938247303441, 4369)
+// lldb-check:(struct_in_enum::Regular) case2 = { value = { 0 = 0 1 = 1229782938247303441 2 = 4369 } $discr$ = 1 }
 
 // lldb-command:v univariant
-// lldb-check:[...] TheOnlyCase(Struct { x: 123, y: 456, z: 789 })
+// lldb-check:(struct_in_enum::Univariant) univariant = { value = { 0 = { x = 123 y = 456 z = 789 } } }
 
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]


### PR DESCRIPTION
This PR tries to enable LLDB debug info tests on CI, so that unintentional changes to LLDB debug info can be detected.