### PR TITLE
bootstrap: translate Windows paths in a way that works for both Cygwin and MSYS2

### DIFF
--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -38,7 +38,9 @@ fn sanitize_sh(path: &Path, is_cygwin: bool) -> String {
         if ch.next() != Some('/') {
             return None;
         }
-        Some(format!("/{}/{}", drive, &s[drive.len_utf8() + 2..]))
+        // The prefix for Windows drives in Cygwin/MSYS2 is configurable, but
+        // /proc/cygdrive is available regardless of configuration since 1.7.33
+        Some(format!("/proc/cygdrive/{}/{}", drive, &s[drive.len_utf8() + 2..]))
     }
 }
 


### PR DESCRIPTION
Cygwin defaults to rooting Windows paths in /cygdrive/X, while MSYS2 configures them to be /X.  Regardless of configuration, drives are always accessible as /proc/cygdrive/X, so use that.

If there are other shells on Windows that are supported and use /X style paths, perhaps something more complicated needs to be done.

r? @jieyouxu 

@Berrysoft @mati865