### PR TITLE
Add eholk to compiler reviewer rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1196,6 +1196,7 @@ compiler = [
     "@BoxyUwU",
     "@compiler-errors",
     "@davidtwco",
+    "@eholk",
     "@fee1-dead",
     "@fmease",
     "@jieyouxu",


### PR DESCRIPTION
Now that we have work queue limits on triagebot, I'm happy to share some of the review load.

r? @wesleywiser 