### PR TITLE
test-float-parse: apply `cfg(not(bootstrap))`

### DIFF
--- a/src/etc/test-float-parse/src/lib.rs
+++ b/src/etc/test-float-parse/src/lib.rs
@@ -119,6 +119,7 @@ pub fn register_tests(cfg: &Config) -> Vec<TestInfo> {
 
     // Register normal generators for all floats.
 
+    #[cfg(not(bootstrap))]
     #[cfg(target_has_reliable_f16)]
     register_float::<f16>(&mut tests, cfg);
     register_float::<f32>(&mut tests, cfg);

--- a/src/etc/test-float-parse/src/traits.rs
+++ b/src/etc/test-float-parse/src/traits.rs
@@ -170,6 +170,7 @@ macro_rules! impl_float {
 
 impl_float!(f32, u32; f64, u64);
 
+#[cfg(not(bootstrap))]
 #[cfg(target_has_reliable_f16)]
 impl_float!(f16, u16);
 


### PR DESCRIPTION
Prior to stage 0 redesign, `test-float-parse` ran against in-tree std but now it runs against beta std. `f16::FromStr` is only present in in-tree std and not yet beta std, so apply `cfg(not(bootstrap))` gating to unbrick `./x check --stage=0`.

Fixes rust-lang/rust#141900.

`./x check --stage=0` in CI is intended for follow-up.

r? @Mark-Simulacrum (or bootstrap/libs)
cc @tgross35 