### PR TITLE
rustdoc-json-type: Depend on `serde` and `serde_derive` seperately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,6 +4673,7 @@ dependencies = [
  "bincode",
  "rustc-hash 2.1.1",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -10,7 +10,8 @@ path = "lib.rs"
 default = ["rustc-hash"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
+serde_derive = "1.0"
 rustc-hash = { version = "2.0", optional = true }
 
 [dev-dependencies]

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 
 #[cfg(feature = "rustc-hash")]
 use rustc_hash::FxHashMap as HashMap;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 


### PR DESCRIPTION
Before this commit, serde_derive is built before serde. But serde does not depend on serde_derive, so that is not needed. Instead, build serde and serde_derive in parallel.

This speeds up compilation for users depending on rustdoc-json-types out of tree.

Imports: https://github.com/rust-lang/rustdoc-types/pull/49

CC @Enselic 

r? @GuillaumeGomez 
