### PR TITLE
const-eval error: always say in which item the error occurred

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -88,11 +88,9 @@ const_eval_division_overflow =
 const_eval_dyn_call_not_a_method =
     `dyn` call trying to call something that is not a method
 
-const_eval_error = {$error_kind ->
-    [static] evaluation of static initializer failed here
-    [const] evaluation of constant value failed here
-    [const_with_path] evaluation of `{$instance}` failed here
-    *[other] {""}
+const_eval_error = evaluation of `{$instance}` failed {$num_frames ->
+    [0] here
+    *[other] inside this call
 }
 
 const_eval_exact_div_has_remainder =

--- a/src/tools/miri/tests/fail/const-ub-checks.stderr
+++ b/src/tools/miri/tests/fail/const-ub-checks.stderr
@@ -2,7 +2,7 @@ error[E0080]: accessing memory based on pointer with alignment ALIGN, but alignm
   --> tests/fail/const-ub-checks.rs:LL:CC
    |
 LL |     ptr.read();
-   |     ^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^ evaluation of `UNALIGNED_READ` failed here
 
 note: erroneous constant encountered
   --> tests/fail/const-ub-checks.rs:LL:CC

--- a/src/tools/miri/tests/fail/erroneous_const2.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const2.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `5_u32 - 6_u32`, which would overflow
   --> tests/fail/erroneous_const2.rs:LL:CC
    |
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
-   |                   ^^^^^ evaluation of constant value failed here
+   |                   ^^^^^ evaluation of `FOO` failed here
 
 note: erroneous constant encountered
   --> tests/fail/erroneous_const2.rs:LL:CC

--- a/tests/rustdoc-ui/const-evalutation-ice.stderr
+++ b/tests/rustdoc-ui/const-evalutation-ice.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `0_usize - 1_usize`, which would overflow
   --> $DIR/const-evalutation-ice.rs:10:22
    |
 LL | pub const N: usize = 0 - (mem::size_of::<S>() != 400) as usize;
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `N` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/array-slice-vec/array_const_index-0.stderr
+++ b/tests/ui/array-slice-vec/array_const_index-0.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 0 but the index is 1
   --> $DIR/array_const_index-0.rs:2:16
    |
 LL | const B: i32 = (&A)[1];
-   |                ^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^ evaluation of `B` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/array-slice-vec/array_const_index-1.stderr
+++ b/tests/ui/array-slice-vec/array_const_index-1.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 0 but the index is 1
   --> $DIR/array_const_index-1.rs:2:16
    |
 LL | const B: i32 = A[1];
-   |                ^^^^ evaluation of constant value failed here
+   |                ^^^^ evaluation of `B` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-81899.rs:6:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
 note: inside `f::<{closure@$DIR/issue-81899.rs:6:31: 6:34}>`
   --> $DIR/issue-81899.rs:13:5

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-88434-minimal-example.rs:5:22
    |
 LL | const _CONST: &() = &f(&|_| {});
-   |                      ^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
 note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:5:25: 5:28}>`
   --> $DIR/issue-88434-minimal-example.rs:12:5

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-88434-removal-index-should-be-less.rs:5:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
 note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:5:31: 5:34}>`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:12:5

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: Some error occurred
   --> $DIR/const-errs-dont-conflict-103369.rs:5:25
    |
 LL | impl ConstGenericTrait<{my_fn(1)}> for () {}
-   |                         ^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^ evaluation of `<() as ConstGenericTrait<{my_fn(1)}>>::{constant#0}` failed inside this call
    |
 note: inside `my_fn`
   --> $DIR/const-errs-dont-conflict-103369.rs:10:5
@@ -14,7 +14,7 @@ error[E0080]: evaluation panicked: Some error occurred
   --> $DIR/const-errs-dont-conflict-103369.rs:7:25
    |
 LL | impl ConstGenericTrait<{my_fn(2)}> for () {}
-   |                         ^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^ evaluation of `<() as ConstGenericTrait<{my_fn(2)}>>::{constant#0}` failed inside this call
    |
 note: inside `my_fn`
   --> $DIR/const-errs-dont-conflict-103369.rs:10:5

--- a/tests/ui/const-generics/defaults/default-param-wf-concrete.next.stderr
+++ b/tests/ui/const-generics/defaults/default-param-wf-concrete.next.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `u8::MAX + 1_u8`, which would overflow
   --> $DIR/default-param-wf-concrete.rs:4:28
    |
 LL | struct Foo<const N: u8 = { 255 + 1 }>;
-   |                            ^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^ evaluation of `Foo::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/default-param-wf-concrete.old.stderr
+++ b/tests/ui/const-generics/defaults/default-param-wf-concrete.old.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `u8::MAX + 1_u8`, which would overflow
   --> $DIR/default-param-wf-concrete.rs:4:28
    |
 LL | struct Foo<const N: u8 = { 255 + 1 }>;
-   |                            ^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^ evaluation of `Foo::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/wfness.stderr
+++ b/tests/ui/const-generics/defaults/wfness.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `u8::MAX + 1_u8`, which would overflow
   --> $DIR/wfness.rs:1:33
    |
 LL | struct Ooopsies<const N: u8 = { u8::MAX + 1 }>;
-   |                                 ^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^ evaluation of `Ooopsies::{constant#0}` failed here
 
 error[E0277]: the trait bound `(): Trait<2>` is not satisfied
   --> $DIR/wfness.rs:8:9

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -2,7 +2,7 @@ error[E0080]: writing to ALLOC0 which is read-only
   --> $DIR/issue-100313.rs:18:5
    |
 LL |     x.set_false();
-   |     ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `T::<&true>::set_false`
   --> $DIR/issue-100313.rs:11:13

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
@@ -2,7 +2,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
-   |                                ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#7}` failed here
 
 error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:42:14
@@ -30,7 +30,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/invalid-patterns.rs:44:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |                                                          ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                          ^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#11}` failed here
 
 error[E0308]: mismatched types
   --> $DIR/invalid-patterns.rs:31:21

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
@@ -2,7 +2,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
-   |                                ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#7}` failed here
 
 error[E0080]: constructing invalid value: encountered 0x42, but expected a boolean
   --> $DIR/invalid-patterns.rs:42:14
@@ -30,7 +30,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/invalid-patterns.rs:44:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |                                                          ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                          ^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#11}` failed here
 
 error[E0308]: mismatched types
   --> $DIR/invalid-patterns.rs:31:21

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -103,13 +103,13 @@ error[E0080]: evaluation panicked: assertion failed: 0 < pointee_size && pointee
   --> $DIR/forbidden_slices.rs:50:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R1` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC10 which is only 4 bytes from the end of the allocation
   --> $DIR/forbidden_slices.rs:54:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
-   |                         ^^^^^^^^^^ evaluation of static initializer failed here
+   |                         ^^^^^^^^^^ evaluation of `R2` failed here
 
 error[E0080]: constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:57:1
@@ -161,19 +161,19 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
   --> $DIR/forbidden_slices.rs:79:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ^^^^^^^^^^ evaluation of static initializer failed here
+   |                         ^^^^^^^^^^ evaluation of `R8` failed here
 
 error[E0080]: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
   --> $DIR/forbidden_slices.rs:85:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R9` failed here
 
 error[E0080]: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
   --> $DIR/forbidden_slices.rs:87:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R10` failed here
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -2,19 +2,19 @@ error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0
   --> $DIR/out_of_bounds_read.rs:8:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_READ` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/out_of_bounds_read.rs:10:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
-   |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of `main::_CONST_READ` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/out_of_bounds_read.rs:12:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_MUT_READ` failed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/assert-type-intrinsics.stderr
+++ b/tests/ui/consts/assert-type-intrinsics.stderr
@@ -2,19 +2,19 @@ error[E0080]: evaluation panicked: aborted execution: attempted to instantiate u
   --> $DIR/assert-type-intrinsics.rs:11:9
    |
 LL |         MaybeUninit::<!>::uninit().assume_init();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_BAD1` failed here
 
 error[E0080]: evaluation panicked: aborted execution: attempted to leave type `&i32` uninitialized, which is invalid
   --> $DIR/assert-type-intrinsics.rs:15:9
    |
 LL |         intrinsics::assert_mem_uninitialized_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_BAD2` failed here
 
 error[E0080]: evaluation panicked: aborted execution: attempted to zero-initialize type `&i32`, which is invalid
   --> $DIR/assert-type-intrinsics.rs:19:9
    |
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_BAD3` failed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-array-oob.stderr
+++ b/tests/ui/consts/const-array-oob.stderr
@@ -2,13 +2,13 @@ error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/const-array-oob.rs:5:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
-   |                   ^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^ evaluation of `BLUB::{constant#0}` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 5
   --> $DIR/const-array-oob.rs:2:20
    |
 LL | const BAR: usize = FOO[5];
-   |                    ^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^ evaluation of `BAR` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-assert-unchecked-ub.stderr
+++ b/tests/ui/consts/const-assert-unchecked-ub.stderr
@@ -2,7 +2,7 @@ error[E0080]: `assume` called with `false`
   --> $DIR/const-assert-unchecked-ub.rs:3:5
    |
 LL |     std::hint::assert_unchecked(n < 32);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-compare-bytes-ub.stderr
+++ b/tests/ui/consts/const-compare-bytes-ub.stderr
@@ -2,49 +2,49 @@ error[E0080]: memory access failed: attempting to access 1 byte, but got null po
   --> $DIR/const-compare-bytes-ub.rs:9:9
    |
 LL |         compare_bytes(0 as *const u8, 2 as *const u8, 1)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_NULL` failed here
 
 error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/const-compare-bytes-ub.rs:13:9
    |
 LL |         compare_bytes(1 as *const u8, 0 as *const u8, 1)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_NULL` failed here
 
 error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/const-compare-bytes-ub.rs:17:9
    |
 LL |         compare_bytes(1 as *const u8, 2 as *const u8, 1)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::DANGLING_PTR_NON_ZERO_LENGTH` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0 which is only 3 bytes from the end of the allocation
   --> $DIR/const-compare-bytes-ub.rs:21:9
    |
 LL |         compare_bytes([1, 2, 3].as_ptr(), [1, 2, 3, 4].as_ptr(), 4)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_OUT_OF_BOUNDS` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC1 which is only 3 bytes from the end of the allocation
   --> $DIR/const-compare-bytes-ub.rs:25:9
    |
 LL |         compare_bytes([1, 2, 3, 4].as_ptr(), [1, 2, 3].as_ptr(), 4)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_OUT_OF_BOUNDS` failed here
 
 error[E0080]: reading memory at ALLOC2[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/const-compare-bytes-ub.rs:29:9
    |
 LL |         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_UNINIT` failed here
 
 error[E0080]: reading memory at ALLOC3[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
   --> $DIR/const-compare-bytes-ub.rs:33:9
    |
 LL |         compare_bytes([1].as_ptr(), MaybeUninit::uninit().as_ptr(), 1)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_UNINIT` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/const-compare-bytes-ub.rs:37:9
    |
 LL |         compare_bytes([&1].as_ptr().cast(), [&2].as_ptr().cast(), std::mem::size_of::<usize>())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::WITH_PROVENANCE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/const-deref-ptr.stderr
+++ b/tests/ui/consts/const-deref-ptr.stderr
@@ -2,7 +2,7 @@ error[E0080]: memory access failed: attempting to access 8 bytes, but got 0xdead
   --> $DIR/const-deref-ptr.rs:4:30
    |
 LL |     static C: u64 = unsafe { *(0xdeadbeef as *const u64) };
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::C` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-err-early.stderr
+++ b/tests/ui/consts/const-err-early.stderr
@@ -2,31 +2,31 @@ error[E0080]: attempt to negate `i8::MIN`, which would overflow
   --> $DIR/const-err-early.rs:1:19
    |
 LL | pub const A: i8 = -i8::MIN;
-   |                   ^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^ evaluation of `A` failed here
 
 error[E0080]: attempt to compute `200_u8 + 200_u8`, which would overflow
   --> $DIR/const-err-early.rs:2:19
    |
 LL | pub const B: u8 = 200u8 + 200u8;
-   |                   ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^^^^^^ evaluation of `B` failed here
 
 error[E0080]: attempt to compute `200_u8 * 4_u8`, which would overflow
   --> $DIR/const-err-early.rs:3:19
    |
 LL | pub const C: u8 = 200u8 * 4;
-   |                   ^^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^^ evaluation of `C` failed here
 
 error[E0080]: attempt to compute `42_u8 - 43_u8`, which would overflow
   --> $DIR/const-err-early.rs:4:19
    |
 LL | pub const D: u8 = 42u8 - (42u8 + 1);
-   |                   ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^^^^^^^^^^ evaluation of `D` failed here
 
 error[E0080]: index out of bounds: the length is 1 but the index is 1
   --> $DIR/const-err-early.rs:5:19
    |
 LL | pub const E: u8 = [5u8][1];
-   |                   ^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^ evaluation of `E` failed here
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/const-err-enum-discriminant.stderr
+++ b/tests/ui/consts/const-err-enum-discriminant.stderr
@@ -2,7 +2,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/const-err-enum-discriminant.rs:8:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-   |                     ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^^^^^^^^ evaluation of `Bar::Boo::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-err-multi.rs
+++ b/tests/ui/consts/const-err-multi.rs
@@ -1,12 +1,12 @@
 pub const A: i8 = -i8::MIN;
-//~^ NOTE constant
+//~^ NOTE failed here
 //~| ERROR attempt to negate `i8::MIN`, which would overflow
 pub const B: i8 = A;
-//~^ NOTE constant
+//~^ NOTE erroneous constant
 pub const C: u8 = A as u8;
-//~^ NOTE constant
+//~^ NOTE erroneous constant
 pub const D: i8 = 50 - A;
-//~^ NOTE constant
+//~^ NOTE erroneous constant
 
 fn main() {
     let _ = (A, B, C, D);

--- a/tests/ui/consts/const-err-multi.stderr
+++ b/tests/ui/consts/const-err-multi.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to negate `i8::MIN`, which would overflow
   --> $DIR/const-err-multi.rs:1:19
    |
 LL | pub const A: i8 = -i8::MIN;
-   |                   ^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^ evaluation of `A` failed here
 
 note: erroneous constant encountered
   --> $DIR/const-err-multi.rs:4:19

--- a/tests/ui/consts/const-eval-fail-too-big.stderr
+++ b/tests/ui/consts/const-eval-fail-too-big.stderr
@@ -2,7 +2,7 @@ error[E0080]: values of the type `[u8; usize::MAX]` are too big for the target a
   --> $DIR/const-eval-fail-too-big.rs:4:28
    |
 LL |                    let x = [0u8; !0usize];
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `B::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/assign-to-static-within-other-static.stderr
+++ b/tests/ui/consts/const-eval/assign-to-static-within-other-static.stderr
@@ -2,7 +2,7 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/assign-to-static-within-other-static.rs:8:5
    |
 LL |     FOO = 5;
-   |     ^^^^^^^ evaluation of static initializer failed here
+   |     ^^^^^^^ evaluation of `BOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/tests/ui/consts/const-eval/conditional_array_execution.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `5_u32 - 6_u32`, which would overflow
   --> $DIR/conditional_array_execution.rs:3:19
    |
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
-   |                   ^^^^^ evaluation of constant value failed here
+   |                   ^^^^^ evaluation of `FOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-2.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-2.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to negate `i8::MIN`, which would overflow
   --> $DIR/const-eval-overflow-2.rs:11:25
    |
 LL | const NEG_NEG_128: i8 = -NEG_128;
-   |                         ^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^ evaluation of `NEG_NEG_128` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-3.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `i8::MAX + 1_i8`, which would overflow
   --> $DIR/const-eval-overflow-3.rs:18:11
    |
 LL |     = [0; (i8::MAX + 1) as usize];
-   |           ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |           ^^^^^^^^^^^^^ evaluation of `A_I8_I::{constant#1}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `i8::MAX + 1_i8`, which would overflow
   --> $DIR/const-eval-overflow-4.rs:11:13
    |
 LL |     : [u32; (i8::MAX as i8 + 1i8) as usize]
-   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of `A_I8_T::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -2,49 +2,49 @@ error[E0080]: attempt to compute `i8::MIN - 1_i8`, which would overflow
   --> $DIR/const-eval-overflow2.rs:12:6
    |
 LL |      i8::MIN - 1,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_I8` failed here
 
 error[E0080]: attempt to compute `i16::MIN - 1_i16`, which would overflow
   --> $DIR/const-eval-overflow2.rs:18:6
    |
 LL |      i16::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I16` failed here
 
 error[E0080]: attempt to compute `i32::MIN - 1_i32`, which would overflow
   --> $DIR/const-eval-overflow2.rs:24:6
    |
 LL |      i32::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I32` failed here
 
 error[E0080]: attempt to compute `i64::MIN - 1_i64`, which would overflow
   --> $DIR/const-eval-overflow2.rs:30:6
    |
 LL |      i64::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I64` failed here
 
 error[E0080]: attempt to compute `0_u8 - 1_u8`, which would overflow
   --> $DIR/const-eval-overflow2.rs:36:6
    |
 LL |      u8::MIN - 1,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_U8` failed here
 
 error[E0080]: attempt to compute `0_u16 - 1_u16`, which would overflow
   --> $DIR/const-eval-overflow2.rs:41:6
    |
 LL |      u16::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U16` failed here
 
 error[E0080]: attempt to compute `0_u32 - 1_u32`, which would overflow
   --> $DIR/const-eval-overflow2.rs:46:6
    |
 LL |      u32::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U32` failed here
 
 error[E0080]: attempt to compute `0_u64 - 1_u64`, which would overflow
   --> $DIR/const-eval-overflow2.rs:52:6
    |
 LL |      u64::MIN - 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U64` failed here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -2,49 +2,49 @@ error[E0080]: attempt to compute `i8::MAX + 1_i8`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:12:6
    |
 LL |      i8::MAX + 1,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_I8` failed here
 
 error[E0080]: attempt to compute `i16::MAX + 1_i16`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:18:6
    |
 LL |      i16::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I16` failed here
 
 error[E0080]: attempt to compute `i32::MAX + 1_i32`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:24:6
    |
 LL |      i32::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I32` failed here
 
 error[E0080]: attempt to compute `i64::MAX + 1_i64`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:30:6
    |
 LL |      i64::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I64` failed here
 
 error[E0080]: attempt to compute `u8::MAX + 1_u8`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:36:6
    |
 LL |      u8::MAX + 1,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_U8` failed here
 
 error[E0080]: attempt to compute `u16::MAX + 1_u16`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:41:6
    |
 LL |      u16::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U16` failed here
 
 error[E0080]: attempt to compute `u32::MAX + 1_u32`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:46:6
    |
 LL |      u32::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U32` failed here
 
 error[E0080]: attempt to compute `u64::MAX + 1_u64`, which would overflow
   --> $DIR/const-eval-overflow2b.rs:52:6
    |
 LL |      u64::MAX + 1,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U64` failed here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -2,49 +2,49 @@ error[E0080]: attempt to compute `i8::MIN * 2_i8`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:12:6
    |
 LL |      i8::MIN * 2,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_I8` failed here
 
 error[E0080]: attempt to compute `i16::MIN * 2_i16`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:18:6
    |
 LL |      i16::MIN * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I16` failed here
 
 error[E0080]: attempt to compute `i32::MIN * 2_i32`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:24:6
    |
 LL |      i32::MIN * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I32` failed here
 
 error[E0080]: attempt to compute `i64::MIN * 2_i64`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:30:6
    |
 LL |      i64::MIN * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_I64` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 2_u8`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:36:6
    |
 LL |      u8::MAX * 2,
-   |      ^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^ evaluation of `VALS_U8` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 2_u16`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:41:6
    |
 LL |      u16::MAX * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U16` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 2_u32`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:46:6
    |
 LL |      u32::MAX * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U32` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 2_u64`, which would overflow
   --> $DIR/const-eval-overflow2c.rs:52:6
    |
 LL |      u64::MAX * 2,
-   |      ^^^^^^^^^^^^ evaluation of constant value failed here
+   |      ^^^^^^^^^^^^ evaluation of `VALS_U64` failed here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -2,7 +2,7 @@ error: internal compiler error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/const-eval-query-stack.rs:16:16
    |
 LL | const X: i32 = 1 / 0;
-   |                ^^^^^ evaluation of constant value failed here
+   |                ^^^^^ evaluation of `X` failed here
 
 
 note: please make sure that you have updated to the latest nightly

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
@@ -2,7 +2,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:27:49
    |
 LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_USIZE_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -11,7 +11,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:30:43
    |
 LL |     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_8 };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U8_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -20,7 +20,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:33:45
    |
 LL |     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uint_16 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U16_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -29,7 +29,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:36:45
    |
 LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uint_32 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -38,7 +38,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:39:45
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -47,13 +47,13 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/const-pointer-values-in-various-types.rs:42:47
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_U128_UNION` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:45:43
    |
 LL |     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I8_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -62,7 +62,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:48:45
    |
 LL |     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int_16 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I16_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -71,7 +71,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:51:45
    |
 LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int_32 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -80,7 +80,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:54:45
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -89,13 +89,13 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/const-pointer-values-in-various-types.rs:57:47
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_I128_UNION` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:60:45
    |
 LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_F32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -104,7 +104,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:63:45
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_F64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -113,7 +113,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:66:47
    |
 LL |     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_BOOL_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -122,7 +122,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:69:47
    |
 LL |     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.character };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::I32_REF_CHAR_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -131,7 +131,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:72:39
    |
 LL |     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_U8_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -140,7 +140,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:75:41
    |
 LL |     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_U16_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -149,7 +149,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:78:41
    |
 LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_U32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -158,7 +158,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:81:41
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_U64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -167,7 +167,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:84:43
    |
 LL |     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_U128_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -176,7 +176,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:87:39
    |
 LL |     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_I8_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -185,7 +185,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:90:41
    |
 LL |     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_I16_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -194,7 +194,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:93:41
    |
 LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_I32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -203,7 +203,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:96:41
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_I64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -212,7 +212,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:99:43
    |
 LL |     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_I128_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -221,7 +221,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:102:41
    |
 LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_F32_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -230,7 +230,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:105:41
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_F64_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -239,7 +239,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:108:43
    |
 LL |     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_BOOL_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -248,7 +248,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/const-pointer-values-in-various-types.rs:111:43
    |
 LL |     const STR_CHAR_UNION: char = unsafe { Nonsense { stringy: "3" }.character };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::STR_CHAR_UNION` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -14,10 +14,10 @@ const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
 }
 
 const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-//~^ NOTE evaluation of constant value failed
+//~^ NOTE failed inside this call
 //~| ERROR calling non-const function `double`
 const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-//~^ NOTE evaluation of constant value failed
+//~^ NOTE failed inside this call
 //~| ERROR calling non-const function `double`
 
 fn main() {

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `double`
   --> $DIR/const_fn_ptr_fail2.rs:16:18
    |
 LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^^^^ evaluation of `Y` failed inside this call
    |
 note: inside `bar`
   --> $DIR/const_fn_ptr_fail2.rs:9:5
@@ -14,7 +14,7 @@ error[E0080]: calling non-const function `double`
   --> $DIR/const_fn_ptr_fail2.rs:19:18
    |
 LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^^^^^^^^^ evaluation of `Z` failed inside this call
    |
 note: inside `bar`
   --> $DIR/const_fn_ptr_fail2.rs:9:5

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked:
   --> $DIR/const_panic-normalize-tabs-115498.rs:3:17
    |
 LL | struct Bug([u8; panic!{"\t"}]);
-   |                 ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                 ^^^^^^^^^^^^ evaluation of `Bug::0::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -2,25 +2,25 @@ error[E0080]: evaluation panicked: cheese
   --> $DIR/const_panic.rs:6:15
    |
 LL | const Z: () = std::panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `Z` failed here
 
 error[E0080]: evaluation panicked: explicit panic
   --> $DIR/const_panic.rs:9:16
    |
 LL | const Z2: () = std::panic!();
