### PR TITLE
Update `compiler-builtins` to 0.1.160

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.159"
+version = "0.1.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448068da8f2326b2a0472353cb401dd8795a89c007ef30fff90f50706e862e72"
+checksum = "6376049cfa92c0aa8b9ac95fae22184b981c658208d4ed8a1dc553cd83612895"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.159", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.160", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.159" }
+compiler_builtins = { version = "=0.1.160" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',


### PR DESCRIPTION
Includes the following changes:

* Enable `__powitf2` on MSVC [1]
* Update `CmpResult` to use a pointer-sized return type [2]
* Better code reuse between `libm` and `compiler-builtins` [3], [4]
* Stop building C versions of `__netf2` [5] since we have our own implementation

[1]: https://github.com/rust-lang/compiler-builtins/pull/918
[2]: https://github.com/rust-lang/compiler-builtins/pull/920
[3]: https://github.com/rust-lang/compiler-builtins/pull/879
[4]: https://github.com/rust-lang/compiler-builtins/pull/925
[5]: https://github.com/rust-lang/compiler-builtins/pull/828