### PR TITLE
Don't refer to 'this tail expression' in expansion.

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3841,7 +3841,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     .expr_ty_adjusted_opt(inner_expr)
                     .unwrap_or(Ty::new_misc_error(tcx));
                 let span = inner_expr.span;
-                if Some(span) != err.span.primary_span() {
+                if Some(span) != err.span.primary_span()
+                    && !span.in_external_macro(tcx.sess.source_map())
+                {
                     err.span_label(
                         span,
                         if ty.references_error() {

--- a/tests/ui/never_type/feature-gate-never_type_fallback.stderr
+++ b/tests/ui/never_type/feature-gate-never_type_fallback.stderr
@@ -2,10 +2,8 @@ error[E0277]: the trait bound `(): T` is not satisfied
   --> $DIR/feature-gate-never_type_fallback.rs:10:9
    |
 LL |     foo(panic!())
-   |     --- ^^^^^^^^
-   |     |   |
-   |     |   the trait `T` is not implemented for `()`
-   |     |   this tail expression is of type `()`
+   |     --- ^^^^^^^^ the trait `T` is not implemented for `()`
+   |     |
    |     required by a bound introduced by this call
    |
 help: this trait has no implementations, consider adding one


### PR DESCRIPTION
The user has no clue what the compiler is talking about when it says "this tail expression". It is an implementation detail of the macro that it uses a block with tail expression.