### PR TITLE
float: Disable `total_cmp` sNaN tests for `f16`

### DIFF
--- a/library/coretests/tests/floats/f16.rs
+++ b/library/coretests/tests/floats/f16.rs
@@ -596,12 +596,15 @@ fn test_total_cmp() {
         f16::from_bits(f16::NAN.to_bits() | quiet_bit_mask())
     }
 
-    fn s_nan() -> f16 {
-        f16::from_bits((f16::NAN.to_bits() & !quiet_bit_mask()) + 42)
-    }
+    // FIXME(f16_f128): Tests involving sNaN are disabled because without optimizations,
+    // `total_cmp` is getting incorrectly lowered to code that includes a `extend`/`trunc` round
+    // trip, which quiets sNaNs. See: https://github.com/llvm/llvm-project/issues/104915
+    // fn s_nan() -> f16 {
+    //     f16::from_bits((f16::NAN.to_bits() & !quiet_bit_mask()) + 42)
+    // }
 
     assert_eq!(Ordering::Equal, (-q_nan()).total_cmp(&-q_nan()));
-    assert_eq!(Ordering::Equal, (-s_nan()).total_cmp(&-s_nan()));
+    // assert_eq!(Ordering::Equal, (-s_nan()).total_cmp(&-s_nan()));
     assert_eq!(Ordering::Equal, (-f16::INFINITY).total_cmp(&-f16::INFINITY));
     assert_eq!(Ordering::Equal, (-f16::MAX).total_cmp(&-f16::MAX));
     assert_eq!(Ordering::Equal, (-2.5_f16).total_cmp(&-2.5));
@@ -622,11 +625,11 @@ fn test_total_cmp() {
     assert_eq!(Ordering::Equal, 2.5_f16.total_cmp(&2.5));
     assert_eq!(Ordering::Equal, f16::MAX.total_cmp(&f16::MAX));
     assert_eq!(Ordering::Equal, f16::INFINITY.total_cmp(&f16::INFINITY));
-    assert_eq!(Ordering::Equal, s_nan().total_cmp(&s_nan()));
+    // assert_eq!(Ordering::Equal, s_nan().total_cmp(&s_nan()));
     assert_eq!(Ordering::Equal, q_nan().total_cmp(&q_nan()));
 
-    assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-s_nan()));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::INFINITY));
+    // assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-s_nan()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::INFINITY));
     assert_eq!(Ordering::Less, (-f16::INFINITY).total_cmp(&-f16::MAX));
     assert_eq!(Ordering::Less, (-f16::MAX).total_cmp(&-2.5));
     assert_eq!(Ordering::Less, (-2.5_f16).total_cmp(&-1.5));
@@ -646,11 +649,11 @@ fn test_total_cmp() {
     assert_eq!(Ordering::Less, 1.5_f16.total_cmp(&2.5));
     assert_eq!(Ordering::Less, 2.5_f16.total_cmp(&f16::MAX));
     assert_eq!(Ordering::Less, f16::MAX.total_cmp(&f16::INFINITY));
-    assert_eq!(Ordering::Less, f16::INFINITY.total_cmp(&s_nan()));
-    assert_eq!(Ordering::Less, s_nan().total_cmp(&q_nan()));
+    // assert_eq!(Ordering::Less, f16::INFINITY.total_cmp(&s_nan()));
+    // assert_eq!(Ordering::Less, s_nan().total_cmp(&q_nan()));
 
-    assert_eq!(Ordering::Greater, (-s_nan()).total_cmp(&-q_nan()));
-    assert_eq!(Ordering::Greater, (-f16::INFINITY).total_cmp(&-s_nan()));
+    // assert_eq!(Ordering::Greater, (-s_nan()).total_cmp(&-q_nan()));
+    // assert_eq!(Ordering::Greater, (-f16::INFINITY).total_cmp(&-s_nan()));
     assert_eq!(Ordering::Greater, (-f16::MAX).total_cmp(&-f16::INFINITY));
     assert_eq!(Ordering::Greater, (-2.5_f16).total_cmp(&-f16::MAX));
     assert_eq!(Ordering::Greater, (-1.5_f16).total_cmp(&-2.5));
@@ -670,10 +673,10 @@ fn test_total_cmp() {
     assert_eq!(Ordering::Greater, 2.5_f16.total_cmp(&1.5));
     assert_eq!(Ordering::Greater, f16::MAX.total_cmp(&2.5));
     assert_eq!(Ordering::Greater, f16::INFINITY.total_cmp(&f16::MAX));
-    assert_eq!(Ordering::Greater, s_nan().total_cmp(&f16::INFINITY));
-    assert_eq!(Ordering::Greater, q_nan().total_cmp(&s_nan()));
+    // assert_eq!(Ordering::Greater, s_nan().total_cmp(&f16::INFINITY));
+    // assert_eq!(Ordering::Greater, q_nan().total_cmp(&s_nan()));
 
-    assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-s_nan()));
+    // assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-s_nan()));
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-f16::INFINITY));
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-f16::MAX));
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&-2.5));
@@ -694,29 +697,29 @@ fn test_total_cmp() {
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&2.5));
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&f16::MAX));
     assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&f16::INFINITY));
-    assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&s_nan()));
+    // assert_eq!(Ordering::Less, (-q_nan()).total_cmp(&s_nan()));
 
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::INFINITY));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::MAX));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-2.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-1.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-1.0));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-0.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::MIN_POSITIVE));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-max_subnorm()));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-min_subnorm()));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-0.0));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&0.0));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&min_subnorm()));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&max_subnorm()));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::MIN_POSITIVE));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&0.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&1.0));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&1.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&2.5));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::MAX));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::INFINITY));
-    assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&s_nan()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::INFINITY));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::MAX));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-2.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-1.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-1.0));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-0.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-f16::MIN_POSITIVE));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-max_subnorm()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-min_subnorm()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&-0.0));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&0.0));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&min_subnorm()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&max_subnorm()));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::MIN_POSITIVE));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&0.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&1.0));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&1.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&2.5));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::MAX));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&f16::INFINITY));
+    // assert_eq!(Ordering::Less, (-s_nan()).total_cmp(&s_nan()));
 }
 
 #[test]


### PR DESCRIPTION
There is an LLVM bug with lowering of basic `f16` operations that mean a round trip via `__extendhfsf2` and `__truncsfhf2` may happen for simple `abs` calls or bitcasts [1]. This is problematic because the round trip quiets signaling NaNs. For most operations this is acceptable, but it is causing `total_cmp` tests to fail unless optimizations are enabled.

Disable `total_cmp` tests involving signaling NaNs until this issue is resolved.

Fixes: https://github.com/rust-lang/rustc_codegen_cranelift/issues/1578
Fixes: https://github.com/rust-lang/rust/issues/141503

[1]: https://github.com/llvm/llvm-project/issues/104915