### PR TITLE
Make the `dangerous_implicit_autorefs` lint deny-by-default

### DIFF
--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -16,7 +16,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
     ///     unsafe { &raw mut (*ptr)[..16] }
     ///     //                      ^^^^^^ this calls `IndexMut::index_mut(&mut ..., ..16)`,
@@ -51,7 +51,7 @@ declare_lint! {
     /// }
     /// ```
     pub DANGEROUS_IMPLICIT_AUTOREFS,
-    Warn,
+    Deny,
     "implicit reference to a dereference of a raw pointer",
     report_in_external_macro
 }

--- a/tests/ui/lint/implicit_autorefs.fixed
+++ b/tests/ui/lint/implicit_autorefs.fixed
@@ -1,4 +1,4 @@
-//@ check-pass
+//@ check-fail
 //@ run-rustfix
 
 #![allow(dead_code)] // For the rustfix-ed code.
@@ -8,7 +8,7 @@ use std::ops::Deref;
 
 unsafe fn test_const(ptr: *const [u8]) {
     let _ = (&(*ptr))[..16];
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 struct Test {
@@ -17,36 +17,36 @@ struct Test {
 
 unsafe fn test_field(ptr: *const Test) -> *const [u8] {
     let l = (&(*ptr).field).len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 
     &raw const (&(*ptr).field)[..l - 1]
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_builtin_index(a: *mut [String]) {
     _ = (&(*a)[0]).len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 
     _ = (&(&(*a))[..1][0]).len();
-    //~^ WARN implicit autoref
-    //~^^ WARN implicit autoref
+    //~^ ERROR implicit autoref
+    //~^^ ERROR implicit autoref
 }
 
 unsafe fn test_overloaded_deref_const(ptr: *const ManuallyDrop<Test>) {
     let _ = (&(*ptr)).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = &raw const (&(*ptr)).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_overloaded_deref_mut(ptr: *mut ManuallyDrop<Test>) {
     let _ = (&(*ptr)).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_double_overloaded_deref_const(ptr: *const ManuallyDrop<ManuallyDrop<Test>>) {
     let _ = (&(*ptr)).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_manually_overloaded_deref() {
@@ -54,52 +54,55 @@ unsafe fn test_manually_overloaded_deref() {
 
     impl<T> Deref for W<T> {
         type Target = T;
-        fn deref(&self) -> &T { &self.0 }
+        fn deref(&self) -> &T {
+            &self.0
+        }
     }
 
     let w: W<i32> = W(5);
     let w = &raw const w;
     let _p: *const i32 = &raw const *(&**w);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 struct Test2 {
     // Derefs to `[u8]`.
-    field: &'static [u8]
+    field: &'static [u8],
 }
 
 fn test_more_manual_deref(ptr: *const Test2) -> usize {
     unsafe { (&(*ptr).field).len() }
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_no_attr(ptr: *mut ManuallyDrop<u8>) {
-    ptr.write(ManuallyDrop::new(1)); // Should not warn, as `ManuallyDrop::write` is not
-                                     // annotated with `#[rustc_no_implicit_auto_ref]`
+    // Should not warn, as `ManuallyDrop::write` is not
+    // annotated with `#[rustc_no_implicit_auto_ref]`
+    ptr.write(ManuallyDrop::new(1));
 }
 
 unsafe fn test_vec_get(ptr: *mut Vec<u8>) {
     let _ = (&(*ptr)).get(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (&(*ptr)).get_unchecked(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (&mut (*ptr)).get_mut(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (&mut (*ptr)).get_unchecked_mut(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_string(ptr: *mut String) {
     let _ = (&(*ptr)).len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (&(*ptr)).is_empty();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
     let _ = (&(&(*slice))[..]).len();
-    //~^ WARN implicit autoref
-    //~^^ WARN implicit autoref
+    //~^ ERROR implicit autoref
+    //~^^ ERROR implicit autoref
 }
 
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.rs
+++ b/tests/ui/lint/implicit_autorefs.rs
@@ -1,4 +1,4 @@
-//@ check-pass
+//@ check-fail
 //@ run-rustfix
 
 #![allow(dead_code)] // For the rustfix-ed code.
@@ -8,7 +8,7 @@ use std::ops::Deref;
 
 unsafe fn test_const(ptr: *const [u8]) {
     let _ = (*ptr)[..16];
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 struct Test {
@@ -17,36 +17,36 @@ struct Test {
 
 unsafe fn test_field(ptr: *const Test) -> *const [u8] {
     let l = (*ptr).field.len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 
     &raw const (*ptr).field[..l - 1]
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_builtin_index(a: *mut [String]) {
     _ = (*a)[0].len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 
     _ = (*a)[..1][0].len();
-    //~^ WARN implicit autoref
-    //~^^ WARN implicit autoref
+    //~^ ERROR implicit autoref
+    //~^^ ERROR implicit autoref
 }
 
 unsafe fn test_overloaded_deref_const(ptr: *const ManuallyDrop<Test>) {
     let _ = (*ptr).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = &raw const (*ptr).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_overloaded_deref_mut(ptr: *mut ManuallyDrop<Test>) {
     let _ = (*ptr).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_double_overloaded_deref_const(ptr: *const ManuallyDrop<ManuallyDrop<Test>>) {
     let _ = (*ptr).field;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_manually_overloaded_deref() {
@@ -54,52 +54,55 @@ unsafe fn test_manually_overloaded_deref() {
 
     impl<T> Deref for W<T> {
         type Target = T;
-        fn deref(&self) -> &T { &self.0 }
+        fn deref(&self) -> &T {
+            &self.0
+        }
     }
 
     let w: W<i32> = W(5);
     let w = &raw const w;
     let _p: *const i32 = &raw const **w;
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 struct Test2 {
     // Derefs to `[u8]`.
-    field: &'static [u8]
+    field: &'static [u8],
 }
 
 fn test_more_manual_deref(ptr: *const Test2) -> usize {
     unsafe { (*ptr).field.len() }
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_no_attr(ptr: *mut ManuallyDrop<u8>) {
-    ptr.write(ManuallyDrop::new(1)); // Should not warn, as `ManuallyDrop::write` is not
-                                     // annotated with `#[rustc_no_implicit_auto_ref]`
+    // Should not warn, as `ManuallyDrop::write` is not
+    // annotated with `#[rustc_no_implicit_auto_ref]`
+    ptr.write(ManuallyDrop::new(1));
 }
 
 unsafe fn test_vec_get(ptr: *mut Vec<u8>) {
     let _ = (*ptr).get(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (*ptr).get_unchecked(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (*ptr).get_mut(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (*ptr).get_unchecked_mut(0);
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn test_string(ptr: *mut String) {
     let _ = (*ptr).len();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
     let _ = (*ptr).is_empty();
-    //~^ WARN implicit autoref
+    //~^ ERROR implicit autoref
 }
 
 unsafe fn slice_ptr_len_because_of_msrv<T>(slice: *const [T]) {
     let _ = (*slice)[..].len();
-    //~^ WARN implicit autoref
-    //~^^ WARN implicit autoref
+    //~^ ERROR implicit autoref
+    //~^^ ERROR implicit autoref
 }
 
 fn main() {}

--- a/tests/ui/lint/implicit_autorefs.stderr
+++ b/tests/ui/lint/implicit_autorefs.stderr
@@ -1,4 +1,4 @@
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:10:13
    |
 LL |     let _ = (*ptr)[..16];
@@ -12,13 +12,13 @@ note: autoref is being applied to this expression, resulting in: `&[u8]`
    |
 LL |     let _ = (*ptr)[..16];
    |             ^^^^^^
-   = note: `#[warn(dangerous_implicit_autorefs)]` on by default
+   = note: `#[deny(dangerous_implicit_autorefs)]` on by default
 help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
    |
 LL |     let _ = (&(*ptr))[..16];
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:19:13
    |
 LL |     let l = (*ptr).field.len();
@@ -39,7 +39,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let l = (&(*ptr).field).len();
    |             ++            +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:22:16
    |
 LL |     &raw const (*ptr).field[..l - 1]
@@ -58,7 +58,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     &raw const (&(*ptr).field)[..l - 1]
    |                ++            +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:27:9
    |
 LL |     _ = (*a)[0].len();
@@ -79,7 +79,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     _ = (&(*a)[0]).len();
    |         ++       +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
@@ -100,7 +100,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     _ = (&(*a)[..1][0]).len();
    |         ++            +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:30:9
    |
 LL |     _ = (*a)[..1][0].len();
@@ -119,7 +119,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     _ = (&(*a))[..1][0].len();
    |         ++    +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:36:13
    |
 LL |     let _ = (*ptr).field;
@@ -134,7 +134,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).field;
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:38:24
    |
 LL |     let _ = &raw const (*ptr).field;
@@ -149,7 +149,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = &raw const (&(*ptr)).field;
    |                        ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:43:13
    |
 LL |     let _ = (*ptr).field;
@@ -164,7 +164,7 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).field;
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
+error: implicit autoref creates a reference to the dereference of a raw pointer
   --> $DIR/implicit_autorefs.rs:48:13
    |
 LL |     let _ = (*ptr).field;
@@ -179,8 +179,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).field;
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:62:26
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:64:26
    |
 LL |     let _p: *const i32 = &raw const **w;
    |                          ^^^^^^^^^^^^^-
@@ -189,7 +189,7 @@ LL |     let _p: *const i32 = &raw const **w;
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&W<i32>`
-  --> $DIR/implicit_autorefs.rs:62:38
+  --> $DIR/implicit_autorefs.rs:64:38
    |
 LL |     let _p: *const i32 = &raw const **w;
    |                                      ^^
@@ -198,8 +198,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _p: *const i32 = &raw const *(&**w);
    |                                      +++  +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:72:14
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:74:14
    |
 LL |     unsafe { (*ptr).field.len() }
    |              ^^---^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ LL |     unsafe { (*ptr).field.len() }
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&[u8]`
-  --> $DIR/implicit_autorefs.rs:72:14
+  --> $DIR/implicit_autorefs.rs:74:14
    |
 LL |     unsafe { (*ptr).field.len() }
    |              ^^^^^^^^^^^^
@@ -219,8 +219,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     unsafe { (&(*ptr).field).len() }
    |              ++            +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:82:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:85:13
    |
 LL |     let _ = (*ptr).get(0);
    |             ^^---^^^^^^^^
@@ -229,7 +229,7 @@ LL |     let _ = (*ptr).get(0);
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&[u8]`
-  --> $DIR/implicit_autorefs.rs:82:13
+  --> $DIR/implicit_autorefs.rs:85:13
    |
 LL |     let _ = (*ptr).get(0);
    |             ^^^^^^
@@ -240,8 +240,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).get(0);
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:84:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:87:13
    |
 LL |     let _ = (*ptr).get_unchecked(0);
    |             ^^---^^^^^^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ LL |     let _ = (*ptr).get_unchecked(0);
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&[u8]`
-  --> $DIR/implicit_autorefs.rs:84:13
+  --> $DIR/implicit_autorefs.rs:87:13
    |
 LL |     let _ = (*ptr).get_unchecked(0);
    |             ^^^^^^
@@ -261,8 +261,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).get_unchecked(0);
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:86:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:89:13
    |
 LL |     let _ = (*ptr).get_mut(0);
    |             ^^---^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     let _ = (*ptr).get_mut(0);
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&mut [u8]`
-  --> $DIR/implicit_autorefs.rs:86:13
+  --> $DIR/implicit_autorefs.rs:89:13
    |
 LL |     let _ = (*ptr).get_mut(0);
    |             ^^^^^^
@@ -282,8 +282,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&mut (*ptr)).get_mut(0);
    |             +++++       +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:88:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:91:13
    |
 LL |     let _ = (*ptr).get_unchecked_mut(0);
    |             ^^---^^^^^^^^^^^^^^^^^^^^^^
@@ -292,7 +292,7 @@ LL |     let _ = (*ptr).get_unchecked_mut(0);
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&mut [u8]`
-  --> $DIR/implicit_autorefs.rs:88:13
+  --> $DIR/implicit_autorefs.rs:91:13
    |
 LL |     let _ = (*ptr).get_unchecked_mut(0);
    |             ^^^^^^
@@ -303,8 +303,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&mut (*ptr)).get_unchecked_mut(0);
    |             +++++       +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:93:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:96:13
    |
 LL |     let _ = (*ptr).len();
    |             ^^---^^^^^^^
@@ -313,7 +313,7 @@ LL |     let _ = (*ptr).len();
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&String`
-  --> $DIR/implicit_autorefs.rs:93:13
+  --> $DIR/implicit_autorefs.rs:96:13
    |
 LL |     let _ = (*ptr).len();
    |             ^^^^^^
@@ -324,8 +324,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).len();
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:95:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:98:13
    |
 LL |     let _ = (*ptr).is_empty();
    |             ^^---^^^^^^^^^^^^
@@ -334,7 +334,7 @@ LL |     let _ = (*ptr).is_empty();
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&String`
-  --> $DIR/implicit_autorefs.rs:95:13
+  --> $DIR/implicit_autorefs.rs:98:13
    |
 LL |     let _ = (*ptr).is_empty();
    |             ^^^^^^
@@ -345,8 +345,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*ptr)).is_empty();
    |             ++      +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:100:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:103:13
    |
 LL |     let _ = (*slice)[..].len();
    |             ^^-----^^^^^^^^^^^
@@ -355,7 +355,7 @@ LL |     let _ = (*slice)[..].len();
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&[T]`
-  --> $DIR/implicit_autorefs.rs:100:13
+  --> $DIR/implicit_autorefs.rs:103:13
    |
 LL |     let _ = (*slice)[..].len();
    |             ^^^^^^^^^^^^
@@ -366,8 +366,8 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*slice)[..]).len();
    |             ++            +
 
-warning: implicit autoref creates a reference to the dereference of a raw pointer
-  --> $DIR/implicit_autorefs.rs:100:13
+error: implicit autoref creates a reference to the dereference of a raw pointer
+  --> $DIR/implicit_autorefs.rs:103:13
    |
 LL |     let _ = (*slice)[..].len();
    |             ^^-----^^^^^
@@ -376,7 +376,7 @@ LL |     let _ = (*slice)[..].len();
    |
    = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
 note: autoref is being applied to this expression, resulting in: `&[T]`
-  --> $DIR/implicit_autorefs.rs:100:13
+  --> $DIR/implicit_autorefs.rs:103:13
    |
 LL |     let _ = (*slice)[..].len();
    |             ^^^^^^^^
@@ -385,5 +385,5 @@ help: try using a raw pointer method instead; or if this reference is intentiona
 LL |     let _ = (&(*slice))[..].len();
    |             ++        +
 
-warning: 20 warnings emitted
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
I intended for the `dangerous_implicit_autorefs` lint to be deny-by-default, the [T-lang nomination comment](https://github.com/rust-lang/rust/pull/123239#issuecomment-2727551097) even clearly mentioned deny-by-default, but somehow I and other missed that it is only warn-by-default.

I think the lint should still be deny-by-default as the implicit aliasing requirements can be quite dangerous.

In any-case, opening this PR for T-lang awareness.

@rustbot label +I-lang-nominated +T-lang
r? @traviscross 
