### PR TITLE
ci: move tests from x86_64-gnu-llvm-19 job to aarch64

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-llvm-19/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-llvm-19/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:24.10
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bzip2 \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  llvm-19-tools \
+  llvm-19-dev \
+  libedit-dev \
+  libssl-dev \
+  pkg-config \
+  zlib1g-dev \
+  xz-utils \
+  nodejs \
+  mingw-w64 \
+  # libgccjit dependencies
+  flex \
+  libmpfr-dev \
+  libgmp-dev \
+  libmpc3 \
+  libmpc-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+# We are disabling CI LLVM since this builder is intentionally using a host
+# LLVM, rather than the typical src/llvm-project LLVM.
+ENV NO_DOWNLOAD_CI_LLVM 1
+ENV EXTERNAL_LLVM 1
+
+# Using llvm-link-shared due to libffi issues -- see #34486
+ENV RUST_CONFIGURE_ARGS \
+      --build=aarch64-unknown-linux-gnu \
+      --llvm-root=/usr/lib/llvm-19 \
+      --enable-llvm-link-shared \
+      --set rust.randomize-layout=true \
+      --set rust.thin-lto-import-instr-limit=10
+
+COPY scripts/shared.sh /scripts/
+
+ARG SCRIPT_ARG
+
+COPY scripts/stage_2_test_set1.sh /tmp/
+COPY scripts/stage_2_test_set2.sh /tmp/
+
+ENV SCRIPT "/tmp/${SCRIPT_ARG}"

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-# NOTE: intentionally uses all of `x.py`, `x`, and `x.ps1` to make sure they all work on Linux.
-../x.py --stage 2 test --skip src/tools/tidy
+# NOTE: intentionally uses `x`, and `x.ps1` to make sure they work on Linux.
+#       Make sure that `x.py` is tested elsewhere.
 
 # Run the `mir-opt` tests again but this time for a 32-bit target.
 # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -121,7 +121,17 @@ pr:
     env:
       ENABLE_GCC_CODEGEN: "1"
       DOCKER_SCRIPT: x86_64-gnu-llvm.sh
-    <<: *job-linux-16c
+    <<: *job-linux-4c
+  - name: aarch64-gnu-llvm-19-1
+    env:
+      IMAGE: aarch64-gnu-llvm-19
+      DOCKER_SCRIPT: stage_2_test_set1.sh
+    <<: *job-aarch64-linux-8c
+  - name: aarch64-gnu-llvm-19-2
+    env:
+      IMAGE: aarch64-gnu-llvm-19
+      DOCKER_SCRIPT: stage_2_test_set2.sh
+    <<: *job-aarch64-linux
   - name: x86_64-gnu-tools
     <<: *job-linux-36c-codebuild
 

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -2,6 +2,7 @@
 //@ min-gdb-version: 13.0
 //@ compile-flags:-g
 //@ ignore-windows-gnu: #128973
+//@ ignore-aarch64-unknown-linux-gnu (gdb tries to read from 0x0; FIXME: #128973)
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/run-make/mte-ffi/bar.h
+++ b/tests/run-make/mte-ffi/bar.h
@@ -1,3 +1,5 @@
+// FIXME(#141600) the mte-ffi test doesn't fail in aarch64-gnu
+
 #ifndef __BAR_H
 #define __BAR_H
 

--- a/tests/run-make/mte-ffi/bar_float.c
+++ b/tests/run-make/mte-ffi/bar_float.c
@@ -3,9 +3,9 @@
 #include <stdint.h>
 #include "bar.h"
 
-extern void foo(char*);
+extern void foo(float*);
 
-void bar(char *ptr) {
+void bar(float *ptr) {
     if (((uintptr_t)ptr >> 56) != 0x1f) {
         fprintf(stderr, "Top byte corrupted on Rust -> C FFI boundary!\n");
         exit(1);

--- a/tests/run-make/mte-ffi/bar_int.c
+++ b/tests/run-make/mte-ffi/bar_int.c
@@ -5,7 +5,7 @@
 
 extern void foo(unsigned int *);
 
-void bar(char *ptr) {
+void bar(unsigned int *ptr) {
     if (((uintptr_t)ptr >> 56) != 0x1f) {
         fprintf(stderr, "Top byte corrupted on Rust -> C FFI boundary!\n");
         exit(1);

--- a/tests/run-make/mte-ffi/bar_string.c
+++ b/tests/run-make/mte-ffi/bar_string.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 #include "bar.h"
 
 extern void foo(char*);
@@ -32,7 +33,7 @@ int main(void)
 
     // Store an arbitrary tag in bits 56-59 of the pointer (where an MTE tag may be),
     // and a different value in the ignored top 4 bits.
-    ptr = (unsigned int *)((uintptr_t)ptr | 0x1fl << 56);
+    ptr = (char *)((uintptr_t)ptr | 0x1fl << 56);
 
     if (mte_enabled()) {
         set_tag(ptr);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This PR splits the tests of the `x86_64-gnu-llvm-19` job in multiple jobs, using two free runners and one 8 core ARM large runner instead of one 16 core x86 runner.

One job is still on x86 because it is fast enough.

We are effectively replacing a 16 core large runner with an 8 core, which is more efficient.

<!-- homu-ignore:end -->
