### PR TITLE
Fix `proc_macro::Ident`'s handling of `$crate`

### DIFF
--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -33,7 +33,7 @@ impl Symbol {
     /// Validates and normalizes before converting it to a symbol.
     pub(crate) fn new_ident(string: &str, is_raw: bool) -> Self {
         // Fast-path: check if this is a valid ASCII identifier
-        if Self::is_valid_ascii_ident(string.as_bytes()) {
+        if Self::is_valid_ascii_ident(string.as_bytes()) || string == "$crate" {
             if is_raw && !Self::can_be_raw(string) {
                 panic!("`{}` cannot be a raw identifier", string);
             }
@@ -79,7 +79,7 @@ impl Symbol {
     // Mimics the behavior of `Symbol::can_be_raw` from `rustc_span`
     fn can_be_raw(string: &str) -> bool {
         match string {
-            "_" | "super" | "self" | "Self" | "crate" => false,
+            "_" | "super" | "self" | "Self" | "crate" | "$crate" => false,
             _ => true,
         }
     }

--- a/tests/ui/proc-macro/auxiliary/mixed-site-span.rs
+++ b/tests/ui/proc-macro/auxiliary/mixed-site-span.rs
@@ -3,33 +3,89 @@
 extern crate proc_macro;
 use proc_macro::*;
 
-#[proc_macro]
-pub fn proc_macro_rules(input: TokenStream) -> TokenStream {
-    if input.is_empty() {
-        let id = |s| TokenTree::from(Ident::new(s, Span::mixed_site()));
-        let item_def = id("ItemDef");
-        let local_def = id("local_def");
-        let item_use = id("ItemUse");
-        let local_use = id("local_use");
-        let mut single_quote = Punct::new('\'', Spacing::Joint);
-        single_quote.set_span(Span::mixed_site());
-        let label_use: TokenStream = [
-            TokenTree::from(single_quote),
-            id("label_use"),
-        ].iter().cloned().collect();
-        quote!(
-            struct $item_def;
-            let $local_def = 0;
 
-            $item_use; // OK
-            $local_use; // ERROR
-            break $label_use; // ERROR
-        )
-    } else {
-        let mut dollar_crate = input.into_iter().next().unwrap();
-        dollar_crate.set_span(Span::mixed_site());
-        quote!(
-            type A = $dollar_crate::ItemUse;
-        )
+#[proc_macro]
+pub fn proc_macro_item(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[proc_macro]
+pub fn proc_macro_rules(_input: TokenStream) -> TokenStream {
+    let id = |s| TokenTree::from(Ident::new(s, Span::mixed_site()));
+    let item_def = id("ItemDef");
+    let local_def = id("local_def");
+    let item_use = id("ItemUse");
+    let local_use = id("local_use");
+    let mut single_quote = Punct::new('\'', Spacing::Joint);
+    single_quote.set_span(Span::mixed_site());
+    let label_use: TokenStream = [
+        TokenTree::from(single_quote),
+        id("label_use"),
+    ].iter().cloned().collect();
+    let dollar_crate = id("$crate");
+    quote!(
+        use $dollar_crate::proc_macro_item as _; // OK
+        type A = $dollar_crate::ItemUse; // ERROR
+
+        struct $item_def;
+        let $local_def = 0;
+
+        $item_use; // OK
+        $local_use; // ERROR
+        break $label_use; // ERROR
+    )
+}
+
+#[proc_macro]
+pub fn with_crate(input: TokenStream) -> TokenStream {
+    let mut input = input.into_iter();
+    let TokenTree::Ident(mut krate) = input.next().unwrap() else { panic!("missing $crate") };
+    let TokenTree::Ident(span) = input.next().unwrap() else { panic!("missing span") };
+    let TokenTree::Ident(ident) = input.next().unwrap() else { panic!("missing ident") };
+
+    match (krate.to_string().as_str(), span.to_string().as_str()) {
+        ("$crate", "input") => {},
+        (_, "input") => krate = Ident::new("$crate", krate.span()),
+
+        ("$crate", "mixed") => krate.set_span(Span::mixed_site()),
+        (_, "mixed") => krate = Ident::new("$crate", Span::mixed_site()),
+
+        ("$crate", "call") => krate.set_span(Span::call_site()),
+        (_, "call") => krate = Ident::new("$crate", Span::call_site()),
+
+        (_, x) => panic!("bad span {}", x),
     }
+
+    quote!(use $krate::$ident as _;)
+}
+
+#[proc_macro]
+pub fn declare_macro(input: TokenStream) -> TokenStream {
+    let mut input = input.into_iter();
+    let TokenTree::Ident(mut krate) = input.next().unwrap() else { panic!("missing $crate") };
+    let TokenTree::Ident(span) = input.next().unwrap() else { panic!("missing span") };
+    let TokenTree::Ident(ident) = input.next().unwrap() else { panic!("missing ident") };
+
+
+    match (krate.to_string().as_str(), span.to_string().as_str()) {
+        ("$crate", "input") => {},
+        (_, "input") => krate = Ident::new("$crate", krate.span()),
+
+        ("$crate", "mixed") => krate.set_span(Span::mixed_site()),
+        (_, "mixed") => krate = Ident::new("$crate", Span::mixed_site()),
+
+        ("$crate", "call") => krate.set_span(Span::call_site()),
+        (_, "call") => krate = Ident::new("$crate", Span::call_site()),
+
+        (_, x) => panic!("bad span {}", x),
+    }
+
+    quote!(
+        #[macro_export]
+        macro_rules! $ident {
+            ($$i:ident) => {
+                use $krate::$$i as _;
+            };
+        }
+    )
 }

--- a/tests/ui/proc-macro/auxiliary/token-site-span.rs
+++ b/tests/ui/proc-macro/auxiliary/token-site-span.rs
@@ -1,0 +1,30 @@
+// Testing token span hygiene.
+
+//@ proc-macro: mixed-site-span.rs
+
+extern crate mixed_site_span;
+
+use mixed_site_span::declare_macro;
+
+pub struct TokenItem;
+
+#[macro_export]
+macro_rules! invoke_with_crate {
+    ($s:ident $i:ident) => { with_crate!{$crate $s $i} };
+}
+
+#[macro_export]
+macro_rules! invoke_with_ident {
+    ($s:ident $i:ident) => { with_crate!{krate $s $i} };
+    ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+}
+
+macro_rules! local {() => {
+    declare_macro!{$crate input use_input_crate}
+    declare_macro!{$crate mixed use_mixed_crate}
+    declare_macro!{$crate call use_call_crate}
+}}
+local!{}
+declare_macro!{krate input use_input_krate}
+declare_macro!{krate mixed use_mixed_krate}
+declare_macro!{krate call use_call_krate}

--- a/tests/ui/proc-macro/mixed-site-span.rs
+++ b/tests/ui/proc-macro/mixed-site-span.rs
@@ -1,24 +1,174 @@
 // Proc macros using `mixed_site` spans exhibit usual properties of `macro_rules` hygiene.
 
+//@ aux-build: token-site-span.rs
 //@ proc-macro: mixed-site-span.rs
 
-#[macro_use]
 extern crate mixed_site_span;
+extern crate token_site_span;
 
-struct ItemUse;
+use mixed_site_span::{proc_macro_rules, with_crate};
+use token_site_span::{
+    invoke_with_crate, invoke_with_ident,
+    use_input_crate, use_mixed_crate, use_call_crate,
+    use_input_krate, use_mixed_krate, use_call_krate,
+};
+
+pub struct ItemUse;
 
 fn main() {
     'label_use: loop {
         let local_use = 1;
         proc_macro_rules!();
-        //~^ ERROR use of undeclared label `'label_use`
+        //~^ ERROR cannot find type `ItemUse` in crate `$crate`
+        //~| ERROR use of undeclared label `'label_use`
         //~| ERROR cannot find value `local_use` in this scope
         ItemDef; // OK
         local_def; //~ ERROR cannot find value `local_def` in this scope
     }
 }
 
-macro_rules! pass_dollar_crate {
-    () => (proc_macro_rules!($crate);) //~ ERROR cannot find type `ItemUse` in crate `$crate`
-}
-pass_dollar_crate!();
+// Successful resolutions of `mixed_site_span::proc_macro_item`
+const _: () = {
+    invoke_with_crate!{mixed proc_macro_item}
+    invoke_with_ident!{mixed proc_macro_item}
+    invoke_with_ident!{krate mixed proc_macro_item}
+    with_crate!{krate mixed proc_macro_item}
+
+    macro_rules! test {() => {
+        invoke_with_ident!{$crate mixed proc_macro_item}
+        with_crate!{$crate mixed proc_macro_item}
+    }}
+    test!();
+};
+
+// Failed resolutions of `proc_macro_item`
+const _: () = {
+    // token_site_span::proc_macro_item
+    invoke_with_crate!{input proc_macro_item}            //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{input proc_macro_item}            //~ ERROR unresolved import `$crate`
+    invoke_with_crate!{call proc_macro_item}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{call proc_macro_item}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{hello call proc_macro_item}       //~ ERROR unresolved import `$crate`
+
+    // crate::proc_macro_item
+    invoke_with_ident!{krate input proc_macro_item}      //~ ERROR unresolved import `$crate::proc_macro_item`
+    with_crate!{krate input proc_macro_item}             //~ ERROR unresolved import `$crate::proc_macro_item`
+    with_crate!{krate call proc_macro_item}              //~ ERROR unresolved import `$crate`
+
+    macro_rules! test {() => {
+        // crate::proc_macro_item
+        invoke_with_ident!{$crate input proc_macro_item} //~ ERROR unresolved import `$crate`
+        with_crate!{$crate input proc_macro_item}        //~ ERROR unresolved import `$crate`
+        with_crate!{$crate call proc_macro_item}         //~ ERROR unresolved import `$crate`
+
+        // token_site_span::proc_macro_item
+        invoke_with_ident!{$crate call proc_macro_item}  //~ ERROR unresolved import `$crate`
+    }}
+    test!();
+};
+
+// Successful resolutions of `token_site_span::TokenItem`
+const _: () = {
+    invoke_with_crate!{input TokenItem}
+    invoke_with_ident!{input TokenItem}
+    invoke_with_crate!{call TokenItem}
+    invoke_with_ident!{call TokenItem}
+    invoke_with_ident!{hello call TokenItem}
+
+    macro_rules! test {() => {
+        invoke_with_ident!{$crate call TokenItem}
+    }}
+    test!();
+};
+
+// Failed resolutions of `TokenItem`
+const _: () = {
+    // crate::TokenItem
+    invoke_with_ident!{krate input TokenItem}       //~ ERROR unresolved import `$crate::TokenItem`
+    with_crate!{krate input TokenItem}              //~ ERROR unresolved import `$crate::TokenItem`
+    with_crate!{krate call TokenItem}               //~ ERROR unresolved import `$crate`
+
+    // mixed_site_span::TokenItem
+    invoke_with_crate!{mixed TokenItem}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{mixed TokenItem}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{krate mixed TokenItem}       //~ ERROR unresolved import `$crate`
+    with_crate!{krate mixed TokenItem}              //~ ERROR unresolved import `$crate`
+
+    macro_rules! test {() => {
+        // crate::TokenItem
+        invoke_with_ident!{$crate input TokenItem}  //~ ERROR unresolved import `$crate`
+        with_crate!{$crate input TokenItem}         //~ ERROR unresolved import `$crate`
+        with_crate!{$crate call TokenItem}          //~ ERROR unresolved import `$crate`
+
+        // mixed_site_span::TokenItem
+        invoke_with_ident!{$crate mixed TokenItem}  //~ ERROR unresolved import `$crate`
+        with_crate!{$crate mixed TokenItem}         //~ ERROR unresolved import `$crate`
+
+    }}
+    test!();
+};
+
+
+// Successful resolutions of `crate::ItemUse`
+const _: () = {
+    invoke_with_ident!{krate input ItemUse}
+    with_crate!{krate input ItemUse}
+    with_crate!{krate call ItemUse}
+
+    macro_rules! test {() => {
+        invoke_with_ident!{$crate input ItemUse}
+        with_crate!{$crate input ItemUse}
+        with_crate!{$crate call ItemUse}
+    }}
+    test!();
+};
+
+// Failed resolutions of `ItemUse`
+const _: () = {
+    // token_site_span::ItemUse
+    invoke_with_crate!{input ItemUse}            //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{input ItemUse}            //~ ERROR unresolved import `$crate`
+
+    // mixed_site_span::ItemUse
+    invoke_with_crate!{mixed ItemUse}            //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{mixed ItemUse}            //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{krate mixed ItemUse}      //~ ERROR unresolved import `$crate`
+    with_crate!{krate mixed ItemUse}             //~ ERROR unresolved import `$crate`
+
+    invoke_with_crate!{call ItemUse}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{call ItemUse}             //~ ERROR unresolved import `$crate`
+    invoke_with_ident!{hello call ItemUse}       //~ ERROR unresolved import `$crate`
+
+    macro_rules! test {() => {
+        invoke_with_ident!{$crate mixed ItemUse} //~ ERROR unresolved import `$crate`
+        with_crate!{$crate mixed ItemUse}        //~ ERROR unresolved import `$crate`
+
+        invoke_with_ident!{$crate call ItemUse}  //~ ERROR unresolved import `$crate`
+    }}
+    test!();
+};
+
+
+// Only mixed should see mixed_site_span::proc_macro_item
+use_input_crate!{proc_macro_item}   //~ ERROR unresolved import `$crate`
+use_input_krate!{proc_macro_item}   //~ ERROR unresolved import `$crate`
+use_mixed_crate!{proc_macro_item}
+use_mixed_krate!{proc_macro_item}
+use_call_crate!{proc_macro_item}    //~ ERROR unresolved import `$crate`
+use_call_krate!{proc_macro_item}    //~ ERROR unresolved import `$crate`
+
+// Only mixed should fail to see token_site_span::TokenItem
+use_input_crate!{TokenItem}
+use_input_krate!{TokenItem}
+use_mixed_crate!{TokenItem}         //~ ERROR unresolved import `$crate`
+use_mixed_krate!{TokenItem}         //~ ERROR unresolved import `$crate`
+use_call_crate!{TokenItem}
+use_call_krate!{TokenItem}
+
+// Everything should fail to see crate::ItemUse
+use_input_crate!{ItemUse}           //~ ERROR unresolved import `$crate`
+use_input_krate!{ItemUse}           //~ ERROR unresolved import `$crate`
+use_mixed_crate!{ItemUse}           //~ ERROR unresolved import `$crate`
+use_mixed_krate!{ItemUse}           //~ ERROR unresolved import `$crate`
+use_call_crate!{ItemUse}            //~ ERROR unresolved import `$crate`
+use_call_krate!{ItemUse}            //~ ERROR unresolved import `$crate`

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -1,13 +1,595 @@
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:47:5
+   |
+LL |     invoke_with_crate!{input proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:48:5
+   |
+LL |     invoke_with_ident!{input proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:49:5
+   |
+LL |     invoke_with_crate!{call proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:50:5
+   |
+LL |     invoke_with_ident!{call proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:51:5
+   |
+LL |     invoke_with_ident!{hello call proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate::proc_macro_item`
+  --> $DIR/mixed-site-span.rs:54:5
+   |
+LL |     invoke_with_ident!{krate input proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |     |                              |
+   |     |                              help: a similar name exists in the module: `proc_macro_rules`
+   |     no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate::proc_macro_item`
+  --> $DIR/mixed-site-span.rs:55:5
+   |
+LL |     with_crate!{krate input proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |     |                       |
+   |     |                       help: a similar name exists in the module: `proc_macro_rules`
+   |     no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:56:5
+   |
+LL |     with_crate!{krate call proc_macro_item}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |     |                      |
+   |     |                      help: a similar name exists in the module: `proc_macro_rules`
+   |     no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:60:28
+   |
+LL |         invoke_with_ident!{$crate input proc_macro_item}
+   |                            ^^^^^^       --------------- help: a similar name exists in the module: `proc_macro_rules`
+   |                            |
+   |                            no `proc_macro_item` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:61:21
+   |
+LL |         with_crate!{$crate input proc_macro_item}
+   |                     ^^^^^^       --------------- help: a similar name exists in the module: `proc_macro_rules`
+   |                     |
+   |                     no `proc_macro_item` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:62:9
+   |
+LL |         with_crate!{$crate call proc_macro_item}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |         |                       |
+   |         |                       help: a similar name exists in the module: `proc_macro_rules`
+   |         no `proc_macro_item` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:67:5
+   |
+LL |     test!();
+   |     ^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate::TokenItem`
+  --> $DIR/mixed-site-span.rs:87:5
+   |
+LL |     invoke_with_ident!{krate input TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/mixed-site-span.rs:59:34
+   |
+LL |     quote!(use $krate::$ident as token_site_span::TokenItem as _;)
+   |                                  +++++++++++++++++++++++++++++
+
+error[E0432]: unresolved import `$crate::TokenItem`
+  --> $DIR/mixed-site-span.rs:88:5
+   |
+LL |     with_crate!{krate input TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/mixed-site-span.rs:59:34
+   |
+LL |     quote!(use $krate::$ident as token_site_span::TokenItem as _;)
+   |                                  +++++++++++++++++++++++++++++
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:89:5
+   |
+LL |     with_crate!{krate call TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -     with_crate!{krate call TokenItem}
+LL +     token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:92:5
+   |
+LL |     invoke_with_crate!{mixed TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:13:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{$crate $s $i} };
+LL +     ($s:ident $i:ident) => { token_site_span::TokenItem as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:93:5
+   |
+LL |     invoke_with_ident!{mixed TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:18:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{krate $s $i} };
+LL +     ($s:ident $i:ident) => { token_site_span::TokenItem as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:94:5
+   |
+LL |     invoke_with_ident!{krate mixed TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { token_site_span::TokenItem as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:95:5
+   |
+LL |     with_crate!{krate mixed TokenItem}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -     with_crate!{krate mixed TokenItem}
+LL +     token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:99:28
+   |
+LL |         invoke_with_ident!{$crate input TokenItem}
+   |                            ^^^^^^ no `TokenItem` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -         invoke_with_ident!{$crate input TokenItem}
+LL +         invoke_with_ident!{token_site_span::TokenItem as _ input TokenItem}
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:100:21
+   |
+LL |         with_crate!{$crate input TokenItem}
+   |                     ^^^^^^ no `TokenItem` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -         with_crate!{$crate input TokenItem}
+LL +         with_crate!{token_site_span::TokenItem as _ input TokenItem}
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:101:9
+   |
+LL |         with_crate!{$crate call TokenItem}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -         with_crate!{$crate call TokenItem}
+LL +         token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:108:5
+   |
+LL |     test!();
+   |     ^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { token_site_span::TokenItem as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:105:9
+   |
+LL |         with_crate!{$crate mixed TokenItem}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -         with_crate!{$crate mixed TokenItem}
+LL +         token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:129:5
+   |
+LL |     invoke_with_crate!{input ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:13:42
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{$crate $s $i} };
+LL +     ($s:ident $i:ident) => { with_crate!{ItemUse as _ $s $i} };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:130:5
+   |
+LL |     invoke_with_ident!{input ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:18:42
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{krate $s $i} };
+LL +     ($s:ident $i:ident) => { with_crate!{ItemUse as _ $s $i} };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:133:5
+   |
+LL |     invoke_with_crate!{mixed ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:13:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{$crate $s $i} };
+LL +     ($s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:134:5
+   |
+LL |     invoke_with_ident!{mixed ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:18:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{krate $s $i} };
+LL +     ($s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:135:5
+   |
+LL |     invoke_with_ident!{krate mixed ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:136:5
+   |
+LL |     with_crate!{krate mixed ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -     with_crate!{krate mixed ItemUse}
+LL +     ItemUse as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:138:5
+   |
+LL |     invoke_with_crate!{call ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:13:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{$crate $s $i} };
+LL +     ($s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:139:5
+   |
+LL |     invoke_with_ident!{call ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:18:30
+   |
+LL -     ($s:ident $i:ident) => { with_crate!{krate $s $i} };
+LL +     ($s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:140:5
+   |
+LL |     invoke_with_ident!{hello call ItemUse}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:148:5
+   |
+LL |     test!();
+   |     ^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:144:9
+   |
+LL |         with_crate!{$crate mixed ItemUse}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+...
+LL |     test!();
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+   |
+LL -         with_crate!{$crate mixed ItemUse}
+LL +         ItemUse as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:148:5
+   |
+LL |     test!();
+   |     ^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:19:39
+   |
+LL -     ($m:ident $s:ident $i:ident) => { with_crate!{$m $s $i} };
+LL +     ($m:ident $s:ident $i:ident) => { ItemUse as _ };
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:153:1
+   |
+LL | use_input_crate!{proc_macro_item}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `use_input_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:154:1
+   |
+LL | use_input_krate!{proc_macro_item}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `use_input_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:157:1
+   |
+LL | use_call_crate!{proc_macro_item}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `use_call_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:158:1
+   |
+LL | use_call_krate!{proc_macro_item}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |
+   = note: this error originates in the macro `use_call_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:163:1
+   |
+LL | use_mixed_crate!{TokenItem}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `use_mixed_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:24:5
+   |
+LL -     declare_macro!{$crate mixed use_mixed_crate}
+LL +     token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:164:1
+   |
+LL | use_mixed_krate!{TokenItem}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |
+   = note: this error originates in the macro `use_mixed_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct instead
+  --> $DIR/auxiliary/token-site-span.rs:29:1
+   |
+LL - declare_macro!{krate mixed use_mixed_krate}
+LL + token_site_span::TokenItem as _
+   |
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:169:1
+   |
+LL | use_input_crate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_input_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:170:1
+   |
+LL | use_input_krate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_input_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:171:1
+   |
+LL | use_mixed_crate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_mixed_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:172:1
+   |
+LL | use_mixed_krate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_mixed_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:173:1
+   |
+LL | use_call_crate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_call_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `$crate`
+  --> $DIR/mixed-site-span.rs:174:1
+   |
+LL | use_call_krate!{ItemUse}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |
+   = note: this error originates in the macro `use_call_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0426]: use of undeclared label `'label_use`
-  --> $DIR/mixed-site-span.rs:13:9
+  --> $DIR/mixed-site-span.rs:21:9
    |
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
    |
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0412]: cannot find type `ItemUse` in crate `$crate`
+  --> $DIR/mixed-site-span.rs:21:9
+   |
+LL |         proc_macro_rules!();
+   |         ^^^^^^^^^^^^^^^^^^^ not found in `$crate`
+   |
+   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this struct
+   |
+LL + use ItemUse;
+   |
+
 error[E0425]: cannot find value `local_use` in this scope
-  --> $DIR/mixed-site-span.rs:13:9
+  --> $DIR/mixed-site-span.rs:21:9
    |
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `local_def`
@@ -15,20 +597,12 @@ LL |         proc_macro_rules!();
    = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope
-  --> $DIR/mixed-site-span.rs:17:9
+  --> $DIR/mixed-site-span.rs:26:9
    |
 LL |         local_def;
    |         ^^^^^^^^^ help: a local variable with a similar name exists: `local_use`
 
-error[E0412]: cannot find type `ItemUse` in crate `$crate`
-  --> $DIR/mixed-site-span.rs:24:1
-   |
-LL | pass_dollar_crate!();
-   | ^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
-   |
-   = note: this error originates in the macro `proc_macro_rules` which comes from the expansion of the macro `pass_dollar_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
+error: aborting due to 52 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0412, E0425, E0426.
+Some errors have detailed explanations: E0412, E0425, E0426, E0432.
 For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
This PR is addresses a few minor bugs, all relating to `proc_macro::Ident`'s support for `$crate`. `Ident` currently supports `$crate` (as can be seen in the `mixed-site-span` test), but:
* `proc_macro::Symbol::can_be_raw` is out of sync with `rustc_span::Symbol::can_be_raw`
  * former doesn't cover `$crate` while the latter does cover `kw::DollarCrate`
* `Ident::new` rejects `$crate`
  * This conflicts with the [reference definition](https://doc.rust-lang.org/nightly/reference/macros-by-example.html#r-macro.decl.meta.specifier) of `ident` which includes `$crate`.
  * This also conflicts with the documentation on [`Display for Ident`](https://doc.rust-lang.org/proc_macro/struct.Ident.html#impl-Display-for-Ident) which says the output "should be losslessly convertible back into the same identifier".

This PR fixes the above issues and extends the `mixed-site-span` test to exercise these fixed code paths, as well as validating the different possible spans resolve `$crate`  as expected (for both the new and old `$crate` construction code paths).