### PR TITLE
Use non-2015 edition paths in tests that do not test for their resolution

### DIFF
--- a/tests/ui/autoref-autoderef/autoderef-privacy.rs
+++ b/tests/ui/autoref-autoderef/autoderef-privacy.rs
@@ -14,28 +14,28 @@ impl Bar2 {
 
 mod foo {
     #[derive(Default)]
-    pub struct Bar { i: ::Bar2 }
+    pub struct Bar { i: crate::Bar2 }
     #[derive(Default)]
-    pub struct Baz(::Baz2);
+    pub struct Baz(crate::Baz2);
 
     impl Bar {
         fn f(&self) -> bool { false }
     }
 
     impl ::std::ops::Deref for Bar {
-        type Target = ::Bar2;
-        fn deref(&self) -> &::Bar2 { &self.i }
+        type Target = crate::Bar2;
+        fn deref(&self) -> &crate::Bar2 { &self.i }
     }
 
     impl ::std::ops::Deref for Baz {
-        type Target = ::Baz2;
-        fn deref(&self) -> &::Baz2 { &self.0 }
+        type Target = crate::Baz2;
+        fn deref(&self) -> &crate::Baz2 { &self.0 }
     }
 
     pub fn f(bar: &Bar, baz: &Baz) {
         // Since the private fields and methods are visible here, there should be no autoderefs.
-        let _: &::Bar2 = &bar.i;
-        let _: &::Baz2 = &baz.0;
+        let _: &crate::Bar2 = &bar.i;
+        let _: &crate::Baz2 = &baz.0;
         assert!(!bar.f());
     }
 }

--- a/tests/ui/auxiliary/crate-method-reexport-grrrrrrr2.rs
+++ b/tests/ui/auxiliary/crate-method-reexport-grrrrrrr2.rs
@@ -16,7 +16,7 @@ pub mod name_pool {
 }
 
 pub mod rust {
-    pub use name_pool::add;
+    pub use crate::name_pool::add;
 
     pub type rt = Box<()>;
 

--- a/tests/ui/auxiliary/pub-and-stability.rs
+++ b/tests/ui/auxiliary/pub-and-stability.rs
@@ -44,7 +44,7 @@ mod m {
         #[unstable(feature = "unstable_undeclared", issue = "38412")] // SILLY
         pub(crate) b_crate: i32,
         #[unstable(feature = "unstable_declared", issue = "38412")] // SILLY
-        pub(in m) c_mod: i32,
+        pub(in crate::m) c_mod: i32,
         #[stable(feature = "unit_test", since = "1.0.0")] // SILLY
         d_priv: i32
     }
@@ -60,7 +60,7 @@ mod m {
         pub i32,
 
         pub(crate) i32,
-        pub(in m) i32,
+        pub(in crate::m) i32,
         i32);
 
     impl Record {
@@ -113,7 +113,7 @@ mod m {
         #[unstable(feature = "unstable_undeclared", issue = "38412")] // SILLY
         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
         #[unstable(feature = "unstable_declared", issue = "38412")] // SILLY
-        pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
+        pub(in crate::m) fn pub_mod(&self) -> i32 { self.d_priv }
         #[stable(feature = "unit_test", since = "1.0.0")] // SILLY
         fn private(&self) -> i32 { self.d_priv }
     }
@@ -127,7 +127,7 @@ mod m {
         pub fn stable(&self) -> i32 { self.0 }
 
         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
-        pub(in m) fn pub_mod(&self) -> i32 { self.0 }
+        pub(in crate::m) fn pub_mod(&self) -> i32 { self.0 }
         fn private(&self) -> i32 { self.0 }
     }
 }

--- a/tests/ui/coherence/coherence_inherent.rs
+++ b/tests/ui/coherence/coherence_inherent.rs
@@ -15,8 +15,8 @@ mod Lib {
 
 mod Import {
     // Trait is in scope here:
-    use Lib::TheStruct;
-    use Lib::TheTrait;
+    use crate::Lib::TheStruct;
+    use crate::Lib::TheTrait;
 
     fn call_the_fn(s: &TheStruct) {
         s.the_fn();
@@ -25,7 +25,7 @@ mod Import {
 
 mod NoImport {
     // Trait is not in scope here:
-    use Lib::TheStruct;
+    use crate::Lib::TheStruct;
 
     fn call_the_fn(s: &TheStruct) {
         s.the_fn();

--- a/tests/ui/consts/const-blocks/migrate-fail.rs
+++ b/tests/ui/consts/const-blocks/migrate-fail.rs
@@ -4,7 +4,7 @@
 struct Bar;
 
 mod non_constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_multiple_elements() {
         let x = None;

--- a/tests/ui/consts/const-blocks/migrate-pass.rs
+++ b/tests/ui/consts/const-blocks/migrate-pass.rs
@@ -5,7 +5,7 @@
 struct Bar;
 
 mod constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_no_elements() {
         const FOO: Option<Bar> = None;
@@ -69,7 +69,7 @@ mod constants {
 }
 
 mod non_constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_no_elements() {
         let x = None;

--- a/tests/ui/consts/const-blocks/nll-fail.rs
+++ b/tests/ui/consts/const-blocks/nll-fail.rs
@@ -4,7 +4,7 @@
 struct Bar;
 
 mod non_constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_multiple_elements() {
         let x = None;

--- a/tests/ui/consts/const-blocks/nll-pass.rs
+++ b/tests/ui/consts/const-blocks/nll-pass.rs
@@ -5,7 +5,7 @@
 struct Bar;
 
 mod constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_no_elements() {
         const FOO: Option<Bar> = None;
@@ -69,7 +69,7 @@ mod constants {
 }
 
 mod non_constants {
-    use Bar;
+    use crate::Bar;
 
     fn no_impl_copy_empty_value_no_elements() {
         let x = None;

--- a/tests/ui/cross-crate/auxiliary/static_priv_by_default.rs
+++ b/tests/ui/cross-crate/auxiliary/static_priv_by_default.rs
@@ -31,11 +31,11 @@ mod foo {
 }
 
 pub mod bar {
-    pub use foo::reexported_a as e;
-    pub use foo::reexported_b as f;
-    pub use foo::reexported_c as g;
-    pub use foo::reexported_d as h;
-    pub use foo::reexported_e as i;
+    pub use crate::foo::reexported_a as e;
+    pub use crate::foo::reexported_b as f;
+    pub use crate::foo::reexported_c as g;
+    pub use crate::foo::reexported_d as h;
+    pub use crate::foo::reexported_e as i;
 }
 
 pub static a: isize = 0;

--- a/tests/ui/dep-graph/dep-graph-assoc-type-codegen.rs
+++ b/tests/ui/dep-graph/dep-graph-assoc-type-codegen.rs
@@ -15,7 +15,7 @@ pub trait Foo: Sized {
 }
 
 mod x {
-    use Foo;
+    use crate::Foo;
 
     #[rustc_if_this_changed]
     impl Foo for char { type T = char; }
@@ -24,7 +24,7 @@ mod x {
 }
 
 mod y {
-    use Foo;
+    use crate::Foo;
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR OK
     pub fn use_char_assoc() {

--- a/tests/ui/dep-graph/dep-graph-caller-callee.rs
+++ b/tests/ui/dep-graph/dep-graph-caller-callee.rs
@@ -15,7 +15,7 @@ mod x {
 }
 
 mod y {
-    use x;
+    use crate::x;
 
     // These dependencies SHOULD exist:
     #[rustc_then_this_would_need(typeck)] //~ ERROR OK
@@ -25,7 +25,7 @@ mod y {
 }
 
 mod z {
-    use y;
+    use crate::y;
 
     // These are expected to yield errors, because changes to `x`
     // affect the BODY of `y`, but not its signature.

--- a/tests/ui/dep-graph/dep-graph-struct-signature.rs
+++ b/tests/ui/dep-graph/dep-graph-struct-signature.rs
@@ -23,7 +23,7 @@ struct WontChange {
 
 // these are valid dependencies
 mod signatures {
-    use WillChange;
+    use crate::WillChange;
 
     #[rustc_then_this_would_need(type_of)] //~ ERROR no path
     #[rustc_then_this_would_need(associated_item)] //~ ERROR no path
@@ -70,7 +70,7 @@ mod signatures {
 }
 
 mod invalid_signatures {
-    use WontChange;
+    use crate::WontChange;
 
     #[rustc_then_this_would_need(type_of)] //~ ERROR no path
     trait A {

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits-same-method.rs
@@ -19,7 +19,7 @@ pub trait Bar: Sized {
 }
 
 mod x {
-    use {Foo, Bar};
+    use crate::{Foo, Bar};
 
     #[rustc_if_this_changed]
     impl Foo for u32 { }
@@ -28,7 +28,7 @@ mod x {
 }
 
 mod y {
-    use {Foo, Bar};
+    use crate::{Foo, Bar};
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR OK
     pub fn with_char() {
@@ -37,7 +37,7 @@ mod y {
 }
 
 mod z {
-    use y;
+    use crate::y;
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR no path
     pub fn z() {

--- a/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl-two-traits.rs
@@ -18,7 +18,7 @@ pub trait Bar: Sized {
 }
 
 mod x {
-    use {Foo, Bar};
+    use crate::{Foo, Bar};
 
     #[rustc_if_this_changed]
     impl Foo for char { }
@@ -27,7 +27,7 @@ mod x {
 }
 
 mod y {
-    use {Foo, Bar};
+    use crate::{Foo, Bar};
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR no path
     pub fn call_bar() {
@@ -36,7 +36,7 @@ mod y {
 }
 
 mod z {
-    use y;
+    use crate::y;
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR no path
     pub fn z() {

--- a/tests/ui/dep-graph/dep-graph-trait-impl.rs
+++ b/tests/ui/dep-graph/dep-graph-trait-impl.rs
@@ -14,7 +14,7 @@ pub trait Foo: Sized {
 }
 
 mod x {
-    use Foo;
+    use crate::Foo;
 
     #[rustc_if_this_changed]
     impl Foo for char { }
@@ -23,7 +23,7 @@ mod x {
 }
 
 mod y {
-    use Foo;
+    use crate::Foo;
 
     #[rustc_then_this_would_need(typeck)] //~ ERROR OK
     pub fn with_char() {
@@ -49,7 +49,7 @@ mod y {
 }
 
 mod z {
-    use y;
+    use crate::y;
 
     // These are expected to yield errors, because changes to `x`
     // affect the BODY of `y`, but not its signature.

--- a/tests/ui/derived-errors/issue-31997.rs
+++ b/tests/ui/derived-errors/issue-31997.rs
@@ -11,7 +11,7 @@ fn closure<F, T>(x: F) -> Result<T, ()>
 }
 
 fn foo() -> Result<(), ()> {
-    try!(closure(|| bar(core::ptr::null_mut()))); //~ ERROR cannot find function `bar` in this scope
+    closure(|| bar(core::ptr::null_mut()))?; //~ ERROR cannot find function `bar` in this scope
     Ok(())
 }
 

--- a/tests/ui/derived-errors/issue-31997.stderr
+++ b/tests/ui/derived-errors/issue-31997.stderr
@@ -1,8 +1,8 @@
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/issue-31997.rs:14:21
+  --> $DIR/issue-31997.rs:14:16
    |
-LL |     try!(closure(|| bar(core::ptr::null_mut())));
-   |                     ^^^ not found in this scope
+LL |     closure(|| bar(core::ptr::null_mut()))?;
+   |                ^^^ not found in this scope
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
@@ -163,7 +163,7 @@ pub mod d {
             };
             self.log.borrow_mut().push(self.uid);
             indent_println(self.trail, &format!("+-- Drop {}", self));
-            indent_println(::PREF_INDENT, "");
+            indent_println(super::PREF_INDENT, "");
         }
     }
 }

--- a/tests/ui/drop/issue-23611-enum-swap-in-drop.rs
+++ b/tests/ui/drop/issue-23611-enum-swap-in-drop.rs
@@ -256,7 +256,7 @@ pub mod d {
             };
             self.log.borrow_mut().push(self.uid);
             indent_println(self.trail, &format!("+-- Drop {}", self));
-            indent_println(::PREF_INDENT, "");
+            indent_println(super::PREF_INDENT, "");
         }
     }
 }

--- a/tests/ui/dropck/dropck_trait_cycle_checked.rs
+++ b/tests/ui/dropck/dropck_trait_cycle_checked.rs
@@ -17,7 +17,7 @@ mod s {
 }
 
 mod id {
-    use s;
+    use crate::s;
     #[derive(Debug)]
     pub struct Id {
         orig_count: usize,

--- a/tests/ui/error-codes/E0659.rs
+++ b/tests/ui/error-codes/E0659.rs
@@ -7,8 +7,8 @@ mod earth {
 }
 
 mod collider {
-    pub use moon::*;
-    pub use earth::*;
+    pub use crate::moon::*;
+    pub use crate::earth::*;
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0659.stderr
+++ b/tests/ui/error-codes/E0659.stderr
@@ -8,14 +8,14 @@ LL |     collider::foo();
 note: `foo` could refer to the function imported here
   --> $DIR/E0659.rs:10:13
    |
-LL |     pub use moon::*;
-   |             ^^^^^^^
+LL |     pub use crate::moon::*;
+   |             ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
   --> $DIR/E0659.rs:11:13
    |
-LL |     pub use earth::*;
-   |             ^^^^^^^^
+LL |     pub use crate::earth::*;
+   |             ^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
 error: aborting due to 1 previous error

--- a/tests/ui/explore-issue-38412.stderr
+++ b/tests/ui/explore-issue-38412.stderr
@@ -103,8 +103,8 @@ LL |     r.pub_mod();
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:116:9
    |
-LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
-   |         ---------------------------------- private method defined here
+LL |         pub(in crate::m) fn pub_mod(&self) -> i32 { self.d_priv }
+   |         ----------------------------------------- private method defined here
 
 error[E0624]: method `private` is private
   --> $DIR/explore-issue-38412.rs:50:7
@@ -156,8 +156,8 @@ LL |     t.pub_mod();
    |
   ::: $DIR/auxiliary/pub-and-stability.rs:130:9
    |
-LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
-   |         ---------------------------------- private method defined here
+LL |         pub(in crate::m) fn pub_mod(&self) -> i32 { self.0 }
+   |         ----------------------------------------- private method defined here
 
 error[E0624]: method `private` is private
   --> $DIR/explore-issue-38412.rs:63:7

--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -7,27 +7,27 @@ mod b {
 }
 
 mod c {
-    pub use a::foo;
+    pub use crate::a::foo;
 }
 
 mod d {
-    use a::foo;
-    use a::foo; //~ ERROR the name `foo` is defined multiple times
+    use crate::a::foo;
+    use crate::a::foo; //~ ERROR the name `foo` is defined multiple times
 }
 
 mod e {
-    pub use a::*;
-    pub use c::*; // ok
+    pub use crate::a::*;
+    pub use crate::c::*; // ok
 }
 
 mod f {
-    pub use a::*;
-    pub use b::*;
+    pub use crate::a::*;
+    pub use crate::b::*;
 }
 
 mod g {
-    pub use a::*;
-    pub use f::*;
+    pub use crate::a::*;
+    pub use crate::f::*;
 }
 
 fn main() {

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -1,10 +1,10 @@
 error[E0252]: the name `foo` is defined multiple times
   --> $DIR/duplicate.rs:15:9
    |
-LL |     use a::foo;
-   |         ------ previous import of the value `foo` here
-LL |     use a::foo;
-   |         ^^^^^^ `foo` reimported here
+LL |     use crate::a::foo;
+   |         ------------- previous import of the value `foo` here
+LL |     use crate::a::foo;
+   |         ^^^^^^^^^^^^^ `foo` reimported here
    |
    = note: `foo` must be defined only once in the value namespace of this module
 
@@ -38,14 +38,14 @@ LL |     f::foo();
 note: `foo` could refer to the function imported here
   --> $DIR/duplicate.rs:24:13
    |
-LL |     pub use a::*;
-   |             ^^^^
+LL |     pub use crate::a::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
   --> $DIR/duplicate.rs:25:13
    |
-LL |     pub use b::*;
-   |             ^^^^
+LL |     pub use crate::b::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
 error[E0659]: `foo` is ambiguous
@@ -80,14 +80,14 @@ LL |     g::foo();
 note: `foo` could refer to the function imported here
   --> $DIR/duplicate.rs:24:13
    |
-LL |     pub use a::*;
-   |             ^^^^
+LL |     pub use crate::a::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
   --> $DIR/duplicate.rs:25:13
    |
-LL |     pub use b::*;
-   |             ^^^^
+LL |     pub use crate::b::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
    = note: `#[warn(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/export-glob-imports-target.rs
+++ b/tests/ui/imports/export-glob-imports-target.rs
@@ -9,7 +9,7 @@
 
 
 mod foo {
-    use foo::bar::*;
+    use crate::foo::bar::*;
     pub mod bar {
         pub static a : isize = 10;
     }

--- a/tests/ui/imports/glob-cycles.rs
+++ b/tests/ui/imports/glob-cycles.rs
@@ -1,12 +1,12 @@
 //@ check-pass
 
 mod foo {
-    pub use bar::*;
-    pub use main as f;
+    pub use crate::bar::*;
+    pub use crate::main as f;
 }
 
 mod bar {
-    pub use foo::*;
+    pub use crate::foo::*;
 }
 
 pub use foo::*;

--- a/tests/ui/imports/glob-shadowing.rs
+++ b/tests/ui/imports/glob-shadowing.rs
@@ -6,7 +6,7 @@ mod m {
 }
 
 mod glob_in_normal_module {
-    use m::*;
+    use crate::m::*;
     fn check() {
         let x = env!("PATH"); //~ ERROR `env` is ambiguous
     }
@@ -14,7 +14,7 @@ mod glob_in_normal_module {
 
 mod glob_in_block_module {
     fn block() {
-        use m::*;
+        use crate::m::*;
         fn check() {
             let x = env!("PATH"); //~ ERROR `env` is ambiguous
         }
@@ -24,7 +24,7 @@ mod glob_in_block_module {
 mod glob_shadows_item {
     pub macro fenv($e: expr) { $e }
     fn block() {
-        use m::*;
+        use crate::m::*;
         fn check() {
             let x = fenv!(); //~ ERROR `fenv` is ambiguous
         }

--- a/tests/ui/imports/glob-shadowing.stderr
+++ b/tests/ui/imports/glob-shadowing.stderr
@@ -9,8 +9,8 @@ LL |         let x = env!("PATH");
 note: `env` could also refer to the macro imported here
   --> $DIR/glob-shadowing.rs:9:9
    |
-LL |     use m::*;
-   |         ^^^^
+LL |     use crate::m::*;
+   |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `env` to disambiguate
    = help: or use `self::env` to refer to this macro unambiguously
 
@@ -25,8 +25,8 @@ LL |             let x = env!("PATH");
 note: `env` could also refer to the macro imported here
   --> $DIR/glob-shadowing.rs:17:13
    |
-LL |         use m::*;
-   |             ^^^^
+LL |         use crate::m::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `env` to disambiguate
 
 error[E0659]: `fenv` is ambiguous
@@ -39,8 +39,8 @@ LL |             let x = fenv!();
 note: `fenv` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:27:13
    |
-LL |         use m::*;
-   |             ^^^^
+LL |         use crate::m::*;
+   |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `fenv` to disambiguate
 note: `fenv` could also refer to the macro defined here
   --> $DIR/glob-shadowing.rs:25:5

--- a/tests/ui/imports/import-glob-1.rs
+++ b/tests/ui/imports/import-glob-1.rs
@@ -21,7 +21,7 @@ mod bar {
 }
 
 mod foo {
-    use bar::Baz::{Baz1, Baz2};
+    use crate::bar::Baz::{Baz1, Baz2};
 }
 
 fn main() {}

--- a/tests/ui/imports/import-glob-circular.rs
+++ b/tests/ui/imports/import-glob-circular.rs
@@ -1,17 +1,17 @@
 mod circ1 {
-    pub use circ2::f2;
+    pub use crate::circ2::f2;
     pub fn f1() { println!("f1"); }
     pub fn common() -> usize { return 0; }
 }
 
 mod circ2 {
-    pub use circ1::f1;
+    pub use crate::circ1::f1;
     pub fn f2() { println!("f2"); }
     pub fn common() -> usize { return 1; }
 }
 
 mod test {
-    use circ1::*;
+    use crate::circ1::*;
 
     fn test() { f1066(); } //~ ERROR cannot find function `f1066` in this scope
 }

--- a/tests/ui/imports/import-loop-2.rs
+++ b/tests/ui/imports/import-loop-2.rs
@@ -1,9 +1,9 @@
 mod a {
-    pub use b::x;
+    pub use crate::b::x;
 }
 
 mod b {
-    pub use a::x; //~ ERROR unresolved import `a::x`
+    pub use crate::a::x; //~ ERROR unresolved import `crate::a::x`
 
     fn main() { let y = x; }
 }

--- a/tests/ui/imports/import-loop-2.stderr
+++ b/tests/ui/imports/import-loop-2.stderr
@@ -1,8 +1,8 @@
-error[E0432]: unresolved import `a::x`
+error[E0432]: unresolved import `crate::a::x`
   --> $DIR/import-loop-2.rs:6:13
    |
-LL |     pub use a::x;
-   |             ^^^^ no `x` in `a`
+LL |     pub use crate::a::x;
+   |             ^^^^^^^^^^^ no `x` in `a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-loop.rs
+++ b/tests/ui/imports/import-loop.rs
@@ -1,7 +1,7 @@
 use y::x;
 
 mod y {
-    pub use y::x; //~ ERROR unresolved import `y::x`
+    pub use crate::y::x; //~ ERROR unresolved import `crate::y::x`
 }
 
 fn main() { }

--- a/tests/ui/imports/import-loop.stderr
+++ b/tests/ui/imports/import-loop.stderr
@@ -1,8 +1,8 @@
-error[E0432]: unresolved import `y::x`
+error[E0432]: unresolved import `crate::y::x`
   --> $DIR/import-loop.rs:4:13
    |
-LL |     pub use y::x;
-   |             ^^^^ no `x` in `y`
+LL |     pub use crate::y::x;
+   |             ^^^^^^^^^^^ no `x` in `y`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-rpass.rs
+++ b/tests/ui/imports/import-rpass.rs
@@ -4,8 +4,8 @@ mod foo {
 }
 
 mod bar {
-    use foo::x;
-    use foo::x as z;
+    use crate::foo::x;
+    use crate::foo::x as z;
     pub fn thing() { x(10); z(10); }
 }
 

--- a/tests/ui/imports/import4.rs
+++ b/tests/ui/imports/import4.rs
@@ -1,4 +1,4 @@
-mod a { pub use b::foo; }
-mod b { pub use a::foo; } //~ ERROR unresolved import `a::foo`
+mod a { pub use crate::b::foo; }
+mod b { pub use crate::a::foo; } //~ ERROR unresolved import `crate::a::foo`
 
 fn main() { println!("loop"); }

--- a/tests/ui/imports/import4.stderr
+++ b/tests/ui/imports/import4.stderr
@@ -1,8 +1,8 @@
-error[E0432]: unresolved import `a::foo`
+error[E0432]: unresolved import `crate::a::foo`
   --> $DIR/import4.rs:2:17
    |
-LL | mod b { pub use a::foo; }
-   |                 ^^^^^^ no `foo` in `a`
+LL | mod b { pub use crate::a::foo; }
+   |                 ^^^^^^^^^^^^^ no `foo` in `a`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import5.rs
+++ b/tests/ui/imports/import5.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 use foo::bar;
 mod foo {
-    pub use foo::zed::bar;
+    pub use crate::foo::zed::bar;
     pub mod zed {
         pub fn bar() { println!("foo"); }
     }

--- a/tests/ui/imports/import6.rs
+++ b/tests/ui/imports/import6.rs
@@ -10,6 +10,6 @@ mod foo {
     }
 }
 mod bar {
-    pub use foo::zed::baz;
+    pub use crate::foo::zed::baz;
 }
 pub fn main() { baz(); }

--- a/tests/ui/imports/imports.rs
+++ b/tests/ui/imports/imports.rs
@@ -3,7 +3,7 @@
 
 // Like other items, private imports can be imported and used non-lexically in paths.
 mod a {
-    use a as foo;
+    use crate::a as foo;
     use self::foo::foo as bar;
 
     mod b {
@@ -18,22 +18,22 @@ pub fn f() -> bool { true }
 
 // Items and explicit imports shadow globs.
 fn g() {
-    use foo::*;
-    use bar::*;
+    use crate::foo::*;
+    use crate::bar::*;
     fn f() -> bool { true }
     let _: bool = f();
 }
 
 fn h() {
-    use foo::*;
-    use bar::*;
-    use f;
+    use crate::foo::*;
+    use crate::bar::*;
+    use crate::f;
     let _: bool = f();
 }
 
 // Here, there appears to be shadowing but isn't because of namespaces.
 mod b {
-    use foo::*; // This imports `f` in the value namespace.
+    use crate::foo::*; // This imports `f` in the value namespace.
     use super::b as f; // This imports `f` only in the type namespace,
     fn test() { self::f(); } // so the glob isn't shadowed.
 }
@@ -55,12 +55,13 @@ mod c {
 
 // Unused names can be ambiguous.
 mod d {
-    pub use foo::*; // This imports `f` in the value namespace.
-    pub use bar::*; // This also imports `f` in the value namespace.
+    pub use crate::foo::*; // This imports `f` in the value namespace.
+    pub use crate::bar::*; // This also imports `f` in the value namespace.
 }
 
 mod e {
-    pub use d::*; // n.b. Since `e::f` is not used, this is not considered to be a use of `d::f`.
+    pub use crate::d::*; // n.b. Since `e::f` is not used,
+                         // this is not considered to be a use of `d::f`.
 }
 
 fn main() {}

--- a/tests/ui/imports/issue-18083.rs
+++ b/tests/ui/imports/issue-18083.rs
@@ -5,7 +5,7 @@
 // each other and be reported as unresolved.
 
 mod a {
-    use b::{B};
+    use crate::b::{B};
     pub use self::inner::A;
 
     mod inner {
@@ -14,7 +14,7 @@ mod a {
 }
 
 mod b {
-    use a::{A};
+    use crate::a::{A};
     pub use self::inner::B;
 
     mod inner {

--- a/tests/ui/imports/issue-19498.rs
+++ b/tests/ui/imports/issue-19498.rs
@@ -7,7 +7,7 @@ mod A {} //~ ERROR the name `A` is defined multiple times
 pub mod B {} //~ ERROR the name `B` is defined multiple times
 //~| NOTE `B` redefined here
 mod C {
-    use C::D;
+    use crate::C::D;
     mod D {} //~ ERROR the name `D` is defined multiple times
     //~| NOTE `D` redefined here
 }

--- a/tests/ui/imports/issue-19498.stderr
+++ b/tests/ui/imports/issue-19498.stderr
@@ -31,16 +31,16 @@ LL | use self::B as OtherB;
 error[E0255]: the name `D` is defined multiple times
   --> $DIR/issue-19498.rs:11:5
    |
-LL |     use C::D;
-   |         ---- previous import of the module `D` here
+LL |     use crate::C::D;
+   |         ----------- previous import of the module `D` here
 LL |     mod D {}
    |     ^^^^^ `D` redefined here
    |
    = note: `D` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL |     use C::D as OtherD;
-   |              +++++++++
+LL |     use crate::C::D as OtherD;
+   |                     +++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/imports/issue-32222.rs
+++ b/tests/ui/imports/issue-32222.rs
@@ -16,7 +16,7 @@ mod a {
 }
 
 mod b {
-    pub use a::bar;
+    pub use crate::a::bar;
 }
 
 fn main() {}

--- a/tests/ui/imports/issue-4366-2.rs
+++ b/tests/ui/imports/issue-4366-2.rs
@@ -7,11 +7,11 @@ mod foo {
 }
 mod a {
     pub mod b {
-        use foo::foo;
+        use crate::foo::foo;
         type Bar = isize;
     }
     pub mod sub {
-        use a::b::*;
+        use crate::a::b::*;
         fn sub() -> Bar { 1 }
         //~^ ERROR cannot find type `Bar` in this scope
     }

--- a/tests/ui/imports/issue-4366.rs
+++ b/tests/ui/imports/issue-4366.rs
@@ -10,11 +10,11 @@ mod foo {
 }
 mod a {
     pub mod b {
-        use foo::foo;
+        use crate::foo::foo;
         type Bar = isize;
     }
     pub mod sub {
-        use a::b::*;
+        use crate::a::b::*;
         fn sub() -> isize { foo(); 1 } //~ ERROR cannot find function `foo` in this scope
     }
 }

--- a/tests/ui/imports/issue-4865-1.rs
+++ b/tests/ui/imports/issue-4865-1.rs
@@ -6,16 +6,16 @@
 // because these previous imports were not resolved.
 
 pub mod a {
-    use b::fn_b;
-    use c::*;
+    use crate::b::fn_b;
+    use crate::c::*;
 
     pub fn fn_a(){
     }
 }
 
 pub mod b {
-    use a::fn_a;
-    use c::*;
+    use crate::a::fn_a;
+    use crate::c::*;
 
     pub fn fn_b(){
     }

--- a/tests/ui/imports/issue-4865-2.rs
+++ b/tests/ui/imports/issue-4865-2.rs
@@ -12,7 +12,7 @@ pub mod say {
 }
 
 pub mod hello {
-    use say;
+    use crate::say;
 
     pub fn hello() {
         say::hello();

--- a/tests/ui/imports/issue-4865-3.rs
+++ b/tests/ui/imports/issue-4865-3.rs
@@ -4,11 +4,11 @@
 // they are not `pub`.
 
 pub mod a {
-    use b::*;
+    use crate::b::*;
 }
 
 pub mod b {
-    use a::*;
+    use crate::a::*;
 }
 
 use a::*;

--- a/tests/ui/imports/issue-8208.rs
+++ b/tests/ui/imports/issue-8208.rs
@@ -2,7 +2,7 @@ use self::*; //~ ERROR: unresolved import `self::*` [E0432]
              //~^ NOTE cannot glob-import a module into itself
 
 mod foo {
-    use foo::*; //~ ERROR: unresolved import `foo::*` [E0432]
+    use crate::foo::*; //~ ERROR: unresolved import `crate::foo::*` [E0432]
                 //~^ NOTE cannot glob-import a module into itself
 
     mod bar {

--- a/tests/ui/imports/issue-8208.stderr
+++ b/tests/ui/imports/issue-8208.stderr
@@ -4,11 +4,11 @@ error[E0432]: unresolved import `self::*`
 LL | use self::*;
    |     ^^^^^^^ cannot glob-import a module into itself
 
-error[E0432]: unresolved import `foo::*`
+error[E0432]: unresolved import `crate::foo::*`
   --> $DIR/issue-8208.rs:5:9
    |
-LL |     use foo::*;
-   |         ^^^^^^ cannot glob-import a module into itself
+LL |     use crate::foo::*;
+   |         ^^^^^^^^^^^^^ cannot glob-import a module into itself
 
 error[E0432]: unresolved import `super::bar::*`
   --> $DIR/issue-8208.rs:9:13

--- a/tests/ui/imports/issue-8640.rs
+++ b/tests/ui/imports/issue-8640.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 
 mod foo {
-    use baz::bar;
+    use crate::baz::bar;
     mod bar {}
     //~^ ERROR the name `bar` is defined multiple times
 }

--- a/tests/ui/imports/issue-8640.stderr
+++ b/tests/ui/imports/issue-8640.stderr
@@ -1,16 +1,16 @@
 error[E0255]: the name `bar` is defined multiple times
   --> $DIR/issue-8640.rs:5:5
    |
-LL |     use baz::bar;
-   |         -------- previous import of the module `bar` here
+LL |     use crate::baz::bar;
+   |         --------------- previous import of the module `bar` here
 LL |     mod bar {}
    |     ^^^^^^^ `bar` redefined here
    |
    = note: `bar` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL |     use baz::bar as other_bar;
-   |                  ++++++++++++
+LL |     use crate::baz::bar as other_bar;
+   |                         ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/local-modularized-tricky-fail-2.rs
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.rs
@@ -10,13 +10,13 @@ macro_rules! define_exported { () => {
 define_exported!();
 
 mod m {
-    use exported;
+    use crate::exported;
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
     //~| WARN this was previously accepted
 }
 
 fn main() {
-    ::exported!();
+    crate::exported!();
     //~^ ERROR macro-expanded `macro_export` macros from the current crate cannot
     //~| WARN this was previously accepted
 }

--- a/tests/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -1,8 +1,8 @@
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
   --> $DIR/local-modularized-tricky-fail-2.rs:13:9
    |
-LL |     use exported;
-   |         ^^^^^^^^
+LL |     use crate::exported;
+   |         ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
@@ -22,8 +22,8 @@ LL |   define_exported!();
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
   --> $DIR/local-modularized-tricky-fail-2.rs:19:5
    |
-LL |     ::exported!();
-   |     ^^^^^^^^^^
+LL |     crate::exported!();
+   |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>

--- a/tests/ui/imports/macros.rs
+++ b/tests/ui/imports/macros.rs
@@ -8,13 +8,13 @@ mod foo {
 
 mod m1 {
     m!(use two_macros::*;);
-    use foo::m; // This shadows the glob import
+    use crate::foo::m; // This shadows the glob import
 }
 
 mod m2 {
     use two_macros::*;
     m! { //~ ERROR ambiguous
-        use foo::m;
+        use crate::foo::m;
     }
 }
 

--- a/tests/ui/imports/macros.stderr
+++ b/tests/ui/imports/macros.stderr
@@ -8,8 +8,8 @@ LL |     m! {
 note: `m` could refer to the macro imported here
   --> $DIR/macros.rs:17:13
    |
-LL |         use foo::m;
-   |             ^^^^^^
+LL |         use crate::foo::m;
+   |             ^^^^^^^^^^^^^
 note: `m` could also refer to the macro imported here
   --> $DIR/macros.rs:15:9
    |

--- a/tests/ui/imports/reexport-star.rs
+++ b/tests/ui/imports/reexport-star.rs
@@ -6,7 +6,7 @@ mod a {
 }
 
 mod b {
-    pub use a::*;
+    pub use crate::a::*;
 }
 
 pub fn main() {

--- a/tests/ui/imports/reexports.rs
+++ b/tests/ui/imports/reexports.rs
@@ -33,8 +33,8 @@ mod b {
 
 mod c {
     // Test that `foo` is not re-exported.
-    use b::a::foo::S; //~ ERROR `foo`
-    use b::b::foo::S as T; //~ ERROR `foo`
+    use crate::b::a::foo::S; //~ ERROR `foo`
+    use crate::b::b::foo::S as T; //~ ERROR `foo`
 }
 
 fn main() {}

--- a/tests/ui/imports/reexports.stderr
+++ b/tests/ui/imports/reexports.stderr
@@ -11,10 +11,10 @@ LL |         pub use super::foo;
    |                 ^^^^^^^^^^
 
 error[E0603]: module import `foo` is private
-  --> $DIR/reexports.rs:36:15
+  --> $DIR/reexports.rs:36:22
    |
-LL |     use b::a::foo::S;
-   |               ^^^ private module import
+LL |     use crate::b::a::foo::S;
+   |                      ^^^ private module import
    |
 note: the module import `foo` is defined here...
   --> $DIR/reexports.rs:24:17
@@ -28,10 +28,10 @@ LL |     mod foo {
    |     ^^^^^^^
 
 error[E0603]: module import `foo` is private
-  --> $DIR/reexports.rs:37:15
+  --> $DIR/reexports.rs:37:22
    |
-LL |     use b::b::foo::S as T;
-   |               ^^^ private module import
+LL |     use crate::b::b::foo::S as T;
+   |                      ^^^ private module import
    |
 note: the module import `foo` is defined here...
   --> $DIR/reexports.rs:29:17

--- a/tests/ui/imports/shadow_builtin_macros.rs
+++ b/tests/ui/imports/shadow_builtin_macros.rs
@@ -6,17 +6,17 @@ mod foo {
 }
 
 mod m1 {
-    use foo::panic; // ok
+    use crate::foo::panic; // ok
     fn f() { panic!(); }
 }
 
 mod m2 {
-    use foo::*;
+    use crate::foo::*;
     fn f() { panic!(); } //~ ERROR ambiguous
 }
 
 mod m3 {
-    ::two_macros::m!(use foo::panic;);
+    ::two_macros::m!(use crate::foo::panic;);
     fn f() { panic!(); } //~ ERROR ambiguous
 }
 
@@ -40,12 +40,12 @@ mod bar {
 }
 
 mod m6 {
-    use bar::n; // ok
+    use crate::bar::n; // ok
     n!();
 }
 
 mod m7 {
-    use bar::*;
+    use crate::bar::*;
     n!(); //~ ERROR ambiguous
 }
 

--- a/tests/ui/imports/shadow_builtin_macros.stderr
+++ b/tests/ui/imports/shadow_builtin_macros.stderr
@@ -9,8 +9,8 @@ LL |     fn f() { panic!(); }
 note: `panic` could also refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:14:9
    |
-LL |     use foo::*;
-   |         ^^^^^^
+LL |     use crate::foo::*;
+   |         ^^^^^^^^^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
    = help: or use `self::panic` to refer to this macro unambiguously
 
@@ -42,8 +42,8 @@ LL |     n!();
 note: `n` could refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:48:9
    |
-LL |     use bar::*;
-   |         ^^^^^^
+LL |     use crate::bar::*;
+   |         ^^^^^^^^^^^^^
    = help: consider adding an explicit import of `n` to disambiguate
    = help: or use `self::n` to refer to this macro unambiguously
 note: `n` could also refer to the macro imported here
@@ -63,8 +63,8 @@ LL |     fn f() { panic!(); }
 note: `panic` could also refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:19:26
    |
-LL |     ::two_macros::m!(use foo::panic;);
-   |                          ^^^^^^^^^^
+LL |     ::two_macros::m!(use crate::foo::panic;);
+   |                          ^^^^^^^^^^^^^^^^^
    = help: use `self::panic` to refer to this macro unambiguously
 
 error: aborting due to 4 previous errors

--- a/tests/ui/intrinsics/intrinsic-alignment.rs
+++ b/tests/ui/intrinsics/intrinsic-alignment.rs
@@ -24,16 +24,16 @@ mod m {
     #[cfg(target_arch = "x86")]
     pub fn main() {
         unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 4);
+            assert_eq!(crate::rusti::pref_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::min_align_of::<u64>(), 4);
         }
     }
 
     #[cfg(not(target_arch = "x86"))]
     pub fn main() {
         unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::pref_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::min_align_of::<u64>(), 8);
         }
     }
 }
@@ -43,8 +43,8 @@ mod m {
     #[cfg(target_arch = "x86_64")]
     pub fn main() {
         unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::pref_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::min_align_of::<u64>(), 8);
         }
     }
 }
@@ -53,8 +53,8 @@ mod m {
 mod m {
     pub fn main() {
         unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::pref_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::min_align_of::<u64>(), 8);
         }
     }
 }
@@ -63,8 +63,8 @@ mod m {
 mod m {
     pub fn main() {
         unsafe {
-            assert_eq!(::rusti::pref_align_of::<u64>(), 8);
-            assert_eq!(::rusti::min_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::pref_align_of::<u64>(), 8);
+            assert_eq!(crate::rusti::min_align_of::<u64>(), 8);
         }
     }
 }


### PR DESCRIPTION


This allows for testing these tests on editions other than 2015

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
