### PR TITLE
Add `generic_arg_infer` test

### DIFF
--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
@@ -1,0 +1,11 @@
+#![feature(generic_arg_infer)]
+
+// Test that we enforce repeat expr element types are `Copy` even
+// when the repeat count is only inferred at a later point in type
+// checking.
+
+fn main() {
+    let a = [String::new(); _];
+    //~^ ERROR: the trait bound `String: Copy` is not satisfied
+    let b: [_; 2] = a;
+}

--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/copy-check-when-count-inferred-later.rs:8:14
+   |
+LL |     let a = [String::new(); _];
+   |              ^^^^^^^^^^^^^
+   |              |
+   |              the trait `Copy` is not implemented for `String`
+   |              help: create an inline `const` block: `const { String::new() }`
+   |
+   = note: the `Copy` trait is required because this value will be copied for each element of the array
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
I think most of our existing tests around behaviour of repeat expr inferred counts fail by not having enough inference progress, rather than by having enough inference progress but the element not actually implementing `Copy`.

