### PR TITLE
Add missing `dyn` keywords to tests that do not test for them Part 2

### DIFF
--- a/tests/ui/issues/auxiliary/issue-11224.rs
+++ b/tests/ui/issues/auxiliary/issue-11224.rs
@@ -11,6 +11,6 @@ mod inner {
 }
 
 pub fn foo() {
-    let a = &1isize as &inner::Trait;
+    let a = &1isize as &dyn inner::Trait;
     a.f();
 }

--- a/tests/ui/issues/auxiliary/issue-13507.rs
+++ b/tests/ui/issues/auxiliary/issue-13507.rs
@@ -16,7 +16,7 @@ pub mod testtypes {
             TypeId::of::<FooFnPtr>(),
             TypeId::of::<FooNil>(),
             TypeId::of::<FooTuple>(),
-            TypeId::of::<FooTrait>(),
+            TypeId::of::<dyn FooTrait>(),
             TypeId::of::<FooStruct>(),
             TypeId::of::<FooEnum>()
         ]

--- a/tests/ui/issues/auxiliary/issue-17662.rs
+++ b/tests/ui/issues/auxiliary/issue-17662.rs
@@ -4,9 +4,9 @@ pub trait Foo<'a, T> {
     fn foo(&'a self) -> T;
 }
 
-pub fn foo<'a, T>(x: &'a Foo<'a, T>) -> T {
-    let x: &'a Foo<T> = x;
-    //            ^ the lifetime parameter of Foo is left to be inferred.
+pub fn foo<'a, T>(x: &'a dyn Foo<'a, T>) -> T {
+    let x: &'a dyn Foo<T> = x;
+    //                ^ the lifetime parameter of Foo is left to be inferred.
     x.foo()
     // ^ encoding this method call in metadata triggers an ICE.
 }

--- a/tests/ui/issues/auxiliary/issue-2380.rs
+++ b/tests/ui/issues/auxiliary/issue-2380.rs
@@ -6,8 +6,8 @@ pub trait i<T>
     fn dummy(&self, t: T) -> T { panic!() }
 }
 
-pub fn f<T>() -> Box<i<T>+'static> {
+pub fn f<T>() -> Box<dyn i<T>+'static> {
     impl<T> i<T> for () { }
 
-    Box::new(()) as Box<i<T>+'static>
+    Box::new(()) as Box<dyn i<T>+'static>
 }

--- a/tests/ui/issues/auxiliary/issue-25467.rs
+++ b/tests/ui/issues/auxiliary/issue-25467.rs
@@ -7,4 +7,4 @@ pub trait Trait {
     type Issue25467BarT;
 }
 
-pub type Object = Option<Box<Trait<Issue25467FooT=(),Issue25467BarT=()>>>;
+pub type Object = Option<Box<dyn Trait<Issue25467FooT=(),Issue25467BarT=()>>>;

--- a/tests/ui/issues/auxiliary/issue-34796-aux.rs
+++ b/tests/ui/issues/auxiliary/issue-34796-aux.rs
@@ -9,7 +9,7 @@ impl Future for u32 {
     type Error = Box<()>;
 }
 
