### PR TITLE
Rollup of 17 pull requests

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1041,78 +1041,6 @@ pub fn walk_item_kind<K: WalkItemKind>(
     kind.walk(span, id, visibility, ctxt, vis)
 }
 
-impl WalkItemKind for AssocItemKind {
-    type Ctxt = AssocCtxt;
-    fn walk<V: MutVisitor>(
-        &mut self,
-        span: Span,
-        id: NodeId,
-        visibility: &mut Visibility,
-        ctxt: Self::Ctxt,
-        visitor: &mut V,
-    ) {
-        match self {
-            AssocItemKind::Const(item) => {
-                walk_const_item(visitor, item);
-            }
-            AssocItemKind::Fn(func) => {
-                visitor.visit_fn(FnKind::Fn(FnCtxt::Assoc(ctxt), visibility, &mut *func), span, id);
-            }
-            AssocItemKind::Type(box TyAlias {
-                defaultness,
-                ident,
-                generics,
-                where_clauses,
-                bounds,
-                ty,
-            }) => {
-                visit_defaultness(visitor, defaultness);
-                visitor.visit_ident(ident);
-                visitor.visit_generics(generics);
-                visit_bounds(visitor, bounds, BoundKind::Bound);
-                visit_opt(ty, |ty| visitor.visit_ty(ty));
-                walk_ty_alias_where_clauses(visitor, where_clauses);
-            }
-            AssocItemKind::MacCall(mac) => visitor.visit_mac_call(mac),
-            AssocItemKind::Delegation(box Delegation {
-                id,
-                qself,
-                path,
-                ident,
-                rename,
-                body,
-                from_glob: _,
-            }) => {
-                visitor.visit_id(id);
-                visitor.visit_qself(qself);
-                visitor.visit_path(path);
-                visitor.visit_ident(ident);
-                if let Some(rename) = rename {
-                    visitor.visit_ident(rename);
-                }
-                if let Some(body) = body {
-                    visitor.visit_block(body);
-                }
-            }
-            AssocItemKind::DelegationMac(box DelegationMac { qself, prefix, suffixes, body }) => {
-                visitor.visit_qself(qself);
-                visitor.visit_path(prefix);
-                if let Some(suffixes) = suffixes {
-                    for (ident, rename) in suffixes {
-                        visitor.visit_ident(ident);
-                        if let Some(rename) = rename {
-                            visitor.visit_ident(rename);
-                        }
-                    }
-                }
-                if let Some(body) = body {
-                    visitor.visit_block(body);
-                }
-            }
-        }
-    }
-}
-
 pub fn walk_crate<T: MutVisitor>(vis: &mut T, krate: &mut Crate) {
     let Crate { attrs, items, spans, id, is_placeholder: _ } = krate;
     vis.visit_id(id);
@@ -1121,14 +1049,6 @@ pub fn walk_crate<T: MutVisitor>(vis: &mut T, krate: &mut Crate) {
     let ModSpans { inner_span, inject_use_span } = spans;
     vis.visit_span(inner_span);
     vis.visit_span(inject_use_span);
-}
-
-pub fn walk_item(visitor: &mut impl MutVisitor, item: &mut P<Item<impl WalkItemKind<Ctxt = ()>>>) {
-    walk_item_ctxt(visitor, item, ())
-}
-
-pub fn walk_assoc_item(visitor: &mut impl MutVisitor, item: &mut P<AssocItem>, ctxt: AssocCtxt) {
-    walk_item_ctxt(visitor, item, ctxt)
 }
 
 pub fn walk_flat_map_item(vis: &mut impl MutVisitor, mut item: P<Item>) -> SmallVec<[P<Item>; 1]> {
@@ -1151,53 +1071,6 @@ pub fn walk_flat_map_assoc_item(
 ) -> SmallVec<[P<AssocItem>; 1]> {
     vis.visit_assoc_item(&mut item, ctxt);
     smallvec![item]
-}
-
-impl WalkItemKind for ForeignItemKind {
-    type Ctxt = ();
-    fn walk<V: MutVisitor>(
-        &mut self,
-        span: Span,
-        id: NodeId,
-        visibility: &mut Visibility,
-        _ctxt: Self::Ctxt,
-        visitor: &mut V,
-    ) {
-        match self {
-            ForeignItemKind::Static(box StaticItem {
-                ident,
-                ty,
-                mutability: _,
-                expr,
-                safety: _,
-                define_opaque,
-            }) => {
-                visitor.visit_ident(ident);
-                visitor.visit_ty(ty);
-                visit_opt(expr, |expr| visitor.visit_expr(expr));
-                walk_define_opaques(visitor, define_opaque);
-            }
-            ForeignItemKind::Fn(func) => {
-                visitor.visit_fn(FnKind::Fn(FnCtxt::Foreign, visibility, &mut *func), span, id);
-            }
-            ForeignItemKind::TyAlias(box TyAlias {
-                defaultness,
-                ident,
-                generics,
-                where_clauses,
-                bounds,
-                ty,
-            }) => {
-                visit_defaultness(visitor, defaultness);
-                visitor.visit_ident(ident);
-                visitor.visit_generics(generics);
-                visit_bounds(visitor, bounds, BoundKind::Bound);
-                visit_opt(ty, |ty| visitor.visit_ty(ty));
-                walk_ty_alias_where_clauses(visitor, where_clauses);
-            }
-            ForeignItemKind::MacCall(mac) => visitor.visit_mac_call(mac),
-        }
-    }
 }
 
 pub fn walk_pat<T: MutVisitor>(vis: &mut T, pat: &mut P<Pat>) {

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -310,7 +310,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
         let ty = tcx.ty_ordering_enum(None);
         let layout =
             tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty)).unwrap();
-        Self::from_scalar(Scalar::from_i8(c as i8), layout)
+        Self::from_scalar(Scalar::Int(c.into()), layout)
     }
 
     pub fn from_pair(a: Self, b: Self, cx: &(impl HasTypingEnv<'tcx> + HasTyCtxt<'tcx>)) -> Self {

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -1325,7 +1325,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             ));
             self.note("consider using `--verbose` to print the full type name to the console");
         }
-        Box::into_inner(self.diag.take().unwrap())
+        *self.diag.take().unwrap()
     }
 
     /// This method allows us to access the path of the file where "long types" are written to.

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(array_windows)]
 #![feature(assert_matches)]
 #![feature(associated_type_defaults)]
