### PR TITLE
Fix TLS model on bootstrap for cygwin

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1004,7 +1004,12 @@ impl Builder<'_> {
         // efficient initial-exec TLS model. This doesn't work with `dlopen`,
         // so we can't use it by default in general, but we can use it for tools
         // and our own internal libraries.
-        if !mode.must_support_dlopen() && !target.triple.starts_with("powerpc-") {
+        //
+        // Cygwin only supports emutls.
+        if !mode.must_support_dlopen()
+            && !target.triple.starts_with("powerpc-")
+            && !target.triple.contains("cygwin")
+        {
             cargo.env("RUSTC_TLS_MODEL_INITIAL_EXEC", "1");
         }
 


### PR DESCRIPTION
There aren't other targets that both use emutls and enable `has_thread_local`, so cygwin triggers this bug first.

r? mati865

See: https://github.com/rust-lang/rust/pull/141719#issuecomment-2925445263

@jeremyd2019 Could you check if this PR fixes the issue? I just found my pre-built stage-0 rustc was too old to build the current rustc :(