### PR TITLE
improve `core::ffi::VaList`

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -230,6 +230,7 @@ language_item_table! {
     UnsafePinned,            sym::unsafe_pinned,       unsafe_pinned_type,         Target::Struct,         GenericRequirement::None;
 
     VaList,                  sym::va_list,             va_list,                    Target::Struct,         GenericRequirement::None;
+    VaListTag,               sym::va_list_tag,         va_list_tag,                Target::Struct,         GenericRequirement::None;
 
     Deref,                   sym::deref,               deref_trait,                Target::Trait,          GenericRequirement::Exact(0);
     DerefMut,                sym::deref_mut,           deref_mut_trait,            Target::Trait,          GenericRequirement::Exact(0);

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -175,8 +175,8 @@ pub(crate) fn check_intrinsic_type(
         ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon),
         ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
     ]);
-    let mk_va_list_ty = |mutbl| {
-        let did = tcx.require_lang_item(LangItem::VaList, span);
+    let mk_va_list_tag_ty = |mutbl| {
+        let did = tcx.require_lang_item(LangItem::VaListTag, span);
         let region = ty::Region::new_bound(
             tcx,
             ty::INNERMOST,
@@ -507,16 +507,16 @@ pub(crate) fn check_intrinsic_type(
         }
 
         sym::va_start | sym::va_end => {
-            (0, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], tcx.types.unit)
+            (0, 0, vec![mk_va_list_tag_ty(hir::Mutability::Mut).0], tcx.types.unit)
         }
 
         sym::va_copy => {
-            let (va_list_ref_ty, va_list_ty) = mk_va_list_ty(hir::Mutability::Not);
+            let (va_list_ref_ty, va_list_ty) = mk_va_list_tag_ty(hir::Mutability::Not);
             let va_list_ptr_ty = Ty::new_mut_ptr(tcx, va_list_ty);
             (0, 0, vec![va_list_ptr_ty, va_list_ref_ty], tcx.types.unit)
         }
 
-        sym::va_arg => (1, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], param(0)),
+        sym::va_arg => (1, 0, vec![mk_va_list_tag_ty(hir::Mutability::Mut).0], param(0)),
 
         sym::nontemporal_store => {
             (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2312,6 +2312,7 @@ symbols! {
         va_copy,
         va_end,
         va_list,
+        va_list_tag,
         va_start,
         val,
         validity,

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -28,7 +28,7 @@ pub mod c_str;
     issue = "44930",
     reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
 )]
-pub use self::va_list::{VaArgSafe, VaList, VaListImpl};
+pub use self::va_list::{VaArgSafe, VaList, VaListTag, va_copy};
 
 #[unstable(
     feature = "c_variadic",

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -177,6 +177,7 @@
 #![feature(staged_api)]
 #![feature(stmt_expr_attributes)]
 #![feature(strict_provenance_lints)]
+#![feature(super_let)]
 #![feature(trait_alias)]
 #![feature(transparent_unions)]
 #![feature(try_blocks)]

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -172,7 +172,7 @@ pub use core::ffi::c_void;
               all supported platforms",
     issue = "44930"
 )]
-pub use core::ffi::{VaArgSafe, VaList, VaListImpl};
+pub use core::ffi::{VaArgSafe, VaList, VaListTag, va_copy};
 #[stable(feature = "core_ffi_c", since = "1.64.0")]
 pub use core::ffi::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,

--- a/tests/codegen/cffi/c-variadic-copy.rs
+++ b/tests/codegen/cffi/c-variadic-copy.rs
@@ -3,14 +3,14 @@
 #![crate_type = "lib"]
 #![feature(c_variadic)]
 #![no_std]
-use core::ffi::VaList;
+use core::ffi::{VaList, va_copy};
 
 extern "C" {
     fn foreign_c_variadic_1(_: VaList, ...);
 }
 
 pub unsafe extern "C" fn clone_variadic(ap: VaList) {
-    let mut ap2 = ap.clone();
+    let mut ap2 = va_copy!(ap);
     // CHECK: call void @llvm.va_copy
-    foreign_c_variadic_1(ap2.as_va_list(), 42i32);
+    foreign_c_variadic_1(ap2, 42i32);
 }

