### PR TITLE
Fix `create-docs-artifacts.sh` with new bors

### DIFF
--- a/src/ci/scripts/create-doc-artifacts.sh
+++ b/src/ci/scripts/create-doc-artifacts.sh
@@ -15,7 +15,8 @@ fi
 branch=$(git branch --show-current || echo)
 
 if [ -n "$branch" ]; then
-    branch="${branch}-"
+    # Strip automation/bors/ prefix if present
+    branch="${branch#automation/bors/}-"
 fi
 
 if [ "${GITHUB_EVENT_NAME:=none}" = "pull_request" ]; then


### PR DESCRIPTION
The slashes in the branch name (`automation/bors/try`) were causing issues for this script (https://github.com/rust-lang/rust/actions/runs/15391908130/job/43303193243).

r? @marcoieni

try-job: `mingw-check*`