### PR TITLE
Use more detailed spans in dyn compat errors within bodies

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -31,7 +31,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{self, InferKind, Visitor, VisitorExt, walk_generics};
 use rustc_hir::{self as hir, GenericParamKind, HirId, Node, PreciseCapturingArgKind};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
@@ -40,7 +40,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 use rustc_trait_selection::infer::InferCtxtExt;
-use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_trait_selection::traits::{ObligationCtxt, hir_ty_lowering_dyn_compatibility_violations};
 use tracing::{debug, instrument};
 
 use crate::errors;
@@ -624,6 +624,10 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         }
 
         (input_tys, output_ty)
+    }
+
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation> {
+        hir_ty_lowering_dyn_compatibility_violations(self.tcx, trait_def_id)
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::{
 };
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::error_reporting::traits::report_dyn_incompatibility;
-use rustc_trait_selection::traits::{self, hir_ty_lowering_dyn_compatibility_violations};
+use rustc_trait_selection::traits;
 use smallvec::{SmallVec, smallvec};
 use tracing::{debug, instrument};
 
@@ -97,8 +97,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // to avoid ICEs.
         for (clause, span) in user_written_bounds {
             if let Some(trait_pred) = clause.as_trait_clause() {
-                let violations =
-                    hir_ty_lowering_dyn_compatibility_violations(tcx, trait_pred.def_id());
+                let violations = self.dyn_compatibility_violations(trait_pred.def_id());
                 if !violations.is_empty() {
                     let reported = report_dyn_incompatibility(
                         tcx,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -33,7 +33,7 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, AnonConst, GenericArg, GenericArgs, HirId};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::mir::interpret::LitToConstInput;
 use rustc_middle::ty::print::PrintPolyTraitRefExt as _;
@@ -200,6 +200,10 @@ pub trait HirTyLowerer<'tcx> {
     {
         self
     }
+
+    /// Performs minimalistic dyn compat checks outside of bodies, but full within bodies.
+    /// Outside of bodies we could end up in cycles, so we delay most checks to later phases.
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation>;
 }
 
 /// The "qualified self" of an associated item path.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -14,7 +14,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, HirId, ItemLocalMap};
 use rustc_hir_analysis::hir_ty_lowering::{HirTyLowerer, RegionInferReason};
 use rustc_infer::infer;
-use rustc_infer::traits::Obligation;
+use rustc_infer::traits::{DynCompatibilityViolation, Obligation};
 use rustc_middle::ty::{self, Const, Ty, TyCtxt, TypeVisitableExt};
 use rustc_session::Session;
 use rustc_span::{self, DUMMY_SP, ErrorGuaranteed, Ident, Span, sym};
@@ -387,6 +387,10 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
             hir::FnRetTy::DefaultReturn(..) => self.tcx().types.unit,
         };
         (input_tys, output_ty)
+    }
+
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation> {
+        self.tcx.dyn_compatibility_violations(trait_def_id).to_vec()
     }
 }
 

--- a/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
+++ b/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/mut-is-pointer-like.rs:35:16
+  --> $DIR/mut-is-pointer-like.rs:35:29
    |
 LL |         let x: Pin<&mut dyn AsyncTrait<Output = ()>> = f;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/dyn/works.stderr
+++ b/tests/ui/async-await/dyn/works.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/works.rs:27:16
+  --> $DIR/works.rs:27:21
    |
 LL |         let x: &dyn AsyncTrait = &"hello, world!";
-   |                ^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                     ^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/dyn/wrong-size.stderr
+++ b/tests/ui/async-await/dyn/wrong-size.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/wrong-size.rs:21:12
+  --> $DIR/wrong-size.rs:21:17
    |
 LL |     let x: &dyn AsyncTrait = &"hello, world!";
-   |            ^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                 ^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/async-await/in-trait/dyn-compatibility.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:9:12
+  --> $DIR/dyn-compatibility.rs:9:17
    |
 LL |     let x: &dyn Foo = todo!();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
