### PR TITLE
rustdoc: add ways of collapsing all impl blocks

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -568,7 +568,11 @@ function preLoadCss(cssUrl) {
                 break;
             case "-":
                 ev.preventDefault();
-                collapseAllDocs();
+                collapseAllDocs(false);
+                break;
+            case "_":
+                ev.preventDefault();
+                collapseAllDocs(true);
                 break;
 
             case "?":
@@ -1038,11 +1042,14 @@ function preLoadCss(cssUrl) {
         innerToggle.children[0].innerText = "Summary";
     }
 
-    function collapseAllDocs() {
+    /**
+     * @param {boolean} collapseImpls - also collapse impl blocks if set to true
+     */
+    function collapseAllDocs(collapseImpls) {
         const innerToggle = document.getElementById(toggleAllDocsId);
         addClass(innerToggle, "will-expand");
         onEachLazy(document.getElementsByClassName("toggle"), e => {
-            if (e.parentNode.id !== "implementations-list" ||
+            if ((collapseImpls || e.parentNode.id !== "implementations-list") ||
                 (!hasClass(e, "implementors-toggle") &&
                  !hasClass(e, "type-contents-toggle"))
             ) {
@@ -1053,7 +1060,10 @@ function preLoadCss(cssUrl) {
         innerToggle.children[0].innerText = "Show all";
     }
 
-    function toggleAllDocs() {
+    /**
+     * @param {MouseEvent=} ev
+     */
+    function toggleAllDocs(ev) {
         const innerToggle = document.getElementById(toggleAllDocsId);
         if (!innerToggle) {
             return;
@@ -1061,7 +1071,7 @@ function preLoadCss(cssUrl) {
         if (hasClass(innerToggle, "will-expand")) {
             expandAllDocs();
         } else {
-            collapseAllDocs();
+            collapseAllDocs(ev !== undefined && ev.shiftKey);
         }
     }
 
@@ -1519,6 +1529,10 @@ function preLoadCss(cssUrl) {
             ["&#9166;", "Go to active search result"],
             ["+", "Expand all sections"],
             ["-", "Collapse all sections"],
+            // for the sake of brevity, we don't say "inherint impl blocks",
+            // although that would be more correct,
+            // since trait impl blocks are collapsed by -
+            ["_", "Collapse all sections, including impl blocks"],
         ].map(x => "<dt>" +
             x[0].split(" ")
                 .map((y, index) => ((index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " "))

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -418,7 +418,9 @@ class RustdocToolbarElement extends HTMLElement {
         <div id="help-button" tabindex="-1">
             <a href="${rootPath}help.html"><span class="label">Help</span></a>
         </div>
-        <button id="toggle-all-docs"><span class="label">Summary</span></button>`;
+        <button id="toggle-all-docs"
+title="Collapse sections (shift-click to also collapse impl blocks)"><span
+class="label">Summary</span></button>`;
     }
 }
 window.customElements.define("rustdoc-toolbar", RustdocToolbarElement);


### PR DESCRIPTION
either shift+click the Summary button,
or use the `_` key.

this collapses everything,
including (inherent) impl blocks.

no need for a special "expand all impl blocks"
method, as impl blocks are expanded during regular "expand all".
doing "expand all" -> "collapse all" will always
result in only impl blocks being expaned.

not sure the best way to add a GUI test.

fixes https://github.com/rust-lang/rust/issues/134429

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
