### PR TITLE
add track_caller attribute to map_err and ok_or/_else

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1305,6 +1305,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.ok_or(0), Err(0));
     /// ```
     #[inline]
+    #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or<E>(self, err: E) -> Result<T, E> {
         match self {
@@ -1330,6 +1331,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.ok_or_else(|| 0), Err(0));
     /// ```
     #[inline]
+    #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or_else<E, F>(self, err: F) -> Result<T, E>
     where

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -907,6 +907,7 @@ impl<T, E> Result<T, E> {
     /// assert_eq!(x.map_err(stringify), Err("error code: 13".to_string()));
     /// ```
     #[inline]
+    #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn map_err<F, O: FnOnce(E) -> F>(self, op: O) -> Result<T, F> {
         match self {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Motivation https://github.com/unicode-org/icu4x/issues/4048

This PR resolves a common edge case where users attempting to manually track `std::panic::Location`s of their callers in their `Error` types end up with irrelevant locations inside of `std`.

The main concern with this approach that I'm aware of is that `#[track_caller]` increases the stack sizes of the functions it is applied to, though I think this is a non-issue since we already have `#[track_caller]` on `Result`'s `FromResidual` impl which is used far more frequently than any of these APIs when converting errors between different types. This change brings these functions in line with that impl.

example demonstrating the issue: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=8205bcd02b380d9fd02b1f1153ac9c4e