### PR TITLE
Introduce `impl` restrictions to AST, lower to `rustc_middle`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -32,7 +32,7 @@ use rustc_data_structures::tagged_ptr::Tag;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 pub use rustc_span::AttrId;
 use rustc_span::source_map::{Spanned, respan};
-use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, kw, sym};
+use rustc_span::{DUMMY_SP, ErrorGuaranteed, Ident, Span, Symbol, kw, sym};
 use thin_vec::{ThinVec, thin_vec};
 
 pub use crate::format::*;
@@ -3313,6 +3313,42 @@ pub enum VisibilityKind {
 impl VisibilityKind {
     pub fn is_pub(&self) -> bool {
         matches!(self, VisibilityKind::Public)
+    }
+}
+
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub struct Restriction {
+    pub kind: RestrictionKind,
+    pub span: Span,
+    pub tokens: Option<LazyAttrTokenStream>,
+}
+
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub enum RestrictionKind {
+    Unrestricted,
+    Restricted { path: P<Path>, id: NodeId, shorthand: bool },
+    Implied,
+}
+
+impl Restriction {
+    pub fn unrestricted() -> Self {
+        Restriction { kind: RestrictionKind::Unrestricted, span: DUMMY_SP, tokens: None }
+    }
+
+    pub fn restricted(path: P<Path>, id: NodeId, shorthand: bool) -> Self {
+        Restriction {
+            kind: RestrictionKind::Restricted { path, id, shorthand },
+            span: DUMMY_SP,
+            tokens: None,
+        }
+    }
+
+    pub fn implied() -> Self {
+        Restriction { kind: RestrictionKind::Implied, span: DUMMY_SP, tokens: None }
+    }
+
+    pub fn with_span(self, span: Span) -> Self {
+        Restriction { span, ..self }
     }
 }
 

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3530,6 +3530,7 @@ impl Default for FnHeader {
 
 #[derive(Clone, Encodable, Decodable, Debug)]
 pub struct Trait {
+    pub impl_restriction: Restriction,
     pub safety: Safety,
     pub is_auto: IsAuto,
     pub ident: Ident,

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -9,8 +9,8 @@ use crate::ptr::P;
 use crate::tokenstream::LazyAttrTokenStream;
 use crate::{
     Arm, AssocItem, AttrItem, AttrKind, AttrVec, Attribute, Block, Crate, Expr, ExprField,
-    FieldDef, ForeignItem, GenericParam, Item, NodeId, Param, Pat, PatField, Path, Stmt, StmtKind,
-    Ty, Variant, Visibility, WherePredicate,
+    FieldDef, ForeignItem, GenericParam, Item, NodeId, Param, Pat, PatField, Path, Restriction,
+    Stmt, StmtKind, Ty, Variant, Visibility, WherePredicate,
 };
 
 /// A trait for AST nodes having an ID.
@@ -98,7 +98,19 @@ macro_rules! impl_has_tokens_none {
     };
 }
 
-impl_has_tokens!(AssocItem, AttrItem, Block, Expr, ForeignItem, Item, Pat, Path, Ty, Visibility);
+impl_has_tokens!(
+    AssocItem,
+    AttrItem,
+    Block,
+    Expr,
+    ForeignItem,
+    Item,
+    Pat,
+    Path,
+    Restriction,
+    Ty,
+    Visibility
+);
 impl_has_tokens_none!(
     Arm,
     ExprField,
@@ -243,7 +255,7 @@ impl_has_attrs!(
     Variant,
     WherePredicate,
 );
-impl_has_attrs_none!(Attribute, AttrItem, Block, Pat, Path, Ty, Visibility);
+impl_has_attrs_none!(Attribute, AttrItem, Block, Pat, Path, Restriction, Ty, Visibility);
 
 impl<T: HasAttrs> HasAttrs for P<T> {
     const SUPPORTS_CUSTOM_INNER_ATTRS: bool = T::SUPPORTS_CUSTOM_INNER_ATTRS;

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -327,6 +327,10 @@ pub trait MutVisitor: Sized {
         walk_vis(self, vis);
     }
 
+    fn visit_restriction(&mut self, restriction: &mut Restriction) {
+        walk_restriction(self, restriction);
+    }
+
     fn visit_id(&mut self, _id: &mut NodeId) {
         // Do nothing.
     }
@@ -1398,6 +1402,18 @@ fn walk_vis<T: MutVisitor>(vis: &mut T, visibility: &mut Visibility) {
     match kind {
         VisibilityKind::Public | VisibilityKind::Inherited => {}
         VisibilityKind::Restricted { path, id, shorthand: _ } => {
+            vis.visit_id(id);
+            vis.visit_path(path);
+        }
+    }
+    vis.visit_span(span);
+}
+
+fn walk_restriction<T: MutVisitor>(vis: &mut T, restriction: &mut Restriction) {
+    let Restriction { kind, span, tokens: _ } = restriction;
+    match kind {
+        RestrictionKind::Unrestricted | RestrictionKind::Implied => {}
+        RestrictionKind::Restricted { path, id, shorthand: _ } => {
             vis.visit_id(id);
             vis.visit_path(path);
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -557,7 +557,16 @@ macro_rules! common_visitor_and_walkers {
                             <V as Visitor<$lt>>::Result::output()
                         )?
                     }
-                    ItemKind::Trait(box Trait { safety, is_auto: _, ident, generics, bounds, items }) => {
+                    ItemKind::Trait(box Trait {
+                        impl_restriction,
+                        safety,
+                        is_auto: _,
+                        ident,
+                        generics,
+                        bounds,
+                        items,
+                    }) => {
+                        try_visit!(vis.visit_restriction(impl_restriction));
                         try_visit!(visit_safety(vis, safety));
                         try_visit!(vis.visit_ident(ident));
                         try_visit!(vis.visit_generics(generics));

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -268,6 +268,9 @@ pub trait Visitor<'ast>: Sized {
     fn visit_vis(&mut self, vis: &'ast Visibility) -> Self::Result {
         walk_vis(self, vis)
     }
+    fn visit_restriction(&mut self, restriction: &'ast Restriction) -> Self::Result {
+        walk_restriction(self, restriction)
+    }
     fn visit_fn_ret_ty(&mut self, ret_ty: &'ast FnRetTy) -> Self::Result {
         walk_fn_ret_ty(self, ret_ty)
     }
@@ -1512,6 +1515,20 @@ pub fn walk_vis<'a, V: Visitor<'a>>(visitor: &mut V, vis: &'a Visibility) -> V::
             try_visit!(visitor.visit_path(path, *id));
         }
         VisibilityKind::Public | VisibilityKind::Inherited => {}
+    }
+    V::Result::output()
+}
+
+pub fn walk_restriction<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    restriction: &'a Restriction,
+) -> V::Result {
+    let Restriction { kind, span: _, tokens: _ } = restriction;
+    match kind {
+        RestrictionKind::Unrestricted | RestrictionKind::Implied => {}
+        RestrictionKind::Restricted { path, id, shorthand: _ } => {
+            try_visit!(visitor.visit_path(path, *id));
+        }
     }
     V::Result::output()
 }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -415,7 +415,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     items: new_impl_items,
                 }))
             }
-            ItemKind::Trait(box Trait { is_auto, safety, ident, generics, bounds, items }) => {
+            ItemKind::Trait(box Trait {
+                impl_restriction: _,
+                is_auto,
+                safety,
+                ident,
+                generics,
+                bounds,
+                items,
+            }) => {
                 let ident = self.lower_ident(*ident);
                 let (generics, (safety, items, bounds)) = self.lower_generics(
                     generics,

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -515,6 +515,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(where_clause_attrs, "attributes in `where` clause are unstable");
     gate_all!(super_let, "`super let` is experimental");
     gate_all!(frontmatter, "frontmatters are experimental");
+    gate_all!(impl_restriction, "impl restrictions are experimental");
 
     if !visitor.features.never_patterns() {
         if let Some(spans) = spans.get(&sym::never_patterns) {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1071,6 +1071,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         Self::to_string(|s| s.print_visibility(v))
     }
 
+    fn restriction_to_string(&self, kw: &'static str, r: &ast::Restriction) -> String {
+        Self::to_string(|s| s.print_restriction(kw, r))
+    }
+
     fn block_to_string(&self, blk: &ast::Block) -> String {
         Self::to_string(|s| {
             let (cb, ib) = s.head("");

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -357,6 +357,7 @@ impl<'a> State<'a> {
                 self.bclose(item.span, empty, cb);
             }
             ast::ItemKind::Trait(box ast::Trait {
+                impl_restriction,
                 safety,
                 is_auto,
                 ident,
@@ -366,6 +367,7 @@ impl<'a> State<'a> {
             }) => {
                 let (cb, ib) = self.head("");
                 self.print_visibility(&item.vis);
+                self.print_restriction("impl", impl_restriction);
                 self.print_safety(*safety);
                 self.print_is_auto(*is_auto);
                 self.word_nbsp("trait");

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -473,6 +473,22 @@ impl<'a> State<'a> {
         }
     }
 
+    // FIXME(jhpratt) make `kw` into a const generic once permitted
+    pub(crate) fn print_restriction(&mut self, kw: &'static str, restriction: &ast::Restriction) {
+        match restriction.kind {
+            ast::RestrictionKind::Unrestricted => self.word_nbsp(kw),
+            ast::RestrictionKind::Restricted { ref path, shorthand, id: _ } => {
+                let path = Self::to_string(|s| s.print_path(path, false, 0));
+                if shorthand {
+                    self.word_nbsp(format!("{kw}({path})"))
+                } else {
+                    self.word_nbsp(format!("{kw}(in {path})"))
+                }
+            }
+            ast::RestrictionKind::Implied => {}
+        }
+    }
+
     fn print_defaultness(&mut self, defaultness: ast::Defaultness) {
         if let ast::Defaultness::Default(_) = defaultness {
             self.word_nbsp("default");

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -534,6 +534,8 @@ declare_features! (
     (unstable, half_open_range_patterns_in_slices, "1.66.0", Some(67264)),
     /// Allows `if let` guard in match arms.
     (unstable, if_let_guard, "1.47.0", Some(51114)),
+    /// Allows `impl(crate) trait Foo` restrictions
+    (unstable, impl_restriction, "CURRENT_RUSTC_VERSION", Some(105077)),
     /// Allows `impl Trait` to be used inside associated types (RFC 2515).
     (unstable, impl_trait_in_assoc_type, "1.70.0", Some(63063)),
     /// Allows `impl Trait` in bindings (`let`).

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1179,7 +1179,7 @@ pub(super) fn crate_hash(tcx: TyCtxt<'_>, _: LocalCrate) -> Svh {
         }
         tcx.sess.opts.dep_tracking_hash(true).hash_stable(&mut hcx, &mut stable_hasher);
         tcx.stable_crate_id(LOCAL_CRATE).hash_stable(&mut hcx, &mut stable_hasher);
-        // Hash visibility information since it does not appear in HIR.
+        // Hash visibility and restriction information since it does not appear in HIR.
         // FIXME: Figure out how to remove `visibilities_for_hashing` by hashing visibilities on
         // the fly in the resolver, storing only their accumulated hash in `ResolverGlobalCtxt`,
         // and combining it with other hashes here.
@@ -1187,6 +1187,7 @@ pub(super) fn crate_hash(tcx: TyCtxt<'_>, _: LocalCrate) -> Svh {
         with_metavar_spans(|mspans| {
             mspans.freeze_and_get_read_spans().hash_stable(&mut hcx, &mut stable_hasher);
         });
+        resolutions.impl_restrictions.hash_stable(&mut hcx, &mut stable_hasher);
         stable_hasher.finish()
     });
 

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -377,12 +377,12 @@ parse_inclusive_range_no_end = inclusive range with no end
 parse_incorrect_parens_trait_bounds = incorrect parentheses around trait bounds
 parse_incorrect_parens_trait_bounds_sugg = fix the parentheses
 
-parse_incorrect_restriction = incorrect {$noun} restriction
-    .help = some possible {$noun} restrictions are:
-            `{$keyword}(crate)`: {$adjective} only in the current crate
-            `{$keyword}(super)`: {$adjective} only in the current module's parent
-            `{$keyword}(in path::to::module)`: {$adjective} only in the specified path
-    .suggestion = make this {$adjective} only to module `{$inner_str}` with `in`
+parse_incorrect_restriction = incorrect {parse_restriction_noun} restriction
+    .help = some possible {parse_restriction_noun} restrictions are:
+            `{$keyword}(crate)`: {parse_restriction_adjective} only in the current crate
+            `{$keyword}(super)`: {parse_restriction_adjective} only in the current module's parent
+            `{$keyword}(in path::to::module)`: {parse_restriction_adjective} only in the specified path
+    .suggestion = make this {parse_restriction_adjective} only to module `{$path}` with `in`
 
 parse_incorrect_semicolon =
     expected item, found `;`
@@ -789,6 +789,18 @@ parse_reserved_multihash = reserved multi-hash token is forbidden
 parse_reserved_string = invalid string literal
     .note = unprefixed guarded string literals are reserved for future use since Rust 2024
     .suggestion_whitespace = consider inserting whitespace here
+
+# internal use only
+parse_restriction_adjective = { $keyword ->
+    [impl] implementable
+    *[DEFAULT_IS_BUG] BUG
+}
+
+# internal use only
+parse_restriction_noun = { $keyword ->
+    [impl] impl
+    *[DEFAULT_IS_BUG] BUG
+}
 
 parse_return_types_use_thin_arrow = return types are denoted using `->`
     .suggestion = use `->` instead

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -377,6 +377,13 @@ parse_inclusive_range_no_end = inclusive range with no end
 parse_incorrect_parens_trait_bounds = incorrect parentheses around trait bounds
 parse_incorrect_parens_trait_bounds_sugg = fix the parentheses
 
+parse_incorrect_restriction = incorrect {$noun} restriction
+    .help = some possible {$noun} restrictions are:
+            `{$keyword}(crate)`: {$adjective} only in the current crate
+            `{$keyword}(super)`: {$adjective} only in the current module's parent
+            `{$keyword}(in path::to::module)`: {$adjective} only in the specified path
+    .suggestion = make this {$adjective} only to module `{$inner_str}` with `in`
+
 parse_incorrect_semicolon =
     expected item, found `;`
     .suggestion = remove this semicolon
@@ -853,6 +860,7 @@ parse_trailing_vert_not_allowed = a trailing `|` is not allowed in an or-pattern
 parse_trait_alias_cannot_be_auto = trait aliases cannot be `auto`
 parse_trait_alias_cannot_be_unsafe = trait aliases cannot be `unsafe`
 
+parse_trait_alias_cannot_have_impl_restriction = trait alias cannot have `impl` restriction
 parse_transpose_dyn_or_impl = `for<...>` expected after `{$kw}`, not before
     .suggestion = move `{$kw}` before the `for<...>`
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1042,6 +1042,19 @@ pub(crate) struct IncorrectVisibilityRestriction {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_incorrect_restriction, code = E0704)]
+#[help]
+pub(crate) struct IncorrectRestriction<'kw> {
+    #[primary_span]
+    #[suggestion(code = "in {inner_str}", applicability = "machine-applicable", style = "verbose")]
+    pub span: Span,
+    pub inner_str: String,
+    pub keyword: &'kw str,
+    pub adjective: &'static str,
+    pub noun: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_assignment_else_not_allowed)]
 pub(crate) struct AssignmentElseNotAllowed {
     #[primary_span]
@@ -1944,6 +1957,16 @@ pub(crate) struct ExtraImplKeywordInTraitImpl {
 pub(crate) struct BoundsNotAllowedOnTraitAliases {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_trait_alias_cannot_have_impl_restriction)]
+pub(crate) struct TraitAliasCannotHaveImplRestriction {
+    #[primary_span]
+    #[label(parse_trait_alias_cannot_have_impl_restriction)]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "short")]
+    pub restriction: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1046,12 +1046,10 @@ pub(crate) struct IncorrectVisibilityRestriction {
 #[help]
 pub(crate) struct IncorrectRestriction<'kw> {
     #[primary_span]
-    #[suggestion(code = "in {inner_str}", applicability = "machine-applicable", style = "verbose")]
+    #[suggestion(code = "in {path}", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
-    pub inner_str: String,
+    pub path: String,
     pub keyword: &'kw str,
-    pub adjective: &'static str,
-    pub noun: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -931,8 +931,13 @@ impl<'a> Parser<'a> {
 
     /// Parses `[ impl(in path) ]? unsafe? auto? trait Foo { ... }` or `trait Foo = Bar;`.
     fn parse_item_trait(&mut self, attrs: &mut AttrVec, lo: Span) -> PResult<'a, ItemKind> {
-        let impl_restriction =
-            self.parse_restriction(exp!(Impl), "implementable", "impl", FollowedByType::No)?;
+        let impl_restriction = self.parse_restriction(
+            exp!(Impl),
+            Some(sym::impl_restriction),
+            "implementable",
+            "impl",
+            FollowedByType::No,
+        )?;
         let safety = self.parse_safety(Case::Sensitive);
         // Parse optional `auto` prefix.
         let is_auto = if self.eat_keyword(exp!(Auto)) {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -262,7 +262,7 @@ impl<'a> Parser<'a> {
                     define_opaque: None,
                 }))
             }
-        } else if self.check_keyword(exp!(Trait)) || self.check_auto_or_unsafe_trait_item() {
+        } else if self.check_keyword(exp!(Trait)) || self.check_trait_item_with_modifiers() {
             // TRAIT ITEM
             self.parse_item_trait(attrs, lo)?
         } else if self.check_keyword(exp!(Impl))
@@ -373,7 +373,7 @@ impl<'a> Parser<'a> {
     pub(super) fn is_path_start_item(&mut self) -> bool {
         self.is_kw_followed_by_ident(kw::Union) // no: `union::b`, yes: `union U { .. }`
         || self.is_reuse_path_item()
-        || self.check_auto_or_unsafe_trait_item() // no: `auto::b`, yes: `auto trait X { .. }`
+        || self.check_trait_item_with_modifiers() // no: `auto::b`, yes: `auto trait X { .. }`
         || self.is_async_fn() // no(2015): `async::b`, yes: `async fn`
         || matches!(self.is_macro_rules_item(), IsMacroRulesItem::Yes{..}) // no: `macro_rules::b`, yes: `macro_rules! mac`
     }
@@ -872,16 +872,67 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Is this an `(unsafe auto? | auto) trait` item?
-    fn check_auto_or_unsafe_trait_item(&mut self) -> bool {
-        // auto trait
-        self.check_keyword(exp!(Auto)) && self.is_keyword_ahead(1, &[kw::Trait])
-            // unsafe auto trait
-            || self.check_keyword(exp!(Unsafe)) && self.is_keyword_ahead(1, &[kw::Trait, kw::Auto])
+    /// Is this an `[ impl(in path) ]? unsafe? auto? trait` item?
+    fn check_trait_item_with_modifiers(&mut self) -> bool {
+        let current_token = TokenTree::Token(self.token.clone(), self.token_spacing);
+        let look_ahead = |index| match index {
+            0 => Some(&current_token),
+            _ => self.token_cursor.curr.look_ahead(index - 1),
+        };
+
+        let mut has_impl_restriction = false;
+        let mut has_unsafe = false;
+        let mut has_auto = false;
+        let mut has_trait = false;
+
+        let mut index = 0;
+
+        if let Some(TokenTree::Token(token, _)) = look_ahead(index)
+            && token.is_keyword(kw::Impl)
+        {
+            has_impl_restriction = true;
+            index += 1;
+        }
+        // impl restrictions require parens, but we enforce this later.
+        if has_impl_restriction
+            && matches!(
+                look_ahead(index),
+                Some(TokenTree::Delimited(_, _, Delimiter::Parenthesis, _))
+            )
+        {
+            index += 1;
+        }
+        if let Some(TokenTree::Token(token, _)) = look_ahead(index)
+            && token.is_keyword(kw::Unsafe)
+        {
+            has_unsafe = true;
+            index += 1;
+        }
+        if let Some(TokenTree::Token(token, _)) = look_ahead(index)
+            && token.is_keyword(kw::Auto)
+        {
+            has_auto = true;
+            index += 1;
+        }
+        if let Some(TokenTree::Token(token, _)) = look_ahead(index)
+            && token.is_keyword(kw::Trait)
+        {
+            has_trait = true;
+        }
+
+        let ret = (has_impl_restriction || has_unsafe || has_auto) && has_trait;
+        if !ret {
+            self.expected_token_types.insert(exp!(Impl).token_type);
+            self.expected_token_types.insert(exp!(Unsafe).token_type);
+            self.expected_token_types.insert(exp!(Auto).token_type);
+        }
+        ret
     }
 
-    /// Parses `unsafe? auto? trait Foo { ... }` or `trait Foo = Bar;`.
+    /// Parses `[ impl(in path) ]? unsafe? auto? trait Foo { ... }` or `trait Foo = Bar;`.
     fn parse_item_trait(&mut self, attrs: &mut AttrVec, lo: Span) -> PResult<'a, ItemKind> {
+        let impl_restriction =
+            self.parse_restriction(exp!(Impl), "implementable", "impl", FollowedByType::No)?;
         let safety = self.parse_safety(Case::Sensitive);
         // Parse optional `auto` prefix.
         let is_auto = if self.eat_keyword(exp!(Auto)) {
@@ -913,6 +964,12 @@ impl<'a> Parser<'a> {
             self.expect_semi()?;
 
             let whole_span = lo.to(self.prev_token.span);
+            if !matches!(impl_restriction.kind, RestrictionKind::Implied) {
+                self.dcx().emit_err(errors::TraitAliasCannotHaveImplRestriction {
+                    span: whole_span,
+                    restriction: impl_restriction.span,
+                });
+            }
             if is_auto == IsAuto::Yes {
                 self.dcx().emit_err(errors::TraitAliasCannotBeAuto { span: whole_span });
             }
@@ -927,7 +984,15 @@ impl<'a> Parser<'a> {
             // It's a normal trait.
             generics.where_clause = self.parse_where_clause()?;
             let items = self.parse_item_list(attrs, |p| p.parse_trait_item(ForceCollect::No))?;
-            Ok(ItemKind::Trait(Box::new(Trait { is_auto, safety, ident, generics, bounds, items })))
+            Ok(ItemKind::Trait(Box::new(Trait {
+                impl_restriction,
+                is_auto,
+                safety,
+                ident,
+                generics,
+                bounds,
+                items,
+            })))
         }
     }
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -931,13 +931,8 @@ impl<'a> Parser<'a> {
 
     /// Parses `[ impl(in path) ]? unsafe? auto? trait Foo { ... }` or `trait Foo = Bar;`.
     fn parse_item_trait(&mut self, attrs: &mut AttrVec, lo: Span) -> PResult<'a, ItemKind> {
-        let impl_restriction = self.parse_restriction(
-            exp!(Impl),
-            Some(sym::impl_restriction),
-            "implementable",
-            "impl",
-            FollowedByType::No,
-        )?;
+        let impl_restriction =
+            self.parse_restriction(exp!(Impl), Some(sym::impl_restriction), FollowedByType::No)?;
         let safety = self.parse_safety(Case::Sensitive);
         // Parse optional `auto` prefix.
         let is_auto = if self.eat_keyword(exp!(Auto)) {

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -353,6 +353,16 @@ resolve_remove_surrounding_derive =
 
 resolve_remove_unnecessary_import = remove unnecessary import
 
+resolve_restriction_ancestor_only = restrictions can only be restricted to ancestor modules
+
+resolve_restriction_indeterminate = cannot determine resolution for the restriction
+
+resolve_restriction_module_only = restriction must resolve to a module
+
+resolve_restriction_relative_2018 =
+    relative paths are not supported in restrictions in 2018 edition or later
+    .suggestion = try
+
 resolve_self_import_can_only_appear_once_in_the_list =
     `self` import can only appear once in an import list
     .label = can only appear once in an import list

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1244,3 +1244,25 @@ pub(crate) struct TraitImplMismatch {
     #[label(resolve_trait_impl_mismatch_label_item)]
     pub(crate) trait_item_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(resolve_restriction_relative_2018)]
+pub(crate) struct RestrictionRelative2018 {
+    #[primary_span]
+    pub(crate) span: Span,
+    #[suggestion(code = "crate::{path_str}", applicability = "maybe-incorrect")]
+    pub(crate) path_span: Span,
+    pub(crate) path_str: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_restriction_ancestor_only, code = E0742)]
+pub(crate) struct RestrictionAncestorOnly(#[primary_span] pub(crate) Span);
+
+#[derive(Diagnostic)]
+#[diag(resolve_restriction_indeterminate, code = E0578)]
+pub(crate) struct RestrictionIndeterminate(#[primary_span] pub(crate) Span);
+
+#[derive(Diagnostic)]
+#[diag(resolve_restriction_module_only)]
+pub(crate) struct RestrictionModuleOnly(#[primary_span] pub(crate) Span);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1154,6 +1154,7 @@ symbols! {
         ignore,
         impl_header_lifetime_elision,
         impl_lint_pass,
+        impl_restriction,
         impl_trait_in_assoc_type,
         impl_trait_in_bindings,
         impl_trait_in_fn_trait_return,

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -444,6 +444,7 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
         },
         (
             Trait(box ast::Trait {
+                impl_restriction: _, // does not affect item kind
                 is_auto: la,
                 safety: lu,
                 ident: li,
@@ -452,6 +453,7 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 items: lis,
             }),
             Trait(box ast::Trait {
+                impl_restriction: _, // does not affect item kind
                 is_auto: ra,
                 safety: ru,
                 ident: ri,

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1172,7 +1172,7 @@ pub(crate) fn format_trait(
         unreachable!();
     };
     let ast::Trait {
-        impl_restriction: _,
+        ref impl_restriction,
         is_auto,
         safety,
         ident,
@@ -1183,8 +1183,9 @@ pub(crate) fn format_trait(
 
     let mut result = String::with_capacity(128);
     let header = format!(
-        "{}{}{}trait ",
+        "{}{}{}{}trait ",
         format_visibility(context, &item.vis),
+        format_restriction("impl", context, impl_restriction),
         format_safety(safety),
         format_auto(is_auto),
     );

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1172,6 +1172,7 @@ pub(crate) fn format_trait(
         unreachable!();
     };
     let ast::Trait {
+        impl_restriction: _,
         is_auto,
         safety,
         ident,

--- a/src/tools/rustfmt/tests/source/restriction.rs
+++ b/src/tools/rustfmt/tests/source/restriction.rs
@@ -1,0 +1,16 @@
+pub
+impl(crate)
+trait Foo {}
+
+pub impl
+( in
+crate )
+trait
+Bar
+{}
+
+pub
+impl ( in foo
+::
+bar )
+trait Baz {}

--- a/src/tools/rustfmt/tests/target/restriction.rs
+++ b/src/tools/rustfmt/tests/target/restriction.rs
@@ -1,0 +1,5 @@
+pub impl(crate) trait Foo {}
+
+pub impl(in crate) trait Bar {}
+
+pub impl(in foo::bar) trait Baz {}

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -793,6 +793,16 @@ fn test_vis() {
     // Attributes are not allowed on visibilities.
 }
 
+#[test]
+fn test_impl_restriction() {
+    assert_eq!(stringify!(pub impl(crate) trait Foo {}), "pub impl(crate) trait Foo {}");
+    assert_eq!(stringify!(pub impl(in crate) trait Foo {}), "pub impl(in crate) trait Foo {}");
+    assert_eq!(stringify!(pub impl(super) trait Foo {}), "pub impl(super) trait Foo {}");
+    assert_eq!(stringify!(pub impl(in super) trait Foo {}), "pub impl(in super) trait Foo {}");
+    assert_eq!(stringify!(pub impl(self) trait Foo {}), "pub impl(self) trait Foo {}");
+    assert_eq!(stringify!(pub impl(in self) trait Foo {}), "pub impl(in self) trait Foo {}");
+}
+
 macro_rules! p {
     ([$($tt:tt)*], $s:literal) => {
         assert_eq!(stringify!($($tt)*), $s);

--- a/tests/ui/restrictions/feature-gate-impl-restriction.rs
+++ b/tests/ui/restrictions/feature-gate-impl-restriction.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --crate-type=lib
+//@ revisions: with_gate without_gate
+//@[with_gate] check-pass
+
+#![cfg_attr(with_gate, feature(impl_restriction))]
+
+pub impl(crate) trait Bar {} //[without_gate]~ ERROR
+
+mod foo {
+    pub impl(in crate::foo) trait Baz {} //[without_gate]~ ERROR
+}

--- a/tests/ui/restrictions/feature-gate-impl-restriction.without_gate.stderr
+++ b/tests/ui/restrictions/feature-gate-impl-restriction.without_gate.stderr
@@ -1,0 +1,23 @@
+error[E0658]: impl restrictions are experimental
+  --> $DIR/feature-gate-impl-restriction.rs:7:5
+   |
+LL | pub impl(crate) trait Bar {}
+   |     ^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(impl_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: impl restrictions are experimental
+  --> $DIR/feature-gate-impl-restriction.rs:10:9
+   |
+LL |     pub impl(in crate::foo) trait Baz {}
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(impl_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
RFC approved in [RFC 3323](https://rust-lang.github.io/rfcs/3323-restrictions.html); part of tracking issue rust-lang/rust#105077 and a [2025H1 project goal](https://github.com/rust-lang/rust-project-goals/issues/257).

This is likely easiest to review commit-by-commit.

First, the `impl` restriction is introduced to the AST, followed by actually parsing it into the AST on trait definitions (the only place it's permitted). Next we add the ability for `rustfmt` to handle it in the most logical manner; unstable features are permitted to choose a sane format without a team decision. After placing it behind a feature gate, the restriction is lowered to `rustc_middle` with identical limitations to visibility. Finally, the diagnostics are partially moved into Fluent to make them a bit more translatable.

This is the groundwork for the restriction and does not actually enforce anything; that is coming in another PR soon.

r? @Urgau as discussed