### PR TITLE
Remove out-of-date `noop_*` names.

### DIFF
--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -349,7 +349,7 @@ impl MutVisitor for PlaceholderExpander {
     fn filter_map_expr(&mut self, expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
         match expr.kind {
             ast::ExprKind::MacCall(_) => self.remove(expr.id).make_opt_expr(),
-            _ => noop_filter_map_expr(self, expr),
+            _ => walk_filter_map_expr(self, expr),
         }
     }
 


### PR DESCRIPTION
`mut_visit.rs` has a single function with a `noop_` prefix: `noop_filter_map_expr`. This commit renames as `walk_filter_map_expr` which is consistent with other functions in this file.

The commit also removes out-of-date comments that refer to `noop_*` methods.

r? @petrochenkov