### PR TITLE
don't panic for incompatible download-rustc options outside of CI env

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2823,7 +2823,14 @@ impl Config {
                             return None;
                         }
 
-                        res.unwrap();
+                        // On CI, avoid using download-rustc if the configuration differs from the one used to build download-rustc.
+                        // We typically use `DISABLE_CI_RUSTC_IF_INCOMPATIBLE` to skip download-rustc in such cases.
+                        if CiEnv::is_ci() {
+                            res.unwrap();
+                        } else if let Err(err) = res {
+                            // For non-CI environments, print the error instead of panicking.
+                            eprintln!("{err}");
+                        }
                     }
 
                     Some(commit.clone())


### PR DESCRIPTION
Prints the error instead of panicking when doing the incompatibility check outside of CI environments.

See the alternative solution with config-based approach: https://github.com/rust-lang/rust/pull/142055

Fixes rust-lang/rust#141953