### PR TITLE
Avoid over-counting of `UsePath` in the HIR stats.

### DIFF
--- a/tests/ui/stats/input-stats.rs
+++ b/tests/ui/stats/input-stats.rs
@@ -3,6 +3,10 @@
 //@ only-64bit
 // layout randomization affects the hir stat output
 //@ needs-deterministic-layouts
+//
+// Filter out the percentages because a change to a single count can affect
+// many or all percentages, which makes the diffs hard to read.
+//@ normalize-stderr: "\([0-9 ][0-9]\.[0-9]%\)" -> "(NN.N%)"
 
 // Type layouts sometimes change. When that happens, until the next bootstrap
 // bump occurs, stage1 and stage2 will give different outputs for this test.

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -171,8 +171,8 @@ hir-stats - Impl                      88 (NN.N%)             1
 hir-stats - Trait                     88 (NN.N%)             1
 hir-stats - Fn                       176 (NN.N%)             2
 hir-stats - Use                      352 (NN.N%)             4
-hir-stats Path                   1_240 (NN.N%)            31            40
-hir-stats PathSegment            1_920 (NN.N%)            40            48
+hir-stats Path                   1_040 (NN.N%)            26            40
+hir-stats PathSegment            1_776 (NN.N%)            37            48
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_988                   180
+hir-stats Total                  8_644                   172
 hir-stats

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -1,178 +1,178 @@
 ast-stats-1 PRE EXPANSION AST STATS
 ast-stats-1 Name                Accumulated Size         Count     Item Size
 ast-stats-1 ----------------------------------------------------------------
