### PR TITLE
CI: Add cargo tests to aarch64-apple-darwin

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -459,7 +459,9 @@ auto:
 
   - name: aarch64-apple
     env:
-      SCRIPT: ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin
+      SCRIPT: >
+        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin &&
+        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin src/tools/cargo
       RUST_CONFIGURE_ARGS: >-
         --enable-sanitizers
         --enable-profiler


### PR DESCRIPTION
This adds running of cargo's tests to the aarch64-apple-darwin job. The reason for this is that tier-1 targets are ostensibly supposed to run tests for host tools, but we are not doing that here. We do have fairly good coverage in Cargo's CI, but we don't cover the beta or stable branches here. I think it would be good to have a fallback here.

I think this should only add about 7 minutes of CI time, but I have not measured it. The current job is about 1.5 hours.

In summary of the tier-1 targets:

| Target | rust-lang/cargo | rust-lang/rust |
|--------|-----------------|----------------|
| aarch64-apple-darwin | stable/nightly | ❌ (this PR) |
| aarch64-unknown-linux-gnu | stable/nightly | ✓ |
| x86_64-apple-darwin | nightly | ❌ |
| x86_64-pc-windows-gnu | nightly | ❌ |
| x86_64-pc-windows-msvc | stable | ✓ |
| x86_64-unknown-linux-gnu | stable/beta/nightly | ✓ |
| i686-pc-windows-msvc | ❌ | ❌ |
| i686-unknown-linux-gnu | ❌ | ❌ |

try-job: aarch64-apple