### PR TITLE
add new config: `rust.download_rustc_incompatibility_check`

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -546,6 +546,9 @@
 # compiler.
 #download-rustc = false
 
+# Whether to check and detect incompatible options when using download-rustc.
+#download_rustc_incompatibility_check = true
+
 # Number of codegen units to use for each compiler invocation. A value of 0
 # means "the number of cores on this machine", and 1+ is passed through to the
 # compiler.

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -416,4 +416,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Stage0 library no longer matches the in-tree library, which means stage1 compiler now uses the beta library.",
     },
+    ChangeInfo {
+        change_id: 142055,
+        severity: ChangeSeverity::Info,
+        summary: "Added a new option `rust.download_rustc_incompatibility_check`: it is now possible to disable the config incompatibility check for `download-rustc` usage.",
+    },
 ];


### PR DESCRIPTION
Unlike https://github.com/rust-lang/rust/pull/142054, this adds a config-based approach to control `download-rustc` incompatibility check.

Fixes rust-lang/rust#142054