### PR TITLE
Allow PR builds to read sccache entries from S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CACHES_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CACHES_AWS_SECRET_ACCESS_KEY }}
+          # Allow reading (but not writing) sccache on PR builds
+          SCCACHE_S3_NO_CREDENTIALS: ${{ (needs.calculate_matrix.outputs.run_type == 'pr' && '1') || '0' }}
 
       - name: create github artifacts
         run: src/ci/scripts/create-doc-artifacts.sh


### PR DESCRIPTION
Should be useful especially after https://github.com/rust-lang/rust/pull/136942. The option is documented [here](https://github.com/mozilla/sccache/blob/main/docs/S3.md).

r? @marcoieni