### PR TITLE
Add musl submodule to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,3 +51,7 @@
 	path = src/gcc
 	url = https://github.com/rust-lang/gcc.git
 	shallow = true
+[submodule "library/compiler-builtins/crates/musl-math-sys/musl"]
+	path = library/compiler-builtins/crates/musl-math-sys/musl
+	url = https://git.musl-libc.org/git/musl
+	shallow = true


### PR DESCRIPTION
The compiler-builtins subtree has musl as a submodule, but it is not present in the git root .gitmodules.  This breaks some workflows with `build.submodules = false` That is, a naive `git submodule update --init` will error out with:

```
fatal: No url found for submodule path 'library/compiler-builtins/crates/musl-math-sys/musl' in .gitmodules
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
