### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -1325,7 +1325,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             ));
             self.note("consider using `--verbose` to print the full type name to the console");
         }
-        Box::into_inner(self.diag.take().unwrap())
+        *self.diag.take().unwrap()
     }
 
     /// This method allows us to access the path of the file where "long types" are written to.

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(array_windows)]
 #![feature(assert_matches)]
 #![feature(associated_type_defaults)]
-#![feature(box_into_inner)]
 #![feature(box_patterns)]
 #![feature(default_field_values)]
 #![feature(error_reporter)]

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -321,7 +321,10 @@ fn opaque_types_defined_by<'tcx>(
             collector.collect_taits_declared_in_body();
         }
         // Closures and coroutines are type checked with their parent
-        DefKind::Closure | DefKind::InlineConst => {
+        // Note that we also support `SyntheticCoroutineBody` since we create
+        // a MIR body for the def kind, and some MIR passes (like promotion)
+        // may require doing analysis using its typing env.
+        DefKind::Closure | DefKind::InlineConst | DefKind::SyntheticCoroutineBody => {
             collector.opaques.extend(tcx.opaque_types_defined_by(tcx.local_parent(item)));
         }
         DefKind::AssocTy | DefKind::TyAlias | DefKind::GlobalAsm => {}
@@ -343,8 +346,7 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::ForeignMod
         | DefKind::Field
         | DefKind::LifetimeParam
-        | DefKind::Impl { .. }
-        | DefKind::SyntheticCoroutineBody => {
+        | DefKind::Impl { .. } => {
             span_bug!(
                 tcx.def_span(item),
                 "`opaque_types_defined_by` not defined for {} `{item:?}`",

--- a/src/doc/rustc/src/check-cfg/cargo-specifics.md
+++ b/src/doc/rustc/src/check-cfg/cargo-specifics.md
@@ -9,8 +9,8 @@ rustc, not Cargo.
 -->
 
 This document is intended to summarize the principal ways Cargo interacts with
-the `unexpected_cfgs` lint and `--check-cfg` flag. It is not intended to provide
-individual details, for that refer to the [`--check-cfg` documentation](../check-cfg.md) and
+the `unexpected_cfgs` lint and `--check-cfg` flag.
+For individual details, refer to the [`--check-cfg` documentation](../check-cfg.md) and
 to the [Cargo book](../../cargo/index.html).
 
 > The full list of well known cfgs (aka builtins) can be found under [Checking conditional configurations / Well known names and values](../check-cfg.md#well-known-names-and-values).

--- a/src/tools/rustbook/Cargo.lock
+++ b/src/tools/rustbook/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72bc08f096e1fb15cfc382babe218317c2897d2040f967c4db40d156ca28e21"
+checksum = "a87e65420ab45ca9c1b8cdf698f95b710cc826d373fa550f0f7fad82beac9328"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -15,6 +15,6 @@ mdbook-i18n-helpers = "0.3.3"
 mdbook-spec = { path = "../../doc/reference/mdbook-spec" }
 
 [dependencies.mdbook]
-version = "0.4.50"
+version = "0.4.51"
 default-features = false
 features = ["search"]

--- a/tests/ui/async-await/async-closures/promote-in-body.rs
+++ b/tests/ui/async-await/async-closures/promote-in-body.rs
@@ -1,0 +1,13 @@
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ edition: 2024
+
+union U {
+    f: i32,
+}
+
+fn foo() {
+    async || {
+        &U { f: 1 }
+    };
+}

--- a/tests/ui/async-await/async-fn/edition-2015-not-async-bound.rs
+++ b/tests/ui/async-await/async-fn/edition-2015-not-async-bound.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ check-pass
 // Make sure that we don't eagerly recover `async ::Bound` in edition 2015.
 

--- a/tests/ui/async-await/async-fn/edition-2015.rs
+++ b/tests/ui/async-await/async-fn/edition-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 fn foo(x: impl async Fn()) -> impl async Fn() { x }
 //~^ ERROR `async` trait bounds are only allowed in Rust 2018 or later
 //~| ERROR `async` trait bounds are only allowed in Rust 2018 or later

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -1,5 +1,5 @@
 error: `async` trait bounds are only allowed in Rust 2018 or later
-  --> $DIR/edition-2015.rs:1:16
+  --> $DIR/edition-2015.rs:2:16
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
@@ -8,7 +8,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: `async` trait bounds are only allowed in Rust 2018 or later
-  --> $DIR/edition-2015.rs:1:36
+  --> $DIR/edition-2015.rs:2:36
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^
@@ -17,7 +17,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0658]: `async` trait bounds are unstable
-  --> $DIR/edition-2015.rs:1:16
+  --> $DIR/edition-2015.rs:2:16
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
@@ -28,7 +28,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error[E0658]: `async` trait bounds are unstable
-  --> $DIR/edition-2015.rs:1:36
+  --> $DIR/edition-2015.rs:2:36
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^

--- a/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.rs
+++ b/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 #![allow(non_camel_case_types)]
 #![deny(keyword_idents)]
 

--- a/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
+++ b/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
@@ -1,5 +1,5 @@
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:5:13
+  --> $DIR/2015-edition-error-various-positions.rs:6:13
    |
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -7,14 +7,14 @@ LL |     pub mod await {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 note: the lint level is defined here
-  --> $DIR/2015-edition-error-various-positions.rs:2:9
+  --> $DIR/2015-edition-error-various-positions.rs:3:9
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
    = note: `#[deny(keyword_idents_2018)]` implied by `#[deny(keyword_idents)]`
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:7:20
+  --> $DIR/2015-edition-error-various-positions.rs:8:20
    |
 LL |         pub struct await;
    |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -23,7 +23,7 @@ LL |         pub struct await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:11:16
+  --> $DIR/2015-edition-error-various-positions.rs:12:16
    |
 LL | use outer_mod::await::await;
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -32,7 +32,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:11:23
+  --> $DIR/2015-edition-error-various-positions.rs:12:23
    |
 LL | use outer_mod::await::await;
    |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -41,7 +41,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:16:14
+  --> $DIR/2015-edition-error-various-positions.rs:17:14
    |
 LL | struct Foo { await: () }
    |              ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -50,7 +50,7 @@ LL | struct Foo { await: () }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:20:15
+  --> $DIR/2015-edition-error-various-positions.rs:21:15
    |
 LL | impl Foo { fn await() {} }
    |               ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -59,7 +59,7 @@ LL | impl Foo { fn await() {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:24:14
+  --> $DIR/2015-edition-error-various-positions.rs:25:14
    |
 LL | macro_rules! await {
    |              ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -68,7 +68,7 @@ LL | macro_rules! await {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:31:5
+  --> $DIR/2015-edition-error-various-positions.rs:32:5
    |
 LL |     await!();
    |     ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -77,7 +77,7 @@ LL |     await!();
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:34:11
+  --> $DIR/2015-edition-error-various-positions.rs:35:11
    |
 LL |     match await { await => {} }
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -86,7 +86,7 @@ LL |     match await { await => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:34:19
+  --> $DIR/2015-edition-error-various-positions.rs:35:19
    |
 LL |     match await { await => {} }
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.fixed
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.fixed
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.rs
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.stderr
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.stderr
@@ -1,5 +1,5 @@
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:7:13
+  --> $DIR/2015-edition-warning.rs:8:13
    |
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -7,14 +7,14 @@ LL |     pub mod await {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 note: the lint level is defined here
-  --> $DIR/2015-edition-warning.rs:4:9
+  --> $DIR/2015-edition-warning.rs:5:9
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
    = note: `#[deny(keyword_idents_2018)]` implied by `#[deny(keyword_idents)]`
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:10:20
+  --> $DIR/2015-edition-warning.rs:11:20
    |
 LL |         pub struct await;
    |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -23,7 +23,7 @@ LL |         pub struct await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:16
+  --> $DIR/2015-edition-warning.rs:16:16
    |
 LL | use outer_mod::await::await;
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -32,7 +32,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:23
+  --> $DIR/2015-edition-warning.rs:16:23
    |
 LL | use outer_mod::await::await;
    |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -41,7 +41,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:11
+  --> $DIR/2015-edition-warning.rs:23:11
    |
 LL |     match await { await => {} }
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -50,7 +50,7 @@ LL |     match await { await => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:19
+  --> $DIR/2015-edition-warning.rs:23:19
    |
 LL |     match await { await => {} }
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`

--- a/tests/ui/async-await/for-await-2015.rs
+++ b/tests/ui/async-await/for-await-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ check-pass
 
 #![feature(async_for_loop)]

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2015.stderr
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2015.stderr
@@ -1,16 +1,16 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:24:13
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:25:13
    |
 LL |     r#fn {}.r#struct();
    |             ^^^^^^^^ multiple `r#struct` found
    |
 note: candidate #1 is defined in an impl of the trait `async` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:7:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:8:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `await` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:13:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:14:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2018.stderr
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2018.stderr
@@ -1,16 +1,16 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:24:13
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:25:13
    |
 LL |     r#fn {}.r#struct();
    |             ^^^^^^^^ multiple `r#struct` found
    |
 note: candidate #1 is defined in an impl of the trait `r#async` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:7:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:8:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `r#await` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:13:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:14:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.rs
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.rs
@@ -1,4 +1,5 @@
 //@ revisions: edition2015 edition2018
+//@[edition2015]edition:2015
 //@[edition2018]edition:2018
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ rustc-env:CARGO_CRATE_NAME=foo
 
 use std::pin::Pin;

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `await` on type `await_on_struct_missing::S`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:11:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:12:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -9,7 +9,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:24:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:25:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -24,7 +24,7 @@ LL +     x.awai;
    |
 
 error[E0609]: no field `await` on type `Pin<&mut dyn Future<Output = ()>>`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:34:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:35:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -34,7 +34,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:43:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:44:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field

--- a/tests/ui/async-await/suggest-switching-edition-on-await.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 use std::pin::Pin;
 use std::future::Future;
 

--- a/tests/ui/async-await/suggest-switching-edition-on-await.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `await` on type `await_on_struct_missing::S`
-  --> $DIR/suggest-switching-edition-on-await.rs:9:7
+  --> $DIR/suggest-switching-edition-on-await.rs:10:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -9,7 +9,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
-  --> $DIR/suggest-switching-edition-on-await.rs:22:7
+  --> $DIR/suggest-switching-edition-on-await.rs:23:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -24,7 +24,7 @@ LL +     x.awai;
    |
 
 error[E0609]: no field `await` on type `Pin<&mut dyn Future<Output = ()>>`
-  --> $DIR/suggest-switching-edition-on-await.rs:32:7
+  --> $DIR/suggest-switching-edition-on-await.rs:33:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -34,7 +34,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
-  --> $DIR/suggest-switching-edition-on-await.rs:41:7
+  --> $DIR/suggest-switching-edition-on-await.rs:42:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field

--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
@@ -1,0 +1,11 @@
+#![feature(generic_arg_infer)]
+
+// Test that we enforce repeat expr element types are `Copy` even
+// when the repeat count is only inferred at a later point in type
+// checking.
+
+fn main() {
+    let a = [String::new(); _];
+    //~^ ERROR: the trait bound `String: Copy` is not satisfied
+    let b: [_; 2] = a;
+}

--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/copy-check-when-count-inferred-later.rs:8:14
+   |
+LL |     let a = [String::new(); _];
+   |              ^^^^^^^^^^^^^
+   |              |
+   |              the trait `Copy` is not implemented for `String`
+   |              help: create an inline `const` block: `const { String::new() }`
+   |
+   = note: the `Copy` trait is required because this value will be copied for each element of the array
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1170,7 +1170,6 @@ contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "fmease",
     "jyn514",
-    "spastorino",
 ]
 
 [[assign.warn_non_default_branch.exceptions]]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141584 (Support `opaque_types_defined_by` for `SyntheticCoroutineBody`)
 - rust-lang/rust#141587 (Add missing edition directives for async-await tests)
 - rust-lang/rust#141594 (Add `generic_arg_infer` test)
 - rust-lang/rust#141596 (rustc book: fix erratic sentence by making it more simple)
 - rust-lang/rust#141599 (Remove an unnecessary use of `Box::into_inner`.)
 - rust-lang/rust#141611 (Update mdbook to 0.4.51)
 - rust-lang/rust#141616 (Remove spastorino from vacations)
 - rust-lang/rust#141623 (use custom types to clarify arguments to `emit_ptr_va_arg`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141584,141587,141594,141596,141599,141611,141616,141623)
<!-- homu-ignore:end -->