### PR TITLE
Add `Command::resolve_in_parent_path`

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1195,6 +1195,22 @@ impl Command {
     pub fn get_current_dir(&self) -> Option<&Path> {
         self.inner.get_current_dir()
     }
+
+    /// Resolve the program given in [`new`](Self::new) using the parent's PATH.
+    ///
+    /// Usually when a `env` is used to set `PATH` on a child process,
+    /// that new `PATH` will be used to discover the process.
+    /// With `resolve_in_parent_path` to `true`, the parent's `PATH` will be used instead.
+    ///
+    /// # Platform-specific behavior
+    ///
+    /// On Unix the process is executed after fork and after setting up the rest of the new environment.
+    /// So if `chroot`, `uid`, `gid` or `groups` are used then the way `PATH` is interpreted may be changed.
+    #[unstable(feature = "command_resolve", issue = "none")]
+    pub fn resolve_in_parent_path(&mut self, use_parent: bool) -> &mut Self {
+        self.inner.resolve_in_parent_path(use_parent);
+        self
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -78,6 +78,10 @@ impl Command {
         self.stderr = Some(stderr);
     }
 
+    pub fn resolve_in_parent_path(&mut self, _use_parent: bool) -> &mut Self {
+        self
+    }
+
     pub fn get_program(&self) -> &OsStr {
         self.prog.as_ref()
     }

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -98,6 +98,7 @@ pub struct Command {
     #[cfg(target_os = "linux")]
     create_pidfd: bool,
     pgroup: Option<pid_t>,
+    resolve_in_parent_path: bool,
 }
 
 // passed back to std::process with the pipes connected to the child, if any
@@ -185,6 +186,7 @@ impl Command {
             #[cfg(target_os = "linux")]
             create_pidfd: false,
             pgroup: None,
+            resolve_in_parent_path: false,
         }
     }
 
@@ -219,6 +221,9 @@ impl Command {
         if self.cwd.is_none() {
             self.cwd(&OsStr::new("/"));
         }
+    }
+    pub fn resolve_in_parent_path(&mut self, use_parent: bool) {
+        self.resolve_in_parent_path = use_parent;
     }
 
     #[cfg(target_os = "linux")]
@@ -297,6 +302,10 @@ impl Command {
     #[allow(dead_code)]
     pub fn get_chroot(&self) -> Option<&CStr> {
         self.chroot.as_deref()
+    }
+    #[allow(dead_code)]
+    pub fn get_resolve_in_parent_path(&self) -> bool {
+        self.resolve_in_parent_path
     }
 
     pub fn get_closures(&mut self) -> &mut Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>> {

--- a/library/std/src/sys/process/unsupported.rs
+++ b/library/std/src/sys/process/unsupported.rs
@@ -21,6 +21,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    force_parent_path: bool,
 }
 
 // passed back to std::process with the pipes connected to the child, if any
@@ -52,6 +53,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
+            force_parent_path: false,
         }
     }
 
@@ -77,6 +79,10 @@ impl Command {
 
     pub fn stderr(&mut self, stderr: Stdio) {
         self.stderr = Some(stderr);
+    }
+
+    pub fn resolve_in_parent_path(&mut self, use_parent: bool) {
+        self.force_parent_path = use_parent;
     }
 
     pub fn get_program(&self) -> &OsStr {

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -158,6 +158,7 @@ pub struct Command {
     startupinfo_fullscreen: bool,
     startupinfo_untrusted_source: bool,
     startupinfo_force_feedback: Option<bool>,
+    force_parent_path: bool,
 }
 
 pub enum Stdio {
@@ -192,6 +193,7 @@ impl Command {
             startupinfo_fullscreen: false,
             startupinfo_untrusted_source: false,
             startupinfo_force_feedback: None,
+            force_parent_path: false,
         }
     }
 
@@ -222,6 +224,10 @@ impl Command {
 
     pub fn force_quotes(&mut self, enabled: bool) {
         self.force_quotes_enabled = enabled;
+    }
+
+    pub fn resolve_in_parent_path(&mut self, use_parent: bool) {
+        self.force_parent_path = use_parent;
     }
 
     pub fn raw_arg(&mut self, command_str_to_append: &OsStr) {
@@ -274,7 +280,10 @@ impl Command {
         let env_saw_path = self.env.have_changed_path();
         let maybe_env = self.env.capture_if_changed();
 
-        let child_paths = if env_saw_path && let Some(env) = maybe_env.as_ref() {
+        let child_paths = if env_saw_path
+            && !self.force_parent_path
+            && let Some(env) = maybe_env.as_ref()
+        {
             env.get(&EnvKey::new("PATH")).map(|s| s.as_os_str())
         } else {
             None


### PR DESCRIPTION
This is part of https://github.com/rust-lang/rust/issues/141976 (ACP: https://github.com/rust-lang/libs-team/issues/591). libs-api could not come to a consensus on what the final API should look like so they've agreed to experiment with a few different approaches.

This PR just implements the `resolve_in_parent_path` method which forces `Command` to ignore `PATH` set on the child for the purposes of resolving the executable. There was no consensus on what should happen if, for example, `chroot` is set (which can change the meaning of paths) so for now I've just done the easy thing. Figuring out the correct behaviour here will need to be done before this is considered for stabilisation but hopefully having it on nightly will nudge people in to giving their opinions.