### PR TITLE
ci: use free runner for aarch64-gnu-llvm-19-1 PR job

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -126,7 +126,7 @@ pr:
     env:
       IMAGE: aarch64-gnu-llvm-19
       DOCKER_SCRIPT: stage_2_test_set1.sh
-    <<: *job-aarch64-linux-8c
+    <<: *job-aarch64-linux
   - name: aarch64-gnu-llvm-19-2
     env:
       IMAGE: aarch64-gnu-llvm-19


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
By using a free runner, this PR job now takes 70 minutes instead of 60. I think it's fine because soon https://github.com/rust-lang/rust/pull/136942 should reduce how long it takes to run this job anyway.
<!-- homu-ignore:end -->
