### PR TITLE
Remove bootstrap cfgs from library/

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -32,7 +32,6 @@ optimize_for_size = ["core/optimize_for_size"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bootstrap)',
     'cfg(no_global_oom_handling)',
     'cfg(no_rc)',
     'cfg(no_sync)',

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -66,7 +66,6 @@
 )]
 #![doc(cfg_hide(
     not(test),
-    not(any(test, bootstrap)),
     no_global_oom_handling,
     not(no_global_oom_handling),
     not(no_rc),

--- a/library/alloctests/Cargo.toml
+++ b/library/alloctests/Cargo.toml
@@ -39,7 +39,6 @@ harness = false
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bootstrap)',
     'cfg(no_global_oom_handling)',
     'cfg(no_rc)',
     'cfg(no_sync)',

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -29,7 +29,6 @@ debug_typeid = []
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bootstrap)',
     'cfg(no_fp_fmt_parse)',
     # core use #[path] imports to portable-simd `core_simd` crate
     # and to stdarch `core_arch` crate which messes-up with Cargo list

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -413,38 +413,7 @@ pub unsafe fn atomic_cxchgweak_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: 
 /// [`atomic`] types via the `load` method. For example, [`AtomicBool::load`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-#[cfg(not(bootstrap))]
 pub unsafe fn atomic_load<T: Copy, const ORD: AtomicOrdering>(src: *const T) -> T;
-/// Loads the current value of the pointer.
-/// `T` must be an integer or pointer type.
-///
-/// The stabilized version of this intrinsic is available on the
-/// [`atomic`] types via the `load` method by passing
-/// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::load`].
-#[rustc_intrinsic]
-#[rustc_nounwind]
-#[cfg(bootstrap)]
-pub unsafe fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
-/// Loads the current value of the pointer.
-/// `T` must be an integer or pointer type.
-///
-/// The stabilized version of this intrinsic is available on the
-/// [`atomic`] types via the `load` method by passing
-/// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::load`].
-#[rustc_intrinsic]
-#[rustc_nounwind]
-#[cfg(bootstrap)]
-pub unsafe fn atomic_load_acquire<T: Copy>(src: *const T) -> T;
-/// Loads the current value of the pointer.
-/// `T` must be an integer or pointer type.
-///
-/// The stabilized version of this intrinsic is available on the
-/// [`atomic`] types via the `load` method by passing
-/// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::load`].
-#[rustc_intrinsic]
-#[rustc_nounwind]
-#[cfg(bootstrap)]
-pub unsafe fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
 
 /// Stores the value at the specified memory location.
 /// `T` must be an integer or pointer type.
@@ -1767,7 +1736,6 @@ pub const unsafe fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 /// - `index < PtrMetadata(slice_ptr)`, so the indexing is in-bounds for the slice
 /// - the resulting offsetting is in-bounds of the allocated object, which is
 ///   always the case for references, but needs to be upheld manually for pointers