-fn foo() -> Box<Future<Item=(), Error=Box<()>>> {
+fn foo() -> Box<dyn Future<Item=(), Error=Box<()>>> {
     Box::new(0u32)
 }
 

--- a/tests/ui/issues/auxiliary/issue-38226-aux.rs
+++ b/tests/ui/issues/auxiliary/issue-38226-aux.rs
@@ -2,7 +2,7 @@
 
 #[inline(never)]
 pub fn foo<T>() {
-    let _: Box<SomeTrait> = Box::new(SomeTraitImpl);
+    let _: Box<dyn SomeTrait> = Box::new(SomeTraitImpl);
 }
 
 pub fn bar() {

--- a/tests/ui/issues/auxiliary/issue-8401.rs
+++ b/tests/ui/issues/auxiliary/issue-8401.rs
@@ -8,9 +8,9 @@ trait A {
 struct B;
 impl A for B {}
 
-fn bar<T>(_: &mut A, _: &T) {}
+fn bar<T>(_: &mut dyn A, _: &T) {}
 
 fn foo<T>(t: &T) {
     let mut b = B;
-    bar(&mut b as &mut A, t)
+    bar(&mut b as &mut dyn A, t)
 }

--- a/tests/ui/issues/issue-34373.rs
+++ b/tests/ui/issues/issue-34373.rs
@@ -4,7 +4,7 @@ trait Trait<T> {
     fn foo(_: T) {}
 }
 
-pub struct Foo<T = Box<Trait<DefaultFoo>>>;  //~ ERROR cycle detected
+pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;  //~ ERROR cycle detected
 //~^ ERROR `T` is never used
 type DefaultFoo = Foo;
 

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -1,8 +1,8 @@
 error[E0391]: cycle detected when computing type of `Foo::T`
-  --> $DIR/issue-34373.rs:7:30
+  --> $DIR/issue-34373.rs:7:34
    |
-LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
-   |                              ^^^^^^^^^^
+LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
+   |                                  ^^^^^^^^^^
    |
 note: ...which requires expanding type alias `DefaultFoo`...
   --> $DIR/issue-34373.rs:9:19
@@ -13,15 +13,15 @@ LL | type DefaultFoo = Foo;
 note: cycle used when checking that `Foo` is well-formed
   --> $DIR/issue-34373.rs:7:1
    |
-LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/issue-34373.rs:7:16
    |
-LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused type parameter
+LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead

--- a/tests/ui/lifetimes/auxiliary/lifetime_bound_will_change_warning_lib.rs
+++ b/tests/ui/lifetimes/auxiliary/lifetime_bound_will_change_warning_lib.rs
@@ -3,9 +3,8 @@
 // Helper for testing that we get suitable warnings when lifetime
 // bound change will cause breakage.
 
-pub fn just_ref(x: &Fn()) {
-}
+pub fn just_ref(x: &dyn Fn()) {}
 
-pub fn ref_obj(x: &Box<Fn()>) {
+pub fn ref_obj(x: &Box<dyn Fn()>) {
     // this will change to &Box<Fn()+'static>...
 }

--- a/tests/ui/parser/bounds-obj-parens.rs
+++ b/tests/ui/parser/bounds-obj-parens.rs
@@ -1,7 +1,5 @@
 //@ check-pass
 
-#![allow(bare_trait_objects)]
-
-type A = Box<(Fn(u8) -> u8) + 'static + Send + Sync>; // OK (but see #39318)
+type A = Box<dyn (Fn(u8) -> u8) + 'static + Send + Sync>; // OK (but see #39318)
 
 fn main() {}

--- a/tests/ui/parser/trailing-plus-in-bounds.rs
+++ b/tests/ui/parser/trailing-plus-in-bounds.rs
@@ -1,9 +1,7 @@
 //@ check-pass
 
-#![allow(bare_trait_objects)]
-
 use std::fmt::Debug;
 
 fn main() {
-    let x: Box<Debug+> = Box::new(3) as Box<Debug+>; // Trailing `+` is OK
+    let x: Box<dyn Debug+> = Box::new(3) as Box<dyn Debug+>; // Trailing `+` is OK
 }

--- a/tests/ui/regions/region-object-lifetime-1.rs
+++ b/tests/ui/regions/region-object-lifetime-1.rs
@@ -10,7 +10,7 @@ trait Foo {
 
 // Here the receiver and return value all have the same lifetime,
 // so no error results.
-fn borrowed_receiver_same_lifetime<'a>(x: &'a Foo) -> &'a () {
+fn borrowed_receiver_same_lifetime<'a>(x: &'a dyn Foo) -> &'a () {
     x.borrowed()
 }
 

--- a/tests/ui/regions/region-object-lifetime-3.rs
+++ b/tests/ui/regions/region-object-lifetime-3.rs
@@ -10,7 +10,7 @@ trait Foo {
 
 // Borrowed receiver with two distinct lifetimes, but we know that
 // 'b:'a, hence &'a () is permitted.
-fn borrowed_receiver_related_lifetimes<'a,'b>(x: &'a (Foo+'b)) -> &'a () {
+fn borrowed_receiver_related_lifetimes<'a,'b>(x: &'a (dyn Foo+'b)) -> &'a () {
     x.borrowed()
 }
 


### PR DESCRIPTION
Some more tests that were found
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
