### PR TITLE
Don't create .msi installer for gnullvm hosts

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1681,7 +1681,8 @@ impl Step for Extended {
             cmd.run(builder);
         }
 
-        if target.is_windows() {
+        // FIXME(mati865): `gnullvm` here is temporary, remove it once it can host itself
+        if target.is_windows() && !target.contains("gnullvm") {
             let exe = tmp.join("exe");
             let _ = fs::remove_dir_all(&exe);
 


### PR DESCRIPTION
WIX toolset works only on Windows hosts, but gnullvm doesn't have host toolchain yet. To get out of this loop, we will create a single release without MSI installer.

Split out from: https://github.com/rust-lang/rust/pull/140772
