### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -696,14 +696,8 @@ impl TokenStream {
 
     /// Compares two `TokenStream`s, checking equality without regarding span information.
     pub fn eq_unspanned(&self, other: &TokenStream) -> bool {
-        let mut iter1 = self.iter();
-        let mut iter2 = other.iter();
-        for (tt1, tt2) in iter::zip(&mut iter1, &mut iter2) {
-            if !tt1.eq_unspanned(tt2) {
-                return false;
-            }
-        }
-        iter1.next().is_none() && iter2.next().is_none()
+        self.len() == other.len()
+            && self.iter().zip(other.iter()).all(|(tt1, tt2)| tt1.eq_unspanned(tt2))
     }
 
     /// Create a token stream containing a single token with alone spacing. The

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -57,7 +57,9 @@ impl TokenTree {
         match (self, other) {
             (TokenTree::Token(token, _), TokenTree::Token(token2, _)) => token.kind == token2.kind,
             (TokenTree::Delimited(.., delim, tts), TokenTree::Delimited(.., delim2, tts2)) => {
-                delim == delim2 && tts.eq_unspanned(tts2)
+                delim == delim2
+                    && tts.len() == tts2.len()
+                    && tts.iter().zip(tts2.iter()).all(|(a, b)| a.eq_unspanned(b))
             }
             _ => false,
         }
@@ -692,12 +694,6 @@ impl TokenStream {
 
     pub fn iter(&self) -> TokenStreamIter<'_> {
         TokenStreamIter::new(self)
-    }
-
-    /// Compares two `TokenStream`s, checking equality without regarding span information.
-    pub fn eq_unspanned(&self, other: &TokenStream) -> bool {
-        self.len() == other.len()
-            && self.iter().zip(other.iter()).all(|(tt1, tt2)| tt1.eq_unspanned(tt2))
     }
 
     /// Create a token stream containing a single token with alone spacing. The

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -121,6 +121,10 @@ pub enum LifetimeCtxt {
 /// explicitly, you need to override each method. (And you also need
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
+///
+/// Every `walk_*` method uses deconstruction to access fields of structs and
+/// enums. This will result in a compile error if a field is added, which makes
+/// it more likely the appropriate visit call will be added for it.
 pub trait Visitor<'ast>: Sized {
     /// The result type of the `visit_*` methods. Can be either `()`,
     /// or `ControlFlow<T>`.

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -53,7 +53,7 @@ fn parse_unstable<'a>(
 
     for param in list.mixed() {
         let param_span = param.span();
-        if let Some(ident) = param.meta_item().and_then(|i| i.path_without_args().word()) {
+        if let Some(ident) = param.meta_item().and_then(|i| i.path().word()) {
             res.push(ident.name);
         } else {
             cx.emit_err(session_diagnostics::ExpectsFeatures {

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -79,7 +79,7 @@ impl SingleAttributeParser for DeprecationParser {
                     return None;
                 };
 
-                let ident_name = param.path_without_args().word_sym();
+                let ident_name = param.path().word_sym();
 
                 match ident_name {
                     Some(name @ sym::since) => {
@@ -102,7 +102,7 @@ impl SingleAttributeParser for DeprecationParser {
                     _ => {
                         cx.emit_err(session_diagnostics::UnknownMetaItem {
                             span: param_span,
-                            item: param.path_without_args().to_string(),
+                            item: param.path().to_string(),
                             expected: if features.deprecated_suggestion() {
                                 &["since", "note", "suggestion"]
                             } else {

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -96,7 +96,7 @@ fn parse_repr(cx: &AcceptContext<'_>, param: &MetaItemParser<'_>) -> Option<Repr
 
     // FIXME(jdonszelmann): invert the parsing here to match on the word first and then the
     // structure.
-    let (name, ident_span) = if let Some(ident) = param.path_without_args().word() {
+    let (name, ident_span) = if let Some(ident) = param.path().word() {
         (Some(ident.name), ident.span)
     } else {
         (None, rustc_span::DUMMY_SP)

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -204,7 +204,7 @@ fn insert_value_into_option_or_error(
     if item.is_some() {
         cx.emit_err(session_diagnostics::MultipleItem {
             span: param.span(),
-            item: param.path_without_args().to_string(),
+            item: param.path().to_string(),
         });
         None
     } else if let Some(v) = param.args().name_value()
@@ -242,13 +242,13 @@ pub(crate) fn parse_stability(
             return None;
         };
 
-        match param.path_without_args().word_sym() {
+        match param.path().word_sym() {
             Some(sym::feature) => insert_value_into_option_or_error(cx, &param, &mut feature)?,
             Some(sym::since) => insert_value_into_option_or_error(cx, &param, &mut since)?,
             _ => {
                 cx.emit_err(session_diagnostics::UnknownMetaItem {
                     span: param_span,
-                    item: param.path_without_args().to_string(),
+                    item: param.path().to_string(),
                     expected: &["feature", "since"],
                 });
                 return None;
@@ -310,7 +310,7 @@ pub(crate) fn parse_unstability(
             return None;
         };
 
-        match param.path_without_args().word_sym() {
+        match param.path().word_sym() {
             Some(sym::feature) => insert_value_into_option_or_error(cx, &param, &mut feature)?,
             Some(sym::reason) => insert_value_into_option_or_error(cx, &param, &mut reason)?,
             Some(sym::issue) => {
@@ -349,7 +349,7 @@ pub(crate) fn parse_unstability(
             _ => {
                 cx.emit_err(session_diagnostics::UnknownMetaItem {
                     span: param.span(),
-                    item: param.path_without_args().to_string(),
+                    item: param.path().to_string(),
                     expected: &["feature", "reason", "issue", "soft", "implied_by"],
                 });
                 return None;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -260,7 +260,7 @@ impl<'sess> AttributeParser<'sess> {
                 // }
                 ast::AttrKind::Normal(n) => {
                     let parser = MetaItemParser::from_attr(n, self.dcx());
-                    let path = parser.path_without_args();
+                    let path = parser.path();
                     let args = parser.args();
                     let parts = path.segments().map(|i| i.name).collect::<Vec<_>>();
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -260,7 +260,8 @@ impl<'sess> AttributeParser<'sess> {
                 // }
                 ast::AttrKind::Normal(n) => {
                     let parser = MetaItemParser::from_attr(n, self.dcx());
-                    let (path, args) = parser.deconstruct();
+                    let path = parser.path_without_args();
+                    let args = parser.args();
                     let parts = path.segments().map(|i| i.name).collect::<Vec<_>>();
 
                     if let Some(accepts) = ATTRIBUTE_MAPPING.0.get(parts.as_slice()) {

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -277,36 +277,13 @@ impl<'a> MetaItemParser<'a> {
     }
 
     /// Asserts that this MetaItem starts with a word, or single segment path.
-    /// Doesn't return the args parser.
-    ///
-    /// For examples. see [`Self::word`]
-    pub fn word_without_args(&self) -> Option<Ident> {
-        Some(self.word()?.0)
-    }
-
-    /// Asserts that this MetaItem starts with a word, or single segment path.
     ///
     /// Some examples:
     /// - `#[inline]`: `inline` is a word
     /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path,
     ///   and not a word and should instead be parsed using [`path`](Self::path)
-    pub fn word(&self) -> Option<(Ident, &ArgParser<'a>)> {
-        let (path, args) = self.deconstruct();
-        Some((path.word()?, args))
-    }
-
-    /// Asserts that this MetaItem starts with some specific word.
-    ///
-    /// See [`word`](Self::word) for examples of what a word is.
     pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser<'a>> {
         self.path_without_args().word_is(sym).then(|| self.args())
-    }
-
-    /// Asserts that this MetaItem starts with some specific path.
-    ///
-    /// See [`word`](Self::path) for examples of what a word is.
-    pub fn path_is(&self, segments: &[Symbol]) -> Option<&ArgParser<'a>> {
-        self.path_without_args().segments_is(segments).then(|| self.args())
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -561,20 +561,6 @@ impl<'a> MetaItemListParser<'a> {
         self.len() == 0
     }
 
-    /// Asserts that every item in the list is another list starting with a word.
-    ///
-    /// See [`MetaItemParser::word`] for examples of words.
-    pub fn all_word_list<'s>(&'s self) -> Option<Vec<(Ident, &'s ArgParser<'a>)>> {
-        self.mixed().map(|i| i.meta_item()?.word()).collect()
-    }
-
-    /// Asserts that every item in the list is another list starting with a full path.
-    ///
-    /// See [`MetaItemParser::path`] for examples of paths.
-    pub fn all_path_list<'s>(&'s self) -> Option<Vec<(PathParser<'a>, &'s ArgParser<'a>)>> {
-        self.mixed().map(|i| Some(i.meta_item()?.path())).collect()
-    }
-
     /// Returns Some if the list contains only a single element.
     ///
     /// Inside the Some is the parser to parse this single element.

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -253,7 +253,11 @@ impl<'a> MetaItemParser<'a> {
         }
     }
 
-    /// Gets just the path, without the args.
+    /// Gets just the path, without the args. Some examples:
+    ///
+    /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path
+    /// - `#[allow(clippy::complexity)]`: `clippy::complexity` is a path
+    /// - `#[inline]`: `inline` is a single segment path
     pub fn path_without_args(&self) -> PathParser<'a> {
         self.path.clone()
     }
@@ -261,19 +265,6 @@ impl<'a> MetaItemParser<'a> {
     /// Gets just the args parser, without caring about the path.
     pub fn args(&self) -> &ArgParser<'a> {
         &self.args
-    }
-
-    pub fn deconstruct(&self) -> (PathParser<'a>, &ArgParser<'a>) {
-        (self.path_without_args(), self.args())
-    }
-
-    /// Asserts that this MetaItem starts with a path. Some examples:
-    ///
-    /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path
-    /// - `#[allow(clippy::complexity)]`: `clippy::complexity` is a path
-    /// - `#[inline]`: `inline` is a single segment path
-    pub fn path(&self) -> (PathParser<'a>, &ArgParser<'a>) {
-        self.deconstruct()
     }
 
     /// Asserts that this MetaItem starts with a word, or single segment path.

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -258,8 +258,8 @@ impl<'a> MetaItemParser<'a> {
     /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path
     /// - `#[allow(clippy::complexity)]`: `clippy::complexity` is a path
     /// - `#[inline]`: `inline` is a single segment path
-    pub fn path_without_args(&self) -> PathParser<'a> {
-        self.path.clone()
+    pub fn path(&self) -> &PathParser<'a> {
+        &self.path
     }
 
     /// Gets just the args parser, without caring about the path.
@@ -274,7 +274,7 @@ impl<'a> MetaItemParser<'a> {
     /// - `#[rustfmt::skip]`: `rustfmt::skip` is a path,
     ///   and not a word and should instead be parsed using [`path`](Self::path)
     pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser<'a>> {
-        self.path_without_args().word_is(sym).then(|| self.args())
+        self.path().word_is(sym).then(|| self.args())
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -549,7 +549,7 @@ impl<'a> MetaItemListParser<'a> {
     }
 
     /// Lets you pick and choose as what you want to parse each element in the list
-    pub fn mixed<'s>(&'s self) -> impl Iterator<Item = &'s MetaItemOrLitParser<'a>> + 's {
+    pub fn mixed(&self) -> impl Iterator<Item = &MetaItemOrLitParser<'a>> {
         self.sub_parsers.iter()
     }
 

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -200,6 +200,10 @@ use nested_filter::NestedFilter;
 /// explicitly, you need to override each method. (And you also need
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
+///
+/// Every `walk_*` method uses deconstruction to access fields of structs and
+/// enums. This will result in a compile error if a field is added, which makes
+/// it more likely the appropriate visit call will be added for it.
 pub trait Visitor<'v>: Sized {
     // This type should not be overridden, it exists for convenient usage as `Self::MaybeTyCtxt`.
     type MaybeTyCtxt: HirTyCtxt<'v> = <Self::NestedFilter as NestedFilter<'v>>::MaybeTyCtxt;
@@ -1201,7 +1205,6 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     trait_item: &'v TraitItem<'v>,
 ) -> V::Result {
-    // N.B., deliberately force a compilation error if/when new fields are added.
     let TraitItem { ident, generics, ref defaultness, ref kind, span, owner_id: _ } = *trait_item;
     let hir_id = trait_item.hir_id();
     try_visit!(visitor.visit_ident(ident));
@@ -1240,7 +1243,6 @@ pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     trait_item_ref: &'v TraitItemRef,
 ) -> V::Result {
-    // N.B., deliberately force a compilation error if/when new fields are added.
     let TraitItemRef { id, ident, ref kind, span: _ } = *trait_item_ref;
     try_visit!(visitor.visit_nested_trait_item(id));
     try_visit!(visitor.visit_ident(ident));
@@ -1251,7 +1253,6 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item: &'v ImplItem<'v>,
 ) -> V::Result {
-    // N.B., deliberately force a compilation error if/when new fields are added.
     let ImplItem {
         owner_id: _,
         ident,
@@ -1286,7 +1287,6 @@ pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     foreign_item_ref: &'v ForeignItemRef,
 ) -> V::Result {
-    // N.B., deliberately force a compilation error if/when new fields are added.
     let ForeignItemRef { id, ident, span: _ } = *foreign_item_ref;
     try_visit!(visitor.visit_nested_foreign_item(id));
     visitor.visit_ident(ident)
@@ -1296,7 +1296,6 @@ pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item_ref: &'v ImplItemRef,
 ) -> V::Result {
-    // N.B., deliberately force a compilation error if/when new fields are added.
     let ImplItemRef { id, ident, ref kind, span: _, trait_item_def_id: _ } = *impl_item_ref;
     try_visit!(visitor.visit_nested_impl_item(id));
     try_visit!(visitor.visit_ident(ident));

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -3,6 +3,9 @@ use super::{
     Pat, PatKind, Stmt, StmtKind, Thir,
 };
 
+/// Every `walk_*` method uses deconstruction to access fields of structs and
+/// enums. This will result in a compile error if a field is added, which makes
+/// it more likely the appropriate visit call will be added for it.
 pub trait Visitor<'thir, 'tcx: 'thir>: Sized {
     fn thir(&self) -> &'thir Thir<'tcx>;
 

--- a/compiler/rustc_parse/src/parser/tokenstream/tests.rs
+++ b/compiler/rustc_parse/src/parser/tokenstream/tests.rs
@@ -14,6 +14,10 @@ fn sp(a: u32, b: u32) -> Span {
     Span::with_root_ctxt(BytePos(a), BytePos(b))
 }
 
+fn cmp_token_stream(a: &TokenStream, b: &TokenStream) -> bool {
+    a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.eq_unspanned(y))
+}
+
 #[test]
 fn test_concat() {
     create_default_session_globals_then(|| {
@@ -25,7 +29,7 @@ fn test_concat() {
         eq_res.push_stream(test_snd);
         assert_eq!(test_res.iter().count(), 5);
         assert_eq!(eq_res.iter().count(), 5);
-        assert_eq!(test_res.eq_unspanned(&eq_res), true);
+        assert_eq!(cmp_token_stream(&test_res, &eq_res), true);
     })
 }
 
@@ -104,7 +108,7 @@ fn test_dotdotdot() {
         stream.push_tree(TokenTree::token_joint(token::Dot, sp(0, 1)));
         stream.push_tree(TokenTree::token_joint(token::Dot, sp(1, 2)));
         stream.push_tree(TokenTree::token_alone(token::Dot, sp(2, 3)));
-        assert!(stream.eq_unspanned(&string_to_ts("...")));
+        assert!(cmp_token_stream(&stream, &string_to_ts("...")));
         assert_eq!(stream.iter().count(), 1);
     })
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1416,18 +1416,18 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
     ///
     /// # Examples
     ///
-    /// Splitting a map into even and odd keys, reusing the original map:
-    ///
     /// ```
     /// #![feature(btree_extract_if)]
     /// use std::collections::BTreeMap;
     ///
+    /// // Splitting a map into even and odd keys, reusing the original map:
     /// let mut map: BTreeMap<i32, i32> = (0..8).map(|x| (x, x)).collect();
     /// let evens: BTreeMap<_, _> = map.extract_if(.., |k, _v| k % 2 == 0).collect();
     /// let odds = map;
     /// assert_eq!(evens.keys().copied().collect::<Vec<_>>(), [0, 2, 4, 6]);
     /// assert_eq!(odds.keys().copied().collect::<Vec<_>>(), [1, 3, 5, 7]);
     ///
+    /// // Splitting a map into low and high halves, reusing the original map:
     /// let mut map: BTreeMap<i32, i32> = (0..8).map(|x| (x, x)).collect();
     /// let low: BTreeMap<_, _> = map.extract_if(0..4, |_k, _v| true).collect();
     /// let high = map;

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1201,21 +1201,21 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// [`retain`]: BTreeSet::retain
     /// # Examples
     ///
-    /// Splitting a set into even and odd values, reusing the original set:
-    ///
     /// ```
     /// #![feature(btree_extract_if)]
     /// use std::collections::BTreeSet;
     ///
+    /// // Splitting a set into even and odd values, reusing the original set:
     /// let mut set: BTreeSet<i32> = (0..8).collect();
     /// let evens: BTreeSet<_> = set.extract_if(.., |v| v % 2 == 0).collect();
     /// let odds = set;
     /// assert_eq!(evens.into_iter().collect::<Vec<_>>(), vec![0, 2, 4, 6]);
     /// assert_eq!(odds.into_iter().collect::<Vec<_>>(), vec![1, 3, 5, 7]);
     ///
-    /// let mut map: BTreeSet<i32> = (0..8).collect();
-    /// let low: BTreeSet<_> = map.extract_if(0..4, |_v| true).collect();
-    /// let high = map;
+    /// // Splitting a set into low and high halves, reusing the original set:
+    /// let mut set: BTreeSet<i32> = (0..8).collect();
+    /// let low: BTreeSet<_> = set.extract_if(0..4, |_v| true).collect();
+    /// let high = set;
     /// assert_eq!(low.into_iter().collect::<Vec<_>>(), [0, 1, 2, 3]);
     /// assert_eq!(high.into_iter().collect::<Vec<_>>(), [4, 5, 6, 7]);
     /// ```

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -175,7 +175,6 @@ impl_from!(u8 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")
 impl_from!(u8 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u8 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u8 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(u16 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -30,6 +30,7 @@
 #![feature(duration_constructors)]
 #![feature(duration_constructors_lite)]
 #![feature(error_generic_member_access)]
+#![feature(exact_div)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extern_types)]

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -690,6 +690,12 @@ macro_rules! int_module {
         const EXACT_DIV_SUCCESS_DIVIDEND2: $T = 18;
         const EXACT_DIV_SUCCESS_DIVISOR2: $T = 3;
         const EXACT_DIV_SUCCESS_QUOTIENT2: $T = 6;
+        const EXACT_DIV_SUCCESS_DIVIDEND3: $T = -91;
+        const EXACT_DIV_SUCCESS_DIVISOR3: $T = 13;
+        const EXACT_DIV_SUCCESS_QUOTIENT3: $T = -7;
+        const EXACT_DIV_SUCCESS_DIVIDEND4: $T = -57;
+        const EXACT_DIV_SUCCESS_DIVISOR4: $T = -3;
+        const EXACT_DIV_SUCCESS_QUOTIENT4: $T = 19;
 
         test_runtime_and_compiletime! {
             fn test_exact_div() {
@@ -700,6 +706,14 @@ macro_rules! int_module {
                 // 18 / 3
                 assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), Some(EXACT_DIV_SUCCESS_QUOTIENT2));
                 assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), EXACT_DIV_SUCCESS_QUOTIENT2);
+
+                // -91 / 13
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND3, EXACT_DIV_SUCCESS_DIVISOR3), Some(EXACT_DIV_SUCCESS_QUOTIENT3));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND3, EXACT_DIV_SUCCESS_DIVISOR3), EXACT_DIV_SUCCESS_QUOTIENT3);
+
+                // -57 / -3
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND4, EXACT_DIV_SUCCESS_DIVISOR4), Some(EXACT_DIV_SUCCESS_QUOTIENT4));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND4, EXACT_DIV_SUCCESS_DIVISOR4), EXACT_DIV_SUCCESS_QUOTIENT4);
 
                 // failures
                 assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(1, 2), None);

--- a/library/coretests/tests/num/int_macros.rs
+++ b/library/coretests/tests/num/int_macros.rs
@@ -683,5 +683,29 @@ macro_rules! int_module {
                 assert_eq_const_safe!($T: <$T>::unbounded_shr(17, SHIFT_AMOUNT_OVERFLOW3), 0);
             }
         }
+
+        const EXACT_DIV_SUCCESS_DIVIDEND1: $T = 42;
+        const EXACT_DIV_SUCCESS_DIVISOR1: $T = 6;
+        const EXACT_DIV_SUCCESS_QUOTIENT1: $T = 7;
+        const EXACT_DIV_SUCCESS_DIVIDEND2: $T = 18;
+        const EXACT_DIV_SUCCESS_DIVISOR2: $T = 3;
+        const EXACT_DIV_SUCCESS_QUOTIENT2: $T = 6;
+
+        test_runtime_and_compiletime! {
+            fn test_exact_div() {
+                // 42 / 6
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND1, EXACT_DIV_SUCCESS_DIVISOR1), Some(EXACT_DIV_SUCCESS_QUOTIENT1));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND1, EXACT_DIV_SUCCESS_DIVISOR1), EXACT_DIV_SUCCESS_QUOTIENT1);
+
+                // 18 / 3
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), Some(EXACT_DIV_SUCCESS_QUOTIENT2));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), EXACT_DIV_SUCCESS_QUOTIENT2);
+
+                // failures
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(1, 2), None);
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(<$T>::MIN, -1), None);
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(0, 0), None);
+            }
+        }
     };
 }

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -516,5 +516,28 @@ macro_rules! uint_module {
                 assert_eq_const_safe!($T: <$T>::unbounded_shr(17, SHIFT_AMOUNT_OVERFLOW3), 0);
             }
         }
+
+        const EXACT_DIV_SUCCESS_DIVIDEND1: $T = 42;
+        const EXACT_DIV_SUCCESS_DIVISOR1: $T = 6;
+        const EXACT_DIV_SUCCESS_QUOTIENT1: $T = 7;
+        const EXACT_DIV_SUCCESS_DIVIDEND2: $T = 18;
+        const EXACT_DIV_SUCCESS_DIVISOR2: $T = 3;
+        const EXACT_DIV_SUCCESS_QUOTIENT2: $T = 6;
+
+        test_runtime_and_compiletime! {
+            fn test_exact_div() {
+                // 42 / 6
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND1, EXACT_DIV_SUCCESS_DIVISOR1), Some(EXACT_DIV_SUCCESS_QUOTIENT1));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND1, EXACT_DIV_SUCCESS_DIVISOR1), EXACT_DIV_SUCCESS_QUOTIENT1);
+
+                // 18 / 3
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), Some(EXACT_DIV_SUCCESS_QUOTIENT2));
+                assert_eq_const_safe!($T: <$T>::exact_div(EXACT_DIV_SUCCESS_DIVIDEND2, EXACT_DIV_SUCCESS_DIVISOR2), EXACT_DIV_SUCCESS_QUOTIENT2);
+
+                // failures
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(1, 2), None);
+                assert_eq_const_safe!(Option<$T>: <$T>::checked_exact_div(0, 0), None);
+            }
+        }
     };
 }

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -960,5 +960,7 @@ pub fn eq_attr_args(l: &AttrArgs, r: &AttrArgs) -> bool {
 }
 
 pub fn eq_delim_args(l: &DelimArgs, r: &DelimArgs) -> bool {
-    l.delim == r.delim && l.tokens.eq_unspanned(&r.tokens)
+    l.delim == r.delim
+        && l.tokens.len() == r.tokens.len()
+        && l.tokens.iter().zip(r.tokens.iter()).all(|(a, b)| a.eq_unspanned(b))
 }

