### PR TITLE
Fix citool tests when executed locally

### DIFF
--- a/src/ci/citool/tests/jobs.rs
+++ b/src/ci/citool/tests/jobs.rs
@@ -51,6 +51,8 @@ fn get_matrix(event_name: &str, commit_msg: &str, branch_ref: &str) -> String {
         .env("GITHUB_EVENT_NAME", event_name)
         .env("COMMIT_MESSAGE", commit_msg)
         .env("GITHUB_REF", branch_ref)
+        .env("GITHUB_RUN_ID", "123")
+        .env("GITHUB_RUN_ATTEMPT", "1")
         .stdout(Stdio::piped())
         .output()
         .expect("Failed to execute command");


### PR DESCRIPTION
They couldn't be executed locally before due to some additional environment reads.

I also investigated the annoying rebuilds that we see on CI all the time, and they are caused by `ring`'s build script. It should be fixed in the next ring release (https://github.com/briansmith/ring/issues/2525), so we can just wait for that and then update `ring`. 

r? @marcoieni
