### PR TITLE
doc: Fix inverted meaning in E0783.md

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0783.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0783.md
@@ -9,7 +9,7 @@ match 2u8 {
 }
 ```
 
-Older Rust code using previous editions allowed `...` to stand for exclusive
+Older Rust code using previous editions allowed `...` to stand for inclusive
 ranges which are now signified using `..=`.
 
 To make this code compile replace the `...` with `..=`.


### PR DESCRIPTION
`...` (three dots) was the old way of saying `..=`, which both denote the *inclusive* range, not the *exclusive* one.