### PR TITLE
Add more missing 2015 edition directives

### DIFF
--- a/tests/ui/issues/issue-10806.rs
+++ b/tests/ui/issues/issue-10806.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 #![allow(unused_imports)]
 

--- a/tests/ui/issues/issue-12729.rs
+++ b/tests/ui/issues/issue-12729.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![allow(dead_code)]
 

--- a/tests/ui/issues/issue-13105.rs
+++ b/tests/ui/issues/issue-13105.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-13775.rs
+++ b/tests/ui/issues/issue-13775.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-15774.rs
+++ b/tests/ui/issues/issue-15774.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 
 #![deny(warnings)]

--- a/tests/ui/issues/issue-34074.rs
+++ b/tests/ui/issues/issue-34074.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 // Make sure several unnamed function parameters don't conflict with each other
 

--- a/tests/ui/issues/issue-50571.fixed
+++ b/tests/ui/issues/issue-50571.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.rs
+++ b/tests/ui/issues/issue-50571.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.stderr
+++ b/tests/ui/issues/issue-50571.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/issue-50571.rs:5:12
+  --> $DIR/issue-50571.rs:6:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^

--- a/tests/ui/issues/issue-86756.rs
+++ b/tests/ui/issues/issue-86756.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 trait Foo<T, T = T> {}
 //~^ ERROR the name `T` is already used for a generic parameter in this item's generic parameters
 

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -1,5 +1,5 @@
 error[E0403]: the name `T` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/issue-86756.rs:1:14
+  --> $DIR/issue-86756.rs:2:14
    |
 LL | trait Foo<T, T = T> {}
    |           -  ^ already used
@@ -7,13 +7,13 @@ LL | trait Foo<T, T = T> {}
    |           first use of `T`
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/issue-86756.rs:5:10
+  --> $DIR/issue-86756.rs:6:10
    |
 LL |     eq::<dyn, Foo>
    |          ^^^ not found in this scope
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^
@@ -27,13 +27,13 @@ LL |     eq::<dyn, dyn Foo>
    |               +++
 
 error[E0107]: missing generics for trait `Foo`
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^ expected at least 1 generic argument
    |
 note: trait defined here, with at least 1 generic parameter: `T`
-  --> $DIR/issue-86756.rs:1:7
+  --> $DIR/issue-86756.rs:2:7
    |
 LL | trait Foo<T, T = T> {}
    |       ^^^ -

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
@@ -1,4 +1,5 @@
 //@ revisions: rust2015 rust2018 rust2021
