### PR TITLE
Triagebot: Remove `assign.users_on_vacation`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1174,10 +1174,6 @@ cc = ["@m-ou-se"]
 [assign]
 warn_non_default_branch.enable = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = [
-    "fmease",
-    "jyn514",
-]
 
 [[assign.warn_non_default_branch.exceptions]]
 title = "[beta"


### PR DESCRIPTION
It's been superseded by triagebot's [review queue tracking](https://forge.rust-lang.org/triagebot/review-queue-tracking.html), more specifically *rotation mode*.

r? Kobzol or triagebot