### PR TITLE
bootstrap: Fix file permissions when dereferencing symlinks

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1795,11 +1795,12 @@ Executed at: {executed_at}"#,
             let now = t!(SystemTime::now().duration_since(SystemTime::UNIX_EPOCH));
             let _ = fs::rename(dst, format!("{}-{}", dst.display(), now.as_nanos()));
         }
-        let metadata = t!(src.symlink_metadata(), format!("src = {}", src.display()));
+        let mut metadata = t!(src.symlink_metadata(), format!("src = {}", src.display()));
         let mut src = src.to_path_buf();
         if metadata.file_type().is_symlink() {
             if dereference_symlinks {
                 src = t!(fs::canonicalize(src));
+                metadata = t!(fs::metadata(&src), format!("target = {}", src.display()));
             } else {
                 let link = t!(fs::read_link(src));
                 t!(self.symlink_file(link, dst));


### PR DESCRIPTION
## Problem
When copying files in the bootstrap process with `dereference_symlinks = true`, we're incorrectly using the symlink's metadata to set permissions on the copied regular file, which results in the following error:
```
Warning: Failed to set file times for "/build/nix-build-rustc-1.86.0.drv-0/rustc-1.86.0-src/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-strip" (permissions: Permissions(FilePermissions { mode: 0o100000 (----------) })) error: Permission denied (os error 13)
```

Verbose Logs confirming the error:
```
TRACE: Found llvm-strip copy operation
  Source: /n/nix/tech/store/n34yzv2n50p6lbjmx089vjym121wbl4j-llvm-19.1.7/bin/llvm-strip
  Destination: /build/nix-build-rustc-1.86.0.drv-0/rustc-1.86.0-src/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-strip
  Source is_symlink (via symlink_metadata): true
  Source symlink_metadata permissions: 120000
  Source symlink_metadata file_type: FileType { is_file: false, is_dir: false, is_symlink: true, .. }

  Source is symlink pointing to: llvm-objcopy
  Source raw mode: 120000
  Source filetype: 120000

  Setting permissions: Permissions(FilePermissions { mode: 0o120000 (l---------) })
  Permission mode to set: 120000
  Raw permission bits: 120000
  File type bits being set: 120000
  Permission bits being set: 0

  WARNING: Attempting to set symlink file type (120000) on regular file!
  WARNING: Setting zero permission bits will make file inaccessible!
  Destination permissions after set_permissions: 100000 
```

## Solution
After canonicalizing a symlink path, fetch the metadata of the target file instead of continuing to use the symlink's metadata. This ensures:
- Correct file type detection
- Proper permission bits for the target file
- Maintains existing behavior for non-symlink cases

## Testing
Verified fix resolves permission errors:
```
rustc> llvm-strip: Original metadata mode: 120000, is_symlink: true
rustc> llvm-strip: Target metadata mode after fix: 100555
rustc> llvm-strip: Final permissions mode: 100555
```