### PR TITLE
allow macro_use as first segment

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2312,7 +2312,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     }
 
     fn check_macro_use(&self, hir_id: HirId, attr: &Attribute, target: Target) {
-        let name = attr.name().unwrap();
+        let Some(name) = attr.name() else {
+            return;
+        };
         match target {
             Target::ExternCrate | Target::Mod => {}
             _ => {

--- a/tests/crashes/140255.rs
+++ b/tests/crashes/140255.rs
@@ -1,3 +1,0 @@
-//@ known-bug: #140255
-#[unsafe(macro_use::VAR2)]
-fn dead_code() {}

--- a/tests/ui/attributes/auxiliary/external-macro-use.rs
+++ b/tests/ui/attributes/auxiliary/external-macro-use.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_attribute]
+pub fn a(_: TokenStream, input: TokenStream) -> TokenStream {
+   input
+}

--- a/tests/ui/attributes/illegal-macro-use.rs
+++ b/tests/ui/attributes/illegal-macro-use.rs
@@ -1,0 +1,15 @@
+// issue#140255
+
+#[macro_use::a]       //~ ERROR failed to resolve: use of unresolved module or unlinked crate `macro_use`
+fn f0() {}
+
+#[macro_use::a::b]    //~ ERROR failed to resolve: use of unresolved module or unlinked crate `macro_use`
+fn f1() {}
+
+#[macro_escape::a]    //~ ERROR failed to resolve: use of unresolved module or unlinked crate `macro_escape`
+fn f2() {}
+
+#[macro_escape::a::b] //~ ERROR failed to resolve: use of unresolved module or unlinked crate `macro_escape`
+fn f3() {}
+
+fn main() {}

--- a/tests/ui/attributes/illegal-macro-use.stderr
+++ b/tests/ui/attributes/illegal-macro-use.stderr
@@ -1,0 +1,27 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `macro_escape`
+  --> $DIR/illegal-macro-use.rs:12:3
+   |
+LL | #[macro_escape::a::b]
+   |   ^^^^^^^^^^^^ use of unresolved module or unlinked crate `macro_escape`
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `macro_escape`
+  --> $DIR/illegal-macro-use.rs:9:3
+   |
+LL | #[macro_escape::a]
+   |   ^^^^^^^^^^^^ use of unresolved module or unlinked crate `macro_escape`
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `macro_use`
+  --> $DIR/illegal-macro-use.rs:6:3
+   |
+LL | #[macro_use::a::b]
+   |   ^^^^^^^^^ use of unresolved module or unlinked crate `macro_use`
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `macro_use`
+  --> $DIR/illegal-macro-use.rs:3:3
+   |
+LL | #[macro_use::a]
+   |   ^^^^^^^^^ use of unresolved module or unlinked crate `macro_use`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/attributes/use-extern-crate-named-macro-use.rs
+++ b/tests/ui/attributes/use-extern-crate-named-macro-use.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ proc-macro: external-macro-use.rs
+
+// issue#140255
+
+extern crate external_macro_use as macro_use;
+
+#[macro_use::a]
+fn f() {}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#140255 

This issue may raise a question: It's reasonable an external crate name or import target be legally named `macro_use`?