--- a/tests/ui/issues/issue-10806.rs
+++ b/tests/ui/issues/issue-10806.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 #![allow(unused_imports)]
 

--- a/tests/ui/issues/issue-12729.rs
+++ b/tests/ui/issues/issue-12729.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![allow(dead_code)]
 

--- a/tests/ui/issues/issue-13105.rs
+++ b/tests/ui/issues/issue-13105.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-13775.rs
+++ b/tests/ui/issues/issue-13775.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 
 trait Foo {

--- a/tests/ui/issues/issue-15774.rs
+++ b/tests/ui/issues/issue-15774.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-pass
 
 #![deny(warnings)]

--- a/tests/ui/issues/issue-34074.rs
+++ b/tests/ui/issues/issue-34074.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 // Make sure several unnamed function parameters don't conflict with each other
 

--- a/tests/ui/issues/issue-50571.fixed
+++ b/tests/ui/issues/issue-50571.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.rs
+++ b/tests/ui/issues/issue-50571.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 
 #![allow(dead_code)]

--- a/tests/ui/issues/issue-50571.stderr
+++ b/tests/ui/issues/issue-50571.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/issue-50571.rs:5:12
+  --> $DIR/issue-50571.rs:6:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^

--- a/tests/ui/issues/issue-86756.rs
+++ b/tests/ui/issues/issue-86756.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 trait Foo<T, T = T> {}
 //~^ ERROR the name `T` is already used for a generic parameter in this item's generic parameters
 

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -1,5 +1,5 @@
 error[E0403]: the name `T` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/issue-86756.rs:1:14
+  --> $DIR/issue-86756.rs:2:14
    |
 LL | trait Foo<T, T = T> {}
    |           -  ^ already used
@@ -7,13 +7,13 @@ LL | trait Foo<T, T = T> {}
    |           first use of `T`
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/issue-86756.rs:5:10
+  --> $DIR/issue-86756.rs:6:10
    |
 LL |     eq::<dyn, Foo>
    |          ^^^ not found in this scope
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^
@@ -27,13 +27,13 @@ LL |     eq::<dyn, dyn Foo>
    |               +++
 
 error[E0107]: missing generics for trait `Foo`
-  --> $DIR/issue-86756.rs:5:15
+  --> $DIR/issue-86756.rs:6:15
    |
 LL |     eq::<dyn, Foo>
    |               ^^^ expected at least 1 generic argument
    |
 note: trait defined here, with at least 1 generic parameter: `T`
-  --> $DIR/issue-86756.rs:1:7
+  --> $DIR/issue-86756.rs:2:7
    |
 LL | trait Foo<T, T = T> {}
    |       ^^^ -

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rs
@@ -1,4 +1,5 @@
 //@ revisions: rust2015 rust2018 rust2021
+//@[rust2015] edition:2015
 //@[rust2018] edition:2018
 //@[rust2021] edition:2021
 fn main() {

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2015.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2018.stderr
@@ -1,5 +1,5 @@
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
+++ b/tests/ui/lexer/lex-bad-str-literal-as-char-3.rust2021.stderr
@@ -1,5 +1,5 @@
 error: prefix `world` is unknown
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:21
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:21
    |
 LL |     println!('hello world');
    |                     ^^^^^ unknown prefix
@@ -12,7 +12,7 @@ LL +     println!("hello world");
    |
 
 error[E0762]: unterminated character literal
-  --> $DIR/lex-bad-str-literal-as-char-3.rs:5:26
+  --> $DIR/lex-bad-str-literal-as-char-3.rs:6:26
    |
 LL |     println!('hello world');
    |                          ^^^

--- a/tests/ui/lifetimes/bare-trait-object-borrowck.rs
+++ b/tests/ui/lifetimes/bare-trait-object-borrowck.rs
@@ -1,5 +1,7 @@
-#![allow(bare_trait_objects)]
+//@ edition: 2015
 //@ check-pass
+#![allow(bare_trait_objects)]
+
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
     /// FormatWith uses interior mutability because Display::fmt takes &self.

--- a/tests/ui/lifetimes/bare-trait-object.rs
+++ b/tests/ui/lifetimes/bare-trait-object.rs
@@ -1,4 +1,5 @@
 // Verify that lifetime resolution correctly accounts for `Fn` bare trait objects.
+//@ edition: 2015
 //@ check-pass
 #![allow(bare_trait_objects)]
 

--- a/tests/ui/lint/bare-trait-objects-path.rs
+++ b/tests/ui/lint/bare-trait-objects-path.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 #![feature(associated_type_defaults)]
 
 trait Assoc {

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:14:5
+  --> $DIR/bare-trait-objects-path.rs:15:5
    |
 LL |     Dyn::func();
    |     ^^^
@@ -13,7 +13,7 @@ LL |     <dyn Dyn>::func();
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:17:5
+  --> $DIR/bare-trait-objects-path.rs:18:5
    |
 LL |     ::Dyn::func();
    |     ^^^^^
@@ -26,7 +26,7 @@ LL |     <dyn (::Dyn)>::func();
    |     ++++++     ++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:20:5
+  --> $DIR/bare-trait-objects-path.rs:21:5
    |
 LL |     Dyn::CONST;
    |     ^^^
@@ -39,7 +39,7 @@ LL |     <dyn Dyn>::CONST;
    |     ++++    +
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^
@@ -52,7 +52,7 @@ LL |     let _: <dyn Dyn>::Ty;
    |            ++++    +
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bare-trait-objects-path.rs:23:12
+  --> $DIR/bare-trait-objects-path.rs:24:12
    |
 LL |     let _: Dyn::Ty;
    |            ^^^^^^^

--- a/tests/ui/lint/lint-pre-expansion-extern-module.rs
+++ b/tests/ui/lint/lint-pre-expansion-extern-module.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -W rust-2018-compatibility
+//@ edition: 2015
 
 fn main() {}
 

--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ run-rustfix
 #![deny(unused_qualifications)]
 #![deny(unused_imports)]

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -1,11 +1,11 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:12:5
+  --> $DIR/lint-qualification.rs:13:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:2:9
+  --> $DIR/lint-qualification.rs:3:9
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:13:5
+  --> $DIR/lint-qualification.rs:14:5
    |
 LL |     crate::foo::bar();
    |     ^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL +     bar();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:18:13
+  --> $DIR/lint-qualification.rs:19:13
    |
 LL |     let _ = std::string::String::new();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL +     let _ = String::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:12
+  --> $DIR/lint-qualification.rs:21:12
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |            ^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
    |
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:20:36
+  --> $DIR/lint-qualification.rs:21:36
    |
 LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,19 +64,19 @@ LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
    |
 
 error: unused import: `std::fmt`
-  --> $DIR/lint-qualification.rs:24:9
+  --> $DIR/lint-qualification.rs:25:9
    |
 LL |     use std::fmt;
    |         ^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/lint-qualification.rs:3:9
+  --> $DIR/lint-qualification.rs:4:9
    |
 LL | #![deny(unused_imports)]
    |         ^^^^^^^^^^^^^^
 
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:29:13
+  --> $DIR/lint-qualification.rs:30:13
    |
 LL |     let _ = <bool as std::default::Default>::default(); // issue #121999 (modified)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.rs
@@ -1,3 +1,4 @@
+//@ edition: 2015
 //@ check-pass
 #![warn(redundant_imports)]
 

--- a/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
+++ b/tests/ui/lint/use-redundant/use-redundant-prelude-rust-2015.stderr
@@ -1,5 +1,5 @@
 warning: the item `Some` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:5:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
    |
 LL | use std::option::Option::Some;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL | use std::option::Option::Some;
    = note: the item `Some` is already defined here
    |
 note: the lint level is defined here
-  --> $DIR/use-redundant-prelude-rust-2015.rs:2:9
+  --> $DIR/use-redundant-prelude-rust-2015.rs:3:9
    |
 LL | #![warn(redundant_imports)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: the item `None` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:6:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:7:5
    |
 LL | use std::option::Option::None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | use std::option::Option::None;
    = note: the item `None` is already defined here
 
 warning: the item `Ok` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:8:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
    |
 LL | use std::result::Result::Ok;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL | use std::result::Result::Ok;
    = note: the item `Ok` is already defined here
 
 warning: the item `Err` is imported redundantly
-  --> $DIR/use-redundant-prelude-rust-2015.rs:9:5
+  --> $DIR/use-redundant-prelude-rust-2015.rs:10:5
    |
 LL | use std::result::Result::Err;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/try-macro.rs
+++ b/tests/ui/macros/try-macro.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ edition: 2015
 #![allow(deprecated)] // for deprecated `try!()` macro
 use std::num::{ParseFloatError, ParseIntError};
 

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -1,47 +1,47 @@
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:1:11
+  --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A0 = dyn;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:11
+  --> $DIR/dyn-trait-compatibility.rs:7:11
    |
 LL | type A2 = dyn<dyn, dyn>;
    |           ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:15
+  --> $DIR/dyn-trait-compatibility.rs:7:15
    |
 LL | type A2 = dyn<dyn, dyn>;
    |               ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:5:20
+  --> $DIR/dyn-trait-compatibility.rs:7:20
    |
 LL | type A2 = dyn<dyn, dyn>;
    |                    ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:11
+  --> $DIR/dyn-trait-compatibility.rs:11:11
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |           ^^^ not found in this scope
 
 error[E0405]: cannot find trait `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:23
+  --> $DIR/dyn-trait-compatibility.rs:11:23
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                       ^^^ not found in this scope
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/dyn-trait-compatibility.rs:9:16
+  --> $DIR/dyn-trait-compatibility.rs:11:16
    |
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
-  --> $DIR/dyn-trait-compatibility.rs:3:11
+  --> $DIR/dyn-trait-compatibility.rs:5:11
    |
 LL | type A1 = dyn::dyn;
    |           ^^^ use of unresolved module or unlinked crate `dyn`

--- a/tests/ui/parser/extern-crate-async.rs
+++ b/tests/ui/parser/extern-crate-async.rs
@@ -1,6 +1,7 @@
-// Make sure that we don't parse `extern crate async`
+// Make sure that we don't parse `extern crate async` as
 // the front matter of a function leading us astray.
 
+//@ edition: 2015
 //@ check-pass
 
 fn main() {}

--- a/tests/ui/parser/fn-field-parse-error-ice.rs
+++ b/tests/ui/parser/fn-field-parse-error-ice.rs
@@ -1,4 +1,5 @@
 // Regression test for #85794
+//@ edition: 2015
 
 struct Baz {
     inner : dyn fn ()

--- a/tests/ui/parser/fn-field-parse-error-ice.stderr
+++ b/tests/ui/parser/fn-field-parse-error-ice.stderr
@@ -1,11 +1,11 @@
 error: expected `,`, or `}`, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:16
+  --> $DIR/fn-field-parse-error-ice.rs:5:16
    |
 LL |     inner : dyn fn ()
    |                ^ help: try adding a comma: `,`
 
 error: expected identifier, found keyword `fn`
-  --> $DIR/fn-field-parse-error-ice.rs:4:17
+  --> $DIR/fn-field-parse-error-ice.rs:5:17
    |
 LL | struct Baz {
    |        --- while parsing this struct
@@ -18,7 +18,7 @@ LL |     inner : dyn r#fn ()
    |                 ++
 
 error[E0412]: cannot find type `dyn` in this scope
-  --> $DIR/fn-field-parse-error-ice.rs:4:13
+  --> $DIR/fn-field-parse-error-ice.rs:5:13
    |
 LL |     inner : dyn fn ()
    |             ^^^ not found in this scope

--- a/tests/ui/parser/issues/issue-114219.rs
+++ b/tests/ui/parser/issues/issue-114219.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 fn main() {
     async move {};
     //~^ ERROR `async move` blocks are only allowed in Rust 2018 or later

--- a/tests/ui/parser/issues/issue-114219.stderr
+++ b/tests/ui/parser/issues/issue-114219.stderr
@@ -1,5 +1,5 @@
 error: `async move` blocks are only allowed in Rust 2018 or later
-  --> $DIR/issue-114219.rs:2:5
+  --> $DIR/issue-114219.rs:4:5
    |
 LL |     async move {};
    |     ^^^^^^^^^^

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -1,3 +1,5 @@
+//@ edition: 2015
+
 trait Trait {}
 
 fn test(_: &for<'a> dyn Trait) {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -1,5 +1,5 @@
 error: `for<...>` expected after `dyn`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:3:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:5:21
    |
 LL | fn test(_: &for<'a> dyn Trait) {}
    |                     ^^^
@@ -11,7 +11,7 @@ LL + fn test(_: &dyn for<'a> Trait) {}
    |
 
 error: `for<...>` expected after `impl`, not before
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:6:21
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:8:21
    |
 LL | fn test2(_: for<'a> impl Trait) {}
    |                     ^^^^
@@ -23,7 +23,7 @@ LL + fn test2(_: impl for<'a> Trait) {}
    |
 
 error: expected identifier, found `>`
-  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:10:24
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:12:24
    |
 LL | type A2 = dyn<for<> dyn>;
    |                        ^ expected identifier

--- a/tests/ui/proc-macro/trait-fn-args-2015.rs
+++ b/tests/ui/proc-macro/trait-fn-args-2015.rs
@@ -1,6 +1,7 @@
 // Unnamed arguments in trait functions can be passed through proc macros on 2015 edition.
 
 //@ check-pass
+//@ edition: 2015
 //@ proc-macro: test-macros.rs
 
 #![allow(anonymous_parameters)]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141271 (Streamline some attr parsing APIs)
 - rust-lang/rust#141570 (Fix incorrect eq_unspanned in TokenStream)
 - rust-lang/rust#141893 (remove `f16: From<u16>`)
 - rust-lang/rust#141924 (Lightly tweak docs for BTree{Map,Set}::extract_if)
 - rust-lang/rust#141939 (exact_div: add tests)
 - rust-lang/rust#141959 (Add more missing 2015 edition directives)
 - rust-lang/rust#142007 (Improve some `Visitor` comments.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141271,141570,141893,141924,141939,141959,142007)
<!-- homu-ignore:end -->