-   |                ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^^^^^^ evaluation of `Z2` failed here
 
 error[E0080]: evaluation panicked: internal error: entered unreachable code
   --> $DIR/const_panic.rs:12:15
    |
 LL | const Y: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation of `Y` failed here
 
 error[E0080]: evaluation panicked: not implemented
   --> $DIR/const_panic.rs:15:15
    |
 LL | const X: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `X` failed here
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -28,37 +28,37 @@ error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:18:15
    |
 LL | const W: () = std::panic!(MSG);
-   |               ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^ evaluation of `W` failed here
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:21:16
    |
 LL | const W2: () = std::panic!("{}", MSG);
-   |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `W2` failed here
 
 error[E0080]: evaluation panicked: cheese
   --> $DIR/const_panic.rs:24:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `Z_CORE` failed here
 
 error[E0080]: evaluation panicked: explicit panic
   --> $DIR/const_panic.rs:27:21
    |
 LL | const Z2_CORE: () = core::panic!();
-   |                     ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^^^^^^^ evaluation of `Z2_CORE` failed here
 
 error[E0080]: evaluation panicked: internal error: entered unreachable code
   --> $DIR/const_panic.rs:30:20
    |
 LL | const Y_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of `Y_CORE` failed here
 
 error[E0080]: evaluation panicked: not implemented
   --> $DIR/const_panic.rs:33:20
    |
 LL | const X_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `X_CORE` failed here
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,13 +66,13 @@ error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:36:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
-   |                    ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^ evaluation of `W_CORE` failed here
 
 error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic.rs:39:21
    |
 LL | const W2_CORE: () = core::panic!("{}", MSG);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `W2_CORE` failed here
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -2,25 +2,25 @@ error[E0080]: evaluation panicked: blåhaj
   --> $DIR/const_panic_2021.rs:6:15
    |
 LL | const A: () = std::panic!("blåhaj");
-   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `A` failed here
 
 error[E0080]: evaluation panicked: explicit panic
   --> $DIR/const_panic_2021.rs:9:15
    |
 LL | const B: () = std::panic!();
-   |               ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^ evaluation of `B` failed here
 
 error[E0080]: evaluation panicked: internal error: entered unreachable code
   --> $DIR/const_panic_2021.rs:12:15
    |
 LL | const C: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation of `C` failed here
 
 error[E0080]: evaluation panicked: not implemented
   --> $DIR/const_panic_2021.rs:15:15
    |
 LL | const D: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation of `D` failed here
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -28,31 +28,31 @@ error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic_2021.rs:18:15
    |
 LL | const E: () = std::panic!("{}", MSG);
-   |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `E` failed here
 
 error[E0080]: evaluation panicked: shark
   --> $DIR/const_panic_2021.rs:21:20
    |
 LL | const A_CORE: () = core::panic!("shark");
-   |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation of `A_CORE` failed here
 
 error[E0080]: evaluation panicked: explicit panic
   --> $DIR/const_panic_2021.rs:24:20
    |
 LL | const B_CORE: () = core::panic!();
-   |                    ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^ evaluation of `B_CORE` failed here
 
 error[E0080]: evaluation panicked: internal error: entered unreachable code
   --> $DIR/const_panic_2021.rs:27:20
    |
 LL | const C_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of `C_CORE` failed here
 
 error[E0080]: evaluation panicked: not implemented
   --> $DIR/const_panic_2021.rs:30:20
    |
 LL | const D_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `D_CORE` failed here
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ error[E0080]: evaluation panicked: hello
   --> $DIR/const_panic_2021.rs:33:20
    |
 LL | const E_CORE: () = core::panic!("{}", MSG);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `E_CORE` failed here
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -2,19 +2,19 @@ error[E0080]: evaluation panicked: cheese
   --> $DIR/const_panic_libcore_bin.rs:8:15
    |
 LL | const Z: () = panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^ evaluation of `Z` failed here
 
 error[E0080]: evaluation panicked: internal error: entered unreachable code
   --> $DIR/const_panic_libcore_bin.rs:11:15
    |
 LL | const Y: () = unreachable!();
-   |               ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^ evaluation of `Y` failed here
 
 error[E0080]: evaluation panicked: not implemented
   --> $DIR/const_panic_libcore_bin.rs:14:15
    |
 LL | const X: () = unimplemented!();
-   |               ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^ evaluation of `X` failed here
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_track_caller.rs
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.rs
@@ -17,5 +17,5 @@ const fn c() -> u32 {
 }
 
 const X: u32 = c();
-//~^ NOTE evaluation of constant value failed
+//~^ NOTE failed inside this call
 //~| ERROR hey

--- a/tests/ui/consts/const-eval/const_panic_track_caller.stderr
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: hey
   --> $DIR/const_panic_track_caller.rs:19:16
    |
 LL | const X: u32 = c();
-   |                ^^^ evaluation of constant value failed here
+   |                ^^^ evaluation of `X` failed inside this call
    |
 note: inside `c`
   --> $DIR/const_panic_track_caller.rs:15:5

--- a/tests/ui/consts/const-eval/const_raw_ptr_ops2.stderr
+++ b/tests/ui/consts/const-eval/const_raw_ptr_ops2.stderr
@@ -2,13 +2,13 @@ error[E0080]: memory access failed: attempting to access 4 bytes, but got 0x2a[n
   --> $DIR/const_raw_ptr_ops2.rs:7:26
    |
 LL | const Z2: i32 = unsafe { *(42 as *const i32) };
-   |                          ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^^ evaluation of `Z2` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got 0x2c[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/const_raw_ptr_ops2.rs:8:26
    |
 LL | const Z3: i32 = unsafe { *(44 as *const i32) };
-   |                          ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^^ evaluation of `Z3` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -2,7 +2,7 @@ error[E0080]: invalid align passed to `const_allocate`: 3 is not a power of 2
   --> $DIR/alloc_intrinsic_errors.rs:7:18
    |
 LL | const FOO: i32 = foo();
-   |                  ^^^^^ evaluation of constant value failed here
+   |                  ^^^^^ evaluation of `FOO` failed inside this call
    |
 note: inside `foo`
   --> $DIR/alloc_intrinsic_errors.rs:10:17

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -13,7 +13,7 @@ error[E0080]: memory access failed: ALLOC1 has been freed, so this pointer is da
   --> $DIR/dealloc_intrinsic_dangling.rs:22:5
    |
 LL |     *reference
-   |     ^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^ evaluation of `_Y` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.stderr
@@ -2,7 +2,7 @@ error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is da
   --> $DIR/dealloc_intrinsic_duplicate.rs:9:5
    |
 LL |     intrinsics::const_deallocate(ptr, 4, 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_X` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.stderr
@@ -2,25 +2,25 @@ error[E0080]: incorrect layout on deallocation: ALLOC0 has size 4 and alignment 
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:8:5
    |
 LL |     intrinsics::const_deallocate(ptr, 4, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_X` failed here
 
 error[E0080]: incorrect layout on deallocation: ALLOC1 has size 4 and alignment 4, but gave size 2 and alignment 4
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:13:5
    |
 LL |     intrinsics::const_deallocate(ptr, 2, 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_Y` failed here
 
 error[E0080]: incorrect layout on deallocation: ALLOC2 has size 4 and alignment 4, but gave size 3 and alignment 4
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:19:5
    |
 LL |     intrinsics::const_deallocate(ptr, 3, 4);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_Z` failed here
 
 error[E0080]: invalid align passed to `const_deallocate`: 3 is not a power of 2
   --> $DIR/dealloc_intrinsic_incorrect_layout.rs:25:5
    |
 LL |     intrinsics::const_deallocate(ptr, 4, 3);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_W` failed here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-eval/index_out_of_bounds.stderr
+++ b/tests/ui/consts/const-eval/index_out_of_bounds.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 0 but the index is 0
   --> $DIR/index_out_of_bounds.rs:1:19
    |
 LL | static FOO: i32 = [][0];
-   |                   ^^^^^ evaluation of static initializer failed here
+   |                   ^^^^^ evaluation of `FOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/issue-43197.stderr
+++ b/tests/ui/consts/const-eval/issue-43197.stderr
@@ -2,13 +2,13 @@ error[E0080]: attempt to compute `0_u32 - 1_u32`, which would overflow
   --> $DIR/issue-43197.rs:6:20
    |
 LL |     const X: u32 = 0 - 1;
-   |                    ^^^^^ evaluation of constant value failed here
+   |                    ^^^^^ evaluation of `main::X` failed here
 
 error[E0080]: attempt to compute `0_u32 - 1_u32`, which would overflow
   --> $DIR/issue-43197.rs:8:24
    |
 LL |     const Y: u32 = foo(0 - 1);
-   |                        ^^^^^ evaluation of constant value failed here
+   |                        ^^^^^ evaluation of `main::Y` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/issue-49296.stderr
+++ b/tests/ui/consts/const-eval/issue-49296.stderr
@@ -2,7 +2,7 @@ error[E0080]: memory access failed: ALLOC0 has been freed, so this pointer is da
   --> $DIR/issue-49296.rs:9:16
    |
 LL | const X: u64 = *wat(42);
-   |                ^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^ evaluation of `X` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/issue-91827-extern-types-field-offset.stderr
+++ b/tests/ui/consts/const-eval/issue-91827-extern-types-field-offset.stderr
@@ -2,7 +2,7 @@ error[E0080]: `extern type` field does not have a known offset
   --> $DIR/issue-91827-extern-types-field-offset.rs:38:17
    |
 LL |     let field = &x.a;
-   |                 ^^^^ evaluation of constant value failed here
+   |                 ^^^^ evaluation of `OFFSET` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/mod-static-with-const-fn.stderr
+++ b/tests/ui/consts/const-eval/mod-static-with-const-fn.stderr
@@ -2,7 +2,7 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/mod-static-with-const-fn.rs:14:5
    |
 LL |     *FOO.0.get() = 5;
-   |     ^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |     ^^^^^^^^^^^^^^^^ evaluation of `BAR` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
+++ b/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
@@ -2,7 +2,7 @@ error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noa
   --> $DIR/nonnull_as_ref_ub.rs:4:29
    |
 LL | const _: () = assert!(42 == *unsafe { NON_NULL.as_ref() });
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/panic-assoc-never-type.rs:10:21
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^ evaluation of `PrintName::VOID` failed here
 
 note: erroneous constant encountered
   --> $DIR/panic-assoc-never-type.rs:15:13

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/panic-never-type.rs:4:17
    |
 LL | const VOID: ! = panic!();
-   |                 ^^^^^^^^ evaluation of constant value failed here
+   |                 ^^^^^^^^ evaluation of `VOID` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range
   --> $DIR/parse_ints.rs:5:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_TOO_LOW` failed inside this call
    |
 note: inside `core::num::<impl u64>::from_str_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL
@@ -14,7 +14,7 @@ error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range
   --> $DIR/parse_ints.rs:6:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_TOO_HIGH` failed inside this call
    |
 note: inside `core::num::<impl u64>::from_str_radix`
   --> $SRC_DIR/core/src/num/mod.rs:LL:COL

--- a/tests/ui/consts/const-eval/partial_ptr_overwrite.stderr
+++ b/tests/ui/consts/const-eval/partial_ptr_overwrite.stderr
@@ -2,7 +2,7 @@ error[E0080]: unable to overwrite parts of a pointer in memory at ALLOC0
   --> $DIR/partial_ptr_overwrite.rs:7:9
    |
 LL |         *(ptr as *mut u8) = 123;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PARTIAL_OVERWRITE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -1,14 +1,14 @@
 const MISALIGNED_LOAD: () = unsafe {
     let mem = [0u32; 8];
     let ptr = mem.as_ptr().byte_add(1);
-    let _val = *ptr; //~NOTE: evaluation of constant value failed
+    let _val = *ptr; //~NOTE: failed here
     //~^ERROR: based on pointer with alignment 1, but alignment 4 is required
 };
 
 const MISALIGNED_STORE: () = unsafe {
     let mut mem = [0u32; 8];
     let ptr = mem.as_mut_ptr().byte_add(1);
-    *ptr = 0; //~NOTE: evaluation of constant value failed
+    *ptr = 0; //~NOTE: failed here
     //~^ERROR: based on pointer with alignment 1, but alignment 4 is required
 };
 
@@ -17,7 +17,7 @@ const MISALIGNED_COPY: () = unsafe {
     let y = x.as_ptr().cast::<u32>();
     let mut z = 123;
     y.copy_to_nonoverlapping(&mut z, 1);
-    //~^ NOTE evaluation of constant value failed
+    //~^ NOTE failed inside this call
     //~| NOTE inside `std::ptr::copy_nonoverlapping::<u32>`
     //~| ERROR accessing memory with alignment 1, but alignment 4 is required
     // The actual error points into the implementation of `copy_to_nonoverlapping`.
@@ -30,14 +30,14 @@ const MISALIGNED_FIELD: () = unsafe {
     let mem = [0f32; 8];
     let ptr = mem.as_ptr().cast::<Aligned>();
     // Accessing an f32 field but we still require the alignment of the pointer type.
-    let _val = (*ptr).0; //~NOTE: evaluation of constant value failed
+    let _val = (*ptr).0; //~NOTE: failed here
     //~^ERROR: based on pointer with alignment 4, but alignment 16 is required
 };
 
 const OOB: () = unsafe {
     let mem = [0u32; 1];
     let ptr = mem.as_ptr().cast::<u64>();
-    let _val = *ptr; //~NOTE: evaluation of constant value failed
+    let _val = *ptr; //~NOTE: failed here
     //~^ERROR: is only 4 bytes from the end of the allocation
 };
 

--- a/tests/ui/consts/const-eval/raw-pointer-ub.stderr
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.stderr
@@ -2,19 +2,19 @@ error[E0080]: accessing memory based on pointer with alignment 1, but alignment 
   --> $DIR/raw-pointer-ub.rs:4:16
    |
 LL |     let _val = *ptr;
-   |                ^^^^ evaluation of constant value failed here
+   |                ^^^^ evaluation of `MISALIGNED_LOAD` failed here
 
 error[E0080]: accessing memory based on pointer with alignment 1, but alignment 4 is required
   --> $DIR/raw-pointer-ub.rs:11:5
    |
 LL |     *ptr = 0;
-   |     ^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^ evaluation of `MISALIGNED_STORE` failed here
 
 error[E0080]: accessing memory with alignment 1, but alignment 4 is required
   --> $DIR/raw-pointer-ub.rs:19:5
    |
 LL |     y.copy_to_nonoverlapping(&mut z, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MISALIGNED_COPY` failed inside this call
    |
 note: inside `std::ptr::copy_nonoverlapping::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -23,13 +23,13 @@ error[E0080]: accessing memory based on pointer with alignment 4, but alignment 
   --> $DIR/raw-pointer-ub.rs:33:16
    |
 LL |     let _val = (*ptr).0;
-   |                ^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^ evaluation of `MISALIGNED_FIELD` failed here
 
 error[E0080]: memory access failed: attempting to access 8 bytes, but got ALLOC0 which is only 4 bytes from the end of the allocation
   --> $DIR/raw-pointer-ub.rs:40:16
    |
 LL |     let _val = *ptr;
-   |                ^^^^ evaluation of constant value failed here
+   |                ^^^^ evaluation of `OOB` failed here
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/const-eval/ref_to_int_match.32bit.stderr
+++ b/tests/ui/consts/const-eval/ref_to_int_match.32bit.stderr
@@ -2,7 +2,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ref_to_int_match.rs:24:27
    |
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
-   |                           ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                           ^^^^^^^^^^^^^^^^ evaluation of `BAR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/const-eval/ref_to_int_match.64bit.stderr
+++ b/tests/ui/consts/const-eval/ref_to_int_match.64bit.stderr
@@ -2,7 +2,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ref_to_int_match.rs:24:27
    |
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
-   |                           ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                           ^^^^^^^^^^^^^^^^ evaluation of `BAR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/const-eval/shift_overflow.stderr
+++ b/tests/ui/consts/const-eval/shift_overflow.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to shift left by `4294967296_u64`, which would overflow
   --> $DIR/shift_overflow.rs:3:9
    |
 LL |     X = 1 << ((u32::MAX as u64) + 1),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `Foo::X::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.rs
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.rs
@@ -19,10 +19,10 @@ const unsafe fn mir_transmute<T, U>(x: T) -> U {
     }
 }
 
-const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) }; //~ NOTE evaluation of constant value failed
+const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) }; //~ NOTE failed inside this call
 //~^ ERROR transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
 
