### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -696,14 +696,8 @@ impl TokenStream {
 
     /// Compares two `TokenStream`s, checking equality without regarding span information.
     pub fn eq_unspanned(&self, other: &TokenStream) -> bool {
-        let mut iter1 = self.iter();
-        let mut iter2 = other.iter();
-        for (tt1, tt2) in iter::zip(&mut iter1, &mut iter2) {
-            if !tt1.eq_unspanned(tt2) {
-                return false;
-            }
-        }
-        iter1.next().is_none() && iter2.next().is_none()
+        self.len() == other.len()
+            && self.iter().zip(other.iter()).all(|(tt1, tt2)| tt1.eq_unspanned(tt2))
     }
 
     /// Create a token stream containing a single token with alone spacing. The

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -57,7 +57,9 @@ impl TokenTree {
         match (self, other) {
             (TokenTree::Token(token, _), TokenTree::Token(token2, _)) => token.kind == token2.kind,
             (TokenTree::Delimited(.., delim, tts), TokenTree::Delimited(.., delim2, tts2)) => {
-                delim == delim2 && tts.eq_unspanned(tts2)
+                delim == delim2
+                    && tts.len() == tts2.len()
+                    && tts.iter().zip(tts2.iter()).all(|(a, b)| a.eq_unspanned(b))
             }
             _ => false,
         }
@@ -692,12 +694,6 @@ impl TokenStream {
 
     pub fn iter(&self) -> TokenStreamIter<'_> {
         TokenStreamIter::new(self)
-    }
-
-    /// Compares two `TokenStream`s, checking equality without regarding span information.
-    pub fn eq_unspanned(&self, other: &TokenStream) -> bool {
-        self.len() == other.len()
-            && self.iter().zip(other.iter()).all(|(tt1, tt2)| tt1.eq_unspanned(tt2))
     }
 
     /// Create a token stream containing a single token with alone spacing. The

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -282,6 +282,14 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
         }
         // Filter out features that are not supported by the current LLVM version
         ("riscv32" | "riscv64", "zacas") if get_version().0 < 20 => None,
+        (
+            "s390x",
+            "message-security-assist-extension12"
+            | "concurrent-functions"
+            | "miscellaneous-extensions-4"
+            | "vector-enhancements-3"
+            | "vector-packed-decimal-enhancement-3",
+        ) if get_version().0 < 20 => None,
         // Enable the evex512 target feature if an avx512 target feature is enabled.
         ("x86", s) if s.starts_with("avx512") => Some(LLVMFeature::with_dependencies(
             s,

--- a/compiler/rustc_parse/src/parser/tokenstream/tests.rs
+++ b/compiler/rustc_parse/src/parser/tokenstream/tests.rs
@@ -14,6 +14,10 @@ fn sp(a: u32, b: u32) -> Span {
     Span::with_root_ctxt(BytePos(a), BytePos(b))
 }
 
+fn cmp_token_stream(a: &TokenStream, b: &TokenStream) -> bool {
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.eq_unspanned(y))
+}
+
 #[test]
 fn test_concat() {
     create_default_session_globals_then(|| {
@@ -25,7 +29,7 @@ fn test_concat() {
         eq_res.push_stream(test_snd);
         assert_eq!(test_res.iter().count(), 5);
         assert_eq!(eq_res.iter().count(), 5);
-        assert_eq!(test_res.eq_unspanned(&eq_res), true);
+        assert_eq!(cmp_token_stream(&test_res, &eq_res), true);
     })
 }
 
@@ -104,7 +108,7 @@ fn test_dotdotdot() {
         stream.push_tree(TokenTree::token_joint(token::Dot, sp(0, 1)));
         stream.push_tree(TokenTree::token_joint(token::Dot, sp(1, 2)));
         stream.push_tree(TokenTree::token_alone(token::Dot, sp(2, 3)));
-        assert!(stream.eq_unspanned(&string_to_ts("...")));
+        assert!(cmp_token_stream(&stream, &string_to_ts("...")));
         assert_eq!(stream.iter().count(), 1);
     })
 }

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -710,29 +710,35 @@ static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-end
 ];
 
+#[rustfmt::skip]
 const IBMZ_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("backchain", Unstable(sym::s390x_target_feature), &[]),
+    ("concurrent-functions", Unstable(sym::s390x_target_feature), &[]),
     ("deflate-conversion", Unstable(sym::s390x_target_feature), &[]),
     ("enhanced-sort", Unstable(sym::s390x_target_feature), &[]),
     ("guarded-storage", Unstable(sym::s390x_target_feature), &[]),
     ("high-word", Unstable(sym::s390x_target_feature), &[]),
