### PR TITLE
Fix false positive lint error from no_implicit_prelude attr

### DIFF
--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -193,6 +193,16 @@ impl<'a, 'ra, 'tcx> UnusedImportCheckVisitor<'a, 'ra, 'tcx> {
                 continue;
             }
 
+            let module = self
+                .r
+                .get_nearest_non_block_module(self.r.local_def_id(extern_crate.id).to_def_id());
+            if module.no_implicit_prelude {
+                // If the module has `no_implicit_prelude`, then we don't suggest
+                // replacing the extern crate with a use, as it would not be
+                // inserted into the prelude. User writes `extern` style deliberately.
+                continue;
+            }
+
             let vis_span = extern_crate
                 .vis_span
                 .find_ancestor_inside(extern_crate.span)

--- a/tests/ui/resolve/extern-crate-lint-issue-141785.rs
+++ b/tests/ui/resolve/extern-crate-lint-issue-141785.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ edition:2018
+
+#![no_implicit_prelude]
+#![warn(unused_extern_crates)]
+
+extern crate std;
+fn main() {
+    let r = 1u16..10;
+    std::println!("{:?}", r.is_empty());
+}


### PR DESCRIPTION
Fixes rust-lang/rust#141785

r? @petrochenkov 