### PR TITLE
Do not run PGO/BOLT in x64 Linux alt builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -96,14 +96,13 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.lto=thin \
       --set rust.codegen-units=1
 
-# Note that `rust.debug` is set to true *only* for `opt-dist`
-ENV SCRIPT python3 ../x.py build --set rust.debug=true opt-dist && \
-    ./build/$HOSTS/stage0-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \
-    --host $HOSTS --target $HOSTS \
-    --include-default-paths \
-    build-manifest bootstrap && \
-    # Use GCC for building GCC, as it seems to behave badly when built with Clang
-    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc
+ARG SCRIPT_ARG
+
+COPY host-x86_64/dist-x86_64-linux/dist.sh /scripts/
+COPY host-x86_64/dist-x86_64-linux/dist-alt.sh /scripts/
+
+ENV SCRIPT /scripts/${SCRIPT_ARG}
+
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This is the only builder which will create source tarballs

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist-alt.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist-alt.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eux
+
+python3 ../x.py dist \
+    --host $HOSTS --target $HOSTS \
+    --include-default-paths \
+    build-manifest bootstrap

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux
+
+python3 ../x.py build --set rust.debug=true opt-dist
+
+./build/$HOSTS/stage0-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \
+    --host $HOSTS --target $HOSTS \
+    --include-default-paths \
+    build-manifest bootstrap
+
+# Use GCC for building GCC, as it seems to behave badly when built with Clang
+CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -10,6 +10,10 @@ runners:
     free_disk: true
     <<: *base-job
 
+  - &job-linux-4c-largedisk
+    os: ubuntu-24.04-4core-16gb
+    <<: *base-job
+
   - &job-linux-8c
     os: ubuntu-24.04-8core-32gb
     <<: *base-job
@@ -107,6 +111,15 @@ envs:
   pr:
     PR_CI_JOB: 1
 
+jobs:
+  dist-x86_64-linux: &job-dist-x86_64-linux
+    name: dist-x86_64-linux
+    env:
+      CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
+    <<: *job-linux-36c-codebuild
+
+
 # Jobs that run on each push to a pull request (PR)
 # These jobs automatically inherit envs.pr, to avoid repeating
 # it in each job definition.
@@ -138,11 +151,7 @@ pr:
 # These jobs automatically inherit envs.try, to avoid repeating
 # it in each job definition.
 try:
-  - name: dist-x86_64-linux
-    env:
-      CODEGEN_BACKENDS: llvm,cranelift
-      DOCKER_SCRIPT: dist.sh
-    <<: *job-linux-36c-codebuild
+  - <<: *job-dist-x86_64-linux
 
 # Main CI jobs that have to be green to merge a commit into master
 # These jobs automatically inherit envs.auto, to avoid repeating
@@ -235,18 +244,14 @@ auto:
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 
-  - name: dist-x86_64-linux
-    env:
-      CODEGEN_BACKENDS: llvm,cranelift
-      DOCKER_SCRIPT: dist.sh
-    <<: *job-linux-36c-codebuild
+  - <<: *job-dist-x86_64-linux
 
   - name: dist-x86_64-linux-alt
     env:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist-alt.sh
-    <<: *job-linux-16c
+    <<: *job-linux-4c-largedisk
 
   - name: dist-x86_64-musl
     env:

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -141,6 +141,7 @@ try:
   - name: dist-x86_64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
     <<: *job-linux-36c-codebuild
 
 # Main CI jobs that have to be green to merge a commit into master
@@ -237,12 +238,14 @@ auto:
   - name: dist-x86_64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
     <<: *job-linux-36c-codebuild
 
   - name: dist-x86_64-linux-alt
     env:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist-alt.sh
     <<: *job-linux-16c
 
   - name: dist-x86_64-musl


### PR DESCRIPTION
Should unblock https://github.com/rust-lang/rust/pull/131077 and also reduce our CI costs. It seems to run ~1.5h on the x64 larger runner (free runner runs out of disk space, sadly).

Discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Utility.20of.20the.20.60dist-x86_64-linux-alt.60.20job/with/521324477).

r? @marcoieni

try-job: `dist-x86_64-linux*`