### PR TITLE
Add `loongarch64` with `d` feature to `f32::midpoint` fast path

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -999,6 +999,7 @@ impl f32 {
                 target_arch = "x86_64",
                 target_arch = "aarch64",
                 all(any(target_arch = "riscv32", target_arch = "riscv64"), target_feature = "d"),
+                all(target_arch = "loongarch64", target_feature = "d"),
                 all(target_arch = "arm", target_feature = "vfp2"),
                 target_arch = "wasm32",
                 target_arch = "wasm64",


### PR DESCRIPTION
This patch enables the optimized implementation of `f32::midpoint` for `loongarch64` targets that support the `d`feature. Targets with reliable 64-bit float support can safely use the faster and more accurate computation via `f64`, avoiding the fallback branchy version.