### PR TITLE
dist: make sure llvm-project submodule is present

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2282,6 +2282,10 @@ impl Step for LlvmTools {
             }
         }
 
+        if !builder.config.dry_run() {
+            builder.require_submodule("src/llvm-project", None);
+        }
+
         builder.ensure(crate::core::build_steps::llvm::Llvm { target });
 
         let mut tarball = Tarball::new(builder, "llvm-tools", &target.triple);
@@ -2398,6 +2402,10 @@ impl Step for RustDev {
                 builder.info(&format!("Skipping RustDev ({target}): external LLVM"));
                 return None;
             }
+        }
+
+        if !builder.config.dry_run() {
+            builder.require_submodule("src/llvm-project", None);
         }
 
         let mut tarball = Tarball::new(builder, "rust-dev", &target.triple);


### PR DESCRIPTION
Zero-config `x install` fails when bootstrap tries to copy files from the LLVM submodule because it's not properly initialized/handled. This diff handles that.


Fixes https://github.com/rust-lang/rust/issues/141393