@@ -4,4 +4,5 @@ fn main() {
     let _: &Copy + 'static; //~ ERROR expected a path
     //~^ ERROR is not dyn compatible
     let _: &'static Copy + 'static; //~ ERROR expected a path
+    //~^ ERROR is not dyn compatible
 }

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -21,16 +21,26 @@ LL |     let _: &'static (Copy + 'static);
    |                     +              +
 
 error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:13
    |
 LL |     let _: &Copy + 'static;
-   |            ^^^^^ `Copy` is not dyn compatible
+   |             ^^^^ `Copy` is not dyn compatible
    |
    = note: the trait is not dyn compatible because it requires `Self: Sized`
    = note: for a trait to be dyn compatible it needs to allow building a vtable
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
-error: aborting due to 3 previous errors
+error[E0038]: the trait `Copy` is not dyn compatible
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:6:21
+   |
+LL |     let _: &'static Copy + 'static;
+   |                     ^^^^ `Copy` is not dyn compatible
+   |
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0038, E0178.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
+++ b/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
@@ -16,10 +16,10 @@ LL |     fn transmute(&self, t: T) -> <Self as Super<NotActuallySuper>>::Assoc;
    = help: consider moving `transmute` to another trait
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/almost-supertrait-associated-type.rs:7:27
+  --> $DIR/almost-supertrait-associated-type.rs:7:32
    |
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
-   |                           ^^^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                ^^^^^^^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/generics.stderr
+++ b/tests/ui/dyn-compatibility/generics.stderr
@@ -31,10 +31,10 @@ LL |     fn bar<T>(&self, t: T);
    = help: consider moving `bar` to another trait
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/generics.rs:22:10
+  --> $DIR/generics.rs:22:15
    |
 LL |     t as &dyn Bar
-   |          ^^^^^^^^ `Bar` is not dyn compatible
+   |               ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
+++ b/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:15
+  --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:24
    |
 LL |     let test: &mut dyn Bar = &mut thing;
-   |               ^^^^^^^^^^^^ `Bar` is not dyn compatible
+   |                        ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/no-static.stderr
+++ b/tests/ui/dyn-compatibility/no-static.stderr
@@ -23,10 +23,10 @@ LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/no-static.rs:18:12
+  --> $DIR/no-static.rs:18:20
    |
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
-   |            ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                    ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:25
+  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:33
    |
 LL |     fn ptr(self: Ptr<Self>);
    |                  --------- help: consider changing method `ptr`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
-   |                         ^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |                                 ^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-76535.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.stderr
@@ -15,10 +15,10 @@ LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperS
    |                                        ++++
 
 error[E0038]: the trait `SuperTrait` is not dyn compatible
-  --> $DIR/issue-76535.rs:34:14
+  --> $DIR/issue-76535.rs:34:22
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-78671.stderr
+++ b/tests/ui/generic-associated-types/issue-78671.stderr
@@ -15,10 +15,10 @@ LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
    |                                                     +++
 
 error[E0038]: the trait `CollectionFamily` is not dyn compatible
-  --> $DIR/issue-78671.rs:5:25
+  --> $DIR/issue-78671.rs:5:30
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-79422.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.stderr
@@ -15,10 +15,10 @@ LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
    |                                            ++++
 
 error[E0038]: the trait `MapLike` is not dyn compatible
-  --> $DIR/issue-79422.rs:45:12
+  --> $DIR/issue-79422.rs:45:20
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
@@ -15,5 +15,4 @@ fn main() {
     //~^ ERROR the trait `Foo` is not dyn compatible
 
     needs_bar(x);
-    //~^ ERROR mismatched types
 }

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/span-bug-issue-121597.rs:14:12
+  --> $DIR/span-bug-issue-121597.rs:14:17
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,23 +13,6 @@ LL | trait Foo: for<T> Bar<T> {}
    |       |
    |       this trait is not dyn compatible...
 
