### PR TITLE
Suggest to bind `self.x` to `x` when field `x` may be in format string

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -26,7 +26,7 @@ use rustc_middle::ty;
 use rustc_session::{Session, lint};
 use rustc_span::edit_distance::{edit_distance, find_best_match_for_name};
 use rustc_span::edition::Edition;
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
+use rustc_span::{DUMMY_SP, DesugaringKind, Ident, Span, Symbol, kw, sym};
 use thin_vec::ThinVec;
 use tracing::debug;
 
@@ -980,12 +980,15 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     AssocSuggestion::Field(field_span) => {
                         if self_is_available {
                             let source_map = self.r.tcx.sess.source_map();
-                            // check if the field is used in a format string, such as `"{x}"`
-                            let field_is_format_named_arg = source_map
+                            let field_is_format_named_arg = matches!(
+                                span.desugaring_kind(),
+                                Some(DesugaringKind::FormatLiteral { .. })
+                            ) && source_map
                                 .span_to_source(span, |s, start, _| {
-                                    Ok(s.get(start - 1..start) == Some("{"))
-                                });
-                            if let Ok(true) = field_is_format_named_arg {
+                                    Ok(s.get(start.saturating_sub(1)..start) == Some("{"))
+                                })
+                                .unwrap_or(false);
+                            if field_is_format_named_arg {
                                 err.help(
                                     format!("you might have meant to use the available field in a format string: `\"{{}}\", self.{}`", segment.ident.name),
                                 );

--- a/tests/ui/resolve/suggestions/sugg-field-in-format-string-issue-141136.rs
+++ b/tests/ui/resolve/suggestions/sugg-field-in-format-string-issue-141136.rs
@@ -9,6 +9,7 @@ impl Foo {
         let _ = format!("{ x}"); //~ ERROR invalid format string: expected `}`, found `x`
         let _ = format!("{}", x); //~ ERROR cannot find value `x` in this scope [E0425]
         println!("{x}"); //~ ERROR cannot find value `x` in this scope [E0425]
+        let _ = {x}; //~ERROR cannot find value `x` in this scope [E0425]
     }
 }
 

--- a/tests/ui/resolve/suggestions/sugg-field-in-format-string-issue-141136.stderr
+++ b/tests/ui/resolve/suggestions/sugg-field-in-format-string-issue-141136.stderr
@@ -14,7 +14,10 @@ error[E0425]: cannot find value `x` in this scope
 LL |         let _ = format!("{x}");
    |                           ^
    |
-   = help: you might have meant to use the available field in a format string: `"{}", self.x`
+help: you might have meant to use the available field
+   |
+LL |         let _ = format!("{self.x}");
+   |                           +++++
 
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/sugg-field-in-format-string-issue-141136.rs:8:27
@@ -22,7 +25,10 @@ error[E0425]: cannot find value `x` in this scope
 LL |         let _ = format!("{x }");
    |                           ^^
    |
-   = help: you might have meant to use the available field in a format string: `"{}", self.x`
+help: you might have meant to use the available field
+   |
+LL |         let _ = format!("{self.x }");
+   |                           +++++
 
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/sugg-field-in-format-string-issue-141136.rs:10:31
@@ -41,8 +47,22 @@ error[E0425]: cannot find value `x` in this scope
 LL |         println!("{x}");
    |                    ^
    |
-   = help: you might have meant to use the available field in a format string: `"{}", self.x`
+help: you might have meant to use the available field
+   |
+LL |         println!("{self.x}");
+   |                    +++++
 
-error: aborting due to 5 previous errors
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/sugg-field-in-format-string-issue-141136.rs:12:18
+   |
+LL |         let _ = {x};
+   |                  ^
+   |
+help: you might have meant to use the available field
+   |
+LL |         let _ = {self.x};
+   |                  +++++
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -34,7 +34,10 @@ error[E0425]: cannot find value `config` in this scope
 LL |         println!("{config}");
    |                    ^^^^^^
    |
-   = help: you might have meant to use the available field in a format string: `"{}", self.config`
+help: you might have meant to use the available field
+   |
+LL |         println!("{self.config}");
+   |                    +++++
 help: a local variable with a similar name exists
    |
 LL -         println!("{config}");


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/141633)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#141350

I added the new test in the first commit, and committed the changes in the second one.

r? @fmease  
cc @mejrs 