### PR TITLE
Clean `rustc_attr_parsing/src/lib.rs` documentation

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -74,7 +74,7 @@ pub(crate) trait AttributeParser: Default + 'static {
 pub(crate) trait SingleAttributeParser: 'static {
     const PATH: &'static [Symbol];
 
-    /// Caled when a duplicate attribute is found.
+    /// Called when a duplicate attribute is found.
     ///
     /// `first_span` is the span of the first occurrence of this attribute.
     // FIXME(jdonszelmann): default error


### PR DESCRIPTION
Improves the documentation clarity in `rustc_attr_parsing` by restructuring content with clearer section headers, simplifying explanations of attribute types, making technical descriptions more precise.


r? @oli-obk 