### PR TITLE
Don't refer to 'local binding' in extern macro.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3314,7 +3314,13 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     "function parameter".to_string(),
                     "function parameter borrowed here".to_string(),
                 ),
-                LocalKind::Temp if self.body.local_decls[local].is_user_variable() => {
+                LocalKind::Temp
+                    if self.body.local_decls[local].is_user_variable()
+                        && !self.body.local_decls[local]
+                            .source_info
+                            .span
+                            .in_external_macro(self.infcx.tcx.sess.source_map()) =>
+                {
                     ("local binding".to_string(), "local binding introduced here".to_string())
                 }
                 LocalKind::ReturnPointer | LocalKind::Temp => {

--- a/tests/ui/macros/return_from_external_macro.rs
+++ b/tests/ui/macros/return_from_external_macro.rs
@@ -5,7 +5,7 @@ extern crate ret_from_ext;
 
 fn foo() -> impl Sized {
     drop(|| ret_from_ext::foo!());
-    //~^ ERROR cannot return reference to local binding
+    //~^ ERROR cannot return reference to temporary value
 
     ret_from_ext::foo!()
     //~^ ERROR temporary value dropped while borrowed

--- a/tests/ui/macros/return_from_external_macro.stderr
+++ b/tests/ui/macros/return_from_external_macro.stderr
@@ -1,11 +1,11 @@
-error[E0515]: cannot return reference to local binding
+error[E0515]: cannot return reference to temporary value
   --> $DIR/return_from_external_macro.rs:7:13
    |
 LL |     drop(|| ret_from_ext::foo!());
    |             ^^^^^^^^^^^^^^^^^^^^
    |             |
    |             returns a reference to data owned by the current function
-   |             local binding introduced here
+   |             temporary value created here
    |
    = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
When it comes from a macro expansion, the user has no clue what 'local binding' the compiler is talking about, if they don't know the expansion of the macro. Better to just say 'temporary value'.