-ast-stats-1 Crate                     40 ( 0.6%)             1            40
-ast-stats-1 GenericArgs               40 ( 0.6%)             1            40
-ast-stats-1 - AngleBracketed            40 ( 0.6%)             1
-ast-stats-1 ExprField                 48 ( 0.7%)             1            48
-ast-stats-1 Attribute                 64 ( 0.9%)             2            32
-ast-stats-1 - DocComment                32 ( 0.5%)             1
-ast-stats-1 - Normal                    32 ( 0.5%)             1
-ast-stats-1 WherePredicate            72 ( 1.1%)             1            72
-ast-stats-1 - BoundPredicate            72 ( 1.1%)             1
-ast-stats-1 ForeignItem               80 ( 1.2%)             1            80
-ast-stats-1 - Fn                        80 ( 1.2%)             1
-ast-stats-1 Arm                       96 ( 1.4%)             2            48
-ast-stats-1 Local                     96 ( 1.4%)             1            96
-ast-stats-1 FnDecl                   120 ( 1.8%)             5            24
-ast-stats-1 Param                    160 ( 2.4%)             4            40
-ast-stats-1 Stmt                     160 ( 2.4%)             5            32
-ast-stats-1 - Let                       32 ( 0.5%)             1
-ast-stats-1 - MacCall                   32 ( 0.5%)             1
-ast-stats-1 - Expr                      96 ( 1.4%)             3
-ast-stats-1 Block                    192 ( 2.8%)             6            32
-ast-stats-1 FieldDef                 208 ( 3.1%)             2           104
-ast-stats-1 Variant                  208 ( 3.1%)             2           104
-ast-stats-1 AssocItem                320 ( 4.7%)             4            80
-ast-stats-1 - Fn                       160 ( 2.4%)             2
-ast-stats-1 - Type                     160 ( 2.4%)             2
-ast-stats-1 GenericBound             352 ( 5.2%)             4            88
-ast-stats-1 - Trait                    352 ( 5.2%)             4
-ast-stats-1 GenericParam             480 ( 7.1%)             5            96
-ast-stats-1 Pat                      504 ( 7.5%)             7            72
-ast-stats-1 - Struct                    72 ( 1.1%)             1
-ast-stats-1 - Wild                      72 ( 1.1%)             1
-ast-stats-1 - Ident                    360 ( 5.3%)             5
-ast-stats-1 Expr                     576 ( 8.5%)             8            72
-ast-stats-1 - Match                     72 ( 1.1%)             1
-ast-stats-1 - Path                      72 ( 1.1%)             1
-ast-stats-1 - Struct                    72 ( 1.1%)             1
-ast-stats-1 - Lit                      144 ( 2.1%)             2
-ast-stats-1 - Block                    216 ( 3.2%)             3
-ast-stats-1 PathSegment              744 (11.0%)            31            24
-ast-stats-1 Ty                       896 (13.3%)            14            64
-ast-stats-1 - Ptr                       64 ( 0.9%)             1
-ast-stats-1 - Ref                       64 ( 0.9%)             1
-ast-stats-1 - ImplicitSelf             128 ( 1.9%)             2
-ast-stats-1 - Path                     640 ( 9.5%)            10
-ast-stats-1 Item                   1_296 (19.2%)             9           144
-ast-stats-1 - Enum                     144 ( 2.1%)             1
-ast-stats-1 - ForeignMod               144 ( 2.1%)             1
-ast-stats-1 - Impl                     144 ( 2.1%)             1
-ast-stats-1 - Trait                    144 ( 2.1%)             1
-ast-stats-1 - Fn                       288 ( 4.3%)             2
-ast-stats-1 - Use                      432 ( 6.4%)             3
+ast-stats-1 Crate                     40 (NN.N%)             1            40
+ast-stats-1 GenericArgs               40 (NN.N%)             1            40
+ast-stats-1 - AngleBracketed            40 (NN.N%)             1
+ast-stats-1 ExprField                 48 (NN.N%)             1            48
+ast-stats-1 Attribute                 64 (NN.N%)             2            32
+ast-stats-1 - DocComment                32 (NN.N%)             1
+ast-stats-1 - Normal                    32 (NN.N%)             1
+ast-stats-1 WherePredicate            72 (NN.N%)             1            72
+ast-stats-1 - BoundPredicate            72 (NN.N%)             1
+ast-stats-1 ForeignItem               80 (NN.N%)             1            80
+ast-stats-1 - Fn                        80 (NN.N%)             1
+ast-stats-1 Arm                       96 (NN.N%)             2            48
+ast-stats-1 Local                     96 (NN.N%)             1            96
+ast-stats-1 FnDecl                   120 (NN.N%)             5            24
+ast-stats-1 Param                    160 (NN.N%)             4            40
+ast-stats-1 Stmt                     160 (NN.N%)             5            32
+ast-stats-1 - Let                       32 (NN.N%)             1
+ast-stats-1 - MacCall                   32 (NN.N%)             1
+ast-stats-1 - Expr                      96 (NN.N%)             3
+ast-stats-1 Block                    192 (NN.N%)             6            32
+ast-stats-1 FieldDef                 208 (NN.N%)             2           104
+ast-stats-1 Variant                  208 (NN.N%)             2           104
+ast-stats-1 AssocItem                320 (NN.N%)             4            80
+ast-stats-1 - Fn                       160 (NN.N%)             2
+ast-stats-1 - Type                     160 (NN.N%)             2
+ast-stats-1 GenericBound             352 (NN.N%)             4            88
+ast-stats-1 - Trait                    352 (NN.N%)             4
+ast-stats-1 GenericParam             480 (NN.N%)             5            96
+ast-stats-1 Pat                      504 (NN.N%)             7            72
+ast-stats-1 - Struct                    72 (NN.N%)             1
+ast-stats-1 - Wild                      72 (NN.N%)             1
+ast-stats-1 - Ident                    360 (NN.N%)             5
+ast-stats-1 Expr                     576 (NN.N%)             8            72
+ast-stats-1 - Match                     72 (NN.N%)             1
+ast-stats-1 - Path                      72 (NN.N%)             1
+ast-stats-1 - Struct                    72 (NN.N%)             1
+ast-stats-1 - Lit                      144 (NN.N%)             2
+ast-stats-1 - Block                    216 (NN.N%)             3
+ast-stats-1 PathSegment              744 (NN.N%)            31            24
+ast-stats-1 Ty                       896 (NN.N%)            14            64
+ast-stats-1 - Ptr                       64 (NN.N%)             1
+ast-stats-1 - Ref                       64 (NN.N%)             1
+ast-stats-1 - ImplicitSelf             128 (NN.N%)             2
+ast-stats-1 - Path                     640 (NN.N%)            10
+ast-stats-1 Item                   1_296 (NN.N%)             9           144
+ast-stats-1 - Enum                     144 (NN.N%)             1
+ast-stats-1 - ForeignMod               144 (NN.N%)             1
+ast-stats-1 - Impl                     144 (NN.N%)             1
+ast-stats-1 - Trait                    144 (NN.N%)             1
+ast-stats-1 - Fn                       288 (NN.N%)             2
+ast-stats-1 - Use                      432 (NN.N%)             3
 ast-stats-1 ----------------------------------------------------------------
 ast-stats-1 Total                  6_752                   116
 ast-stats-1
 ast-stats-2 POST EXPANSION AST STATS
 ast-stats-2 Name                Accumulated Size         Count     Item Size
 ast-stats-2 ----------------------------------------------------------------