+    // LLVM does not define message-security-assist-extension versions 1, 2, 6, 10 and 11.
+    ("message-security-assist-extension12", Unstable(sym::s390x_target_feature), &[]),
+    ("message-security-assist-extension3", Unstable(sym::s390x_target_feature), &[]),
+    ("message-security-assist-extension4", Unstable(sym::s390x_target_feature), &[]),
+    ("message-security-assist-extension5", Unstable(sym::s390x_target_feature), &[]),
+    ("message-security-assist-extension8", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3"]),
+    ("message-security-assist-extension9", Unstable(sym::s390x_target_feature), &["message-security-assist-extension3", "message-security-assist-extension4"]),
+    ("miscellaneous-extensions-2", Unstable(sym::s390x_target_feature), &[]),
+    ("miscellaneous-extensions-3", Unstable(sym::s390x_target_feature), &[]),
+    ("miscellaneous-extensions-4", Unstable(sym::s390x_target_feature), &[]),
     ("nnp-assist", Unstable(sym::s390x_target_feature), &["vector"]),
     ("transactional-execution", Unstable(sym::s390x_target_feature), &[]),
     ("vector", Unstable(sym::s390x_target_feature), &[]),
     ("vector-enhancements-1", Unstable(sym::s390x_target_feature), &["vector"]),
     ("vector-enhancements-2", Unstable(sym::s390x_target_feature), &["vector-enhancements-1"]),
+    ("vector-enhancements-3", Unstable(sym::s390x_target_feature), &["vector-enhancements-2"]),
     ("vector-packed-decimal", Unstable(sym::s390x_target_feature), &["vector"]),
-    (
-        "vector-packed-decimal-enhancement",
-        Unstable(sym::s390x_target_feature),
-        &["vector-packed-decimal"],
-    ),
-    (
-        "vector-packed-decimal-enhancement-2",
-        Unstable(sym::s390x_target_feature),
-        &["vector-packed-decimal-enhancement"],
-    ),
+    ("vector-packed-decimal-enhancement", Unstable(sym::s390x_target_feature), &["vector-packed-decimal"]),
+    ("vector-packed-decimal-enhancement-2", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement"]),
+    ("vector-packed-decimal-enhancement-3", Unstable(sym::s390x_target_feature), &["vector-packed-decimal-enhancement-2"]),
     // tidy-alphabetical-end
 ];
 

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1416,18 +1416,18 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Splitting a map into even and odd keys, reusing the original map:
-    ///
     /// ```
     /// #![feature(btree_extract_if)]
     /// use std::collections::BTreeMap;
     ///
+    /// // Splitting a map into even and odd keys, reusing the original map:
     /// let mut map: BTreeMap<i32, i32> = (0..8).map(|x| (x, x)).collect();
     /// let evens: BTreeMap<_, _> = map.extract_if(.., |k, _v| k % 2 == 0).collect();
     /// let odds = map;
     /// assert_eq!(evens.keys().copied().collect::<Vec<_>>(), [0, 2, 4, 6]);
     /// assert_eq!(odds.keys().copied().collect::<Vec<_>>(), [1, 3, 5, 7]);
     ///
+    /// // Splitting a map into low and high halves, reusing the original map:
     /// let mut map: BTreeMap<i32, i32> = (0..8).map(|x| (x, x)).collect();
     /// let low: BTreeMap<_, _> = map.extract_if(0..4, |_k, _v| true).collect();
     /// let high = map;

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1201,21 +1201,21 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// [`retain`]: BTreeSet::retain
     /// # Examples
     ///
-    /// Splitting a set into even and odd values, reusing the original set:
-    ///
     /// ```
     /// #![feature(btree_extract_if)]
     /// use std::collections::BTreeSet;
     ///
+    /// // Splitting a set into even and odd values, reusing the original set:
     /// let mut set: BTreeSet<i32> = (0..8).collect();
     /// let evens: BTreeSet<_> = set.extract_if(.., |v| v % 2 == 0).collect();
     /// let odds = set;
     /// assert_eq!(evens.into_iter().collect::<Vec<_>>(), vec![0, 2, 4, 6]);
     /// assert_eq!(odds.into_iter().collect::<Vec<_>>(), vec![1, 3, 5, 7]);
     ///
-    /// let mut map: BTreeSet<i32> = (0..8).collect();
-    /// let low: BTreeSet<_> = map.extract_if(0..4, |_v| true).collect();
-    /// let high = map;
+    /// // Splitting a set into low and high halves, reusing the original set:
+    /// let mut set: BTreeSet<i32> = (0..8).collect();
+    /// let low: BTreeSet<_> = set.extract_if(0..4, |_v| true).collect();
+    /// let high = set;
     /// assert_eq!(low.into_iter().collect::<Vec<_>>(), [0, 1, 2, 3]);
     /// assert_eq!(high.into_iter().collect::<Vec<_>>(), [4, 5, 6, 7]);
     /// ```

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -175,7 +175,6 @@ impl_from!(u8 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")
 impl_from!(u8 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u8 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u8 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(u16 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -960,5 +960,7 @@ pub fn eq_attr_args(l: &AttrArgs, r: &AttrArgs) -> bool {
 }
 
 pub fn eq_delim_args(l: &DelimArgs, r: &DelimArgs) -> bool {
-    l.delim == r.delim && l.tokens.eq_unspanned(&r.tokens)
+    l.delim == r.delim
+        && l.tokens.len() == r.tokens.len()
+        && l.tokens.iter().zip(r.tokens.iter()).all(|(a, b)| a.eq_unspanned(b))
 }

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -62,6 +62,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `c`
 `cache`
 `cmpxchg16b`
+`concurrent-functions`
 `crc`
 `crt-static`
 `cssc`
@@ -159,6 +160,15 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `lzcnt`
 `m`
 `mclass`
+`message-security-assist-extension12`
+`message-security-assist-extension3`
+`message-security-assist-extension4`
+`message-security-assist-extension5`
+`message-security-assist-extension8`
+`message-security-assist-extension9`
+`miscellaneous-extensions-2`
+`miscellaneous-extensions-3`
+`miscellaneous-extensions-4`
 `mops`
 `movbe`
 `movrs`
@@ -287,9 +297,11 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `vector`
 `vector-enhancements-1`
 `vector-enhancements-2`
+`vector-enhancements-3`
 `vector-packed-decimal`
 `vector-packed-decimal-enhancement`
 `vector-packed-decimal-enhancement-2`
+`vector-packed-decimal-enhancement-3`
 `vfp2`
 `vfp3`
 `vfp4`

--- a/tests/ui/issues/issue-10806.rs
+++ b/tests/ui/issues/issue-10806.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 #![allow(unused_imports)]
 

--- a/tests/ui/issues/issue-12729.rs
+++ b/tests/ui/issues/issue-12729.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![allow(dead_code)]
 

--- a/tests/ui/issues/issue-13105.rs
+++ b/tests/ui/issues/issue-13105.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-13775.rs
+++ b/tests/ui/issues/issue-13775.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-15774.rs
+++ b/tests/ui/issues/issue-15774.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 
 #![deny(warnings)]

--- a/tests/ui/issues/issue-20427.rs
+++ b/tests/ui/issues/issue-20427.rs
@@ -59,7 +59,7 @@ mod reuse {
 
     pub fn check<u16>() {
         assert_eq!(size_of::<u8>(), 8);
-        assert_eq!(size_of::<::u64>(), 0);
+        assert_eq!(size_of::<crate::u64>(), 0);
         assert_eq!(size_of::<i16>(), 3 * size_of::<*const ()>());
         assert_eq!(size_of::<u16>(), 0);
     }

--- a/tests/ui/issues/issue-28983.rs
+++ b/tests/ui/issues/issue-28983.rs
@@ -7,7 +7,7 @@ impl Test for u32 {
 
 pub mod export {
     #[no_mangle]
-    pub extern "C" fn issue_28983(t: <u32 as ::Test>::T) -> i32 { t*3 }
+    pub extern "C" fn issue_28983(t: <u32 as crate::Test>::T) -> i32 { t*3 }
 }
 
 // to test both exporting and importing functions, import

--- a/tests/ui/issues/issue-31776.rs
+++ b/tests/ui/issues/issue-31776.rs
@@ -8,7 +8,7 @@ struct S;
 
 mod m {
     fn f() {
-        impl ::S {
+        impl crate::S {
             pub fn s(&self) {}
         }
     }
@@ -24,7 +24,7 @@ pub struct S1;
 fn f() {
     pub struct Z;
 
-    impl ::Tr for ::S1 {
+    impl crate::Tr for crate::S1 {
         type A = Z; // Private-in-public error unless `struct Z` is pub
     }
 }
@@ -43,7 +43,7 @@ mod m1 {
             pub field: u8
         }
 
-        impl ::Tr1 for ::S2 {
+        impl crate::Tr1 for crate::S2 {
             type A = Z;
             fn pull(&self) -> Self::A { Z{field: 10} }
         }

--- a/tests/ui/issues/issue-32797.rs
+++ b/tests/ui/issues/issue-32797.rs
@@ -7,7 +7,7 @@ mod bar {
 
 pub use baz::*;
 mod baz {
-    pub use main as f;
+    pub use crate::main as f;
 }
 
 pub fn main() {}

--- a/tests/ui/issues/issue-34074.rs
+++ b/tests/ui/issues/issue-34074.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 // Make sure several unnamed function parameters don't conflict with each other
 

--- a/tests/ui/issues/issue-41053.rs
+++ b/tests/ui/issues/issue-41053.rs
@@ -11,7 +11,7 @@ impl Iterator for Foo {
     type Item = Box<dyn Trait>;
     fn next(&mut self) -> Option<Box<dyn Trait>> {
         extern crate issue_41053;
-        impl ::Trait for issue_41053::Test {
+        impl crate::Trait for issue_41053::Test {
             fn foo(&self) {}
         }
         Some(Box::new(issue_41053::Test))

--- a/tests/ui/issues/issue-47364.rs
+++ b/tests/ui/issues/issue-47364.rs
@@ -18,18 +18,18 @@ pub enum IResult<I,O> {
     Incomplete(u32, u64)
 }
 
-pub fn multispace<T: Copy>(input: T) -> ::IResult<i8, i8> {
-    ::IResult::Done(0, 0)
+pub fn multispace<T: Copy>(input: T) -> crate::IResult<i8, i8> {
+    crate::IResult::Done(0, 0)
 }
 
 mod nom_sql {
-    fn where_clause(i: &[u8]) -> ::IResult<&[u8], Option<String>> {
-        let X = match ::multispace(i) {
-            ::IResult::Done(..) => ::IResult::Done(i, None::<String>),
-            _ => ::IResult::Error(::Err::NodePosition(0)),
+    fn where_clause(i: &[u8]) -> crate::IResult<&[u8], Option<String>> {
+        let X = match crate::multispace(i) {
+            crate::IResult::Done(..) => crate::IResult::Done(i, None::<String>),
+            _ => crate::IResult::Error(crate::Err::NodePosition(0)),
         };
         match X {
-            ::IResult::Done(_, _) => ::IResult::Done(i, None),
+            crate::IResult::Done(_, _) => crate::IResult::Done(i, None),
             _ => X
         }
     }
@@ -39,16 +39,16 @@ mod nom_sql {
             match {
                 where_clause(i)
             } {
-                ::IResult::Done(_, o) => ::IResult::Done(i, Some(o)),
-                ::IResult::Error(_) => ::IResult::Done(i, None),
-                _ => ::IResult::Incomplete(0, 0),
+                crate::IResult::Done(_, o) => crate::IResult::Done(i, Some(o)),
+                crate::IResult::Error(_) => crate::IResult::Done(i, None),
+                _ => crate::IResult::Incomplete(0, 0),
             }
         } {
-            ::IResult::Done(z, _) => ::IResult::Done(z, None::<String>),
+            crate::IResult::Done(z, _) => crate::IResult::Done(z, None::<String>),
             _ => return ()
         };
         match Y {
-            ::IResult::Done(x, _) => {
+            crate::IResult::Done(x, _) => {
                 let bytes = b";   ";
                 let len = x.len();
                 bytes[len];

--- a/tests/ui/issues/issue-50187.rs
+++ b/tests/ui/issues/issue-50187.rs
@@ -13,20 +13,20 @@ mod macro_ns {
 }
 
 mod merge2 {
-    pub use type_ns::A;
-    pub use value_ns::A;
+    pub use crate::type_ns::A;
+    pub use crate::value_ns::A;
 }
 mod merge3 {
-    pub use type_ns::A;
-    pub use value_ns::A;
-    pub use macro_ns::A;
+    pub use crate::type_ns::A;
+    pub use crate::value_ns::A;
+    pub use crate::macro_ns::A;
 }
 
 mod use2 {
-    pub use merge2::A;
+    pub use crate::merge2::A;
 }
 mod use3 {
-    pub use merge3::A;
+    pub use crate::merge3::A;
 }
 
 fn main() {

--- a/tests/ui/issues/issue-50571.fixed
+++ b/tests/ui/issues/issue-50571.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.rs
+++ b/tests/ui/issues/issue-50571.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.stderr
+++ b/tests/ui/issues/issue-50571.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/issue-50571.rs:5:12
+  --> $DIR/issue-50571.rs:6:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^

--- a/tests/ui/issues/issue-50761.rs
+++ b/tests/ui/issues/issue-50761.rs
@@ -14,7 +14,7 @@ mod b {
     }
 
     impl Builder {
-        pub fn with_a(&mut self, _a: fn() -> dyn (::a::A)) {}
+        pub fn with_a(&mut self, _a: fn() -> dyn (crate::a::A)) {}
     }
 }
 

--- a/tests/ui/issues/issue-6936.rs
+++ b/tests/ui/issues/issue-6936.rs
@@ -1,22 +1,22 @@
 struct T;
 
 mod t1 {
-    type Foo = ::T;
+    type Foo = crate::T;
     mod Foo {} //~ ERROR the name `Foo` is defined multiple times
 }
 
 mod t2 {
-    type Foo = ::T;
+    type Foo = crate::T;
     struct Foo; //~ ERROR the name `Foo` is defined multiple times
 }
 
 mod t3 {
-    type Foo = ::T;
+    type Foo = crate::T;
     enum Foo {} //~ ERROR the name `Foo` is defined multiple times
 }
 
 mod t4 {
-    type Foo = ::T;
+    type Foo = crate::T;
     fn Foo() {} // ok
 }
 
@@ -26,7 +26,7 @@ mod t5 {
 }
 
 mod t6 {
-    type Foo = ::T;
+    type Foo = crate::T;
     impl Foo {} // ok
 }
 

--- a/tests/ui/issues/issue-6936.stderr
+++ b/tests/ui/issues/issue-6936.stderr
@@ -1,8 +1,8 @@
 error[E0428]: the name `Foo` is defined multiple times
   --> $DIR/issue-6936.rs:5:5
    |
-LL |     type Foo = ::T;
-   |     --------------- previous definition of the type `Foo` here
+LL |     type Foo = crate::T;
+   |     -------------------- previous definition of the type `Foo` here
 LL |     mod Foo {}
    |     ^^^^^^^ `Foo` redefined here
    |
@@ -11,8 +11,8 @@ LL |     mod Foo {}
 error[E0428]: the name `Foo` is defined multiple times
   --> $DIR/issue-6936.rs:10:5
    |
-LL |     type Foo = ::T;
-   |     --------------- previous definition of the type `Foo` here
+LL |     type Foo = crate::T;
+   |     -------------------- previous definition of the type `Foo` here
 LL |     struct Foo;
    |     ^^^^^^^^^^^ `Foo` redefined here
    |
@@ -21,8 +21,8 @@ LL |     struct Foo;
 error[E0428]: the name `Foo` is defined multiple times
   --> $DIR/issue-6936.rs:15:5
    |
-LL |     type Foo = ::T;
-   |     --------------- previous definition of the type `Foo` here
+LL |     type Foo = crate::T;
+   |     -------------------- previous definition of the type `Foo` here
 LL |     enum Foo {}
    |     ^^^^^^^^ `Foo` redefined here
    |

--- a/tests/ui/issues/issue-7663.rs
+++ b/tests/ui/issues/issue-7663.rs
@@ -8,7 +8,7 @@ mod test1 {
     mod bar { pub fn p() -> isize { 2 } }
 
     pub mod baz {
-        use test1::bar::p;
+        use crate::test1::bar::p;
 
         pub fn my_main() { assert_eq!(p(), 2); }
     }
@@ -20,7 +20,7 @@ mod test2 {
     mod bar { pub fn p() -> isize { 2 } }
 
     pub mod baz {
-        use test2::bar::p;
+        use crate::test2::bar::p;
 
         pub fn my_main() { assert_eq!(p(), 2); }
     }

--- a/tests/ui/issues/issue-86756.rs
+++ b/tests/ui/issues/issue-86756.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 trait Foo<T, T = T> {}
 //~^ ERROR the name `T` is already used for a generic parameter in this item's generic parameters
 

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -1,5 +1,5 @@
 error[E0403]: the name `T` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/issue-86756.rs:1:14
+  --> $DIR/issue-86756.rs:2:14
    |
 LL | trait Foo<T, T = T> {}
    |           -  ^ already used
@@ -7,13 +7,13 @@ LL | trait Foo<T, T = T> {}
    |           first use of `T`
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/issue-86756.rs:5:10
+  --> $DIR/issue-86756.rs:6:10
    |
 LL |     eq::<dyn, Foo>
    |          ^^^ not found in this scope
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^
@@ -27,13 +27,13 @@ LL |     eq::<dyn, dyn Foo>
    |               +++
 
 error[E0107]: missing generics for trait `Foo`
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^ expected at least 1 generic argument
    |
 note: trait defined here, with at least 1 generic parameter: `T`
-  --> $DIR/issue-86756.rs:1:7
+  --> $DIR/issue-86756.rs:2:7
    |
 LL | trait Foo<T, T = T> {}
    |       ^^^ -

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
@@ -1,4 +1,5 @@
 //@ revisions: rust2015 rust2018 rust2021
+//@[rust2015] edition:2015
 //@[rust2018] edition:2018
 //@[rust2021] edition:2021
 fn main() {

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
@@ -1,5 +1,5 @@
 error: prefix `world` is unknown
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:21
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:21
    |
 LL |     println!('hello world');
    |                     ^^^^^ unknown prefix
@@ -12,7 +12,7 @@ LL +     println!("hello world");
    |
 
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lifetimes/bare-trait-object-borrowck.rs
+++ b/tests/ui/lifetimes/bare-trait-object-borrowck.rs
@@ -1,5 +1,7 @@
-#![allow(bare_trait_objects)]
+//@ edition: 2015
 //@ check-pass
+#![allow(bare_trait_objects)]
+
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
     /// FormatWith uses interior mutability because Display::fmt takes &self.

--- a/tests/ui/lifetimes/bare-trait-object.rs
+++ b/tests/ui/lifetimes/bare-trait-object.rs
@@ -1,4 +1,5 @@
 // Verify that lifetime resolution correctly accounts for `Fn` bare trait objects.
+//@ edition: 2015
 //@ check-pass
 #![allow(bare_trait_objects)]
 

--- a/tests/ui/lint/bare-trait-objects-path.rs
+++ b/tests/ui/lint/bare-trait-objects-path.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![feature(associated_type_defaults)]
 
 trait Assoc {

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:14:5
+  --> $DIR/bare-trait-objects-path.rs:15:5
    |
 LL |     Dyn::func();
    |     ^^^
@@ -13,7 +13,7 @@ LL |     <dyn Dyn>::func();
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:17:5
+  --> $DIR/bare-trait-objects-path.rs:18:5
    |
 LL |     ::Dyn::func();
    |     ^^^^^
@@ -26,7 +26,7 @@ LL |     <dyn (::Dyn)>::func();
    |     ++++++     ++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:20:5
+  --> $DIR/bare-trait-objects-path.rs:21:5
    |
 LL |     Dyn::CONST;
    |     ^^^
@@ -39,7 +39,7 @@ LL |     <dyn Dyn>::CONST;
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^
@@ -52,7 +52,7 @@ LL |     let _: <dyn Dyn>::Ty;
    |            ++++    +
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^^^^^

--- a/tests/ui/lint/lint-directives-on-use-items-issue-10534.rs
+++ b/tests/ui/lint/lint-directives-on-use-items-issue-10534.rs
@@ -9,16 +9,16 @@
 mod a { pub static x: isize = 3; pub static y: isize = 4; }
 
 mod b {
-    use a::x; //~ ERROR: unused import
+    use crate::a::x; //~ ERROR: unused import
     #[allow(unused_imports)]
-    use a::y; // no error here
+    use crate::a::y; // no error here
 }
 
 #[allow(unused_imports)]
 mod c {
-    use a::x;
+    use crate::a::x;
     #[deny(unused_imports)]
-    use a::y; //~ ERROR: unused import
+    use crate::a::y; //~ ERROR: unused import
 }
 
 fn main() {}

--- a/tests/ui/lint/lint-directives-on-use-items-issue-10534.stderr
+++ b/tests/ui/lint/lint-directives-on-use-items-issue-10534.stderr
@@ -1,8 +1,8 @@
-error: unused import: `a::x`
+error: unused import: `crate::a::x`
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:12:9
    |
-LL |     use a::x;
-   |         ^^^^
+LL |     use crate::a::x;
+   |         ^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:1:9
@@ -10,11 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
-error: unused import: `a::y`
+error: unused import: `crate::a::y`
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:21:9
    |
-LL |     use a::y;
-   |         ^^^^
+LL |     use crate::a::y;
+   |         ^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-directives-on-use-items-issue-10534.rs:20:12

--- a/tests/ui/lint/lint-missing-doc.rs
+++ b/tests/ui/lint/lint-missing-doc.rs
@@ -184,10 +184,10 @@ mod internal_impl {
 }
 /// dox
 pub mod public_interface {
-    pub use internal_impl::documented as foo;
-    pub use internal_impl::undocumented1 as bar;
-    pub use internal_impl::{documented, undocumented2};
-    pub use internal_impl::globbed::*;
+    pub use crate::internal_impl::documented as foo;
+    pub use crate::internal_impl::undocumented1 as bar;
+    pub use crate::internal_impl::{documented, undocumented2};
+    pub use crate::internal_impl::globbed::*;
 }
 
 extern "C" {

--- a/tests/ui/lint/lint-pre-expansion-extern-module.rs
+++ b/tests/ui/lint/lint-pre-expansion-extern-module.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -W rust-2018-compatibility
+//@ edition: 2015
 
 fn main() {}
 

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -1,11 +1,11 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:12:5
+  --> $DIR/lint-qualification.rs:13:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:2:9
+  --> $DIR/lint-qualification.rs:3:9
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:13:5
+  --> $DIR/lint-qualification.rs:14:5
    |
 LL |     crate::foo::bar();
    |     ^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:18:13
+  --> $DIR/lint-qualification.rs:19:13
    |
 LL |     let _ = std::string::String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL +     let _ = String::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:12
+  --> $DIR/lint-qualification.rs:21:12
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:36
+  --> $DIR/lint-qualification.rs:21:36
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,19 +64,19 @@ LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
    |
 
 error: unused import: `std::fmt`
-  --> $DIR/lint-qualification.rs:24:9
+  --> $DIR/lint-qualification.rs:25:9
    |
 LL |     use std::fmt;
    |         ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:3:9
+  --> $DIR/lint-qualification.rs:4:9
    |
 LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:29:13
+  --> $DIR/lint-qualification.rs:30:13
    |
 LL |     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/lint-unnecessary-import-braces.rs
+++ b/tests/ui/lint/lint-unnecessary-import-braces.rs
@@ -1,10 +1,10 @@
 #![deny(unused_import_braces)]
 
-use test::{A}; //~ ERROR braces around A is unnecessary
+use crate::test::{A}; //~ ERROR braces around A is unnecessary
 
 mod test {
-    use test::{self}; // OK
-    use test::{self as rename}; // OK
+    use crate::test::{self}; // OK
+    use crate::test::{self as rename}; // OK
     pub struct A;
 }
 

--- a/tests/ui/lint/lint-unnecessary-import-braces.stderr
+++ b/tests/ui/lint/lint-unnecessary-import-braces.stderr
@@ -1,8 +1,8 @@
 error: braces around A is unnecessary
   --> $DIR/lint-unnecessary-import-braces.rs:3:1
    |
-LL | use test::{A};
-   | ^^^^^^^^^^^^^^
+LL | use crate::test::{A};
+   | ^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-unnecessary-import-braces.rs:1:9

--- a/tests/ui/lint/unused/lint-unused-imports.rs
+++ b/tests/ui/lint/unused/lint-unused-imports.rs
@@ -48,8 +48,8 @@ pub mod bar {
     pub struct Square;
 
     pub mod c {
-        use foo::Point;
-        use foo::Square; //~ ERROR unused import: `foo::Square`
+        use crate::foo::Point;
+        use crate::foo::Square; //~ ERROR unused import: `crate::foo::Square`
         pub fn cc(_p: Point) -> super::Square {
             fn f() -> super::Square {
                 super::Square
@@ -74,7 +74,7 @@ fn g() {
 // cf. issue #35135.
 #[allow(unused_variables)]
 fn h() {
-    use test2::foo; //~ ERROR unused import: `test2::foo`
+    use crate::test2::foo; //~ ERROR unused import: `crate::test2::foo`
     let foo = 0;
 }
 
@@ -83,6 +83,6 @@ fn main() {
     let mut a = 3;
     let mut b = 4;
     swap(&mut a, &mut b);
-    test::C.b();
+    crate::test::C.b();
     foo();
 }

--- a/tests/ui/lint/unused/lint-unused-imports.stderr
+++ b/tests/ui/lint/unused/lint-unused-imports.stderr
@@ -28,11 +28,11 @@ error: unused import: `bar`
 LL | use test2::{foo, bar};
    |                  ^^^
 
-error: unused import: `foo::Square`
+error: unused import: `crate::foo::Square`
   --> $DIR/lint-unused-imports.rs:52:13
    |
-LL |         use foo::Square;
-   |             ^^^^^^^^^^^
+LL |         use crate::foo::Square;
+   |             ^^^^^^^^^^^^^^^^^^
 
 error: unused import: `self::g`
   --> $DIR/lint-unused-imports.rs:68:9
@@ -40,11 +40,11 @@ error: unused import: `self::g`
 LL |     use self::g;
    |         ^^^^^^^
 
-error: unused import: `test2::foo`
+error: unused import: `crate::test2::foo`
   --> $DIR/lint-unused-imports.rs:77:9
    |
-LL |     use test2::foo;
-   |         ^^^^^^^^^^
+LL |     use crate::test2::foo;
+   |         ^^^^^^^^^^^^^^^^^
 
 error: unused import: `test::B2`
   --> $DIR/lint-unused-imports.rs:20:5

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![warn(redundant_imports)]
 

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
@@ -1,5 +1,5 @@
 warning: the item `Some` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:5:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
    |
 LL | use std::option::Option::Some;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL | use std::option::Option::Some;
    = note: the item `Some` is already defined here
    |
 note: the lint level is defined here
-  --> $DIR/use-redundant-prelude-rust-2015.rs:2:9
+  --> $DIR/use-redundant-prelude-rust-2015.rs:3:9
    |
 LL | #![warn(redundant_imports)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: the item `None` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:7:5
    |
 LL | use std::option::Option::None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | use std::option::Option::None;
    = note: the item `None` is already defined here
 
 warning: the item `Ok` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:8:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
    |
 LL | use std::result::Result::Ok;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL | use std::result::Result::Ok;
    = note: the item `Ok` is already defined here
 
 warning: the item `Err` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:10:5
    |
 LL | use std::result::Result::Err;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/macro-pub-matcher.rs
+++ b/tests/ui/macros/macro-pub-matcher.rs
@@ -68,15 +68,15 @@ mod with_crate {
 
 mod garden {
     mod with_pub_restricted_path {
-        vis_passthru! { pub(in garden) const A: i32 = 0; }
-        vis_passthru! { pub(in garden) enum B {} }
-        vis_passthru! { pub(in garden) extern "C" fn c() {} }
-        vis_passthru! { pub(in garden) mod d {} }
-        vis_passthru! { pub(in garden) static E: i32 = 0; }
-        vis_passthru! { pub(in garden) struct F; }
-        vis_passthru! { pub(in garden) trait G {} }
-        vis_passthru! { pub(in garden) type H = i32; }
-        vis_passthru! { pub(in garden) use A as I; }
+        vis_passthru! { pub(in crate::garden) const A: i32 = 0; }
+        vis_passthru! { pub(in crate::garden) enum B {} }
+        vis_passthru! { pub(in crate::garden) extern "C" fn c() {} }
+        vis_passthru! { pub(in crate::garden) mod d {} }
+        vis_passthru! { pub(in crate::garden) static E: i32 = 0; }
+        vis_passthru! { pub(in crate::garden) struct F; }
+        vis_passthru! { pub(in crate::garden) trait G {} }
+        vis_passthru! { pub(in crate::garden) type H = i32; }
+        vis_passthru! { pub(in crate::garden) use A as I; }
     }
 }
 

--- a/tests/ui/macros/paths-in-macro-invocations.rs
+++ b/tests/ui/macros/paths-in-macro-invocations.rs
@@ -11,26 +11,26 @@ mod foo { pub use two_macros::macro_one as bar; }
 
 trait T {
     foo::bar!();
-    ::foo::bar!();
+    crate::foo::bar!();
 }
 
 struct S {
     x: foo::bar!(i32),
-    y: ::foo::bar!(i32),
+    y: crate::foo::bar!(i32),
 }
 
 impl S {
     foo::bar!();
-    ::foo::bar!();
+    crate::foo::bar!();
 }
 
 fn main() {
     foo::bar!();
-    ::foo::bar!();
+    crate::foo::bar!();
 
     let _ = foo::bar!(0);
-    let _ = ::foo::bar!(0);
+    let _ = crate::foo::bar!(0);
 
     let foo::bar!(_) = 0;
-    let ::foo::bar!(_) = 0;
+    let crate::foo::bar!(_) = 0;
 }

--- a/tests/ui/macros/try-macro.rs
+++ b/tests/ui/macros/try-macro.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ edition: 2015
 #![allow(deprecated)] // for deprecated `try!()` macro
 use std::num::{ParseFloatError, ParseIntError};
 

--- a/tests/ui/moves/issue-34721.fixed
+++ b/tests/ui/moves/issue-34721.fixed
@@ -9,15 +9,15 @@ impl Foo for u32 {
 }
 
 pub mod bar {
-    pub use Foo;
+    pub use crate::Foo;
     pub fn bar<T: Foo>(x: T) -> T {
       x.zero()
     }
 }
 
 mod baz {
-    use bar;
-    use Foo;
+    use crate::bar;
+    use crate::Foo;
     pub fn baz<T: Foo + Copy>(x: T) -> T {
         if 0 == 1 {
             bar::bar(x.zero())

--- a/tests/ui/moves/issue-34721.rs
+++ b/tests/ui/moves/issue-34721.rs
@@ -9,15 +9,15 @@ impl Foo for u32 {
 }
 
 pub mod bar {
-    pub use Foo;
+    pub use crate::Foo;
     pub fn bar<T: Foo>(x: T) -> T {
       x.zero()
     }
 }
 
 mod baz {
-    use bar;
-    use Foo;
+    use crate::bar;
+    use crate::Foo;
     pub fn baz<T: Foo>(x: T) -> T {
         if 0 == 1 {
             bar::bar(x.zero())

--- a/tests/ui/namespace/namespaced-enum-glob-import-no-impls.rs
+++ b/tests/ui/namespace/namespaced-enum-glob-import-no-impls.rs
@@ -12,11 +12,11 @@ mod m2 {
 }
 
 mod m {
-    pub use m2::Foo::*;
+    pub use crate::m2::Foo::*;
 }
 
 pub fn main() {
-    use m2::Foo::*;
+    use crate::m2::Foo::*;
 
     foo(); //~ ERROR cannot find function `foo` in this scope
     m::foo(); //~ ERROR cannot find function `foo` in module `m`

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -1,47 +1,47 @@
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:1:11
+  --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A0 = dyn;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:11
+  --> $DIR/dyn-trait-compatibility.rs:7:11
    |
 LL | type A2 = dyn<dyn, dyn>;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:15
+  --> $DIR/dyn-trait-compatibility.rs:7:15
    |
 LL | type A2 = dyn<dyn, dyn>;
    |               ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:20
+  --> $DIR/dyn-trait-compatibility.rs:7:20
    |
 LL | type A2 = dyn<dyn, dyn>;
    |                    ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:11
+  --> $DIR/dyn-trait-compatibility.rs:11:11
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |           ^^^ not found in this scope
 
 error[E0405]: cannot find trait `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:23
+  --> $DIR/dyn-trait-compatibility.rs:11:23
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                       ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:16
+  --> $DIR/dyn-trait-compatibility.rs:11:16
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
-  --> $DIR/dyn-trait-compatibility.rs:3:11
+  --> $DIR/dyn-trait-compatibility.rs:5:11
    |
 LL | type A1 = dyn::dyn;
    |           ^^^ use of unresolved module or unlinked crate `dyn`

--- a/tests/ui/parser/extern-crate-async.rs
+++ b/tests/ui/parser/extern-crate-async.rs
@@ -1,6 +1,7 @@
-// Make sure that we don't parse `extern crate async`
+// Make sure that we don't parse `extern crate async` as
 // the front matter of a function leading us astray.
 
+//@ edition: 2015
 //@ check-pass
 
 fn main() {}

--- a/tests/ui/parser/fn-field-parse-error-ice.rs
+++ b/tests/ui/parser/fn-field-parse-error-ice.rs
@@ -1,4 +1,5 @@
 // Regression test for #85794
+//@ edition: 2015
 
 struct Baz {
     inner : dyn fn ()

--- a/tests/ui/parser/fn-field-parse-error-ice.stderr
+++ b/tests/ui/parser/fn-field-parse-error-ice.stderr
@@ -1,11 +1,11 @@
 error: expected `,`, or `}`, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:16
+  --> $DIR/fn-field-parse-error-ice.rs:5:16
    |
 LL |     inner : dyn fn ()
    |                ^ help: try adding a comma: `,`
 
 error: expected identifier, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:17
+  --> $DIR/fn-field-parse-error-ice.rs:5:17
    |
 LL | struct Baz {
    |        --- while parsing this struct
@@ -18,7 +18,7 @@ LL |     inner : dyn r#fn ()
    |                 ++
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/fn-field-parse-error-ice.rs:4:13
+  --> $DIR/fn-field-parse-error-ice.rs:5:13
    |
 LL |     inner : dyn fn ()
    |             ^^^ not found in this scope

--- a/tests/ui/parser/issues/issue-114219.rs
+++ b/tests/ui/parser/issues/issue-114219.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 fn main() {
     async move {};
     //~^ ERROR `async move` blocks are only allowed in Rust 2018 or later

--- a/tests/ui/parser/issues/issue-114219.stderr
+++ b/tests/ui/parser/issues/issue-114219.stderr
@@ -1,5 +1,5 @@
 error: `async move` blocks are only allowed in Rust 2018 or later
-  --> $DIR/issue-114219.rs:2:5
+  --> $DIR/issue-114219.rs:4:5
    |
 LL |     async move {};
    |     ^^^^^^^^^^

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 trait Trait {}
 
 fn test(_: &for<'a> dyn Trait) {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -1,5 +1,5 @@
 error: `for<...>` expected after `dyn`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:3:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:5:21
    |
 LL | fn test(_: &for<'a> dyn Trait) {}
    |                     ^^^
@@ -11,7 +11,7 @@ LL + fn test(_: &dyn for<'a> Trait) {}
    |
 
 error: `for<...>` expected after `impl`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:6:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:8:21
    |
 LL | fn test2(_: for<'a> impl Trait) {}
    |                     ^^^^
@@ -23,7 +23,7 @@ LL + fn test2(_: impl for<'a> Trait) {}
    |
 
 error: expected identifier, found `>`
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:10:24
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:12:24
    |
 LL | type A2 = dyn<for<> dyn>;
    |                        ^ expected identifier

--- a/tests/ui/pattern/issue-14221.rs
+++ b/tests/ui/pattern/issue-14221.rs
@@ -8,7 +8,7 @@ pub enum E {
 }
 
 pub mod b {
-    pub fn key(e: ::E) -> &'static str {
+    pub fn key(e: crate::E) -> &'static str {
         match e {
             A => "A",
 //~^ ERROR pattern binding `A` is named the same as one of the variants of the type `E`

--- a/tests/ui/pattern/issue-22546.rs
+++ b/tests/ui/pattern/issue-22546.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 #[derive(Default)]
 pub struct Foo<T>(T, T);
 
-impl<T: ::std::fmt::Display> Foo<T> {
+impl<T: std::fmt::Display> Foo<T> {
     fn foo(&self) {
         match *self {
             Foo::<T>(ref x, ref y) => println!("Goodbye, World! {} {}", x, y)
@@ -36,7 +36,7 @@ fn main() {
     let w = Wrapper { value: Foo(10u8, 11u8) };
     match w {
         Wrapper::<Foo<u8>> { value: Foo(10, 11) } => {},
-        ::Wrapper::<<Foo<_> as Tr>::U> { value: Foo::<u8>(11, 16) } => { panic!() },
+        crate::Wrapper::<<Foo<_> as Tr>::U> { value: Foo::<u8>(11, 16) } => { panic!() },
         _ => { panic!() }
     }
 

--- a/tests/ui/pattern/issue-6449.rs
+++ b/tests/ui/pattern/issue-6449.rs
@@ -13,32 +13,32 @@ enum Other {
 
 fn main() {
     match Foo::Baz {
-        ::Foo::Bar(3) => panic!(),
-        ::Foo::Bar(_) if false => panic!(),
-        ::Foo::Bar(..) if false => panic!(),
-        ::Foo::Bar(_n) => panic!(),
-        ::Foo::Baz => {}
+        crate::Foo::Bar(3) => panic!(),
+        crate::Foo::Bar(_) if false => panic!(),
+        crate::Foo::Bar(..) if false => panic!(),
+        crate::Foo::Bar(_n) => panic!(),
+        crate::Foo::Baz => {}
     }
     match Foo::Bar(3) {
-        ::Foo::Bar(3) => {}
-        ::Foo::Bar(_) if false => panic!(),
-        ::Foo::Bar(..) if false => panic!(),
-        ::Foo::Bar(_n) => panic!(),
-        ::Foo::Baz => panic!(),
+        crate::Foo::Bar(3) => {}
+        crate::Foo::Bar(_) if false => panic!(),
+        crate::Foo::Bar(..) if false => panic!(),
+        crate::Foo::Bar(_n) => panic!(),
+        crate::Foo::Baz => panic!(),
     }
     match Foo::Bar(4) {
-        ::Foo::Bar(3) => panic!(),
-        ::Foo::Bar(_) if false => panic!(),
-        ::Foo::Bar(..) if false => panic!(),
-        ::Foo::Bar(n) => assert_eq!(n, 4),
-        ::Foo::Baz => panic!(),
+        crate::Foo::Bar(3) => panic!(),
+        crate::Foo::Bar(_) if false => panic!(),
+        crate::Foo::Bar(..) if false => panic!(),
+        crate::Foo::Bar(n) => assert_eq!(n, 4),
+        crate::Foo::Baz => panic!(),
     }
 
     match Other::Other1(Foo::Baz) {
-        ::Other::Other1(::Foo::Baz) => {}
-        ::Other::Other1(::Foo::Bar(_)) => {}
-        ::Other::Other2(::Foo::Baz, ::Foo::Bar(_)) => {}
-        ::Other::Other2(::Foo::Bar(..), ::Foo::Baz) => {}
-        ::Other::Other2(..) => {}
+        crate::Other::Other1(crate::Foo::Baz) => {}
+        crate::Other::Other1(crate::Foo::Bar(_)) => {}
+        crate::Other::Other2(crate::Foo::Baz, crate::Foo::Bar(_)) => {}
+        crate::Other::Other2(crate::Foo::Bar(..), crate::Foo::Baz) => {}
+        crate::Other::Other2(..) => {}
     }
 }

--- a/tests/ui/pattern/missing_lifetime.rs
+++ b/tests/ui/pattern/missing_lifetime.rs
@@ -20,6 +20,6 @@ enum Other {
 
 fn main() {
     match Other::Other1(Foo::Baz) {
-        ::Other::Other2(::Foo::Bar(..)) => {}
+        crate::Other::Other2(crate::Foo::Bar(..)) => {}
     }
 }

--- a/tests/ui/pattern/usefulness/uninhabited.rs
+++ b/tests/ui/pattern/usefulness/uninhabited.rs
@@ -120,7 +120,7 @@ mod visibility {
     mod c {
         use super::*;
         pub struct AlsoSecretlyUninhabited {
-            _priv: ::Struct1,
+            _priv: crate::Struct1,
         }
         assert_empty!(SometimesEmptyStruct);
         assert_non_empty!(SometimesEmptyEnum);

--- a/tests/ui/privacy/auxiliary/pub_use_mods_xcrate.rs
+++ b/tests/ui/privacy/auxiliary/pub_use_mods_xcrate.rs
@@ -1,5 +1,5 @@
 pub mod a {
-    pub use a::b::c;
+    pub use crate::a::b::c;
 
     pub mod b {
         pub mod c {

--- a/tests/ui/privacy/crate-private-reexport.rs
+++ b/tests/ui/privacy/crate-private-reexport.rs
@@ -5,10 +5,10 @@ struct S1 {
     bar: i32,
 }
 mod m1 {
-    pub use ::f1; //~ ERROR `f1` is only public within the crate, and cannot be re-exported outside
-    pub use ::S1; //~ ERROR `S1` is only public within the crate, and cannot be re-exported outside
-    pub use ::E1; //~ ERROR `E1` is only public within the crate, and cannot be re-exported outside
-    pub use ::E1::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+    pub use crate::f1; //~ ERROR `f1` is only public within the crate, and cannot be re-exported outside
+    pub use crate::S1; //~ ERROR `S1` is only public within the crate, and cannot be re-exported outside
+    pub use crate::E1; //~ ERROR `E1` is only public within the crate, and cannot be re-exported outside
+    pub use crate::E1::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 pub(crate) fn f2() {}
@@ -20,10 +20,10 @@ pub(crate) struct S2 {
     bar: i32,
 }
 mod m2 {
-    pub use ::f2; //~ ERROR `f2` is only public within the crate, and cannot be re-exported outside
-    pub use ::S2; //~ ERROR `S2` is only public within the crate, and cannot be re-exported outside
-    pub use ::E2; //~ ERROR `E2` is only public within the crate, and cannot be re-exported outside
-    pub use ::E2::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
+    pub use crate::f2; //~ ERROR `f2` is only public within the crate, and cannot be re-exported outside
+    pub use crate::S2; //~ ERROR `S2` is only public within the crate, and cannot be re-exported outside
+    pub use crate::E2; //~ ERROR `E2` is only public within the crate, and cannot be re-exported outside
+    pub use crate::E2::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 }
 
 mod m3 {
@@ -42,7 +42,7 @@ pub use m3::E3; //~ ERROR `E3` is only public within the crate, and cannot be re
 pub use m3::E3::V; //~ ERROR `V` is only public within the crate, and cannot be re-exported outside
 
 pub(self) fn f4() {}
-pub use ::f4 as f5; //~ ERROR `f4` is only public within the crate, and cannot be re-exported outside
+pub use crate::f4 as f5; //~ ERROR `f4` is only public within the crate, and cannot be re-exported outside
 
 pub mod m10 {
     pub mod m {

--- a/tests/ui/privacy/crate-private-reexport.stderr
+++ b/tests/ui/privacy/crate-private-reexport.stderr
@@ -1,82 +1,82 @@
 error[E0364]: `f1` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:8:13
    |
-LL |     pub use ::f1;
-   |             ^^^^
+LL |     pub use crate::f1;
+   |             ^^^^^^^^^
    |
 note: consider marking `f1` as `pub` in the imported module
   --> $DIR/crate-private-reexport.rs:8:13
    |
-LL |     pub use ::f1;
-   |             ^^^^
+LL |     pub use crate::f1;
+   |             ^^^^^^^^^
 
 error[E0365]: `S1` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:9:13
    |
-LL |     pub use ::S1;
-   |             ^^^^ re-export of crate public `S1`
+LL |     pub use crate::S1;
+   |             ^^^^^^^^^ re-export of crate public `S1`
    |
    = note: consider declaring type or module `S1` with `pub`
 
 error[E0365]: `E1` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:10:13
    |
-LL |     pub use ::E1;
-   |             ^^^^ re-export of crate public `E1`
+LL |     pub use crate::E1;
+   |             ^^^^^^^^^ re-export of crate public `E1`
    |
    = note: consider declaring type or module `E1` with `pub`
 
 error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:11:13
    |
-LL |     pub use ::E1::V;
-   |             ^^^^^^^
+LL |     pub use crate::E1::V;
+   |             ^^^^^^^^^^^^
    |
 note: consider marking `V` as `pub` in the imported module
   --> $DIR/crate-private-reexport.rs:11:13
    |
-LL |     pub use ::E1::V;
-   |             ^^^^^^^
+LL |     pub use crate::E1::V;
+   |             ^^^^^^^^^^^^
 
 error[E0364]: `f2` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:23:13
    |
-LL |     pub use ::f2;
-   |             ^^^^
+LL |     pub use crate::f2;
+   |             ^^^^^^^^^
    |
 note: consider marking `f2` as `pub` in the imported module
   --> $DIR/crate-private-reexport.rs:23:13
    |
-LL |     pub use ::f2;
-   |             ^^^^
+LL |     pub use crate::f2;
+   |             ^^^^^^^^^
 
 error[E0365]: `S2` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:24:13
    |
-LL |     pub use ::S2;
-   |             ^^^^ re-export of crate public `S2`
+LL |     pub use crate::S2;
+   |             ^^^^^^^^^ re-export of crate public `S2`
    |
    = note: consider declaring type or module `S2` with `pub`
 
 error[E0365]: `E2` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:25:13
    |
-LL |     pub use ::E2;
-   |             ^^^^ re-export of crate public `E2`
+LL |     pub use crate::E2;
+   |             ^^^^^^^^^ re-export of crate public `E2`
    |
    = note: consider declaring type or module `E2` with `pub`
 
 error[E0364]: `V` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:26:13
    |
-LL |     pub use ::E2::V;
-   |             ^^^^^^^
+LL |     pub use crate::E2::V;
+   |             ^^^^^^^^^^^^
    |
 note: consider marking `V` as `pub` in the imported module
   --> $DIR/crate-private-reexport.rs:26:13
    |
-LL |     pub use ::E2::V;
-   |             ^^^^^^^
+LL |     pub use crate::E2::V;
+   |             ^^^^^^^^^^^^
 
 error[E0364]: `f3` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:39:9
@@ -121,14 +121,14 @@ LL | pub use m3::E3::V;
 error[E0364]: `f4` is only public within the crate, and cannot be re-exported outside
   --> $DIR/crate-private-reexport.rs:45:9
    |
-LL | pub use ::f4 as f5;
-   |         ^^^^^^^^^^
+LL | pub use crate::f4 as f5;
+   |         ^^^^^^^^^^^^^^^
    |
 note: consider marking `f4` as `pub` in the imported module
   --> $DIR/crate-private-reexport.rs:45:9
    |
-LL | pub use ::f4 as f5;
-   |         ^^^^^^^^^^
+LL | pub use crate::f4 as f5;
+   |         ^^^^^^^^^^^^^^^
 
 error[E0364]: `f6` is private, and cannot be re-exported
   --> $DIR/crate-private-reexport.rs:53:13

--- a/tests/ui/privacy/issue-30079.rs
+++ b/tests/ui/privacy/issue-30079.rs
@@ -2,7 +2,7 @@ struct SemiPriv;
 
 mod m1 {
     struct Priv;
-    impl ::SemiPriv {
+    impl crate::SemiPriv {
         pub fn f(_: Priv) {} //~ WARN type `m1::Priv` is more private than the item `m1::<impl SemiPriv>::f`
     }
 
@@ -13,12 +13,12 @@ mod m1 {
 
 mod m2 {
     struct Priv;
-    impl ::std::ops::Deref for ::SemiPriv {
+    impl std::ops::Deref for crate::SemiPriv {
         type Target = Priv; //~ ERROR private type `m2::Priv` in public interface
         fn deref(&self) -> &Self::Target { unimplemented!() }
     }
 
-    impl ::std::ops::Deref for Priv {
+    impl std::ops::Deref for Priv {
         type Target = Priv; // ok
         fn deref(&self) -> &Self::Target { unimplemented!() }
     }
@@ -30,7 +30,7 @@ trait SemiPrivTrait {
 
 mod m3 {
     struct Priv;
-    impl ::SemiPrivTrait for () {
+    impl crate::SemiPrivTrait for () {
         type Assoc = Priv; //~ ERROR private type `m3::Priv` in public interface
     }
 }

--- a/tests/ui/privacy/issue-30079.stderr
+++ b/tests/ui/privacy/issue-30079.stderr
@@ -16,7 +16,7 @@ error[E0446]: private type `m2::Priv` in public interface
    |
 LL |     struct Priv;
    |     ----------- `m2::Priv` declared as private
-LL |     impl ::std::ops::Deref for ::SemiPriv {
+LL |     impl std::ops::Deref for crate::SemiPriv {
 LL |         type Target = Priv;
    |         ^^^^^^^^^^^ can't leak private type
 
@@ -25,7 +25,7 @@ error[E0446]: private type `m3::Priv` in public interface
    |
 LL |     struct Priv;
    |     ----------- `m3::Priv` declared as private
-LL |     impl ::SemiPrivTrait for () {
+LL |     impl crate::SemiPrivTrait for () {
 LL |         type Assoc = Priv;
    |         ^^^^^^^^^^ can't leak private type
 

--- a/tests/ui/privacy/issue-46209-private-enum-variant-reexport.rs
+++ b/tests/ui/privacy/issue-46209-private-enum-variant-reexport.rs
@@ -26,7 +26,7 @@ mod rank {
         Full,
     }
 
-    pub(in rank) enum PettyOfficer {
+    pub(in crate::rank) enum PettyOfficer {
         SecondClass,
         FirstClass,
         Chief,

--- a/tests/ui/privacy/legacy-ctor-visibility.rs
+++ b/tests/ui/privacy/legacy-ctor-visibility.rs
@@ -4,7 +4,7 @@ mod m {
     pub struct S(u8);
 
     mod n {
-        use S;
+        use crate::S;
         fn f() {
             S(10);
             //~^ ERROR expected function, tuple struct or tuple variant, found struct `S`

--- a/tests/ui/privacy/privacy-in-paths.rs
+++ b/tests/ui/privacy/privacy-in-paths.rs
@@ -2,7 +2,7 @@ mod foo {
     pub use self::bar::S;
     mod bar {
         pub struct S;
-        pub use baz;
+        pub use crate::baz;
     }
 
     trait T {
@@ -21,9 +21,9 @@ pub mod baz {
     fn f() {}
 
     fn g() {
-        ::foo::bar::baz::f(); //~ERROR module `bar` is private
-        ::foo::bar::S::f(); //~ERROR module `bar` is private
-        <() as ::foo::T>::Assoc::f(); //~ERROR trait `T` is private
+        crate::foo::bar::baz::f(); //~ERROR module `bar` is private
+        crate::foo::bar::S::f(); //~ERROR module `bar` is private
+        <() as crate::foo::T>::Assoc::f(); //~ERROR trait `T` is private
     }
 }
 

--- a/tests/ui/privacy/privacy-in-paths.stderr
+++ b/tests/ui/privacy/privacy-in-paths.stderr
@@ -1,10 +1,10 @@
 error[E0603]: module `bar` is private
-  --> $DIR/privacy-in-paths.rs:24:16
+  --> $DIR/privacy-in-paths.rs:24:21
    |
-LL |         ::foo::bar::baz::f();
-   |                ^^^       - function `f` is not publicly re-exported
-   |                |
-   |                private module
+LL |         crate::foo::bar::baz::f();
+   |                     ^^^       - function `f` is not publicly re-exported
+   |                     |
+   |                     private module
    |
 note: the module `bar` is defined here
   --> $DIR/privacy-in-paths.rs:3:5
@@ -13,10 +13,10 @@ LL |     mod bar {
    |     ^^^^^^^
 
 error[E0603]: module `bar` is private
-  --> $DIR/privacy-in-paths.rs:25:16
+  --> $DIR/privacy-in-paths.rs:25:21
    |
-LL |         ::foo::bar::S::f();
-   |                ^^^ private module
+LL |         crate::foo::bar::S::f();
+   |                     ^^^ private module
    |
 note: the module `bar` is defined here
   --> $DIR/privacy-in-paths.rs:3:5
@@ -25,17 +25,17 @@ LL |     mod bar {
    |     ^^^^^^^
 help: consider importing this struct through its public re-export instead
    |
-LL -         ::foo::bar::S::f();
+LL -         crate::foo::bar::S::f();
 LL +         foo::S::f();
    |
 
 error[E0603]: trait `T` is private
-  --> $DIR/privacy-in-paths.rs:26:23
+  --> $DIR/privacy-in-paths.rs:26:28
    |
-LL |         <() as ::foo::T>::Assoc::f();
-   |                       ^   ----- associated type `Assoc` is not publicly re-exported
-   |                       |
-   |                       private trait
+LL |         <() as crate::foo::T>::Assoc::f();
+   |                            ^   ----- associated type `Assoc` is not publicly re-exported
+   |                            |
+   |                            private trait
    |
 note: the trait `T` is defined here
   --> $DIR/privacy-in-paths.rs:8:5

--- a/tests/ui/privacy/privacy-ufcs.rs
+++ b/tests/ui/privacy/privacy-ufcs.rs
@@ -9,5 +9,5 @@ mod foo {
 }
 
 fn main() {
-    <i32 as ::foo::Bar>::baz(); //~ERROR trait `Bar` is private
+    <i32 as crate::foo::Bar>::baz(); //~ERROR trait `Bar` is private
 }

--- a/tests/ui/privacy/privacy-ufcs.stderr
+++ b/tests/ui/privacy/privacy-ufcs.stderr
@@ -1,10 +1,10 @@
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ufcs.rs:12:20
+  --> $DIR/privacy-ufcs.rs:12:25
    |
-LL |     <i32 as ::foo::Bar>::baz();
-   |                    ^^^   --- associated function `baz` is not publicly re-exported
-   |                    |
-   |                    private trait
+LL |     <i32 as crate::foo::Bar>::baz();
+   |                         ^^^   --- associated function `baz` is not publicly re-exported
+   |                         |
+   |                         private trait
    |
 note: the trait `Bar` is defined here
   --> $DIR/privacy-ufcs.rs:4:5

--- a/tests/ui/privacy/privacy1.rs
+++ b/tests/ui/privacy/privacy1.rs
@@ -98,34 +98,34 @@ fn lol() {
 
 mod foo {
     fn test() {
-        ::bar::A::foo();
-        ::bar::A::bar();        //~ ERROR: associated function `bar` is private
-        ::bar::A.foo2();
-        ::bar::baz::A::foo();   //~ ERROR: module `baz` is private
-        ::bar::baz::A::bar();   //~ ERROR: module `baz` is private
+        crate::bar::A::foo();
+        crate::bar::A::bar();        //~ ERROR: associated function `bar` is private
+        crate::bar::A.foo2();
+        crate::bar::baz::A::foo();   //~ ERROR: module `baz` is private
+        crate::bar::baz::A::bar();   //~ ERROR: module `baz` is private
                                 //~^ ERROR: associated function `bar` is private
-        ::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
-        ::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
+        crate::bar::baz::A.foo2();   //~ ERROR: module `baz` is private
+        crate::bar::baz::A.bar2();   //~ ERROR: module `baz` is private
                                 //~^ ERROR: method `bar2` is private
 
         let _: isize =
-        ::bar::B::foo();        //~ ERROR: trait `B` is private
-        ::lol();
+        crate::bar::B::foo();        //~ ERROR: trait `B` is private
+        crate::lol();
 
-        ::bar::Enum::Pub;
+        crate::bar::Enum::Pub;
 
         unsafe {
-            ::bar::epriv(); //~ ERROR: function `epriv` is private
-            ::bar::epub();
+            crate::bar::epriv(); //~ ERROR: function `epriv` is private
+            crate::bar::epub();
         }
 
-        ::bar::foo();
-        ::bar::bar();
+        crate::bar::foo();
+        crate::bar::bar();
 
-        ::bar::gpub();
+        crate::bar::gpub();
 
-        ::bar::baz::foo(); //~ ERROR: module `baz` is private
-        ::bar::baz::bar(); //~ ERROR: module `baz` is private
+        crate::bar::baz::foo(); //~ ERROR: module `baz` is private
+        crate::bar::baz::bar(); //~ ERROR: module `baz` is private
     }
 
     fn test2() {
@@ -154,7 +154,7 @@ mod foo {
         bar::bar();
     }
 
-    impl ::bar::B for f32 { fn foo() -> f32 { 1.0 } }
+    impl crate::bar::B for f32 { fn foo() -> f32 { 1.0 } }
     //~^ ERROR: trait `B` is private
 }
 

--- a/tests/ui/privacy/privacy1.stderr
+++ b/tests/ui/privacy/privacy1.stderr
@@ -48,26 +48,12 @@ LL |         mod i {
    |         ^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:104:16
+  --> $DIR/privacy1.rs:104:21
    |
-LL |         ::bar::baz::A::foo();
-   |                ^^^  - struct `A` is not publicly re-exported
-   |                |
-   |                private module
-   |
-note: the module `baz` is defined here
-  --> $DIR/privacy1.rs:50:5
-   |
-LL |     mod baz {
-   |     ^^^^^^^
-
-error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:105:16
-   |
-LL |         ::bar::baz::A::bar();
-   |                ^^^  - struct `A` is not publicly re-exported
-   |                |
-   |                private module
+LL |         crate::bar::baz::A::foo();
+   |                     ^^^  - struct `A` is not publicly re-exported
+   |                     |
+   |                     private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -76,12 +62,12 @@ LL |     mod baz {
    |     ^^^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:107:16
+  --> $DIR/privacy1.rs:105:21
    |
-LL |         ::bar::baz::A.foo2();
-   |                ^^^  - unit struct `A` is not publicly re-exported
-   |                |
-   |                private module
+LL |         crate::bar::baz::A::bar();
+   |                     ^^^  - struct `A` is not publicly re-exported
+   |                     |
+   |                     private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -90,12 +76,26 @@ LL |     mod baz {
    |     ^^^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:108:16
+  --> $DIR/privacy1.rs:107:21
    |
-LL |         ::bar::baz::A.bar2();
-   |                ^^^  - unit struct `A` is not publicly re-exported
-   |                |
-   |                private module
+LL |         crate::bar::baz::A.foo2();
+   |                     ^^^  - unit struct `A` is not publicly re-exported
+   |                     |
+   |                     private module
+   |
+note: the module `baz` is defined here
+  --> $DIR/privacy1.rs:50:5
+   |
+LL |     mod baz {
+   |     ^^^^^^^
+
+error[E0603]: module `baz` is private
+  --> $DIR/privacy1.rs:108:21
+   |
+LL |         crate::bar::baz::A.bar2();
+   |                     ^^^  - unit struct `A` is not publicly re-exported
+   |                     |
+   |                     private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -104,12 +104,12 @@ LL |     mod baz {
    |     ^^^^^^^
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:112:16
+  --> $DIR/privacy1.rs:112:21
    |
-LL |         ::bar::B::foo();
-   |                ^  --- associated function `foo` is not publicly re-exported
-   |                |
-   |                private trait
+LL |         crate::bar::B::foo();
+   |                     ^  --- associated function `foo` is not publicly re-exported
+   |                     |
+   |                     private trait
    |
 note: the trait `B` is defined here
   --> $DIR/privacy1.rs:40:5
@@ -118,10 +118,10 @@ LL |     trait B {
    |     ^^^^^^^
 
 error[E0603]: function `epriv` is private
-  --> $DIR/privacy1.rs:118:20
+  --> $DIR/privacy1.rs:118:25
    |
-LL |             ::bar::epriv();
-   |                    ^^^^^ private function
+LL |             crate::bar::epriv();
+   |                         ^^^^^ private function
    |
 note: the function `epriv` is defined here
   --> $DIR/privacy1.rs:65:9
@@ -130,10 +130,10 @@ LL |         fn epriv();
    |         ^^^^^^^^^^^
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:127:16
+  --> $DIR/privacy1.rs:127:21
    |
-LL |         ::bar::baz::foo();
-   |                ^^^ private module
+LL |         crate::bar::baz::foo();
+   |                     ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -142,15 +142,15 @@ LL |     mod baz {
    |     ^^^^^^^
 help: consider importing this function through its public re-export instead
    |
-LL -         ::bar::baz::foo();
+LL -         crate::bar::baz::foo();
 LL +         bar::foo();
    |
 
 error[E0603]: module `baz` is private
-  --> $DIR/privacy1.rs:128:16
+  --> $DIR/privacy1.rs:128:21
    |
-LL |         ::bar::baz::bar();
-   |                ^^^ private module
+LL |         crate::bar::baz::bar();
+   |                     ^^^ private module
    |
 note: the module `baz` is defined here
   --> $DIR/privacy1.rs:50:5
@@ -159,15 +159,15 @@ LL |     mod baz {
    |     ^^^^^^^
 help: consider importing this function through its public re-export instead
    |
-LL -         ::bar::baz::bar();
+LL -         crate::bar::baz::bar();
 LL +         bar::bar();
    |
 
 error[E0603]: trait `B` is private
-  --> $DIR/privacy1.rs:157:17
+  --> $DIR/privacy1.rs:157:22
    |
-LL |     impl ::bar::B for f32 { fn foo() -> f32 { 1.0 } }
-   |                 ^ private trait
+LL |     impl crate::bar::B for f32 { fn foo() -> f32 { 1.0 } }
+   |                      ^ private trait
    |
 note: the trait `B` is defined here
   --> $DIR/privacy1.rs:40:5
@@ -194,31 +194,31 @@ LL |     bar::A::bar();
    |             ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:102:19
+  --> $DIR/privacy1.rs:102:24
    |
 LL |         fn bar() {}
    |         -------- private associated function defined here
 ...
-LL |         ::bar::A::bar();
-   |                   ^^^ private associated function
+LL |         crate::bar::A::bar();
+   |                        ^^^ private associated function
 
 error[E0624]: associated function `bar` is private
-  --> $DIR/privacy1.rs:105:24
+  --> $DIR/privacy1.rs:105:29
    |
 LL |             fn bar() {}
    |             -------- private associated function defined here
 ...
-LL |         ::bar::baz::A::bar();
-   |                        ^^^ private associated function
+LL |         crate::bar::baz::A::bar();
+   |                             ^^^ private associated function
 
 error[E0624]: method `bar2` is private
-  --> $DIR/privacy1.rs:108:23
+  --> $DIR/privacy1.rs:108:28
    |
 LL |             fn bar2(&self) {}
    |             -------------- private method defined here
 ...
-LL |         ::bar::baz::A.bar2();
-   |                       ^^^^ private method
+LL |         crate::bar::baz::A.bar2();
+   |                            ^^^^ private method
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/privacy/privacy2.rs
+++ b/tests/ui/privacy/privacy2.rs
@@ -10,7 +10,7 @@ mod bar {
     pub use self::glob::*;
 
     pub mod glob {
-        use foo;
+        use crate::foo;
     }
 }
 

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -13,8 +13,8 @@ LL |     use bar::glob::foo;
 note: the function import `foo` is defined here...
   --> $DIR/privacy2.rs:13:13
    |
-LL |         use foo;
-   |             ^^^
+LL |         use crate::foo;
+   |             ^^^^^^^^^^
 note: ...and refers to the function `foo` which is defined here
   --> $DIR/privacy2.rs:17:1
    |

--- a/tests/ui/privacy/private-inferred-type-1.rs
+++ b/tests/ui/privacy/private-inferred-type-1.rs
@@ -12,9 +12,9 @@ trait Ref {
 mod m {
     struct Priv;
 
-    impl ::Arr0 for [Priv; 0] { fn arr0_secret(&self) {} }
-    impl ::TyParam for Option<Priv> { fn ty_param_secret(&self) {} }
-    impl<'a> ::Ref for &'a Priv { fn ref_secret(self) {} }
+    impl crate::Arr0 for [Priv; 0] { fn arr0_secret(&self) {} }
+    impl crate::TyParam for Option<Priv> { fn ty_param_secret(&self) {} }
+    impl<'a> crate::Ref for &'a Priv { fn ref_secret(self) {} }
 }
 
 fn anyref<'a, T>() -> &'a T { panic!() }

--- a/tests/ui/privacy/restricted/lookup-ignores-private.rs
+++ b/tests/ui/privacy/restricted/lookup-ignores-private.rs
@@ -2,14 +2,14 @@
 #![allow(warnings)]
 
 mod foo {
-    pub use foo::bar::S;
+    pub use crate::foo::bar::S;
     mod bar {
         #[derive(Default)]
         pub struct S {
-            pub(in foo) x: i32,
+            pub(in crate::foo) x: i32,
         }
         impl S {
-            pub(in foo) fn f(&self) -> i32 { 0 }
+            pub(in crate::foo) fn f(&self) -> i32 { 0 }
         }
 
         pub struct S2 {
@@ -19,7 +19,7 @@ mod foo {
             pub(crate) fn f(&self) -> bool { false }
         }
 
-        impl ::std::ops::Deref for S {
+        impl std::ops::Deref for S {
             type Target = S2;
             fn deref(&self) -> &S2 { unimplemented!() }
         }

--- a/tests/ui/privacy/restricted/private-in-public.rs
+++ b/tests/ui/privacy/restricted/private-in-public.rs
@@ -2,7 +2,7 @@
 mod foo {
     struct Priv;
     mod bar {
-        use foo::Priv;
+        use crate::foo::Priv;
         pub(super) fn f(_: Priv) {}
         pub(crate) fn g(_: Priv) {}
         pub(crate) fn h(_: Priv) {}

--- a/tests/ui/privacy/restricted/struct-literal-field.rs
+++ b/tests/ui/privacy/restricted/struct-literal-field.rs
@@ -3,7 +3,7 @@
 mod foo {
     pub mod bar {
         pub struct S {
-            pub(in foo) x: i32,
+            pub(in crate::foo) x: i32,
         }
     }
 
@@ -14,6 +14,6 @@ mod foo {
 }
 
 fn main() {
-    use foo::bar::S;
+    use crate::foo::bar::S;
     S { x: 0 }; //~ ERROR private
 }

--- a/tests/ui/proc-macro/crate-var.rs
+++ b/tests/ui/proc-macro/crate-var.rs
@@ -31,7 +31,7 @@ macro_rules! local { () => {
 
     mod qself {
         #[derive(Double)]
-        struct QSelf(<::Foo as $crate::Trait>::Assoc);
+        struct QSelf(<crate::Foo as $crate::Trait>::Assoc);
     }
 
     mod qself_recurse {
@@ -43,7 +43,7 @@ macro_rules! local { () => {
         #[derive(Double)]
         #[repr(u32)]
         enum QSelfInConst {
-            Variant = <::Foo as $crate::Trait>::CONST,
+            Variant = <crate::Foo as $crate::Trait>::CONST,
         }
     }
 } }

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import.rs
@@ -10,7 +10,7 @@ use self::two::*;
 mod empty_helper {}
 
 mod one {
-    use empty_helper;
+    use crate::empty_helper;
 
     #[derive(Empty)]
     #[empty_helper]
@@ -18,7 +18,7 @@ mod one {
 }
 
 mod two {
-    use empty_helper;
+    use crate::empty_helper;
 
     #[derive(Empty)]
     #[empty_helper]

--- a/tests/ui/proc-macro/issue-50493.rs
+++ b/tests/ui/proc-macro/issue-50493.rs
@@ -5,7 +5,7 @@ extern crate issue_50493;
 
 #[derive(Derive)]
 struct Restricted {
-    pub(in restricted) field: usize, //~ ERROR visibilities can only be restricted to ancestor modules
+    pub(in crate::restricted) field: usize, //~ ERROR visibilities can only be restricted to ancestor modules
 }
 
 mod restricted {}

--- a/tests/ui/proc-macro/issue-50493.stderr
+++ b/tests/ui/proc-macro/issue-50493.stderr
@@ -1,8 +1,8 @@
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/issue-50493.rs:8:12
    |
-LL |     pub(in restricted) field: usize,
-   |            ^^^^^^^^^^
+LL |     pub(in crate::restricted) field: usize,
+   |            ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/issue-53481.rs
+++ b/tests/ui/proc-macro/issue-53481.rs
@@ -5,7 +5,7 @@
 extern crate test_macros;
 
 mod m1 {
-    use m2::Empty;
+    use crate::m2::Empty;
 
     #[derive(Empty)]
     struct A {}

--- a/tests/ui/proc-macro/trait-fn-args-2015.rs
+++ b/tests/ui/proc-macro/trait-fn-args-2015.rs
@@ -1,6 +1,7 @@
 // Unnamed arguments in trait functions can be passed through proc macros on 2015 edition.
 
 //@ check-pass
+//@ edition: 2015
 //@ proc-macro: test-macros.rs
 
 #![allow(anonymous_parameters)]

--- a/tests/ui/pub/pub-reexport-priv-extern-crate.rs
+++ b/tests/ui/pub/pub-reexport-priv-extern-crate.rs
@@ -7,14 +7,14 @@ mod foo1 {
 }
 
 mod foo2 {
-    use foo1::core; //~ ERROR crate import `core` is private
+    use crate::foo1::core; //~ ERROR crate import `core` is private
     pub mod bar {
         extern crate core;
     }
 }
 
 mod baz {
-    pub use foo2::bar::core; //~ ERROR crate import `core` is private
+    pub use crate::foo2::bar::core; //~ ERROR crate import `core` is private
 }
 
 fn main() {}

--- a/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
+++ b/tests/ui/pub/pub-reexport-priv-extern-crate.stderr
@@ -1,8 +1,8 @@
 error[E0603]: crate import `core` is private
-  --> $DIR/pub-reexport-priv-extern-crate.rs:10:15
+  --> $DIR/pub-reexport-priv-extern-crate.rs:10:22
    |
-LL |     use foo1::core;
-   |               ^^^^ private crate import
+LL |     use crate::foo1::core;
+   |                      ^^^^ private crate import
    |
 note: the crate import `core` is defined here
   --> $DIR/pub-reexport-priv-extern-crate.rs:6:5
@@ -11,10 +11,10 @@ LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^
 
 error[E0603]: crate import `core` is private
-  --> $DIR/pub-reexport-priv-extern-crate.rs:17:24
+  --> $DIR/pub-reexport-priv-extern-crate.rs:17:31
    |
-LL |     pub use foo2::bar::core;
-   |                        ^^^^ private crate import
+LL |     pub use crate::foo2::bar::core;
+   |                               ^^^^ private crate import
    |
 note: the crate import `core` is defined here
   --> $DIR/pub-reexport-priv-extern-crate.rs:12:9

--- a/tests/ui/pub/pub-restricted.rs
+++ b/tests/ui/pub/pub-restricted.rs
@@ -7,7 +7,7 @@ pub (crate::a) fn cfn() {} //~ ERROR incorrect visibility restriction
 pub fn privfn() {}
 mod x {
     mod y {
-        pub (in x) fn foo() {}
+        pub (in crate::x) fn foo() {}
         pub (super) fn bar() {}
         pub (crate) fn qux() {}
     }
@@ -18,9 +18,9 @@ mod y {
         pub (crate) c: usize,
         pub (super) s: usize,
         valid_private: usize,
-        pub (in y) valid_in_x: usize,
+        pub (in crate::y) valid_in_x: usize,
         pub (a) invalid: usize, //~ ERROR incorrect visibility restriction
-        pub (in x) non_parent_invalid: usize, //~ ERROR visibilities can only be restricted
+        pub (in crate::x) non_parent_invalid: usize, //~ ERROR visibilities can only be restricted
     }
 }
 

--- a/tests/ui/pub/pub-restricted.stderr
+++ b/tests/ui/pub/pub-restricted.stderr
@@ -76,8 +76,8 @@ LL | pub (in xyz) fn xyz() {}
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/pub-restricted.rs:23:17
    |
-LL |         pub (in x) non_parent_invalid: usize,
-   |                 ^
+LL |         pub (in crate::x) non_parent_invalid: usize,
+   |                 ^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/recursion/auxiliary/recursive_reexports.rs
+++ b/tests/ui/recursion/auxiliary/recursive_reexports.rs
@@ -1,3 +1,3 @@
 pub mod foo {
-    pub use foo;
+    pub use crate::foo;
 }

--- a/tests/ui/recursion_limit/issue-40003.rs
+++ b/tests/ui/recursion_limit/issue-40003.rs
@@ -17,7 +17,7 @@ use future::{Future, IntoFuture};
 mod future {
     use std::result;
 
-    use {stream, Stream};
+    use crate::{stream, Stream};
 
     pub trait Future {
         type Item;
@@ -100,7 +100,7 @@ mod future {
 }
 
 mod stream {
-    use IntoFuture;
+    use crate::IntoFuture;
 
     pub trait Stream {
         type Item;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141250 (add s390x z17 target features)
 - rust-lang/rust#141570 (Fix incorrect eq_unspanned in TokenStream)
 - rust-lang/rust#141893 (remove `f16: From<u16>`)
 - rust-lang/rust#141924 (Lightly tweak docs for BTree{Map,Set}::extract_if)
 - rust-lang/rust#141959 (Add more missing 2015 edition directives)
 - rust-lang/rust#141960 (Use non-2015 edition paths in tests that do not test for their resolution)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141250,141570,141893,141924,141959,141960)
<!-- homu-ignore:end -->