### PR TITLE
Do not move thread-locals before dropping

### DIFF
--- a/library/std/src/sys/thread_local/native/lazy.rs
+++ b/library/std/src/sys/thread_local/native/lazy.rs
@@ -57,12 +57,18 @@ where
         if let State::Alive = self.state.get() {
             self.value.get().cast()
         } else {
-            self.get_or_init_slow(i, f)
+            unsafe { self.get_or_init_slow(i, f) }
         }
     }
 
+    /// # Safety
+    /// The `self` reference must remain valid until the TLS destructor is run.
     #[cold]
-    fn get_or_init_slow(&self, i: Option<&mut Option<T>>, f: impl FnOnce() -> T) -> *const T {
+    unsafe fn get_or_init_slow(
+        &self,
+        i: Option<&mut Option<T>>,
+        f: impl FnOnce() -> T,
+    ) -> *const T {
         match self.state.get() {
             State::Uninitialized => {}
             State::Alive => return self.value.get().cast(),

--- a/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
+++ b/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
@@ -1,0 +1,39 @@
+//@ run-pass
+#![allow(stable_features)]
+//@ needs-threads
+#![feature(thread_local_try_with)]
+
+use std::cell::Cell;
+use std::thread;
+
+#[derive(Default)]
+struct Foo {
+    ptr: Cell<*const Foo>,
+}
+
+impl Foo {
+    fn touch(&self) {
+        if self.ptr.get().is_null() {
+            self.ptr.set(self);
+        } else {
+            assert!(self.ptr.get() == self);
+        }
+    }
+}
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        self.touch();
+    }
+}
+
+thread_local!(static FOO: Foo = Foo::default());
+
+fn main() {
+    thread::spawn(|| {
+        FOO.with(|foo| foo.touch());
+        FOO.with(|foo| foo.touch());
+    })
+    .join()
+    .unwrap();
+}

--- a/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
+++ b/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![allow(stable_features)]
 //@ needs-threads
 
 use std::cell::Cell;

--- a/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
+++ b/tests/ui/threads-sendsync/tls-dont-move-after-init.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 #![allow(stable_features)]
 //@ needs-threads
-#![feature(thread_local_try_with)]
 
 use std::cell::Cell;
 use std::thread;


### PR DESCRIPTION
Fixes rust-lang/rust#140816. I also (potentially) improved the speed of `get_or_init` a bit by having an explicit hot/cold path.

We still move the value before dropping in the event of a recursive initialization (leading to double-initialization with one value being silently dropped). This is the old behavior, but changing this to panic instead would involve changing tests and also the other OS-specific `thread_local/os.rs` implementation, which is more than I'd like in this PR.