### PR TITLE
Fix AIX build

### DIFF
--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -282,7 +282,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
         return getcwd().map(|cwd| cwd.join(path))?.canonicalize();
     }
     // Search PATH to infer current_exe.
-    if let Some(p) = getenv(OsStr::from_bytes("PATH".as_bytes())) {
+    if let Some(p) = env::var_os(OsStr::from_bytes("PATH".as_bytes())) {
         for search_path in split_paths(&p) {
             let pb = search_path.join(&path);
             if pb.is_file()


### PR DESCRIPTION
Fix rust-lang/rust#141543.

`getenv` was moved out of this file to `sys::env::getenv` in rust-lang/rust#140143. Replace its usage with `std::env::var_os`, the publicly exposed version. This matches the other usages of the same function in this file.