### PR TITLE
bootstrap: Document that setting description changes the version hash

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -217,6 +217,8 @@
 # upstream Rust you need to set this to "". However, note that if you set this to "" but
 # are not actually compatible -- for example if you've backported patches that change
 # behavior -- this may lead to miscompilations or other bugs.
+#
+# Changing `description` will be change version hash.
 #description = ""
 
 # Build triple for the pre-compiled snapshot compiler. If `rustc` is set, this must match its host


### PR DESCRIPTION
I'm trying to solve a problem rust-lang/rust#103557
As I understand it, it is necessary to add a comment about the change `description` in the boostrap.example file

r? @nnethercote
