### PR TITLE
compiler: use FramePointer::NonLeaf on illumos

### DIFF
--- a/compiler/rustc_target/src/spec/base/illumos.rs
+++ b/compiler/rustc_target/src/spec/base/illumos.rs
@@ -32,7 +32,8 @@ pub(crate) fn opts() -> TargetOptions {
         is_like_solaris: true,
         linker_flavor: LinkerFlavor::Unix(Cc::Yes),
         limit_rdylib_exports: false, // Linker doesn't support this
-        frame_pointer: FramePointer::Always,
+        // required by illumos tooling
+        frame_pointer: FramePointer::NonLeaf,
         eh_frame_header: false,
         late_link_args,
 


### PR DESCRIPTION
It's not clear to me if Illumos requires full frame-pointers, including leaf frames, or not. I figured I'd ask the maintainers.

r? @ghost

cc @jclulow @pfmooney