-ast-stats-2 Crate                     40 ( 0.5%)             1            40
-ast-stats-2 GenericArgs               40 ( 0.5%)             1            40
-ast-stats-2 - AngleBracketed            40 ( 0.5%)             1
-ast-stats-2 ExprField                 48 ( 0.6%)             1            48
-ast-stats-2 WherePredicate            72 ( 1.0%)             1            72
-ast-stats-2 - BoundPredicate            72 ( 1.0%)             1
-ast-stats-2 ForeignItem               80 ( 1.1%)             1            80
-ast-stats-2 - Fn                        80 ( 1.1%)             1
-ast-stats-2 Arm                       96 ( 1.3%)             2            48
-ast-stats-2 Local                     96 ( 1.3%)             1            96
-ast-stats-2 FnDecl                   120 ( 1.6%)             5            24
-ast-stats-2 InlineAsm                120 ( 1.6%)             1           120
-ast-stats-2 Attribute                128 ( 1.7%)             4            32
-ast-stats-2 - DocComment                32 ( 0.4%)             1
-ast-stats-2 - Normal                    96 ( 1.3%)             3
-ast-stats-2 Param                    160 ( 2.2%)             4            40
-ast-stats-2 Stmt                     160 ( 2.2%)             5            32
-ast-stats-2 - Let                       32 ( 0.4%)             1
-ast-stats-2 - Semi                      32 ( 0.4%)             1
-ast-stats-2 - Expr                      96 ( 1.3%)             3
-ast-stats-2 Block                    192 ( 2.6%)             6            32
-ast-stats-2 FieldDef                 208 ( 2.8%)             2           104
-ast-stats-2 Variant                  208 ( 2.8%)             2           104
-ast-stats-2 AssocItem                320 ( 4.3%)             4            80
-ast-stats-2 - Fn                       160 ( 2.2%)             2
-ast-stats-2 - Type                     160 ( 2.2%)             2
-ast-stats-2 GenericBound             352 ( 4.7%)             4            88
-ast-stats-2 - Trait                    352 ( 4.7%)             4
-ast-stats-2 GenericParam             480 ( 6.5%)             5            96
-ast-stats-2 Pat                      504 ( 6.8%)             7            72
-ast-stats-2 - Struct                    72 ( 1.0%)             1
-ast-stats-2 - Wild                      72 ( 1.0%)             1
-ast-stats-2 - Ident                    360 ( 4.9%)             5
-ast-stats-2 Expr                     648 ( 8.7%)             9            72
-ast-stats-2 - InlineAsm                 72 ( 1.0%)             1
-ast-stats-2 - Match                     72 ( 1.0%)             1
-ast-stats-2 - Path                      72 ( 1.0%)             1
-ast-stats-2 - Struct                    72 ( 1.0%)             1
-ast-stats-2 - Lit                      144 ( 1.9%)             2
-ast-stats-2 - Block                    216 ( 2.9%)             3
-ast-stats-2 PathSegment              864 (11.7%)            36            24
-ast-stats-2 Ty                       896 (12.1%)            14            64
-ast-stats-2 - Ptr                       64 ( 0.9%)             1
-ast-stats-2 - Ref                       64 ( 0.9%)             1
-ast-stats-2 - ImplicitSelf             128 ( 1.7%)             2
-ast-stats-2 - Path                     640 ( 8.6%)            10
-ast-stats-2 Item                   1_584 (21.4%)            11           144
-ast-stats-2 - Enum                     144 ( 1.9%)             1
-ast-stats-2 - ExternCrate              144 ( 1.9%)             1
-ast-stats-2 - ForeignMod               144 ( 1.9%)             1
-ast-stats-2 - Impl                     144 ( 1.9%)             1
-ast-stats-2 - Trait                    144 ( 1.9%)             1
-ast-stats-2 - Fn                       288 ( 3.9%)             2
-ast-stats-2 - Use                      576 ( 7.8%)             4
+ast-stats-2 Crate                     40 (NN.N%)             1            40
+ast-stats-2 GenericArgs               40 (NN.N%)             1            40
+ast-stats-2 - AngleBracketed            40 (NN.N%)             1
+ast-stats-2 ExprField                 48 (NN.N%)             1            48
+ast-stats-2 WherePredicate            72 (NN.N%)             1            72
+ast-stats-2 - BoundPredicate            72 (NN.N%)             1
+ast-stats-2 ForeignItem               80 (NN.N%)             1            80
+ast-stats-2 - Fn                        80 (NN.N%)             1
+ast-stats-2 Arm                       96 (NN.N%)             2            48
+ast-stats-2 Local                     96 (NN.N%)             1            96
+ast-stats-2 FnDecl                   120 (NN.N%)             5            24
+ast-stats-2 InlineAsm                120 (NN.N%)             1           120
+ast-stats-2 Attribute                128 (NN.N%)             4            32
+ast-stats-2 - DocComment                32 (NN.N%)             1
+ast-stats-2 - Normal                    96 (NN.N%)             3
+ast-stats-2 Param                    160 (NN.N%)             4            40
+ast-stats-2 Stmt                     160 (NN.N%)             5            32
+ast-stats-2 - Let                       32 (NN.N%)             1
+ast-stats-2 - Semi                      32 (NN.N%)             1
+ast-stats-2 - Expr                      96 (NN.N%)             3
+ast-stats-2 Block                    192 (NN.N%)             6            32
+ast-stats-2 FieldDef                 208 (NN.N%)             2           104
+ast-stats-2 Variant                  208 (NN.N%)             2           104
+ast-stats-2 AssocItem                320 (NN.N%)             4            80
+ast-stats-2 - Fn                       160 (NN.N%)             2
+ast-stats-2 - Type                     160 (NN.N%)             2
+ast-stats-2 GenericBound             352 (NN.N%)             4            88
+ast-stats-2 - Trait                    352 (NN.N%)             4
+ast-stats-2 GenericParam             480 (NN.N%)             5            96
+ast-stats-2 Pat                      504 (NN.N%)             7            72
+ast-stats-2 - Struct                    72 (NN.N%)             1
+ast-stats-2 - Wild                      72 (NN.N%)             1
+ast-stats-2 - Ident                    360 (NN.N%)             5
+ast-stats-2 Expr                     648 (NN.N%)             9            72
+ast-stats-2 - InlineAsm                 72 (NN.N%)             1
+ast-stats-2 - Match                     72 (NN.N%)             1
+ast-stats-2 - Path                      72 (NN.N%)             1
+ast-stats-2 - Struct                    72 (NN.N%)             1
+ast-stats-2 - Lit                      144 (NN.N%)             2
+ast-stats-2 - Block                    216 (NN.N%)             3
+ast-stats-2 PathSegment              864 (NN.N%)            36            24
+ast-stats-2 Ty                       896 (NN.N%)            14            64
+ast-stats-2 - Ptr                       64 (NN.N%)             1
+ast-stats-2 - Ref                       64 (NN.N%)             1
+ast-stats-2 - ImplicitSelf             128 (NN.N%)             2
+ast-stats-2 - Path                     640 (NN.N%)            10
+ast-stats-2 Item                   1_584 (NN.N%)            11           144
+ast-stats-2 - Enum                     144 (NN.N%)             1
+ast-stats-2 - ExternCrate              144 (NN.N%)             1
+ast-stats-2 - ForeignMod               144 (NN.N%)             1
+ast-stats-2 - Impl                     144 (NN.N%)             1
+ast-stats-2 - Trait                    144 (NN.N%)             1
+ast-stats-2 - Fn                       288 (NN.N%)             2
+ast-stats-2 - Use                      576 (NN.N%)             4
 ast-stats-2 ----------------------------------------------------------------
 ast-stats-2 Total                  7_416                   127
 ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size
 hir-stats ----------------------------------------------------------------
