### PR TITLE
Structurally normalize types as needed in `projection_ty_core`

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -474,17 +474,15 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             let projected_ty = curr_projected_ty.projection_ty_core(
                 tcx,
                 proj,
-                |this, field, ()| {
-                    let ty = this.field_ty(tcx, field);
-                    self.structurally_resolve(ty, locations)
-                },
-                |_, _| unreachable!(),
+                |ty| self.structurally_resolve(ty, locations),
+                |ty, variant_index, field, ()| PlaceTy::field_ty(tcx, ty, variant_index, field),
+                |_| unreachable!(),
             );
             curr_projected_ty = projected_ty;
         }
         trace!(?curr_projected_ty);
 
-        let ty = curr_projected_ty.ty;
+        let ty = self.normalize(curr_projected_ty.ty, locations);
         self.relate_types(ty, v.xform(ty::Contravariant), a, locations, category)?;
 
         Ok(())
@@ -1852,7 +1850,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             | ProjectionElem::Downcast(..) => {}
             ProjectionElem::Field(field, fty) => {
                 let fty = self.normalize(fty, location);
-                let ty = base_ty.field_ty(tcx, field);
+                let ty = PlaceTy::field_ty(tcx, base_ty.ty, base_ty.variant_index, field);
                 let ty = self.normalize(ty, location);
                 debug!(?fty, ?ty);
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -482,6 +482,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
         trace!(?curr_projected_ty);
 
+        // Need to renormalize `a` as typecheck may have failed to normalize
+        // higher-ranked aliases if normalization was ambiguous due to inference.
+        let a = self.normalize(a, locations);
         let ty = self.normalize(curr_projected_ty.ty, locations);
         self.relate_types(ty, v.xform(ty::Contravariant), a, locations, category)?;
 

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -323,9 +323,9 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
     fn parse_place_inner(&self, expr_id: ExprId) -> PResult<(Place<'tcx>, PlaceTy<'tcx>)> {
         let (parent, proj) = parse_by_kind!(self, expr_id, expr, "place",
             @call(mir_field, args) => {
-                let (parent, ty) = self.parse_place_inner(args[0])?;
+                let (parent, place_ty) = self.parse_place_inner(args[0])?;
                 let field = FieldIdx::from_u32(self.parse_integer_literal(args[1])? as u32);
-                let field_ty = ty.field_ty(self.tcx, field);
+                let field_ty = PlaceTy::field_ty(self.tcx, place_ty.ty, place_ty.variant_index, field);
                 let proj = PlaceElem::Field(field, field_ty);
                 let place = parent.project_deeper(&[proj], self.tcx);
                 return Ok((place, PlaceTy::from_ty(field_ty)));

--- a/tests/ui/nll/user-annotations/normalizing-user-annotation.rs
+++ b/tests/ui/nll/user-annotations/normalizing-user-annotation.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/rust/issues/141708>.
+
+// See description in there; this has to do with fundamental limitations
+// to the old trait solver surrounding higher-ranked aliases with infer
+// vars. This always worked in the new trait solver, but I added a revision
+// just for good measure.
+
+trait Foo<'a> {
+    type Assoc;
+}
+
+impl Foo<'_> for i32 {
+    type Assoc = u32;
+}
+
+impl Foo<'_> for u32 {
+    type Assoc = u32;
+}
+
+fn foo<'b: 'b, T: for<'a> Foo<'a>, F: for<'a> Fn(<T as Foo<'a>>::Assoc)>(_: F) -> (T, F) {
+    todo!()
+}
+
+fn main() {
+    let (x, c): (i32, _) = foo::<'static, _, _>(|_| {});
+}

--- a/tests/ui/traits/next-solver/normalize/normalize-place-elem.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-place-elem.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/221>.
+// Ensure that we normalize after applying projection elems in MIR typeck.
+
+use std::marker::PhantomData;
+
+#[derive(Copy, Clone)]
+struct Span;
+
+trait AstKind {
+    type Inner;
+}
+
+struct WithSpan;
+impl AstKind for WithSpan {
+    type Inner
+        = (i32,);
+}
+
+struct Expr<'a> { f: &'a <WithSpan as AstKind>::Inner }
+
+impl Expr<'_> {
+    fn span(self) {
+        match self {
+            Self { f: (n,) } => {},
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Introduce a `structurally_normalize` callback to `projection_ty_core`, and then use it before we match on the ty kind in `projection_ty_core`.

Previously we were only structurally normalizing the return type of the `handle_field` struct, but if we were to (e.g.) apply a deref projection to that type, then the resulting type is not guaranteed to be structurally normalized and any subsequent projections applied would ICE.

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/221

I'll leave a few comments inline to explain the changes.

r? lcnr

---

Also fixes rust-lang/rust#141708 

