### PR TITLE
Ensure query keys are printed with reduced queries

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -2,6 +2,7 @@ use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::Session;
 
+use crate::ty::print::with_reduced_queries;
 use crate::ty::{self, TyCtxt};
 
 #[macro_use]
@@ -83,5 +84,9 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
     #[inline]
     fn dep_kind_info(&self, dk: DepKind) -> &DepKindStruct<'tcx> {
         &self.query_kinds[dk.as_usize()]
+    }
+
+    fn with_reduced_queries<T>(self, f: impl FnOnce() -> T) -> T {
+        with_reduced_queries!(f())
     }
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1886,7 +1886,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     ) -> Result<(), PrintError> {
         define_scoped_cx!(self);
 
-        if self.should_print_verbose() {
+        if with_reduced_queries() || self.should_print_verbose() {
             p!(write("ValTree({:?}: ", cv.valtree), print(cv.ty), ")");
             return Ok(());
         }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -178,9 +178,7 @@ pub trait DepNodeParams<Tcx: DepContext>: fmt::Debug + Sized {
         panic!("Not implemented. Accidentally called on anonymous node?")
     }
 
-    fn to_debug_str(&self, _: Tcx) -> String {
-        format!("{self:?}")
-    }
+    fn to_debug_str(&self, tcx: Tcx) -> String;
 
     /// This method tries to recover the query key from the given `DepNode`,
     /// something which is needed when forcing `DepNode`s during red-green
@@ -210,8 +208,11 @@ where
     }
 
     #[inline(always)]
-    default fn to_debug_str(&self, _: Tcx) -> String {
-        format!("{:?}", *self)
+    default fn to_debug_str(&self, tcx: Tcx) -> String {
+        // Make sure to print dep node params with reduced queries since printing
+        // may themselves call queries, which may lead to (possibly untracked!)
+        // query cycles.
+        tcx.with_reduced_queries(|| format!("{self:?}"))
     }
 
     #[inline(always)]

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -88,6 +88,8 @@ pub trait DepContext: Copy {
             f(self, dep_node)
         }
     }
+
+    fn with_reduced_queries<T>(self, _: impl FnOnce() -> T) -> T;
 }
 
 pub trait Deps: DynSync {

--- a/tests/incremental/print-dep-node-cycle.rs
+++ b/tests/incremental/print-dep-node-cycle.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -Z query-dep-graph
+//@ revisions: rpass1
+
+// Exercises a debug-assertions-only query cycle that when printing a valtree const in
+// a dep node's debug representation, we end up invoking a query that also has a valtree
+// const in its dep node's debug representation, which leads to a cycle (and ICE, since
+// deps are not tracked when printing dep nodes' debug representations).
+
+#![feature(adt_const_params)]
+
+use std::marker::ConstParamTy;
+
+#[derive(Debug, ConstParamTy, PartialEq, Eq)]
+enum Foo {
+    A1,
+}
+
+#[inline(never)]
+fn hello<const F: Foo>() {
+    println!("{:#?}", F);
+}
+
+fn main() {
+    hello::<{ Foo::A1 }>();
+}

--- a/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.stderr
+++ b/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.stderr
@@ -12,7 +12,7 @@ LL |     struct ExplicitlyPadded(Box<ExplicitlyPadded>);
 error[E0391]: cycle detected when computing layout of `should_pad_explicitly_packed_field::ExplicitlyPadded`
    |
    = note: ...which immediately requires computing layout of `should_pad_explicitly_packed_field::ExplicitlyPadded` again
-   = note: cycle used when evaluating trait selection obligation `(): core::mem::transmutability::TransmuteFrom<should_pad_explicitly_packed_field::ExplicitlyPadded, core::mem::transmutability::Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
+   = note: cycle used when evaluating trait selection obligation `(): core::mem::transmutability::TransmuteFrom<should_pad_explicitly_packed_field::ExplicitlyPadded, ValTree(Branch([Leaf(0x00), Leaf(0x00), Leaf(0x00), Leaf(0x00)]): core::mem::transmutability::Assume)>`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Using `-Z query-dep-graph` and debug assertions leads to an ICE that was originally discovered in rust-lang/rust#141700:

> This isn't an incremental bug per se, but instead a bug that has to do with debug printing query keys when debug assertions and `-Z query-dep-graph` is enabled. We end up printing a const (b/c we're using generic const args here) whose debug printing for -Z query-dep-graph requires invoking the same query cyclically 😃
>
> I've pushed a commit which should fix this.

This isn't related to the standard library changes, but instead b/c it seems to be the first usage of `feature(adt_const_params)` in the standard library that ends up being triggered in incremental tests.

r? oli-obk