### PR TITLE
rustdoc: make srcIndex no longer a global variable

### DIFF
--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -477,11 +477,7 @@ impl SourcesPart {
         // This needs to be `var`, not `const`.
         // This variable needs declared in the current global scope so that if
         // src-script.js loads first, it can pick it up.
-        SortedTemplate::from_before_after(
-            r"var srcIndex = new Map(JSON.parse('[",
-            r"]'));
-createSrcSidebar();",
-        )
+        SortedTemplate::from_before_after(r"createSrcSidebar('[", r"]');")
     }
 
     fn get(cx: &Context<'_>, crate_name: &OrderedJson) -> Result<PartsAndLocations<Self>, Error> {

--- a/src/librustdoc/html/render/write_shared/tests.rs
+++ b/src/librustdoc/html/render/write_shared/tests.rs
@@ -22,23 +22,11 @@ fn but_last_line(s: &str) -> &str {
 #[test]
 fn sources_template() {
     let mut template = SourcesPart::blank();
-    assert_eq!(
-        but_last_line(&template.to_string()),
-        r"var srcIndex = new Map(JSON.parse('[]'));
-createSrcSidebar();"
-    );
+    assert_eq!(but_last_line(&template.to_string()), r"createSrcSidebar('[]');");
     template.append(EscapedJson::from(OrderedJson::serialize("u").unwrap()).to_string());
-    assert_eq!(
-        but_last_line(&template.to_string()),
-        r#"var srcIndex = new Map(JSON.parse('["u"]'));
-createSrcSidebar();"#
-    );
+    assert_eq!(but_last_line(&template.to_string()), r#"createSrcSidebar('["u"]');"#);
     template.append(EscapedJson::from(OrderedJson::serialize("v").unwrap()).to_string());
-    assert_eq!(
-        but_last_line(&template.to_string()),
-        r#"var srcIndex = new Map(JSON.parse('["u","v"]'));
-createSrcSidebar();"#
-    );
+    assert_eq!(but_last_line(&template.to_string()), r#"createSrcSidebar('["u","v"]');"#);
 }
 
 #[test]

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -4,8 +4,6 @@
 
 /* eslint-disable */
 declare global {
-    /** Map from crate name to directory structure, for source view */
-    declare var srcIndex: Map<string, rustdoc.Dir>;
     /** Defined and documented in `storage.js` */
     declare function nonnull(x: T|null, msg: string|undefined);
     /** Defined and documented in `storage.js` */
@@ -64,7 +62,7 @@ declare global {
          * create's the sidebar in source code view.
          * called in generated `src-files.js`.
          */
-        createSrcSidebar?: function(),
+        createSrcSidebar?: function(string),
         /**
          * Set up event listeners for a scraped source example.
          */
@@ -129,7 +127,7 @@ declare namespace rustdoc {
 
     /**
      * A single parsed "atom" in a search query. For example,
-     * 
+     *
      *     std::fmt::Formatter, Write -> Result<()>
      *     ┏━━━━━━━━━━━━━━━━━━  ┌────    ┏━━━━━┅┅┅┅┄┄┄┄┄┄┄┄┄┄┄┄┄┄┐
      *     ┃                    │        ┗ QueryElement {        ┊

--- a/src/librustdoc/html/static/js/src-script.js
+++ b/src/librustdoc/html/static/js/src-script.js
@@ -1,6 +1,3 @@
-// From rust:
-/* global srcIndex */
-
 // Local js definitions:
 /* global addClass, onEachLazy, removeClass, browserSupportsHistoryApi */
 /* global updateLocalStorage, getVar, nonnull */
@@ -100,11 +97,15 @@ window.rustdocToggleSrcSidebar = () => {
 
 // This function is called from "src-files.js", generated in `html/render/write_shared.rs`.
 // eslint-disable-next-line no-unused-vars
-function createSrcSidebar() {
+/**
+ * @param {string} srcIndexStr - strinified json map from crate name to dir structure
+ */
+function createSrcSidebar(srcIndexStr) {
     const container = nonnull(document.querySelector("nav.sidebar"));
 
     const sidebar = document.createElement("div");
     sidebar.id = "src-sidebar";
+    const srcIndex = new Map(JSON.parse(srcIndexStr));
 
     let hasFoundFile = false;
 

--- a/tests/rustdoc-gui/globals.goml
+++ b/tests/rustdoc-gui/globals.goml
@@ -6,7 +6,6 @@
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=sa'%3Bda'%3Bds"
 wait-for: "#search-tabs"
 assert-window-property-false: {"searchIndex": null}
-assert-window-property: {"srcIndex": null}
 
 // Form input
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
@@ -14,11 +13,9 @@ write-into: (".search-input", "Foo")
 press-key: 'Enter'
 wait-for: "#search-tabs"
 assert-window-property-false: {"searchIndex": null}
-assert-window-property: {"srcIndex": null}
 
 // source sidebar
 go-to: "file://" + |DOC_PATH| + "/src/test_docs/lib.rs.html"
 click: "#sidebar-button"
 wait-for: "#src-sidebar details"
-assert-window-property-false: {"srcIndex": null}
 assert-window-property: {"searchIndex": null}


### PR DESCRIPTION
this is one-time initialization data, it can just
be a function parameter.

while we're doing that, we can more the json parsing into the function and save a few extra bytes of storage for free, at least in the case of multiple crates in a doc bundle.

fixes https://github.com/rust-lang/rust/issues/138467
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