-const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) }; //~ NOTE evaluation of constant value failed
+const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) }; //~ NOTE failed inside this call
 //~^ ERROR transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
 
 fn main() {}

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0080]: transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
   --> $DIR/transmute-size-mismatch.rs:22:35
    |
 LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `FROM_BIGGER` failed inside this call
    |
 note: inside `mir_transmute::<i32, u16>`
   --> $DIR/transmute-size-mismatch.rs:12:13
@@ -14,7 +14,7 @@ error[E0080]: transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
   --> $DIR/transmute-size-mismatch.rs:25:36
    |
 LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `FROM_SMALLER` failed inside this call
    |
 note: inside `mir_transmute::<i16, u32>`
   --> $DIR/transmute-size-mismatch.rs:12:13

--- a/tests/ui/consts/const-eval/ub-enum-overwrite.stderr
+++ b/tests/ui/consts/const-eval/ub-enum-overwrite.stderr
@@ -2,7 +2,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-enum-overwrite.rs:11:14
    |
 LL |     unsafe { *p }
-   |              ^^ evaluation of constant value failed here
+   |              ^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -13,7 +13,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-enum.rs:32:1
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -22,7 +22,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-enum.rs:35:1
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_WRAPPED` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -42,7 +42,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-enum.rs:49:1
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -51,7 +51,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-enum.rs:52:1
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_WRAPPED` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -60,13 +60,13 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-enum.rs:61:41
    |
 LL | const BAD_ENUM2_UNDEF: Enum2 = unsafe { MaybeUninit { uninit: () }.init };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_UNDEF` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-enum.rs:65:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_OPTION_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -108,19 +108,19 @@ error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabi
   --> $DIR/ub-enum.rs:97:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(0u64) };
-   |                                                                             ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                                             ^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_WITH_DATA1` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
   --> $DIR/ub-enum.rs:99:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(0u64) };
-   |                                                                             ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                                             ^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_WITH_DATA2` failed here
 
 error[E0080]: read discriminant of an uninhabited enum variant
   --> $DIR/ub-enum.rs:105:9
    |
 LL |         std::mem::discriminant(&*(&() as *const () as *const Never));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TEST_ICE_89765` failed inside this call
    |
 note: inside `discriminant::<Never>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/consts/const-eval/ub-invalid-values.rs
+++ b/tests/ui/consts/const-eval/ub-invalid-values.rs
@@ -5,7 +5,7 @@ const fn bool_cast(ptr: *const bool) { unsafe {
 
 const _: () = {
     let v = 3_u8;
-    bool_cast(&v as *const u8 as *const bool); //~ NOTE: evaluation of constant value failed
+    bool_cast(&v as *const u8 as *const bool); //~ NOTE: failed inside this call
     //~^ ERROR interpreting an invalid 8-bit value as a bool
 };
 

--- a/tests/ui/consts/const-eval/ub-invalid-values.stderr
+++ b/tests/ui/consts/const-eval/ub-invalid-values.stderr
@@ -2,7 +2,7 @@ error[E0080]: interpreting an invalid 8-bit value as a bool: 0x03
   --> $DIR/ub-invalid-values.rs:8:5
    |
 LL |     bool_cast(&v as *const u8 as *const bool);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `bool_cast`
   --> $DIR/ub-invalid-values.rs:2:16

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -13,7 +13,7 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
   --> $DIR/ub-nonnull.rs:22:29
    |
 LL |     let out_of_bounds_ptr = &ptr[255];
-   |                             ^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:26:1
@@ -41,7 +41,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-nonnull.rs:36:38
    |
 LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT` failed here
 
 error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
   --> $DIR/ub-nonnull.rs:44:1

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -46,7 +46,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-ref-ptr.rs:33:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -55,7 +55,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-ref-ptr.rs:36:39
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_SLICE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -70,7 +70,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-ref-ptr.rs:39:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   |                                                                                      ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                                                      ^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_BOX_SLICE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -107,7 +107,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-ref-ptr.rs:48:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:51:1
@@ -124,7 +124,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-ref-ptr.rs:53:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_FN_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:55:1
@@ -152,7 +152,7 @@ error[E0080]: accessing memory based on pointer with alignment 1, but alignment 
   --> $DIR/ub-ref-ptr.rs:64:5
    |
 LL |     ptr.read();
-   |     ^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^ evaluation of `UNALIGNED_READ` failed here
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -2,7 +2,7 @@ error[E0080]: constructing invalid value: encountered a value of uninhabited typ
   --> $DIR/ub-uninhabit.rs:20:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_BAD` failed here
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
   --> $DIR/ub-uninhabit.rs:23:1
@@ -19,13 +19,13 @@ error[E0080]: constructing invalid value at [0]: encountered a value of uninhabi
   --> $DIR/ub-uninhabit.rs:26:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_ARRAY` failed here
 
 error[E0080]: constructing invalid value: encountered a value of the never type `!`
   --> $DIR/ub-uninhabit.rs:32:16
    |
 LL |     let _val = intrinsics::read_via_copy(ptr);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `READ_NEVER` failed here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -24,7 +24,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-wide-ptr.rs:44:1
    |
 LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -33,7 +33,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-wide-ptr.rs:47:1
    |
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -75,7 +75,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-wide-ptr.rs:63:1
    |
 LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_UNINIT` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-wide-ptr.rs:69:1
@@ -103,7 +103,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-wide-ptr.rs:75:1
    |
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -123,7 +123,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/ub-wide-ptr.rs:81:1
    |
 LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR_BOX` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -183,7 +183,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/ub-wide-ptr.rs:101:1
    |
 LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_SLICE_LENGTH_UNINIT` failed here
 
 error[E0080]: constructing invalid value at .0: encountered ALLOC12<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:109:1

--- a/tests/ui/consts/const-eval/ub-write-through-immutable.stderr
+++ b/tests/ui/consts/const-eval/ub-write-through-immutable.stderr
@@ -2,13 +2,13 @@ error[E0080]: writing through a pointer that was derived from a shared (immutabl
   --> $DIR/ub-write-through-immutable.rs:10:5
    |
 LL |     *ptr = 0;
-   |     ^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^ evaluation of `WRITE_AFTER_CAST` failed here
 
 error[E0080]: writing through a pointer that was derived from a shared (immutable) reference
   --> $DIR/ub-write-through-immutable.rs:16:5
    |
 LL |     *ptr = 0;
-   |     ^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^ evaluation of `WRITE_AFTER_TRANSMUTE` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/tests/ui/consts/const-eval/union-const-eval-field.stderr
@@ -2,7 +2,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/union-const-eval-field.rs:28:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
-   |                                     ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                     ^^^^^^^^^^^^ evaluation of `read_field3::FIELD3` failed here
 
 note: erroneous constant encountered
   --> $DIR/union-const-eval-field.rs:30:5

--- a/tests/ui/consts/const-eval/union-ice.stderr
+++ b/tests/ui/consts/const-eval/union-ice.stderr
@@ -2,19 +2,19 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/union-ice.rs:14:33
    |
 LL | const FIELD3: Field3 = unsafe { UNION.field3 };
-   |                                 ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^ evaluation of `FIELD3` failed here
 
 error[E0080]: using uninitialized data, but this operation requires initialized memory
   --> $DIR/union-ice.rs:19:17
    |
 LL |     b: unsafe { UNION.field3 },
-   |                 ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                 ^^^^^^^^^^^^ evaluation of `FIELD_PATH` failed here
 
 error[E0080]: using uninitialized data, but this operation requires initialized memory
   --> $DIR/union-ice.rs:31:18
    |
 LL |         unsafe { UNION.field3 },
-   |                  ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^^^^^^^ evaluation of `FIELD_PATH2` failed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/union-ub.32bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.32bit.stderr
@@ -13,7 +13,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_BOOL` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/union-ub.64bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.64bit.stderr
@@ -13,7 +13,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT_BOOL` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/unused-broken-const.stderr
+++ b/tests/ui/consts/const-eval/unused-broken-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 0 but the index is 0
   --> $DIR/unused-broken-const.rs:5:18
    |
 LL | const FOO: i32 = [][0];
-   |                  ^^^^^ evaluation of constant value failed here
+   |                  ^^^^^ evaluation of `FOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/unwind-abort.rs:7:15
    |
 LL | const _: () = foo();
-   |               ^^^^^ evaluation of constant value failed here
+   |               ^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `foo`
   --> $DIR/unwind-abort.rs:4:5

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -2,7 +2,7 @@ error[E0080]: constructing invalid value: encountered a value of the never type 
   --> $DIR/validate_uninhabited_zsts.rs:17:33
    |
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
-   |                                 ^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^ evaluation of `FOO` failed inside this call
    |
 note: inside `foo`
   --> $DIR/validate_uninhabited_zsts.rs:4:14
@@ -14,7 +14,7 @@ error[E0080]: constructing invalid value at .0: encountered a value of uninhabit
   --> $DIR/validate_uninhabited_zsts.rs:20:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAR` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/validation-ice-extern-type-field.stderr
+++ b/tests/ui/consts/const-eval/validation-ice-extern-type-field.stderr
@@ -2,7 +2,7 @@ error[E0080]: `extern type` field does not have a known offset
   --> $DIR/validation-ice-extern-type-field.rs:12:1
    |
 LL | const C1: &ThinDst = unsafe { std::mem::transmute(b"d".as_ptr()) };
-   | ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^ evaluation of `C1` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-external-macro-const-err.stderr
+++ b/tests/ui/consts/const-external-macro-const-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 1 but the index is 1
   --> $DIR/const-external-macro-const-err.rs:12:5
    |
 LL |     static_assert!(2 + 2 == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::_` failed here
    |
    = note: this error originates in the macro `static_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-int-unchecked.stderr
+++ b/tests/ui/consts/const-int-unchecked.stderr
@@ -2,295 +2,295 @@ error[E0080]: overflowing shift by 8 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:14:29
    |
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_U8` failed here
 
 error[E0080]: overflowing shift by 16 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:16:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_U16` failed here
 
 error[E0080]: overflowing shift by 32 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:18:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_U32` failed here
 
 error[E0080]: overflowing shift by 64 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:20:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_U64` failed here
 
 error[E0080]: overflowing shift by 128 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:22:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_U128` failed here
 
 error[E0080]: overflowing shift by 8 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:27:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I8` failed here
 
 error[E0080]: overflowing shift by 16 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:29:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_i16, 16) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I16` failed here
 
 error[E0080]: overflowing shift by 32 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:31:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I32` failed here
 
 error[E0080]: overflowing shift by 64 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:33:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I64` failed here
 
 error[E0080]: overflowing shift by 128 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:35:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I128` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:40:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I8_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:42:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_i16, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I16_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:44:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I32_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:46:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I64_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:48:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I128_NEG` failed here
 
 error[E0080]: overflowing shift by -6 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:54:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I8_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -13 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:56:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_i16, -13) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I16_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -25 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:58:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I32_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -30 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:60:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I64_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -93 in `unchecked_shl`
   --> $DIR/const-int-unchecked.rs:62:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHL_I128_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by 8 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:69:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_U8` failed here
 
 error[E0080]: overflowing shift by 16 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:71:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_U16` failed here
 
 error[E0080]: overflowing shift by 32 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:73:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_U32` failed here
 
 error[E0080]: overflowing shift by 64 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:75:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_U64` failed here
 
 error[E0080]: overflowing shift by 128 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:77:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_U128` failed here
 
 error[E0080]: overflowing shift by 8 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:82:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I8` failed here
 
 error[E0080]: overflowing shift by 16 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:84:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_i16, 16) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I16` failed here
 
 error[E0080]: overflowing shift by 32 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:86:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I32` failed here
 
 error[E0080]: overflowing shift by 64 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:88:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I64` failed here
 
 error[E0080]: overflowing shift by 128 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:90:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I128` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:95:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I8_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:97:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_i16, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I16_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:99:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I32_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:101:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I64_NEG` failed here
 
 error[E0080]: overflowing shift by -1 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:103:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I128_NEG` failed here
 
 error[E0080]: overflowing shift by -6 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:109:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I8_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -13 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:111:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_i16, -13) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I16_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -25 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:113:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I32_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -30 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:115:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I64_NEG_RANDOM` failed here
 
 error[E0080]: overflowing shift by -93 in `unchecked_shr`
   --> $DIR/const-int-unchecked.rs:117:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SHR_I128_NEG_RANDOM` failed here
 
 error[E0080]: arithmetic overflow in `unchecked_add`
   --> $DIR/const-int-unchecked.rs:122:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: arithmetic overflow in `unchecked_sub`
   --> $DIR/const-int-unchecked.rs:125:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: arithmetic overflow in `unchecked_mul`
   --> $DIR/const-int-unchecked.rs:128:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: dividing by zero
   --> $DIR/const-int-unchecked.rs:131:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: overflow in signed division (dividing MIN by -1)
   --> $DIR/const-int-unchecked.rs:133:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: calculating the remainder with a divisor of zero
   --> $DIR/const-int-unchecked.rs:136:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: overflow in signed remainder (dividing MIN by -1)
   --> $DIR/const-int-unchecked.rs:138:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: `ctlz_nonzero` called on 0
   --> $DIR/const-int-unchecked.rs:143:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: `cttz_nonzero` called on 0
   --> $DIR/const-int-unchecked.rs:145:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 49 previous errors
 

--- a/tests/ui/consts/const-len-underflow-separate-spans.next.stderr
+++ b/tests/ui/consts/const-len-underflow-separate-spans.next.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `1_usize - 2_usize`, which would overflow
   --> $DIR/const-len-underflow-separate-spans.rs:10:20
    |
 LL | const LEN: usize = ONE - TWO;
-   |                    ^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^ evaluation of `LEN` failed here
 
 note: erroneous constant encountered
   --> $DIR/const-len-underflow-separate-spans.rs:15:17

--- a/tests/ui/consts/const-len-underflow-separate-spans.old.stderr
+++ b/tests/ui/consts/const-len-underflow-separate-spans.old.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `1_usize - 2_usize`, which would overflow
   --> $DIR/const-len-underflow-separate-spans.rs:10:20
    |
 LL | const LEN: usize = ONE - TWO;
-   |                    ^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^ evaluation of `LEN` failed here
 
 note: erroneous constant encountered
   --> $DIR/const-len-underflow-separate-spans.rs:15:17

--- a/tests/ui/consts/const-len-underflow-separate-spans.rs
+++ b/tests/ui/consts/const-len-underflow-separate-spans.rs
@@ -8,7 +8,7 @@
 const ONE: usize = 1;
 const TWO: usize = 2;
 const LEN: usize = ONE - TWO;
