### PR TITLE
Visit the ident in `PreciseCapturingNonLifetimeArg`.

### DIFF
--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1333,8 +1333,9 @@ pub fn walk_precise_capturing_arg<'v, V: Visitor<'v>>(
     match *arg {
         PreciseCapturingArg::Lifetime(lt) => visitor.visit_lifetime(lt),
         PreciseCapturingArg::Param(param) => {
-            let PreciseCapturingNonLifetimeArg { hir_id, ident: _, res: _ } = param;
-            visitor.visit_id(hir_id)
+            let PreciseCapturingNonLifetimeArg { hir_id, ident, res: _ } = param;
+            try_visit!(visitor.visit_id(hir_id));
+            visitor.visit_ident(ident)
         }
     }
 }


### PR DESCRIPTION
It's currently skipped, presumably by accident.

r? @BoxyUwU 