### PR TITLE
enable TLS for windows-gnu

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::spec::{
     BinaryFormat, Cc, DebuginfoKind, LinkSelfContainedDefault, LinkerFlavor, Lld, SplitDebuginfo,
-    TargetOptions, add_link_args, crt_objects, cvs,
+    TargetOptions, TlsModel, add_link_args, crt_objects, cvs,
 };
 
 pub(crate) fn opts() -> TargetOptions {
@@ -109,6 +109,8 @@ pub(crate) fn opts() -> TargetOptions {
         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
         // output DWO, despite using DWARF, doesn't use ELF..
         supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+        tls_model: TlsModel::Emulated,
+        has_thread_local: true,
         ..Default::default()
     }
 }


### PR DESCRIPTION
It didn't work a few years ago but seems to be working now.

try-job: x86_64-mingw-1
try-job: x86_64-mingw-2
try-job: dist-x86_64-mingw
try-job: dist-i686-mingw