### PR TITLE
Fix for async drop inside async gen fn

### DIFF
--- a/tests/ui/async-await/async-drop/assign-incompatible-types.rs
+++ b/tests/ui/async-await/async-drop/assign-incompatible-types.rs
@@ -1,7 +1,8 @@
-//@ known-bug: #140530
+// ex-ice: #140530
 //@ edition: 2024
-
+//@ build-pass
 #![feature(async_drop, gen_blocks)]
+#![allow(incomplete_features)]
 async gen fn a() {
   _ = async {}
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
    https://github.com/rust-lang/rust/issues/126482
    r? oli-obk
-->
<!-- homu-ignore:end -->

Return value (for yield) is corrected for async drop inside async gen function.
In CFG, when internal async drop future is polled and returned `Poll<()>::Pending`, then async gen resume function returns `Poll<(OptRet)>::Pending`.

Fixes rust-lang/rust#140530