### PR TITLE
Fix parsing of frontmatters with inner hyphens

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -545,11 +545,12 @@ impl Cursor<'_> {
 
         let mut s = self.as_str();
         let mut found = false;
+        let mut size = 0;
         while let Some(closing) = s.find(&"-".repeat(length_opening as usize)) {
             let preceding_chars_start = s[..closing].rfind("\n").map_or(0, |i| i + 1);
             if s[preceding_chars_start..closing].chars().all(is_whitespace) {
                 // candidate found
-                self.bump_bytes(closing);
+                self.bump_bytes(size + closing);
                 // in case like
                 // ---cargo
                 // --- blahblah
@@ -562,6 +563,7 @@ impl Cursor<'_> {
                 break;
             } else {
                 s = &s[closing + length_opening as usize..];
+                size += closing + length_opening as usize;
             }
         }
 

--- a/tests/ui/frontmatter/frontmatter-inner-hyphens-1.rs
+++ b/tests/ui/frontmatter/frontmatter-inner-hyphens-1.rs
@@ -1,0 +1,10 @@
+---
+x ---🚧️
+---
+
+// Regression test for #141483
+//@check-pass
+
+#![feature(frontmatter)]
+
+fn main() {}

--- a/tests/ui/frontmatter/frontmatter-inner-hyphens-2.rs
+++ b/tests/ui/frontmatter/frontmatter-inner-hyphens-2.rs
@@ -1,0 +1,11 @@
+---
+x ---y
+---
+
+// Test that hypens are allowed inside frontmatters if there is some
+// non-whitespace character preceding them.
+//@check-pass
+
+#![feature(frontmatter)]
+
+fn main() {}


### PR DESCRIPTION
closes rust-lang/rust#141483

r? fee1-dead
