### PR TITLE
Switch `x86_64-msvc-{1,2}` back to Windows Server 2025 images

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -30,8 +30,6 @@ runners:
     os: windows-2022
     <<: *base-job
 
-  # FIXME(#141022): Windows Server 2025 20250504.1.0 currently experiences
-  # insufficient disk space.
   - &job-windows-25
     os: windows-2025
     <<: *base-job
@@ -492,17 +490,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-sanitizers --enable-profiler
       SCRIPT: make ci-msvc-py
-    # FIXME(#141022): Windows Server 2025 20250504.1.0 currently experiences
-    # insufficient disk space.
-    <<: *job-windows
+    <<: *job-windows-25
 
   - name: x86_64-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-sanitizers --enable-profiler
       SCRIPT: make ci-msvc-ps1
-    # FIXME(#141022): Windows Server 2025 20250504.1.0 currently experiences
-    # insufficient disk space.
-    <<: *job-windows
+    <<: *job-windows-25
 
   # i686-msvc is split into two jobs to run tests in parallel.
   - name: i686-msvc-1


### PR DESCRIPTION
New Windows Server 2025 images have been released (**20250527.1.0**). New images appear to not exhibit the lack-of-disk-space problem as tracked by rust-lang/rust#141022, and the new runner image's storage capacity appears to be configured correctly.

Windows Server 2025 image version **20250527.1.0** release notes: <https://github.com/actions/runner-images/releases/tag/win25%2F20250527.1>.

Resolves rust-lang/rust#141022.
