### PR TITLE
ci: fix llvm test coverage

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -332,7 +332,7 @@ auto:
     env:
       RUST_BACKTRACE: 1
       IMAGE: x86_64-gnu-llvm-20
-      DOCKER_SCRIPT: stage_2_test_set1.sh
+      DOCKER_SCRIPT: stage_2_test_set2.sh
     <<: *job-linux-4c
 
   # Skip tests that run in x86_64-gnu-llvm-20-{1,3}
@@ -357,7 +357,7 @@ auto:
     env:
       RUST_BACKTRACE: 1
       IMAGE: x86_64-gnu-llvm-19
-      DOCKER_SCRIPT: stage_2_test_set1.sh
+      DOCKER_SCRIPT: stage_2_test_set2.sh
     <<: *job-linux-4c
 
   # Skip tests that run in x86_64-gnu-llvm-19-{1,3}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
I introduced a bug in https://github.com/rust-lang/rust/pull/134427/files
`stage_2_test_set1.sh` is already executed by `x86_64-gnu-llvm-20-2` in [`x86_64-gnu-llvm2.sh`](https://github.com/rust-lang/rust/blob/b5eb9893f42a469d330046089539f908d4728384/src/ci/docker/scripts/x86_64-gnu-llvm2.sh#L7).

This PR changes the `x86_64-gnu-llvm-XX-1` jobs to run `stage_2_test_set2.sh`, which wasn't covered in CI 😔


r? @Kobzol 
<!-- homu-ignore:end -->

try-job: x86_64-gnu-llvm-19-1
try-job: x86_64-gnu-llvm-20-1
