### PR TITLE
rustdoc: display doc(cfg(false)) properly

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -171,10 +171,15 @@ impl Cfg {
 
     /// Renders the configuration for long display, as a long HTML description.
     pub(crate) fn render_long_html(&self) -> String {
-        let on = if self.should_use_with_in_description() { "with" } else { "on" };
+        let on = if self.omit_preposition() {
+            ""
+        } else if self.should_use_with_in_description() {
+            "with "
+        } else {
+            "on "
+        };
 
-        let mut msg =
-            format!("Available {on} <strong>{}</strong>", Display(self, Format::LongHtml));
+        let mut msg = format!("Available {on}<strong>{}</strong>", Display(self, Format::LongHtml));
         if self.should_append_only_to_description() {
             msg.push_str(" only");
         }
@@ -243,6 +248,10 @@ impl Cfg {
         } else {
             Some(self.clone())
         }
+    }
+
+    fn omit_preposition(&self) -> bool {
+        matches!(self, Cfg::True | Cfg::False)
     }
 }
 

--- a/tests/rustdoc/cfg-bool.rs
+++ b/tests/rustdoc/cfg-bool.rs
@@ -1,0 +1,13 @@
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+// regression test for https://github.com/rust-lang/rust/issues/138112
+
+//@ has 'foo/fn.foo.html' '//div[@class="stab portability"]' 'Available nowhere'
+#[doc(cfg(false))]
+pub fn foo() {}
+
+// a cfg(true) will simply be ommited, as it is the same as no cfg.
+//@ !has 'foo/fn.bar.html' '//div[@class="stab portability"]' ''
+#[doc(cfg(true))]
+pub fn bar() {}


### PR DESCRIPTION
before we had an extra 'on' that was
ungramatical.

fixes https://github.com/rust-lang/rust/issues/138112

this is what it looks like now:
![screenshot: Available nowhere](https://github.com/user-attachments/assets/e27b4990-09a7-4f13-8bcf-26d44c8c1bea)


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
