### PR TITLE
transmutability: shift abstraction boundary

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2558,32 +2558,31 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         rustc_transmute::Reason::SrcIsNotYetSupported => {
                             format!("analyzing the transmutability of `{src}` is not yet supported")
                         }
-
                         rustc_transmute::Reason::DstIsNotYetSupported => {
                             format!("analyzing the transmutability of `{dst}` is not yet supported")
                         }
-
                         rustc_transmute::Reason::DstIsBitIncompatible => {
                             format!(
                                 "at least one value of `{src}` isn't a bit-valid value of `{dst}`"
                             )
                         }
-
                         rustc_transmute::Reason::DstUninhabited => {
                             format!("`{dst}` is uninhabited")
                         }
-
                         rustc_transmute::Reason::DstMayHaveSafetyInvariants => {
                             format!("`{dst}` may carry safety invariants")
                         }
                         rustc_transmute::Reason::DstIsTooBig => {
                             format!("the size of `{src}` is smaller than the size of `{dst}`")
                         }
-                        rustc_transmute::Reason::DstRefIsTooBig { src, dst } => {
-                            let src_size = src.size;
-                            let dst_size = dst.size;
+                        rustc_transmute::Reason::DstRefIsTooBig {
+                            src,
+                            src_size,
+                            dst,
+                            dst_size,
+                        } => {
                             format!(
-                                "the referent size of `{src}` ({src_size} bytes) \
+                                "the size of `{src}` ({src_size} bytes) \
                         is smaller than that of `{dst}` ({dst_size} bytes)"
                             )
                         }

--- a/compiler/rustc_transmute/src/layout/tree/tests.rs
+++ b/compiler/rustc_transmute/src/layout/tree/tests.rs
@@ -20,13 +20,13 @@ mod prune {
 
         #[test]
         fn seq_1() {
-            let layout: Tree<Def, !> = Tree::def(Def::NoSafetyInvariants).then(Tree::byte(0x00));
+            let layout: Tree<Def, !, !> = Tree::def(Def::NoSafetyInvariants).then(Tree::byte(0x00));
             assert_eq!(layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)), Tree::byte(0x00));
         }
 
         #[test]
         fn seq_2() {
-            let layout: Tree<Def, !> =
+            let layout: Tree<Def, !, !> =
                 Tree::byte(0x00).then(Tree::def(Def::NoSafetyInvariants)).then(Tree::byte(0x01));
 
             assert_eq!(
@@ -41,7 +41,7 @@ mod prune {
 
         #[test]
         fn invisible_def() {
-            let layout: Tree<Def, !> = Tree::def(Def::HasSafetyInvariants);
+            let layout: Tree<Def, !, !> = Tree::def(Def::HasSafetyInvariants);
             assert_eq!(
                 layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)),
                 Tree::uninhabited()
@@ -50,7 +50,7 @@ mod prune {
 
         #[test]
         fn invisible_def_in_seq_len_2() {
-            let layout: Tree<Def, !> =
+            let layout: Tree<Def, !, !> =
                 Tree::def(Def::NoSafetyInvariants).then(Tree::def(Def::HasSafetyInvariants));
             assert_eq!(
                 layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)),
@@ -60,7 +60,7 @@ mod prune {
 
         #[test]
         fn invisible_def_in_seq_len_3() {
-            let layout: Tree<Def, !> = Tree::def(Def::NoSafetyInvariants)
+            let layout: Tree<Def, !, !> = Tree::def(Def::NoSafetyInvariants)
                 .then(Tree::byte(0x00))
                 .then(Tree::def(Def::HasSafetyInvariants));
             assert_eq!(
@@ -75,20 +75,20 @@ mod prune {
 
         #[test]
         fn visible_def() {
-            let layout: Tree<Def, !> = Tree::def(Def::NoSafetyInvariants);
+            let layout: Tree<Def, !, !> = Tree::def(Def::NoSafetyInvariants);
             assert_eq!(layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)), Tree::unit());
         }
 
         #[test]
         fn visible_def_in_seq_len_2() {
-            let layout: Tree<Def, !> =
+            let layout: Tree<Def, !, !> =
                 Tree::def(Def::NoSafetyInvariants).then(Tree::def(Def::NoSafetyInvariants));
             assert_eq!(layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)), Tree::unit());
         }
 
         #[test]
         fn visible_def_in_seq_len_3() {
-            let layout: Tree<Def, !> = Tree::def(Def::NoSafetyInvariants)
+            let layout: Tree<Def, !, !> = Tree::def(Def::NoSafetyInvariants)
                 .then(Tree::byte(0x00))
                 .then(Tree::def(Def::NoSafetyInvariants));
             assert_eq!(layout.prune(&|d| matches!(d, Def::HasSafetyInvariants)), Tree::byte(0x00));

--- a/tests/ui/transmutability/references/reject_extension.stderr
+++ b/tests/ui/transmutability/references/reject_extension.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&Packed<Two>` cannot be safely transmuted into `&Packed<Four>`
   --> $DIR/reject_extension.rs:48:37
    |
 LL |     assert::is_transmutable::<&Src, &Dst>();
-   |                                     ^^^^ the referent size of `&Packed<Two>` (2 bytes) is smaller than that of `&Packed<Four>` (4 bytes)
+   |                                     ^^^^ the size of `Packed<Two>` (2 bytes) is smaller than that of `Packed<Four>` (4 bytes)
    |
 note: required by a bound in `is_transmutable`
   --> $DIR/reject_extension.rs:13:14

--- a/tests/ui/transmutability/references/unit-to-u8.stderr
+++ b/tests/ui/transmutability/references/unit-to-u8.stderr
@@ -2,7 +2,7 @@ error[E0277]: `&Unit` cannot be safely transmuted into `&u8`
   --> $DIR/unit-to-u8.rs:22:52
    |
 LL |     assert::is_maybe_transmutable::<&'static Unit, &'static u8>();
-   |                                                    ^^^^^^^^^^^ the referent size of `&Unit` (0 bytes) is smaller than that of `&u8` (1 bytes)
+   |                                                    ^^^^^^^^^^^ the size of `Unit` (0 bytes) is smaller than that of `u8` (1 bytes)
    |
 note: required by a bound in `is_maybe_transmutable`
   --> $DIR/unit-to-u8.rs:9:14

--- a/tests/ui/transmutability/references/unsafecell.rs
+++ b/tests/ui/transmutability/references/unsafecell.rs
@@ -38,10 +38,10 @@ fn mut_to_mut() {
 }
 
 fn mut_to_ref() {
-    // We don't care about `UnsafeCell` for transmutations in the form `&mut T
-    // -> &U`, because downgrading a `&mut T` to a `&U` deactivates `&mut T` for
-    // the lifetime of `&U`.
-    assert::is_maybe_transmutable::<&'static mut u8, &'static UnsafeCell<u8>>();
-    assert::is_maybe_transmutable::<&'static mut UnsafeCell<u8>, &'static u8>();
-    assert::is_maybe_transmutable::<&'static mut UnsafeCell<u8>, &'static UnsafeCell<u8>>();
+    // `&mut UnsafeCell` is irrelevant in the source.
+    assert::is_maybe_transmutable::<&'static mut UnsafeCell<bool>, &'static u8>();
+    // `&UnsafeCell` in forbidden in the destination, since the destination can be used to
+    // invalidate a shadowed source reference.
+    assert::is_maybe_transmutable::<&'static mut bool, &'static UnsafeCell<u8>>(); //~ ERROR: cannot be safely transmuted
+    assert::is_maybe_transmutable::<&'static mut UnsafeCell<bool>, &'static UnsafeCell<u8>>(); //~ ERROR: cannot be safely transmuted
 }

--- a/tests/ui/transmutability/references/unsafecell.stderr
+++ b/tests/ui/transmutability/references/unsafecell.stderr
@@ -28,6 +28,36 @@ LL |     where
 LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
-error: aborting due to 2 previous errors
+error[E0277]: `&mut bool` cannot be safely transmuted into `&UnsafeCell<u8>`
+  --> $DIR/unsafecell.rs:45:56
+   |
+LL |     assert::is_maybe_transmutable::<&'static mut bool, &'static UnsafeCell<u8>>();
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/unsafecell.rs:12:14
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>()
+   |            --------------------- required by a bound in this function
+LL |     where
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+
+error[E0277]: `&mut UnsafeCell<bool>` cannot be safely transmuted into `&UnsafeCell<u8>`
+  --> $DIR/unsafecell.rs:46:68
+   |
+LL |     assert::is_maybe_transmutable::<&'static mut UnsafeCell<bool>, &'static UnsafeCell<u8>>();
+   |                                                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Freeze` is not implemented for `UnsafeCell<u8>`
+   |
+note: required by a bound in `is_maybe_transmutable`
+  --> $DIR/unsafecell.rs:12:14
+   |
+LL |     pub fn is_maybe_transmutable<Src, Dst>()
+   |            --------------------- required by a bound in this function
+LL |     where
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Previously, `rustc_transmute`'s layout representations were genericized over `R`, a reference. Now, it's instead genericized over representations of type and region. This allows us to move reference transmutability logic from `rustc_trait_selection` to `rustc_transmutability` (and thus unit test it independently of the compiler), and — in a follow-up PR — will make it possible to support analyzing function pointer transmutability with minimal surgery.

r? @compiler-errors 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
