### PR TITLE
bootstrap: Remove `bin_root` from `PATH`

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1118,7 +1118,6 @@ class RustBuild(object):
         if "RUSTFLAGS_BOOTSTRAP" in env:
             env["RUSTFLAGS"] += " " + env["RUSTFLAGS_BOOTSTRAP"]
 
-        env["PATH"] = os.path.join(self.bin_root(), "bin") + os.pathsep + env["PATH"]
         if not os.path.isfile(self.cargo()):
             raise Exception("no cargo executable found at `{}`".format(self.cargo()))
         args = [


### PR DESCRIPTION
It's not currently load bearing in typical setups on typical targets.
Basically, if it passes the standard CI, then we can remove it, I think.

If someone later reports this breaking the build, then we can address it in a more fine grained way.
E.g. add it to `PATH` last and not first, only on specific targets, and only if specific files are not already found in `PATH` directories.

Fixes [#t-infra/bootstrap > Build broken in MSYS2 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Build.20broken.20in.20MSYS2/near/520709527)