### PR TITLE
Report the actual item that evaluation failed for

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -454,11 +454,12 @@ fn report_eval_error<'tcx>(
             // FIXME(oli-obk): figure out how to use structured diagnostics again.
             diag.code(E0080);
             diag.span_label(span, crate::fluent_generated::const_eval_error);
-            diag.arg("instance", instance);
-            diag.arg("error_kind", kind);
             for frame in frames {
                 diag.subdiagnostic(frame);
             }
+            // Add after the frame rendering above, as it adds its own `instance` args.
+            diag.arg("instance", instance);
+            diag.arg("error_kind", kind);
         },
     )
 }

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -2,7 +2,7 @@ error[E0080]: calling non-const function `<Vec<u32> as Drop>::drop`
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^ evaluation of `drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed here
+   |                               ^ evaluation of `<std::string::String as Bar<std::vec::Vec<u32>, std::string::String>>::F` failed here
    |
 note: inside `drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -11,6 +11,7 @@ pub const unsafe fn hint_unreachable() -> ! {
 
 trait Const {
     const CONSTANT: i32 = unsafe { fake_type() }; //~ ERROR reached the configured maximum number of stack frames
+    //~^ NOTE evaluation of `<i32 as Const>::CONSTANT` failed here
 }
 
 impl<T> Const for T {}

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -2,7 +2,7 @@ error[E0080]: reached the configured maximum number of stack frames
   --> $DIR/uninhabited-const-issue-61744.rs:13:36
    |
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
-   |                                    ^^^^^^^^^^^ evaluation of `fake_type::<!>` failed here
+   |                                    ^^^^^^^^^^^ evaluation of `<i32 as Const>::CONSTANT` failed here
    |
 note: inside `fake_type::<i32>`
   --> $DIR/uninhabited-const-issue-61744.rs:5:5


### PR DESCRIPTION
instead of id of the last frame in the evaluation stack

r? @RalfJung 

fixes rust-lang/rust#142010