### PR TITLE
Increase timeout for new bors try builds

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -1,1 +1,2 @@
-timeout = 14400
+# 6 hours timeout for CI builds
+timeout = 21600


### PR DESCRIPTION
To sync it with [homu](https://github.com/rust-lang/homu/blob/master/cfg.production.toml#L34). Saw the timeout [here](https://github.com/rust-lang/rust/pull/138699#issuecomment-2922456283), it was set to only 4 hours for new bors.

r? @marcoieni