### PR TITLE
Merge `Cfg::render_long_html` and `Cfg::render_long_plain` methods common code

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -169,33 +169,36 @@ impl Cfg {
         msg
     }
 
-    /// Renders the configuration for long display, as a long HTML description.
-    pub(crate) fn render_long_html(&self) -> String {
+    fn render_long_inner(&self, format: Format) -> String {
         let on = if self.omit_preposition() {
-            ""
+            " "
         } else if self.should_use_with_in_description() {
-            "with "
+            " with "
         } else {
-            "on "
+            " on "
         };
 
-        let mut msg = format!("Available {on}<strong>{}</strong>", Display(self, Format::LongHtml));
+        let mut msg = if matches!(format, Format::LongHtml) {
+            format!("Available{on}<strong>{}</strong>", Display(self, format))
+        } else {
+            format!("Available{on}{}", Display(self, format))
+        };
         if self.should_append_only_to_description() {
             msg.push_str(" only");
         }
+        msg
+    }
+
+    /// Renders the configuration for long display, as a long HTML description.
+    pub(crate) fn render_long_html(&self) -> String {
+        let mut msg = self.render_long_inner(Format::LongHtml);
         msg.push('.');
         msg
     }
 
     /// Renders the configuration for long display, as a long plain text description.
     pub(crate) fn render_long_plain(&self) -> String {
-        let on = if self.should_use_with_in_description() { "with" } else { "on" };
-
-        let mut msg = format!("Available {on} {}", Display(self, Format::LongPlain));
-        if self.should_append_only_to_description() {
-            msg.push_str(" only");
-        }
-        msg
+        self.render_long_inner(Format::LongPlain)
     }
 
     fn should_capitalize_first_letter(&self) -> bool {

--- a/tests/rustdoc/cfg-bool.rs
+++ b/tests/rustdoc/cfg-bool.rs
@@ -3,11 +3,15 @@
 
 // regression test for https://github.com/rust-lang/rust/issues/138112
 
-//@ has 'foo/fn.foo.html' '//div[@class="stab portability"]' 'Available nowhere'
+//@ has 'foo/index.html'
+//@ has - '//*[@class="stab portability"]/@title' 'Available nowhere'
+
+//@ count 'foo/fn.foo.html' '//*[@class="stab portability"]' 1
+//@ has 'foo/fn.foo.html' '//*[@class="stab portability"]' 'Available nowhere'
 #[doc(cfg(false))]
 pub fn foo() {}
 
-// a cfg(true) will simply be ommited, as it is the same as no cfg.
-//@ !has 'foo/fn.bar.html' '//div[@class="stab portability"]' ''
+// a cfg(true) will simply be omitted, as it is the same as no cfg.
+//@ count 'foo/fn.bar.html' '//*[@class="stab portability"]' 0
 #[doc(cfg(true))]
 pub fn bar() {}


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/141747.

Thanks @camelid for spotting it!

r? @camelid