### PR TITLE
rustdoc search: prefer stable items in search results

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -586,7 +586,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         search_type,
         aliases,
         deprecation,
-        stability: item.stability(tcx),
+        is_unstable: item.stability(tcx).map(|x| x.is_unstable()).unwrap_or(false),
     };
     cache.search_index.push(index_item);
 }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -586,6 +586,7 @@ fn add_item_to_search_index(tcx: TyCtxt<'_>, cache: &mut Cache, item: &clean::It
         search_type,
         aliases,
         deprecation,
+        stability: item.stability(tcx),
     };
     cache.search_index.push(index_item);
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -50,8 +50,7 @@ use std::{fs, str};
 use askama::Template;
 use itertools::Either;
 use rustc_attr_data_structures::{
-    ConstStability, DeprecatedSince, Deprecation, RustcVersion, Stability, StabilityLevel,
-    StableSince,
+    ConstStability, DeprecatedSince, Deprecation, RustcVersion, StabilityLevel, StableSince,
 };
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::Mutability;
@@ -141,12 +140,7 @@ pub(crate) struct IndexItem {
     pub(crate) search_type: Option<IndexItemFunctionType>,
     pub(crate) aliases: Box<[Symbol]>,
     pub(crate) deprecation: Option<Deprecation>,
-    pub(crate) stability: Option<Stability>,
-}
-impl IndexItem {
-    fn is_unstable(&self) -> bool {
-        matches!(&self.stability, Some(Stability { level: StabilityLevel::Unstable { .. }, .. }))
-    }
+    pub(crate) is_unstable: bool,
 }
 
 /// A type used for the search index.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -50,7 +50,8 @@ use std::{fs, str};
 use askama::Template;
 use itertools::Either;
 use rustc_attr_data_structures::{
-    ConstStability, DeprecatedSince, Deprecation, RustcVersion, StabilityLevel, StableSince,
+    ConstStability, DeprecatedSince, Deprecation, RustcVersion, Stability, StabilityLevel,
+    StableSince,
 };
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::Mutability;
@@ -140,6 +141,12 @@ pub(crate) struct IndexItem {
     pub(crate) search_type: Option<IndexItemFunctionType>,
     pub(crate) aliases: Box<[Symbol]>,
     pub(crate) deprecation: Option<Deprecation>,
+    pub(crate) stability: Option<Stability>,
+}
+impl IndexItem {
+    fn is_unstable(&self) -> bool {
+        matches!(&self.stability, Some(Stability { level: StabilityLevel::Unstable { .. }, .. }))
+    }
 }
 
 /// A type used for the search index.

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -93,7 +93,7 @@ pub(crate) fn build_index(
                 ),
                 aliases: item.attrs.get_doc_aliases(),
                 deprecation: item.deprecation(tcx),
-                stability: item.stability(tcx),
+                is_unstable: item.stability(tcx).is_some_and(|x| x.is_unstable()),
             });
         }
     }
@@ -700,7 +700,7 @@ pub(crate) fn build_index(
                     // bitmasks always use 1-indexing for items, with 0 as the crate itself
                     deprecated.push(u32::try_from(index + 1).unwrap());
                 }
-                if item.is_unstable() {
+                if item.is_unstable {
                     unstable.push(u32::try_from(index + 1).unwrap());
                 }
             }

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -93,6 +93,7 @@ pub(crate) fn build_index(
                 ),
                 aliases: item.attrs.get_doc_aliases(),
                 deprecation: item.deprecation(tcx),
+                stability: item.stability(tcx),
             });
         }
     }
