### PR TITLE
Check documentation of bootstrap in PR CI

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -30,6 +30,7 @@ ENV SCRIPT \
         python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
+        python3 ../x.py doc --stage 0 bootstrap && \
         # Build both public and internal documentation.
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 0 compiler && \
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library && \


### PR DESCRIPTION
It's annoying when wrong doc comments in bootstrap [break](https://github.com/rust-lang/rust/pull/141272#issuecomment-2943614152) `auto` CI. This has happened a few times recently, and documenting bootstrap with the stage0 compiler should be pretty quick, so let's add it to PR CI.

r? @marcoieni