### PR TITLE
Start moving wf checking away from HIR

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4862,6 +4862,10 @@ impl<'hir> Node<'hir> {
                 ImplItemKind::Type(ty) => Some(ty),
                 _ => None,
             },
+            Node::ForeignItem(it) => match it.kind {
+                ForeignItemKind::Static(ty, ..) => Some(ty),
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -881,10 +881,6 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     hir::ForeignItemKind::Fn(sig, _, _) => {
                         require_c_abi_if_c_variadic(tcx, sig.decl, abi, item.span);
                     }
-                    hir::ForeignItemKind::Static(..) => {
-                        check_static_inhabited(tcx, def_id);
-                        check_static_linkage(tcx, def_id);
-                    }
                     _ => {}
                 }
             }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -37,7 +37,8 @@ use {rustc_attr_data_structures as attrs, rustc_hir as hir};
 use super::compare_impl_item::check_type_bounds;
 use super::*;
 use crate::check::wfcheck::{
-    check_trait_item, check_variances_for_type_defn, check_where_clauses, enter_wf_checking_ctxt,
+    check_associated_item, check_trait_item, check_variances_for_type_defn, check_where_clauses,
+    enter_wf_checking_ctxt,
 };
 
 fn add_abi_diag_help<T: EmissionGuarantee>(abi: ExternAbi, diag: &mut Diag<'_, T>) {
@@ -981,6 +982,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().fn_sig(def_id);
             tcx.ensure_ok().predicates_of(def_id);
+            res = res.and(check_associated_item(tcx, def_id));
             let assoc_item = tcx.associated_item(def_id);
             match assoc_item.container {
                 ty::AssocItemContainer::Impl => {}
@@ -992,6 +994,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
         DefKind::AssocConst => {
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().predicates_of(def_id);
+            res = res.and(check_associated_item(tcx, def_id));
             let assoc_item = tcx.associated_item(def_id);
             match assoc_item.container {
                 ty::AssocItemContainer::Impl => {}
@@ -1002,6 +1005,7 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
         }
         DefKind::AssocTy => {
             tcx.ensure_ok().predicates_of(def_id);
+            res = res.and(check_associated_item(tcx, def_id));
 
             let assoc_item = tcx.associated_item(def_id);
             let has_type = match assoc_item.container {

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -230,7 +230,6 @@ fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) -> Result<()
         ?item.owner_id,
         item.name = ? tcx.def_path_str(def_id)
     );
-    crate::collect::lower_item(tcx, item.item_id());
 
     match item.kind {
         // Right now we check that every default trait implementation

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -978,7 +978,7 @@ pub(crate) fn check_associated_item(
                 let sig = tcx.fn_sig(item.def_id).instantiate_identity();
                 let hir_sig =
                     tcx.hir_node_by_def_id(item_id).fn_sig().expect("bad signature for method");
-                check_fn_or_method(wfcx, sig, hir_sig.decl, item.def_id.expect_local());
+                check_fn_or_method(wfcx, sig, hir_sig.decl, item_id);
                 check_method_receiver(wfcx, hir_sig, item, self_ty)
             }
             ty::AssocKind::Type { .. } => {
@@ -1655,17 +1655,18 @@ fn check_method_receiver<'tcx>(
     }
 
     let span = fn_sig.decl.inputs[0].span;
+    let loc = Some(WellFormedLoc::Param { function: method.def_id.expect_local(), param_idx: 0 });
 
     let sig = tcx.fn_sig(method.def_id).instantiate_identity();
     let sig = tcx.liberate_late_bound_regions(method.def_id, sig);
-    let sig = wfcx.normalize(span, None, sig);
+    let sig = wfcx.normalize(DUMMY_SP, loc, sig);
 
     debug!("check_method_receiver: sig={:?}", sig);
 
-    let self_ty = wfcx.normalize(span, None, self_ty);
+    let self_ty = wfcx.normalize(DUMMY_SP, loc, self_ty);
 
     let receiver_ty = sig.inputs()[0];
-    let receiver_ty = wfcx.normalize(span, None, receiver_ty);
+    let receiver_ty = wfcx.normalize(DUMMY_SP, loc, receiver_ty);
 
     // If the receiver already has errors reported, consider it valid to avoid
     // unnecessary errors (#58712).

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -328,8 +328,6 @@ fn check_trait_item<'tcx>(
 ) -> Result<(), ErrorGuaranteed> {
     let def_id = trait_item.owner_id.def_id;
 
-    crate::collect::lower_trait_item(tcx, trait_item.trait_item_id());
-
     let (method_sig, span) = match trait_item.kind {
         hir::TraitItemKind::Fn(ref sig, _) => (Some(sig), trait_item.span),
         hir::TraitItemKind::Type(_bounds, Some(ty)) => (None, ty.span),
@@ -831,8 +829,6 @@ fn check_impl_item<'tcx>(
     tcx: TyCtxt<'tcx>,
     impl_item: &'tcx hir::ImplItem<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {
-    crate::collect::lower_impl_item(tcx, impl_item.impl_item_id());
-
     let (method_sig, span) = match impl_item.kind {
         hir::ImplItemKind::Fn(ref sig, _) => (Some(sig), impl_item.span),
         // Constrain binding and overflow error spans to `<Ty>` in `type foo = <Ty>`.

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -615,53 +615,6 @@ fn get_new_lifetime_name<'tcx>(
     (1..).flat_map(a_to_z_repeat_n).find(|lt| !existing_lifetimes.contains(lt.as_str())).unwrap()
 }
 
-pub(crate) fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
-    let trait_item = tcx.hir_trait_item(trait_item_id);
-    let def_id = trait_item_id.owner_id;
-    tcx.ensure_ok().generics_of(def_id);
-
-    match trait_item.kind {
-        hir::TraitItemKind::Fn(..) => {
-            tcx.ensure_ok().codegen_fn_attrs(def_id);
-            tcx.ensure_ok().type_of(def_id);
-            tcx.ensure_ok().fn_sig(def_id);
-        }
-
-        hir::TraitItemKind::Const(..) => {
-            tcx.ensure_ok().type_of(def_id);
-        }
-
-        hir::TraitItemKind::Type(_, Some(_)) => {
-            tcx.ensure_ok().item_bounds(def_id);
-            tcx.ensure_ok().item_self_bounds(def_id);
-            tcx.ensure_ok().type_of(def_id);
-        }
-
-        hir::TraitItemKind::Type(_, None) => {
-            tcx.ensure_ok().item_bounds(def_id);
-            tcx.ensure_ok().item_self_bounds(def_id);
-        }
-    };
-
-    tcx.ensure_ok().predicates_of(def_id);
-}
-
-pub(super) fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
-    let def_id = impl_item_id.owner_id;
-    tcx.ensure_ok().generics_of(def_id);
-    tcx.ensure_ok().type_of(def_id);
-    tcx.ensure_ok().predicates_of(def_id);
-    let impl_item = tcx.hir_impl_item(impl_item_id);
-    match impl_item.kind {
-        hir::ImplItemKind::Fn(..) => {
-            tcx.ensure_ok().codegen_fn_attrs(def_id);
-            tcx.ensure_ok().fn_sig(def_id);
-        }
-        hir::ImplItemKind::Type(_) => {}
-        hir::ImplItemKind::Const(..) => {}
-    }
-}
-
 pub(super) fn lower_variant_ctor(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     tcx.ensure_ok().generics_of(def_id);
     tcx.ensure_ok().type_of(def_id);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1186,7 +1186,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         ty: Ty<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) -> Diag<'a> {
-        let span = obligation.cause.span;
+        let param = obligation.cause.body_id;
+        let hir::GenericParamKind::Const { ty: &hir::Ty { span, .. }, .. } =
+            self.tcx.hir_node_by_def_id(param).expect_generic_param().kind
+        else {
+            bug!()
+        };
 
         let mut diag = match ty.kind() {
             ty::Float(_) => {

--- a/tests/incremental/cyclic-trait-hierarchy.rs
+++ b/tests/incremental/cyclic-trait-hierarchy.rs
@@ -6,7 +6,7 @@
 pub trait T2 {}
 #[cfg(cfail2)]
 pub trait T2: T1 {}
-//[cfail2]~^ ERROR cycle detected when computing the implied predicates of `T2`
+//[cfail2]~^ ERROR cycle detected when computing the super predicates of `T2`
 
 pub trait T1: T2 {}
 

--- a/tests/incremental/cyclic-trait-hierarchy.rs
+++ b/tests/incremental/cyclic-trait-hierarchy.rs
@@ -6,7 +6,7 @@
 pub trait T2 {}
 #[cfg(cfail2)]
 pub trait T2: T1 {}
-//[cfail2]~^ ERROR cycle detected when computing the super predicates of `T2`
+//[cfail2]~^ ERROR cycle detected when computing the implied predicates of `T2`
 
 pub trait T1: T2 {}
 

--- a/tests/incremental/issue-54242.rs
+++ b/tests/incremental/issue-54242.rs
@@ -14,7 +14,7 @@ impl Tr for str {
     type Arr = [u8; 8];
     #[cfg(cfail)]
     type Arr = [u8; Self::C];
-    //[cfail]~^ ERROR cycle detected when evaluating type-level constant
+    //[cfail]~^ ERROR cycle detected when caching mir
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.rs
@@ -12,7 +12,7 @@ fn take(
         K = { () }
     >,
 ) {}
-//~^^^^^^ ERROR implementation of `Project` is not general enough
+//~^^^^^ ERROR implementation of `Project` is not general enough
 //~^^^^ ERROR higher-ranked subtype error
 //~| ERROR higher-ranked subtype error
 

--- a/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-bound-var-in-ty-not-wf.stderr
@@ -13,10 +13,14 @@ LL |         K = { () }
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: implementation of `Project` is not general enough
-  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:9:4
+  --> $DIR/assoc-const-eq-bound-var-in-ty-not-wf.rs:10:13
    |
-LL | fn take(
-   |    ^^^^ implementation of `Project` is not general enough
+LL |       _: impl Trait<
+   |  _____________^
+LL | |         <<for<'a> fn(&'a str) -> &'a str as Project>::Out as Discard>::Out,
+LL | |         K = { () }
+LL | |     >,
+   | |_____^ implementation of `Project` is not general enough
    |
    = note: `Project` would have to be implemented for the type `for<'a> fn(&'a str) -> &'a str`
    = note: ...but `Project` is actually implemented for the type `fn(&'0 str) -> &'0 str`, for some specific lifetime `'0`

--- a/tests/ui/associated-inherent-types/issue-111879-0.stderr
+++ b/tests/ui/associated-inherent-types/issue-111879-0.stderr
@@ -1,8 +1,8 @@
 error: overflow evaluating associated type `Carrier<'b>::Focus<i32>`
-  --> $DIR/issue-111879-0.rs:9:25
+  --> $DIR/issue-111879-0.rs:9:5
    |
 LL |     pub type Focus<T> = &'a mut for<'b> fn(Carrier<'b>::Focus<i32>);
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/normalization-overflow.stderr
+++ b/tests/ui/associated-inherent-types/normalization-overflow.stderr
@@ -1,8 +1,8 @@
 error: overflow evaluating associated type `T::This`
-  --> $DIR/normalization-overflow.rs:9:17
+  --> $DIR/normalization-overflow.rs:9:5
    |
 LL |     type This = Self::This;
-   |                 ^^^^^^^^^^
+   |     ^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/regionck-1.stderr
+++ b/tests/ui/associated-inherent-types/regionck-1.stderr
@@ -1,10 +1,11 @@
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/regionck-1.rs:9:30
+  --> $DIR/regionck-1.rs:9:5
    |
 LL |     type NoTyOutliv<'a, T> = &'a T;
-   |                     --       ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
-   |                     |
-   |                     the parameter type `T` must be valid for the lifetime `'a` as defined here...
+   |     ^^^^^^^^^^^^^^^^--^^^^
+   |     |               |
+   |     |               the parameter type `T` must be valid for the lifetime `'a` as defined here...
+   |     ...so that the reference type `&'a T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |
@@ -12,10 +13,10 @@ LL |     type NoTyOutliv<'a, T: 'a> = &'a T;
    |                          ++++
 
 error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
-  --> $DIR/regionck-1.rs:10:31
+  --> $DIR/regionck-1.rs:10:5
    |
 LL |     type NoReOutliv<'a, 'b> = &'a &'b ();
-   |                               ^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regionck-1.rs:10:21

--- a/tests/ui/associated-types/impl-wf-cycle-4.stderr
+++ b/tests/ui/associated-types/impl-wf-cycle-4.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when computing normalized predicates of `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>`
+error[E0391]: cycle detected when computing whether `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` has a guaranteed unsized self type
   --> $DIR/impl-wf-cycle-4.rs:5:1
    |
 LL | / impl<T> Filter for T
@@ -6,14 +6,14 @@ LL | | where
 LL | |     T: Fn(Self::ToMatch),
    | |_________________________^
    |
-note: ...which requires computing whether `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` has a guaranteed unsized self type...
+note: ...which requires computing normalized predicates of `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>`...
   --> $DIR/impl-wf-cycle-4.rs:5:1
    |
 LL | / impl<T> Filter for T
 LL | | where
 LL | |     T: Fn(Self::ToMatch),
    | |_________________________^
-   = note: ...which again requires computing normalized predicates of `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>`, completing the cycle
+   = note: ...which again requires computing whether `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` has a guaranteed unsized self type, completing the cycle
 note: cycle used when checking that `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` is well-formed
   --> $DIR/impl-wf-cycle-4.rs:5:1
    |

--- a/tests/ui/associated-types/issue-38821.rs
+++ b/tests/ui/associated-types/issue-38821.rs
@@ -32,16 +32,16 @@ pub trait Column: Expression {}
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 pub enum ColumnInsertValue<Col, Expr> where
 //~^ ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
     Col: Column,
     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+//~^ ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 {
     Expression(Col, Expr),
     Default(Col),

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:40:1
+  --> $DIR/issue-38821.rs:35:1
    |
 LL | pub enum ColumnInsertValue<Col, Expr> where
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
@@ -17,16 +17,10 @@ LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Co
    |                                                                         +++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:40:1
+  --> $DIR/issue-38821.rs:38:22
    |
-LL | / pub enum ColumnInsertValue<Col, Expr> where
-LL | |
-LL | |
-LL | |     Col: Column,
-...  |
-LL | |     Default(Col),
-LL | | }
-   | |_^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -88,29 +82,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:10
+  --> $DIR/issue-38821.rs:38:22
    |
-LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting the associated type
-   |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
-   |                                                                       +++++++++++++++++++++++++++++++++++++++
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:17
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -137,7 +112,24 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider further restricting the associated type
+   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
+   |                                                                       +++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:38:22
+   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -191,10 +183,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:23
+  --> $DIR/issue-38821.rs:38:22
    |
-LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -203,7 +195,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -225,10 +216,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:10
+  --> $DIR/issue-38821.rs:38:22
    |
-LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -237,7 +228,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:23
@@ -255,10 +245,10 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:23
+  --> $DIR/issue-38821.rs:38:22
    |
-LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -71,40 +71,40 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
    |                                                                       +++++++++++++++++++++++++++++++++++++++
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:10
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:10
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:17
@@ -174,40 +174,40 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
    |                                                                       +++++++++++++++++++++++++++++++++++++++
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:23
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:23
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10

--- a/tests/ui/associated-types/issue-59324.rs
+++ b/tests/ui/associated-types/issue-59324.rs
@@ -10,8 +10,8 @@ pub trait Service {
 
 pub trait ThriftService<Bug: NotFoo>:
 //~^ ERROR the trait bound `Bug: Foo` is not satisfied
-//~| ERROR the trait bound `Bug: Foo` is not satisfied
     Service<AssocType = <Bug as Foo>::OnlyFoo>
+//~^ ERROR the trait bound `Bug: Foo` is not satisfied
 {
     fn get_service(
     //~^ ERROR the trait bound `Bug: Foo` is not satisfied

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Bug: Foo` is not satisfied
   --> $DIR/issue-59324.rs:11:1
    |
 LL | / pub trait ThriftService<Bug: NotFoo>:
-...  |
+LL | |
 LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
    | |______________________________________________^ the trait `Foo` is not implemented for `Bug`
    |
@@ -12,15 +12,10 @@ LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
 
 error[E0277]: the trait bound `Bug: Foo` is not satisfied
-  --> $DIR/issue-59324.rs:11:1
+  --> $DIR/issue-59324.rs:13:13
    |
-LL | / pub trait ThriftService<Bug: NotFoo>:
-LL | |
-LL | |
-LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
-...  |
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `Bug`
+LL |     Service<AssocType = <Bug as Foo>::OnlyFoo>
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bug`
    |
 help: consider further restricting type parameter `Bug` with trait `Foo`
    |

--- a/tests/ui/async-await/async-fn/impl-header.stderr
+++ b/tests/ui/async-await/async-fn/impl-header.stderr
@@ -22,6 +22,14 @@ LL | impl async Fn<()> for F {}
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/impl-header.rs:5:1
+   |
+LL | impl async Fn<()> for F {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: ()) -> <Self as FnOnce<()>>::Output { todo!() }`
+
 error[E0277]: expected a `FnMut()` closure, found `F`
   --> $DIR/impl-header.rs:5:23
    |
@@ -32,14 +40,6 @@ LL | impl async Fn<()> for F {}
    = note: wrap the `F` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error[E0046]: not all trait items implemented, missing: `call`
-  --> $DIR/impl-header.rs:5:1
-   |
-LL | impl async Fn<()> for F {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
-   |
-   = help: implement the missing item: `fn call(&self, _: ()) -> <Self as FnOnce<()>>::Output { todo!() }`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/coherence/coherence-impl-trait-for-trait-dyn-compatible.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait-dyn-compatible.stderr
@@ -1,3 +1,11 @@
+error[E0046]: not all trait items implemented, missing: `eq`
+  --> $DIR/coherence-impl-trait-for-trait-dyn-compatible.rs:7:1
+   |
+LL | trait DynIncompatible { fn eq(&self, other: Self); }
+   |                         -------------------------- `eq` from trait
+LL | impl DynIncompatible for dyn DynIncompatible { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `eq` in implementation
+
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/coherence-impl-trait-for-trait-dyn-compatible.rs:7:26
    |
@@ -13,14 +21,6 @@ LL | trait DynIncompatible { fn eq(&self, other: Self); }
    |       |
    |       this trait is not dyn compatible...
    = help: consider moving `eq` to another trait
-
-error[E0046]: not all trait items implemented, missing: `eq`
-  --> $DIR/coherence-impl-trait-for-trait-dyn-compatible.rs:7:1
-   |
-LL | trait DynIncompatible { fn eq(&self, other: Self); }
-   |                         -------------------------- `eq` from trait
-LL | impl DynIncompatible for dyn DynIncompatible { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `eq` in implementation
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
+++ b/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
@@ -1,3 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Assoc`
+  --> $DIR/best-obligation-ICE.rs:10:1
+   |
+LL |     type Assoc;
+   |     ---------- `Assoc` from trait
+...
+LL | impl<T> Trait for W<W<W<T>>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Assoc` in implementation
+
 error[E0277]: the trait bound `W<W<T>>: Trait` is not satisfied
   --> $DIR/best-obligation-ICE.rs:10:19
    |
@@ -45,15 +54,6 @@ help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | impl<T: Trait> Trait for W<W<W<T>>> {}
    |       +++++++
-
-error[E0046]: not all trait items implemented, missing: `Assoc`
-  --> $DIR/best-obligation-ICE.rs:10:1
-   |
-LL |     type Assoc;
-   |     ---------- `Assoc` from trait
-...
-LL | impl<T> Trait for W<W<W<T>>> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Assoc` in implementation
 
 error[E0119]: conflicting implementations of trait `NoOverlap` for type `W<W<W<W<_>>>>`
   --> $DIR/best-obligation-ICE.rs:18:1

--- a/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.rs
+++ b/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.rs
@@ -5,6 +5,7 @@
 struct Foo;
 impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
 //~^ ERROR the const parameter `NUM` is not constrained by the impl trait, self type, or predicates
+//~| ERROR missing: `Output`, `add`
 where
     [(); 1 + 0]: Sized,
 {

--- a/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `unimplemented` is not a member of trait `std::ops::Add`
-  --> $DIR/post-analysis-user-facing-param-env.rs:11:5
+  --> $DIR/post-analysis-user-facing-param-env.rs:12:5
    |
 LL | /     fn unimplemented(self, _: &Foo) -> Self::Output {
 LL | |
@@ -17,6 +17,19 @@ LL | #![feature(generic_const_exprs)]
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
+error[E0046]: not all trait items implemented, missing: `Output`, `add`
+  --> $DIR/post-analysis-user-facing-param-env.rs:6:1
+   |
+LL | / impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
+LL | |
+LL | |
+LL | | where
+LL | |     [(); 1 + 0]: Sized,
+   | |_______________________^ missing `Output`, `add` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+   = help: implement the missing item: `fn add(self, _: &'a Foo) -> <Self as Add<&'a Foo>>::Output { todo!() }`
+
 error[E0207]: the const parameter `NUM` is not constrained by the impl trait, self type, or predicates
   --> $DIR/post-analysis-user-facing-param-env.rs:6:10
    |
@@ -27,7 +40,7 @@ LL | impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0284]: type annotations needed
-  --> $DIR/post-analysis-user-facing-param-env.rs:11:40
+  --> $DIR/post-analysis-user-facing-param-env.rs:12:40
    |
 LL |     fn unimplemented(self, _: &Foo) -> Self::Output {
    |                                        ^^^^^^^^^^^^ cannot infer the value of const parameter `NUM`
@@ -40,7 +53,7 @@ LL | impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
    |          |
    |          unsatisfied trait bound introduced here
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0207, E0284, E0407.
-For more information about an error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0046, E0207, E0284, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -1,11 +1,3 @@
-error: the constant `N` is not of type `usize`
-  --> $DIR/type_mismatch.rs:8:26
-   |
-LL | impl<const N: u64> Q for [u8; N] {}
-   |                          ^^^^^^^ expected `usize`, found `u64`
-   |
-   = note: the length of array `[u8; N]` must be type `usize`
-
 error[E0046]: not all trait items implemented, missing: `ASSOC`
   --> $DIR/type_mismatch.rs:8:1
    |
@@ -14,6 +6,14 @@ LL |     const ASSOC: usize;
 ...
 LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
+
+error: the constant `N` is not of type `usize`
+  --> $DIR/type_mismatch.rs:8:26
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |                          ^^^^^^^ expected `usize`, found `u64`
+   |
+   = note: the length of array `[u8; N]` must be type `usize`
 
 error: the constant `13` is not of type `u64`
   --> $DIR/type_mismatch.rs:12:26

--- a/tests/ui/const-generics/ice-unexpected-inference-var-122549.rs
+++ b/tests/ui/const-generics/ice-unexpected-inference-var-122549.rs
@@ -15,6 +15,7 @@ struct ConstChunksExact<'rem, T: 'a, const N: usize> {}
 impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
 //~^ ERROR the const parameter `N` is not constrained by the impl trait, self type, or predicates
 //~^^ ERROR mismatched types
+//~| ERROR missing: `next`
     type Item = &'a [T; N];
 }
 

--- a/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
+++ b/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
@@ -49,6 +49,20 @@ LL | struct ConstChunksExact<'rem, T: 'a, const N: usize> {}
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
+error[E0308]: mismatched types
+  --> $DIR/ice-unexpected-inference-var-122549.rs:15:66
+   |
+LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
+   |                                                                  ^^ expected `usize`, found `()`
+
+error[E0046]: not all trait items implemented, missing: `next`
+  --> $DIR/ice-unexpected-inference-var-122549.rs:15:1
+   |
+LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `next` in implementation
+   |
+   = help: implement the missing item: `fn next(&mut self) -> Option<<Self as Iterator>::Item> { todo!() }`
+
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
   --> $DIR/ice-unexpected-inference-var-122549.rs:15:13
    |
@@ -58,13 +72,7 @@ LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error[E0308]: mismatched types
-  --> $DIR/ice-unexpected-inference-var-122549.rs:15:66
-   |
-LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
-   |                                                                  ^^ expected `usize`, found `()`
-
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0046, E0207, E0261, E0308, E0392.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/issues/issue-71202.stderr
+++ b/tests/ui/const-generics/issues/issue-71202.stderr
@@ -7,7 +7,7 @@ LL | |             const VALUE: bool = false;
 ...  |
 LL | |         <IsCopy<T>>::VALUE
 LL | |     } as usize] = [];
-   | |_____________________^
+   | |_______________^
    |
 help: try adding a `where` bound
    |

--- a/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.rs
+++ b/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.rs
@@ -14,5 +14,6 @@ impl<'a, T: std::fmt::Debug, const N: usize> Iterator for ConstChunksExact<'a, T
     //~^ ERROR mismatched types [E0308]
     //~| ERROR the const parameter `N` is not constrained by the impl trait, self type, or predicates [E0207]
     type Item = &'a [T; N]; }
+    //~^ ERROR: `Item` specializes an item from a parent `impl`, but that item is not marked `default`
 
 fn main() {}

--- a/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.stderr
+++ b/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.stderr
@@ -34,6 +34,17 @@ LL | struct ConstChunksExact<'a, T: '_, const assert: usize> {}
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
+error[E0520]: `Item` specializes an item from a parent `impl`, but that item is not marked `default`
+  --> $DIR/normalizing_with_unconstrained_impl_params.rs:16:5
+   |
+LL | impl<'a, T: std::fmt::Debug, const N: usize> Iterator for ConstChunksExact<'a, T, { N }> {
+   | ---------------------------------------------------------------------------------------- parent `impl` is here
+...
+LL |     type Item = &'a [T; N]; }
+   |     ^^^^^^^^^ cannot specialize default item `Item`
+   |
+   = note: to specialize, `Item` in the parent `impl` must be marked `default`
+
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
   --> $DIR/normalizing_with_unconstrained_impl_params.rs:13:30
    |
@@ -54,7 +65,7 @@ LL |     fn next(&mut self) -> Option<Self::Item> {}
    = note:   expected enum `Option<_>`
            found unit type `()`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0046, E0207, E0308, E0392, E0637.
+Some errors have detailed explanations: E0046, E0207, E0308, E0392, E0520, E0637.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
+++ b/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
@@ -11,7 +11,7 @@ LL | trait Trait<const N: dyn Trait = bar> {
    |                          ^^^^^
    |
    = note: ...which immediately requires computing type of `Trait::N` again
-note: cycle used when computing explicit predicates of trait `Trait`
+note: cycle used when checking that `Trait` is well-formed
   --> $DIR/not_wf_param_in_rpitit.rs:3:1
    |
 LL | trait Trait<const N: dyn Trait = bar> {

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -17,19 +17,19 @@ LL | const CONST_FOO: str = *"foo";
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:11:18
+  --> $DIR/const-unsized.rs:11:1
    |
 LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
-   |                  ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:15:20
+  --> $DIR/const-unsized.rs:15:1
    |
 LL | static STATIC_BAR: str = *"bar";
-   |                    ^^^ doesn't have a size known at compile-time
+   | ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -24,10 +24,10 @@ LL |     static FOO: dyn Sync = AtomicUsize::new(0);
    |                 +++
 
 error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:5
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
-   |                 ^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
    = note: statics and constants must have a statically known size

--- a/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
+++ b/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dont-ctfe-unsized-initializer.rs:1:11
+  --> $DIR/dont-ctfe-unsized-initializer.rs:1:1
    |
 LL | static S: str = todo!();
-   |           ^^^ doesn't have a size known at compile-time
+   | ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -29,7 +29,7 @@ LL | struct S<const S: (), const S: S = { S }>;
    |                                ^
    |
    = note: ...which immediately requires computing type of `S::S` again
-note: cycle used when computing explicit predicates of `S`
+note: cycle used when checking that `S` is well-formed
   --> $DIR/issue-103790.rs:4:1
    |
 LL | struct S<const S: (), const S: S = { S }>;

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
@@ -8,10 +8,8 @@ LL | trait Chromosome: Chromosome {
 note: cycle used when checking that `Chromosome` is well-formed
   --> $DIR/cycle-trait-supertrait-direct.rs:3:1
    |
-LL | / trait Chromosome: Chromosome {
-LL | |
-LL | | }
-   | |_^
+LL | trait Chromosome: Chromosome {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/cycle-trait/issue-12511.stderr
+++ b/tests/ui/cycle-trait/issue-12511.stderr
@@ -13,10 +13,8 @@ LL | trait T2 : T1 {
 note: cycle used when checking that `T1` is well-formed
   --> $DIR/issue-12511.rs:1:1
    |
-LL | / trait T1 : T2 {
-LL | |
-LL | | }
-   | |_^
+LL | trait T1 : T2 {
+   | ^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/delegation/unsupported.stderr
+++ b/tests/ui/delegation/unsupported.stderr
@@ -10,11 +10,11 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>` is well-formed
-  --> $DIR/unsupported.rs:21:5
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:22:25
    |
-LL |     impl ToReuse for u8 {
-   |     ^^^^^^^^^^^^^^^^^^^
+LL |         reuse to_reuse::opaque_ret;
+   |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>::opaque_ret::{anon_assoc#0}`
@@ -29,11 +29,11 @@ note: ...which requires comparing an impl and trait method signature, inferring 
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>` is well-formed
-  --> $DIR/unsupported.rs:24:5
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:25:24
    |
-LL |     impl ToReuse for u16 {
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |         reuse ToReuse::opaque_ret;
+   |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: recursive delegation is not supported yet

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:27:18
+  --> $DIR/explicit-drop-bounds.rs:32:5
    |
-LL | impl<T> Drop for DropMe<T>
-   |                  ^^^^^^^^^ the trait `Copy` is not implemented for `T`
+LL |     fn drop(&mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18
@@ -15,10 +15,10 @@ LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply
    |                   ++++++++++++++++++++
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:32:5
+  --> $DIR/explicit-drop-bounds.rs:27:18
    |
-LL |     fn drop(&mut self) {}
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+LL | impl<T> Drop for DropMe<T>
+   |                  ^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18

--- a/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:38:18
+  --> $DIR/explicit-drop-bounds.rs:41:5
    |
-LL | impl<T> Drop for DropMe<T>
-   |                  ^^^^^^^^^ the trait `Copy` is not implemented for `T`
+LL |     fn drop(&mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18
@@ -15,10 +15,10 @@ LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/explicit-drop-bounds.rs:41:5
+  --> $DIR/explicit-drop-bounds.rs:38:18
    |
-LL |     fn drop(&mut self) {}
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+LL | impl<T> Drop for DropMe<T>
+   |                  ^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `DropMe`
   --> $DIR/explicit-drop-bounds.rs:7:18

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.rs
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.rs
@@ -3,5 +3,6 @@ struct Foo {}
 impl<const UNUSED: usize> Drop for Foo {}
 //~^ ERROR: `Drop` impl requires `the constant `_` has type `usize``
 //~| ERROR: the const parameter `UNUSED` is not constrained by the impl trait, self type, or predicates
+//~| ERROR: missing: `drop`
 
 fn main() {}

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
@@ -10,6 +10,14 @@ note: the implementor must specify the same requirement
 LL | struct Foo {}
    | ^^^^^^^^^^
 
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/unconstrained_const_param_on_drop.rs:3:1
+   |
+LL | impl<const UNUSED: usize> Drop for Foo {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+
 error[E0207]: the const parameter `UNUSED` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained_const_param_on_drop.rs:3:6
    |
@@ -19,7 +27,7 @@ LL | impl<const UNUSED: usize> Drop for Foo {}
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0207, E0367.
-For more information about an error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0046, E0207, E0367.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/enum-discriminant/eval-error.stderr
+++ b/tests/ui/enum-discriminant/eval-error.stderr
@@ -15,6 +15,18 @@ LL | |     A
 LL | | }
    | |_- not a struct or union
 
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/eval-error.rs:2:5
+   |
+LL |     a: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     a: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/eval-error.rs:2:8
    |
@@ -32,18 +44,6 @@ help: the `Box` type always has a statically known size and allocates its conten
    |
 LL |     a: Box<str>,
    |        ++++   +
-
-error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/eval-error.rs:2:5
-   |
-LL |     a: str,
-   |     ^^^^^^
-   |
-   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
-help: wrap the field type in `ManuallyDrop<...>`
-   |
-LL |     a: std::mem::ManuallyDrop<str>,
-   |        +++++++++++++++++++++++   +
 
 error[E0080]: the type `Foo` has an unknown layout
   --> $DIR/eval-error.rs:9:30

--- a/tests/ui/error-codes/E0081.stderr
+++ b/tests/ui/error-codes/E0081.stderr
@@ -73,6 +73,14 @@ LL |
 LL |     V9,
    |     -- `-2` assigned here
 
+error[E0370]: enum discriminant overflowed
+  --> $DIR/E0081.rs:87:5
+   |
+LL |     X256,
+   |     ^^^^ overflowed on value after 255
+   |
+   = note: explicitly set `X256 = 0` if that is desired outcome
+
 error[E0081]: discriminant value `0` assigned more than once
   --> $DIR/E0081.rs:57:1
    |
@@ -87,14 +95,6 @@ LL |     X000, X001, X002, X003, X004, X005, X006, X007, X008, X009,
 ...
 LL |     X256,
    |     ---- `0` assigned here
-
-error[E0370]: enum discriminant overflowed
-  --> $DIR/E0081.rs:87:5
-   |
-LL |     X256,
-   |     ^^^^ overflowed on value after 255
-   |
-   = note: explicitly set `X256 = 0` if that is desired outcome
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/error-codes/E0081.stderr
+++ b/tests/ui/error-codes/E0081.stderr
@@ -73,14 +73,6 @@ LL |
 LL |     V9,
    |     -- `-2` assigned here
 
-error[E0370]: enum discriminant overflowed
-  --> $DIR/E0081.rs:87:5
-   |
-LL |     X256,
-   |     ^^^^ overflowed on value after 255
-   |
-   = note: explicitly set `X256 = 0` if that is desired outcome
-
 error[E0081]: discriminant value `0` assigned more than once
   --> $DIR/E0081.rs:57:1
    |
@@ -95,6 +87,14 @@ LL |     X000, X001, X002, X003, X004, X005, X006, X007, X008, X009,
 ...
 LL |     X256,
    |     ---- `0` assigned here
+
+error[E0370]: enum discriminant overflowed
+  --> $DIR/E0081.rs:87:5
+   |
+LL |     X256,
+   |     ^^^^ overflowed on value after 255
+   |
+   = note: explicitly set `X256 = 0` if that is desired outcome
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
-  --> $DIR/issue-36122-accessing-externed-dst.rs:3:24
+  --> $DIR/issue-36122-accessing-externed-dst.rs:3:9
    |
 LL |         static symbol: [usize];
-   |                        ^^^^^^^ doesn't have a size known at compile-time
+   |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[usize]`
    = note: statics and constants must have a statically known size

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -56,6 +56,19 @@ LL | impl Fn<()> for Foo {
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
+error[E0053]: method `call` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:32
+   |
+LL |     extern "rust-call" fn call(self, args: ()) -> () {}
+   |                                ^^^^ expected `&Foo`, found `Foo`
+   |
+   = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
+              found signature `extern "rust-call" fn(Foo, ()) -> ()`
+help: change the self-receiver type to match the trait
+   |
+LL |     extern "rust-call" fn call(&self, args: ()) -> () {}
+   |                                +
+
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
@@ -84,19 +97,6 @@ LL | impl Fn<()> for Foo {
    = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error[E0053]: method `call` has an incompatible type for trait
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:32
-   |
-LL |     extern "rust-call" fn call(self, args: ()) -> () {}
-   |                                ^^^^ expected `&Foo`, found `Foo`
-   |
-   = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
-              found signature `extern "rust-call" fn(Foo, ()) -> ()`
-help: change the self-receiver type to match the trait
-   |
-LL |     extern "rust-call" fn call(&self, args: ()) -> () {}
-   |                                +
 
 error[E0183]: manual implementations of `FnOnce` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
@@ -144,17 +144,6 @@ LL | impl FnOnce() for Foo1 {
    |
    = help: implement the missing item: `type Output = /* Type */;`
 
-error[E0277]: expected a `FnOnce()` closure, found `Bar`
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
-   |
-LL | impl FnMut<()> for Bar {
-   |                    ^^^ expected an `FnOnce()` closure, found `Bar`
-   |
-   = help: the trait `FnOnce()` is not implemented for `Bar`
-   = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
-note: required by a bound in `FnMut`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
 error[E0053]: method `call_mut` has an incompatible type for trait
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:36
    |
@@ -167,6 +156,17 @@ help: change the self-receiver type to match the trait
    |
 LL |     extern "rust-call" fn call_mut(&mut self, args: ()) -> () {}
    |                                     +++
+
+error[E0277]: expected a `FnOnce()` closure, found `Bar`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
+   |
+LL | impl FnMut<()> for Bar {
+   |                    ^^^ expected an `FnOnce()` closure, found `Bar`
+   |
+   = help: the trait `FnOnce()` is not implemented for `Bar`
+   = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `FnMut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error[E0046]: not all trait items implemented, missing: `Output`
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:1

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -10,6 +10,14 @@ help: parenthesized trait syntax expands to `Fn<(u32,), Output=u32>`
 LL | impl Fn(u32) -> u32 for S {
    |      ^^^^^^^^^^^^^^
 
+error[E0050]: method `call` has 1 parameter but the declaration in trait `call` has 2
+  --> $DIR/issue-39259.rs:9:13
+   |
+LL |     fn call(&self) -> u32 {
+   |             ^^^^^ expected 2 parameters, found 1
+   |
+   = note: `call` from trait: `extern "rust-call" fn(&Self, Args) -> <Self as FnOnce<Args>>::Output`
+
 error[E0277]: expected a `FnMut(u32)` closure, found `S`
   --> $DIR/issue-39259.rs:6:25
    |
@@ -19,14 +27,6 @@ LL | impl Fn(u32) -> u32 for S {
    = help: the trait `FnMut(u32)` is not implemented for `S`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error[E0050]: method `call` has 1 parameter but the declaration in trait `call` has 2
-  --> $DIR/issue-39259.rs:9:13
-   |
-LL |     fn call(&self) -> u32 {
-   |             ^^^^^ expected 2 parameters, found 1
-   |
-   = note: `call` from trait: `extern "rust-call" fn(&Self, Args) -> <Self as FnOnce<Args>>::Output`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/bugs/issue-87735.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-87735.stderr
@@ -5,12 +5,13 @@ LL | impl<'b, T, U> AsRef2 for Foo<T>
    |             ^ unconstrained type parameter
 
 error[E0309]: the parameter type `U` may not live long enough
-  --> $DIR/issue-87735.rs:34:21
+  --> $DIR/issue-87735.rs:34:3
    |
 LL |   type Output<'a> = FooRef<'a, U> where Self: 'a;
-   |               --    ^^^^^^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds...
-   |               |
-   |               the parameter type `U` must be valid for the lifetime `'a` as defined here...
+   |   ^^^^^^^^^^^^--^
+   |   |           |
+   |   |           the parameter type `U` must be valid for the lifetime `'a` as defined here...
+   |   ...so that the type `U` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/issue-87735.rs:23:22

--- a/tests/ui/generic-associated-types/bugs/issue-88526.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88526.stderr
@@ -5,12 +5,13 @@ LL | impl<'q, Q, I, F> A for TestB<Q, F>
    |             ^ unconstrained type parameter
 
 error[E0309]: the parameter type `F` may not live long enough
-  --> $DIR/issue-88526.rs:16:18
+  --> $DIR/issue-88526.rs:16:5
    |
 LL |     type I<'a> = &'a F;
-   |            --    ^^^^^ ...so that the reference type `&'a F` does not outlive the data it points at
-   |            |
-   |            the parameter type `F` must be valid for the lifetime `'a` as defined here...
+   |     ^^^^^^^--^
+   |     |      |
+   |     |      the parameter type `F` must be valid for the lifetime `'a` as defined here...
+   |     ...so that the reference type `&'a F` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |

--- a/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.rs
@@ -9,6 +9,7 @@ impl <T, T1> Foo for T {
     type F<T1> = &[u8];
       //~^ ERROR: the name `T1` is already used for
       //~| ERROR: `&` without an explicit lifetime name cannot be used here
+      //~| ERROR: has 1 type parameter but its trait declaration has 0 type parameters
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
@@ -13,13 +13,22 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     type F<T1> = &[u8];
    |                  ^ explicit lifetime name needed here
 
+error[E0049]: associated type `F` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/gat-trait-path-generic-type-arg.rs:9:12
+   |
+LL |     type F<'a>;
+   |            -- expected 0 type parameters
+...
+LL |     type F<T1> = &[u8];
+   |            ^^ found 1 type parameter
+
 error[E0207]: the type parameter `T1` is not constrained by the impl trait, self type, or predicates
   --> $DIR/gat-trait-path-generic-type-arg.rs:7:10
    |
 LL | impl <T, T1> Foo for T {
    |          ^^ unconstrained type parameter
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0207, E0403, E0637.
-For more information about an error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0049, E0207, E0403, E0637.
+For more information about an error, try `rustc --explain E0049`.

--- a/tests/ui/generic-associated-types/issue-84931.stderr
+++ b/tests/ui/generic-associated-types/issue-84931.stderr
@@ -18,12 +18,13 @@ LL |     type Item<'a> = &'a mut T where Self: 'a;
    |                               ++++++++++++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/issue-84931.rs:14:21
+  --> $DIR/issue-84931.rs:14:5
    |
 LL |     type Item<'a> = &'a mut T;
-   |               --    ^^^^^^^^^ ...so that the reference type `&'a mut T` does not outlive the data it points at
-   |               |
-   |               the parameter type `T` must be valid for the lifetime `'a` as defined here...
+   |     ^^^^^^^^^^--^
+   |     |         |
+   |     |         the parameter type `T` must be valid for the lifetime `'a` as defined here...
+   |     ...so that the reference type `&'a mut T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |

--- a/tests/ui/generic-associated-types/static-lifetime-tip-with-default-type.stderr
+++ b/tests/ui/generic-associated-types/static-lifetime-tip-with-default-type.stderr
@@ -82,6 +82,14 @@ help: consider adding an explicit lifetime bound
 LL | struct Far<T: 'static
    |             +++++++++
 
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/static-lifetime-tip-with-default-type.rs:22:10
+   |
+LL | struct S<'a, K: 'a = i32>(&'static K);
+   |          ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
 error[E0310]: the parameter type `K` may not live long enough
   --> $DIR/static-lifetime-tip-with-default-type.rs:22:27
    |
@@ -95,14 +103,6 @@ help: consider adding an explicit lifetime bound
    |
 LL | struct S<'a, K: 'a + 'static = i32>(&'static K);
    |                    +++++++++
-
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/static-lifetime-tip-with-default-type.rs:22:10
-   |
-LL | struct S<'a, K: 'a = i32>(&'static K);
-   |          ^^ unused lifetime parameter
-   |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/generic-const-items/evaluatable-bounds.stderr
+++ b/tests/ui/generic-const-items/evaluatable-bounds.stderr
@@ -2,7 +2,7 @@ error: unconstrained generic constant
   --> $DIR/evaluatable-bounds.rs:14:5
    |
 LL |     const ARRAY: [i32; Self::LEN];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: try adding a `where` bound
    |

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -53,10 +53,10 @@ LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EthernetWorker`
 
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:22:20
+  --> $DIR/issue-89118.rs:22:5
    |
 LL |     type Handler = Ctx<C::Dispatcher>;
-   |                    ^^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
+   |     ^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-89118.rs:1:1

--- a/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
+++ b/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
@@ -19,6 +19,28 @@ help: consider further restricting type parameter `F` with trait `MyFn`
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
 
+error[E0277]: the trait bound `F: MyFn<i32>` is not satisfied
+  --> $DIR/false-positive-predicate-entailment-error.rs:36:5
+   |
+LL | /     fn autobatch<F>(self) -> impl Trait
+...  |
+LL | |     where
+LL | |         F: Callback<Self::CallbackArg>,
+   | |_______________________________________^ the trait `MyFn<i32>` is not implemented for `F`
+   |
+note: required for `F` to implement `Callback<i32>`
+  --> $DIR/false-positive-predicate-entailment-error.rs:14:21
+   |
+LL | impl<A, F: MyFn<A>> Callback<A> for F {
+   |            -------  ^^^^^^^^^^^     ^
+   |            |
+   |            unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider further restricting type parameter `F` with trait `MyFn`
+   |
+LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
+   |                                        +++++++++++
+
 error[E0277]: the trait bound `F: Callback<i32>` is not satisfied
   --> $DIR/false-positive-predicate-entailment-error.rs:42:12
    |
@@ -40,28 +62,6 @@ LL | trait ChannelSender {
 ...
 LL |     fn autobatch<F>(self) -> impl Trait
    |        ^^^^^^^^^ this trait's method doesn't have the requirement `F: Callback<i32>`
-help: consider further restricting type parameter `F` with trait `MyFn`
-   |
-LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
-   |                                        +++++++++++
-
-error[E0277]: the trait bound `F: MyFn<i32>` is not satisfied
-  --> $DIR/false-positive-predicate-entailment-error.rs:36:5
-   |
-LL | /     fn autobatch<F>(self) -> impl Trait
-...  |
-LL | |     where
-LL | |         F: Callback<Self::CallbackArg>,
-   | |_______________________________________^ the trait `MyFn<i32>` is not implemented for `F`
-   |
-note: required for `F` to implement `Callback<i32>`
-  --> $DIR/false-positive-predicate-entailment-error.rs:14:21
-   |
-LL | impl<A, F: MyFn<A>> Callback<A> for F {
-   |            -------  ^^^^^^^^^^^     ^
-   |            |
-   |            unsatisfied trait bound introduced here
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
@@ -46,11 +46,11 @@ note: ...which requires type-checking `<impl at $DIR/method-compatability-via-le
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking that `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>` is well-formed
-  --> $DIR/method-compatability-via-leakage-cycle.rs:17:1
+note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
+  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
-LL | impl Trait for u32 {
-   | ^^^^^^^^^^^^^^^^^^
+LL |     fn foo(b: bool) -> impl Sized {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
@@ -50,11 +50,11 @@ note: ...which requires type-checking `<impl at $DIR/method-compatability-via-le
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking that `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>` is well-formed
-  --> $DIR/method-compatability-via-leakage-cycle.rs:17:1
+note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
+  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
-LL | impl Trait for u32 {
-   | ^^^^^^^^^^^^^^^^^^
+LL |     fn foo(b: bool) -> impl Sized {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0391]: cycle detected when computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`
@@ -109,11 +109,11 @@ note: ...which requires type-checking `<impl at $DIR/method-compatability-via-le
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking that `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>` is well-formed
-  --> $DIR/method-compatability-via-leakage-cycle.rs:17:1
+note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
+  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
-LL | impl Trait for u32 {
-   | ^^^^^^^^^^^^^^^^^^
+LL |     fn foo(b: bool) -> impl Sized {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.rs
@@ -9,6 +9,7 @@ pub trait Mirror {
 impl<T: ?Sized> Mirror for () {
     //~^ ERROR the type parameter `T` is not constrained
     type Assoc = T;
+    //~^ ERROR the size for values of type `T` cannot be known at compilation time
 }
 
 pub trait First {

--- a/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-resolution-errors.stderr
@@ -4,6 +4,31 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Mirror for () {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/refine-resolution-errors.rs:11:18
+   |
+LL | impl<T: ?Sized> Mirror for () {
+   |      - this type parameter needs to be `Sized`
+LL |
+LL |     type Assoc = T;
+   |                  ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Mirror::Assoc`
+  --> $DIR/refine-resolution-errors.rs:7:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Mirror::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Mirror for () {
+LL + impl<T> Mirror for () {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/impl-trait/in-trait/span-bug-issue-121457.stderr
+++ b/tests/ui/impl-trait/in-trait/span-bug-issue-121457.stderr
@@ -1,3 +1,15 @@
+error[E0195]: lifetime parameters or bounds on associated type `Item` do not match the trait declaration
+  --> $DIR/span-bug-issue-121457.rs:10:14
+   |
+LL |     type Item<'a>
+   |              ---- lifetimes in impl do not match this associated type in trait
+LL |     where
+LL |         Self: 'a;
+   |               -- this bound might be missing in the impl
+...
+LL |     type Item = u32;
+   |              ^ lifetimes do not match associated type in trait
+
 error[E0582]: binding for associated type `Item` references lifetime `'missing`, which does not appear in the trait input types
   --> $DIR/span-bug-issue-121457.rs:13:51
    |
@@ -11,18 +23,6 @@ LL |     fn iter(&self) -> impl for<'missing> Iterator<Item = Self::Item<'missin
    |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0195]: lifetime parameters or bounds on associated type `Item` do not match the trait declaration
-  --> $DIR/span-bug-issue-121457.rs:10:14
-   |
-LL |     type Item<'a>
-   |              ---- lifetimes in impl do not match this associated type in trait
-LL |     where
-LL |         Self: 'a;
-   |               -- this bound might be missing in the impl
-...
-LL |     type Item = u32;
-   |              ^ lifetimes do not match associated type in trait
 
 error[E0277]: `()` is not an iterator
   --> $DIR/span-bug-issue-121457.rs:13:23

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.rs
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.rs
@@ -6,6 +6,7 @@ impl<'a, T> Foo for T {
     //~^ ERROR the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
 
     fn test() -> &'a () {
+        //~^ WARN: does not match trait method signature
         &()
     }
 }

--- a/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
+++ b/tests/ui/impl-trait/in-trait/unconstrained-lt.stderr
@@ -1,9 +1,27 @@
+warning: impl trait in impl method signature does not match trait method signature
+  --> $DIR/unconstrained-lt.rs:8:18
+   |
+LL |     fn test() -> impl Sized;
+   |                  ---------- return type from trait method defined here
+...
+LL |     fn test() -> &'a () {
+   |                  ^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+   = note: `#[warn(refining_impl_trait_internal)]` on by default
+help: replace the return type so that it matches the trait
+   |
+LL -     fn test() -> &'a () {
+LL +     fn test() -> impl Sized {
+   |
+
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-lt.rs:5:6
    |
 LL | impl<'a, T> Foo for T {
    |      ^^ unconstrained lifetime parameter
 
-error: aborting due to 1 previous error
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/implied-bounds/impl-header-unnormalized-types.stderr
+++ b/tests/ui/implied-bounds/impl-header-unnormalized-types.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a &'b ()`, reference has a longer lifetime than the data it references
-  --> $DIR/impl-header-unnormalized-types.rs:15:18
+  --> $DIR/impl-header-unnormalized-types.rs:15:5
    |
 LL |     type Assoc = &'a &'b ();
-   |                  ^^^^^^^^^^
+   |     ^^^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/impl-header-unnormalized-types.rs:14:6

--- a/tests/ui/infinite/infinite-trait-alias-recursion.stderr
+++ b/tests/ui/infinite/infinite-trait-alias-recursion.stderr
@@ -20,7 +20,7 @@ note: cycle used when checking that `T1` is well-formed
   --> $DIR/infinite-trait-alias-recursion.rs:3:1
    |
 LL | trait T1 = T2;
-   | ^^^^^^^^^^^^^^
+   | ^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/infinite/infinite-type-alias-mutual-recursion.feature.stderr
+++ b/tests/ui/infinite/infinite-type-alias-mutual-recursion.feature.stderr
@@ -1,24 +1,24 @@
 error[E0275]: overflow normalizing the type alias `X2`
-  --> $DIR/infinite-type-alias-mutual-recursion.rs:6:11
+  --> $DIR/infinite-type-alias-mutual-recursion.rs:6:1
    |
 LL | type X1 = X2;
-   |           ^^
+   | ^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
 error[E0275]: overflow normalizing the type alias `X3`
-  --> $DIR/infinite-type-alias-mutual-recursion.rs:9:11
+  --> $DIR/infinite-type-alias-mutual-recursion.rs:9:1
    |
 LL | type X2 = X3;
-   |           ^^
+   | ^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
 error[E0275]: overflow normalizing the type alias `X1`
-  --> $DIR/infinite-type-alias-mutual-recursion.rs:11:11
+  --> $DIR/infinite-type-alias-mutual-recursion.rs:11:1
    |
 LL | type X3 = X1;
-   |           ^^
+   | ^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 

--- a/tests/ui/infinite/infinite-vec-type-recursion.feature.stderr
+++ b/tests/ui/infinite/infinite-vec-type-recursion.feature.stderr
@@ -1,8 +1,8 @@
 error[E0275]: overflow normalizing the type alias `X`
-  --> $DIR/infinite-vec-type-recursion.rs:6:10
+  --> $DIR/infinite-vec-type-recursion.rs:6:1
    |
 LL | type X = Vec<X>;
-   |          ^^^^^^
+   | ^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
-  --> $DIR/issue-54410.rs:2:28
+  --> $DIR/issue-54410.rs:2:5
    |
 LL |     pub static mut symbol: [i8];
-   |                            ^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i8]`
    = note: statics and constants must have a statically known size

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `RefCell<isize>` cannot be shared between threads safely
-  --> $DIR/issue-7364.rs:4:15
+  --> $DIR/issue-7364.rs:4:1
    |
 LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
-   |               ^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<isize>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead

--- a/tests/ui/layout/ice-non-last-unsized-field-issue-121473.stderr
+++ b/tests/ui/layout/ice-non-last-unsized-field-issue-121473.stderr
@@ -70,6 +70,18 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |         field2: Box<str>, // Unsized
    |                 ++++   +
 
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/ice-non-last-unsized-field-issue-121473.rs:46:5
+   |
+LL |     field2: str, // Unsized
+   |     ^^^^^^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     field2: std::mem::ManuallyDrop<str>, // Unsized
+   |             +++++++++++++++++++++++   +
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/ice-non-last-unsized-field-issue-121473.rs:46:13
    |
@@ -87,18 +99,6 @@ help: the `Box` type always has a statically known size and allocates its conten
    |
 LL |     field2: Box<str>, // Unsized
    |             ++++   +
-
-error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/ice-non-last-unsized-field-issue-121473.rs:46:5
-   |
-LL |     field2: str, // Unsized
-   |     ^^^^^^^^^^^
-   |
-   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
-help: wrap the field type in `ManuallyDrop<...>`
-   |
-LL |     field2: std::mem::ManuallyDrop<str>, // Unsized
-   |             +++++++++++++++++++++++   +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -1,4 +1,17 @@
 error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
+  --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:31:5
+   |
+LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
+   |
+note: required by a bound in `FnOnce`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
+   |
+LL |     A: Eq + Hash + Clone + std::marker::Tuple,
+   |                          ++++++++++++++++++++
+
+error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
   --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:24:12
    |
 LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
@@ -12,9 +25,9 @@ LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
 
 error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
-  --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:31:5
+  --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:45:5
    |
-LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
+LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnOnce`
@@ -31,19 +44,6 @@ LL | impl<A, B> FnMut<A> for CachedFun<A, B>
    |            ^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
 note: required by a bound in `FnMut`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting type parameter `A` with unstable trait `Tuple`
-   |
-LL |     A: Eq + Hash + Clone + std::marker::Tuple,
-   |                          ++++++++++++++++++++
-
-error[E0059]: type parameter to bare `FnOnce` trait must be a tuple
-  --> $DIR/rust-call-abi-not-a-tuple-ice-81974.rs:45:5
-   |
-LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
-   |
-note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -14,6 +14,17 @@ LL | impl Loop {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
+error: type parameter `T` is only used recursively
+  --> $DIR/inherent-impls-overflow.rs:17:24
+   |
+LL | type Poly0<T> = Poly1<(T,)>;
+   |            -           ^
+   |            |
+   |            type parameter must be used non-recursively in the definition
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
+
 error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:17:17
    |
@@ -21,6 +32,17 @@ LL | type Poly0<T> = Poly1<(T,)>;
    |                 ^^^^^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: type parameter `T` is only used recursively
+  --> $DIR/inherent-impls-overflow.rs:21:24
+   |
+LL | type Poly1<T> = Poly0<(T,)>;
+   |            -           ^
+   |            |
+   |            type parameter must be used non-recursively in the definition
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
 
 error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
   --> $DIR/inherent-impls-overflow.rs:21:17
@@ -38,6 +60,6 @@ LL | impl Poly0<()> {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.current.stderr
@@ -1,8 +1,8 @@
 error[E0275]: overflow normalizing the type alias `Loop`
-  --> $DIR/inherent-impls-overflow.rs:8:13
+  --> $DIR/inherent-impls-overflow.rs:8:1
    |
 LL | type Loop = Loop;
-   |             ^^^^
+   | ^^^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
@@ -14,41 +14,19 @@ LL | impl Loop {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: type parameter `T` is only used recursively
-  --> $DIR/inherent-impls-overflow.rs:17:24
-   |
-LL | type Poly0<T> = Poly1<(T,)>;
-   |            -           ^
-   |            |
-   |            type parameter must be used non-recursively in the definition
-   |
-   = help: consider removing `T` or referring to it in the body of the type alias
-   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
-
 error[E0275]: overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
-  --> $DIR/inherent-impls-overflow.rs:17:17
+  --> $DIR/inherent-impls-overflow.rs:17:1
    |
 LL | type Poly0<T> = Poly1<(T,)>;
-   |                 ^^^^^^^^^^^
+   | ^^^^^^^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: type parameter `T` is only used recursively
-  --> $DIR/inherent-impls-overflow.rs:21:24
-   |
-LL | type Poly1<T> = Poly0<(T,)>;
-   |            -           ^
-   |            |
-   |            type parameter must be used non-recursively in the definition
-   |
-   = help: consider removing `T` or referring to it in the body of the type alias
-   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
-
 error[E0275]: overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
-  --> $DIR/inherent-impls-overflow.rs:21:17
+  --> $DIR/inherent-impls-overflow.rs:21:1
    |
 LL | type Poly1<T> = Poly0<(T,)>;
-   |                 ^^^^^^^^^^^
+   | ^^^^^^^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
@@ -60,6 +38,6 @@ LL | impl Poly0<()> {}
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
@@ -1,8 +1,8 @@
 error[E0271]: type mismatch resolving `Loop normalizes-to _`
-  --> $DIR/inherent-impls-overflow.rs:8:13
+  --> $DIR/inherent-impls-overflow.rs:8:1
    |
 LL | type Loop = Loop;
-   |             ^^^^ types differ
+   | ^^^^^^^^^ types differ
 
 error[E0271]: type mismatch resolving `Loop normalizes-to _`
   --> $DIR/inherent-impls-overflow.rs:12:1
@@ -16,6 +16,14 @@ error[E0271]: type mismatch resolving `Loop normalizes-to _`
 LL | impl Loop {}
    |      ^^^^ types differ
 
+error[E0275]: overflow evaluating the requirement `Poly1<(T,)> == _`
+  --> $DIR/inherent-impls-overflow.rs:17:1
+   |
+LL | type Poly0<T> = Poly1<(T,)>;
+   | ^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
+
 error: type parameter `T` is only used recursively
   --> $DIR/inherent-impls-overflow.rs:17:24
    |
@@ -27,11 +35,11 @@ LL | type Poly0<T> = Poly1<(T,)>;
    = help: consider removing `T` or referring to it in the body of the type alias
    = note: all type parameters must be used in a non-recursive way in order to constrain their variance
 
-error[E0275]: overflow evaluating the requirement `Poly1<(T,)> == _`
-  --> $DIR/inherent-impls-overflow.rs:17:17
+error[E0275]: overflow evaluating the requirement `Poly0<(T,)> == _`
+  --> $DIR/inherent-impls-overflow.rs:21:1
    |
-LL | type Poly0<T> = Poly1<(T,)>;
-   |                 ^^^^^^^^^^^
+LL | type Poly1<T> = Poly0<(T,)>;
+   | ^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
 
@@ -45,14 +53,6 @@ LL | type Poly1<T> = Poly0<(T,)>;
    |
    = help: consider removing `T` or referring to it in the body of the type alias
    = note: all type parameters must be used in a non-recursive way in order to constrain their variance
-
-error[E0275]: overflow evaluating the requirement `Poly0<(T,)> == _`
-  --> $DIR/inherent-impls-overflow.rs:21:17
-   |
-LL | type Poly1<T> = Poly0<(T,)>;
-   |                 ^^^^^^^^^^^
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
 
 error[E0275]: overflow evaluating the requirement `Poly0<()> == _`
   --> $DIR/inherent-impls-overflow.rs:26:1

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
@@ -16,14 +16,6 @@ error[E0271]: type mismatch resolving `Loop normalizes-to _`
 LL | impl Loop {}
    |      ^^^^ types differ
 
-error[E0275]: overflow evaluating the requirement `Poly1<(T,)> == _`
-  --> $DIR/inherent-impls-overflow.rs:17:17
-   |
-LL | type Poly0<T> = Poly1<(T,)>;
-   |                 ^^^^^^^^^^^
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
-
 error: type parameter `T` is only used recursively
   --> $DIR/inherent-impls-overflow.rs:17:24
    |
@@ -35,10 +27,10 @@ LL | type Poly0<T> = Poly1<(T,)>;
    = help: consider removing `T` or referring to it in the body of the type alias
    = note: all type parameters must be used in a non-recursive way in order to constrain their variance
 
-error[E0275]: overflow evaluating the requirement `Poly0<(T,)> == _`
-  --> $DIR/inherent-impls-overflow.rs:21:17
+error[E0275]: overflow evaluating the requirement `Poly1<(T,)> == _`
+  --> $DIR/inherent-impls-overflow.rs:17:17
    |
-LL | type Poly1<T> = Poly0<(T,)>;
+LL | type Poly0<T> = Poly1<(T,)>;
    |                 ^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
@@ -53,6 +45,14 @@ LL | type Poly1<T> = Poly0<(T,)>;
    |
    = help: consider removing `T` or referring to it in the body of the type alias
    = note: all type parameters must be used in a non-recursive way in order to constrain their variance
+
+error[E0275]: overflow evaluating the requirement `Poly0<(T,)> == _`
+  --> $DIR/inherent-impls-overflow.rs:21:17
+   |
+LL | type Poly1<T> = Poly0<(T,)>;
+   |                 ^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
 
 error[E0275]: overflow evaluating the requirement `Poly0<()> == _`
   --> $DIR/inherent-impls-overflow.rs:26:1

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -16,12 +16,12 @@ impl Loop {}
 
 type Poly0<T> = Poly1<(T,)>;
 //[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
-//~^^ ERROR type parameter `T` is only used recursively
-//[next]~^^^ ERROR overflow evaluating the requirement
+//[next]~^^ ERROR type parameter `T` is only used recursively
+//[next]~| ERROR overflow evaluating the requirement
 type Poly1<T> = Poly0<(T,)>;
 //[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
-//~^^ ERROR type parameter `T` is only used recursively
-//[next]~^^^ ERROR overflow evaluating the requirement
+//[next]~^^ ERROR type parameter `T` is only used recursively
+//[next]~| ERROR overflow evaluating the requirement
 
 impl Poly0<()> {}
 //[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -16,12 +16,12 @@ impl Loop {}
 
 type Poly0<T> = Poly1<(T,)>;
 //[current]~^ ERROR overflow normalizing the type alias `Poly0<(((((((...,),),),),),),)>`
-//[next]~^^ ERROR type parameter `T` is only used recursively
-//[next]~| ERROR overflow evaluating the requirement
+//~^^ ERROR type parameter `T` is only used recursively
+//[next]~^^^ ERROR overflow evaluating the requirement
 type Poly1<T> = Poly0<(T,)>;
 //[current]~^ ERROR  overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`
-//[next]~^^ ERROR type parameter `T` is only used recursively
-//[next]~| ERROR overflow evaluating the requirement
+//~^^ ERROR type parameter `T` is only used recursively
+//[next]~^^^ ERROR overflow evaluating the requirement
 
 impl Poly0<()> {}
 //[current]~^ ERROR overflow normalizing the type alias `Poly1<(((((((...,),),),),),),)>`

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
@@ -4,6 +4,5 @@
 impl<T> Loop<T> {} //~ ERROR the type parameter `T` is not constrained
 
 type Loop<T> = Loop<T>; //~ ERROR overflow
-//~^ ERROR: `T` is only used recursively
 
 fn main() {}

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
@@ -4,5 +4,6 @@
 impl<T> Loop<T> {} //~ ERROR the type parameter `T` is not constrained
 
 type Loop<T> = Loop<T>; //~ ERROR overflow
+//~^ ERROR: `T` is only used recursively
 
 fn main() {}

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
@@ -4,26 +4,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> Loop<T> {}
    |      ^ unconstrained type parameter
 
-error: type parameter `T` is only used recursively
-  --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:21
-   |
-LL | type Loop<T> = Loop<T>;
-   |           -         ^
-   |           |
-   |           type parameter must be used non-recursively in the definition
-   |
-   = help: consider removing `T` or referring to it in the body of the type alias
-   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
-
 error[E0275]: overflow normalizing the type alias `Loop<T>`
-  --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:16
+  --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:1
    |
 LL | type Loop<T> = Loop<T>;
-   |                ^^^^^^^
+   | ^^^^^^^^^^^^
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0207, E0275.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
@@ -4,6 +4,17 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> Loop<T> {}
    |      ^ unconstrained type parameter
 
+error: type parameter `T` is only used recursively
+  --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:21
+   |
+LL | type Loop<T> = Loop<T>;
+   |           -         ^
+   |           |
+   |           type parameter must be used non-recursively in the definition
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
+
 error[E0275]: overflow normalizing the type alias `Loop<T>`
   --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:16
    |
@@ -12,7 +23,7 @@ LL | type Loop<T> = Loop<T>;
    |
    = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0207, E0275.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
+++ b/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
@@ -7,12 +7,6 @@ LL |     beta: [(); foo::<&'a ()>()],
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error: generic `Self` types are currently not permitted in anonymous constants
-  --> $DIR/issue-64173-unused-lifetimes.rs:4:28
-   |
-LL |     array: [(); size_of::<&Self>()],
-   |                            ^^^^
-
 error[E0392]: lifetime parameter `'s` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:3:12
    |
@@ -20,6 +14,12 @@ LL | struct Foo<'s> {
    |            ^^ unused lifetime parameter
    |
    = help: consider removing `'s`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/issue-64173-unused-lifetimes.rs:4:28
+   |
+LL |     array: [(); size_of::<&Self>()],
+   |                            ^^^^
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:15:12

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.rs
@@ -7,10 +7,12 @@ async fn wrapper<F>(f: F)
 //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 //~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 where
 F:,
 for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+//~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+//~| ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
 {
     //~^ ERROR: expected a `FnOnce(&'a mut i32)` closure, found `i32`
     let mut i = 41;

--- a/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
+++ b/tests/ui/lifetimes/issue-76168-hr-outlives-3.stderr
@@ -10,10 +10,26 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:6:10
+  --> $DIR/issue-76168-hr-outlives-3.rs:12:50
    |
-LL | async fn wrapper<F>(f: F)
-   |          ^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
+LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   |                                                  ^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+  --> $DIR/issue-76168-hr-outlives-3.rs:12:57
+   |
+LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   |                                                         ^^^^^^^^^^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
+   |
+   = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
+
+error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
+  --> $DIR/issue-76168-hr-outlives-3.rs:12:72
+   |
+LL | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a,
+   |                                                                        ^^ expected an `FnOnce(&'a mut i32)` closure, found `i32`
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
@@ -41,7 +57,7 @@ LL | | for<'a> <i32 as FnOnce<(&'a mut i32,)>>::Output: Future<Output = ()> + 'a
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `FnOnce(&'a mut i32)` closure, found `i32`
-  --> $DIR/issue-76168-hr-outlives-3.rs:14:1
+  --> $DIR/issue-76168-hr-outlives-3.rs:16:1
    |
 LL | / {
 LL | |
@@ -52,6 +68,6 @@ LL | | }
    |
    = help: the trait `for<'a> FnOnce(&'a mut i32)` is not implemented for `i32`
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -32,6 +32,14 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-95023.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
 error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
   --> $DIR/issue-95023.rs:3:21
    |
@@ -41,14 +49,6 @@ LL | impl Fn(&isize) for Error {
    = help: the trait `FnMut(&isize)` is not implemented for `Error`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error[E0046]: not all trait items implemented, missing: `call`
-  --> $DIR/issue-95023.rs:3:1
-   |
-LL | impl Fn(&isize) for Error {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
-   |
-   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
 
 error[E0220]: associated type `B` not found for `Self`
   --> $DIR/issue-95023.rs:8:44

--- a/tests/ui/macros/macro-span-issue-116502.stderr
+++ b/tests/ui/macros/macro-span-issue-116502.stderr
@@ -4,6 +4,17 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |             _
    |             ^ not allowed in type signatures
 ...
+LL |     struct S<T = m!()>(m!(), T)
+   |                  ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
 LL |         T: Trait<m!()>;
    |                  ---- in this macro invocation
    |
@@ -17,17 +28,6 @@ LL |             _
 ...
 LL |     struct S<T = m!()>(m!(), T)
    |                        ---- in this macro invocation
-   |
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/macro-span-issue-116502.rs:7:13
-   |
-LL |             _
-   |             ^ not allowed in type signatures
-...
-LL |     struct S<T = m!()>(m!(), T)
-   |                  ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/methods/filter-relevant-fn-bounds.rs
+++ b/tests/ui/methods/filter-relevant-fn-bounds.rs
@@ -7,11 +7,10 @@ struct Wrapper;
 impl Wrapper {
     fn do_something_wrapper<O, F>(self, _: F)
     //~^ ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
-    //~| ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
     where
         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-        //~^ ERROR the trait bound `F: Output<'_>` is not satisfied
-        //~| ERROR the trait bound `F: Output<'_>` is not satisfied
+        //~^ ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
+        //~| ERROR the trait bound `for<'a> F: Output<'a>` is not satisfied
     {
     }
 }

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -3,7 +3,6 @@ error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
    |
 LL | /     fn do_something_wrapper<O, F>(self, _: F)
 LL | |
-LL | |
 LL | |     where
 LL | |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    | |___________________________________________________^ the trait `for<'a> Output<'a>` is not implemented for `F`
@@ -14,54 +13,43 @@ LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
 
 error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
-  --> $DIR/filter-relevant-fn-bounds.rs:8:8
+  --> $DIR/filter-relevant-fn-bounds.rs:11:12
    |
-LL |     fn do_something_wrapper<O, F>(self, _: F)
-   |        ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
+LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
 help: consider further restricting type parameter `F` with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
 
-error[E0277]: the trait bound `F: Output<'_>` is not satisfied
-  --> $DIR/filter-relevant-fn-bounds.rs:12:12
+error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
+  --> $DIR/filter-relevant-fn-bounds.rs:11:20
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
 help: consider further restricting type parameter `F` with trait `Output`
    |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
-   |                                                    ++++++++++++
+LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
+   |                                                    ++++++++++++++++++++
 
-error[E0277]: the trait bound `F: Output<'_>` is not satisfied
-  --> $DIR/filter-relevant-fn-bounds.rs:12:20
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
-   |
-help: consider further restricting type parameter `F` with trait `Output`
-   |
-LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
-   |                                                    ++++++++++++
-
-error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:21:34: 21:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:21:34: 21:41}`
-  --> $DIR/filter-relevant-fn-bounds.rs:21:34
+error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+  --> $DIR/filter-relevant-fn-bounds.rs:20:34
    |
 LL |     wrapper.do_something_wrapper(|value| ());
-   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:21:34: 21:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:21:34: 21:41}`
+   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Output<'a>` is not implemented for closure `{closure@$DIR/filter-relevant-fn-bounds.rs:21:34: 21:41}`
+   = help: the trait `for<'a> Output<'a>` is not implemented for closure `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
 help: this trait has no implementations, consider adding one
   --> $DIR/filter-relevant-fn-bounds.rs:1:1
    |
 LL | trait Output<'a> {
    | ^^^^^^^^^^^^^^^^
 note: required by a bound in `Wrapper::do_something_wrapper`
-  --> $DIR/filter-relevant-fn-bounds.rs:12:12
+  --> $DIR/filter-relevant-fn-bounds.rs:11:12
    |
 LL |     fn do_something_wrapper<O, F>(self, _: F)
    |        -------------------- required by a bound in this associated function
@@ -69,6 +57,6 @@ LL |     fn do_something_wrapper<O, F>(self, _: F)
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Wrapper::do_something_wrapper`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
+++ b/tests/ui/regions/lifetime-not-long-enough-suggestion-regression-test-124563.stderr
@@ -1,8 +1,8 @@
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:19:16
+  --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:19:5
    |
 LL |     type Bar = BarImpl<'a, 'b, T>;
-   |                ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/lifetime-not-long-enough-suggestion-regression-test-124563.rs:14:6

--- a/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -4,6 +4,14 @@ error[E0226]: only a single explicit lifetime bound is permitted
 LL |     z: Box<dyn Is<'a>+'b+'c>,
    |                          ^^
 
+error[E0392]: lifetime parameter `'c` is never used
+  --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:18
+   |
+LL | struct Foo<'a,'b,'c> {
+   |                  ^^ unused lifetime parameter
+   |
+   = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
+
 error[E0478]: lifetime bound not satisfied
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:21:8
    |
@@ -20,14 +28,6 @@ note: but lifetime parameter must outlive the lifetime `'a` as defined here
    |
 LL | struct Foo<'a,'b,'c> {
    |            ^^
-
-error[E0392]: lifetime parameter `'c` is never used
-  --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:18
-   |
-LL | struct Foo<'a,'b,'c> {
-   |                  ^^ unused lifetime parameter
-   |
-   = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/regions/regions-normalize-in-where-clause-list.rs
+++ b/tests/ui/regions/regions-normalize-in-where-clause-list.rs
@@ -22,9 +22,9 @@ where
 
 // Here we get an error: we need `'a: 'b`.
 fn bar<'a, 'b>()
-//~^ ERROR cannot infer
 where
     <() as Project<'a, 'b>>::Item: Eq,
+    //~^ ERROR cannot infer
 {
 }
 

--- a/tests/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/tests/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -1,8 +1,8 @@
 error[E0803]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/regions-normalize-in-where-clause-list.rs:24:4
+  --> $DIR/regions-normalize-in-where-clause-list.rs:26:36
    |
-LL | fn bar<'a, 'b>()
-   |    ^^^
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |                                    ^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:8
@@ -15,10 +15,10 @@ note: ...but the lifetime must also be valid for the lifetime `'b` as defined he
 LL | fn bar<'a, 'b>()
    |            ^^
 note: ...so that the types are compatible
-  --> $DIR/regions-normalize-in-where-clause-list.rs:24:4
+  --> $DIR/regions-normalize-in-where-clause-list.rs:26:36
    |
-LL | fn bar<'a, 'b>()
-   |    ^^^
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |                                    ^^
    = note: expected `Project<'a, 'b>`
               found `Project<'_, '_>`
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-region-rev.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-region-rev.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a Foo<'b>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-nominal-type-region-rev.rs:17:20
+  --> $DIR/regions-outlives-nominal-type-region-rev.rs:17:9
    |
 LL |         type Out = &'a Foo<'b>;
-   |                    ^^^^^^^^^^^
+   |         ^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-region-rev.rs:16:10

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-region.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-region.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a Foo<'b>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-nominal-type-region.rs:17:20
+  --> $DIR/regions-outlives-nominal-type-region.rs:17:9
    |
 LL |         type Out = &'a Foo<'b>;
-   |                    ^^^^^^^^^^^
+   |         ^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-region.rs:16:10

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-type-rev.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-type-rev.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a Foo<&'b i32>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-nominal-type-type-rev.rs:17:20
+  --> $DIR/regions-outlives-nominal-type-type-rev.rs:17:9
    |
 LL |         type Out = &'a Foo<&'b i32>;
-   |                    ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-type-rev.rs:16:10

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-type.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-outlives-nominal-type-type.stderr
@@ -1,8 +1,8 @@
 error[E0491]: in type `&'a Foo<&'b i32>`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-outlives-nominal-type-type.rs:17:20
+  --> $DIR/regions-outlives-nominal-type-type.rs:17:9
    |
 LL |         type Out = &'a Foo<&'b i32>;
-   |                    ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-outlives-nominal-type-type.rs:16:10

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-struct-not-wf.stderr
@@ -1,10 +1,10 @@
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/regions-struct-not-wf.rs:13:16
+  --> $DIR/regions-struct-not-wf.rs:13:5
    |
 LL | impl<'a, T> Trait<'a, T> for usize {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a T;
-   |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |     ^^^^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |
@@ -12,12 +12,12 @@ LL | impl<'a, T: 'a> Trait<'a, T> for usize {
    |           ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/regions-struct-not-wf.rs:21:16
+  --> $DIR/regions-struct-not-wf.rs:21:5
    |
 LL | impl<'a, T> Trait<'a, T> for u32 {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = RefOk<'a, T>;
-   |                ^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |     ^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
    |
 note: ...that is required by this bound
   --> $DIR/regions-struct-not-wf.rs:16:20
@@ -30,10 +30,10 @@ LL | impl<'a, T: 'a> Trait<'a, T> for u32 {
    |           ++++
 
 error[E0491]: in type `&'a &'b T`, reference has a longer lifetime than the data it references
-  --> $DIR/regions-struct-not-wf.rs:25:16
+  --> $DIR/regions-struct-not-wf.rs:25:5
    |
 LL |     type Out = &'a &'b T;
-   |                ^^^^^^^^^
+   |     ^^^^^^^^
    |
 note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/regions-struct-not-wf.rs:24:6

--- a/tests/ui/simd/array-trait.stderr
+++ b/tests/ui/simd/array-trait.stderr
@@ -1,3 +1,9 @@
+error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+  --> $DIR/array-trait.rs:22:1
+   |
+LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
+   | ^^^^^^^^^^^^^^^^^^^^^
+
 error: unconstrained generic constant
   --> $DIR/array-trait.rs:22:23
    |
@@ -8,12 +14,6 @@ help: try adding a `where` bound
    |
 LL | pub struct T<S: Simd>([S::Lane; S::SIZE]) where [(); S::SIZE]:;
    |                                           ++++++++++++++++++++
-
-error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
-  --> $DIR/array-trait.rs:22:1
-   |
-LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: unconstrained generic constant
   --> $DIR/array-trait.rs:22:23

--- a/tests/ui/specialization/defaultimpl/validation.stderr
+++ b/tests/ui/specialization/defaultimpl/validation.stderr
@@ -18,14 +18,6 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error: impls of auto traits cannot be default
-  --> $DIR/validation.rs:9:21
-   |
-LL | default unsafe impl Send for S {}
-   | -------             ^^^^ auto trait
-   | |
-   | default because of this
-
 error[E0367]: `!Send` impl requires `Z: Send` but the struct it is implemented for does not
   --> $DIR/validation.rs:12:1
    |
@@ -37,6 +29,14 @@ note: the implementor must specify the same requirement
    |
 LL | struct Z;
    | ^^^^^^^^
+
+error: impls of auto traits cannot be default
+  --> $DIR/validation.rs:9:21
+   |
+LL | default unsafe impl Send for S {}
+   | -------             ^^^^ auto trait
+   | |
+   | default because of this
 
 error: impls of auto traits cannot be default
   --> $DIR/validation.rs:12:15

--- a/tests/ui/specialization/issue-51892.stderr
+++ b/tests/ui/specialization/issue-51892.stderr
@@ -1,8 +1,8 @@
 error: unconstrained generic constant
-  --> $DIR/issue-51892.rs:14:17
+  --> $DIR/issue-51892.rs:14:5
    |
 LL |     type Type = [u8; std::mem::size_of::<<T as Trait>::Type>()];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^
    |
 help: try adding a `where` bound
    |

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `B: Clone` is not satisfied
-  --> $DIR/issue-79224.rs:28:29
+  --> $DIR/issue-79224.rs:30:5
    |
-LL | impl<B: ?Sized> Display for Cow<'_, B> {
-   |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
+LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting type parameter `B` with trait `Clone`
@@ -11,10 +11,10 @@ LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
 
 error[E0277]: the trait bound `B: Clone` is not satisfied
-  --> $DIR/issue-79224.rs:30:5
+  --> $DIR/issue-79224.rs:28:29
    |
-LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
+LL | impl<B: ?Sized> Display for Cow<'_, B> {
+   |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting type parameter `B` with trait `Clone`

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -1,12 +1,3 @@
-error[E0658]: use of unstable library feature `unstable_default`
-  --> $DIR/generics-default-stability-where.rs:7:45
-   |
-LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
-   |                                             ^^^^^
-   |
-   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
   --> $DIR/generics-default-stability-where.rs:7:6
    |
@@ -15,6 +6,15 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
+
+error[E0658]: use of unstable library feature `unstable_default`
+  --> $DIR/generics-default-stability-where.rs:7:45
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |                                             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -1,12 +1,3 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/generics-default-stability-where.rs:7:6
-   |
-LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
-   |
-   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
-   = note: only traits defined in the current crate can be implemented for a type parameter
-
 error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability-where.rs:7:45
    |
@@ -15,6 +6,15 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/generics-default-stability-where.rs:7:6
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -1,17 +1,17 @@
 error[E0277]: `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
-  --> $DIR/issue-24446.rs:2:17
+  --> $DIR/issue-24446.rs:2:5
    |
 LL |     static foo: dyn Fn() -> u32 = || -> u32 {
-   |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
    = note: shared static variables must have a type that implements `Sync`
 
 error[E0277]: the size for values of type `(dyn Fn() -> u32 + 'static)` cannot be known at compilation time
-  --> $DIR/issue-24446.rs:2:17
+  --> $DIR/issue-24446.rs:2:5
    |
 LL |     static foo: dyn Fn() -> u32 = || -> u32 {
-   |                 ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
    = note: statics and constants must have a statically known size

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Foo` cannot be shared between threads safely
-  --> $DIR/issue-17718-static-sync.rs:9:13
+  --> $DIR/issue-17718-static-sync.rs:9:1
    |
 LL | static BAR: Foo = Foo;
-   |             ^^^ `Foo` cannot be shared between threads safely
+   | ^^^^^^^^^^^^^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
    = note: shared static variables must have a type that implements `Sync`

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -1,8 +1,8 @@
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:6:5
+  --> $DIR/uninhabited-static.rs:12:1
    |
-LL |     static VOID: Void;
-   |     ^^^^^^^^^^^^^^^^^
+LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
+   | ^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
@@ -14,30 +14,30 @@ LL | #![deny(uninhabited_static)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:8:5
-   |
-LL |     static NEVER: !;
-   |     ^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
-   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
-
-error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:12:1
-   |
-LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
-   | ^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
-   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
-
-error: static of uninhabited type
   --> $DIR/uninhabited-static.rs:15:1
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:6:5
+   |
+LL |     static VOID: Void;
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:8:5
+   |
+LL |     static NEVER: !;
+   |     ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>

--- a/tests/ui/statics/unsized_type2.stderr
+++ b/tests/ui/statics/unsized_type2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized_type2.rs:14:24
+  --> $DIR/unsized_type2.rs:14:1
    |
 LL | pub static WITH_ERROR: Foo = Foo { version: 0 };
-   |                        ^^^ doesn't have a size known at compile-time
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Foo`, the trait `Sized` is not implemented for `str`
 note: required because it appears within the type `Foo`

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -22,10 +22,10 @@ LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++
 
 error[E0277]: `(dyn Qux + 'static)` cannot be shared between threads safely
-  --> $DIR/unsizing-wfcheck-issue-127299.rs:12:13
+  --> $DIR/unsizing-wfcheck-issue-127299.rs:12:1
    |
 LL | static FOO: &Lint = &Lint { desc: "desc" };
-   |             ^^^^^ `(dyn Qux + 'static)` cannot be shared between threads safely
+   | ^^^^^^^^^^^^^^^^^ `(dyn Qux + 'static)` cannot be shared between threads safely
    |
    = help: within `&'static Lint`, the trait `Sync` is not implemented for `(dyn Qux + 'static)`
    = note: required because it appears within the type `&'static (dyn Qux + 'static)`

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -1,9 +1,3 @@
-error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
-   |
-LL | impl<T, S> Trait<T> for i32 {
-   |         ^ unconstrained type parameter
-
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12
    |
@@ -15,6 +9,12 @@ note: trait defined here, with 1 generic parameter: `T`
    |
 LL | pub trait Trait<T> {
    |           ^^^^^ -
+
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
+   |
+LL | impl<T, S> Trait<T> for i32 {
+   |         ^ unconstrained type parameter
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:19:12

--- a/tests/ui/traits/constrained-type-params-trait-impl.stderr
+++ b/tests/ui/traits/constrained-type-params-trait-impl.stderr
@@ -35,6 +35,17 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
 LL | impl<T, U> Foo<T> for [isize; 1] {
    |         ^ unconstrained type parameter
 
+error[E0119]: conflicting implementations of trait `Bar`
+  --> $DIR/constrained-type-params-trait-impl.rs:48:1
+   |
+LL |   impl<T, U> Bar for T {
+   |   -------------------- first implementation here
+...
+LL | / impl<T, U> Bar for T
+LL | | where
+LL | |     T: Bar<Out = U>,
+   | |____________________^ conflicting implementation
+
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/constrained-type-params-trait-impl.rs:42:9
    |
@@ -58,17 +69,6 @@ error[E0207]: the type parameter `V` is not constrained by the impl trait, self 
    |
 LL | impl<T, U, V> Foo<T> for T
    |            ^ unconstrained type parameter
-
-error[E0119]: conflicting implementations of trait `Bar`
-  --> $DIR/constrained-type-params-trait-impl.rs:48:1
-   |
-LL |   impl<T, U> Bar for T {
-   |   -------------------- first implementation here
-...
-LL | / impl<T, U> Bar for T
-LL | | where
-LL | |     T: Bar<Out = U>,
-   | |____________________^ conflicting implementation
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/traits/deep-norm-pending.rs
+++ b/tests/ui/traits/deep-norm-pending.rs
@@ -8,13 +8,13 @@ trait Bar {
 }
 impl<T> Bar for T
 //~^ ERROR the trait bound `T: Foo` is not satisfied
-//~| ERROR the trait bound `T: Foo` is not satisfied
 where
     <T as Foo>::Assoc: Sized,
+    //~^ ERROR the trait bound `T: Foo` is not satisfied
+    //~| ERROR the trait bound `T: Foo` is not satisfied
 {
     fn method() {}
     //~^ ERROR the trait bound `T: Foo` is not satisfied
-    //~| ERROR the trait bound `T: Foo` is not satisfied
     //~| ERROR the trait bound `T: Foo` is not satisfied
     //~| ERROR the trait bound `T: Foo` is not satisfied
     //~| ERROR the trait bound `T: Foo` is not satisfied

--- a/tests/ui/traits/deep-norm-pending.stderr
+++ b/tests/ui/traits/deep-norm-pending.stderr
@@ -3,7 +3,6 @@ error[E0277]: the trait bound `T: Foo` is not satisfied
    |
 LL | / impl<T> Bar for T
 LL | |
-LL | |
 LL | | where
 LL | |     <T as Foo>::Assoc: Sized,
    | |_____________________________^ the trait `Foo` is not implemented for `T`
@@ -14,7 +13,7 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
+  --> $DIR/deep-norm-pending.rs:16:5
    |
 LL |     fn method() {}
    |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
@@ -25,7 +24,7 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
+  --> $DIR/deep-norm-pending.rs:16:5
    |
 LL |     fn method() {}
    |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
@@ -37,7 +36,7 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
+  --> $DIR/deep-norm-pending.rs:16:5
    |
 LL |     fn method() {}
    |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
@@ -56,7 +55,7 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
+  --> $DIR/deep-norm-pending.rs:16:5
    |
 LL |     fn method() {}
    |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
@@ -87,15 +86,10 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:9:1
+  --> $DIR/deep-norm-pending.rs:12:24
    |
-LL | / impl<T> Bar for T
-LL | |
-LL | |
-LL | | where
-...  |
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `T`
+LL |     <T as Foo>::Assoc: Sized,
+   |                        ^^^^^ the trait `Foo` is not implemented for `T`
    |
 help: consider further restricting type parameter `T` with trait `Foo`
    |
@@ -103,7 +97,7 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
+  --> $DIR/deep-norm-pending.rs:16:5
    |
 LL |     fn method() {}
    |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
@@ -115,11 +109,12 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:8
+  --> $DIR/deep-norm-pending.rs:12:24
    |
-LL |     fn method() {}
-   |        ^^^^^^ the trait `Foo` is not implemented for `T`
+LL |     <T as Foo>::Assoc: Sized,
+   |                        ^^^^^ the trait `Foo` is not implemented for `T`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     <T as Foo>::Assoc: Sized, T: Foo

--- a/tests/ui/traits/deep-norm-pending.stderr
+++ b/tests/ui/traits/deep-norm-pending.stderr
@@ -1,15 +1,4 @@
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:15:5
-   |
-LL |     fn method() {}
-   |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
-   |
-help: consider further restricting type parameter `T` with trait `Foo`
-   |
-LL |     <T as Foo>::Assoc: Sized, T: Foo
-   |                               ++++++
-
-error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/deep-norm-pending.rs:9:1
    |
 LL | / impl<T> Bar for T
@@ -25,15 +14,10 @@ LL |     <T as Foo>::Assoc: Sized, T: Foo
    |                               ++++++
 
 error[E0277]: the trait bound `T: Foo` is not satisfied
-  --> $DIR/deep-norm-pending.rs:9:1
+  --> $DIR/deep-norm-pending.rs:15:5
    |
-LL | / impl<T> Bar for T
-LL | |
-LL | |
-LL | | where
-...  |
-LL | | }
-   | |_^ the trait `Foo` is not implemented for `T`
+LL |     fn method() {}
+   |     ^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
    |
 help: consider further restricting type parameter `T` with trait `Foo`
    |
@@ -97,6 +81,22 @@ LL | impl<T> Bar for T
 ...
 LL |     <T as Foo>::Assoc: Sized,
    |                        ----- unsatisfied trait bound introduced here
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL |     <T as Foo>::Assoc: Sized, T: Foo
+   |                               ++++++
+
+error[E0277]: the trait bound `T: Foo` is not satisfied
+  --> $DIR/deep-norm-pending.rs:9:1
+   |
+LL | / impl<T> Bar for T
+LL | |
+LL | |
+LL | | where
+...  |
+LL | | }
+   | |_^ the trait `Foo` is not implemented for `T`
+   |
 help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     <T as Foo>::Assoc: Sized, T: Foo

--- a/tests/ui/traits/issue-105231.stderr
+++ b/tests/ui/traits/issue-105231.stderr
@@ -1,3 +1,14 @@
+error: type parameter `T` is only used recursively
+  --> $DIR/issue-105231.rs:1:15
+   |
+LL | struct A<T>(B<T>);
+   |          -    ^
+   |          |
+   |          type parameter must be used non-recursively in the definition
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
+
 error[E0072]: recursive types `A` and `B` have infinite size
   --> $DIR/issue-105231.rs:1:1
    |
@@ -14,17 +25,6 @@ LL |
 LL |
 LL ~ struct B<T>(Box<A<A<T>>>);
    |
-
-error: type parameter `T` is only used recursively
-  --> $DIR/issue-105231.rs:1:15
-   |
-LL | struct A<T>(B<T>);
-   |          -    ^
-   |          |
-   |          type parameter must be used non-recursively in the definition
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = note: all type parameters must be used in a non-recursive way in order to constrain their variance
 
 error: type parameter `T` is only used recursively
   --> $DIR/issue-105231.rs:4:17

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -56,6 +56,12 @@ LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
    = help: add `#![feature(dispatch_from_dyn)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0377]: the trait `DispatchFromDyn` may only be implemented for a coercion between structures
+  --> $DIR/issue-78372.rs:3:1
+   |
+LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0307]: invalid `self` parameter type: `Smaht<Self, T>`
   --> $DIR/issue-78372.rs:9:18
    |
@@ -64,12 +70,6 @@ LL |     fn foo(self: Smaht<Self, T>);
    |
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
-
-error[E0377]: the trait `DispatchFromDyn` may only be implemented for a coercion between structures
-  --> $DIR/issue-78372.rs:3:1
-   |
-LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -24,6 +24,14 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-87558.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
 error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
   --> $DIR/issue-87558.rs:3:21
    |
@@ -33,14 +41,6 @@ LL | impl Fn(&isize) for Error {
    = help: the trait `FnMut(&isize)` is not implemented for `Error`
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-
-error[E0046]: not all trait items implemented, missing: `call`
-  --> $DIR/issue-87558.rs:3:1
-   |
-LL | impl Fn(&isize) for Error {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
-   |
-   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -14,10 +14,10 @@ LL | #![feature(lazy_type_alias)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the trait bound `*const T: ToUnit<'a>` is not satisfied
-  --> $DIR/issue-118950-root-region.rs:14:21
+  --> $DIR/issue-118950-root-region.rs:14:1
    |
 LL | type Assoc<'a, T> = <*const T as ToUnit<'a>>::Unit;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ToUnit<'a>` is not implemented for `*const T`
+   | ^^^^^^^^^^^^^^^^^ the trait `ToUnit<'a>` is not implemented for `*const T`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-118950-root-region.rs:8:1

--- a/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -9,7 +9,7 @@ note: cycle used when checking that `A` is well-formed
   --> $DIR/cyclic-trait-resolution.rs:1:1
    |
 LL | trait A: B + A {}
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0391]: cycle detected when computing the implied predicates of `A`

--- a/tests/ui/traits/unconstrained-projection-normalization-2.current.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization-2.current.stderr
@@ -4,6 +4,31 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/unconstrained-projection-normalization-2.rs:16:18
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      - this type parameter needs to be `Sized`
+LL |
+LL |     type Assoc = T;
+   |                  ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Every::Assoc`
+  --> $DIR/unconstrained-projection-normalization-2.rs:12:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Every for Thing {
+LL + impl<T> Every for Thing {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/traits/unconstrained-projection-normalization-2.next.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization-2.next.stderr
@@ -4,13 +4,37 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
 
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/unconstrained-projection-normalization-2.rs:16:18
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      - this type parameter needs to be `Sized`
+LL |
+LL |     type Assoc = T;
+   |                  ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Every::Assoc`
+  --> $DIR/unconstrained-projection-normalization-2.rs:12:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Every for Thing {
+LL + impl<T> Every for Thing {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
+
 error[E0282]: type annotations needed
-  --> $DIR/unconstrained-projection-normalization-2.rs:19:11
+  --> $DIR/unconstrained-projection-normalization-2.rs:20:11
    |
 LL | fn foo(_: <Thing as Every>::Assoc) {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for associated type `<Thing as Every>::Assoc`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0207, E0282.
+Some errors have detailed explanations: E0207, E0277, E0282.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/traits/unconstrained-projection-normalization-2.rs
+++ b/tests/ui/traits/unconstrained-projection-normalization-2.rs
@@ -12,8 +12,9 @@ pub trait Every {
     type Assoc;
 }
 impl<T: ?Sized> Every for Thing {
-//~^ ERROR the type parameter `T` is not constrained
+    //~^ ERROR the type parameter `T` is not constrained
     type Assoc = T;
+    //~^ ERROR: the size for values of type `T` cannot be known at compilation time
 }
 
 fn foo(_: <Thing as Every>::Assoc) {}

--- a/tests/ui/traits/unconstrained-projection-normalization.current.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization.current.stderr
@@ -4,6 +4,31 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/unconstrained-projection-normalization.rs:15:18
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      - this type parameter needs to be `Sized`
+LL |
+LL |     type Assoc = T;
+   |                  ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Every::Assoc`
+  --> $DIR/unconstrained-projection-normalization.rs:11:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Every for Thing {
+LL + impl<T> Every for Thing {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/traits/unconstrained-projection-normalization.next.stderr
+++ b/tests/ui/traits/unconstrained-projection-normalization.next.stderr
@@ -4,6 +4,31 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/unconstrained-projection-normalization.rs:15:18
+   |
+LL | impl<T: ?Sized> Every for Thing {
+   |      - this type parameter needs to be `Sized`
+LL |
+LL |     type Assoc = T;
+   |                  ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Every::Assoc`
+  --> $DIR/unconstrained-projection-normalization.rs:11:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Every::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Every for Thing {
+LL + impl<T> Every for Thing {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/traits/unconstrained-projection-normalization.rs
+++ b/tests/ui/traits/unconstrained-projection-normalization.rs
@@ -11,8 +11,9 @@ pub trait Every {
     type Assoc;
 }
 impl<T: ?Sized> Every for Thing {
-//~^ ERROR the type parameter `T` is not constrained
+    //~^ ERROR the type parameter `T` is not constrained
     type Assoc = T;
+    //~^ ERROR: the size for values of type `T` cannot be known at compilation time
 }
 
 static I: <Thing as Every>::Assoc = 3;

--- a/tests/ui/typeck/issue-13853-5.rs
+++ b/tests/ui/typeck/issue-13853-5.rs
@@ -1,4 +1,4 @@
-trait Deserializer<'a> { }
+trait Deserializer<'a> {}
 
 trait Deserializable {
     fn deserialize_token<'a, D: Deserializer<'a>>(_: D, _: &'a str) -> Self;
@@ -8,6 +8,7 @@ impl<'a, T: Deserializable> Deserializable for &'a str {
     //~^ ERROR type parameter `T` is not constrained
     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
         //~^ ERROR mismatched types
+        //~| ERROR do not match the trait declaration
     }
 }
 

--- a/tests/ui/typeck/issue-13853-5.stderr
+++ b/tests/ui/typeck/issue-13853-5.stderr
@@ -1,3 +1,12 @@
+error[E0195]: lifetime parameters or bounds on associated function `deserialize_token` do not match the trait declaration
+  --> $DIR/issue-13853-5.rs:9:25
+   |
+LL |     fn deserialize_token<'a, D: Deserializer<'a>>(_: D, _: &'a str) -> Self;
+   |                         ------------------------- lifetimes in impl do not match this associated function in trait
+...
+LL |     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
+   |                         ^^^^^^^^^^^^^^^^^^^^^ lifetimes do not match associated function in trait
+
 error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-13853-5.rs:7:10
    |
@@ -19,7 +28,7 @@ LL ~         _y
 LL ~
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0207, E0308.
-For more information about an error, try `rustc --explain E0207`.
+Some errors have detailed explanations: E0195, E0207, E0308.
+For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/union/issue-81199.stderr
+++ b/tests/ui/union/issue-81199.stderr
@@ -1,3 +1,15 @@
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/issue-81199.rs:5:5
+   |
+LL |     components: PtrComponents<T>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     components: std::mem::ManuallyDrop<PtrComponents<T>>,
+   |                 +++++++++++++++++++++++                +
+
 error[E0277]: the trait bound `T: Pointee` is not satisfied
   --> $DIR/issue-81199.rs:5:17
    |
@@ -13,18 +25,6 @@ help: consider further restricting type parameter `T` with trait `Pointee`
    |
 LL | union PtrRepr<T: ?Sized + Pointee> {
    |                         +++++++++
-
-error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/issue-81199.rs:5:5
-   |
-LL |     components: PtrComponents<T>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
-help: wrap the field type in `ManuallyDrop<...>`
-   |
-LL |     components: std::mem::ManuallyDrop<PtrComponents<T>>,
-   |                 +++++++++++++++++++++++                +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/union/union-unsized.stderr
+++ b/tests/ui/union/union-unsized.stderr
@@ -1,3 +1,15 @@
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/union-unsized.rs:2:5
+   |
+LL |     a: str,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     a: std::mem::ManuallyDrop<str>,
+   |        +++++++++++++++++++++++   +
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/union-unsized.rs:2:8
    |
@@ -17,15 +29,15 @@ LL |     a: Box<str>,
    |        ++++   +
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/union-unsized.rs:2:5
+  --> $DIR/union-unsized.rs:11:5
    |
-LL |     a: str,
+LL |     b: str,
    |     ^^^^^^
    |
    = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
 help: wrap the field type in `ManuallyDrop<...>`
    |
-LL |     a: std::mem::ManuallyDrop<str>,
+LL |     b: std::mem::ManuallyDrop<str>,
    |        +++++++++++++++++++++++   +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
@@ -45,18 +57,6 @@ help: the `Box` type always has a statically known size and allocates its conten
    |
 LL |     b: Box<str>,
    |        ++++   +
-
-error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/union-unsized.rs:11:5
-   |
-LL |     b: str,
-   |     ^^^^^^
-   |
-   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
-help: wrap the field type in `ManuallyDrop<...>`
-   |
-LL |     b: std::mem::ManuallyDrop<str>,
-   |        +++++++++++++++++++++++   +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -1,3 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/unsized-trait-impl-self-type.rs:10:1
+   |
+LL |     fn foo(&self, z: &Z);
+   |     --------------------- `foo` from trait
+...
+LL | impl<X: ?Sized> T3<X> for S5<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
+
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-self-type.rs:10:27
    |
@@ -23,15 +32,6 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 LL - impl<X: ?Sized> T3<X> for S5<X> {
 LL + impl<X> T3<X> for S5<X> {
    |
-
-error[E0046]: not all trait items implemented, missing: `foo`
-  --> $DIR/unsized-trait-impl-self-type.rs:10:1
-   |
-LL |     fn foo(&self, z: &Z);
-   |     --------------------- `foo` from trait
-...
-LL | impl<X: ?Sized> T3<X> for S5<X> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -1,3 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/unsized-trait-impl-trait-arg.rs:8:1
+   |
+LL |     fn foo(&self, z: Z);
+   |     -------------------- `foo` from trait
+...
+LL | impl<X: ?Sized> T2<X> for S4<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
+
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
    |
@@ -20,15 +29,6 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait T2<Z: ?Sized> {
    |           ++++++++
-
-error[E0046]: not all trait items implemented, missing: `foo`
-  --> $DIR/unsized-trait-impl-trait-arg.rs:8:1
-   |
-LL |     fn foo(&self, z: Z);
-   |     -------------------- `foo` from trait
-...
-LL | impl<X: ?Sized> T2<X> for S4<X> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -1,3 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `dummy`
+  --> $DIR/unsized7.rs:12:1
+   |
+LL |     fn dummy(&self) -> Z;
+   |     --------------------- `dummy` from trait
+...
+LL | impl<X: ?Sized + T> T1<X> for S3<X> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `dummy` in implementation
+
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized7.rs:12:21
    |
@@ -20,15 +29,6 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait T1<Z: T + ?Sized> {
    |               ++++++++
-
-error[E0046]: not all trait items implemented, missing: `dummy`
-  --> $DIR/unsized7.rs:12:1
-   |
-LL |     fn dummy(&self) -> Z;
-   |     --------------------- `dummy` from trait
-...
-LL | impl<X: ?Sized + T> T1<X> for S3<X> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `dummy` in implementation
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/variance/variance-regions-unused-indirect.stderr
+++ b/tests/ui/variance/variance-regions-unused-indirect.stderr
@@ -1,3 +1,11 @@
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/variance-regions-unused-indirect.rs:3:10
+   |
+LL | enum Foo<'a> {
+   |          ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
 error[E0072]: recursive types `Foo` and `Bar` have infinite size
   --> $DIR/variance-regions-unused-indirect.rs:3:1
    |
@@ -20,14 +28,6 @@ LL |
 LL | enum Bar<'a> {
 LL ~     Bar1(Box<Foo<'a>>)
    |
-
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/variance-regions-unused-indirect.rs:3:10
-   |
-LL | enum Foo<'a> {
-   |          ^^ unused lifetime parameter
-   |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:8:10

--- a/tests/ui/wf/hir-wf-check-erase-regions.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.stderr
@@ -11,10 +11,10 @@ note: required by a bound in `std::iter::IntoIterator::IntoIter`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 
 error[E0277]: `&'a T` is not an iterator
-  --> $DIR/hir-wf-check-erase-regions.rs:7:21
+  --> $DIR/hir-wf-check-erase-regions.rs:7:5
    |
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
+   |     ^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&'a T`
    = help: the trait `Iterator` is implemented for `&mut I`

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -32,7 +32,7 @@ LL | trait Trait<const N: dyn Trait = bar> {
    |                          ^^^^^
    |
    = note: ...which immediately requires computing type of `Trait::N` again
-note: cycle used when computing explicit predicates of trait `Trait`
+note: cycle used when checking that `Trait` is well-formed
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:1:1
    |
 LL | trait Trait<const N: dyn Trait = bar> {

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -37,7 +37,7 @@ note: ...which requires computing type of `Bar::M`...
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `Foo::N`, completing the cycle
-note: cycle used when computing explicit predicates of trait `Foo`
+note: cycle used when checking that `Foo` is well-formed
   --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:1
    |
 LL | trait Foo<const N: Bar<2>> {
@@ -56,7 +56,7 @@ note: ...which requires computing type of `Bar::M`...
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
    = note: ...which again requires computing type of `Foo::N`, completing the cycle
-note: cycle used when computing explicit predicates of trait `Foo`
+note: cycle used when checking that `Foo` is well-formed
   --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:1
    |
 LL | trait Foo<const N: Bar<2>> {

--- a/tests/ui/wf/wf-impl-associated-type-region.stderr
+++ b/tests/ui/wf/wf-impl-associated-type-region.stderr
@@ -1,10 +1,10 @@
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/wf-impl-associated-type-region.rs:10:16
+  --> $DIR/wf-impl-associated-type-region.rs:10:5
    |
 LL | impl<'a, T> Foo<'a> for T {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Bar = &'a T;
-   |                ^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
+   |     ^^^^^^^^ ...so that the reference type `&'a T` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |

--- a/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
+++ b/tests/ui/wf/wf-outlives-ty-in-fn-or-trait.stderr
@@ -1,10 +1,10 @@
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:9:16
+  --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:9:5
    |
 LL | impl<'a, T> Trait<'a, T> for usize {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a fn(T);
-   |                ^^^^^^^^^ ...so that the reference type `&'a fn(T)` does not outlive the data it points at
+   |     ^^^^^^^^ ...so that the reference type `&'a fn(T)` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |
@@ -12,12 +12,12 @@ LL | impl<'a, T: 'a> Trait<'a, T> for usize {
    |           ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:19:16
+  --> $DIR/wf-outlives-ty-in-fn-or-trait.rs:19:5
    |
 LL | impl<'a, T> Trait<'a, T> for u32 {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
 LL |     type Out = &'a dyn Baz<T>;
-   |                ^^^^^^^^^^^^^^ ...so that the reference type `&'a (dyn Baz<T> + 'a)` does not outlive the data it points at
+   |     ^^^^^^^^ ...so that the reference type `&'a (dyn Baz<T> + 'a)` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |

--- a/tests/ui/wf/wf-trait-associated-type-region.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-region.stderr
@@ -1,11 +1,11 @@
 error[E0309]: the associated type `<Self as SomeTrait<'a>>::Type1` may not live long enough
-  --> $DIR/wf-trait-associated-type-region.rs:9:18
+  --> $DIR/wf-trait-associated-type-region.rs:9:5
    |
 LL | trait SomeTrait<'a> {
    |                 -- the associated type `<Self as SomeTrait<'a>>::Type1` must be valid for the lifetime `'a` as defined here...
 LL |     type Type1;
 LL |     type Type2 = &'a Self::Type1;
-   |                  ^^^^^^^^^^^^^^^ ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
+   |     ^^^^^^^^^^ ...so that the reference type `&'a <Self as SomeTrait<'a>>::Type1` does not outlive the data it points at
    |
 help: consider adding an explicit lifetime bound
    |


### PR DESCRIPTION
I'm trying to only access the HIR in the error path. My hope is that once we move significant portions of wfcheck off HIR that incremental will be able to cache wfcheck queries significantly better.

I think I am reaching a blocker because we normally need to provide good spans to `ObligationCause`, so that the trait solver can report good errors. In some cases I have been able to use bad spans and improve them depending on the `ObligationCauseCode` (by loading HIR in the case where we actually want to error). To scale that further we'll likely need to remove spans from the `ObligationCause` entirely (leaving it to some variants of `ObligationCauseCode` to have a span when they can't recompute the information later). Unsure this is the right approach, but we've already been using it. I will create an MCP about it, but that should not affect this PR, which is fairly limited in where it does those kind of tricks.

Especially https://github.com/rust-lang/rust/commit/b862d8828e375ab8c128a9d9e93bf98b77cb5928 is interesting here, because I think it improves spans in all cases