### PR TITLE
bootstrap: Remove `rustc_snapshot_libdir` from PATH in one more place

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1302,10 +1302,8 @@ impl Builder<'_> {
         //
         // Notably this munges the dynamic library lookup path to point to the
         // right location to run `compiler`.
-        let mut lib_paths: Vec<PathBuf> = vec![
-            self.build.rustc_snapshot_libdir(),
-            self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("deps"),
-        ];
+        let mut lib_paths: Vec<PathBuf> =
+            vec![self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("deps")];
 
         // On MSVC a tool may invoke a C compiler (e.g., compiletest in run-make
         // mode) and that C compiler may need some extra PATH modification. Do


### PR DESCRIPTION
Same as https://github.com/rust-lang/rust/pull/141657 but in a different part of the build system, with the same goal of addressing [#t-infra/bootstrap > Build broken in MSYS2 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Build.20broken.20in.20MSYS2/near/520709527).

It seems to work on windows-{gnu,msvc} and linux-gnu at least.

r? jieyouxu