### PR TITLE
Fix borrowck mentioning a name from an external macro we (deliberately) don't save

### DIFF
--- a/tests/ui/macros/auxiliary/borrowck-error-in-macro.rs
+++ b/tests/ui/macros/auxiliary/borrowck-error-in-macro.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! ice {
+    () => {
+        fn main() {
+            let d = &mut 0;
+            let c = || *d += 1;
+            c();
+        }
+    };
+}

--- a/tests/ui/macros/borrowck-error-in-macro.rs
+++ b/tests/ui/macros/borrowck-error-in-macro.rs
@@ -1,0 +1,5 @@
+//@ aux-build: borrowck-error-in-macro.rs
+
+extern crate borrowck_error_in_macro as a;
+
+a::ice! {}

--- a/tests/ui/macros/borrowck-error-in-macro.rs
+++ b/tests/ui/macros/borrowck-error-in-macro.rs
@@ -1,5 +1,6 @@
 //@ aux-build: borrowck-error-in-macro.rs
 //@ error-pattern: a call in this macro requires a mutable binding due to mutable borrow of `d`
+//FIXME: remove error-pattern (see #141896)
 
 extern crate borrowck_error_in_macro as a;
 

--- a/tests/ui/macros/borrowck-error-in-macro.rs
+++ b/tests/ui/macros/borrowck-error-in-macro.rs
@@ -1,5 +1,7 @@
 //@ aux-build: borrowck-error-in-macro.rs
+//@ error-pattern: a call in this macro requires a mutable binding due to mutable borrow of `d`
 
 extern crate borrowck_error_in_macro as a;
 
 a::ice! {}
+//~^ ERROR cannot borrow value as mutable, as it is not declared as mutable

--- a/tests/ui/macros/borrowck-error-in-macro.stderr
+++ b/tests/ui/macros/borrowck-error-in-macro.stderr
@@ -1,0 +1,19 @@
+error[E0596]: cannot borrow value as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-error-in-macro.rs:6:1
+   |
+LL | a::ice! {}
+   | ^^^^^^^^^^
+   | |
+   | cannot borrow as mutable
+   | a call in this macro requires a mutable binding due to mutable borrow of `d`
+   |
+   = note: this error originates in the macro `a::ice` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider changing this to be mutable
+  --> $DIR/auxiliary/borrowck-error-in-macro.rs:6:17
+   |
+LL |             let mut c = || *d += 1;
+   |                 +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/macros/borrowck-error-in-macro.stderr
+++ b/tests/ui/macros/borrowck-error-in-macro.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow value as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-error-in-macro.rs:6:1
+  --> $DIR/borrowck-error-in-macro.rs:7:1
    |
 LL | a::ice! {}
    | ^^^^^^^^^^


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Most of the info is already in the title :shrug: 

Closes rust-lang/rust#141764 
