### PR TITLE
Revert "increase perf of charsearcher for single ascii characters"

### DIFF
--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -656,7 +656,7 @@ impl<'a, P: Pattern> SplitInternal<'a, P> {
         None
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<&'a str> {
         if self.finished {
             return None;

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -429,23 +429,8 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
             SearchStep::Done
         }
     }
-    #[inline(always)]
+    #[inline]
     fn next_match(&mut self) -> Option<(usize, usize)> {
-        if self.utf8_size == 1 {
-            return match self
-                .haystack
-                .as_bytes()
-                .get(self.finger..self.finger_back)?
-                .iter()
-                .position(|x| *x == self.utf8_encoded[0])
-            {
-                Some(x) => {
-                    self.finger += x + 1;
-                    Some((self.finger - 1, self.finger))
-                }
-                None => None,
-            };
-        }
         loop {
             // get the haystack after the last character found
             let bytes = self.haystack.as_bytes().get(self.finger..self.finger_back)?;
@@ -513,21 +498,6 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
     }
     #[inline]
     fn next_match_back(&mut self) -> Option<(usize, usize)> {
-        if self.utf8_size == 1 {
-            return match self
-                .haystack
-                .get(self.finger..self.finger_back)?
-                .as_bytes()
-                .iter()
-                .rposition(|&x| x == self.utf8_encoded[0])
-            {
-                Some(x) => {
-                    self.finger_back = self.finger + x;
-                    Some((self.finger_back, self.finger_back + 1))
-                }
-                None => None,
-            };
-        }
         let haystack = self.haystack.as_bytes();
         loop {
             // get the haystack up to but not including the last character searched


### PR DESCRIPTION
This reverts commit 245bf503e2a948ac98170516d11df632e85a948b (PR https://github.com/rust-lang/rust/pull/141516).

It caused a large `doc` perf. regression in https://github.com/rust-lang/rust/pull/141605.