+//@[rust2015] edition:2015
 //@[rust2018] edition:2018
 //@[rust2021] edition:2021
 fn main() {

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
@@ -1,5 +1,5 @@
 error: prefix `world` is unknown
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:21
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:21
    |
 LL |     println!('hello world');
    |                     ^^^^^ unknown prefix
@@ -12,7 +12,7 @@ LL +     println!("hello world");
    |
 
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lifetimes/bare-trait-object-borrowck.rs
+++ b/tests/ui/lifetimes/bare-trait-object-borrowck.rs
@@ -1,5 +1,7 @@
-#![allow(bare_trait_objects)]
+//@ edition: 2015
 //@ check-pass
+#![allow(bare_trait_objects)]
+
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
     /// FormatWith uses interior mutability because Display::fmt takes &self.

--- a/tests/ui/lifetimes/bare-trait-object.rs
+++ b/tests/ui/lifetimes/bare-trait-object.rs
@@ -1,4 +1,5 @@
 // Verify that lifetime resolution correctly accounts for `Fn` bare trait objects.
+//@ edition: 2015
 //@ check-pass
 #![allow(bare_trait_objects)]
 

--- a/tests/ui/lint/bare-trait-objects-path.rs
+++ b/tests/ui/lint/bare-trait-objects-path.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![feature(associated_type_defaults)]
 
 trait Assoc {

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:14:5
+  --> $DIR/bare-trait-objects-path.rs:15:5
    |
 LL |     Dyn::func();
    |     ^^^
@@ -13,7 +13,7 @@ LL |     <dyn Dyn>::func();
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:17:5
+  --> $DIR/bare-trait-objects-path.rs:18:5
    |
 LL |     ::Dyn::func();
    |     ^^^^^
@@ -26,7 +26,7 @@ LL |     <dyn (::Dyn)>::func();
    |     ++++++     ++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:20:5
+  --> $DIR/bare-trait-objects-path.rs:21:5
    |
 LL |     Dyn::CONST;
    |     ^^^
@@ -39,7 +39,7 @@ LL |     <dyn Dyn>::CONST;
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^
@@ -52,7 +52,7 @@ LL |     let _: <dyn Dyn>::Ty;
    |            ++++    +
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^^^^^

--- a/tests/ui/lint/lint-pre-expansion-extern-module.rs
+++ b/tests/ui/lint/lint-pre-expansion-extern-module.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -W rust-2018-compatibility
+//@ edition: 2015
 
 fn main() {}
 

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -1,11 +1,11 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:12:5
+  --> $DIR/lint-qualification.rs:13:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:2:9
+  --> $DIR/lint-qualification.rs:3:9
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:13:5
+  --> $DIR/lint-qualification.rs:14:5
    |
 LL |     crate::foo::bar();
    |     ^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:18:13
+  --> $DIR/lint-qualification.rs:19:13
    |
 LL |     let _ = std::string::String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL +     let _ = String::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:12
+  --> $DIR/lint-qualification.rs:21:12
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:36
+  --> $DIR/lint-qualification.rs:21:36
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,19 +64,19 @@ LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
    |
 
 error: unused import: `std::fmt`
-  --> $DIR/lint-qualification.rs:24:9
+  --> $DIR/lint-qualification.rs:25:9
    |
 LL |     use std::fmt;
    |         ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:3:9
+  --> $DIR/lint-qualification.rs:4:9
    |
 LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:29:13
+  --> $DIR/lint-qualification.rs:30:13
    |
 LL |     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![warn(redundant_imports)]
 

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
@@ -1,5 +1,5 @@
 warning: the item `Some` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:5:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
    |
 LL | use std::option::Option::Some;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL | use std::option::Option::Some;
    = note: the item `Some` is already defined here
    |
 note: the lint level is defined here
-  --> $DIR/use-redundant-prelude-rust-2015.rs:2:9
+  --> $DIR/use-redundant-prelude-rust-2015.rs:3:9
    |
 LL | #![warn(redundant_imports)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: the item `None` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:7:5
    |
 LL | use std::option::Option::None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | use std::option::Option::None;
    = note: the item `None` is already defined here
 
 warning: the item `Ok` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:8:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
    |
 LL | use std::result::Result::Ok;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL | use std::result::Result::Ok;
    = note: the item `Ok` is already defined here
 
 warning: the item `Err` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:10:5
    |
 LL | use std::result::Result::Err;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/try-macro.rs
+++ b/tests/ui/macros/try-macro.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ edition: 2015
 #![allow(deprecated)] // for deprecated `try!()` macro
 use std::num::{ParseFloatError, ParseIntError};
 

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -1,47 +1,47 @@
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:1:11
+  --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A0 = dyn;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:11
+  --> $DIR/dyn-trait-compatibility.rs:7:11
    |
 LL | type A2 = dyn<dyn, dyn>;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:15
+  --> $DIR/dyn-trait-compatibility.rs:7:15
    |
 LL | type A2 = dyn<dyn, dyn>;
    |               ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:20
+  --> $DIR/dyn-trait-compatibility.rs:7:20
    |
 LL | type A2 = dyn<dyn, dyn>;
    |                    ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:11
+  --> $DIR/dyn-trait-compatibility.rs:11:11
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |           ^^^ not found in this scope
 
 error[E0405]: cannot find trait `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:23
+  --> $DIR/dyn-trait-compatibility.rs:11:23
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                       ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:16
+  --> $DIR/dyn-trait-compatibility.rs:11:16
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
-  --> $DIR/dyn-trait-compatibility.rs:3:11
+  --> $DIR/dyn-trait-compatibility.rs:5:11
    |
 LL | type A1 = dyn::dyn;
    |           ^^^ use of unresolved module or unlinked crate `dyn`

--- a/tests/ui/parser/extern-crate-async.rs
+++ b/tests/ui/parser/extern-crate-async.rs
@@ -1,6 +1,7 @@
-// Make sure that we don't parse `extern crate async`
+// Make sure that we don't parse `extern crate async` as
 // the front matter of a function leading us astray.
 
+//@ edition: 2015
 //@ check-pass
 
 fn main() {}

--- a/tests/ui/parser/fn-field-parse-error-ice.rs
+++ b/tests/ui/parser/fn-field-parse-error-ice.rs
@@ -1,4 +1,5 @@
 // Regression test for #85794
+//@ edition: 2015
 
 struct Baz {
     inner : dyn fn ()

--- a/tests/ui/parser/fn-field-parse-error-ice.stderr
+++ b/tests/ui/parser/fn-field-parse-error-ice.stderr
@@ -1,11 +1,11 @@
 error: expected `,`, or `}`, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:16
+  --> $DIR/fn-field-parse-error-ice.rs:5:16
    |
 LL |     inner : dyn fn ()
    |                ^ help: try adding a comma: `,`
 
 error: expected identifier, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:17
+  --> $DIR/fn-field-parse-error-ice.rs:5:17
    |
 LL | struct Baz {
    |        --- while parsing this struct
@@ -18,7 +18,7 @@ LL |     inner : dyn r#fn ()
    |                 ++
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/fn-field-parse-error-ice.rs:4:13
+  --> $DIR/fn-field-parse-error-ice.rs:5:13
    |
 LL |     inner : dyn fn ()
    |             ^^^ not found in this scope

--- a/tests/ui/parser/issues/issue-114219.rs
+++ b/tests/ui/parser/issues/issue-114219.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 fn main() {
     async move {};
     //~^ ERROR `async move` blocks are only allowed in Rust 2018 or later

--- a/tests/ui/parser/issues/issue-114219.stderr
+++ b/tests/ui/parser/issues/issue-114219.stderr
@@ -1,5 +1,5 @@
 error: `async move` blocks are only allowed in Rust 2018 or later
-  --> $DIR/issue-114219.rs:2:5
+  --> $DIR/issue-114219.rs:4:5
    |
 LL |     async move {};
    |     ^^^^^^^^^^

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 trait Trait {}
 
 fn test(_: &for<'a> dyn Trait) {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -1,5 +1,5 @@
 error: `for<...>` expected after `dyn`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:3:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:5:21
    |
 LL | fn test(_: &for<'a> dyn Trait) {}
    |                     ^^^
@@ -11,7 +11,7 @@ LL + fn test(_: &dyn for<'a> Trait) {}
    |
 
 error: `for<...>` expected after `impl`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:6:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:8:21
    |
 LL | fn test2(_: for<'a> impl Trait) {}
    |                     ^^^^
@@ -23,7 +23,7 @@ LL + fn test2(_: impl for<'a> Trait) {}
    |
 
 error: expected identifier, found `>`
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:10:24
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:12:24
    |
 LL | type A2 = dyn<for<> dyn>;
    |                        ^ expected identifier

--- a/tests/ui/proc-macro/trait-fn-args-2015.rs
+++ b/tests/ui/proc-macro/trait-fn-args-2015.rs
@@ -1,6 +1,7 @@
 // Unnamed arguments in trait functions can be passed through proc macros on 2015 edition.
 
 //@ check-pass
+//@ edition: 2015
 //@ proc-macro: test-macros.rs
 
 #![allow(anonymous_parameters)]


### PR DESCRIPTION
These tests specifically test 2015 edition behavior, so ensure that they can only be run with this edition

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
