### PR TITLE
Support `opaque_types_defined_by` for `SyntheticCoroutineBody`

### DIFF
--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -321,7 +321,10 @@ fn opaque_types_defined_by<'tcx>(
             collector.collect_taits_declared_in_body();
         }
         // Closures and coroutines are type checked with their parent
-        DefKind::Closure | DefKind::InlineConst => {
+        // Note that we also support `SyntheticCoroutineBody` since we create
+        // a MIR body for the def kind, and some MIR passes (like promotion)
+        // may require doing analysis using its typing env.
+        DefKind::Closure | DefKind::InlineConst | DefKind::SyntheticCoroutineBody => {
             collector.opaques.extend(tcx.opaque_types_defined_by(tcx.local_parent(item)));
         }
         DefKind::AssocTy | DefKind::TyAlias | DefKind::GlobalAsm => {}
@@ -343,8 +346,7 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::ForeignMod
         | DefKind::Field
         | DefKind::LifetimeParam
-        | DefKind::Impl { .. }
-        | DefKind::SyntheticCoroutineBody => {
+        | DefKind::Impl { .. } => {
             span_bug!(
                 tcx.def_span(item),
                 "`opaque_types_defined_by` not defined for {} `{item:?}`",

--- a/tests/ui/async-await/async-closures/promote-in-body.rs
+++ b/tests/ui/async-await/async-closures/promote-in-body.rs
@@ -1,0 +1,13 @@
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ edition: 2024
+
+union U {
+    f: i32,
+}
+
+fn foo() {
+    async || {
+        &U { f: 1 }
+    };
+}


### PR DESCRIPTION
We create a synthetic MIR body for the `AsyncFnOnce` impl for async closures. That body goes through all passes that a regular body does, including promotion. 

Promotion sometimes requires computing that the type of an rvalue is `Freeze`, which requires computing the typing env of a body. This requires calling `opaque_types_defined_by` on the body's def id, which leads to an ICE today since we don't expect that query to be called for synthetic bodies.

While we could fix this by, for example, computing the typeck root of the body before calling a `TypingEnv` constructor, I think it's appropriate to do a more general fix here since I think it's reasonable that other passes might do analysis too.

Fixes rust-lang/rust#141466

r? @lcnr or @oli-obk