-#![feature(box_into_inner)]
 #![feature(box_patterns)]
 #![feature(default_field_values)]
 #![feature(error_reporter)]

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -349,7 +349,7 @@ impl MutVisitor for PlaceholderExpander {
     fn filter_map_expr(&mut self, expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
         match expr.kind {
             ast::ExprKind::MacCall(_) => self.remove(expr.id).make_opt_expr(),
-            _ => noop_filter_map_expr(self, expr),
+            _ => walk_filter_map_expr(self, expr),
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -31,7 +31,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{self, InferKind, Visitor, VisitorExt, walk_generics};
 use rustc_hir::{self as hir, GenericParamKind, HirId, Node, PreciseCapturingArgKind};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
@@ -40,7 +40,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 use rustc_trait_selection::infer::InferCtxtExt;
-use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_trait_selection::traits::{ObligationCtxt, hir_ty_lowering_dyn_compatibility_violations};
 use tracing::{debug, instrument};
 
 use crate::errors;
@@ -624,6 +624,10 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         }
 
         (input_tys, output_ty)
+    }
+
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation> {
+        hir_ty_lowering_dyn_compatibility_violations(self.tcx, trait_def_id)
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::{
 };
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::error_reporting::traits::report_dyn_incompatibility;
-use rustc_trait_selection::traits::{self, hir_ty_lowering_dyn_compatibility_violations};
+use rustc_trait_selection::traits;
 use smallvec::{SmallVec, smallvec};
 use tracing::{debug, instrument};
 
@@ -97,8 +97,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // to avoid ICEs.
         for (clause, span) in user_written_bounds {
             if let Some(trait_pred) = clause.as_trait_clause() {
-                let violations =
-                    hir_ty_lowering_dyn_compatibility_violations(tcx, trait_pred.def_id());
+                let violations = self.dyn_compatibility_violations(trait_pred.def_id());
                 if !violations.is_empty() {
                     let reported = report_dyn_incompatibility(
                         tcx,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -33,7 +33,7 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, AnonConst, GenericArg, GenericArgs, HirId};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::mir::interpret::LitToConstInput;
 use rustc_middle::ty::print::PrintPolyTraitRefExt as _;
@@ -200,6 +200,10 @@ pub trait HirTyLowerer<'tcx> {
     {
         self
     }
+
+    /// Performs minimalistic dyn compat checks outside of bodies, but full within bodies.
+    /// Outside of bodies we could end up in cycles, so we delay most checks to later phases.
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation>;
 }
 
 /// The "qualified self" of an associated item path.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1546,25 +1546,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             SuggestionText::Reorder => Some("reorder these arguments".to_string()),
             SuggestionText::DidYouMean => Some("did you mean".to_string()),
         };
-        if let Some(suggestion_text) = suggestion_text {
+        if let Some(suggestion_text) = suggestion_text
+            && !full_call_span.in_external_macro(self.sess().source_map())
+        {
             let source_map = self.sess().source_map();
-            let (mut suggestion, suggestion_span) = if let Some(call_span) =
-                full_call_span.find_ancestor_inside_same_ctxt(error_span)
-            {
-                ("(".to_string(), call_span.shrink_to_hi().to(error_span.shrink_to_hi()))
+            let suggestion_span = if let Some(args_span) = error_span.trim_start(full_call_span) {
+                // Span of the braces, e.g. `(a, b, c)`.
+                args_span
             } else {
-                (
-                    format!(
-                        "{}(",
-                        source_map.span_to_snippet(full_call_span).unwrap_or_else(|_| {
-                            fn_def_id.map_or("".to_string(), |fn_def_id| {
-                                tcx.item_name(fn_def_id).to_string()
-                            })
-                        })
-                    ),
-                    error_span,
-                )
+                // The arg span of a function call that wasn't even given braces
+                // like what might happen with delegation reuse.
+                // e.g. `reuse HasSelf::method;` should suggest `reuse HasSelf::method($args);`.
+                full_call_span.shrink_to_hi()
             };
+            let mut suggestion = "(".to_owned();
             let mut needs_comma = false;
             for (expected_idx, provided_idx) in matched_inputs.iter_enumerated() {
                 if needs_comma {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -14,7 +14,7 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, HirId, ItemLocalMap};
 use rustc_hir_analysis::hir_ty_lowering::{HirTyLowerer, RegionInferReason};
 use rustc_infer::infer;
-use rustc_infer::traits::Obligation;
+use rustc_infer::traits::{DynCompatibilityViolation, Obligation};
 use rustc_middle::ty::{self, Const, Ty, TyCtxt, TypeVisitableExt};
 use rustc_session::Session;
 use rustc_span::{self, DUMMY_SP, ErrorGuaranteed, Ident, Span, sym};
@@ -387,6 +387,10 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
             hir::FnRetTy::DefaultReturn(..) => self.tcx().types.unit,
         };
         (input_tys, output_ty)
+    }
+
+    fn dyn_compatibility_violations(&self, trait_def_id: DefId) -> Vec<DynCompatibilityViolation> {
+        self.tcx.dyn_compatibility_violations(trait_def_id).to_vec()
     }
 }
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -13,6 +13,8 @@ lint_ambiguous_negative_literals = `-` has lower precedence than method calls, w
 lint_ambiguous_wide_pointer_comparisons = ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
     .addr_metadata_suggestion = use explicit `std::ptr::eq` method to compare metadata and addresses
     .addr_suggestion = use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+    .cast_suggestion = use untyped pointers to only compare their addresses
+    .expect_suggestion = or expect the lint to compare the pointers metadata and addresses
 
 lint_associated_const_elided_lifetime = {$elided ->
         [true] `&` without an explicit lifetime name cannot be used here

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -180,27 +180,27 @@ impl<Prov> Scalar<Prov> {
 
     #[inline]
     pub fn from_i8(i: i8) -> Self {
-        Self::from_int(i, Size::from_bits(8))
+        Self::Int(i.into())
     }
 
     #[inline]
     pub fn from_i16(i: i16) -> Self {
-        Self::from_int(i, Size::from_bits(16))
+        Self::Int(i.into())
     }
 
     #[inline]
     pub fn from_i32(i: i32) -> Self {
-        Self::from_int(i, Size::from_bits(32))
+        Self::Int(i.into())
     }
 
     #[inline]
     pub fn from_i64(i: i64) -> Self {
-        Self::from_int(i, Size::from_bits(64))
+        Self::Int(i.into())
     }
 
     #[inline]
     pub fn from_i128(i: i128) -> Self {
-        Self::from_int(i, Size::from_bits(128))
+        Self::Int(i.into())
     }
 
     #[inline]

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -321,7 +321,10 @@ fn opaque_types_defined_by<'tcx>(
             collector.collect_taits_declared_in_body();
         }
         // Closures and coroutines are type checked with their parent
-        DefKind::Closure | DefKind::InlineConst => {
+        // Note that we also support `SyntheticCoroutineBody` since we create
+        // a MIR body for the def kind, and some MIR passes (like promotion)
+        // may require doing analysis using its typing env.
+        DefKind::Closure | DefKind::InlineConst | DefKind::SyntheticCoroutineBody => {
             collector.opaques.extend(tcx.opaque_types_defined_by(tcx.local_parent(item)));
         }
         DefKind::AssocTy | DefKind::TyAlias | DefKind::GlobalAsm => {}
@@ -343,8 +346,7 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::ForeignMod
         | DefKind::Field
         | DefKind::LifetimeParam
-        | DefKind::Impl { .. }
-        | DefKind::SyntheticCoroutineBody => {
+        | DefKind::Impl { .. } => {
             span_bug!(
                 tcx.def_span(item),
                 "`opaque_types_defined_by` not defined for {} `{item:?}`",

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1,7 +1,10 @@
 //! Compiler intrinsics.
 //!
-//! The corresponding definitions are in <https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_llvm/src/intrinsic.rs>.
-//! The corresponding const implementations are in <https://github.com/rust-lang/rust/blob/master/compiler/rustc_const_eval/src/interpret/intrinsics.rs>.
+//! These are the imports making intrinsics available to Rust code. The actual implementations live in the compiler.
+//! Some of these intrinsics are lowered to MIR in <https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_transform/src/lower_intrinsics.rs>.
+//! The remaining intrinsics are implemented for the LLVM backend in <https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs>
+//! and <https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_llvm/src/intrinsic.rs>,
+//! and for const evaluation in <https://github.com/rust-lang/rust/blob/master/compiler/rustc_const_eval/src/interpret/intrinsics.rs>.
 //!
 //! # Const intrinsics
 //!
@@ -20,28 +23,14 @@
 //!
 //! The volatile intrinsics provide operations intended to act on I/O
 //! memory, which are guaranteed to not be reordered by the compiler
-//! across other volatile intrinsics. See the LLVM documentation on
-//! [[volatile]].
-//!
-//! [volatile]: https://llvm.org/docs/LangRef.html#volatile-memory-accesses
+//! across other volatile intrinsics. See [`read_volatile`][ptr::read_volatile]
+//! and [`write_volatile`][ptr::write_volatile].
 //!
 //! # Atomics
 //!
 //! The atomic intrinsics provide common atomic operations on machine
-//! words, with multiple possible memory orderings. They obey the same
-//! semantics as C++11. See the LLVM documentation on [[atomics]].
-//!
-//! [atomics]: https://llvm.org/docs/Atomics.html
-//!
-//! A quick refresher on memory ordering:
-//!
-//! * Acquire - a barrier for acquiring a lock. Subsequent reads and writes
-//!   take place after the barrier.
-//! * Release - a barrier for releasing a lock. Preceding reads and writes
-//!   take place before the barrier.
-//! * Sequentially consistent - sequentially consistent operations are
-//!   guaranteed to happen in order. This is the standard mode for working
-//!   with atomic types and is equivalent to Java's `volatile`.
+//! words, with multiple possible memory orderings. See the
+//! [atomic types][crate::sync::atomic] docs for details.
 //!
 //! # Unwinding
 //!

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2282,6 +2282,10 @@ impl Step for LlvmTools {
             }
         }
 
+        if !builder.config.dry_run() {
+            builder.require_submodule("src/llvm-project", None);
+        }
+
         builder.ensure(crate::core::build_steps::llvm::Llvm { target });
 
         let mut tarball = Tarball::new(builder, "llvm-tools", &target.triple);
@@ -2398,6 +2402,10 @@ impl Step for RustDev {
                 builder.info(&format!("Skipping RustDev ({target}): external LLVM"));
                 return None;
             }
+        }
+
+        if !builder.config.dry_run() {
+            builder.require_submodule("src/llvm-project", None);
         }
 
         let mut tarball = Tarball::new(builder, "rust-dev", &target.triple);

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -38,7 +38,9 @@ fn sanitize_sh(path: &Path, is_cygwin: bool) -> String {
         if ch.next() != Some('/') {
             return None;
         }
-        Some(format!("/{}/{}", drive, &s[drive.len_utf8() + 2..]))
+        // The prefix for Windows drives in Cygwin/MSYS2 is configurable, but
+        // /proc/cygdrive is available regardless of configuration since 1.7.33
+        Some(format!("/proc/cygdrive/{}/{}", drive, &s[drive.len_utf8() + 2..]))
     }
 }
 

--- a/src/doc/rustc/src/check-cfg/cargo-specifics.md
+++ b/src/doc/rustc/src/check-cfg/cargo-specifics.md
@@ -9,8 +9,8 @@ rustc, not Cargo.
 -->
 
 This document is intended to summarize the principal ways Cargo interacts with
-the `unexpected_cfgs` lint and `--check-cfg` flag. It is not intended to provide
-individual details, for that refer to the [`--check-cfg` documentation](../check-cfg.md) and
+the `unexpected_cfgs` lint and `--check-cfg` flag.
+For individual details, refer to the [`--check-cfg` documentation](../check-cfg.md) and
 to the [Cargo book](../../cargo/index.html).
 
 > The full list of well known cfgs (aka builtins) can be found under [Checking conditional configurations / Well known names and values](../check-cfg.md#well-known-names-and-values).

--- a/src/tools/rustbook/Cargo.lock
+++ b/src/tools/rustbook/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.50"
+version = "0.4.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72bc08f096e1fb15cfc382babe218317c2897d2040f967c4db40d156ca28e21"
+checksum = "a87e65420ab45ca9c1b8cdf698f95b710cc826d373fa550f0f7fad82beac9328"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -15,6 +15,6 @@ mdbook-i18n-helpers = "0.3.3"
 mdbook-spec = { path = "../../doc/reference/mdbook-spec" }
 
 [dependencies.mdbook]
-version = "0.4.50"
+version = "0.4.51"
 default-features = false
 features = ["search"]

--- a/tests/ui/async-await/async-closures/promote-in-body.rs
+++ b/tests/ui/async-await/async-closures/promote-in-body.rs
@@ -1,0 +1,13 @@
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ edition: 2024
+
+union U {
+    f: i32,
+}
+
+fn foo() {
+    async || {
+        &U { f: 1 }
+    };
+}

--- a/tests/ui/async-await/async-fn/edition-2015-not-async-bound.rs
+++ b/tests/ui/async-await/async-fn/edition-2015-not-async-bound.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ check-pass
 // Make sure that we don't eagerly recover `async ::Bound` in edition 2015.
 

--- a/tests/ui/async-await/async-fn/edition-2015.rs
+++ b/tests/ui/async-await/async-fn/edition-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 fn foo(x: impl async Fn()) -> impl async Fn() { x }
 //~^ ERROR `async` trait bounds are only allowed in Rust 2018 or later
 //~| ERROR `async` trait bounds are only allowed in Rust 2018 or later

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -1,5 +1,5 @@
 error: `async` trait bounds are only allowed in Rust 2018 or later
-  --> $DIR/edition-2015.rs:1:16
+  --> $DIR/edition-2015.rs:2:16
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
@@ -8,7 +8,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: `async` trait bounds are only allowed in Rust 2018 or later
-  --> $DIR/edition-2015.rs:1:36
+  --> $DIR/edition-2015.rs:2:36
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^
@@ -17,7 +17,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0658]: `async` trait bounds are unstable
-  --> $DIR/edition-2015.rs:1:16
+  --> $DIR/edition-2015.rs:2:16
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
@@ -28,7 +28,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error[E0658]: `async` trait bounds are unstable
-  --> $DIR/edition-2015.rs:1:36
+  --> $DIR/edition-2015.rs:2:36
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^

--- a/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.rs
+++ b/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 #![allow(non_camel_case_types)]
 #![deny(keyword_idents)]
 

--- a/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
+++ b/tests/ui/async-await/await-keyword/2015-edition-error-various-positions.stderr
@@ -1,5 +1,5 @@
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:5:13
+  --> $DIR/2015-edition-error-various-positions.rs:6:13
    |
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -7,14 +7,14 @@ LL |     pub mod await {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 note: the lint level is defined here
-  --> $DIR/2015-edition-error-various-positions.rs:2:9
+  --> $DIR/2015-edition-error-various-positions.rs:3:9
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
    = note: `#[deny(keyword_idents_2018)]` implied by `#[deny(keyword_idents)]`
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:7:20
+  --> $DIR/2015-edition-error-various-positions.rs:8:20
    |
 LL |         pub struct await;
    |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -23,7 +23,7 @@ LL |         pub struct await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:11:16
+  --> $DIR/2015-edition-error-various-positions.rs:12:16
    |
 LL | use outer_mod::await::await;
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -32,7 +32,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:11:23
+  --> $DIR/2015-edition-error-various-positions.rs:12:23
    |
 LL | use outer_mod::await::await;
    |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -41,7 +41,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:16:14
+  --> $DIR/2015-edition-error-various-positions.rs:17:14
    |
 LL | struct Foo { await: () }
    |              ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -50,7 +50,7 @@ LL | struct Foo { await: () }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:20:15
+  --> $DIR/2015-edition-error-various-positions.rs:21:15
    |
 LL | impl Foo { fn await() {} }
    |               ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -59,7 +59,7 @@ LL | impl Foo { fn await() {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:24:14
+  --> $DIR/2015-edition-error-various-positions.rs:25:14
    |
 LL | macro_rules! await {
    |              ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -68,7 +68,7 @@ LL | macro_rules! await {
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:31:5
+  --> $DIR/2015-edition-error-various-positions.rs:32:5
    |
 LL |     await!();
    |     ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -77,7 +77,7 @@ LL |     await!();
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:34:11
+  --> $DIR/2015-edition-error-various-positions.rs:35:11
    |
 LL |     match await { await => {} }
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -86,7 +86,7 @@ LL |     match await { await => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-error-various-positions.rs:34:19
+  --> $DIR/2015-edition-error-various-positions.rs:35:19
    |
 LL |     match await { await => {} }
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.fixed
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.fixed
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.rs
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ run-rustfix
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/await-keyword/2015-edition-warning.stderr
+++ b/tests/ui/async-await/await-keyword/2015-edition-warning.stderr
@@ -1,5 +1,5 @@
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:7:13
+  --> $DIR/2015-edition-warning.rs:8:13
    |
 LL |     pub mod await {
    |             ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -7,14 +7,14 @@ LL |     pub mod await {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 note: the lint level is defined here
-  --> $DIR/2015-edition-warning.rs:4:9
+  --> $DIR/2015-edition-warning.rs:5:9
    |
 LL | #![deny(keyword_idents)]
    |         ^^^^^^^^^^^^^^
    = note: `#[deny(keyword_idents_2018)]` implied by `#[deny(keyword_idents)]`
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:10:20
+  --> $DIR/2015-edition-warning.rs:11:20
    |
 LL |         pub struct await;
    |                    ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -23,7 +23,7 @@ LL |         pub struct await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:16
+  --> $DIR/2015-edition-warning.rs:16:16
    |
 LL | use outer_mod::await::await;
    |                ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -32,7 +32,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:15:23
+  --> $DIR/2015-edition-warning.rs:16:23
    |
 LL | use outer_mod::await::await;
    |                       ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -41,7 +41,7 @@ LL | use outer_mod::await::await;
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:11
+  --> $DIR/2015-edition-warning.rs:23:11
    |
 LL |     match await { await => {} }
    |           ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`
@@ -50,7 +50,7 @@ LL |     match await { await => {} }
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `await` is a keyword in the 2018 edition
-  --> $DIR/2015-edition-warning.rs:22:19
+  --> $DIR/2015-edition-warning.rs:23:19
    |
 LL |     match await { await => {} }
    |                   ^^^^^ help: you can use a raw identifier to stay compatible: `r#await`

--- a/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
+++ b/tests/ui/async-await/dyn/mut-is-pointer-like.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/mut-is-pointer-like.rs:35:16
+  --> $DIR/mut-is-pointer-like.rs:35:29
    |
 LL |         let x: Pin<&mut dyn AsyncTrait<Output = ()>> = f;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/dyn/works.stderr
+++ b/tests/ui/async-await/dyn/works.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/works.rs:27:16
+  --> $DIR/works.rs:27:21
    |
 LL |         let x: &dyn AsyncTrait = &"hello, world!";
-   |                ^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                     ^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/dyn/wrong-size.stderr
+++ b/tests/ui/async-await/dyn/wrong-size.stderr
@@ -8,10 +8,10 @@ LL | #![feature(async_fn_in_dyn_trait)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `AsyncTrait` is not dyn compatible
-  --> $DIR/wrong-size.rs:21:12
+  --> $DIR/wrong-size.rs:21:17
    |
 LL |     let x: &dyn AsyncTrait = &"hello, world!";
-   |            ^^^^^^^^^^^^^^^ `AsyncTrait` is not dyn compatible
+   |                 ^^^^^^^^^^ `AsyncTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/for-await-2015.rs
+++ b/tests/ui/async-await/for-await-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ check-pass
 
 #![feature(async_for_loop)]

--- a/tests/ui/async-await/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/async-await/in-trait/dyn-compatibility.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:9:12
+  --> $DIR/dyn-compatibility.rs:9:17
    |
 LL |     let x: &dyn Foo = todo!();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2015.stderr
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2015.stderr
@@ -1,16 +1,16 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:24:13
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:25:13
    |
 LL |     r#fn {}.r#struct();
    |             ^^^^^^^^ multiple `r#struct` found
    |
 note: candidate #1 is defined in an impl of the trait `async` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:7:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:8:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `await` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:13:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:14:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2018.stderr
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.edition2018.stderr
@@ -1,16 +1,16 @@
 error[E0034]: multiple applicable items in scope
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:24:13
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:25:13
    |
 LL |     r#fn {}.r#struct();
    |             ^^^^^^^^ multiple `r#struct` found
    |
 note: candidate #1 is defined in an impl of the trait `r#async` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:7:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:8:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `r#await` for the type `r#fn`
-  --> $DIR/issue-65634-raw-ident-suggestion.rs:13:5
+  --> $DIR/issue-65634-raw-ident-suggestion.rs:14:5
    |
 LL |     fn r#struct(&self) {
    |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/issue-65634-raw-ident-suggestion.rs
+++ b/tests/ui/async-await/issue-65634-raw-ident-suggestion.rs
@@ -1,4 +1,5 @@
 //@ revisions: edition2015 edition2018
+//@[edition2015]edition:2015
 //@[edition2018]edition:2018
 
 #![allow(non_camel_case_types)]

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ rustc-env:CARGO_CRATE_NAME=foo
 
 use std::pin::Pin;

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `await` on type `await_on_struct_missing::S`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:11:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:12:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -9,7 +9,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:24:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:25:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -24,7 +24,7 @@ LL +     x.awai;
    |
 
 error[E0609]: no field `await` on type `Pin<&mut dyn Future<Output = ()>>`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:34:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:35:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -34,7 +34,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
-  --> $DIR/suggest-switching-edition-on-await-cargo.rs:43:7
+  --> $DIR/suggest-switching-edition-on-await-cargo.rs:44:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field

--- a/tests/ui/async-await/suggest-switching-edition-on-await.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 use std::pin::Pin;
 use std::future::Future;
 

--- a/tests/ui/async-await/suggest-switching-edition-on-await.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `await` on type `await_on_struct_missing::S`
-  --> $DIR/suggest-switching-edition-on-await.rs:9:7
+  --> $DIR/suggest-switching-edition-on-await.rs:10:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -9,7 +9,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
-  --> $DIR/suggest-switching-edition-on-await.rs:22:7
+  --> $DIR/suggest-switching-edition-on-await.rs:23:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -24,7 +24,7 @@ LL +     x.awai;
    |
 
 error[E0609]: no field `await` on type `Pin<&mut dyn Future<Output = ()>>`
-  --> $DIR/suggest-switching-edition-on-await.rs:32:7
+  --> $DIR/suggest-switching-edition-on-await.rs:33:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field
@@ -34,7 +34,7 @@ LL |     x.await;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
-  --> $DIR/suggest-switching-edition-on-await.rs:41:7
+  --> $DIR/suggest-switching-edition-on-await.rs:42:7
    |
 LL |     x.await;
    |       ^^^^^ unknown field

--- a/tests/ui/auxiliary/delegate_macro.rs
+++ b/tests/ui/auxiliary/delegate_macro.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! delegate {
+    ($method:ident) => {
+        <Self>::$method(8)
+    };
+}

--- a/tests/ui/cfg/cfg-version/syntax.rs
+++ b/tests/ui/cfg/cfg-version/syntax.rs
@@ -1,0 +1,152 @@
+//! Check `#[cfg(version(..))]` parsing.
+
+#![feature(cfg_version)]
+
+// Overall grammar
+// ===============
+//
+// `#[cfg(version(..))]` accepts only the `version(VERSION_STRING_LITERAL)` predicate form, where
+// only a single string literal is permitted.
+
+#[cfg(version(42))]
+//~^ ERROR expected a version literal
+fn not_a_string_literal_simple() {}
+
+#[cfg(version(1.20))]
+//~^ ERROR expected a version literal
+fn not_a_string_literal_semver_like() {}
+
+#[cfg(version(false))]
+//~^ ERROR expected a version literal
+fn not_a_string_literal_other() {}
+
+#[cfg(version("1.43", "1.44", "1.45"))]
+//~^ ERROR expected single version literal
+fn multiple_version_literals() {}
+
+// The key-value form `cfg(version = "..")` is not considered a valid `cfg(version(..))` usage, but
+// it will only trigger the `unexpected_cfgs` lint and not a hard error.
+
+#[cfg(version = "1.43")]
+//~^ WARN unexpected `cfg` condition name: `version`
+fn key_value_form() {}
+
+// Additional version string literal constraints
+// =============================================
+//
+// The `VERSION_STRING_LITERAL` ("version literal") has additional constraints on its syntactical
+// well-formedness.
+
+// 1. A valid version literal can only constitute of numbers and periods (a "simple" semver version
+// string). Non-semver strings or "complex" semver strings (such as build metadata) are not
+// considered valid version literals, and will emit a non-lint warning "unknown version literal
+// format".
+
+#[cfg(version("1.43.0"))]
+fn valid_major_minor_patch() {}
+
+#[cfg(version("0.0.0"))]
+fn valid_zero_zero_zero_major_minor_patch() {}
+
+#[cfg(version("foo"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn not_numbers_or_periods() {}
+
+#[cfg(version("1.20.0-stable"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn complex_semver_with_metadata() {}
+
+// 2. "Shortened" version strings are permitted but *only* for the omission of the patch number.
+
+#[cfg(version("1.0"))]
+fn valid_major_minor_1() {}
+
+#[cfg(version("1.43"))]
+fn valid_major_minor_2() {}
+
+#[cfg(not(version("1.44")))]
+fn valid_major_minor_negated_smoke_test() {}
+
+#[cfg(version("0.0"))]
+fn valid_zero_zero_major_minor() {}
+
+#[cfg(version("0.7"))]
+fn valid_zero_major_minor() {}
+
+// 3. Major-only, or other non-Semver-like strings are not permitted.
+
+#[cfg(version("1"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn invalid_major_only() {}
+
+#[cfg(version("0"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn invalid_major_only_zero() {}
+
+#[cfg(version(".7"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn invalid_decimal_like() {}
+
+// Misc parsing overflow/underflow edge cases
+// ==========================================
+//
+// Check that we report "unknown version literal format" user-facing warnings and not ICEs.
+
+#[cfg(version("-1"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn invalid_major_only_negative() {}
+
+// Implementation detail: we store rustc version as `{ major: u16, minor: u16, patch: u16 }`.
+
+#[cfg(version("65536"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn exceed_u16_major() {}
+
+#[cfg(version("1.65536.0"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn exceed_u16_minor() {}
+
+#[cfg(version("1.0.65536"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn exceed_u16_patch() {}
+
+#[cfg(version("65536.0.65536"))]
+//~^ WARN unknown version literal format, assuming it refers to a future version
+fn exceed_u16_mixed() {}
+
+// Usage as `cfg!()`
+// =================
+
+fn cfg_usage() {
+    assert!(cfg!(version("1.0")));
+    assert!(cfg!(version("1.43")));
+    assert!(cfg!(version("1.43.0")));
+
+    assert!(cfg!(version("foo")));
+    //~^ WARN unknown version literal format, assuming it refers to a future version
+    assert!(cfg!(version("1.20.0-stable")));
+    //~^ WARN unknown version literal format, assuming it refers to a future version
+
+    assert!(cfg!(version = "1.43"));
+    //~^ WARN unexpected `cfg` condition name: `version`
+}
+
+fn main() {
+    cfg_usage();
+
+    // `cfg(version = "..")` is not a valid `cfg_version` form, but it only triggers
+    // `unexpected_cfgs` lint, and `cfg(version = "..")` eval to `false`.
+    key_value_form(); //~ ERROR cannot find function
+
+    // Invalid version literal formats within valid `cfg(version(..))` form should also cause
+    // `cfg(version(..))` eval to `false`.
+    not_numbers_or_periods(); //~ ERROR cannot find function
+    complex_semver_with_metadata(); //~ ERROR cannot find function
+    invalid_major_only(); //~ ERROR cannot find function
+    invalid_major_only_zero(); //~ ERROR cannot find function
+    invalid_major_only_negative(); //~ ERROR cannot find function
+    exceed_u16_major(); //~ ERROR cannot find function
+    exceed_u16_minor(); //~ ERROR cannot find function
+    exceed_u16_patch(); //~ ERROR cannot find function
+    exceed_u16_mixed(); //~ ERROR cannot find function
+}

--- a/tests/ui/cfg/cfg-version/syntax.stderr
+++ b/tests/ui/cfg/cfg-version/syntax.stderr
@@ -1,0 +1,188 @@
+error: expected a version literal
+  --> $DIR/syntax.rs:11:15
+   |
+LL | #[cfg(version(42))]
+   |               ^^
+
+error: expected a version literal
+  --> $DIR/syntax.rs:15:15
+   |
+LL | #[cfg(version(1.20))]
+   |               ^^^^
+
+error: expected a version literal
+  --> $DIR/syntax.rs:19:15
+   |
+LL | #[cfg(version(false))]
+   |               ^^^^^
+
+error: expected single version literal
+  --> $DIR/syntax.rs:23:7
+   |
+LL | #[cfg(version("1.43", "1.44", "1.45"))]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:51:15
+   |
+LL | #[cfg(version("foo"))]
+   |               ^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:55:15
+   |
+LL | #[cfg(version("1.20.0-stable"))]
+   |               ^^^^^^^^^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:78:15
+   |
+LL | #[cfg(version("1"))]
+   |               ^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:82:15
+   |
+LL | #[cfg(version("0"))]
+   |               ^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:86:15
+   |
+LL | #[cfg(version(".7"))]
+   |               ^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:95:15
+   |
+LL | #[cfg(version("-1"))]
+   |               ^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:101:15
+   |
+LL | #[cfg(version("65536"))]
+   |               ^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:105:15
+   |
+LL | #[cfg(version("1.65536.0"))]
+   |               ^^^^^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:109:15
+   |
+LL | #[cfg(version("1.0.65536"))]
+   |               ^^^^^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:113:15
+   |
+LL | #[cfg(version("65536.0.65536"))]
+   |               ^^^^^^^^^^^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:125:26
+   |
+LL |     assert!(cfg!(version("foo")));
+   |                          ^^^^^
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/syntax.rs:127:26
+   |
+LL |     assert!(cfg!(version("1.20.0-stable")));
+   |                          ^^^^^^^^^^^^^^^
+
+warning: unexpected `cfg` condition name: `version`
+  --> $DIR/syntax.rs:30:7
+   |
+LL | #[cfg(version = "1.43")]
+   |       ^^^^^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(version, values("1.43"))`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+help: there is a similar config predicate: `version("..")`
+   |
+LL - #[cfg(version = "1.43")]
+LL + #[cfg(version("1.43"))]
+   |
+
+warning: unexpected `cfg` condition name: `version`
+  --> $DIR/syntax.rs:130:18
+   |
+LL |     assert!(cfg!(version = "1.43"));
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(version, values("1.43"))`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+help: there is a similar config predicate: `version("..")`
+   |
+LL -     assert!(cfg!(version = "1.43"));
+LL +     assert!(cfg!(version("1.43")));
+   |
+
+error[E0425]: cannot find function `key_value_form` in this scope
+  --> $DIR/syntax.rs:139:5
+   |
+LL |     key_value_form();
+   |     ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `not_numbers_or_periods` in this scope
+  --> $DIR/syntax.rs:143:5
+   |
+LL |     not_numbers_or_periods();
+   |     ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `complex_semver_with_metadata` in this scope
+  --> $DIR/syntax.rs:144:5
+   |
+LL |     complex_semver_with_metadata();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `invalid_major_only` in this scope
+  --> $DIR/syntax.rs:145:5
+   |
+LL |     invalid_major_only();
+   |     ^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `invalid_major_only_zero` in this scope
+  --> $DIR/syntax.rs:146:5
+   |
+LL |     invalid_major_only_zero();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `invalid_major_only_negative` in this scope
+  --> $DIR/syntax.rs:147:5
+   |
+LL |     invalid_major_only_negative();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `exceed_u16_major` in this scope
+  --> $DIR/syntax.rs:148:5
+   |
+LL |     exceed_u16_major();
+   |     ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `exceed_u16_minor` in this scope
+  --> $DIR/syntax.rs:149:5
+   |
+LL |     exceed_u16_minor();
+   |     ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `exceed_u16_patch` in this scope
+  --> $DIR/syntax.rs:150:5
+   |
+LL |     exceed_u16_patch();
+   |     ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find function `exceed_u16_mixed` in this scope
+  --> $DIR/syntax.rs:151:5
+   |
+LL |     exceed_u16_mixed();
+   |     ^^^^^^^^^^^^^^^^ not found in this scope
+
+error: aborting due to 14 previous errors; 14 warnings emitted
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
@@ -4,4 +4,5 @@ fn main() {
     let _: &Copy + 'static; //~ ERROR expected a path
     //~^ ERROR is not dyn compatible
     let _: &'static Copy + 'static; //~ ERROR expected a path
+    //~^ ERROR is not dyn compatible
 }

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -21,16 +21,26 @@ LL |     let _: &'static (Copy + 'static);
    |                     +              +
 
 error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:13
    |
 LL |     let _: &Copy + 'static;
-   |            ^^^^^ `Copy` is not dyn compatible
+   |             ^^^^ `Copy` is not dyn compatible
    |
    = note: the trait is not dyn compatible because it requires `Self: Sized`
    = note: for a trait to be dyn compatible it needs to allow building a vtable
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
-error: aborting due to 3 previous errors
+error[E0038]: the trait `Copy` is not dyn compatible
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:6:21
+   |
+LL |     let _: &'static Copy + 'static;
+   |                     ^^^^ `Copy` is not dyn compatible
+   |
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0038, E0178.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
+++ b/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
@@ -16,10 +16,10 @@ LL |     fn transmute(&self, t: T) -> <Self as Super<NotActuallySuper>>::Assoc;
    = help: consider moving `transmute` to another trait
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/almost-supertrait-associated-type.rs:7:27
+  --> $DIR/almost-supertrait-associated-type.rs:7:32
    |
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
-   |                           ^^^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                ^^^^^^^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/generics.stderr
+++ b/tests/ui/dyn-compatibility/generics.stderr
@@ -31,10 +31,10 @@ LL |     fn bar<T>(&self, t: T);
    = help: consider moving `bar` to another trait
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/generics.rs:22:10
+  --> $DIR/generics.rs:22:15
    |
 LL |     t as &dyn Bar
-   |          ^^^^^^^^ `Bar` is not dyn compatible
+   |               ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
+++ b/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:15
+  --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:24
    |
 LL |     let test: &mut dyn Bar = &mut thing;
-   |               ^^^^^^^^^^^^ `Bar` is not dyn compatible
+   |                        ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/dyn-compatibility/no-static.stderr
+++ b/tests/ui/dyn-compatibility/no-static.stderr
@@ -23,10 +23,10 @@ LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/no-static.rs:18:12
+  --> $DIR/no-static.rs:18:20
    |
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
-   |            ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                    ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/feature-gates/feature-gate-cfg-version.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-version.rs
@@ -1,49 +1,12 @@
-#[cfg(version(42))] //~ ERROR: expected a version literal
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn foo() {}
-#[cfg(version(1.20))] //~ ERROR: expected a version literal
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn foo() -> bool { true }
-#[cfg(version("1.44"))]
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn foo() -> bool { true }
-#[cfg(not(version("1.44")))]
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn foo() -> bool { false }
+//! Feature gate test for `cfg_version`.
+//!
+//! Tracking issue: #64796.
 
-#[cfg(version("1.43", "1.44", "1.45"))] //~ ERROR: expected single version literal
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version(false))] //~ ERROR: expected a version literal
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("foo"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("999"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("-1"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("65536"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("0"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool { true }
-#[cfg(version("1.0"))]
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool { true }
-#[cfg(version("1.65536.2"))] //~ WARNING: unknown version literal format
-//~^ ERROR `cfg(version)` is experimental and subject to change
-fn bar() -> bool  { false }
-#[cfg(version("1.20.0-stable"))] //~ WARNING: unknown version literal format
+#[cfg(version("1.42"))]
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() {}
 
 fn main() {
-    assert!(foo());
-    assert!(bar());
-    assert!(cfg!(version("1.42"))); //~ ERROR `cfg(version)` is experimental and subject to change
+    assert!(cfg!(version("1.42")));
+    //~^ ERROR `cfg(version)` is experimental and subject to change
 }

--- a/tests/ui/feature-gates/feature-gate-cfg-version.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-version.stderr
@@ -1,39 +1,7 @@
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:1:7
+  --> $DIR/feature-gate-cfg-version.rs:5:7
    |
-LL | #[cfg(version(42))]
-   |       ^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: expected a version literal
-  --> $DIR/feature-gate-cfg-version.rs:1:15
-   |
-LL | #[cfg(version(42))]
-   |               ^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:4:7
-   |
-LL | #[cfg(version(1.20))]
-   |       ^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: expected a version literal
-  --> $DIR/feature-gate-cfg-version.rs:4:15
-   |
-LL | #[cfg(version(1.20))]
-   |               ^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:7:7
-   |
-LL | #[cfg(version("1.44"))]
+LL | #[cfg(version("1.42"))]
    |       ^^^^^^^^^^^^^^^
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
@@ -41,171 +9,7 @@ LL | #[cfg(version("1.44"))]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:10:11
-   |
-LL | #[cfg(not(version("1.44")))]
-   |           ^^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:14:7
-   |
-LL | #[cfg(version("1.43", "1.44", "1.45"))]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: expected single version literal
-  --> $DIR/feature-gate-cfg-version.rs:14:7
-   |
-LL | #[cfg(version("1.43", "1.44", "1.45"))]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:17:7
-   |
-LL | #[cfg(version(false))]
-   |       ^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: expected a version literal
-  --> $DIR/feature-gate-cfg-version.rs:17:15
-   |
-LL | #[cfg(version(false))]
-   |               ^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:20:7
-   |
-LL | #[cfg(version("foo"))]
-   |       ^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:20:15
-   |
-LL | #[cfg(version("foo"))]
-   |               ^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:23:7
-   |
-LL | #[cfg(version("999"))]
-   |       ^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:23:15
-   |
-LL | #[cfg(version("999"))]
-   |               ^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:26:7
-   |
-LL | #[cfg(version("-1"))]
-   |       ^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:26:15
-   |
-LL | #[cfg(version("-1"))]
-   |               ^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:29:7
-   |
-LL | #[cfg(version("65536"))]
-   |       ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:29:15
-   |
-LL | #[cfg(version("65536"))]
-   |               ^^^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:32:7
-   |
-LL | #[cfg(version("0"))]
-   |       ^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:32:15
-   |
-LL | #[cfg(version("0"))]
-   |               ^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:35:7
-   |
-LL | #[cfg(version("1.0"))]
-   |       ^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:38:7
-   |
-LL | #[cfg(version("1.65536.2"))]
-   |       ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:38:15
-   |
-LL | #[cfg(version("1.65536.2"))]
-   |               ^^^^^^^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:41:7
-   |
-LL | #[cfg(version("1.20.0-stable"))]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
-   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: unknown version literal format, assuming it refers to a future version
-  --> $DIR/feature-gate-cfg-version.rs:41:15
-   |
-LL | #[cfg(version("1.20.0-stable"))]
-   |               ^^^^^^^^^^^^^^^
-
-error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:48:18
+  --> $DIR/feature-gate-cfg-version.rs:10:18
    |
 LL |     assert!(cfg!(version("1.42")));
    |                  ^^^^^^^^^^^^^^^
@@ -214,6 +18,6 @@ LL |     assert!(cfg!(version("1.42")));
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 19 previous errors; 7 warnings emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:25
+  --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:33
    |
 LL |     fn ptr(self: Ptr<Self>);
    |                  --------- help: consider changing method `ptr`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
-   |                         ^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |                                 ^^^^^ `Trait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-76535.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.stderr
@@ -15,10 +15,10 @@ LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperS
    |                                        ++++
 
 error[E0038]: the trait `SuperTrait` is not dyn compatible
-  --> $DIR/issue-76535.rs:34:14
+  --> $DIR/issue-76535.rs:34:22
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-78671.stderr
+++ b/tests/ui/generic-associated-types/issue-78671.stderr
@@ -15,10 +15,10 @@ LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
    |                                                     +++
 
 error[E0038]: the trait `CollectionFamily` is not dyn compatible
-  --> $DIR/issue-78671.rs:5:25
+  --> $DIR/issue-78671.rs:5:30
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/generic-associated-types/issue-79422.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.stderr
@@ -15,10 +15,10 @@ LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
    |                                            ++++
 
 error[E0038]: the trait `MapLike` is not dyn compatible
-  --> $DIR/issue-79422.rs:45:12
+  --> $DIR/issue-79422.rs:45:20
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
@@ -15,5 +15,4 @@ fn main() {
     //~^ ERROR the trait `Foo` is not dyn compatible
 
     needs_bar(x);
-    //~^ ERROR mismatched types
 }

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/span-bug-issue-121597.rs:14:12
+  --> $DIR/span-bug-issue-121597.rs:14:17
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -13,23 +13,6 @@ LL | trait Foo: for<T> Bar<T> {}
    |       |
    |       this trait is not dyn compatible...
 
-error[E0308]: mismatched types
-  --> $DIR/span-bug-issue-121597.rs:17:15
-   |
-LL |     needs_bar(x);
-   |     --------- ^ types differ in mutability
-   |     |
-   |     arguments to this function are incorrect
-   |
-   = note: expected raw pointer `*mut Type2`
-                found reference `&dyn Foo`
-note: function defined here
-  --> $DIR/span-bug-issue-121597.rs:11:4
-   |
-LL | fn needs_bar(_: *mut Type2) {}
-   |    ^^^^^^^^^ -------------
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0038, E0308.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
@@ -21,6 +21,8 @@ impl DynIncompatible for B {
 
 fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` is not dyn compatible
 //~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR the trait `DynIncompatible` is not dyn compatible
+//~| ERROR the trait `DynIncompatible` is not dyn compatible
     if true {
         return A;
     }

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -41,6 +41,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
    |
 LL ~ fn car() -> Box<dyn DynIncompatible> {
 LL |
+...
 LL |     if true {
 LL ~         return Box::new(A);
 LL |     }
@@ -48,7 +49,7 @@ LL ~     Box::new(B)
    |
 
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:30:17
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:17
    |
 LL | fn cat() -> Box<dyn DynIncompatible> {
    |                 ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
@@ -75,7 +76,74 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:17
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |                 ^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
+   |
+LL | trait DynIncompatible {
+   |       --------------- this trait is not dyn compatible...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement `DynIncompatible`:
+             A
+             B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
+help: consider using an opaque type instead
+   |
+LL - fn car() -> dyn DynIncompatible {
+LL + fn car() -> impl DynIncompatible {
+   |
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:17
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |                 ^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
+   |
+LL | trait DynIncompatible {
+   |       --------------- this trait is not dyn compatible...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement `DynIncompatible`:
+             A
+             B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider using an opaque type instead
+   |
+LL - fn car() -> dyn DynIncompatible {
+LL + fn car() -> impl DynIncompatible {
+   |
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0038, E0746.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dyn-compatibility.rs:14:33
+  --> $DIR/dyn-compatibility.rs:14:41
    |
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
-   |                                 ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                         ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/foreign-dyn-error.rs:6:12
+  --> $DIR/foreign-dyn-error.rs:6:17
    |
 LL |     let _: &dyn rpitit::Foo = todo!();
-   |            ^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^^^^^^^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/issues/issue-18959.rs
+++ b/tests/ui/issues/issue-18959.rs
@@ -18,4 +18,5 @@ fn main() {
     let test: &dyn Bar = &mut thing;
     //~^ ERROR E0038
     foo(test);
+    //~^ ERROR E0038
 }

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -15,10 +15,10 @@ LL | pub trait Bar: Foo { }
    = help: consider moving `foo` to another trait
 
 error[E0038]: the trait `Bar` is not dyn compatible
-  --> $DIR/issue-18959.rs:18:15
+  --> $DIR/issue-18959.rs:18:20
    |
 LL |     let test: &dyn Bar = &mut thing;
-   |               ^^^^^^^^ `Bar` is not dyn compatible
+   |                    ^^^ `Bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -30,6 +30,22 @@ LL | pub trait Bar: Foo { }
    |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `Bar` is not dyn compatible
+  --> $DIR/issue-18959.rs:20:9
+   |
+LL |     foo(test);
+   |         ^^^^ `Bar` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait is not dyn compatible...
+   = help: consider moving `foo` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/issues/issue-50781.stderr
+++ b/tests/ui/issues/issue-50781.stderr
@@ -16,10 +16,10 @@ LL |     fn foo(&self) where Self: Trait;
    = help: only type `()` implements `X`; consider using it directly instead.
 
 error[E0038]: the trait `X` is not dyn compatible
-  --> $DIR/issue-50781.rs:16:6
+  --> $DIR/issue-50781.rs:16:10
    |
 LL |     <dyn X as X>::foo(&());
-   |      ^^^^^ `X` is not dyn compatible
+   |          ^ `X` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/issues/issue-58734.rs
+++ b/tests/ui/issues/issue-58734.rs
@@ -18,8 +18,7 @@ fn main() {
     Trait::exists(());
     // no dyn-compatibility error
     Trait::nonexistent(());
-    //~^ ERROR no function or associated item named `nonexistent` found
-    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
     //~| ERROR the trait `Trait` is not dyn compatible
 }

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -37,13 +37,6 @@ help: alternatively, consider constraining `dyn_incompatible` so it does not app
 LL |     fn dyn_incompatible() -> Self where Self: Sized;
    |                                   +++++++++++++++++
 
-error[E0599]: no function or associated item named `nonexistent` found for trait object `dyn Trait` in the current scope
-  --> $DIR/issue-58734.rs:20:12
-   |
-LL |     Trait::nonexistent(());
-   |            ^^^^^^^^^^^ function or associated item not found in `dyn Trait`
+error: aborting due to 1 previous error; 1 warning emitted
 
-error: aborting due to 2 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0038, E0599.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/kindck/kindck-inherited-copy-bound.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.stderr
@@ -20,10 +20,10 @@ LL | fn take_param<T:Foo>(foo: &T) { }
    |                 ^^^ required by this bound in `take_param`
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/kindck-inherited-copy-bound.rs:23:19
+  --> $DIR/kindck-inherited-copy-bound.rs:23:24
    |
 LL |     let z = &x as &dyn Foo;
-   |                   ^^^^^^^^ `Foo` is not dyn compatible
+   |                        ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -29,10 +29,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a < b;
    |             ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>() < b.cast::<()>();
    |              +++++++++++++    +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a < b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:26:13
@@ -40,10 +44,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a <= b;
    |             ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>() <= b.cast::<()>();
    |              +++++++++++++     +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a <= b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:28:13
@@ -51,10 +59,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a > b;
    |             ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>() > b.cast::<()>();
    |              +++++++++++++    +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a > b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:30:13
@@ -62,10 +74,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a >= b;
    |             ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>() >= b.cast::<()>();
    |              +++++++++++++     +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a >= b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:33:13
@@ -121,10 +137,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.cmp(&b);
    |             ^^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().cmp(&b.cast::<()>());
    |              +++++++++++++       +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.cmp(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++           +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:43:13
@@ -132,10 +152,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.partial_cmp(&b);
    |             ^^^^^^^^^^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().partial_cmp(&b.cast::<()>());
    |              +++++++++++++               +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.partial_cmp(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++                   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:45:13
@@ -143,10 +167,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.le(&b);
    |             ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().le(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.le(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:47:13
@@ -154,10 +182,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.lt(&b);
    |             ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().lt(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.lt(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:49:13
@@ -165,10 +197,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.ge(&b);
    |             ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().ge(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.ge(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:51:13
@@ -176,10 +212,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |     let _ = a.gt(&b);
    |             ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |     let _ = a.cast::<()>().gt(&b.cast::<()>());
    |              +++++++++++++      +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |     let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.gt(&b) };
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:57:17
@@ -199,10 +239,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a >= b;
    |                 ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = a.as_ptr().cast::<()>() >= b.as_ptr().cast::<()>();
    |                  ++++++++++++++++++++++     ++++++++++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a >= b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:61:17
@@ -246,10 +290,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a < b;
    |                 ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>() < (*b).cast::<()>();
    |                 ++ ++++++++++++++   ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a < b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:76:17
@@ -257,10 +305,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a <= b;
    |                 ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>() <= (*b).cast::<()>();
    |                 ++ ++++++++++++++    ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a <= b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:78:17
@@ -268,10 +320,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a > b;
    |                 ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>() > (*b).cast::<()>();
    |                 ++ ++++++++++++++   ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a > b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:80:17
@@ -279,10 +335,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a >= b;
    |                 ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>() >= (*b).cast::<()>();
    |                 ++ ++++++++++++++    ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a >= b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:83:17
@@ -362,10 +422,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.cmp(&b);
    |                 ^^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().cmp(&(*b).cast::<()>());
    |                 ++ ++++++++++++++      ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.cmp(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++           +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:97:17
@@ -373,10 +437,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.partial_cmp(&b);
    |                 ^^^^^^^^^^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().partial_cmp(&(*b).cast::<()>());
    |                 ++ ++++++++++++++              ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.partial_cmp(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++                   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:99:17
@@ -384,10 +452,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.le(&b);
    |                 ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().le(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.le(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:101:17
@@ -395,10 +467,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.lt(&b);
    |                 ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().lt(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.lt(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:103:17
@@ -406,10 +482,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.ge(&b);
    |                 ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().ge(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.ge(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:105:17
@@ -417,10 +497,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a.gt(&b);
    |                 ^^^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = (*a).cast::<()>().gt(&(*b).cast::<()>());
    |                 ++ ++++++++++++++     ++ ++++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] a.gt(&b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++          +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:110:13
@@ -496,10 +580,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a < b;
    |                 ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = a.cast::<()>() < b.cast::<()>();
    |                  +++++++++++++    +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a < b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:124:17
@@ -507,10 +595,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a <= b;
    |                 ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = a.cast::<()>() <= b.cast::<()>();
    |                  +++++++++++++     +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a <= b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:126:17
@@ -518,10 +610,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a > b;
    |                 ^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = a.cast::<()>() > b.cast::<()>();
    |                  +++++++++++++    +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a > b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++     +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:128:17
@@ -529,10 +625,14 @@ warning: ambiguous wide pointer comparison, the comparison includes metadata whi
 LL |         let _ = a >= b;
    |                 ^^^^^^
    |
-help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+help: use untyped pointers to only compare their addresses
    |
 LL |         let _ = a.cast::<()>() >= b.cast::<()>();
    |                  +++++++++++++     +++++++++++++
+help: or expect the lint to compare the pointers metadata and addresses
+   |
+LL |         let _ = { #[expect(ambiguous_wide_pointer_comparisons, reason = "...")] (a >= b) };
+   |                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++      +++
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:131:17

--- a/tests/ui/not-enough-arguments.rs
+++ b/tests/ui/not-enough-arguments.rs
@@ -1,20 +1,16 @@
+//@ aux-build: delegate_macro.rs
+extern crate delegate_macro;
+use delegate_macro::delegate;
+
 // Check that the only error msg we report is the
 // mismatch between the # of params, and not other
 // unrelated errors.
-
-fn foo(a: isize, b: isize, c: isize, d:isize) {
-  panic!();
+fn foo(a: isize, b: isize, c: isize, d: isize) {
+    panic!();
 }
 
 // Check that all arguments are shown in the error message, even if they're across multiple lines.
-fn bar(
-    a: i32,
-    b: i32,
-    c: i32,
-    d: i32,
-    e: i32,
-    f: i32,
-) {
+fn bar(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
     println!("{}", a);
     println!("{}", b);
     println!("{}", c);
@@ -23,9 +19,35 @@ fn bar(
     println!("{}", f);
 }
 
+macro_rules! delegate_local {
+    ($method:ident) => {
+        <Self>::$method(8)
+        //~^ ERROR function takes 2 arguments but 1
+    };
+}
+
+macro_rules! delegate_from {
+    ($from:ident, $method:ident) => {
+        <$from>::$method(8)
+        //~^ ERROR function takes 2 arguments but 1
+    };
+}
+
+struct Bar;
+
+impl Bar {
+    fn foo(a: u8, b: u8) {}
+    fn bar() {
+        delegate_local!(foo);
+        delegate!(foo);
+        //~^ ERROR function takes 2 arguments but 1
+        delegate_from!(Bar, foo);
+    }
+}
+
 fn main() {
-  foo(1, 2, 3);
-  //~^ ERROR function takes 4 arguments but 3
-  bar(1, 2, 3);
-  //~^ ERROR function takes 6 arguments but 3
+    foo(1, 2, 3);
+    //~^ ERROR function takes 4 arguments but 3
+    bar(1, 2, 3);
+    //~^ ERROR function takes 6 arguments but 3
 }

--- a/tests/ui/not-enough-arguments.stderr
+++ b/tests/ui/not-enough-arguments.stderr
@@ -1,42 +1,88 @@
-error[E0061]: this function takes 4 arguments but 3 arguments were supplied
-  --> $DIR/not-enough-arguments.rs:27:3
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/not-enough-arguments.rs:24:9
    |
-LL |   foo(1, 2, 3);
-   |   ^^^--------- argument #4 of type `isize` is missing
+LL |         <Self>::$method(8)
+   |         ^^^^^^^^^^^^^^^--- argument #2 of type `u8` is missing
+...
+LL |         delegate_local!(foo);
+   |         -------------------- in this macro invocation
    |
-note: function defined here
-  --> $DIR/not-enough-arguments.rs:5:4
+note: associated function defined here
+  --> $DIR/not-enough-arguments.rs:39:8
    |
-LL | fn foo(a: isize, b: isize, c: isize, d:isize) {
-   |    ^^^                               -------
+LL |     fn foo(a: u8, b: u8) {}
+   |        ^^^        -----
+   = note: this error originates in the macro `delegate_local` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: provide the argument
    |
-LL |   foo(1, 2, 3, /* isize */);
-   |              +++++++++++++
+LL |         <Self>::$method(8, /* u8 */)
+   |                          ++++++++++
 
-error[E0061]: this function takes 6 arguments but 3 arguments were supplied
-  --> $DIR/not-enough-arguments.rs:29:3
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/not-enough-arguments.rs:42:9
    |
-LL |   bar(1, 2, 3);
-   |   ^^^--------- three arguments of type `i32`, `i32`, and `i32` are missing
+LL |         delegate!(foo);
+   |         ^^^^^^^^^^^^^^ argument #2 of type `u8` is missing
+   |
+note: associated function defined here
+  --> $DIR/not-enough-arguments.rs:39:8
+   |
+LL |     fn foo(a: u8, b: u8) {}
+   |        ^^^        -----
+   = note: this error originates in the macro `delegate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/not-enough-arguments.rs:31:9
+   |
+LL |         <$from>::$method(8)
+   |         ^^^^^^^^^^^^^^^^--- argument #2 of type `u8` is missing
+...
+LL |         delegate_from!(Bar, foo);
+   |         ------------------------ in this macro invocation
+   |
+note: associated function defined here
+  --> $DIR/not-enough-arguments.rs:39:8
+   |
+LL |     fn foo(a: u8, b: u8) {}
+   |        ^^^        -----
+   = note: this error originates in the macro `delegate_from` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: provide the argument
+   |
+LL |         <$from>::$method(8, /* u8 */)
+   |                           ++++++++++
+
+error[E0061]: this function takes 4 arguments but 3 arguments were supplied
+  --> $DIR/not-enough-arguments.rs:49:5
+   |
+LL |     foo(1, 2, 3);
+   |     ^^^--------- argument #4 of type `isize` is missing
    |
 note: function defined here
-  --> $DIR/not-enough-arguments.rs:10:4
+  --> $DIR/not-enough-arguments.rs:8:4
    |
-LL | fn bar(
-   |    ^^^
-...
-LL |     d: i32,
-   |     ------
-LL |     e: i32,
-   |     ------
-LL |     f: i32,
-   |     ------
+LL | fn foo(a: isize, b: isize, c: isize, d: isize) {
+   |    ^^^                               --------
+help: provide the argument
+   |
+LL |     foo(1, 2, 3, /* isize */);
+   |                +++++++++++++
+
+error[E0061]: this function takes 6 arguments but 3 arguments were supplied
+  --> $DIR/not-enough-arguments.rs:51:5
+   |
+LL |     bar(1, 2, 3);
+   |     ^^^--------- three arguments of type `i32`, `i32`, and `i32` are missing
+   |
+note: function defined here
+  --> $DIR/not-enough-arguments.rs:13:4
+   |
+LL | fn bar(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
+   |    ^^^                         ------  ------  ------
 help: provide the arguments
    |
-LL |   bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
-   |              +++++++++++++++++++++++++++++++++
+LL |     bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
+   |                +++++++++++++++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.rs
@@ -1,0 +1,11 @@
+#![feature(generic_arg_infer)]
+
+// Test that we enforce repeat expr element types are `Copy` even
+// when the repeat count is only inferred at a later point in type
+// checking.
+
+fn main() {
+    let a = [String::new(); _];
+    //~^ ERROR: the trait bound `String: Copy` is not satisfied
+    let b: [_; 2] = a;
+}

--- a/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
+++ b/tests/ui/repeat-expr/copy-check-when-count-inferred-later.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/copy-check-when-count-inferred-later.rs:8:14
+   |
+LL |     let a = [String::new(); _];
+   |              ^^^^^^^^^^^^^
+   |              |
+   |              the trait `Copy` is not implemented for `String`
+   |              help: create an inline `const` block: `const { String::new() }`
+   |
+   = note: the `Copy` trait is required because this value will be copied for each element of the array
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/self/arbitrary-self-types-dyn-incompatible.stderr
+++ b/tests/ui/self/arbitrary-self-types-dyn-incompatible.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/arbitrary-self-types-dyn-incompatible.rs:29:32
+  --> $DIR/arbitrary-self-types-dyn-incompatible.rs:29:39
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  --------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
-   |                                ^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                                       ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/issue-20692.stderr
+++ b/tests/ui/traits/issue-20692.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Array` is not dyn compatible
-  --> $DIR/issue-20692.rs:6:5
+  --> $DIR/issue-20692.rs:6:10
    |
 LL |     &dyn Array;
-   |     ^^^^^^^^^^ `Array` is not dyn compatible
+   |          ^^^^^ `Array` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/issue-38604.stderr
+++ b/tests/ui/traits/issue-38604.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/issue-38604.rs:14:13
+  --> $DIR/issue-38604.rs:14:21
    |
 LL |     let _f: Box<dyn Foo> =
-   |             ^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |                     ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/item-privacy.rs
+++ b/tests/ui/traits/item-privacy.rs
@@ -99,9 +99,7 @@ fn check_assoc_const() {
     S::C; // OK
     // A, B, C are resolved as inherent items, their traits don't need to be in scope
     <dyn C>::A;
-    //~^ ERROR associated constant `A` is private
-    //~| ERROR the trait `assoc_const::C` is not dyn compatible
-    //~| ERROR the trait `assoc_const::C` is not dyn compatible
+    //~^ ERROR the trait `assoc_const::C` is not dyn compatible
     <dyn C>::B;
     //~^ ERROR the trait `assoc_const::C` is not dyn compatible
     C::C; // OK

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -131,44 +131,10 @@ LL + use assoc_const::B;
    |
 
 error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:101:6
+  --> $DIR/item-privacy.rs:101:10
    |
 LL |     <dyn C>::A;
-   |      ^^^^^ `assoc_const::C` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/item-privacy.rs:25:15
-   |
-LL |         const A: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-...
-LL |         const B: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-...
-LL |     pub trait C: A + B {
-   |               - this trait is not dyn compatible...
-LL |         const C: u8 = 0;
-   |               ^ ...because it contains this associated `const`
-   = help: consider moving `C` to another trait
-   = help: consider moving `A` to another trait
-   = help: consider moving `B` to another trait
-   = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
-
-error[E0624]: associated constant `A` is private
-  --> $DIR/item-privacy.rs:101:14
-   |
-LL |         const A: u8 = 0;
-   |         ----------- private associated constant defined here
-...
-LL |     <dyn C>::A;
-   |              ^ private associated constant
-
-error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:101:5
-   |
-LL |     <dyn C>::A;
-   |     ^^^^^^^^^^ `assoc_const::C` is not dyn compatible
+   |          ^ `assoc_const::C` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -190,10 +156,10 @@ LL |         const C: u8 = 0;
    = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
 
 error[E0038]: the trait `assoc_const::C` is not dyn compatible
-  --> $DIR/item-privacy.rs:105:5
+  --> $DIR/item-privacy.rs:103:10
    |
 LL |     <dyn C>::B;
-   |     ^^^^^^^^^^ `assoc_const::C` is not dyn compatible
+   |          ^ `assoc_const::C` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -215,7 +181,7 @@ LL |         const C: u8 = 0;
    = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:118:12
+  --> $DIR/item-privacy.rs:116:12
    |
 LL |     let _: S::A;
    |            ^^^^
@@ -227,7 +193,7 @@ LL +     let _: <S as Example>::A;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:119:12
+  --> $DIR/item-privacy.rs:117:12
    |
 LL |     let _: S::B;
    |            ^^^^
@@ -239,7 +205,7 @@ LL +     let _: <S as assoc_ty::B>::B;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/item-privacy.rs:120:12
+  --> $DIR/item-privacy.rs:118:12
    |
 LL |     let _: S::C;
    |            ^^^^
@@ -251,7 +217,7 @@ LL +     let _: <S as assoc_ty::C>::C;
    |
 
 error[E0624]: associated type `A` is private
-  --> $DIR/item-privacy.rs:122:12
+  --> $DIR/item-privacy.rs:120:12
    |
 LL |         type A = u8;
    |         ------ the associated type is defined here
@@ -260,7 +226,7 @@ LL |     let _: T::A;
    |            ^^^^ private associated type
 
 error[E0624]: associated type `A` is private
-  --> $DIR/item-privacy.rs:131:9
+  --> $DIR/item-privacy.rs:129:9
    |
 LL |         type A = u8;
    |         ------ the associated type is defined here
@@ -268,7 +234,7 @@ LL |         type A = u8;
 LL |         A = u8,
    |         ^^^^^^ private associated type
 
-error: aborting due to 17 previous errors
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0038, E0223, E0599, E0624.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
@@ -19,5 +19,4 @@ fn main() {
     let x: &dyn Foo = &();
     //~^ ERROR the trait `Foo` is not dyn compatible
     needs_bar(x);
-    //~^ ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
@@ -8,10 +8,10 @@ LL | #![feature(non_lifetime_binders)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/supertrait-dyn-compatibility.rs:19:12
+  --> $DIR/supertrait-dyn-compatibility.rs:19:17
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` is not dyn compatible
+   |                 ^^^ `Foo` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -23,22 +23,6 @@ LL | trait Foo: for<T> Bar<T> {}
    |       this trait is not dyn compatible...
    = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/supertrait-dyn-compatibility.rs:21:5
-   |
-LL |     needs_bar(x);
-   |     ^^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/supertrait-dyn-compatibility.rs:4:12
-   |
-LL | trait Foo: for<T> Bar<T> {}
-   |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
-   |       |
-   |       this trait is not dyn compatible...
-   = help: only type `()` implements `Foo`; consider using it directly instead.
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
@@ -9,7 +9,6 @@ trait Try {
 fn w<'a, T: 'a, F: Fn(&'a T)>() {
     let b: &dyn FromResidual = &();
     //~^ ERROR: the trait `FromResidual` is not dyn compatible
-    //~| ERROR the type parameter `R` must be explicitly specified
 }
 
 fn main() {}

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
@@ -1,23 +1,8 @@
-error[E0393]: the type parameter `R` must be explicitly specified
+error[E0038]: the trait `FromResidual` is not dyn compatible
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:17
    |
-LL | trait FromResidual<R = <Self as Try>::Residual> {
-   | ----------------------------------------------- type parameter `R` must be specified for this
-...
 LL |     let b: &dyn FromResidual = &();
-   |                 ^^^^^^^^^^^^
-   |
-   = note: because the parameter default references `Self`, the parameter must be specified on the object type
-help: set the type parameter to the desired type
-   |
-LL |     let b: &dyn FromResidual<R> = &();
-   |                             +++
-
-error[E0038]: the trait `FromResidual` is not dyn compatible
-  --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:12
-   |
-LL |     let b: &dyn FromResidual = &();
-   |            ^^^^^^^^^^^^^^^^^ `FromResidual` is not dyn compatible
+   |                 ^^^^^^^^^^^^ `FromResidual` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -36,7 +21,6 @@ help: alternatively, consider constraining `from_residual` so it does not apply 
 LL |     fn from_residual(residual: R) -> Self where Self: Sized;
    |                                           +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0038, E0393.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/macro-matcher.stderr
+++ b/tests/ui/traits/object/macro-matcher.stderr
@@ -1,18 +1,18 @@
+error[E0038]: the trait `Copy` is not dyn compatible
+  --> $DIR/macro-matcher.rs:8:12
+   |
+LL |     m!(dyn Copy + Send + 'static);
+   |            ^^^^ `Copy` is not dyn compatible
+   |
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+
 error[E0224]: at least one trait is required for an object type
   --> $DIR/macro-matcher.rs:11:8
    |
 LL |     m!(dyn 'static +);
    |        ^^^^^^^^^^^^^
-
-error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/macro-matcher.rs:8:8
-   |
-LL |     m!(dyn Copy + Send + 'static);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` is not dyn compatible
-   |
-   = note: the trait is not dyn compatible because it requires `Self: Sized`
-   = note: for a trait to be dyn compatible it needs to allow building a vtable
-           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/object/safety.stderr
+++ b/tests/ui/traits/object/safety.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `Tr` is not dyn compatible
-  --> $DIR/safety.rs:15:12
+  --> $DIR/safety.rs:15:17
    |
 LL |     let _: &dyn Tr = &St;
-   |            ^^^^^^^ `Tr` is not dyn compatible
+   |                 ^^ `Tr` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -27,10 +27,10 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
 
 error[E0038]: the trait `bar` is not dyn compatible
-  --> $DIR/test-2.rs:13:22
+  --> $DIR/test-2.rs:13:30
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |                      ^^^^^^^^^^^^ `bar` is not dyn compatible
+   |                              ^^^ `bar` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.rs
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.rs
@@ -13,5 +13,4 @@ fn main() {
     let x: i32 = 5;
     let y = x as dyn MyAdd<i32>;
     //~^ ERROR E0038
-    //~| ERROR cast to unsized type: `i32` as `dyn MyAdd<i32>`
 }

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -1,20 +1,8 @@
-error[E0620]: cast to unsized type: `i32` as `dyn MyAdd<i32>`
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:13
-   |
-LL |     let y = x as dyn MyAdd<i32>;
-   |             ^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using a box or reference as appropriate
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:13
-   |
-LL |     let y = x as dyn MyAdd<i32>;
-   |             ^
-
 error[E0038]: the trait `MyAdd` is not dyn compatible
-  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:18
+  --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:22
    |
 LL |     let y = x as dyn MyAdd<i32>;
-   |                  ^^^^^^^^^^^^^^ `MyAdd` is not dyn compatible
+   |                      ^^^^^^^^^^ `MyAdd` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
@@ -25,7 +13,6 @@ LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }
    = help: consider moving `add` to another trait
    = help: only type `i32` implements `MyAdd`; consider using it directly instead.
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0038, E0620.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/wf/wf-dyn-incompatible.stderr
+++ b/tests/ui/wf/wf-dyn-incompatible.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/wf-dyn-incompatible.rs:9:13
+  --> $DIR/wf-dyn-incompatible.rs:9:18
    |
 LL |     let _x: &dyn A;
-   |             ^^^^^^ `A` is not dyn compatible
+   |                  ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1170,7 +1170,6 @@ contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "fmease",
     "jyn514",
-    "spastorino",
 ]
 
 [[assign.warn_non_default_branch.exceptions]]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#140591 (Fix malformed suggestion for E0061 when method is a macro token in macro context)
 - rust-lang/rust#141536 (Improve `ambiguous_wide_pointer_comparisons` lint compare diagnostics)
 - rust-lang/rust#141552 (Pull out dedicated `cfg_version` syntax test from feature gate test)
 - rust-lang/rust#141556 (bootstrap: translate Windows paths in a way that works for both Cygwin and MSYS2)
 - rust-lang/rust#141563 (Remove out-of-date `noop_*` names.)
 - rust-lang/rust#141568 (dist: make sure llvm-project submodule is present)
 - rust-lang/rust#141580 (Use more detailed spans in dyn compat errors within bodies)
 - rust-lang/rust#141582 (intrinsics, ScalarInt: minor cleanup)
 - rust-lang/rust#141584 (Support `opaque_types_defined_by` for `SyntheticCoroutineBody`)
 - rust-lang/rust#141587 (Add missing edition directives for async-await tests)
 - rust-lang/rust#141594 (Add `generic_arg_infer` test)
 - rust-lang/rust#141596 (rustc book: fix erratic sentence by making it more simple)
 - rust-lang/rust#141599 (Remove an unnecessary use of `Box::into_inner`.)
 - rust-lang/rust#141611 (Update mdbook to 0.4.51)
 - rust-lang/rust#141616 (Remove spastorino from vacations)
 - rust-lang/rust#141623 (use custom types to clarify arguments to `emit_ptr_va_arg`)
 - rust-lang/rust#141635 (further dedup `WalkItemKind` for `mut_visit` and `visit`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140591,141536,141552,141556,141563,141568,141580,141582,141584,141587,141594,141596,141599,141611,141616,141623,141635)
<!-- homu-ignore:end -->