-//~^ NOTE constant
+//~^ NOTE failed here
 //~| ERROR attempt to compute `1_usize - 2_usize`, which would overflow
 
 fn main() {

--- a/tests/ui/consts/const-len-underflow-subspans.stderr
+++ b/tests/ui/consts/const-len-underflow-subspans.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `1_usize - 2_usize`, which would overflow
   --> $DIR/const-len-underflow-subspans.rs:8:17
    |
 LL |     let a: [i8; ONE - TWO] = unimplemented!();
-   |                 ^^^^^^^^^ evaluation of constant value failed here
+   |                 ^^^^^^^^^ evaluation of `main::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: null-ness of this pointer cannot be determine
   --> $DIR/const-ptr-is-null.rs:22:14
    |
 LL |     assert!(!ptr.wrapping_sub(512).is_null());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MAYBE_NULL` failed inside this call
    |
 note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL

--- a/tests/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
+++ b/tests/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
@@ -2,13 +2,13 @@ error[E0080]: `extern type` does not have known layout
   --> $DIR/const-size_of_val-align_of_val-extern-type.rs:10:31
    |
 LL | const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_SIZE` failed here
 
 error[E0080]: `extern type` does not have known layout
   --> $DIR/const-size_of_val-align_of_val-extern-type.rs:11:32
    |
 LL | const _ALIGN: usize = unsafe { min_align_of_val(&4 as *const i32 as *const Opaque) };
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_ALIGN` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-slice-oob.stderr
+++ b/tests/ui/consts/const-slice-oob.stderr
@@ -2,7 +2,7 @@ error[E0080]: index out of bounds: the length is 3 but the index is 5
   --> $DIR/const-slice-oob.rs:2:18
    |
 LL | const BAR: u32 = FOO[5];
-   |                  ^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^ evaluation of `BAR` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
   --> $DIR/const-unwrap.rs:6:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAR` failed here
 
 error[E0080]: evaluation panicked: absolutely not!
   --> $DIR/const-unwrap.rs:9:18
    |
 LL | const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAZ` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_refs_to_static_fail.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail.stderr
@@ -19,7 +19,7 @@ error[E0080]: constant accesses mutable global memory
   --> $DIR/const_refs_to_static_fail.rs:18:13
    |
 LL |     assert!(*C2 == 0);
-   |             ^^^ evaluation of constant value failed here
+   |             ^^^ evaluation of `C2_READ` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.rs
@@ -8,7 +8,7 @@ const unsafe fn foo(x: bool) -> bool {
 }
 
 const BAR: bool = unsafe { foo(false) };
-//~^ NOTE evaluation of constant value failed
+//~^ NOTE failed inside this call
 //~| ERROR entering unreachable code
 
 fn main() {

--- a/tests/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -2,7 +2,7 @@ error[E0080]: entering unreachable code
   --> $DIR/const_unsafe_unreachable_ub.rs:10:28
    |
 LL | const BAR: bool = unsafe { foo(false) };
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `BAR` failed inside this call
    |
 note: inside `foo`
   --> $DIR/const_unsafe_unreachable_ub.rs:4:18

--- a/tests/ui/consts/control-flow/assert.stderr
+++ b/tests/ui/consts/control-flow/assert.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: assertion failed: false
   --> $DIR/assert.rs:5:15
    |
 LL | const _: () = assert!(false);
-   |               ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/copy-intrinsic.stderr
+++ b/tests/ui/consts/copy-intrinsic.stderr
@@ -2,25 +2,25 @@ error[E0080]: memory access failed: attempting to access 4 bytes, but got 0x100[
   --> $DIR/copy-intrinsic.rs:20:5
    |
 LL |     copy_nonoverlapping(0x100 as *const i32, dangle, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `COPY_OOB_1` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC0+0x28 which is at or beyond the end of the allocation of size 4 bytes
   --> $DIR/copy-intrinsic.rs:28:5
    |
 LL |     copy_nonoverlapping(dangle, 0x100 as *mut i32, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `COPY_OOB_2` failed here
 
 error[E0080]: overflow computing total size of `copy`
   --> $DIR/copy-intrinsic.rs:34:5
    |
 LL |     copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `COPY_SIZE_OVERFLOW` failed here
 
 error[E0080]: overflow computing total size of `copy_nonoverlapping`
   --> $DIR/copy-intrinsic.rs:39:5
    |
 LL |     copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `COPY_NONOVERLAPPING_SIZE_OVERFLOW` failed here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/eval-enum.stderr
+++ b/tests/ui/consts/eval-enum.stderr
@@ -2,13 +2,13 @@ error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/eval-enum.rs:2:15
    |
 LL |     DivZero = 1 / 0,
-   |               ^^^^^ evaluation of constant value failed here
+   |               ^^^^^ evaluation of `Test::DivZero::{constant#0}` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/eval-enum.rs:4:15
    |
 LL |     RemZero = 1 % 0,
-   |               ^^^^^ evaluation of constant value failed here
+   |               ^^^^^ evaluation of `Test::RemZero::{constant#0}` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.with_flag.stderr
@@ -2,13 +2,13 @@ error[E0080]: constructing invalid value: encountered 0x03, but expected a boole
   --> $DIR/detect-extra-ub.rs:30:20
    |
 LL |     let _x: bool = transmute(3u8);
-   |                    ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^ evaluation of `INVALID_BOOL` failed here
 
 error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
   --> $DIR/detect-extra-ub.rs:35:21
    |
 LL |     let _x: usize = transmute(&3u8);
-   |                     ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^^^^^^^^ evaluation of `INVALID_PTR_IN_INT` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -17,7 +17,7 @@ error[E0080]: constructing invalid value at .<enum-tag>: encountered a pointer, 
   --> $DIR/detect-extra-ub.rs:40:28
    |
 LL |     let _x: PtrSizedEnum = transmute(&3u8);
-   |                            ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^ evaluation of `INVALID_PTR_IN_ENUM` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -26,7 +26,7 @@ error[E0080]: constructing invalid value at .0: encountered a pointer, but expec
   --> $DIR/detect-extra-ub.rs:46:30
    |
 LL |     let _x: (usize, usize) = transmute(x);
-   |                              ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^ evaluation of `INVALID_SLICE_TO_USIZE_TRANSMUTE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -35,19 +35,19 @@ error[E0080]: constructing invalid value: encountered an unaligned reference (re
   --> $DIR/detect-extra-ub.rs:51:20
    |
 LL |     let _x: &u32 = transmute(&[0u8; 4]);
-   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_PTR` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
   --> $DIR/detect-extra-ub.rs:58:13
    |
 LL |     let v = *addr_of!(data).cast::<UninhDiscriminant>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINHABITED_VARIANT` failed here
 
 error[E0080]: constructing invalid value at [0]: encountered a partial pointer or a mix of pointers
   --> $DIR/detect-extra-ub.rs:77:16
    |
 LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PARTIAL_POINTER` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -56,7 +56,7 @@ error[E0080]: constructing invalid value: encountered invalid reference metadata
   --> $DIR/detect-extra-ub.rs:91:16
    |
 LL |     let _val = &*slice;
-   |                ^^^^^^^ evaluation of constant value failed here
+   |                ^^^^^^^ evaluation of `OVERSIZED_REF` failed here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/issue-32829.stderr
+++ b/tests/ui/consts/issue-32829.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: foo
   --> $DIR/issue-32829.rs:1:22
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
-   |                      ^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `S` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-64506.stderr
+++ b/tests/ui/consts/issue-64506.stderr
@@ -2,7 +2,7 @@ error[E0080]: constructing invalid value at .inner: encountered a value of uninh
   --> $DIR/issue-64506.rs:16:22
    |
 LL |     let x = unsafe { Foo { b: () }.a };
-   |                      ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^^^ evaluation of `FOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/tests/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -8,7 +8,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
 LL |     let _ = [false; panic!()];
-   |                     ^^^^^^^^ evaluation of constant value failed here
+   |                     ^^^^^^^^ evaluation of `main::{constant#1}` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -14,13 +14,13 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-66693.rs:16:15
    |
 LL | const _: () = panic!();
-   |               ^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^ evaluation of `_` failed here
 
 error[E0080]: evaluation panicked: panic in static
   --> $DIR/issue-66693.rs:18:19
    |
 LL | static _BAR: () = panic!("panic in static");
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_BAR` failed here
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:11:5

--- a/tests/ui/consts/issue-76064.stderr
+++ b/tests/ui/consts/issue-76064.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: panic
   --> $DIR/issue-76064.rs:1:17
    |
 LL | struct Bug([u8; panic!("panic")]);
-   |                 ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                 ^^^^^^^^^^^^^^^ evaluation of `Bug::0::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -2,7 +2,7 @@ error[E0080]: unable to turn pointer into integer
   --> $DIR/issue-miri-1910.rs:7:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `C` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/large_const_alloc.stderr
+++ b/tests/ui/consts/large_const_alloc.stderr
@@ -2,13 +2,13 @@ error[E0080]: tried to allocate more memory than available to compiler
   --> $DIR/large_const_alloc.rs:11:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
-   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of `FOO` failed here
 
 error[E0080]: tried to allocate more memory than available to compiler
   --> $DIR/large_const_alloc.rs:16:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
-   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |             ^^^^^^^^^^^^^^^^^^^^^ evaluation of `FOO2` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -9,7 +9,7 @@ const fn call_rust_fn(my_fn: extern "Rust" fn()) {
 }
 
 static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-//~^ NOTE evaluation of static initializer failed here
+//~^ NOTE failed inside this call
 //~| ERROR calling a function with calling convention "C" using calling convention "Rust"
 
 fn main() {}

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling a function with calling convention "C" using calling conve
   --> $DIR/abi-mismatch.rs:11:18
    |
 LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VAL` failed inside this call
    |
 note: inside `call_rust_fn`
   --> $DIR/abi-mismatch.rs:7:5

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `<Vec<u32> as Drop>::drop`
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^ evaluation of `<std::string::String as Bar<std::vec::Vec<u32>, std::string::String>>::F` failed here
+   |                               ^ evaluation of `<std::string::String as Bar<std::vec::Vec<u32>, std::string::String>>::F` failed inside this call
    |
 note: inside `drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/box.stderr
+++ b/tests/ui/consts/miri_unleashed/box.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `Box::<i32>::new`
   --> $DIR/box.rs:8:11
    |
 LL |     &mut *(Box::new(0))
-   |           ^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |           ^^^^^^^^^^^^^ evaluation of `TEST_BAD` failed here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -2,19 +2,19 @@ error[E0080]: calling non-const function `AtomicUsize::fetch_add`
   --> $DIR/const_refers_to_static.rs:11:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MUTATE_INTERIOR_MUT` failed here
 
 error[E0080]: constant accesses mutable global memory
   --> $DIR/const_refers_to_static.rs:16:14
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `READ_INTERIOR_MUT` failed here
 
 error[E0080]: constant accesses mutable global memory
   --> $DIR/const_refers_to_static.rs:20:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   |                                ^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^ evaluation of `READ_MUT` failed here
 
 error[E0080]: constructing invalid value: encountered reference to mutable memory in `const`
   --> $DIR/const_refers_to_static.rs:23:1

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -35,7 +35,7 @@ error[E0080]: constant accesses mutable global memory
   --> $DIR/const_refers_to_static_cross_crate.rs:30:15
    |
 LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `U8_MUT3` failed here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/miri_unleashed/drop.rs
+++ b/tests/ui/consts/miri_unleashed/drop.rs
@@ -13,7 +13,7 @@ static TEST_OK: () = {
 // The actual error is tested by the error-pattern above.
 static TEST_BAD: () = {
     let _v: Vec<i32> = Vec::new();
-}; //~ NOTE evaluation of static initializer failed here
+}; //~ NOTE failed inside this call
    //~| ERROR calling non-const function `<Vec<i32> as Drop>::drop`
    //~| NOTE inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
 

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `<Vec<i32> as Drop>::drop`
   --> $DIR/drop.rs:16:1
    |
 LL | };
-   | ^ evaluation of static initializer failed here
+   | ^ evaluation of `TEST_BAD` failed inside this call
    |
 note: inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/extern-static.stderr
+++ b/tests/ui/consts/miri_unleashed/extern-static.stderr
@@ -2,13 +2,13 @@ error[E0080]: cannot access extern static `DATA`
   --> $DIR/extern-static.rs:11:25
    |
 LL |     unsafe { let _val = DATA; }
-   |                         ^^^^ evaluation of static initializer failed here
+   |                         ^^^^ evaluation of `TEST_READ` failed here
 
 error[E0080]: cannot access extern static `DATA`
   --> $DIR/extern-static.rs:15:14
    |
 LL |     unsafe { DATA = 0; }
-   |              ^^^^^^^^ evaluation of static initializer failed here
+   |              ^^^^^^^^ evaluation of `TEST_WRITE` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/tests/ui/consts/miri_unleashed/inline_asm.stderr
@@ -2,7 +2,7 @@ error[E0080]: inline assembly is not supported
   --> $DIR/inline_asm.rs:10:14
    |
 LL |     unsafe { asm!("nop"); }
-   |              ^^^^^^^^^^^ evaluation of static initializer failed here
+   |              ^^^^^^^^^^^ evaluation of `TEST_BAD` failed here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -113,7 +113,7 @@ error[E0080]: constant accesses mutable global memory
   --> $DIR/mutable_references.rs:70:43
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
-   |                                           ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^ evaluation of `POINTS_TO_MUTABLE2` failed here
 
 error: encountered mutable pointer in final value of constant
   --> $DIR/mutable_references.rs:73:1

--- a/tests/ui/consts/miri_unleashed/mutating_global.stderr
+++ b/tests/ui/consts/miri_unleashed/mutating_global.stderr
@@ -2,7 +2,7 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/mutating_global.rs:9:9
    |
 LL |         GLOBAL = 99
-   |         ^^^^^^^^^^^ evaluation of static initializer failed here
+   |         ^^^^^^^^^^^ evaluation of `MUTATING_GLOBAL` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/tests/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `foo`
   --> $DIR/non_const_fn.rs:7:16
    |
 LL | static C: () = foo();
-   |                ^^^^^ evaluation of static initializer failed here
+   |                ^^^^^ evaluation of `C` failed here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/tests/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -2,13 +2,13 @@ error[E0080]: exposing pointers is not possible at compile-time
   --> $DIR/ptr_arith.rs:7:13
    |
 LL |     let x = &0 as *const _ as usize;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PTR_INT_CAST` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/ptr_arith.rs:14:14
    |
 LL |     let _v = x + 0;
-   |              ^ evaluation of static initializer failed here
+   |              ^ evaluation of `PTR_INT_TRANSMUTE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/miri_unleashed/tls.stderr
+++ b/tests/ui/consts/miri_unleashed/tls.stderr
@@ -2,13 +2,13 @@ error[E0080]: cannot access thread local static `A`
   --> $DIR/tls.rs:11:25
    |
 LL |     unsafe { let _val = A; }
-   |                         ^ evaluation of static initializer failed here
+   |                         ^ evaluation of `TEST_BAD` failed here
 
 error[E0080]: cannot access thread local static `A`
   --> $DIR/tls.rs:19:26
    |
 LL |     unsafe { let _val = &A; }
-   |                          ^ evaluation of static initializer failed here
+   |                          ^ evaluation of `TEST_BAD_REF` failed here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -6,7 +6,7 @@ error[E0080]: unable to copy parts of a pointer from memory at ALLOC0
 16 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
 17 | |             mem::size_of::<&i32>(),
 18 | |         );
-   | |_________^ evaluation of constant value failed here
+   | |_________^ evaluation of `X` failed inside this call
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/no-ice-from-static-in-const-issue-52060.stderr
+++ b/tests/ui/consts/no-ice-from-static-in-const-issue-52060.stderr
@@ -2,7 +2,7 @@ error[E0080]: constant accesses mutable global memory
   --> $DIR/no-ice-from-static-in-const-issue-52060.rs:5:35
    |
 LL | static B: [u32; 1] = [0; unsafe { A.len() }];
-   |                                   ^ evaluation of constant value failed here
+   |                                   ^ evaluation of `B::{constant#1}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -2,13 +2,13 @@ error[E0080]: `ptr_offset_from` called on two different pointers that are not bo
   --> $DIR/offset_from_ub.rs:20:27
    |
 LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DIFFERENT_ALLOC` failed here
 
 error[E0080]: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
   --> $DIR/offset_from_ub.rs:26:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NOT_PTR` failed inside this call
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -17,67 +17,67 @@ error[E0080]: exact_div: 1_isize cannot be divided by 2_isize without remainder
   --> $DIR/offset_from_ub.rs:34:14
    |
 LL |     unsafe { ptr_offset_from(field_ptr, base_ptr as *const u16) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NOT_MULTIPLE_OF_SIZE` failed here
 
 error[E0080]: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
   --> $DIR/offset_from_ub.rs:42:14
    |
 LL |     unsafe { ptr_offset_from(ptr2, ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DIFFERENT_INT` failed here
 
 error[E0080]: `ptr_offset_from` called on two different pointers where the memory range between them is not in-bounds of an allocation
   --> $DIR/offset_from_ub.rs:51:14
    |
 LL |     unsafe { ptr_offset_from(end_ptr, start_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_1` failed here
 
 error[E0080]: `ptr_offset_from` called on two different pointers where the memory range between them is not in-bounds of an allocation
   --> $DIR/offset_from_ub.rs:60:14
    |
 LL |     unsafe { ptr_offset_from(start_ptr, end_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_2` failed here
 
 error[E0080]: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
   --> $DIR/offset_from_ub.rs:69:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(field_ptr, base_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DIFFERENT_ALLOC_UNSIGNED` failed here
 
 error[E0080]: `ptr_offset_from` called when first pointer is too far ahead of second
   --> $DIR/offset_from_ub.rs:76:14
    |
 LL |     unsafe { ptr_offset_from(ptr2, ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TOO_FAR_APART1` failed here
 
 error[E0080]: `ptr_offset_from` called when first pointer is too far before second
   --> $DIR/offset_from_ub.rs:82:14
    |
 LL |     unsafe { ptr_offset_from(ptr1, ptr2) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TOO_FAR_APART2` failed here
 
 error[E0080]: `ptr_offset_from` called when first pointer is too far before second
   --> $DIR/offset_from_ub.rs:90:14
    |
 LL |     unsafe { ptr_offset_from(ptr1, ptr2) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TOO_FAR_APART3` failed here
 
 error[E0080]: `ptr_offset_from_unsigned` called when first pointer has smaller offset than second: 0 < 8
   --> $DIR/offset_from_ub.rs:97:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(p, p.add(2)) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `WRONG_ORDER_UNSIGNED` failed here
 
 error[E0080]: `ptr_offset_from_unsigned` called when first pointer is too far ahead of second
   --> $DIR/offset_from_ub.rs:104:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(ptr2, ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TOO_FAR_APART_UNSIGNED` failed here
 
 error[E0080]: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
   --> $DIR/offset_from_ub.rs:112:14
    |
 LL |     unsafe { ptr2.offset_from(ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OFFSET_VERY_FAR1` failed inside this call
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -86,7 +86,7 @@ error[E0080]: `ptr_offset_from` called when first pointer is too far before seco
   --> $DIR/offset_from_ub.rs:118:14
    |
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OFFSET_VERY_FAR2` failed inside this call
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL

--- a/tests/ui/consts/offset_ub.stderr
+++ b/tests/ui/consts/offset_ub.stderr
@@ -2,67 +2,67 @@ error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer 
   --> $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BEFORE_START` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC1 which is only 1 byte from the end of the allocation
   --> $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `AFTER_END` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
   --> $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `AFTER_ARRAY` failed here
 
 error[E0080]: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
   --> $DIR/offset_ub.rs:12:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OVERFLOW` failed here
 
 error[E0080]: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
   --> $DIR/offset_ub.rs:13:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNDERFLOW` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/offset_ub.rs:14:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `OVERFLOW_ADDRESS_SPACE` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/offset_ub.rs:15:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNDERFLOW_ADDRESS_SPACE` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got ALLOC3-0x2 which is only $BYTES bytes from the beginning of the allocation
   --> $DIR/offset_ub.rs:16:49
    |
 LL | pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEGATIVE_OFFSET` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 1 byte, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
   --> $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ZERO_SIZED_ALLOC` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by $BYTES bytes, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/offset_ub.rs:19:42
    |
 LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DANGLING` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by -$BYTES bytes, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
   --> $DIR/offset_ub.rs:22:47
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNDERFLOW_ABS` failed here
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/consts/overflowing-consts.noopt.stderr
+++ b/tests/ui/consts/overflowing-consts.noopt.stderr
@@ -2,1021 +2,1021 @@ error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:18:22
    |
 LL | const _NI8_SHL: i8 = 1i8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:19:26
    |
 LL | const _NI8_SHL_P: &i8 = &(1i8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:21:24
    |
 LL | const _NI16_SHL: i16 = 1i16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:22:28
    |
 LL | const _NI16_SHL_P: &i16 = &(1i16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:24:24
    |
 LL | const _NI32_SHL: i32 = 1i32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:25:28
    |
 LL | const _NI32_SHL_P: &i32 = &(1i32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:27:24
    |
 LL | const _NI64_SHL: i64 = 1i64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:28:28
    |
 LL | const _NI64_SHL_P: &i64 = &(1i64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:30:26
    |
 LL | const _NI128_SHL: i128 = 1i128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:31:30
    |
 LL | const _NI128_SHL_P: &i128 = &(1i128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:33:22
    |
 LL | const _NU8_SHL: u8 = 1u8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:34:26
    |
 LL | const _NU8_SHL_P: &u8 = &(1u8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:36:24
    |
 LL | const _NU16_SHL: u16 = 1u16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:37:28
    |
 LL | const _NU16_SHL_P: &u16 = &(1u16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:39:24
    |
 LL | const _NU32_SHL: u32 = 1u32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:40:28
    |
 LL | const _NU32_SHL_P: &u32 = &(1u32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:42:24
    |
 LL | const _NU64_SHL: u64 = 1u64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:43:28
    |
 LL | const _NU64_SHL_P: &u64 = &(1u64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:45:26
    |
 LL | const _NU128_SHL: u128 = 1u128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:46:30
    |
 LL | const _NU128_SHL_P: &u128 = &(1u128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:48:28
    |
 LL | const _NISIZE_SHL: isize = 1isize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:49:32
    |
 LL | const _NISIZE_SHL_P: &isize = &(1isize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:51:28
    |
 LL | const _NUSIZE_SHL: usize = 1usize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:52:32
    |
 LL | const _NUSIZE_SHL_P: &usize = &(1usize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:55:22
    |
 LL | const _NI8_SHR: i8 = 1i8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:56:26
    |
 LL | const _NI8_SHR_P: &i8 = &(1i8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:58:24
    |
 LL | const _NI16_SHR: i16 = 1i16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:59:28
    |
 LL | const _NI16_SHR_P: &i16 = &(1i16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:61:24
    |
 LL | const _NI32_SHR: i32 = 1i32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:62:28
    |
 LL | const _NI32_SHR_P: &i32 = &(1i32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:64:24
    |
 LL | const _NI64_SHR: i64 = 1i64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:65:28
    |
 LL | const _NI64_SHR_P: &i64 = &(1i64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:67:26
    |
 LL | const _NI128_SHR: i128 = 1i128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:68:30
    |
 LL | const _NI128_SHR_P: &i128 = &(1i128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:70:22
    |
 LL | const _NU8_SHR: u8 = 1u8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:71:26
    |
 LL | const _NU8_SHR_P: &u8 = &(1u8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:73:24
    |
 LL | const _NU16_SHR: u16 = 1u16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:74:28
    |
 LL | const _NU16_SHR_P: &u16 = &(1u16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:76:24
    |
 LL | const _NU32_SHR: u32 = 1u32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:77:28
    |
 LL | const _NU32_SHR_P: &u32 = &(1u32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:79:24
    |
 LL | const _NU64_SHR: u64 = 1u64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:80:28
    |
 LL | const _NU64_SHR_P: &u64 = &(1u64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:82:26
    |
 LL | const _NU128_SHR: u128 = 1u128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:83:30
    |
 LL | const _NU128_SHR_P: &u128 = &(1u128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:85:28
    |
 LL | const _NISIZE_SHR: isize = 1isize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:86:32
    |
 LL | const _NISIZE_SHR_P: &isize = &(1isize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:88:28
    |
 LL | const _NUSIZE_SHR: usize = 1usize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:89:32
    |
 LL | const _NUSIZE_SHR_P: &usize = &(1usize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR_P` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:92:22
    |
 LL | const _NI8_ADD: i8 = 1i8 + i8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NI8_ADD` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:93:26
    |
 LL | const _NI8_ADD_P: &i8 = &(1i8 + i8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NI8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:95:24
    |
 LL | const _NI16_ADD: i16 = 1i16 + i16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:96:28
    |
 LL | const _NI16_ADD_P: &i16 = &(1i16 + i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:98:24
    |
 LL | const _NI32_ADD: i32 = 1i32 + i32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:99:28
    |
 LL | const _NI32_ADD_P: &i32 = &(1i32 + i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:101:24
    |
 LL | const _NI64_ADD: i64 = 1i64 + i64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:102:28
    |
 LL | const _NI64_ADD_P: &i64 = &(1i64 + i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:104:26
    |
 LL | const _NI128_ADD: i128 = 1i128 + i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:105:30
    |
 LL | const _NI128_ADD_P: &i128 = &(1i128 + i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:107:22
    |
 LL | const _NU8_ADD: u8 = 1u8 + u8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NU8_ADD` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:108:26
    |
 LL | const _NU8_ADD_P: &u8 = &(1u8 + u8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NU8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:110:24
    |
 LL | const _NU16_ADD: u16 = 1u16 + u16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:111:28
    |
 LL | const _NU16_ADD_P: &u16 = &(1u16 + u16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:113:24
    |
 LL | const _NU32_ADD: u32 = 1u32 + u32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:114:28
    |
 LL | const _NU32_ADD_P: &u32 = &(1u32 + u32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:116:24
    |
 LL | const _NU64_ADD: u64 = 1u64 + u64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:117:28
    |
 LL | const _NU64_ADD_P: &u64 = &(1u64 + u64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:119:26
    |
 LL | const _NU128_ADD: u128 = 1u128 + u128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:120:30
    |
 LL | const _NU128_ADD_P: &u128 = &(1u128 + u128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:122:28
    |
 LL | const _NISIZE_ADD: isize = 1isize + isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:123:32
    |
 LL | const _NISIZE_ADD_P: &isize = &(1isize + isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:125:28
    |
 LL | const _NUSIZE_ADD: usize = 1usize + usize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:126:32
    |
 LL | const _NUSIZE_ADD_P: &usize = &(1usize + usize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:129:22
    |
 LL | const _NI8_SUB: i8 = -5i8 - i8::MAX;
-   |                      ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^^ evaluation of `_NI8_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:130:26
    |
 LL | const _NI8_SUB_P: &i8 = &(-5i8 - i8::MAX);
-   |                          ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^ evaluation of `_NI8_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:132:24
    |
 LL | const _NI16_SUB: i16 = -5i16 - i16::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:133:28
    |
 LL | const _NI16_SUB_P: &i16 = &(-5i16 - i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:135:24
    |
 LL | const _NI32_SUB: i32 = -5i32 - i32::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:136:28
    |
 LL | const _NI32_SUB_P: &i32 = &(-5i32 - i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:138:24
    |
 LL | const _NI64_SUB: i64 = -5i64 - i64::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:139:28
    |
 LL | const _NI64_SUB_P: &i64 = &(-5i64 - i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:141:26
    |
 LL | const _NI128_SUB: i128 = -5i128 - i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:142:30
    |
 LL | const _NI128_SUB_P: &i128 = &(-5i128 - i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:144:22
    |
 LL | const _NU8_SUB: u8 = 1u8 - 5;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_SUB` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:145:26
    |
 LL | const _NU8_SUB_P: &u8 = &(1u8 - 5);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:147:24
    |
 LL | const _NU16_SUB: u16 = 1u16 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_SUB` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:148:28
    |
 LL | const _NU16_SUB_P: &u16 = &(1u16 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:150:24
    |
 LL | const _NU32_SUB: u32 = 1u32 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_SUB` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:151:28
    |
 LL | const _NU32_SUB_P: &u32 = &(1u32 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:153:24
    |
 LL | const _NU64_SUB: u64 = 1u64 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_SUB` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:154:28
    |
 LL | const _NU64_SUB_P: &u64 = &(1u64 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:156:26
    |
 LL | const _NU128_SUB: u128 = 1u128 - 5;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_SUB` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:157:30
    |
 LL | const _NU128_SUB_P: &u128 = &(1u128 - 5);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:159:28
    |
 LL | const _NISIZE_SUB: isize = -5isize - isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:160:32
    |
 LL | const _NISIZE_SUB_P: &isize = &(-5isize - isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:162:28
    |
 LL | const _NUSIZE_SUB: usize = 1usize - 5;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_SUB` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:163:32
    |
 LL | const _NUSIZE_SUB_P: &usize = &(1usize - 5);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:166:22
    |
 LL | const _NI8_MUL: i8 = i8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NI8_MUL` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:167:26
    |
 LL | const _NI8_MUL_P: &i8 = &(i8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI8_MUL_P` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:169:24
    |
 LL | const _NI16_MUL: i16 = i16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI16_MUL` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:170:28
    |
 LL | const _NI16_MUL_P: &i16 = &(i16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI16_MUL_P` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:172:24
    |
 LL | const _NI32_MUL: i32 = i32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_MUL` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:173:28
    |
 LL | const _NI32_MUL_P: &i32 = &(i32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_MUL_P` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:175:24
    |
 LL | const _NI64_MUL: i64 = i64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI64_MUL` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:176:28
    |
 LL | const _NI64_MUL_P: &i64 = &(i64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI64_MUL_P` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:178:26
    |
 LL | const _NI128_MUL: i128 = i128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI128_MUL` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:179:30
    |
 LL | const _NI128_MUL_P: &i128 = &(i128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NI128_MUL_P` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:181:22
    |
 LL | const _NU8_MUL: u8 = u8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NU8_MUL` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:182:26
    |
 LL | const _NU8_MUL_P: &u8 = &(u8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU8_MUL_P` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:184:24
    |
 LL | const _NU16_MUL: u16 = u16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU16_MUL` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:185:28
    |
 LL | const _NU16_MUL_P: &u16 = &(u16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU16_MUL_P` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:187:24
    |
 LL | const _NU32_MUL: u32 = u32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU32_MUL` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:188:28
    |
 LL | const _NU32_MUL_P: &u32 = &(u32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU32_MUL_P` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:190:24
    |
 LL | const _NU64_MUL: u64 = u64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU64_MUL` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:191:28
    |
 LL | const _NU64_MUL_P: &u64 = &(u64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU64_MUL_P` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:193:26
    |
 LL | const _NU128_MUL: u128 = u128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU128_MUL` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:194:30
    |
 LL | const _NU128_MUL_P: &u128 = &(u128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NU128_MUL_P` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:196:28
    |
 LL | const _NISIZE_MUL: isize = isize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:197:32
    |
 LL | const _NISIZE_MUL_P: &isize = &(isize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL_P` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:199:28
    |
 LL | const _NUSIZE_MUL: usize = usize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:200:32
    |
 LL | const _NUSIZE_MUL_P: &usize = &(usize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL_P` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:203:22
    |
 LL | const _NI8_DIV: i8 = 1i8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_DIV` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:204:26
    |
 LL | const _NI8_DIV_P: &i8 = &(1i8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:206:24
    |
 LL | const _NI16_DIV: i16 = 1i16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_DIV` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:207:28
    |
 LL | const _NI16_DIV_P: &i16 = &(1i16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:209:24
    |
 LL | const _NI32_DIV: i32 = 1i32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_DIV` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:210:28
    |
 LL | const _NI32_DIV_P: &i32 = &(1i32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:212:24
    |
 LL | const _NI64_DIV: i64 = 1i64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_DIV` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:213:28
    |
 LL | const _NI64_DIV_P: &i64 = &(1i64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:215:26
    |
 LL | const _NI128_DIV: i128 = 1i128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_DIV` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:216:30
    |
 LL | const _NI128_DIV_P: &i128 = &(1i128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:218:22
    |
 LL | const _NU8_DIV: u8 = 1u8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_DIV` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:219:26
    |
 LL | const _NU8_DIV_P: &u8 = &(1u8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:221:24
    |
 LL | const _NU16_DIV: u16 = 1u16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_DIV` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:222:28
    |
 LL | const _NU16_DIV_P: &u16 = &(1u16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:224:24
    |
 LL | const _NU32_DIV: u32 = 1u32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_DIV` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:225:28
    |
 LL | const _NU32_DIV_P: &u32 = &(1u32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:227:24
    |
 LL | const _NU64_DIV: u64 = 1u64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_DIV` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:228:28
    |
 LL | const _NU64_DIV_P: &u64 = &(1u64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:230:26
    |
 LL | const _NU128_DIV: u128 = 1u128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_DIV` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:231:30
    |
 LL | const _NU128_DIV_P: &u128 = &(1u128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:233:28
    |
 LL | const _NISIZE_DIV: isize = 1isize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:234:32
    |
 LL | const _NISIZE_DIV_P: &isize = &(1isize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:236:28
    |
 LL | const _NUSIZE_DIV: usize = 1usize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:237:32
    |
 LL | const _NUSIZE_DIV_P: &usize = &(1usize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_DIV_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:240:22
    |
 LL | const _NI8_MOD: i8 = 1i8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:241:26
    |
 LL | const _NI8_MOD_P: &i8 = &(1i8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:243:24
    |
 LL | const _NI16_MOD: i16 = 1i16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:244:28
    |
 LL | const _NI16_MOD_P: &i16 = &(1i16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:246:24
    |
 LL | const _NI32_MOD: i32 = 1i32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:247:28
    |
 LL | const _NI32_MOD_P: &i32 = &(1i32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:249:24
    |
 LL | const _NI64_MOD: i64 = 1i64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:250:28
    |
 LL | const _NI64_MOD_P: &i64 = &(1i64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:252:26
    |
 LL | const _NI128_MOD: i128 = 1i128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:253:30
    |
 LL | const _NI128_MOD_P: &i128 = &(1i128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:255:22
    |
 LL | const _NU8_MOD: u8 = 1u8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:256:26
    |
 LL | const _NU8_MOD_P: &u8 = &(1u8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:258:24
    |
 LL | const _NU16_MOD: u16 = 1u16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:259:28
    |
 LL | const _NU16_MOD_P: &u16 = &(1u16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:261:24
    |
 LL | const _NU32_MOD: u32 = 1u32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:262:28
    |
 LL | const _NU32_MOD_P: &u32 = &(1u32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:264:24
    |
 LL | const _NU64_MOD: u64 = 1u64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:265:28
    |
 LL | const _NU64_MOD_P: &u64 = &(1u64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:267:26
    |
 LL | const _NU128_MOD: u128 = 1u128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:268:30
    |
 LL | const _NU128_MOD_P: &u128 = &(1u128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:270:28
    |
 LL | const _NISIZE_MOD: isize = 1isize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:271:32
    |
 LL | const _NISIZE_MOD_P: &isize = &(1isize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:273:28
    |
 LL | const _NUSIZE_MOD: usize = 1usize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:274:32
    |
 LL | const _NUSIZE_MOD_P: &usize = &(1usize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_MOD_P` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:277:24
    |
 LL | const _NI32_OOB: i32 = [1, 2, 3][4];
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_OOB` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:278:28
    |
 LL | const _NI32_OOB_P: &i32 = &([1, 2, 3][4]);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_OOB_P` failed here
 
 error: aborting due to 170 previous errors
 

--- a/tests/ui/consts/overflowing-consts.opt.stderr
+++ b/tests/ui/consts/overflowing-consts.opt.stderr
@@ -2,1021 +2,1021 @@ error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:18:22
    |
 LL | const _NI8_SHL: i8 = 1i8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:19:26
    |
 LL | const _NI8_SHL_P: &i8 = &(1i8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:21:24
    |
 LL | const _NI16_SHL: i16 = 1i16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:22:28
    |
 LL | const _NI16_SHL_P: &i16 = &(1i16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:24:24
    |
 LL | const _NI32_SHL: i32 = 1i32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:25:28
    |
 LL | const _NI32_SHL_P: &i32 = &(1i32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:27:24
    |
 LL | const _NI64_SHL: i64 = 1i64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:28:28
    |
 LL | const _NI64_SHL_P: &i64 = &(1i64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:30:26
    |
 LL | const _NI128_SHL: i128 = 1i128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:31:30
    |
 LL | const _NI128_SHL_P: &i128 = &(1i128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:33:22
    |
 LL | const _NU8_SHL: u8 = 1u8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:34:26
    |
 LL | const _NU8_SHL_P: &u8 = &(1u8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:36:24
    |
 LL | const _NU16_SHL: u16 = 1u16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:37:28
    |
 LL | const _NU16_SHL_P: &u16 = &(1u16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:39:24
    |
 LL | const _NU32_SHL: u32 = 1u32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:40:28
    |
 LL | const _NU32_SHL_P: &u32 = &(1u32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:42:24
    |
 LL | const _NU64_SHL: u64 = 1u64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:43:28
    |
 LL | const _NU64_SHL_P: &u64 = &(1u64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:45:26
    |
 LL | const _NU128_SHL: u128 = 1u128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:46:30
    |
 LL | const _NU128_SHL_P: &u128 = &(1u128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:48:28
    |
 LL | const _NISIZE_SHL: isize = 1isize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:49:32
    |
 LL | const _NISIZE_SHL_P: &isize = &(1isize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:51:28
    |
 LL | const _NUSIZE_SHL: usize = 1usize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:52:32
    |
 LL | const _NUSIZE_SHL_P: &usize = &(1usize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:55:22
    |
 LL | const _NI8_SHR: i8 = 1i8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:56:26
    |
 LL | const _NI8_SHR_P: &i8 = &(1i8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:58:24
    |
 LL | const _NI16_SHR: i16 = 1i16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:59:28
    |
 LL | const _NI16_SHR_P: &i16 = &(1i16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:61:24
    |
 LL | const _NI32_SHR: i32 = 1i32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:62:28
    |
 LL | const _NI32_SHR_P: &i32 = &(1i32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:64:24
    |
 LL | const _NI64_SHR: i64 = 1i64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:65:28
    |
 LL | const _NI64_SHR_P: &i64 = &(1i64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:67:26
    |
 LL | const _NI128_SHR: i128 = 1i128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:68:30
    |
 LL | const _NI128_SHR_P: &i128 = &(1i128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:70:22
    |
 LL | const _NU8_SHR: u8 = 1u8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:71:26
    |
 LL | const _NU8_SHR_P: &u8 = &(1u8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:73:24
    |
 LL | const _NU16_SHR: u16 = 1u16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:74:28
    |
 LL | const _NU16_SHR_P: &u16 = &(1u16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:76:24
    |
 LL | const _NU32_SHR: u32 = 1u32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:77:28
    |
 LL | const _NU32_SHR_P: &u32 = &(1u32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:79:24
    |
 LL | const _NU64_SHR: u64 = 1u64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:80:28
    |
 LL | const _NU64_SHR_P: &u64 = &(1u64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:82:26
    |
 LL | const _NU128_SHR: u128 = 1u128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:83:30
    |
 LL | const _NU128_SHR_P: &u128 = &(1u128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:85:28
    |
 LL | const _NISIZE_SHR: isize = 1isize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:86:32
    |
 LL | const _NISIZE_SHR_P: &isize = &(1isize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:88:28
    |
 LL | const _NUSIZE_SHR: usize = 1usize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:89:32
    |
 LL | const _NUSIZE_SHR_P: &usize = &(1usize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR_P` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:92:22
    |
 LL | const _NI8_ADD: i8 = 1i8 + i8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NI8_ADD` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:93:26
    |
 LL | const _NI8_ADD_P: &i8 = &(1i8 + i8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NI8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:95:24
    |
 LL | const _NI16_ADD: i16 = 1i16 + i16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:96:28
    |
 LL | const _NI16_ADD_P: &i16 = &(1i16 + i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:98:24
    |
 LL | const _NI32_ADD: i32 = 1i32 + i32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:99:28
    |
 LL | const _NI32_ADD_P: &i32 = &(1i32 + i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:101:24
    |
 LL | const _NI64_ADD: i64 = 1i64 + i64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:102:28
    |
 LL | const _NI64_ADD_P: &i64 = &(1i64 + i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:104:26
    |
 LL | const _NI128_ADD: i128 = 1i128 + i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:105:30
    |
 LL | const _NI128_ADD_P: &i128 = &(1i128 + i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:107:22
    |
 LL | const _NU8_ADD: u8 = 1u8 + u8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NU8_ADD` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:108:26
    |
 LL | const _NU8_ADD_P: &u8 = &(1u8 + u8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NU8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:110:24
    |
 LL | const _NU16_ADD: u16 = 1u16 + u16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:111:28
    |
 LL | const _NU16_ADD_P: &u16 = &(1u16 + u16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:113:24
    |
 LL | const _NU32_ADD: u32 = 1u32 + u32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:114:28
    |
 LL | const _NU32_ADD_P: &u32 = &(1u32 + u32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:116:24
    |
 LL | const _NU64_ADD: u64 = 1u64 + u64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:117:28
    |
 LL | const _NU64_ADD_P: &u64 = &(1u64 + u64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:119:26
    |
 LL | const _NU128_ADD: u128 = 1u128 + u128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:120:30
    |
 LL | const _NU128_ADD_P: &u128 = &(1u128 + u128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:122:28
    |
 LL | const _NISIZE_ADD: isize = 1isize + isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:123:32
    |
 LL | const _NISIZE_ADD_P: &isize = &(1isize + isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:125:28
    |
 LL | const _NUSIZE_ADD: usize = 1usize + usize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:126:32
    |
 LL | const _NUSIZE_ADD_P: &usize = &(1usize + usize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:129:22
    |
 LL | const _NI8_SUB: i8 = -5i8 - i8::MAX;
-   |                      ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^^ evaluation of `_NI8_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:130:26
    |
 LL | const _NI8_SUB_P: &i8 = &(-5i8 - i8::MAX);
-   |                          ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^ evaluation of `_NI8_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:132:24
    |
 LL | const _NI16_SUB: i16 = -5i16 - i16::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:133:28
    |
 LL | const _NI16_SUB_P: &i16 = &(-5i16 - i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:135:24
    |
 LL | const _NI32_SUB: i32 = -5i32 - i32::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:136:28
    |
 LL | const _NI32_SUB_P: &i32 = &(-5i32 - i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:138:24
    |
 LL | const _NI64_SUB: i64 = -5i64 - i64::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:139:28
    |
 LL | const _NI64_SUB_P: &i64 = &(-5i64 - i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:141:26
    |
 LL | const _NI128_SUB: i128 = -5i128 - i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:142:30
    |
 LL | const _NI128_SUB_P: &i128 = &(-5i128 - i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:144:22
    |
 LL | const _NU8_SUB: u8 = 1u8 - 5;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_SUB` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:145:26
    |
 LL | const _NU8_SUB_P: &u8 = &(1u8 - 5);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:147:24
    |
 LL | const _NU16_SUB: u16 = 1u16 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_SUB` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:148:28
    |
 LL | const _NU16_SUB_P: &u16 = &(1u16 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:150:24
    |
 LL | const _NU32_SUB: u32 = 1u32 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_SUB` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:151:28
    |
 LL | const _NU32_SUB_P: &u32 = &(1u32 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:153:24
    |
 LL | const _NU64_SUB: u64 = 1u64 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_SUB` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:154:28
    |
 LL | const _NU64_SUB_P: &u64 = &(1u64 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:156:26
    |
 LL | const _NU128_SUB: u128 = 1u128 - 5;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_SUB` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:157:30
    |
 LL | const _NU128_SUB_P: &u128 = &(1u128 - 5);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:159:28
    |
 LL | const _NISIZE_SUB: isize = -5isize - isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:160:32
    |
 LL | const _NISIZE_SUB_P: &isize = &(-5isize - isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:162:28
    |
 LL | const _NUSIZE_SUB: usize = 1usize - 5;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_SUB` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:163:32
    |
 LL | const _NUSIZE_SUB_P: &usize = &(1usize - 5);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:166:22
    |
 LL | const _NI8_MUL: i8 = i8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NI8_MUL` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:167:26
    |
 LL | const _NI8_MUL_P: &i8 = &(i8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI8_MUL_P` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:169:24
    |
 LL | const _NI16_MUL: i16 = i16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI16_MUL` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:170:28
    |
 LL | const _NI16_MUL_P: &i16 = &(i16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI16_MUL_P` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:172:24
    |
 LL | const _NI32_MUL: i32 = i32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_MUL` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:173:28
    |
 LL | const _NI32_MUL_P: &i32 = &(i32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_MUL_P` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:175:24
    |
 LL | const _NI64_MUL: i64 = i64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI64_MUL` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:176:28
    |
 LL | const _NI64_MUL_P: &i64 = &(i64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI64_MUL_P` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:178:26
    |
 LL | const _NI128_MUL: i128 = i128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI128_MUL` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:179:30
    |
 LL | const _NI128_MUL_P: &i128 = &(i128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NI128_MUL_P` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:181:22
    |
 LL | const _NU8_MUL: u8 = u8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NU8_MUL` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:182:26
    |
 LL | const _NU8_MUL_P: &u8 = &(u8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU8_MUL_P` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:184:24
    |
 LL | const _NU16_MUL: u16 = u16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU16_MUL` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:185:28
    |
 LL | const _NU16_MUL_P: &u16 = &(u16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU16_MUL_P` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:187:24
    |
 LL | const _NU32_MUL: u32 = u32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU32_MUL` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:188:28
    |
 LL | const _NU32_MUL_P: &u32 = &(u32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU32_MUL_P` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:190:24
    |
 LL | const _NU64_MUL: u64 = u64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU64_MUL` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:191:28
    |
 LL | const _NU64_MUL_P: &u64 = &(u64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU64_MUL_P` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:193:26
    |
 LL | const _NU128_MUL: u128 = u128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU128_MUL` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:194:30
    |
 LL | const _NU128_MUL_P: &u128 = &(u128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NU128_MUL_P` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:196:28
    |
 LL | const _NISIZE_MUL: isize = isize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:197:32
    |
 LL | const _NISIZE_MUL_P: &isize = &(isize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL_P` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:199:28
    |
 LL | const _NUSIZE_MUL: usize = usize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:200:32
    |
 LL | const _NUSIZE_MUL_P: &usize = &(usize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL_P` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:203:22
    |
 LL | const _NI8_DIV: i8 = 1i8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_DIV` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:204:26
    |
 LL | const _NI8_DIV_P: &i8 = &(1i8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:206:24
    |
 LL | const _NI16_DIV: i16 = 1i16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_DIV` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:207:28
    |
 LL | const _NI16_DIV_P: &i16 = &(1i16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:209:24
    |
 LL | const _NI32_DIV: i32 = 1i32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_DIV` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:210:28
    |
 LL | const _NI32_DIV_P: &i32 = &(1i32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:212:24
    |
 LL | const _NI64_DIV: i64 = 1i64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_DIV` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:213:28
    |
 LL | const _NI64_DIV_P: &i64 = &(1i64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:215:26
    |
 LL | const _NI128_DIV: i128 = 1i128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_DIV` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:216:30
    |
 LL | const _NI128_DIV_P: &i128 = &(1i128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:218:22
    |
 LL | const _NU8_DIV: u8 = 1u8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_DIV` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:219:26
    |
 LL | const _NU8_DIV_P: &u8 = &(1u8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:221:24
    |
 LL | const _NU16_DIV: u16 = 1u16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_DIV` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:222:28
    |
 LL | const _NU16_DIV_P: &u16 = &(1u16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:224:24
    |
 LL | const _NU32_DIV: u32 = 1u32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_DIV` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:225:28
    |
 LL | const _NU32_DIV_P: &u32 = &(1u32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:227:24
    |
 LL | const _NU64_DIV: u64 = 1u64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_DIV` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:228:28
    |
 LL | const _NU64_DIV_P: &u64 = &(1u64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:230:26
    |
 LL | const _NU128_DIV: u128 = 1u128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_DIV` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:231:30
    |
 LL | const _NU128_DIV_P: &u128 = &(1u128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:233:28
    |
 LL | const _NISIZE_DIV: isize = 1isize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:234:32
    |
 LL | const _NISIZE_DIV_P: &isize = &(1isize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:236:28
    |
 LL | const _NUSIZE_DIV: usize = 1usize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:237:32
    |
 LL | const _NUSIZE_DIV_P: &usize = &(1usize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_DIV_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:240:22
    |
 LL | const _NI8_MOD: i8 = 1i8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:241:26
    |
 LL | const _NI8_MOD_P: &i8 = &(1i8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:243:24
    |
 LL | const _NI16_MOD: i16 = 1i16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:244:28
    |
 LL | const _NI16_MOD_P: &i16 = &(1i16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:246:24
    |
 LL | const _NI32_MOD: i32 = 1i32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:247:28
    |
 LL | const _NI32_MOD_P: &i32 = &(1i32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:249:24
    |
 LL | const _NI64_MOD: i64 = 1i64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:250:28
    |
 LL | const _NI64_MOD_P: &i64 = &(1i64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:252:26
    |
 LL | const _NI128_MOD: i128 = 1i128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:253:30
    |
 LL | const _NI128_MOD_P: &i128 = &(1i128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:255:22
    |
 LL | const _NU8_MOD: u8 = 1u8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:256:26
    |
 LL | const _NU8_MOD_P: &u8 = &(1u8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:258:24
    |
 LL | const _NU16_MOD: u16 = 1u16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:259:28
    |
 LL | const _NU16_MOD_P: &u16 = &(1u16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:261:24
    |
 LL | const _NU32_MOD: u32 = 1u32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:262:28
    |
 LL | const _NU32_MOD_P: &u32 = &(1u32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:264:24
    |
 LL | const _NU64_MOD: u64 = 1u64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:265:28
    |
 LL | const _NU64_MOD_P: &u64 = &(1u64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:267:26
    |
 LL | const _NU128_MOD: u128 = 1u128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:268:30
    |
 LL | const _NU128_MOD_P: &u128 = &(1u128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:270:28
    |
 LL | const _NISIZE_MOD: isize = 1isize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:271:32
    |
 LL | const _NISIZE_MOD_P: &isize = &(1isize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:273:28
    |
 LL | const _NUSIZE_MOD: usize = 1usize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:274:32
    |
 LL | const _NUSIZE_MOD_P: &usize = &(1usize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_MOD_P` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:277:24
    |
 LL | const _NI32_OOB: i32 = [1, 2, 3][4];
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_OOB` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:278:28
    |
 LL | const _NI32_OOB_P: &i32 = &([1, 2, 3][4]);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_OOB_P` failed here
 
 error: aborting due to 170 previous errors
 

--- a/tests/ui/consts/overflowing-consts.opt_with_overflow_checks.stderr
+++ b/tests/ui/consts/overflowing-consts.opt_with_overflow_checks.stderr
@@ -2,1021 +2,1021 @@ error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:18:22
    |
 LL | const _NI8_SHL: i8 = 1i8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:19:26
    |
 LL | const _NI8_SHL_P: &i8 = &(1i8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:21:24
    |
 LL | const _NI16_SHL: i16 = 1i16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:22:28
    |
 LL | const _NI16_SHL_P: &i16 = &(1i16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:24:24
    |
 LL | const _NI32_SHL: i32 = 1i32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:25:28
    |
 LL | const _NI32_SHL_P: &i32 = &(1i32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:27:24
    |
 LL | const _NI64_SHL: i64 = 1i64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:28:28
    |
 LL | const _NI64_SHL_P: &i64 = &(1i64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:30:26
    |
 LL | const _NI128_SHL: i128 = 1i128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:31:30
    |
 LL | const _NI128_SHL_P: &i128 = &(1i128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:33:22
    |
 LL | const _NU8_SHL: u8 = 1u8 << 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHL` failed here
 
 error[E0080]: attempt to shift left by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:34:26
    |
 LL | const _NU8_SHL_P: &u8 = &(1u8 << 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:36:24
    |
 LL | const _NU16_SHL: u16 = 1u16 << 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHL` failed here
 
 error[E0080]: attempt to shift left by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:37:28
    |
 LL | const _NU16_SHL_P: &u16 = &(1u16 << 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:39:24
    |
 LL | const _NU32_SHL: u32 = 1u32 << 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHL` failed here
 
 error[E0080]: attempt to shift left by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:40:28
    |
 LL | const _NU32_SHL_P: &u32 = &(1u32 << 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:42:24
    |
 LL | const _NU64_SHL: u64 = 1u64 << 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHL` failed here
 
 error[E0080]: attempt to shift left by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:43:28
    |
 LL | const _NU64_SHL_P: &u64 = &(1u64 << 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:45:26
    |
 LL | const _NU128_SHL: u128 = 1u128 << 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHL` failed here
 
 error[E0080]: attempt to shift left by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:46:30
    |
 LL | const _NU128_SHL_P: &u128 = &(1u128 << 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:48:28
    |
 LL | const _NISIZE_SHL: isize = 1isize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:49:32
    |
 LL | const _NISIZE_SHL_P: &isize = &(1isize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:51:28
    |
 LL | const _NUSIZE_SHL: usize = 1usize << BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL` failed here
 
 error[E0080]: attempt to shift left by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:52:32
    |
 LL | const _NUSIZE_SHL_P: &usize = &(1usize << BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHL_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:55:22
    |
 LL | const _NI8_SHR: i8 = 1i8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NI8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:56:26
    |
 LL | const _NI8_SHR_P: &i8 = &(1i8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NI8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:58:24
    |
 LL | const _NI16_SHR: i16 = 1i16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:59:28
    |
 LL | const _NI16_SHR_P: &i16 = &(1i16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:61:24
    |
 LL | const _NI32_SHR: i32 = 1i32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:62:28
    |
 LL | const _NI32_SHR_P: &i32 = &(1i32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:64:24
    |
 LL | const _NI64_SHR: i64 = 1i64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NI64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:65:28
    |
 LL | const _NI64_SHR_P: &i64 = &(1i64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NI64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:67:26
    |
 LL | const _NI128_SHR: i128 = 1i128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NI128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:68:30
    |
 LL | const _NI128_SHR_P: &i128 = &(1i128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NI128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:70:22
    |
 LL | const _NU8_SHR: u8 = 1u8 >> 8;
-   |                      ^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^ evaluation of `_NU8_SHR` failed here
 
 error[E0080]: attempt to shift right by `8_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:71:26
    |
 LL | const _NU8_SHR_P: &u8 = &(1u8 >> 8);
-   |                          ^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^ evaluation of `_NU8_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:73:24
    |
 LL | const _NU16_SHR: u16 = 1u16 >> 16;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU16_SHR` failed here
 
 error[E0080]: attempt to shift right by `16_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:74:28
    |
 LL | const _NU16_SHR_P: &u16 = &(1u16 >> 16);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU16_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:76:24
    |
 LL | const _NU32_SHR: u32 = 1u32 >> 32;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU32_SHR` failed here
 
 error[E0080]: attempt to shift right by `32_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:77:28
    |
 LL | const _NU32_SHR_P: &u32 = &(1u32 >> 32);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU32_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:79:24
    |
 LL | const _NU64_SHR: u64 = 1u64 >> 64;
-   |                        ^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^ evaluation of `_NU64_SHR` failed here
 
 error[E0080]: attempt to shift right by `64_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:80:28
    |
 LL | const _NU64_SHR_P: &u64 = &(1u64 >> 64);
-   |                            ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^ evaluation of `_NU64_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:82:26
    |
 LL | const _NU128_SHR: u128 = 1u128 >> 128;
-   |                          ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^ evaluation of `_NU128_SHR` failed here
 
 error[E0080]: attempt to shift right by `128_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:83:30
    |
 LL | const _NU128_SHR_P: &u128 = &(1u128 >> 128);
-   |                              ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^ evaluation of `_NU128_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:85:28
    |
 LL | const _NISIZE_SHR: isize = 1isize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:86:32
    |
 LL | const _NISIZE_SHR_P: &isize = &(1isize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SHR_P` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:88:28
    |
 LL | const _NUSIZE_SHR: usize = 1usize >> BITS;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR` failed here
 
 error[E0080]: attempt to shift right by `%BITS%`, which would overflow
   --> $DIR/overflowing-consts.rs:89:32
    |
 LL | const _NUSIZE_SHR_P: &usize = &(1usize >> BITS);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_SHR_P` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:92:22
    |
 LL | const _NI8_ADD: i8 = 1i8 + i8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NI8_ADD` failed here
 
 error[E0080]: attempt to compute `1_i8 + i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:93:26
    |
 LL | const _NI8_ADD_P: &i8 = &(1i8 + i8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NI8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:95:24
    |
 LL | const _NI16_ADD: i16 = 1i16 + i16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD` failed here
 
 error[E0080]: attempt to compute `1_i16 + i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:96:28
    |
 LL | const _NI16_ADD_P: &i16 = &(1i16 + i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:98:24
    |
 LL | const _NI32_ADD: i32 = 1i32 + i32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD` failed here
 
 error[E0080]: attempt to compute `1_i32 + i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:99:28
    |
 LL | const _NI32_ADD_P: &i32 = &(1i32 + i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:101:24
    |
 LL | const _NI64_ADD: i64 = 1i64 + i64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD` failed here
 
 error[E0080]: attempt to compute `1_i64 + i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:102:28
    |
 LL | const _NI64_ADD_P: &i64 = &(1i64 + i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NI64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:104:26
    |
 LL | const _NI128_ADD: i128 = 1i128 + i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD` failed here
 
 error[E0080]: attempt to compute `1_i128 + i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:105:30
    |
 LL | const _NI128_ADD_P: &i128 = &(1i128 + i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:107:22
    |
 LL | const _NU8_ADD: u8 = 1u8 + u8::MAX;
-   |                      ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^ evaluation of `_NU8_ADD` failed here
 
 error[E0080]: attempt to compute `1_u8 + u8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:108:26
    |
 LL | const _NU8_ADD_P: &u8 = &(1u8 + u8::MAX);
-   |                          ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^ evaluation of `_NU8_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:110:24
    |
 LL | const _NU16_ADD: u16 = 1u16 + u16::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD` failed here
 
 error[E0080]: attempt to compute `1_u16 + u16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:111:28
    |
 LL | const _NU16_ADD_P: &u16 = &(1u16 + u16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU16_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:113:24
    |
 LL | const _NU32_ADD: u32 = 1u32 + u32::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD` failed here
 
 error[E0080]: attempt to compute `1_u32 + u32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:114:28
    |
 LL | const _NU32_ADD_P: &u32 = &(1u32 + u32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU32_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:116:24
    |
 LL | const _NU64_ADD: u64 = 1u64 + u64::MAX;
-   |                        ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD` failed here
 
 error[E0080]: attempt to compute `1_u64 + u64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:117:28
    |
 LL | const _NU64_ADD_P: &u64 = &(1u64 + u64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^ evaluation of `_NU64_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:119:26
    |
 LL | const _NU128_ADD: u128 = 1u128 + u128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD` failed here
 
 error[E0080]: attempt to compute `1_u128 + u128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:120:30
    |
 LL | const _NU128_ADD_P: &u128 = &(1u128 + u128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^ evaluation of `_NU128_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:122:28
    |
 LL | const _NISIZE_ADD: isize = 1isize + isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_isize + isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:123:32
    |
 LL | const _NISIZE_ADD_P: &isize = &(1isize + isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:125:28
    |
 LL | const _NUSIZE_ADD: usize = 1usize + usize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD` failed here
 
 error[E0080]: attempt to compute `1_usize + usize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:126:32
    |
 LL | const _NUSIZE_ADD_P: &usize = &(1usize + usize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_ADD_P` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:129:22
    |
 LL | const _NI8_SUB: i8 = -5i8 - i8::MAX;
-   |                      ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^^^^ evaluation of `_NI8_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i8 - i8::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:130:26
    |
 LL | const _NI8_SUB_P: &i8 = &(-5i8 - i8::MAX);
-   |                          ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^ evaluation of `_NI8_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:132:24
    |
 LL | const _NI16_SUB: i16 = -5i16 - i16::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i16 - i16::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:133:28
    |
 LL | const _NI16_SUB_P: &i16 = &(-5i16 - i16::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI16_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:135:24
    |
 LL | const _NI32_SUB: i32 = -5i32 - i32::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i32 - i32::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:136:28
    |
 LL | const _NI32_SUB_P: &i32 = &(-5i32 - i32::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI32_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:138:24
    |
 LL | const _NI64_SUB: i64 = -5i64 - i64::MAX;
-   |                        ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i64 - i64::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:139:28
    |
 LL | const _NI64_SUB_P: &i64 = &(-5i64 - i64::MAX);
-   |                            ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^ evaluation of `_NI64_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:141:26
    |
 LL | const _NI128_SUB: i128 = -5i128 - i128::MAX;
-   |                          ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB` failed here
 
 error[E0080]: attempt to compute `-5_i128 - i128::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:142:30
    |
 LL | const _NI128_SUB_P: &i128 = &(-5i128 - i128::MAX);
-   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NI128_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:144:22
    |
 LL | const _NU8_SUB: u8 = 1u8 - 5;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_SUB` failed here
 
 error[E0080]: attempt to compute `1_u8 - 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:145:26
    |
 LL | const _NU8_SUB_P: &u8 = &(1u8 - 5);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:147:24
    |
 LL | const _NU16_SUB: u16 = 1u16 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_SUB` failed here
 
 error[E0080]: attempt to compute `1_u16 - 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:148:28
    |
 LL | const _NU16_SUB_P: &u16 = &(1u16 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:150:24
    |
 LL | const _NU32_SUB: u32 = 1u32 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_SUB` failed here
 
 error[E0080]: attempt to compute `1_u32 - 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:151:28
    |
 LL | const _NU32_SUB_P: &u32 = &(1u32 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:153:24
    |
 LL | const _NU64_SUB: u64 = 1u64 - 5;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_SUB` failed here
 
 error[E0080]: attempt to compute `1_u64 - 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:154:28
    |
 LL | const _NU64_SUB_P: &u64 = &(1u64 - 5);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:156:26
    |
 LL | const _NU128_SUB: u128 = 1u128 - 5;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_SUB` failed here
 
 error[E0080]: attempt to compute `1_u128 - 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:157:30
    |
 LL | const _NU128_SUB_P: &u128 = &(1u128 - 5);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_SUB_P` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:159:28
    |
 LL | const _NISIZE_SUB: isize = -5isize - isize::MAX;
-   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB` failed here
 
 error[E0080]: attempt to compute `-5_isize - isize::MAX`, which would overflow
   --> $DIR/overflowing-consts.rs:160:32
    |
 LL | const _NISIZE_SUB_P: &isize = &(-5isize - isize::MAX);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:162:28
    |
 LL | const _NUSIZE_SUB: usize = 1usize - 5;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_SUB` failed here
 
 error[E0080]: attempt to compute `1_usize - 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:163:32
    |
 LL | const _NUSIZE_SUB_P: &usize = &(1usize - 5);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_SUB_P` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:166:22
    |
 LL | const _NI8_MUL: i8 = i8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NI8_MUL` failed here
 
 error[E0080]: attempt to compute `i8::MAX * 5_i8`, which would overflow
   --> $DIR/overflowing-consts.rs:167:26
    |
 LL | const _NI8_MUL_P: &i8 = &(i8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI8_MUL_P` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:169:24
    |
 LL | const _NI16_MUL: i16 = i16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI16_MUL` failed here
 
 error[E0080]: attempt to compute `i16::MAX * 5_i16`, which would overflow
   --> $DIR/overflowing-consts.rs:170:28
    |
 LL | const _NI16_MUL_P: &i16 = &(i16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI16_MUL_P` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:172:24
    |
 LL | const _NI32_MUL: i32 = i32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_MUL` failed here
 
 error[E0080]: attempt to compute `i32::MAX * 5_i32`, which would overflow
   --> $DIR/overflowing-consts.rs:173:28
    |
 LL | const _NI32_MUL_P: &i32 = &(i32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_MUL_P` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:175:24
    |
 LL | const _NI64_MUL: i64 = i64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI64_MUL` failed here
 
 error[E0080]: attempt to compute `i64::MAX * 5_i64`, which would overflow
   --> $DIR/overflowing-consts.rs:176:28
    |
 LL | const _NI64_MUL_P: &i64 = &(i64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI64_MUL_P` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:178:26
    |
 LL | const _NI128_MUL: i128 = i128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NI128_MUL` failed here
 
 error[E0080]: attempt to compute `i128::MAX * 5_i128`, which would overflow
   --> $DIR/overflowing-consts.rs:179:30
    |
 LL | const _NI128_MUL_P: &i128 = &(i128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NI128_MUL_P` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:181:22
    |
 LL | const _NU8_MUL: u8 = u8::MAX * 5;
-   |                      ^^^^^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^^^^^ evaluation of `_NU8_MUL` failed here
 
 error[E0080]: attempt to compute `u8::MAX * 5_u8`, which would overflow
   --> $DIR/overflowing-consts.rs:182:26
    |
 LL | const _NU8_MUL_P: &u8 = &(u8::MAX * 5);
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU8_MUL_P` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:184:24
    |
 LL | const _NU16_MUL: u16 = u16::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU16_MUL` failed here
 
 error[E0080]: attempt to compute `u16::MAX * 5_u16`, which would overflow
   --> $DIR/overflowing-consts.rs:185:28
    |
 LL | const _NU16_MUL_P: &u16 = &(u16::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU16_MUL_P` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:187:24
    |
 LL | const _NU32_MUL: u32 = u32::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU32_MUL` failed here
 
 error[E0080]: attempt to compute `u32::MAX * 5_u32`, which would overflow
   --> $DIR/overflowing-consts.rs:188:28
    |
 LL | const _NU32_MUL_P: &u32 = &(u32::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU32_MUL_P` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:190:24
    |
 LL | const _NU64_MUL: u64 = u64::MAX * 5;
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NU64_MUL` failed here
 
 error[E0080]: attempt to compute `u64::MAX * 5_u64`, which would overflow
   --> $DIR/overflowing-consts.rs:191:28
    |
 LL | const _NU64_MUL_P: &u64 = &(u64::MAX * 5);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NU64_MUL_P` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:193:26
    |
 LL | const _NU128_MUL: u128 = u128::MAX * 5;
-   |                          ^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^ evaluation of `_NU128_MUL` failed here
 
 error[E0080]: attempt to compute `u128::MAX * 5_u128`, which would overflow
   --> $DIR/overflowing-consts.rs:194:30
    |
 LL | const _NU128_MUL_P: &u128 = &(u128::MAX * 5);
-   |                              ^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^^^^^ evaluation of `_NU128_MUL_P` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:196:28
    |
 LL | const _NISIZE_MUL: isize = isize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL` failed here
 
 error[E0080]: attempt to compute `isize::MAX * 5_isize`, which would overflow
   --> $DIR/overflowing-consts.rs:197:32
    |
 LL | const _NISIZE_MUL_P: &isize = &(isize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NISIZE_MUL_P` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:199:28
    |
 LL | const _NUSIZE_MUL: usize = usize::MAX * 5;
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL` failed here
 
 error[E0080]: attempt to compute `usize::MAX * 5_usize`, which would overflow
   --> $DIR/overflowing-consts.rs:200:32
    |
 LL | const _NUSIZE_MUL_P: &usize = &(usize::MAX * 5);
-   |                                ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^ evaluation of `_NUSIZE_MUL_P` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:203:22
    |
 LL | const _NI8_DIV: i8 = 1i8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_DIV` failed here
 
 error[E0080]: attempt to divide `1_i8` by zero
   --> $DIR/overflowing-consts.rs:204:26
    |
 LL | const _NI8_DIV_P: &i8 = &(1i8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:206:24
    |
 LL | const _NI16_DIV: i16 = 1i16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_DIV` failed here
 
 error[E0080]: attempt to divide `1_i16` by zero
   --> $DIR/overflowing-consts.rs:207:28
    |
 LL | const _NI16_DIV_P: &i16 = &(1i16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:209:24
    |
 LL | const _NI32_DIV: i32 = 1i32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_DIV` failed here
 
 error[E0080]: attempt to divide `1_i32` by zero
   --> $DIR/overflowing-consts.rs:210:28
    |
 LL | const _NI32_DIV_P: &i32 = &(1i32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:212:24
    |
 LL | const _NI64_DIV: i64 = 1i64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_DIV` failed here
 
 error[E0080]: attempt to divide `1_i64` by zero
   --> $DIR/overflowing-consts.rs:213:28
    |
 LL | const _NI64_DIV_P: &i64 = &(1i64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:215:26
    |
 LL | const _NI128_DIV: i128 = 1i128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_DIV` failed here
 
 error[E0080]: attempt to divide `1_i128` by zero
   --> $DIR/overflowing-consts.rs:216:30
    |
 LL | const _NI128_DIV_P: &i128 = &(1i128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:218:22
    |
 LL | const _NU8_DIV: u8 = 1u8 / 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_DIV` failed here
 
 error[E0080]: attempt to divide `1_u8` by zero
   --> $DIR/overflowing-consts.rs:219:26
    |
 LL | const _NU8_DIV_P: &u8 = &(1u8 / 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:221:24
    |
 LL | const _NU16_DIV: u16 = 1u16 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_DIV` failed here
 
 error[E0080]: attempt to divide `1_u16` by zero
   --> $DIR/overflowing-consts.rs:222:28
    |
 LL | const _NU16_DIV_P: &u16 = &(1u16 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:224:24
    |
 LL | const _NU32_DIV: u32 = 1u32 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_DIV` failed here
 
 error[E0080]: attempt to divide `1_u32` by zero
   --> $DIR/overflowing-consts.rs:225:28
    |
 LL | const _NU32_DIV_P: &u32 = &(1u32 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:227:24
    |
 LL | const _NU64_DIV: u64 = 1u64 / 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_DIV` failed here
 
 error[E0080]: attempt to divide `1_u64` by zero
   --> $DIR/overflowing-consts.rs:228:28
    |
 LL | const _NU64_DIV_P: &u64 = &(1u64 / 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:230:26
    |
 LL | const _NU128_DIV: u128 = 1u128 / 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_DIV` failed here
 
 error[E0080]: attempt to divide `1_u128` by zero
   --> $DIR/overflowing-consts.rs:231:30
    |
 LL | const _NU128_DIV_P: &u128 = &(1u128 / 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:233:28
    |
 LL | const _NISIZE_DIV: isize = 1isize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/overflowing-consts.rs:234:32
    |
 LL | const _NISIZE_DIV_P: &isize = &(1isize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_DIV_P` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:236:28
    |
 LL | const _NUSIZE_DIV: usize = 1usize / 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_DIV` failed here
 
 error[E0080]: attempt to divide `1_usize` by zero
   --> $DIR/overflowing-consts.rs:237:32
    |
 LL | const _NUSIZE_DIV_P: &usize = &(1usize / 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_DIV_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:240:22
    |
 LL | const _NI8_MOD: i8 = 1i8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NI8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:241:26
    |
 LL | const _NI8_MOD_P: &i8 = &(1i8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:243:24
    |
 LL | const _NI16_MOD: i16 = 1i16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:244:28
    |
 LL | const _NI16_MOD_P: &i16 = &(1i16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:246:24
    |
 LL | const _NI32_MOD: i32 = 1i32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:247:28
    |
 LL | const _NI32_MOD_P: &i32 = &(1i32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:249:24
    |
 LL | const _NI64_MOD: i64 = 1i64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NI64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:250:28
    |
 LL | const _NI64_MOD_P: &i64 = &(1i64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NI64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:252:26
    |
 LL | const _NI128_MOD: i128 = 1i128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NI128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_i128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:253:30
    |
 LL | const _NI128_MOD_P: &i128 = &(1i128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NI128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:255:22
    |
 LL | const _NU8_MOD: u8 = 1u8 % 0;
-   |                      ^^^^^^^ evaluation of constant value failed here
+   |                      ^^^^^^^ evaluation of `_NU8_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u8` with a divisor of zero
   --> $DIR/overflowing-consts.rs:256:26
    |
 LL | const _NU8_MOD_P: &u8 = &(1u8 % 0);
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU8_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:258:24
    |
 LL | const _NU16_MOD: u16 = 1u16 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU16_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u16` with a divisor of zero
   --> $DIR/overflowing-consts.rs:259:28
    |
 LL | const _NU16_MOD_P: &u16 = &(1u16 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU16_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:261:24
    |
 LL | const _NU32_MOD: u32 = 1u32 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU32_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u32` with a divisor of zero
   --> $DIR/overflowing-consts.rs:262:28
    |
 LL | const _NU32_MOD_P: &u32 = &(1u32 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU32_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:264:24
    |
 LL | const _NU64_MOD: u64 = 1u64 % 0;
-   |                        ^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^ evaluation of `_NU64_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u64` with a divisor of zero
   --> $DIR/overflowing-consts.rs:265:28
    |
 LL | const _NU64_MOD_P: &u64 = &(1u64 % 0);
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NU64_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:267:26
    |
 LL | const _NU128_MOD: u128 = 1u128 % 0;
-   |                          ^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^ evaluation of `_NU128_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_u128` with a divisor of zero
   --> $DIR/overflowing-consts.rs:268:30
    |
 LL | const _NU128_MOD_P: &u128 = &(1u128 % 0);
-   |                              ^^^^^^^^^^^ evaluation of constant value failed here
+   |                              ^^^^^^^^^^^ evaluation of `_NU128_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:270:28
    |
 LL | const _NISIZE_MOD: isize = 1isize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NISIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_isize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:271:32
    |
 LL | const _NISIZE_MOD_P: &isize = &(1isize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NISIZE_MOD_P` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:273:28
    |
 LL | const _NUSIZE_MOD: usize = 1usize % 0;
-   |                            ^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^ evaluation of `_NUSIZE_MOD` failed here
 
 error[E0080]: attempt to calculate the remainder of `1_usize` with a divisor of zero
   --> $DIR/overflowing-consts.rs:274:32
    |
 LL | const _NUSIZE_MOD_P: &usize = &(1usize % 0);
-   |                                ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^ evaluation of `_NUSIZE_MOD_P` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:277:24
    |
 LL | const _NI32_OOB: i32 = [1, 2, 3][4];
-   |                        ^^^^^^^^^^^^ evaluation of constant value failed here
+   |                        ^^^^^^^^^^^^ evaluation of `_NI32_OOB` failed here
 
 error[E0080]: index out of bounds: the length is 3 but the index is 4
   --> $DIR/overflowing-consts.rs:278:28
    |
 LL | const _NI32_OOB_P: &i32 = &([1, 2, 3][4]);
-   |                            ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                            ^^^^^^^^^^^^^^ evaluation of `_NI32_OOB_P` failed here
 
 error: aborting due to 170 previous errors
 

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
@@ -2,7 +2,7 @@ error[E0080]: tried to allocate more memory than available to compiler
   --> $DIR/promoted_running_out_of_memory_issue-130687.rs:13:32
    |
 LL | const _: &'static Data = &Data([0; (1 << 47) - 1]);
-   |                                ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                                ^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/promoted_size_overflow.stderr
+++ b/tests/ui/consts/promoted_size_overflow.stderr
@@ -2,7 +2,7 @@ error[E0080]: values of the type `[u8; 4611686018427387903]` are too big for the
   --> $DIR/promoted_size_overflow.rs:3:29
    |
 LL | const _: &'static [Data] = &[];
-   |                             ^^ evaluation of constant value failed here
+   |                             ^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -11,7 +11,7 @@ error[E0080]: calling non-const function `<Vec<u8> as Drop>::drop`
   --> $DIR/qualif-indirect-mutation-fail.rs:18:1
    |
 LL | };
-   | ^ evaluation of constant value failed here
+   | ^ evaluation of `A1` failed inside this call
    |
 note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -32,7 +32,7 @@ error[E0080]: calling non-const function `<Vec<u8> as Drop>::drop`
   --> $DIR/qualif-indirect-mutation-fail.rs:29:1
    |
 LL | };
-   | ^ evaluation of constant value failed here
+   | ^ evaluation of `A2` failed inside this call
    |
 note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/recursive-zst-static.default.stderr
+++ b/tests/ui/consts/recursive-zst-static.default.stderr
@@ -2,7 +2,7 @@ error[E0080]: encountered static that tried to initialize itself with itself
   --> $DIR/recursive-zst-static.rs:10:18
    |
 LL | static FOO: () = FOO;
-   |                  ^^^ evaluation of static initializer failed here
+   |                  ^^^ evaluation of `FOO` failed here
 
 error[E0391]: cycle detected when evaluating initializer of static `A`
   --> $DIR/recursive-zst-static.rs:13:16

--- a/tests/ui/consts/recursive-zst-static.unleash.stderr
+++ b/tests/ui/consts/recursive-zst-static.unleash.stderr
@@ -2,7 +2,7 @@ error[E0080]: encountered static that tried to initialize itself with itself
   --> $DIR/recursive-zst-static.rs:10:18
    |
 LL | static FOO: () = FOO;
-   |                  ^^^ evaluation of static initializer failed here
+   |                  ^^^ evaluation of `FOO` failed here
 
 error[E0391]: cycle detected when evaluating initializer of static `A`
   --> $DIR/recursive-zst-static.rs:13:16

--- a/tests/ui/consts/recursive.stderr
+++ b/tests/ui/consts/recursive.stderr
@@ -13,7 +13,7 @@ error[E0080]: reached the configured maximum number of stack frames
   --> $DIR/recursive.rs:7:15
    |
 LL | const X: () = f(1);
-   |               ^^^^ evaluation of constant value failed here
+   |               ^^^^ evaluation of `X` failed inside this call
    |
 note: [... 126 additional calls inside `f::<i32>` ...]
   --> $DIR/recursive.rs:4:5

--- a/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: entering unreachable code
   --> $DIR/interpret-in-promoted.rs:15:28
    |
 LL |     let _x: &'static () = &ub();
-   |                            ^^^^ evaluation of constant value failed here
+   |                            ^^^^ evaluation of `FOO` failed inside this call
    |
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:9:5

--- a/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: entering unreachable code
   --> $DIR/interpret-in-promoted.rs:15:28
    |
 LL |     let _x: &'static () = &ub();
-   |                            ^^^^ evaluation of constant value failed here
+   |                            ^^^^ evaluation of `FOO` failed inside this call
    |
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:9:5

--- a/tests/ui/consts/slice-index-overflow-issue-130284.stderr
+++ b/tests/ui/consts/slice-index-overflow-issue-130284.stderr
@@ -2,7 +2,7 @@ error[E0080]: overflowing pointer arithmetic: the total offset in bytes does not
   --> $DIR/slice-index-overflow-issue-130284.rs:7:20
    |
 LL |         let _ice = (*fat)[usize::MAX - 1];
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `C` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/static_mut_containing_mut_ref2.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref2.stderr
@@ -2,7 +2,7 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/static_mut_containing_mut_ref2.rs:6:5
    |
 LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STDERR_BUFFER` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/static_mut_containing_mut_ref3.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref3.stderr
@@ -2,7 +2,7 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/static_mut_containing_mut_ref3.rs:3:31
    |
 LL | static mut BAR: () = unsafe { FOO.0 = 99; };
-   |                               ^^^^^^^^^^ evaluation of static initializer failed here
+   |                               ^^^^^^^^^^ evaluation of `BAR` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -11,7 +11,7 @@ pub const unsafe fn hint_unreachable() -> ! {
 
 trait Const {
     const CONSTANT: i32 = unsafe { fake_type() }; //~ ERROR reached the configured maximum number of stack frames
-    //~^ NOTE evaluation of `<i32 as Const>::CONSTANT` failed here
+    //~^ NOTE evaluation of `<i32 as Const>::CONSTANT` failed inside this call
 }
 
 impl<T> Const for T {}

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -2,7 +2,7 @@ error[E0080]: reached the configured maximum number of stack frames
   --> $DIR/uninhabited-const-issue-61744.rs:13:36
    |
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
-   |                                    ^^^^^^^^^^^ evaluation of `<i32 as Const>::CONSTANT` failed here
+   |                                    ^^^^^^^^^^^ evaluation of `<i32 as Const>::CONSTANT` failed inside this call
    |
 note: inside `fake_type::<i32>`
   --> $DIR/uninhabited-const-issue-61744.rs:5:5

--- a/tests/ui/consts/write-to-static-mut-in-static.stderr
+++ b/tests/ui/consts/write-to-static-mut-in-static.stderr
@@ -2,13 +2,13 @@ error[E0080]: modifying a static's initial value from another static's initializ
   --> $DIR/write-to-static-mut-in-static.rs:2:33
    |
 LL | pub static mut B: () = unsafe { A = 1; };
-   |                                 ^^^^^ evaluation of static initializer failed here
+   |                                 ^^^^^ evaluation of `B` failed here
 
 error[E0080]: encountered static that tried to initialize itself with itself
   --> $DIR/write-to-static-mut-in-static.rs:7:21
    |
 LL | pub static D: u32 = D;
-   |                     ^ evaluation of static initializer failed here
+   |                     ^ evaluation of `D` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/enum-discriminant/eval-error.stderr
+++ b/tests/ui/enum-discriminant/eval-error.stderr
@@ -49,7 +49,7 @@ error[E0080]: the type `Foo` has an unknown layout
   --> $DIR/eval-error.rs:9:30
    |
 LL |         let _: Option<Foo> = None;
-   |                              ^^^^ evaluation of constant value failed here
+   |                              ^^^^ evaluation of `Bar::Boo::{constant#0}` failed here
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/error-codes/E0080.stderr
+++ b/tests/ui/error-codes/E0080.stderr
@@ -2,13 +2,13 @@ error[E0080]: attempt to shift left by `500_i32`, which would overflow
   --> $DIR/E0080.rs:2:9
    |
 LL |     X = (1 << 500),
-   |         ^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^ evaluation of `Enum::X::{constant#0}` failed here
 
 error[E0080]: attempt to divide `1_isize` by zero
   --> $DIR/E0080.rs:3:9
    |
 LL |     Y = (1 / 0),
-   |         ^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^ evaluation of `Enum::Y::{constant#0}` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
@@ -2,7 +2,7 @@ error[E0080]: reached the configured maximum number of stack frames
   --> $DIR/ctfe-id-unlimited.rs:28:20
    |
 LL | const ID_ED: u32 = rec_id(ORIGINAL);
-   |                    ^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^^^^^^^^^ evaluation of `ID_ED` failed inside this call
    |
 note: inside `rec_id`
   --> $DIR/ctfe-id-unlimited.rs:21:5

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
@@ -10,7 +10,7 @@ const fn g() {
     //~^ NOTE in this expansion of panic!
 }
 
-const _: () = f(); //~ NOTE evaluation of constant value failed
+const _: () = f(); //~ NOTE failed inside this call
 //~^ ERROR explicit panic
 
 fn main() {}

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/ctfe-tail-call-panic.rs:13:15
    |
 LL | const _: () = f();
-   |               ^^^ evaluation of constant value failed here
+   |               ^^^ evaluation of `_` failed inside this call
    |
 note: inside `g`
   --> $DIR/ctfe-tail-call-panic.rs:9:5

--- a/tests/ui/extern/issue-28324.stderr
+++ b/tests/ui/extern/issue-28324.stderr
@@ -2,7 +2,7 @@ error[E0080]: cannot access extern static `error_message_count`
   --> $DIR/issue-28324.rs:5:23
    |
 LL | pub static BAZ: u32 = *&error_message_count;
-   |                       ^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                       ^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAZ` failed here
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-28324.rs:5:25

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/def-site-eval.rs:13:20
    |
 LL | const _<'_a>: () = panic!();
-   |                    ^^^^^^^^ evaluation of constant value failed here
+   |                    ^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.stderr
+++ b/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.stderr
@@ -4,7 +4,7 @@ error[E0080]: entering unreachable code
 LL | / const UNUSABLE: () = ()
 LL | | where
 LL | |     String: Copy;
-   | |_________________^ evaluation of constant value failed here
+   | |_________________^ evaluation of `UNUSABLE` failed here
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/trivially-unsatisfied-bounds-0.rs:11:13

--- a/tests/ui/generic-const-items/trivially-unsatisfied-bounds-1.stderr
+++ b/tests/ui/generic-const-items/trivially-unsatisfied-bounds-1.stderr
@@ -4,7 +4,7 @@ error[E0080]: entering unreachable code
 LL | / const UNUSED: () = ()
 LL | | where
 LL | |     String: Copy;
-   | |_________________^ evaluation of constant value failed here
+   | |_________________^ evaluation of `UNUSED` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/infinite/infinite-recursion-const-fn.stderr
+++ b/tests/ui/infinite/infinite-recursion-const-fn.stderr
@@ -2,7 +2,7 @@ error[E0080]: reached the configured maximum number of stack frames
   --> $DIR/infinite-recursion-const-fn.rs:9:18
    |
 LL | const ARR: [i32; a()] = [5; 6];
-   |                  ^^^ evaluation of constant value failed here
+   |                  ^^^ evaluation of `ARR::{constant#0}` failed inside this call
    |
 note: inside `a`
   --> $DIR/infinite-recursion-const-fn.rs:4:5

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -2,13 +2,13 @@ error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at
   --> $DIR/intrinsic-raw_eq-const-bad.rs:4:5
    |
 LL |     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_PADDING` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/intrinsic-raw_eq-const-bad.rs:9:5
    |
 LL |     std::intrinsics::raw_eq(&(&0), &(&1))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -17,7 +17,7 @@ error[E0080]: accessing memory with alignment 1, but alignment 4 is required
   --> $DIR/intrinsic-raw_eq-const-bad.rs:16:5
    |
 LL |     std::intrinsics::raw_eq(aref, aref)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: explicit panic
   --> $DIR/issue-76191.rs:8:37
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
-   |                                     ^^^^^^^^ evaluation of constant value failed here
+   |                                     ^^^^^^^^ evaluation of `RANGE2` failed here
 
 error[E0308]: mismatched types
   --> $DIR/issue-76191.rs:14:9

--- a/tests/ui/layout/invalid-unsized-const-eval.stderr
+++ b/tests/ui/layout/invalid-unsized-const-eval.stderr
@@ -11,7 +11,7 @@ error[E0080]: the type `(dyn Sync, ())` has an unknown layout
   --> $DIR/invalid-unsized-const-eval.rs:12:1
    |
 LL | static EMPTY_SET: LazyLock = todo!();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `EMPTY_SET` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
@@ -22,7 +22,7 @@ error[E0080]: the type `MySlice<[bool]>` has an unknown layout
   --> $DIR/invalid-unsized-in-always-sized-tail.rs:15:28
    |
 LL | static CHECK: () = assert!(align_of::<P2>() == 1);
-   |                            ^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                            ^^^^^^^^^^^^^^^^ evaluation of `CHECK` failed inside this call
    |
 note: inside `align_of::<P2>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.stderr
+++ b/tests/ui/layout/issue-unsized-tail-restatic-ice-122488.stderr
@@ -26,7 +26,7 @@ error[E0080]: the type `ArenaSet<Vec<u8>, [u8]>` has an unknown layout
   --> $DIR/issue-unsized-tail-restatic-ice-122488.rs:8:1
    |
 LL | const DATA: *const ArenaSet<Vec<u8>> = std::ptr::null_mut();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `DATA` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/layout/uncomputable-due-to-trivial-bounds-ice-135138.stderr
+++ b/tests/ui/layout/uncomputable-due-to-trivial-bounds-ice-135138.stderr
@@ -2,7 +2,7 @@ error[E0080]: the type `Option<str>` has an unknown layout
   --> $DIR/uncomputable-due-to-trivial-bounds-ice-135138.rs:7:16
    |
 LL |     [(); { let _a: Option<str> = None; 0 }];
-   |                ^^ evaluation of constant value failed here
+   |                ^^ evaluation of `return_str::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/layout/unknown-when-no-type-parameter.rs
+++ b/tests/ui/layout/unknown-when-no-type-parameter.rs
@@ -11,7 +11,7 @@ where
     [(); size_of::<<() as Project>::Assoc>()];
     //~^ ERROR the type `<() as Project>::Assoc` has an unknown layout
     //~| NOTE inside `std::mem::size_of::<<() as Project>::Assoc>`
-    //~| NOTE evaluation of constant value failed
+    //~| NOTE failed inside this call
 }
 
 fn main() {}

--- a/tests/ui/layout/unknown-when-no-type-parameter.stderr
+++ b/tests/ui/layout/unknown-when-no-type-parameter.stderr
@@ -2,7 +2,7 @@ error[E0080]: the type `<() as Project>::Assoc` has an unknown layout
   --> $DIR/unknown-when-no-type-parameter.rs:11:10
    |
 LL |     [(); size_of::<<() as Project>::Assoc>()];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `foo::{constant#0}` failed inside this call
    |
 note: inside `std::mem::size_of::<<() as Project>::Assoc>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/layout/unknown-when-ptr-metadata-is-DST.stderr
+++ b/tests/ui/layout/unknown-when-ptr-metadata-is-DST.stderr
@@ -2,7 +2,7 @@ error[E0080]: the type `str` has an unknown layout
   --> $DIR/unknown-when-ptr-metadata-is-DST.rs:8:16
    |
 LL |     [(); { let _a: Option<&str> = None; 0 }];
-   |                ^^ evaluation of constant value failed here
+   |                ^^ evaluation of `return_str::{constant#0}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
+++ b/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
@@ -2,7 +2,7 @@ error[E0080]: attempt to compute `0_usize - 1_usize`, which would overflow
   --> $DIR/def-site-param-defaults-wf.rs:5:45
    |
 LL | type Alias<T = Vec<str>, const N: usize = { 0 - 1 }> = T;
-   |                                             ^^^^^ evaluation of constant value failed here
+   |                                             ^^^^^ evaluation of `Alias::{constant#0}` failed here
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/def-site-param-defaults-wf.rs:5:16

--- a/tests/ui/limits/huge-static.stderr
+++ b/tests/ui/limits/huge-static.stderr
@@ -2,13 +2,13 @@ error[E0080]: values of the type `[u8; 2305843009213693952]` are too big for the
   --> $DIR/huge-static.rs:18:1
    |
 LL | static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_TOO_BIG_ARRAY_1` failed here
 
 error[E0080]: values of the type `[u8; 2305843009213693952]` are too big for the target architecture
   --> $DIR/huge-static.rs:20:1
    |
 LL | static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_TOO_BIG_ARRAY_2` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -2,7 +2,7 @@ error[E0080]: values of the type `[u8; usize::MAX]` are too big for the target a
   --> $DIR/issue-55878.rs:4:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main` failed inside this call
    |
 note: inside `std::mem::size_of::<[u8; usize::MAX]>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/recursion/recursive-static-definition.stderr
+++ b/tests/ui/recursion/recursive-static-definition.stderr
@@ -2,13 +2,13 @@ error[E0080]: encountered static that tried to initialize itself with itself
   --> $DIR/recursive-static-definition.rs:1:23
    |
 LL | pub static FOO: u32 = FOO;
-   |                       ^^^ evaluation of static initializer failed here
+   |                       ^^^ evaluation of `FOO` failed here
 
 error[E0080]: encountered static that tried to initialize itself with itself
   --> $DIR/recursive-static-definition.rs:9:23
    |
 LL | pub static BAR: Foo = BAR;
-   |                       ^^^ evaluation of static initializer failed here
+   |                       ^^^ evaluation of `BAR` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.32bit.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.32bit.stderr
@@ -13,7 +13,7 @@ error[E0080]: a cycle occurred during layout computation
   --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
-   | ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.64bit.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.64bit.stderr
@@ -13,7 +13,7 @@ error[E0080]: a cycle occurred during layout computation
   --> $DIR/stack-overflow-trait-infer-98842.rs:14:1
    |
 LL | const _: *const Foo = 0 as _;
-   | ^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/statics/issue-14227.stderr
+++ b/tests/ui/statics/issue-14227.stderr
@@ -2,7 +2,7 @@ error[E0080]: cannot access extern static `symbol`
   --> $DIR/issue-14227.rs:4:21
    |
 LL | static CRASH: u32 = symbol;
-   |                     ^^^^^^ evaluation of static initializer failed here
+   |                     ^^^^^^ evaluation of `CRASH` failed here
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-14227.rs:4:21

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -47,13 +47,13 @@ error[E0080]: constructing invalid value: encountered a value of uninhabited typ
   --> $DIR/uninhabited-static.rs:12:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
 error[E0080]: constructing invalid value: encountered a value of uninhabited type `Void`
   --> $DIR/uninhabited-static.rs:15:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of static initializer failed here
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEVER2` failed here
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/structs/default-field-values/invalid-const.stderr
+++ b/tests/ui/structs/default-field-values/invalid-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: asdf
   --> $DIR/invalid-const.rs:5:19
    |
 LL |     pub bax: u8 = panic!("asdf"),
-   |                   ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |                   ^^^^^^^^^^^^^^ evaluation of `Bat::bax::{constant#0}` failed here
 
 error[E0080]: attempt to compute `130_u8 + 130_u8`, which would overflow
   --> $DIR/invalid-const.rs:11:19

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -44,7 +44,7 @@ error[E0080]: evaluation panicked: assertion failed: false
   --> $DIR/uninhabited.rs:41:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^ evaluation of `yawning_void_struct::_` failed here
 
 error[E0277]: `()` cannot be safely transmuted into `yawning_void_enum::Void`
   --> $DIR/uninhabited.rs:71:41
@@ -71,7 +71,7 @@ error[E0080]: evaluation panicked: assertion failed: false
   --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^ evaluation of `yawning_void_enum::_` failed here
 
 error[E0277]: `u128` cannot be safely transmuted into `DistantVoid`
   --> $DIR/uninhabited.rs:92:43
@@ -98,7 +98,7 @@ error[E0080]: evaluation panicked: assertion failed: false
   --> $DIR/uninhabited.rs:87:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ evaluation of constant value failed here
+   |         ^^^^^^^^^^^^^^ evaluation of `distant_void::_` failed here
 
 error[E0277]: `Src` cannot be safely transmuted into `issue_126267::Error`
   --> $DIR/uninhabited.rs:108:42

--- a/tests/ui/treat-err-as-bug/err.stderr
+++ b/tests/ui/treat-err-as-bug/err.stderr
@@ -2,7 +2,7 @@ error: internal compiler error[E0080]: attempt to compute `0_u32 - 1_u32`, which
   --> $DIR/err.rs:9:21
    |
 LL | pub static C: u32 = 0 - 1;
-   |                     ^^^^^ evaluation of static initializer failed here
+   |                     ^^^^^ evaluation of `C` failed here
 
 
 error: the compiler unexpectedly panicked. this is a bug.

--- a/tests/ui/type/pattern_types/literals.stderr
+++ b/tests/ui/type/pattern_types/literals.stderr
@@ -2,31 +2,31 @@ error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/literals.rs:86:62
    |
 LL | fn empty_range_at_base_type_min() -> pattern_type!(u32 is 0..0) {
-   |                                                              ^ evaluation of constant value failed here
+   |                                                              ^ evaluation of `empty_range_at_base_type_min::{constant#1}` failed here
 
 error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/literals.rs:91:63
    |
 LL | fn empty_range_at_base_type_min2() -> pattern_type!(u32 is 0..0) {
-   |                                                               ^ evaluation of constant value failed here
+   |                                                               ^ evaluation of `empty_range_at_base_type_min2::{constant#1}` failed here
 
 error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/literals.rs:106:65
    |
 LL | fn wraparound_range_at_base_ty_end() -> pattern_type!(u32 is 1..0) {
-   |                                                                 ^ evaluation of constant value failed here
+   |                                                                 ^ evaluation of `wraparound_range_at_base_ty_end::{constant#1}` failed here
 
 error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/literals.rs:111:66
    |
 LL | fn wraparound_range_at_base_ty_end2() -> pattern_type!(u32 is 1..0) {
-   |                                                                  ^ evaluation of constant value failed here
+   |                                                                  ^ evaluation of `wraparound_range_at_base_ty_end2::{constant#1}` failed here
 
 error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/literals.rs:116:66
    |
 LL | fn wraparound_range_at_base_ty_end3() -> pattern_type!(u32 is 1..0) {
-   |                                                                  ^ evaluation of constant value failed here
+   |                                                                  ^ evaluation of `wraparound_range_at_base_ty_end3::{constant#1}` failed here
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:9:5

--- a/tests/ui/type/pattern_types/range_patterns.stderr
+++ b/tests/ui/type/pattern_types/range_patterns.stderr
@@ -369,7 +369,7 @@ error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/range_patterns.rs:25:37
    |
 LL | type WRAP = pattern_type!(u32 is 1..0);
-   |                                     ^ evaluation of constant value failed here
+   |                                     ^ evaluation of `WRAP::{constant#1}` failed here
 
 error: the type has an unknown layout
   --> $DIR/range_patterns.rs:25:1

--- a/tests/ui/type/pattern_types/reverse_range.stderr
+++ b/tests/ui/type/pattern_types/reverse_range.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation panicked: exclusive range end at minimum value of type
   --> $DIR/reverse_range.rs:7:36
    |
 LL | const NONE: pattern_type!(u8 is 1..0) = unsafe { std::mem::transmute(3_u8) };
-   |                                    ^ evaluation of constant value failed here
+   |                                    ^ evaluation of `NONE::{constant#1}` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/pattern_types/validity.stderr
+++ b/tests/ui/type/pattern_types/validity.stderr
@@ -13,13 +13,13 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/validity.rs:13:1
    |
 LL | const BAD_UNINIT: pattern_type!(u32 is 1..) =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINIT` failed here
 
 error[E0080]: unable to turn pointer into integer
   --> $DIR/validity.rs:17:1
    |
 LL | const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&42) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -50,7 +50,7 @@ error[E0080]: using uninitialized data, but this operation requires initialized 
   --> $DIR/validity.rs:29:1
    |
 LL | const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CHAR_UNINIT` failed here
 
 error[E0080]: constructing invalid value: encountered 97, but expected something in the range 65..=89
   --> $DIR/validity.rs:33:1


### PR DESCRIPTION
I don't see why "is this generic" should make a difference. It may be reasonable to key this on whether the error occurs in a `const fn` that was invoked by a const (making it non-obvious which constant it is) vs inside the body of the const.

r? @oli-obk 