### PR TITLE
rustc_llvm: add Windows system libs only when cross-compiling from Wi…

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -228,10 +228,10 @@ fn main() {
     let mut cmd = Command::new(&llvm_config);
     cmd.arg(llvm_link_arg).arg("--libs");
 
-    // Don't link system libs if cross-compiling unless targeting Windows.
+    // Don't link system libs if cross-compiling unless targeting Windows from Windows host.
     // On Windows system DLLs aren't linked directly, instead import libraries are used.
     // These import libraries are independent of the host.
-    if !is_crossed || target.contains("windows") {
+    if !is_crossed || target.contains("windows") && host.contains("windows") {
         cmd.arg("--system-libs");
     }
 


### PR DESCRIPTION
…ndows

This obviously doesn't work when cross-compiling from Linux.

Split out from: https://github.com/rust-lang/rust/pull/140772

Fixes the issue described at [#general > Problems while trying to cross compile rustc for windows](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Problems.20while.20trying.20to.20cross.20compile.20rustc.20for.20windows/with/520508561)