### PR TITLE
Run wfcheck in one big loop instead of per module

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -182,9 +182,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
         // what we are intending to discard, to help future type-based refactoring.
         type R = Result<(), ErrorGuaranteed>;
 
-        tcx.par_hir_for_each_module(|module| {
-            let _: R = tcx.ensure_ok().check_mod_type_wf(module);
-        });
+        let _: R = tcx.ensure_ok().check_type_wf(());
 
         for &trait_def_id in tcx.all_local_trait_impls(()).keys() {
             let _: R = tcx.ensure_ok().coherent_trait(trait_def_id);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1148,8 +1148,8 @@ rustc_queries! {
         desc { |tcx| "checking deathness of variables in {}", describe_as_module(key, tcx) }
     }
 
-    query check_mod_type_wf(key: LocalModDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "checking that types are well-formed in {}", describe_as_module(key, tcx) }
+    query check_type_wf(key: ()) -> Result<(), ErrorGuaranteed> {
+        desc { "checking that types are well-formed" }
         return_result_from_ensure_ok
     }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -345,9 +345,7 @@ pub(crate) fn run_global_ctxt(
     // (see `override_queries` in the `config`)
 
     // NOTE: These are copy/pasted from typeck/lib.rs and should be kept in sync with those changes.
-    let _ = tcx.sess.time("wf_checking", || {
-        tcx.try_par_hir_for_each_module(|module| tcx.ensure_ok().check_mod_type_wf(module))
-    });
+    let _ = tcx.sess.time("wf_checking", || tcx.ensure_ok().check_type_wf(()));
 
     tcx.dcx().abort_if_errors();
 

--- a/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
+++ b/tests/ui/impl-trait/in-assoc-type-unconstrained.stderr
@@ -12,14 +12,6 @@ note: required by a bound in `compare_ty::Trait::Ty`
 LL |         type Ty: IntoIterator<Item = ()>;
    |                               ^^^^^^^^^ required by this bound in `Trait::Ty`
 
-error: unconstrained opaque type
-  --> $DIR/in-assoc-type-unconstrained.rs:8:26
-   |
-LL |         type Ty = Option<impl Sized>;
-   |                          ^^^^^^^^^^
-   |
-   = note: `Ty` must be used in combination with a concrete type within the same impl
-
 error[E0053]: method `method` has an incompatible type for trait
   --> $DIR/in-assoc-type-unconstrained.rs:22:24
    |
@@ -41,6 +33,14 @@ help: change the output type to match the trait
 LL -         fn method() -> () {}
 LL +         fn method() -> <() as compare_method::Trait>::Ty {}
    |
+
+error: unconstrained opaque type
+  --> $DIR/in-assoc-type-unconstrained.rs:8:26
+   |
+LL |         type Ty = Option<impl Sized>;
+   |                          ^^^^^^^^^^
+   |
+   = note: `Ty` must be used in combination with a concrete type within the same impl
 
 error: unconstrained opaque type
   --> $DIR/in-assoc-type-unconstrained.rs:20:19

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -15,19 +15,6 @@ LL -         fn eq(&self, _other: &(Foo, i32)) -> bool {
 LL +         fn eq(&self, _other: &(a::Bar, i32)) -> bool {
    |
 
-error: item does not constrain `a::Foo::{opaque#0}`
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:12
-   |
-LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
-   |            ^^
-   |
-   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
-note: this opaque type is supposed to be constrained
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:4:16
-   |
-LL |     type Foo = impl PartialEq<(Foo, i32)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0053]: method `eq` has an incompatible type for trait
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:25:30
    |
@@ -49,6 +36,19 @@ help: change the parameter type to match the trait
 LL -         fn eq(&self, _other: &(Bar, i32)) -> bool {
 LL +         fn eq(&self, _other: &(b::Foo, i32)) -> bool {
    |
+
+error: item does not constrain `a::Foo::{opaque#0}`
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:12
+   |
+LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
+   |            ^^
+   |
+   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
+note: this opaque type is supposed to be constrained
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:4:16
+   |
+LL |     type Foo = impl PartialEq<(Foo, i32)>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unconstrained opaque type
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:19:16

--- a/tests/ui/privacy/privacy3.stderr
+++ b/tests/ui/privacy/privacy3.stderr
@@ -5,6 +5,12 @@ LL |     use bar::gpriv;
    |         ^^^^^^^^^^ no `gpriv` in `bar`
 
 error: requires `sized` lang_item
+  --> $DIR/privacy3.rs:13:20
+   |
+LL |         fn gpriv() {}
+   |                    ^^
+
+error: requires `sized` lang_item
   --> $DIR/privacy3.rs:18:14
    |
 LL | pub fn foo() {}
@@ -27,12 +33,6 @@ error: requires `sized` lang_item
    |
 LL | fn main() {}
    |           ^^
-
-error: requires `sized` lang_item
-  --> $DIR/privacy3.rs:13:20
-   |
-LL |         fn gpriv() {}
-   |                    ^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/type-alias-impl-trait/constrain_inputs.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_inputs.stderr
@@ -25,19 +25,6 @@ LL |     type BadTraitRef = dyn Fn(Ty<'_>) -> &str;
    = note: lifetimes appearing in an associated or opaque type are not considered constrained
    = note: consider introducing a named lifetime parameter
 
-error: item does not constrain `lifetime_params::Ty::{opaque#0}`
-  --> $DIR/constrain_inputs.rs:8:8
-   |
-LL |     fn execute(ty: Ty<'_>) -> &str { todo!() }
-   |        ^^^^^^^
-   |
-   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
-note: this opaque type is supposed to be constrained
-  --> $DIR/constrain_inputs.rs:4:19
-   |
-LL |     type Ty<'a> = impl Sized;
-   |                   ^^^^^^^^^^
-
 error[E0581]: return type references an anonymous lifetime, which is not constrained by the fn input types
   --> $DIR/constrain_inputs.rs:23:31
    |
@@ -46,19 +33,6 @@ LL |     fn execute(ty: Ty<'_>) -> &str { ty() }
    |
    = note: lifetimes appearing in an associated or opaque type are not considered constrained
    = note: consider introducing a named lifetime parameter
-
-error: item does not constrain `lifetime_params_2::Ty::{opaque#0}`
-  --> $DIR/constrain_inputs.rs:23:8
-   |
-LL |     fn execute(ty: Ty<'_>) -> &str { ty() }
-   |        ^^^^^^^
-   |
-   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
-note: this opaque type is supposed to be constrained
-  --> $DIR/constrain_inputs.rs:19:19
-   |
-LL |     type Ty<'a> = impl FnOnce() -> &'a str;
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0581]: return type references an anonymous lifetime, which is not constrained by the fn input types
   --> $DIR/constrain_inputs.rs:34:37
@@ -77,6 +51,32 @@ LL |     type BadTraitRef = dyn Fn(Ty<&str>) -> &str;
    |
    = note: lifetimes appearing in an associated or opaque type are not considered constrained
    = note: consider introducing a named lifetime parameter
+
+error: item does not constrain `lifetime_params::Ty::{opaque#0}`
+  --> $DIR/constrain_inputs.rs:8:8
+   |
+LL |     fn execute(ty: Ty<'_>) -> &str { todo!() }
+   |        ^^^^^^^
+   |
+   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
+note: this opaque type is supposed to be constrained
+  --> $DIR/constrain_inputs.rs:4:19
+   |
+LL |     type Ty<'a> = impl Sized;
+   |                   ^^^^^^^^^^
+
+error: item does not constrain `lifetime_params_2::Ty::{opaque#0}`
+  --> $DIR/constrain_inputs.rs:23:8
+   |
+LL |     fn execute(ty: Ty<'_>) -> &str { ty() }
+   |        ^^^^^^^
+   |
+   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
+note: this opaque type is supposed to be constrained
+  --> $DIR/constrain_inputs.rs:19:19
+   |
+LL |     type Ty<'a> = impl FnOnce() -> &'a str;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Maybe we can merge this big loop in the future with the `par_hir_body_owners` call below and run typeck only on items that didn't fail wfcheck. For now let's just see if perf likes it, as it by itself should be beneficial to parallel rustc