--- a/tests/codegen/cffi/c-variadic-opt.rs
+++ b/tests/codegen/cffi/c-variadic-opt.rs
@@ -3,7 +3,7 @@
 #![crate_type = "lib"]
 #![feature(c_variadic)]
 #![no_std]
-use core::ffi::VaList;
+use core::ffi::{VaList, va_copy};
 
 extern "C" {
     fn vprintf(fmt: *const i8, ap: VaList) -> i32;
@@ -12,19 +12,19 @@ extern "C" {
 // Ensure that `va_start` and `va_end` are properly injected even
 // when the "spoofed" `VaListImpl` is not used.
 #[no_mangle]
-pub unsafe extern "C" fn c_variadic_no_use(fmt: *const i8, mut ap: ...) -> i32 {
+pub unsafe extern "C" fn c_variadic_no_use(fmt: *const i8, ap: ...) -> i32 {
     // CHECK: call void @llvm.va_start
-    vprintf(fmt, ap.as_va_list())
+    vprintf(fmt, ap)
     // CHECK: call void @llvm.va_end
 }
 
-// Check that `VaListImpl::clone` gets inlined into a direct call to `llvm.va_copy`
+// Check that `va_copy!` gets inlined into a direct call to `llvm.va_copy`
 #[no_mangle]
-pub unsafe extern "C" fn c_variadic_clone(fmt: *const i8, mut ap: ...) -> i32 {
+pub unsafe extern "C" fn c_variadic_clone(fmt: *const i8, ap: ...) -> i32 {
     // CHECK: call void @llvm.va_start
-    let mut ap2 = ap.clone();
+    let ap2 = va_copy!(ap);
     // CHECK: call void @llvm.va_copy
-    let res = vprintf(fmt, ap2.as_va_list());
+    let res = vprintf(fmt, ap2);
     res
     // CHECK: call void @llvm.va_end
 }

--- a/tests/ui/c-variadic/variadic-ffi-4.rs
+++ b/tests/ui/c-variadic/variadic-ffi-4.rs
@@ -2,15 +2,15 @@
 #![no_std]
 #![feature(c_variadic)]
 
-use core::ffi::{VaList, VaListImpl};
+use core::ffi::{VaList, va_copy};
 
-pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
+pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaList<'f> {
     ap
     //~^ ERROR: lifetime may not live long enough
     //~| ERROR: lifetime may not live long enough
 }
 
-pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
+pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaList<'static> {
     ap //~ ERROR: lifetime may not live long enough
 }
 
@@ -18,21 +18,33 @@ pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
     let _ = ap.with_copy(|ap| ap); //~ ERROR: lifetime may not live long enough
 }
 
-pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
     *ap0 = ap1;
     //~^ ERROR: lifetime may not live long enough
     //~| ERROR: lifetime may not live long enough
 }
 
-pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
     ap0 = &mut ap1;
     //~^ ERROR: `ap1` does not live long enough
     //~| ERROR: lifetime may not live long enough
     //~| ERROR: lifetime may not live long enough
 }
 
-pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-    *ap0 = ap1.clone();
+pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+    *ap0 = va_copy!(ap1);
     //~^ ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
+    //~| ERROR: temporary value dropped while borrowed
+}
+
+pub unsafe extern "C" fn no_escape6<'f>(ap: ...) -> VaList<'f> {
+    va_copy!(ap)
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: cannot return value referencing temporary value
+}
+
+pub unsafe extern "C" fn no_escape7(ap: ...) -> VaList<'static> {
+    va_copy!(ap)
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: cannot return value referencing temporary value
 }

--- a/tests/ui/c-variadic/variadic-ffi-4.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-4.stderr
@@ -1,41 +1,41 @@
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:8:5
    |
-LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
-   |                                     --            -- has type `VaListImpl<'1>`
+LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaList<'f> {
+   |                                     --            -- has type `VaList<'1>`
    |                                     |
    |                                     lifetime `'f` defined here
 LL |     ap
    |     ^^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'f`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:8:5
    |
-LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
-   |                                     --            -- has type `VaListImpl<'1>`
+LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaList<'f> {
+   |                                     --            -- has type `VaList<'1>`
    |                                     |
    |                                     lifetime `'f` defined here
 LL |     ap
    |     ^^ function was supposed to return data with lifetime `'f` but it is returning data with lifetime `'1`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:14:5
    |
-LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
-   |                                               -- has type `VaListImpl<'1>`
+LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaList<'static> {
+   |                                               -- has type `VaList<'1>`
 LL |     ap
    |     ^^ returning this value requires that `'1` must outlive `'static`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -44,70 +44,74 @@ error: lifetime may not live long enough
 LL |     let _ = ap.with_copy(|ap| ap);
    |                           --- ^^ returning this value requires that `'1` must outlive `'2`
    |                           | |
-   |                           | return type of closure is VaList<'2, '_>
-   |                           has type `VaList<'1, '_>`
-
-error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:22:5
+   |                           | return type of closure is VaList<'2>
+   |                           has type `VaList<'1>`
    |
-LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
-   |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
-LL |     *ap0 = ap1;
-   |     ^^^^ assignment requires that `'1` must outlive `'2`
-   |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:22:5
    |
-LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
+LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               -------               ------- has type `VaList<'2>`
    |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
+   |                                               has type `&mut VaList<'1>`
 LL |     *ap0 = ap1;
-   |     ^^^^ assignment requires that `'2` must outlive `'1`
+   |     ^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/variadic-ffi-4.rs:22:5
+   |
+LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               -------               ------- has type `VaList<'2>`
+   |                                               |
+   |                                               has type `&mut VaList<'1>`
+LL |     *ap0 = ap1;
+   |     ^^^^^^^^^^ assignment requires that `'2` must outlive `'1`
+   |
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:28:5
    |
-LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
+LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               -------               ------- has type `VaList<'2>`
    |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
+   |                                               has type `&mut VaList<'1>`
 LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
    |
-   = note: requirement occurs because of a mutable reference to `VaListImpl<'_>`
+   = note: requirement occurs because of a mutable reference to `VaList<'_>`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:28:5
    |
-LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
+LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               -------               ------- has type `VaList<'2>`
    |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
+   |                                               has type `&mut VaList<'1>`
 LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'2` must outlive `'1`
    |
-   = note: requirement occurs because of a mutable reference to `VaListImpl<'_>`
+   = note: requirement occurs because of a mutable reference to `VaList<'_>`
    = note: mutable references are invariant over their type parameter
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error[E0597]: `ap1` does not live long enough
   --> $DIR/variadic-ffi-4.rs:28:11
    |
-LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                                        -                ------- binding `ap1` declared here
+LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                                        -            ------- binding `ap1` declared here
    |                                                        |
    |                                                        let's call the lifetime of this reference `'3`
 LL |     ap0 = &mut ap1;
@@ -117,36 +121,86 @@ LL |     ap0 = &mut ap1;
    |     assignment requires that `ap1` is borrowed for `'3`
 ...
 LL | }
-   | - `ap1` dropped here while still borrowed
+   |  - `ap1` dropped here while still borrowed
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:35:5
    |
-LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
+LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               -------               ------- has type `VaList<'1>`
    |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
-LL |     *ap0 = ap1.clone();
-   |     ^^^^ assignment requires that `'2` must outlive `'1`
+   |                                               has type `&mut VaList<'2>`
+LL |     *ap0 = va_copy!(ap1);
+   |     ^^^^^^^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
-error: lifetime may not live long enough
+error[E0716]: temporary value dropped while borrowed
   --> $DIR/variadic-ffi-4.rs:35:12
    |
-LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `VaListImpl<'2>`
-   |                                               |
-   |                                               has type `&mut VaListImpl<'1>`
-LL |     *ap0 = ap1.clone();
-   |            ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaList, mut ap1: ...) {
+   |                                               ------- has type `&mut VaList<'2>`
+LL |     *ap0 = va_copy!(ap1);
+   |     -------^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     |      |
+   |     |      creates a temporary value which is freed while still in use
+   |     assignment requires that borrow lasts for `'2`
    |
-   = note: requirement occurs because of the type `VaListImpl<'_>`, which makes the generic argument `'_` invariant
-   = note: the struct `VaListImpl<'f>` is invariant over the parameter `'f`
+   = note: this error originates in the macro `va_copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/variadic-ffi-4.rs:41:5
+   |
+LL | pub unsafe extern "C" fn no_escape6<'f>(ap: ...) -> VaList<'f> {
+   |                                     --  -- has type `VaList<'1>`
+   |                                     |
+   |                                     lifetime `'f` defined here
+LL |     va_copy!(ap)
+   |     ^^^^^^^^^^^^ function was supposed to return data with lifetime `'f` but it is returning data with lifetime `'1`
+   |
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+   = note: this error originates in the macro `va_copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 11 previous errors
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/variadic-ffi-4.rs:41:5
+   |
+LL |     va_copy!(ap)
+   |     ^^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     temporary value created here
+   |
+   = note: this error originates in the macro `va_copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0597`.
+error: lifetime may not live long enough
+  --> $DIR/variadic-ffi-4.rs:47:5
+   |
+LL | pub unsafe extern "C" fn no_escape7(ap: ...) -> VaList<'static> {
+   |                                     -- has type `VaList<'1>`
+LL |     va_copy!(ap)
+   |     ^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |
+   = note: requirement occurs because of the type `VaList<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `VaList<'a>` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+   = note: this error originates in the macro `va_copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/variadic-ffi-4.rs:47:5
+   |
+LL |     va_copy!(ap)
+   |     ^^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     temporary value created here
+   |
+   = note: this error originates in the macro `va_copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0515, E0597, E0716.
+For more information about an error, try `rustc --explain E0515`.

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -31,12 +31,10 @@ extern "C" fn f3_3(..., x: isize) {}
 
 const unsafe extern "C" fn f4_1(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
-//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_2(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
 //~| ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_3(..., x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
@@ -64,7 +62,6 @@ impl X {
     const fn i_f5(x: isize, ...) {}
     //~^ ERROR only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
     //~| ERROR functions cannot be both `const` and C-variadic
-    //~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 }
 
 trait T {

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -65,25 +65,25 @@ LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    | ^^^^^ `const` because of this             ^^^ C-variadic because of this
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:1
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    | ^^^^^ `const` because of this      ^^^ C-variadic because of this
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:1
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | ^^^^^                    ^^^            ^^^ C-variadic because of this
@@ -92,55 +92,55 @@ LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | `const` because of this
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:41:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:47:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:45:13
    |
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:52:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:56:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:58:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:56:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:58:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:56:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:5
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:5
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |     ^^^^^                   ^^^ C-variadic because of this
@@ -148,83 +148,58 @@ LL |     const fn i_f5(x: isize, ...) {}
    |     `const` because of this
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:71:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:73:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:75:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:72:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:77:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:74:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:76:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:76:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:82:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:82:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
-error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:32:43
-   |
-LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
-   |                                           ^^^   - value is dropped here
-   |                                           |
-   |                                           the destructor for this type cannot be evaluated in constant functions
+error: aborting due to 33 previous errors
 
-error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
-   |
-LL | const extern "C" fn f4_2(x: isize, ...) {}
-   |                                    ^^^   - value is dropped here
-   |                                    |
-   |                                    the destructor for this type cannot be evaluated in constant functions
-
-error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
-   |
-LL |     const fn i_f5(x: isize, ...) {}
-   |                             ^^^   - value is dropped here
-   |                             |
-   |                             the destructor for this type cannot be evaluated in constant functions
-
-error: aborting due to 36 previous errors
-
-For more information about this error, try `rustc --explain E0493`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/44930

This PR refactors the `VaList` API. The highlights are 

- `VaListImpl` is no longer user-visible (and internally renamed to `VaListTag`)
- `VaList` now has only a single lifetime parameter
- a new `va_copy!` macro is added to duplicate a `VaList`

This PR mostly touches the `core` implementation of `VaList`, but needs some changes in the rest of the compiler to make it all work.

This change was discussed in https://github.com/rust-lang/rust/issues/141524.

---

This next section is a kind of pseudo-rfc: it describes what the `c_variadic` feature is, and what API surface we have. The lang team likely wants to see a new RFC or extensive stabilization report before stabilizing `c_variadic`.

## Syntax

A c-variadic function looks like this:

```rust
#![feature(c_variadic)]

unsafe extern "C" fn foo(a: i32, b: i32, args: ...) {
    /* body */
}
```

The special `...` argument stands in for an arbitrary number of arguments that the caller may pass. The compiler has no way of verifying that the arguments that are passed to a c-variadic function are correct, and therefore calling a c-variadic function is always `unsafe`.

The `...` argument must be the last argument in the parameter list of a function. Contrary to earlier versions of C, but in line with C23, in rust the `...` argument can be the first (and therefore only) argument to a function.  The `...` syntax is already stable in foreign functions, `c_variadic` additionally allows it in function definitions.

A function with a `...` argument must be an `unsafe` function. Passing an incorrect number of arguments, or arguments of the wrong type is UB, and hence every call site should have a safety comment. 

This document only considers functions with the `"C"` and `"C-unwind`" calling conventions. It is possible to in the future also support e.g. `"sysv64"` or `"win64"`, but for now we consider that to be out-of-scope.

## `VaList`

The type of `...` is `core::ffi::VaList`: the list of variadic arguments. The rust `VaList` type on a given platform is equivalent to the C `va_list` type on that platform: values of this type can be passed to C via FFI, and used like any other `va_list` value.

Across ABIs, there are two ways that `VaList` is implemented:

- the "pointer" approach: the `VaList` is just an opaque pointer. (in practice it is usually a pointer to the caller's stack where the variadic arguments are stored) 
- the "struct on stack" approach: the `VaList` is a mutable reference to a structure (called `VaListTag`) on the callee's stack.

In both cases, there are lifetime constraints on the `VaList`: it must not escape the function in which it was defined!

## desugaring `...`

A function 

```rust
unsafe extern "C" fn foo(args: ...) {
    // ...
}
```

Semantically desugars in one of two ways, depending on the ABI of the target platform. The actual desugaring is built into the compiler, these examples just illustrate what happens. 

**the "pointer" approach**

```rust
struct VaListTag<'a> { 
    ptr: *mut c_void,
    _marker: PhantomData<&'a mut ()>
}

struct VaList(VaListTag<'a>);

fn foo() {
    fn shorten_lifetime<'a>(&'a ()) -> PhantomData<'a> { PhantomData }

    let x = ();
    let reference_to_stack = &x;

    let tag = MaybeUninit::<VaListTag>::uninit();
    va_start(tag.as_mut_ptr())
    let args = unsafe { 
        VaList { 
            ptr: tag.assume_init()
            _marker: shorten_lifetime(reference_to_stack),
    };

    // ...

    va_end(&mut args.ptr)
}
```

**the "struct on stack" approach**

```rust
struct VaListTag<'a> { ... }

struct VaList(&'a mut VaListTag<'a>);

fn foo() {
    let tag = MaybeUninit::<VaListTag>::uninit();
    va_start(tag.as_mut_ptr())
    let args = unsafe { VaList(tag.assume_init_mut()) }

    // ...

    va_end(args.0)
}
```

The builtin desugaring process guarantees the correct lifetime is selected for `VaList` , and that the call to `va_end` is inserted on all return paths.

## `va_arg`

In C, the `va_arg` macro is used to read the next variadic argument. Rust exposes this functionality as 

```rust
impl VaList<'_> {
    unsafe fn arg<T: VaArgSafe>(&mut self) -> T { /* ... * / }
}
```

The `arg` method is unsafe because attempting to read more arguments than were passed or an argument of the wrong type is undefined behavior.

The type parameter `T` is constrained by the `VaArgSafe` trait: small numeric types are subject to implicit upcasting in C. Attempting to read a value of such a type (e.g. `bool`, `i8`, `u16`, `f32`) is undefined behavior. The `VaArgSafe` trait is only implemented for numeric types for which no implicit upcasting occurs, and for const/mut pointer types.  

The `VaArgSafe` trait is public, but cannot currently be implemented outside of `core`.

### A note on LLVM `va_arg`

The llvm `va_arg` intrinsic is known to silently miscompile. I believe this is due to a combination of:

- LLVM does not have sufficient layout information to accurately implement the ABI
- Clang provides its own implementation of `va_arg`, so the LLVM implementation is mostly untested

Hence, like clang, `rustc` implements `va_arg` for most commonly-used targets (specifically including all tier-1 targets) in [`va_arg.rs`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_codegen_llvm/src/va_arg.rs). If no custom implementation is provided, the LLVM implementation is used as a fallback. But again, it may silently miscompile the input program. 

## the `va_copy!` macro

The `VaList` type has a `with_copy` method, that provides access to a copy of the `VaList`. However, `c2rust` ran into this method not being flexible enough to translate C programs seen in the wild (https://github.com/immunant/c2rust/issues/43). The `va_copy!` macro mirrors the C `va_copy` macro, enabling a straightforward translation from C to rust.

The concrete pattern that this macro enables is to (easily) iterate over two copies of the `VaList` in parallel.

The implementation of this macro uses `super let` to give the copied `VaList` the correct lifetime. Currently it relies on some `#[doc(hidden)]` methods on `VaList`, so that `VaListTag` does not need to be exposed. 
## C-variadics  and `const fn`

C-variadics cannot be `const fn` at the time of writing. This is a limitation in MIRI that may be lifted at some point. 
## Other calling conventions

For now we only consider the `"C"` and `"C-unwind"` calling conventions. Other calling conventions are disallowed for now, but we have considered how support may be added in the future.

The difficulty is that currently the target determines the layout of `VaList` and `VaListTag`. Accepting multiple c-variadic functions with ABIs in the same program means that the layout of those types may be different depending on the exact ABI that is used in a function. We also must be clear about when a rust `VaList` is compatible with the C `va_list` type. 

Speaking of C, `clang` and `gcc` won't compile a function that uses variadic arguments and a non-standard calling convention. See also https://github.com/rust-lang/rust/issues/141618, in particular [this comment](https://github.com/rust-lang/rust/issues/141618#issuecomment-2911802411)

Nevertheless, two potential solutions for supporting multiple c-variadic ABIs in the same program have been proposed.
### A generic parameter with a default

The `VaList` structure can be extended like so

```rust
trait VaListAbi {
	type Abi;
}

#[cfg(windows)]
struct VaListWin64<'a> { /* ... */ }

#[cfg(windows)]
type C<'a> = VaListWin64<'a>;

struct VaList<'a, Abi: VaListAbi = C<'a>> { 
    tag: &'a mut Abi::Tag,
    _abi: PhantomData<Abi>
}
```

The `...` parameter in a c-variadic `extern "C" fn` will have type `VaList<'a, C>`, which is guaranteed to be compatible with C `va_list` type for the target platform. Functions using a non-standard abi get a type like `VaList<'a, Win64>`.

### Multiple types

Alternatively, every abi could get its own `VaList` type, and `...` in an `extern "C" fn` desugars to the type that is compatible with the C `va_list` type for the target platform.

A type alias could be used to always be able to refer to the C-compatible `VaList` type. 

---

Review notes

- The changes to the lang items could be split into their own PR, cleaning things up here
- The part I'm least sure about is the `va_copy!` macro. Maybe there are some tricks in `core` to make that nicer? (e.g. make `VaListTag` public, but `#[doc(hidden)]` and perma-unstable somehow, but then allow that unstable feature in the `va_copy` macro expansion?)

r? @joshtriplett 
cc @workingjubilee 
@rustbot label: +F-c_variadic