-#[cfg(not(bootstrap))]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub const unsafe fn slice_get_unchecked<
@@ -3710,7 +3678,7 @@ pub const fn minnumf128(x: f128, y: f128) -> f128;
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn minimumf16(x: f16, y: f16) -> f16 {
     if x < y {
         x
@@ -3731,7 +3699,7 @@ pub const fn minimumf16(x: f16, y: f16) -> f16 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn minimumf32(x: f32, y: f32) -> f32 {
     if x < y {
         x
@@ -3752,7 +3720,7 @@ pub const fn minimumf32(x: f32, y: f32) -> f32 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn minimumf64(x: f64, y: f64) -> f64 {
     if x < y {
         x
@@ -3773,7 +3741,7 @@ pub const fn minimumf64(x: f64, y: f64) -> f64 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn minimumf128(x: f128, y: f128) -> f128 {
     if x < y {
         x
@@ -3848,7 +3816,7 @@ pub const fn maxnumf128(x: f128, y: f128) -> f128;
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn maximumf16(x: f16, y: f16) -> f16 {
     if x > y {
         x
@@ -3868,7 +3836,7 @@ pub const fn maximumf16(x: f16, y: f16) -> f16 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn maximumf32(x: f32, y: f32) -> f32 {
     if x > y {
         x
@@ -3888,7 +3856,7 @@ pub const fn maximumf32(x: f32, y: f32) -> f32 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn maximumf64(x: f64, y: f64) -> f64 {
     if x > y {
         x
@@ -3908,7 +3876,7 @@ pub const fn maximumf64(x: f64, y: f64) -> f64 {
 /// Therefore, implementations must not require the user to uphold
 /// any safety invariants.
 #[rustc_nounwind]
-#[cfg_attr(not(bootstrap), rustc_intrinsic)]
+#[rustc_intrinsic]
 pub const fn maximumf128(x: f128, y: f128) -> f128 {
     if x > y {
         x

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -187,7 +187,6 @@
 //
 // Target features:
 // tidy-alphabetical-start
-#![cfg_attr(bootstrap, feature(avx512_target_feature))]
 #![feature(aarch64_unstable_target_feature)]
 #![feature(arm_target_feature)]
 #![feature(hexagon_target_feature)]
@@ -225,7 +224,6 @@ pub mod assert_matches {
 
 // We don't export this through #[macro_export] for now, to avoid breakage.
 #[unstable(feature = "autodiff", issue = "124509")]
-#[cfg(not(bootstrap))]
 /// Unstable module containing the unstable `autodiff` macro.
 pub mod autodiff {
     #[unstable(feature = "autodiff", issue = "124509")]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1533,7 +1533,6 @@ pub(crate) mod builtin {
     #[unstable(feature = "autodiff", issue = "124509")]
     #[allow_internal_unstable(rustc_attrs)]
     #[rustc_builtin_macro]
-    #[cfg(not(bootstrap))]
     pub macro autodiff_forward($item:item) {
         /* compiler built-in */
     }
@@ -1552,7 +1551,6 @@ pub(crate) mod builtin {
     #[unstable(feature = "autodiff", issue = "124509")]
     #[allow_internal_unstable(rustc_attrs)]
     #[rustc_builtin_macro]
-    #[cfg(not(bootstrap))]
     pub macro autodiff_reverse($item:item) {
         /* compiler built-in */
     }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1092,7 +1092,6 @@ pub use self::unsafe_pinned::UnsafePinned;
 #[rustc_pub_transparent]
 #[derive(Copy, Clone)]
 pub struct Pin<Ptr> {
-    /// Only public for bootstrap.
     pointer: Ptr,
 }
 

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -1,6 +1,5 @@
 //! Indexing implementations for `[T]`.
 
-#[cfg(not(bootstrap))]
 use crate::intrinsics::slice_get_unchecked;
 use crate::panic::const_panic;
 use crate::ub_checks::assert_unsafe_precondition;
@@ -84,22 +83,6 @@ const fn slice_end_index_overflow_fail() -> ! {
 // them in safe indexing is unnecessary and hurts inlining and debug runtime perf.
 // Both the safe and unsafe public methods share these helpers,
 // which use intrinsics directly to get *no* extra checks.
-
-#[cfg(bootstrap)]
-#[inline(always)]
-const unsafe fn get_noubcheck<T>(ptr: *const [T], index: usize) -> *const T {
-    let ptr = ptr as *const T;
-    // SAFETY: The caller already checked these preconditions
-    unsafe { crate::intrinsics::offset(ptr, index) }
-}
-
-#[cfg(bootstrap)]
-#[inline(always)]
-const unsafe fn get_mut_noubcheck<T>(ptr: *mut [T], index: usize) -> *mut T {
-    let ptr = ptr as *mut T;
-    // SAFETY: The caller already checked these preconditions
-    unsafe { crate::intrinsics::offset(ptr, index) }
-}
 
 #[inline(always)]
 const unsafe fn get_offset_len_noubcheck<T>(
@@ -231,16 +214,8 @@ unsafe impl<T> SliceIndex<[T]> for usize {
     #[inline]
     fn get(self, slice: &[T]) -> Option<&T> {
         if self < slice.len() {
-            #[cfg(bootstrap)]
             // SAFETY: `self` is checked to be in bounds.
-            unsafe {
-                Some(&*get_noubcheck(slice, self))
-            }
-            #[cfg(not(bootstrap))]
-            // SAFETY: `self` is checked to be in bounds.
-            unsafe {
-                Some(slice_get_unchecked(slice, self))
-            }
+            unsafe { Some(slice_get_unchecked(slice, self)) }
         } else {
             None
         }
@@ -249,16 +224,8 @@ unsafe impl<T> SliceIndex<[T]> for usize {
     #[inline]
     fn get_mut(self, slice: &mut [T]) -> Option<&mut T> {
         if self < slice.len() {
-            #[cfg(bootstrap)]
             // SAFETY: `self` is checked to be in bounds.
-            unsafe {
-                Some(&mut *get_mut_noubcheck(slice, self))
-            }
-            #[cfg(not(bootstrap))]
-            // SAFETY: `self` is checked to be in bounds.
-            unsafe {
-                Some(slice_get_unchecked(slice, self))
-            }
+            unsafe { Some(slice_get_unchecked(slice, self)) }
         } else {
             None
         }
@@ -280,14 +247,7 @@ unsafe impl<T> SliceIndex<[T]> for usize {
             // Use intrinsics::assume instead of hint::assert_unchecked so that we don't check the
             // precondition of this function twice.
             crate::intrinsics::assume(self < slice.len());
-            #[cfg(bootstrap)]
-            {
-                get_noubcheck(slice, self)
-            }
-            #[cfg(not(bootstrap))]
-            {
-                slice_get_unchecked(slice, self)
-            }
+            slice_get_unchecked(slice, self)
         }
     }
 
@@ -300,16 +260,7 @@ unsafe impl<T> SliceIndex<[T]> for usize {
             (this: usize = self, len: usize = slice.len()) => this < len
         );
         // SAFETY: see comments for `get_unchecked` above.
-        unsafe {
-            #[cfg(bootstrap)]
-            {
-                get_mut_noubcheck(slice, self)
-            }
-            #[cfg(not(bootstrap))]
-            {
-                slice_get_unchecked(slice, self)
-            }
-        }
+        unsafe { slice_get_unchecked(slice, self) }
     }
 
     #[inline]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3822,23 +3822,6 @@ unsafe fn atomic_store<T: Copy>(dst: *mut T, val: T, order: Ordering) {
 
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-#[cfg(bootstrap)]
-unsafe fn atomic_load<T: Copy>(dst: *const T, order: Ordering) -> T {
-    // SAFETY: the caller must uphold the safety contract for `atomic_load`.
-    unsafe {
-        match order {
-            Relaxed => intrinsics::atomic_load_relaxed(dst),
-            Acquire => intrinsics::atomic_load_acquire(dst),
-            SeqCst => intrinsics::atomic_load_seqcst(dst),
-            Release => panic!("there is no such thing as a release load"),
-            AcqRel => panic!("there is no such thing as an acquire-release load"),
-        }
-    }
-}
-
-#[inline]
-#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-#[cfg(not(bootstrap))]
 unsafe fn atomic_load<T: Copy>(dst: *const T, order: Ordering) -> T {
     use intrinsics::AtomicOrdering;
     // SAFETY: the caller must uphold the safety contract for `atomic_load`.

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -951,7 +951,6 @@ macro_rules! test_float {
                 assert!(<$fty>::NAN.div_euclid(<$fty>::INFINITY).is_nan());
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn floor() {
                 $fassert!((0.0 as $fty).floor(), 0.0);
                 $fassert!((0.0 as $fty).floor().is_sign_positive());
@@ -969,7 +968,6 @@ macro_rules! test_float {
                 $fassert!(<$fty>::NEG_INFINITY.floor(), <$fty>::NEG_INFINITY);
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn ceil() {
                 $fassert!((0.0 as $fty).ceil(), 0.0);
                 $fassert!((0.0 as $fty).ceil().is_sign_positive());
@@ -986,7 +984,6 @@ macro_rules! test_float {
                 $fassert!(<$fty>::NEG_INFINITY.ceil(), <$fty>::NEG_INFINITY);
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn round() {
                 $fassert!((0.0 as $fty).round(), 0.0);
                 $fassert!((0.0 as $fty).round().is_sign_positive());
@@ -1003,7 +1000,6 @@ macro_rules! test_float {
                 $fassert!(<$fty>::NEG_INFINITY.round(), <$fty>::NEG_INFINITY);
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn round_ties_even() {
                 $fassert!((0.0 as $fty).round_ties_even(), 0.0);
                 $fassert!((0.0 as $fty).round_ties_even().is_sign_positive());
@@ -1022,7 +1018,6 @@ macro_rules! test_float {
                 $fassert!(<$fty>::NEG_INFINITY.round_ties_even(), <$fty>::NEG_INFINITY);
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn trunc() {
                 $fassert!((0.0 as $fty).trunc(), 0.0);
                 $fassert!((0.0 as $fty).trunc().is_sign_positive());
@@ -1041,7 +1036,6 @@ macro_rules! test_float {
                 $fassert!(<$fty>::NEG_INFINITY.trunc(), <$fty>::NEG_INFINITY);
             }
             #[test]
-            #[cfg(not(bootstrap))]
             fn fract() {
                 $fassert!((0.0 as $fty).fract(), 0.0);
                 $fassert!((0.0 as $fty).fract().is_sign_positive());

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -157,7 +157,6 @@ test = true
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(bootstrap)',
     # std use #[path] imports to portable-simd `std_float` crate
     # and to the `backtrace` crate which messes-up with Cargo list
     # of declared features, we therefor expect any feature cfg

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -276,12 +276,12 @@
 // tidy-alphabetical-start
 
 // stabilization was reverted after it hit beta
-#![cfg_attr(not(bootstrap), feature(autodiff))]
 #![feature(alloc_error_handler)]
 #![feature(allocator_internals)]
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
 #![feature(asm_experimental_arch)]
+#![feature(autodiff)]
 #![feature(cfg_sanitizer_cfi)]
 #![feature(cfg_target_thread_local)]
 #![feature(cfi_encoding)]
@@ -641,7 +641,6 @@ pub mod simd {
 }
 
 #[unstable(feature = "autodiff", issue = "124509")]
-#[cfg(not(bootstrap))]
 /// This module provides support for automatic differentiation.
 pub mod autodiff {
     /// This macro handles automatic differentiation.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -235,12 +235,7 @@
     test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
 )]
 #![doc(rust_logo)]
-#![doc(cfg_hide(
-    not(test),
-    not(any(test, bootstrap)),
-    no_global_oom_handling,
-    not(no_global_oom_handling)
-))]
+#![doc(cfg_hide(not(test), no_global_oom_handling, not(no_global_oom_handling)))]
 // Don't link to std. We are std.
 #![no_std]
 // Tell the compiler to link to either panic_abort or panic_unwind


### PR DESCRIPTION
These `cfg(bootstrap)` are always false now that rust-lang/rust#119899 has landed, and likewise `cfg(not(bootstrap))` is always true. Therefore, we don't need to wait for the usual stage0 bump to clean these up.