@@ -642,6 +643,7 @@ pub(crate) fn build_index(
             let mut parents_backref_queue = VecDeque::new();
             let mut functions = String::with_capacity(self.items.len());
             let mut deprecated = Vec::with_capacity(self.items.len());
+            let mut unstable = Vec::with_capacity(self.items.len());
 
             let mut type_backref_queue = VecDeque::new();
 
@@ -698,6 +700,9 @@ pub(crate) fn build_index(
                     // bitmasks always use 1-indexing for items, with 0 as the crate itself
                     deprecated.push(u32::try_from(index + 1).unwrap());
                 }
+                if item.is_unstable() {
+                    unstable.push(u32::try_from(index + 1).unwrap());
+                }
             }
 
             for (index, path) in &revert_extra_paths {
@@ -736,6 +741,7 @@ pub(crate) fn build_index(
             crate_data.serialize_field("r", &re_exports)?;
             crate_data.serialize_field("b", &self.associated_item_disambiguators)?;
             crate_data.serialize_field("c", &bitmap_to_string(&deprecated))?;
+            crate_data.serialize_field("u", &bitmap_to_string(&unstable))?;
             crate_data.serialize_field("e", &bitmap_to_string(&self.empty_desc))?;
             crate_data.serialize_field("P", &param_names)?;
             if has_aliases {

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -129,7 +129,7 @@ declare namespace rustdoc {
 
     /**
      * A single parsed "atom" in a search query. For example,
-     * 
+     *
      *     std::fmt::Formatter, Write -> Result<()>
      *     ┏━━━━━━━━━━━━━━━━━━  ┌────    ┏━━━━━┅┅┅┅┄┄┄┄┄┄┄┄┄┄┄┄┄┄┐
      *     ┃                    │        ┗ QueryElement {        ┊
@@ -442,6 +442,8 @@ declare namespace rustdoc {
      * of `p`) but is used for modules items like free functions.
      *
      * `c` is an array of item indices that are deprecated.
+     *
+     * `u` is an array of item indices that are unstable.
      */
     type RawSearchIndexCrate = {
     doc: string,
@@ -456,6 +458,7 @@ declare namespace rustdoc {
     p: Array<[number, string] | [number, string, number] | [number, string, number, number] | [number, string, number, number, string]>,
     b: Array<[number, String]>,
     c: string,
+    u: string,
     r: Array<[number, number]>,
     P: Array<[number, string]>,
     };

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -3291,6 +3291,12 @@ class DocSearch {
                 }
 
                 // sort unstable items later
+                // FIXME: there is some doubt if this is the most effecient way to implement this.
+                // alternative options include:
+                // * put is_unstable on each item when the index is built.
+                //   increases memory usage but avoids a hashmap lookup.
+                // * put is_unstable on each item before sorting.
+                //   better worst case performance but worse average case performance.
                 a = Number(
                     // @ts-expect-error
                     this.searchIndexUnstable.get(aaa.item.crate).contains(aaa.item.bitIndex),

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1464,6 +1464,11 @@ class DocSearch {
          */
         this.searchIndexEmptyDesc = new Map();
         /**
+         * @type {Map<String, RoaringBitmap>}
+         */
+        this.searchIndexUnstable = new Map();
+
+        /**
          *  @type {Uint32Array}
          */
         this.functionTypeFingerprint = new Uint32Array(0);
@@ -2048,9 +2053,10 @@ class DocSearch {
             };
             const descShardList = [descShard];
 
-            // Deprecated items and items with no description
+            // Deprecated and unstable items and items with no description
             this.searchIndexDeprecated.set(crate, new RoaringBitmap(crateCorpus.c));
             this.searchIndexEmptyDesc.set(crate, new RoaringBitmap(crateCorpus.e));
+            this.searchIndexUnstable.set(crate, new RoaringBitmap(crateCorpus.u));
             let descIndex = 0;
 
             /**
@@ -3279,6 +3285,19 @@ class DocSearch {
                 b = Number(
                     // @ts-expect-error
                     this.searchIndexDeprecated.get(bbb.item.crate).contains(bbb.item.bitIndex),
+                );
+                if (a !== b) {
+                    return a - b;
+                }
+
+                // sort unstable items later
+                a = Number(
+                    // @ts-expect-error
+                    this.searchIndexUnstable.get(aaa.item.crate).contains(aaa.item.bitIndex),
+                );
+                b = Number(
+                    // @ts-expect-error
+                    this.searchIndexUnstable.get(bbb.item.crate).contains(bbb.item.bitIndex),
                 );
                 if (a !== b) {
                     return a - b;

--- a/tests/rustdoc-js-std/core-transmute.js
+++ b/tests/rustdoc-js-std/core-transmute.js
@@ -3,9 +3,9 @@ const EXPECTED = [
     {
         'query': 'generic:T -> generic:U',
         'others': [
+            { 'path': 'core::mem', 'name': 'transmute' },
             { 'path': 'core::intrinsics::simd', 'name': 'simd_as' },
             { 'path': 'core::intrinsics::simd', 'name': 'simd_cast' },
-            { 'path': 'core::mem', 'name': 'transmute' },
         ],
     },
 ];

--- a/tests/rustdoc-js-std/transmute-fail.js
+++ b/tests/rustdoc-js-std/transmute-fail.js
@@ -6,9 +6,9 @@ const EXPECTED = [
         // should-fail tag and the search query below:
         'query': 'generic:T -> generic:T',
         'others': [
+            { 'path': 'std::mem', 'name': 'transmute' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_as' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_cast' },
-            { 'path': 'std::mem', 'name': 'transmute' },
         ],
     },
 ];

--- a/tests/rustdoc-js-std/transmute.js
+++ b/tests/rustdoc-js-std/transmute.js
@@ -5,9 +5,9 @@ const EXPECTED = [
         // should-fail tag and the search query below:
         'query': 'generic:T -> generic:U',
         'others': [
+            { 'path': 'std::mem', 'name': 'transmute' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_as' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_cast' },
-            { 'path': 'std::mem', 'name': 'transmute' },
         ],
     },
 ];

--- a/tests/rustdoc-js/sort-stability.js
+++ b/tests/rustdoc-js/sort-stability.js
@@ -1,0 +1,9 @@
+const EXPECTED = [
+    {
+        'query': 'foo',
+        'others': [
+            {"path": "sort_stability::old", "name": "foo"},
+            {"path": "sort_stability::new", "name": "foo"},
+        ],
+    },
+];

--- a/tests/rustdoc-js/sort-stability.rs
+++ b/tests/rustdoc-js/sort-stability.rs
@@ -1,0 +1,16 @@
+#![feature(staged_api)]
+#![stable(feature = "foo_lib", since = "1.0.0")]
+
+#[stable(feature = "old_foo", since = "1.0.1")]
+pub mod old {
+    /// Old, stable foo
+    #[stable(feature = "old_foo", since = "1.0.1")]
+    pub fn foo() {}
+}
+
+#[unstable(feature = "new_foo", issue = "none")]
+pub mod new {
+    /// New, unstable foo
+    #[unstable(feature = "new_foo", issue = "none")]
+    pub fn foo() {}
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/138067

this does add a new field to the search index, but since we're only listing unstable items instead of adding a boolean flag to every item, it should only increase the search index size of sysroot crates, since those are the only ones using the `staged_api` feature, at least as far as the rust project is concerned.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
