### PR TITLE
Fix `unused_braces` lint suggestion when encountering attributes

### DIFF
--- a/tests/ui/lint/unused/unused-braces-attrs-issue-141549.fixed
+++ b/tests/ui/lint/unused/unused-braces-attrs-issue-141549.fixed
@@ -1,0 +1,15 @@
+//@ check-pass
+//@ run-rustfix
+
+#![allow(dead_code)]
+#![warn(unused_braces)]
+
+use std::cmp::Ordering;
+
+#[rustfmt::skip]
+fn ptr_cmp<T: ?Sized>(p1: *const T, p2: *const T) -> Ordering {
+    #[expect(ambiguous_wide_pointer_comparisons)] p1.cmp(&p2)
+    //~^ WARN unnecessary braces around block return value
+}
+
+fn main() {}

--- a/tests/ui/lint/unused/unused-braces-attrs-issue-141549.rs
+++ b/tests/ui/lint/unused/unused-braces-attrs-issue-141549.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+//@ run-rustfix
+
+#![allow(dead_code)]
+#![warn(unused_braces)]
+
+use std::cmp::Ordering;
+
+#[rustfmt::skip]
+fn ptr_cmp<T: ?Sized>(p1: *const T, p2: *const T) -> Ordering {
+    { #[expect(ambiguous_wide_pointer_comparisons)] p1.cmp(&p2) }
+    //~^ WARN unnecessary braces around block return value
+}
+
+fn main() {}

--- a/tests/ui/lint/unused/unused-braces-attrs-issue-141549.stderr
+++ b/tests/ui/lint/unused/unused-braces-attrs-issue-141549.stderr
@@ -1,0 +1,19 @@
+warning: unnecessary braces around block return value
+  --> $DIR/unused-braces-attrs-issue-141549.rs:11:5
+   |
+LL |     { #[expect(ambiguous_wide_pointer_comparisons)] p1.cmp(&p2) }
+   |     ^^                                                         ^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-braces-attrs-issue-141549.rs:5:9
+   |
+LL | #![warn(unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     { #[expect(ambiguous_wide_pointer_comparisons)] p1.cmp(&p2) }
+LL +     #[expect(ambiguous_wide_pointer_comparisons)] p1.cmp(&p2)
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This PR fixes the `unused_braces` lint suggestion when encountering attributes by not removing them in the suggestion.

Fixes rust-lang/rust#141549