### PR TITLE
Configure bootstrap backport nominations through triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -729,6 +729,41 @@ don't know
 ]
 message_on_remove = "PR #{number}'s stable-nomination has been removed."
 
+[notify-zulip."beta-nominated".bootstrap]
+required_labels = ["T-bootstrap"]
+zulip_stream = 507486 # #t-infra/bootstrap/backports
+topic = "#{number}: beta-nominated"
+message_on_add = [
+    """\
+@*T-bootstrap* PR #{number} "{title}" has been nominated for beta backport.
+""",
+    """\
+/poll Approve beta backport of #{number}?
+approve
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s beta-nomination has been removed."
+
+[notify-zulip."stable-nominated".bootstrap]
+required_labels = ["T-bootstrap"]
+zulip_stream = 507486 # #t-infra/bootstrap/backports
+topic = "#{number}: stable-nominated"
+message_on_add = [
+    """\
+@*T-bootstrap* PR #{number} "{title}" has been nominated for stable backport.
+""",
+    """\
+/poll Approve stable backport of #{number}?
+approve
+approve (but does not justify new dot release on its own)
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s stable-nomination has been removed."
+
 [notify-zulip."A-edition-2021"]
 required_labels = ["C-bug"]
 zulip_stream = 268952 # #edition


### PR DESCRIPTION
Following the discussion in [#t-infra/bootstrap > ✔ Have triagebot create backport nomination threads?](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/.E2.9C.94.20Have.20triagebot.20create.20backport.20nomination.20threads.3F/with/521876500) where we noticed that bootstrap backport nominations were difficult to track, since:

- We don't really have a dedicated person / group of people checking for bootstrap backport nominations.
- We don't really have an establish way of handling bootstrap backports.

This PR configures triagebot to open backport nominations threads (indicated for bootstrap team if a given PR has the suitable team label, https://github.com/rust-lang/rust/labels/T-bootstrap) in [#t-infra/bootstrap/backports](https://rust-lang.zulipchat.com/#narrow/channel/507486-t-infra.2Fbootstrap.2Fbackports). The current configuration is such that **the whole bootstrap team will be pinged for bootstrap backport nominations**[^diverges].

### Steps

- [x] ~~Ping members who opt-in subscribe to backport channel, or ping the whole bootstrap team?~~
    - Poll: [#t-infra/bootstrap > Have triagebot create backport nomination threads? @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Have.20triagebot.20create.20backport.20nomination.20threads.3F/near/522141337)
    - Votes (as of 2025-06-10): 3 votes "no preference", 1 vote "in favor".
- [x] ~~(Best for follow-up) Maybe also document bootstrap team's backport process / decision process in Forge? It's a bit different from [compiler team's backport process](https://forge.rust-lang.org/compiler/backports.html) because we don't have weekly bootstrap triage meetings and thus don't have sync backport decisions.~~
    - Tracked as follow-up in Forge: https://github.com/rust-lang/rust-forge/issues/889.

---

r? Kobzol

[^diverges]: Note that this configuration is similar to the types team backport nominations, but diverges from the compiler team.