### PR TITLE
Add missing 2015 edition directives

### DIFF
--- a/tests/ui/did_you_mean/E0178.rs
+++ b/tests/ui/did_you_mean/E0178.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 #![allow(bare_trait_objects)]
 
 trait Foo {}

--- a/tests/ui/did_you_mean/E0178.stderr
+++ b/tests/ui/did_you_mean/E0178.stderr
@@ -1,5 +1,5 @@
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/E0178.rs:6:8
+  --> $DIR/E0178.rs:7:8
    |
 LL |     w: &'a Foo + Copy,
    |        ^^^^^^^
@@ -10,7 +10,7 @@ LL |     w: &'a (Foo + Copy),
    |            +          +
 
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/E0178.rs:7:8
+  --> $DIR/E0178.rs:8:8
    |
 LL |     x: &'a Foo + 'a,
    |        ^^^^^^^
@@ -21,7 +21,7 @@ LL |     x: &'a (Foo + 'a),
    |            +        +
 
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/E0178.rs:8:8
+  --> $DIR/E0178.rs:9:8
    |
 LL |     y: &'a mut Foo + 'a,
    |        ^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     y: &'a mut (Foo + 'a),
    |                +        +
 
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/E0178.rs:9:8
+  --> $DIR/E0178.rs:10:8
    |
 LL |     z: fn() -> Foo + 'a,
    |        ^^^^^^^^^^^-----

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![allow(bare_trait_objects)]
 
 fn main() {

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -1,5 +1,5 @@
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:5:12
    |
 LL |     let _: &Copy + 'static;
    |            ^^^^^
@@ -10,7 +10,7 @@ LL |     let _: &(Copy + 'static);
    |             +              +
 
 error[E0178]: expected a path on the left-hand side of `+`
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:6:12
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:7:12
    |
 LL |     let _: &'static Copy + 'static;
    |            ^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL |     let _: &'static (Copy + 'static);
    |                     +              +
 
 error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:13
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:5:13
    |
 LL |     let _: &Copy + 'static;
    |             ^^^^ `Copy` is not dyn compatible
@@ -31,7 +31,7 @@ LL |     let _: &Copy + 'static;
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
 error[E0038]: the trait `Copy` is not dyn compatible
-  --> $DIR/trait-object-reference-without-parens-suggestion.rs:6:21
+  --> $DIR/trait-object-reference-without-parens-suggestion.rs:7:21
    |
 LL |     let _: &'static Copy + 'static;
    |                     ^^^^ `Copy` is not dyn compatible

--- a/tests/ui/editions/async-block-2015.rs
+++ b/tests/ui/editions/async-block-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 async fn foo() {
 //~^ ERROR `async fn` is not permitted in Rust 2015
 //~| NOTE to use `async fn`, switch to Rust 2018 or later

--- a/tests/ui/editions/async-block-2015.stderr
+++ b/tests/ui/editions/async-block-2015.stderr
@@ -1,5 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/async-block-2015.rs:1:1
+  --> $DIR/async-block-2015.rs:2:1
    |
 LL | async fn foo() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -8,7 +8,7 @@ LL | async fn foo() {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected identifier, found keyword `let`
-  --> $DIR/async-block-2015.rs:11:9
+  --> $DIR/async-block-2015.rs:12:9
    |
 LL |     let y = async {
    |             ----- `async` blocks are only allowed in Rust 2018 or later
@@ -19,7 +19,7 @@ LL |         let x = 42;
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected identifier, found `42`
-  --> $DIR/async-block-2015.rs:19:9
+  --> $DIR/async-block-2015.rs:20:9
    |
 LL |     let z = async {
    |             ----- `async` blocks are only allowed in Rust 2018 or later
@@ -30,7 +30,7 @@ LL |         42
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0422]: cannot find struct, variant or union type `async` in this scope
-  --> $DIR/async-block-2015.rs:7:13
+  --> $DIR/async-block-2015.rs:8:13
    |
 LL |     let x = async {};
    |             ^^^^^ `async` blocks are only allowed in Rust 2018 or later

--- a/tests/ui/ergonomic-clones/async/edition-2015.rs
+++ b/tests/ui/ergonomic-clones/async/edition-2015.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 #![feature(ergonomic_clones)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/ergonomic-clones/async/edition-2015.stderr
+++ b/tests/ui/ergonomic-clones/async/edition-2015.stderr
@@ -1,5 +1,5 @@
 error: `async use` blocks are only allowed in Rust 2018 or later
-  --> $DIR/edition-2015.rs:5:5
+  --> $DIR/edition-2015.rs:6:5
    |
 LL |     async use {};
    |     ^^^^^^^^^

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.rs
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 trait MyIterator : Iterator {}
 
 fn main() {

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/dynless-turbofish-e0191-issue-91997.rs:4:13
+  --> $DIR/dynless-turbofish-e0191-issue-91997.rs:5:13
    |
 LL |     let _ = MyIterator::next;
    |             ^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     let _ = <dyn MyIterator>::next;
    |             ++++           +
 
 error[E0191]: the value of the associated type `Item` in `Iterator` must be specified
-  --> $DIR/dynless-turbofish-e0191-issue-91997.rs:4:13
+  --> $DIR/dynless-turbofish-e0191-issue-91997.rs:5:13
    |
 LL |     let _ = MyIterator::next;
    |             ^^^^^^^^^^ help: specify the associated type: `MyIterator::<Item = Type>`

--- a/tests/ui/expr/scope.rs
+++ b/tests/ui/expr/scope.rs
@@ -1,3 +1,4 @@
+//@ edition:2015
 //@ run-pass
 // Regression test for issue #762
 

--- a/tests/ui/imports/import-glob-crate.rs
+++ b/tests/ui/imports/import-glob-crate.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 use std::mem::*;
 


### PR DESCRIPTION
These tests specifically test 2015 edition behavior, so ensure that they can only be run with this edition

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