-error[E0308]: mismatched types
-  --> $DIR/span-bug-issue-121597.rs:17:15
-   |
-LL |     needs_bar(x);
-   |     --------- ^ types differ in mutability
-   |     |
-   |     arguments to this function are incorrect
-   |
-   = note: expected raw pointer `*mut Type2`
-                found reference `&dyn Foo`
-note: function defined here
-  --> $DIR/span-bug-issue-121597.rs:11:4
-   |
-LL | fn needs_bar(_: *mut Type2) {}
-   |    ^^^^^^^^^ -------------
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0038, E0308.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
@@ -21,6 +21,8 @@ impl DynIncompatible for B {
 
 fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` is not dyn compatible
 //~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR the trait `DynIncompatible` is not dyn compatible
+//~| ERROR the trait `DynIncompatible` is not dyn compatible
     if true {
         return A;
     }

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -41,6 +41,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
    |
 LL ~ fn car() -> Box<dyn DynIncompatible> {
 LL |
+...
 LL |     if true {
 LL ~         return Box::new(A);
 LL |     }
@@ -48,7 +49,7 @@ LL ~     Box::new(B)
    |
 
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:30:17
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:17
    |
 LL | fn cat() -> Box<dyn DynIncompatible> {
    |                 ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
@@ -75,7 +76,74 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:17
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |                 ^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
+   |
+LL | trait DynIncompatible {
+   |       --------------- this trait is not dyn compatible...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement `DynIncompatible`:
+             A
+             B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
+help: consider using an opaque type instead
+   |
+LL - fn car() -> dyn DynIncompatible {
+LL + fn car() -> impl DynIncompatible {
+   |
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:17
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |                 ^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
+   |
+LL | trait DynIncompatible {
+   |       --------------- this trait is not dyn compatible...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement `DynIncompatible`:
+             A
+             B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider using an opaque type instead
+   |
+LL - fn car() -> dyn DynIncompatible {
+LL + fn car() -> impl DynIncompatible {
+   |
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0038, E0746.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:14:33
+  --> $DIR/dyn-compatibility.rs:14:41
    |
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
-   |                                 ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                         ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/foreign-dyn-error.rs:6:12
+  --> $DIR/foreign-dyn-error.rs:6:17
    |
 LL |     let _: &dyn rpitit::Foo = todo!();
-   |            ^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^^^^^^^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/issues/issue-18959.rs
+++ b/tests/ui/issues/issue-18959.rs
@@ -18,4 +18,5 @@ fn main() {
     let test: &dyn Bar = &mut thing;
     //~^ ERROR E0038
     foo(test);
+    //~^ ERROR E0038
 }

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -15,10 +15,10 @@ LL | pub trait Bar: Foo { }
    = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-18959.rs:18:15
+  --> $DIR/issue-18959.rs:18:20
    |
 LL |     let test: &dyn Bar = &mut thing;
-   |               ^^^^^^^^ `Bar` is not dyn compatible
+   |                    ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -30,6 +30,22 @@ LL | pub trait Bar: Foo { }
    |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `Bar` is not dyn compatible
+  --> $DIR/issue-18959.rs:20:9
+   |
+LL |     foo(test);
+   |         ^^^^ `Bar` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait is not dyn compatible...
+   = help: consider moving `foo` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/issues/issue-50781.stderr
+++ b/tests/ui/issues/issue-50781.stderr
@@ -16,10 +16,10 @@ LL |     fn foo(&self) where Self: Trait;
    = help: only type `()` implements `X`; consider using it directly instead.
 
 error[E0038]: the trait `X` is not dyn compatible
-  --> $DIR/issue-50781.rs:16:6
+  --> $DIR/issue-50781.rs:16:10
    |
 LL |     <dyn X as X>::foo(&());
-   |      ^^^^^ `X` is not dyn compatible
+   |          ^ `X` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/issues/issue-58734.rs
+++ b/tests/ui/issues/issue-58734.rs
@@ -18,8 +18,7 @@ fn main() {
     Trait::exists(());
     // no dyn-compatibility error
     Trait::nonexistent(());
-    //~^ ERROR no function or associated item named `nonexistent` found
-    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     //~| ERROR the trait `Trait` is not dyn compatible
 }

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -37,13 +37,6 @@ help: alternatively, consider constraining `dyn_incompatible` so it does not app
 LL |     fn dyn_incompatible() -> Self where Self: Sized;
    |                                   +++++++++++++++++
 
-error[E0599]: no function or associated item named `nonexistent` found for trait object `dyn Trait` in the current scope
-  --> $DIR/issue-58734.rs:20:12
-   |
-LL |     Trait::nonexistent(());
-   |            ^^^^^^^^^^^ function or associated item not found in `dyn Trait`
+error: aborting due to 1 previous error; 1 warning emitted
 
-error: aborting due to 2 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0038, E0599.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/kindck/kindck-inherited-copy-bound.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.stderr
@@ -20,10 +20,10 @@ LL | fn take_param<T:Foo>(foo: &T) { }
    |                 ^^^ required by this bound in `take_param`
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/kindck-inherited-copy-bound.rs:23:19
+  --> $DIR/kindck-inherited-copy-bound.rs:23:24
    |
 LL |     let z = &x as &dyn Foo;
-   |                   ^^^^^^^^ `Foo` is not dyn compatible
+   |                        ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/self/arbitrary-self-types-dyn-incompatible.stderr
+++ b/tests/ui/self/arbitrary-self-types-dyn-incompatible.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/arbitrary-self-types-dyn-incompatible.rs:29:32
+  --> $DIR/arbitrary-self-types-dyn-incompatible.rs:29:39
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  --------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
-   |                                ^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                       ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/issue-20692.stderr
+++ b/tests/ui/traits/issue-20692.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Array` is not dyn compatible
-  --> $DIR/issue-20692.rs:6:5
+  --> $DIR/issue-20692.rs:6:10
    |
 LL |     &dyn Array;
-   |     ^^^^^^^^^^ `Array` is not dyn compatible
+   |          ^^^^^ `Array` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/issue-38604.stderr
+++ b/tests/ui/traits/issue-38604.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/issue-38604.rs:14:13
+  --> $DIR/issue-38604.rs:14:21
    |
 LL |     let _f: Box<dyn Foo> =
-   |             ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                     ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/item-privacy.rs
+++ b/tests/ui/traits/item-privacy.rs
@@ -99,9 +99,7 @@ fn check_assoc_const() {
     S::C; // OK
     // A, B, C are resolved as inherent items, their traits don't need to be in scope
     <dyn C>::A;
-    //~^ ERROR associated constant `A` is private
-    //~| ERROR the trait `assoc_const::C` is not dyn compatible
-    //~| ERROR the trait `assoc_const::C` is not dyn compatible
+    //~^ ERROR the trait `assoc_const::C` is not dyn compatible
     <dyn C>::B;
     //~^ ERROR the trait `assoc_const::C` is not dyn compatible
     C::C; // OK

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -131,44 +131,10 @@ LL + use assoc_const::B;
    |
 
 error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:101:6
+  --> $DIR/item-privacy.rs:101:10
    |
 LL |     <dyn C>::A;
-   |      ^^^^^ `assoc_const::C` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/item-privacy.rs:25:15
-   |
-LL |         const A: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-...
-LL |         const B: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-...
-LL |     pub trait C: A + B {
-   |               - this trait is not dyn compatible...
-LL |         const C: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-   = help: consider moving `C` to another trait
-   = help: consider moving `A` to another trait
-   = help: consider moving `B` to another trait
-   = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
-
-error[E0624]: associated constant `A` is private
-  --> $DIR/item-privacy.rs:101:14
-   |
-LL |         const A: u8 = 0;
-   |         ----------- private associated constant defined here
-...
-LL |     <dyn C>::A;
-   |              ^ private associated constant
-
-error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:101:5
-   |
-LL |     <dyn C>::A;
-   |     ^^^^^^^^^^ `assoc_const::C` is not dyn compatible
+   |          ^ `assoc_const::C` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -190,10 +156,10 @@ LL |         const C: u8 = 0;
    = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
 
 error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:105:5
+  --> $DIR/item-privacy.rs:103:10
    |
 LL |     <dyn C>::B;
-   |     ^^^^^^^^^^ `assoc_const::C` is not dyn compatible
+   |          ^ `assoc_const::C` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -215,7 +181,7 @@ LL |         const C: u8 = 0;
    = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:118:12
+  --> $DIR/item-privacy.rs:116:12
    |
 LL |     let _: S::A;
    |            ^^^^
@@ -227,7 +193,7 @@ LL +     let _: <S as Example>::A;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:119:12
+  --> $DIR/item-privacy.rs:117:12
    |
 LL |     let _: S::B;
    |            ^^^^
@@ -239,7 +205,7 @@ LL +     let _: <S as assoc_ty::B>::B;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:120:12
+  --> $DIR/item-privacy.rs:118:12
    |
 LL |     let _: S::C;
    |            ^^^^
@@ -251,7 +217,7 @@ LL +     let _: <S as assoc_ty::C>::C;
    |
 
 error[E0624]: associated type `A` is private
-  --> $DIR/item-privacy.rs:122:12
+  --> $DIR/item-privacy.rs:120:12
    |
 LL |         type A = u8;
    |         ------ the associated type is defined here
@@ -260,7 +226,7 @@ LL |     let _: T::A;
    |            ^^^^ private associated type
 
 error[E0624]: associated type `A` is private
-  --> $DIR/item-privacy.rs:131:9
+  --> $DIR/item-privacy.rs:129:9
    |
 LL |         type A = u8;
    |         ------ the associated type is defined here
@@ -268,7 +234,7 @@ LL |         type A = u8;
 LL |         A = u8,
    |         ^^^^^^ private associated type
 
-error: aborting due to 17 previous errors
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0038, E0223, E0599, E0624.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
@@ -19,5 +19,4 @@ fn main() {
     let x: &dyn Foo = &();
     //~^ ERROR the trait `Foo` is not dyn compatible
     needs_bar(x);
-    //~^ ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
@@ -8,10 +8,10 @@ LL | #![feature(non_lifetime_binders)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/supertrait-dyn-compatibility.rs:19:12
+  --> $DIR/supertrait-dyn-compatibility.rs:19:17
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -23,22 +23,6 @@ LL | trait Foo: for<T> Bar<T> {}
    |       this trait is not dyn compatible...
    = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/supertrait-dyn-compatibility.rs:21:5
-   |
-LL |     needs_bar(x);
-   |     ^^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/supertrait-dyn-compatibility.rs:4:12
-   |
-LL | trait Foo: for<T> Bar<T> {}
-   |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
-   |       |
-   |       this trait is not dyn compatible...
-   = help: only type `()` implements `Foo`; consider using it directly instead.
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
@@ -9,7 +9,6 @@ trait Try {
 fn w<'a, T: 'a, F: Fn(&'a T)>() {
     let b: &dyn FromResidual = &();
     //~^ ERROR: the trait `FromResidual` is not dyn compatible
-    //~| ERROR the type parameter `R` must be explicitly specified
 }
 
 fn main() {}

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
@@ -1,23 +1,8 @@
-error[E0393]: the type parameter `R` must be explicitly specified
+error[E0038]: the trait `FromResidual` is not dyn compatible
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:17
    |
-LL | trait FromResidual<R = <Self as Try>::Residual> {
-   | ----------------------------------------------- type parameter `R` must be specified for this
-...
 LL |     let b: &dyn FromResidual = &();
-   |                 ^^^^^^^^^^^^
-   |
-   = note: because the parameter default references `Self`, the parameter must be specified on the object type
-help: set the type parameter to the desired type
-   |
-LL |     let b: &dyn FromResidual<R> = &();
-   |                             +++
-
-error[E0038]: the trait `FromResidual` is not dyn compatible
-  --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:12
-   |
-LL |     let b: &dyn FromResidual = &();
-   |            ^^^^^^^^^^^^^^^^^ `FromResidual` is not dyn compatible
+   |                 ^^^^^^^^^^^^ `FromResidual` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -36,7 +21,6 @@ help: alternatively, consider constraining `from_residual` so it does not apply 
 LL |     fn from_residual(residual: R) -> Self where Self: Sized;
    |                                           +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0038, E0393.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/macro-matcher.stderr
+++ b/tests/ui/traits/object/macro-matcher.stderr
@@ -1,18 +1,18 @@
+error[E0038]: the trait `Copy` is not dyn compatible
+  --> $DIR/macro-matcher.rs:8:12
+   |
+LL |     m!(dyn Copy + Send + 'static);
+   |            ^^^^ `Copy` is not dyn compatible
+   |
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+
 error[E0224]: at least one trait is required for an object type
   --> $DIR/macro-matcher.rs:11:8
    |
 LL |     m!(dyn 'static +);
    |        ^^^^^^^^^^^^^
-
-error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/macro-matcher.rs:8:8
-   |
-LL |     m!(dyn Copy + Send + 'static);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` is not dyn compatible
-   |
-   = note: the trait is not dyn compatible because it requires `Self: Sized`
-   = note: for a trait to be dyn compatible it needs to allow building a vtable
-           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/object/safety.stderr
+++ b/tests/ui/traits/object/safety.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Tr` is not dyn compatible
-  --> $DIR/safety.rs:15:12
+  --> $DIR/safety.rs:15:17
    |
 LL |     let _: &dyn Tr = &St;
-   |            ^^^^^^^ `Tr` is not dyn compatible
+   |                 ^^ `Tr` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -27,10 +27,10 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
 
 error[E0038]: the trait `bar` is not dyn compatible
-  --> $DIR/test-2.rs:13:22
+  --> $DIR/test-2.rs:13:30
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |                      ^^^^^^^^^^^^ `bar` is not dyn compatible
+   |                              ^^^ `bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.rs
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.rs
@@ -13,5 +13,4 @@ fn main() {
     let x: i32 = 5;
     let y = x as dyn MyAdd<i32>;
     //~^ ERROR E0038
-    //~| ERROR cast to unsized type: `i32` as `dyn MyAdd<i32>`
 }

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -1,20 +1,8 @@
-error[E0620]: cast to unsized type: `i32` as `dyn MyAdd<i32>`
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:13
-   |
-LL |     let y = x as dyn MyAdd<i32>;
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using a box or reference as appropriate
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:13
-   |
-LL |     let y = x as dyn MyAdd<i32>;
-   |             ^
-
 error[E0038]: the trait `MyAdd` is not dyn compatible
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:18
+  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:22
    |
 LL |     let y = x as dyn MyAdd<i32>;
-   |                  ^^^^^^^^^^^^^^ `MyAdd` is not dyn compatible
+   |                      ^^^^^^^^^^ `MyAdd` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -25,7 +13,6 @@ LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }
    = help: consider moving `add` to another trait
    = help: only type `i32` implements `MyAdd`; consider using it directly instead.
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0038, E0620.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/wf/wf-dyn-incompatible.stderr
+++ b/tests/ui/wf/wf-dyn-incompatible.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/wf-dyn-incompatible.rs:9:13
+  --> $DIR/wf-dyn-incompatible.rs:9:18
    |
 LL |     let _x: &dyn A;
-   |             ^^^^^^ `A` is not dyn compatible
+   |                  ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>


### PR DESCRIPTION
Within bodies we can employ the full dyn compat check query instead of only doing the minimal hir ty lowerer one. This in turn gives us better spans and also silences many follow-up duplicate or bogus errors.

alternative to https://github.com/rust-lang/rust/pull/141439, tho I think I could turn the delayed bug from that one into a bug now instead of having an error code path.

r? @compiler-errors
cc @fmease 