-hir-stats ForeignItemRef            24 ( 0.3%)             1            24
-hir-stats Lifetime                  28 ( 0.3%)             1            28
-hir-stats Mod                       32 ( 0.4%)             1            32
-hir-stats ExprField                 40 ( 0.4%)             1            40
-hir-stats TraitItemRef              56 ( 0.6%)             2            28
-hir-stats GenericArg                64 ( 0.7%)             4            16
-hir-stats - Type                      16 ( 0.2%)             1
-hir-stats - Lifetime                  48 ( 0.5%)             3
-hir-stats Param                     64 ( 0.7%)             2            32
-hir-stats Body                      72 ( 0.8%)             3            24
-hir-stats ImplItemRef               72 ( 0.8%)             2            36
-hir-stats InlineAsm                 72 ( 0.8%)             1            72
-hir-stats Local                     72 ( 0.8%)             1            72
-hir-stats WherePredicate            72 ( 0.8%)             3            24
-hir-stats - BoundPredicate            72 ( 0.8%)             3
-hir-stats Arm                       80 ( 0.9%)             2            40
-hir-stats Stmt                      96 ( 1.1%)             3            32
-hir-stats - Expr                      32 ( 0.4%)             1
-hir-stats - Let                       32 ( 0.4%)             1
-hir-stats - Semi                      32 ( 0.4%)             1
-hir-stats FnDecl                   120 ( 1.3%)             3            40
-hir-stats Attribute                128 ( 1.4%)             4            32
-hir-stats FieldDef                 128 ( 1.4%)             2            64
-hir-stats GenericArgs              144 ( 1.6%)             3            48
-hir-stats Variant                  144 ( 1.6%)             2            72
-hir-stats GenericBound             256 ( 2.8%)             4            64
-hir-stats - Trait                    256 ( 2.8%)             4
-hir-stats Block                    288 ( 3.2%)             6            48
-hir-stats Pat                      360 ( 4.0%)             5            72
-hir-stats - Struct                    72 ( 0.8%)             1
-hir-stats - Wild                      72 ( 0.8%)             1
-hir-stats - Binding                  216 ( 2.4%)             3
-hir-stats GenericParam             400 ( 4.5%)             5            80
-hir-stats Generics                 560 ( 6.2%)            10            56
-hir-stats Ty                       720 ( 8.0%)            15            48
-hir-stats - Ptr                       48 ( 0.5%)             1
-hir-stats - Ref                       48 ( 0.5%)             1
-hir-stats - Path                     624 ( 6.9%)            13
-hir-stats Expr                     768 ( 8.5%)            12            64
-hir-stats - InlineAsm                 64 ( 0.7%)             1
-hir-stats - Match                     64 ( 0.7%)             1
-hir-stats - Path                      64 ( 0.7%)             1
-hir-stats - Struct                    64 ( 0.7%)             1
-hir-stats - Lit                      128 ( 1.4%)             2
-hir-stats - Block                    384 ( 4.3%)             6
-hir-stats Item                     968 (10.8%)            11            88
-hir-stats - Enum                      88 ( 1.0%)             1
-hir-stats - ExternCrate               88 ( 1.0%)             1
-hir-stats - ForeignMod                88 ( 1.0%)             1
-hir-stats - Impl                      88 ( 1.0%)             1
-hir-stats - Trait                     88 ( 1.0%)             1
-hir-stats - Fn                       176 ( 2.0%)             2
-hir-stats - Use                      352 ( 3.9%)             4
-hir-stats Path                   1_240 (13.8%)            31            40
-hir-stats PathSegment            1_920 (21.4%)            40            48
+hir-stats ForeignItemRef            24 (NN.N%)             1            24
+hir-stats Lifetime                  28 (NN.N%)             1            28
+hir-stats Mod                       32 (NN.N%)             1            32
+hir-stats ExprField                 40 (NN.N%)             1            40
+hir-stats TraitItemRef              56 (NN.N%)             2            28
+hir-stats GenericArg                64 (NN.N%)             4            16
+hir-stats - Type                      16 (NN.N%)             1
+hir-stats - Lifetime                  48 (NN.N%)             3
+hir-stats Param                     64 (NN.N%)             2            32
+hir-stats Body                      72 (NN.N%)             3            24
+hir-stats ImplItemRef               72 (NN.N%)             2            36
+hir-stats InlineAsm                 72 (NN.N%)             1            72
+hir-stats Local                     72 (NN.N%)             1            72
+hir-stats WherePredicate            72 (NN.N%)             3            24
+hir-stats - BoundPredicate            72 (NN.N%)             3
+hir-stats Arm                       80 (NN.N%)             2            40
+hir-stats Stmt                      96 (NN.N%)             3            32
+hir-stats - Expr                      32 (NN.N%)             1
+hir-stats - Let                       32 (NN.N%)             1
+hir-stats - Semi                      32 (NN.N%)             1
+hir-stats FnDecl                   120 (NN.N%)             3            40
+hir-stats Attribute                128 (NN.N%)             4            32
+hir-stats FieldDef                 128 (NN.N%)             2            64
+hir-stats GenericArgs              144 (NN.N%)             3            48
+hir-stats Variant                  144 (NN.N%)             2            72
+hir-stats GenericBound             256 (NN.N%)             4            64
+hir-stats - Trait                    256 (NN.N%)             4
+hir-stats Block                    288 (NN.N%)             6            48
+hir-stats Pat                      360 (NN.N%)             5            72
+hir-stats - Struct                    72 (NN.N%)             1
+hir-stats - Wild                      72 (NN.N%)             1
+hir-stats - Binding                  216 (NN.N%)             3
+hir-stats GenericParam             400 (NN.N%)             5            80
+hir-stats Generics                 560 (NN.N%)            10            56
+hir-stats Ty                       720 (NN.N%)            15            48
+hir-stats - Ptr                       48 (NN.N%)             1
+hir-stats - Ref                       48 (NN.N%)             1
+hir-stats - Path                     624 (NN.N%)            13
+hir-stats Expr                     768 (NN.N%)            12            64
+hir-stats - InlineAsm                 64 (NN.N%)             1
+hir-stats - Match                     64 (NN.N%)             1
+hir-stats - Path                      64 (NN.N%)             1
+hir-stats - Struct                    64 (NN.N%)             1
+hir-stats - Lit                      128 (NN.N%)             2
+hir-stats - Block                    384 (NN.N%)             6
+hir-stats Item                     968 (NN.N%)            11            88
+hir-stats - Enum                      88 (NN.N%)             1
+hir-stats - ExternCrate               88 (NN.N%)             1
+hir-stats - ForeignMod                88 (NN.N%)             1
+hir-stats - Impl                      88 (NN.N%)             1
+hir-stats - Trait                     88 (NN.N%)             1
+hir-stats - Fn                       176 (NN.N%)             2
+hir-stats - Use                      352 (NN.N%)             4
+hir-stats Path                   1_240 (NN.N%)            31            40
+hir-stats PathSegment            1_920 (NN.N%)            40            48
 hir-stats ----------------------------------------------------------------
 hir-stats Total                  8_988                   180
 hir-stats


### PR DESCRIPTION
Currently we over-count. Details in the individual commits.

r? @BoxyUwU 