### PR TITLE
Add missing `dyn` keywords to tests that do not test for them

### DIFF
--- a/tests/ui/allocator/auxiliary/helper.rs
+++ b/tests/ui/allocator/auxiliary/helper.rs
@@ -6,6 +6,6 @@
 extern crate alloc;
 use alloc::fmt;
 
-pub fn work_with(p: &fmt::Debug) {
+pub fn work_with(p: &dyn fmt::Debug) {
     drop(p);
 }

--- a/tests/ui/coercion/retslot-cast.rs
+++ b/tests/ui/coercion/retslot-cast.rs
@@ -1,7 +1,7 @@
 #![allow(warnings)]
 
-pub fn fail(x: Option<&(Iterator<Item=()>+Send)>)
-            -> Option<&Iterator<Item=()>> {
+pub fn fail(x: Option<&(dyn Iterator<Item=()>+Send)>)
+            -> Option<&dyn Iterator<Item=()>> {
     // This call used to trigger an LLVM assertion because the return
     // slot had type "Option<&Iterator>"* instead of
     // "Option<&(Iterator+Send)>"* -- but this now yields a
@@ -13,8 +13,8 @@ pub fn fail(x: Option<&(Iterator<Item=()>+Send)>)
     inner(x) //~ ERROR mismatched types
 }
 
-pub fn inner(x: Option<&(Iterator<Item=()>+Send)>)
-             -> Option<&(Iterator<Item=()>+Send)> {
+pub fn inner(x: Option<&(dyn Iterator<Item=()>+Send)>)
+             -> Option<&(dyn Iterator<Item=()>+Send)> {
     x
 }
 

--- a/tests/ui/coercion/retslot-cast.stderr
+++ b/tests/ui/coercion/retslot-cast.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
   --> $DIR/retslot-cast.rs:13:5
    |
-LL |             -> Option<&Iterator<Item=()>> {
-   |                -------------------------- expected `Option<&dyn Iterator<Item = ()>>` because of return type
+LL |             -> Option<&dyn Iterator<Item=()>> {
+   |                ------------------------------ expected `Option<&dyn Iterator<Item = ()>>` because of return type
 ...
 LL |     inner(x)
    |     ^^^^^^^^ expected trait `Iterator<Item = ()>`, found trait `Iterator<Item = ()> + Send`

--- a/tests/ui/coroutine/auxiliary/xcrate.rs
+++ b/tests/ui/coroutine/auxiliary/xcrate.rs
@@ -12,7 +12,7 @@ pub fn foo() -> impl Coroutine<(), Yield = (), Return = ()> {
     }
 }
 
-pub fn bar<T: 'static>(t: T) -> Box<Coroutine<(), Yield = T, Return = ()> + Unpin> {
+pub fn bar<T: 'static>(t: T) -> Box<dyn Coroutine<(), Yield = T, Return = ()> + Unpin> {
     Box::new(
         #[coroutine]
         || {

--- a/tests/ui/deprecation/deprecation-lint.rs
+++ b/tests/ui/deprecation/deprecation-lint.rs
@@ -71,7 +71,7 @@ mod cross_crate {
         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
     }
 
-    fn test_method_object(foo: &Trait) {
+    fn test_method_object(foo: &dyn Trait) {
         foo.trait_deprecated(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated`
         foo.trait_deprecated_text(); //~ ERROR use of deprecated method `deprecation_lint::Trait::trait_deprecated_text`: text
     }
@@ -299,7 +299,7 @@ mod this_crate {
         <Foo as Trait>::trait_deprecated_text(&foo); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
     }
 
-    fn test_method_object(foo: &Trait) {
+    fn test_method_object(foo: &dyn Trait) {
         foo.trait_deprecated(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated`
         foo.trait_deprecated_text(); //~ ERROR use of deprecated method `this_crate::Trait::trait_deprecated_text`: text
     }

--- a/tests/ui/dyn-drop/dyn-drop.rs
+++ b/tests/ui/dyn-drop/dyn-drop.rs
@@ -1,8 +1,7 @@
 #![deny(dyn_drop)]
-#![allow(bare_trait_objects)]
 fn foo(_: Box<dyn Drop>) {} //~ ERROR
 fn bar(_: &dyn Drop) {} //~ERROR
-fn baz(_: *mut Drop) {} //~ ERROR
+fn baz(_: *mut dyn Drop) {} //~ ERROR
 struct Foo {
   _x: Box<dyn Drop> //~ ERROR
 }

--- a/tests/ui/dyn-drop/dyn-drop.stderr
+++ b/tests/ui/dyn-drop/dyn-drop.stderr
@@ -1,5 +1,5 @@
 error: types that do not implement `Drop` can still have drop glue, consider instead using `std::mem::needs_drop` to detect whether a type is trivially dropped
-  --> $DIR/dyn-drop.rs:3:19
+  --> $DIR/dyn-drop.rs:2:19
    |
 LL | fn foo(_: Box<dyn Drop>) {}
    |                   ^^^^
@@ -11,25 +11,25 @@ LL | #![deny(dyn_drop)]
    |         ^^^^^^^^
 
 error: types that do not implement `Drop` can still have drop glue, consider instead using `std::mem::needs_drop` to detect whether a type is trivially dropped
-  --> $DIR/dyn-drop.rs:4:16
+  --> $DIR/dyn-drop.rs:3:16
    |
 LL | fn bar(_: &dyn Drop) {}
    |                ^^^^
 
 error: types that do not implement `Drop` can still have drop glue, consider instead using `std::mem::needs_drop` to detect whether a type is trivially dropped
-  --> $DIR/dyn-drop.rs:5:16
+  --> $DIR/dyn-drop.rs:4:20
    |
-LL | fn baz(_: *mut Drop) {}
-   |                ^^^^
+LL | fn baz(_: *mut dyn Drop) {}
+   |                    ^^^^
 
 error: types that do not implement `Drop` can still have drop glue, consider instead using `std::mem::needs_drop` to detect whether a type is trivially dropped
-  --> $DIR/dyn-drop.rs:7:15
+  --> $DIR/dyn-drop.rs:6:15
    |
 LL |   _x: Box<dyn Drop>
    |               ^^^^
 
 error: types that do not implement `Drop` can still have drop glue, consider instead using `std::mem::needs_drop` to detect whether a type is trivially dropped
-  --> $DIR/dyn-drop.rs:14:16
+  --> $DIR/dyn-drop.rs:13:16
    |
 LL |   type T = dyn Drop;
    |                ^^^^

--- a/tests/ui/error-codes/E0657.rs
+++ b/tests/ui/error-codes/E0657.rs
@@ -7,7 +7,7 @@ impl<'a> Lt<'a> for () {}
 impl<T> Id<T> for T {}
 
 fn free_fn_capture_hrtb_in_impl_trait()
-    -> Box<for<'a> Id<impl Lt<'a>>>
+    -> Box<dyn for<'a> Id<impl Lt<'a>>>
         //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
 {
     Box::new(())
@@ -16,7 +16,7 @@ fn free_fn_capture_hrtb_in_impl_trait()
 struct Foo;
 impl Foo {
     fn impl_fn_capture_hrtb_in_impl_trait()
-        -> Box<for<'a> Id<impl Lt<'a>>>
+        -> Box<dyn for<'a> Id<impl Lt<'a>>>
             //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
     {
         Box::new(())

--- a/tests/ui/error-codes/E0657.stderr
+++ b/tests/ui/error-codes/E0657.stderr
@@ -1,26 +1,26 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
-  --> $DIR/E0657.rs:10:31
+  --> $DIR/E0657.rs:10:35
    |
-LL |     -> Box<for<'a> Id<impl Lt<'a>>>
-   |                               ^^
-   |
-note: lifetime declared here
-  --> $DIR/E0657.rs:10:16
-   |
-LL |     -> Box<for<'a> Id<impl Lt<'a>>>
-   |                ^^
-
-error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
-  --> $DIR/E0657.rs:19:35
-   |
-LL |         -> Box<for<'a> Id<impl Lt<'a>>>
+LL |     -> Box<dyn for<'a> Id<impl Lt<'a>>>
    |                                   ^^
    |
 note: lifetime declared here
-  --> $DIR/E0657.rs:19:20
+  --> $DIR/E0657.rs:10:20
    |
-LL |         -> Box<for<'a> Id<impl Lt<'a>>>
+LL |     -> Box<dyn for<'a> Id<impl Lt<'a>>>
    |                    ^^
+
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
+  --> $DIR/E0657.rs:19:39
+   |
+LL |         -> Box<dyn for<'a> Id<impl Lt<'a>>>
+   |                                       ^^
+   |
+note: lifetime declared here
+  --> $DIR/E0657.rs:19:24
+   |
+LL |         -> Box<dyn for<'a> Id<impl Lt<'a>>>
+   |                        ^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/intrinsics/non-integer-atomic.rs
+++ b/tests/ui/intrinsics/non-integer-atomic.rs
@@ -8,7 +8,7 @@ use std::intrinsics::{self, AtomicOrdering};
 
 #[derive(Copy, Clone)]
 pub struct Foo(i64);
-pub type Bar = &'static Fn();
+pub type Bar = &'static dyn Fn();
 pub type Quux = [u8; 100];
 
 pub unsafe fn test_bool_load(p: &mut bool, v: bool) {


### PR DESCRIPTION
This ensures that these tests can be run on editions other than 2015

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
