### PR TITLE
impl `Default` for `array::IntoIter`

### DIFF
--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -224,6 +224,13 @@ impl<T, const N: usize> IntoIter<T, N> {
     }
 }
 
+#[stable(feature = "array_value_iter_default", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> Default for IntoIter<T, N> {
+    fn default() -> Self {
+        IntoIter::empty()
+    }
+}
+
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> Iterator for IntoIter<T, N> {
     type Item = T;


### PR DESCRIPTION
cc rust-lang/rust#91583

my personal use of this feature comes from https://github.com/fee1-dead/w/blob/092db5df631ea515b688bae99c7f02eef12d7221/src/cont.rs#L154-L170

insta-stable, but I feel like this is small enough to _not_ require an ACP (but a FCP per https://forge.rust-lang.org/libs/maintaining-std.html#when-theres-new-trait-impls)? feel free to correct me if I am wrong.