### PR TITLE
lint direct use of rustc_type_ir 

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![cfg_attr(not(bootstrap), allow(rustc::direct_use_of_rustc_type_ir))]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(array_windows)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -16,6 +16,7 @@
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![cfg_attr(not(bootstrap), allow(rustc::direct_use_of_rustc_type_ir))]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(assert_matches)]

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -812,6 +812,9 @@ lint_tykind = usage of `ty::TyKind`
 lint_tykind_kind = usage of `ty::TyKind::<kind>`
     .suggestion = try using `ty::<kind>` directly
 
+lint_type_ir_direct_use = do not use `rustc_type_ir` unless you are implementing type system internals
+    .note = use `rustc_middle::ty` instead
+
 lint_type_ir_inherent_usage = do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
     .note = the method or struct you're looking for is likely defined somewhere else downstream in the compiler
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -668,6 +668,7 @@ fn register_internals(store: &mut LintStore) {
             LintId::of(USAGE_OF_TYPE_IR_TRAITS),
             LintId::of(BAD_OPT_ACCESS),
             LintId::of(SPAN_USE_EQ_CTXT),
+            LintId::of(DIRECT_USE_OF_RUSTC_TYPE_IR),
         ],
     );
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -970,6 +970,11 @@ pub(crate) struct TypeIrInherentUsage;
 pub(crate) struct TypeIrTraitUsage;
 
 #[derive(LintDiagnostic)]
+#[diag(lint_type_ir_direct_use)]
+#[note]
+pub(crate) struct TypeIrDirectUse;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_non_glob_import_type_ir_inherent)]
 pub(crate) struct NonGlobImportTypeIrInherent {
     #[suggestion(code = "{snippet}", applicability = "maybe-incorrect")]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -28,6 +28,7 @@
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![cfg_attr(not(bootstrap), allow(rustc::direct_use_of_rustc_type_ir))]
 #![cfg_attr(not(bootstrap), feature(sized_hierarchy))]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]

--- a/compiler/rustc_next_trait_solver/src/lib.rs
+++ b/compiler/rustc_next_trait_solver/src/lib.rs
@@ -7,6 +7,7 @@
 // tidy-alphabetical-start
 #![allow(rustc::usage_of_type_ir_inherent)]
 #![allow(rustc::usage_of_type_ir_traits)]
+#![cfg_attr(not(bootstrap), allow(rustc::direct_use_of_rustc_type_ir))]
 // tidy-alphabetical-end
 
 pub mod canonicalizer;

--- a/compiler/rustc_passes/src/diagnostic_items.rs
+++ b/compiler/rustc_passes/src/diagnostic_items.rs
@@ -10,7 +10,7 @@
 //! * Compiler internal types like `Ty` and `TyCtxt`
 
 use rustc_hir::diagnostic_items::DiagnosticItems;
-use rustc_hir::{Attribute, OwnerId};
+use rustc_hir::{Attribute, CRATE_OWNER_ID, OwnerId};
 use rustc_middle::query::{LocalCrate, Providers};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
@@ -67,7 +67,7 @@ fn diagnostic_items(tcx: TyCtxt<'_>, _: LocalCrate) -> DiagnosticItems {
 
     // Collect diagnostic items in this crate.
     let crate_items = tcx.hir_crate_items(());
-    for id in crate_items.owners() {
+    for id in crate_items.owners().chain(std::iter::once(CRATE_OWNER_ID)) {
         observe_item(tcx, &mut diagnostic_items, id);
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2183,6 +2183,7 @@ symbols! {
         type_changing_struct_update,
         type_const,
         type_id,
+        type_ir,
         type_ir_infer_ctxt_like,
         type_ir_inherent,
         type_ir_interner,

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir")]
 // tidy-alphabetical-start
 #![allow(rustc::usage_of_ty_tykind)]
 #![allow(rustc::usage_of_type_ir_inherent)]
@@ -7,6 +8,7 @@
     feature(associated_type_defaults, never_type, rustc_attrs, negative_impls)
 )]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
+#![cfg_attr(not(bootstrap), allow(rustc::direct_use_of_rustc_type_ir))]
 // tidy-alphabetical-end
 
 extern crate self as rustc_type_ir;

--- a/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.rs
+++ b/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: -Z unstable-options
+//@ ignore-stage1
+
+#![feature(rustc_private)]
+#![deny(rustc::direct_use_of_rustc_type_ir)]
+
+extern crate rustc_middle;
+extern crate rustc_type_ir;
+
+use rustc_middle::ty::*; // OK, we have to accept rustc_middle::ty::*
+
+// We have to deny direct import of type_ir
+use rustc_type_ir::*;
+//~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals
+
+// We have to deny direct types usages which resolves to type_ir
+fn foo<I: rustc_type_ir::Interner>(cx: I, did: I::DefId) {
+//~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals
+}
+
+fn main() {
+    let _ = rustc_type_ir::InferConst::Fresh(42);
+//~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals
+    let _: rustc_type_ir::InferConst;
+//~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals
+}

--- a/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.stderr
+++ b/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.stderr
@@ -1,0 +1,39 @@
+error: do not use `rustc_type_ir` unless you are implementing type system internals
+  --> $DIR/direct-use-of-rustc-type-ir.rs:13:5
+   |
+LL | use rustc_type_ir::*;
+   |     ^^^^^^^^^^^^^
+   |
+   = note: use `rustc_middle::ty` instead
+note: the lint level is defined here
+  --> $DIR/direct-use-of-rustc-type-ir.rs:5:9
+   |
+LL | #![deny(rustc::direct_use_of_rustc_type_ir)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: do not use `rustc_type_ir` unless you are implementing type system internals
+  --> $DIR/direct-use-of-rustc-type-ir.rs:17:11
+   |
+LL | fn foo<I: rustc_type_ir::Interner>(cx: I, did: I::DefId) {
+   |           ^^^^^^^^^^^^^
+   |
+   = note: use `rustc_middle::ty` instead
+
+error: do not use `rustc_type_ir` unless you are implementing type system internals
+  --> $DIR/direct-use-of-rustc-type-ir.rs:22:13
+   |
+LL |     let _ = rustc_type_ir::InferConst::Fresh(42);
+   |             ^^^^^^^^^^^^^
+   |
+   = note: use `rustc_middle::ty` instead
+
+error: do not use `rustc_type_ir` unless you are implementing type system internals
+  --> $DIR/direct-use-of-rustc-type-ir.rs:24:12
+   |
+LL |     let _: rustc_type_ir::InferConst;
+   |            ^^^^^^^^^^^^^
+   |
+   = note: use `rustc_middle::ty` instead
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
cc rust-lang/rust#138449

As previously discussed with @lcnr,  it is a lint to prevent direct use of rustc_type_ir, except for some internal crates (like next_trait_solver or rustc_middle for example).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
