### PR TITLE
compiler: Add track_caller to AbiMapping::unwrap

### DIFF
--- a/compiler/rustc_target/src/spec/abi_map.rs
+++ b/compiler/rustc_target/src/spec/abi_map.rs
@@ -29,6 +29,7 @@ impl AbiMapping {
         }
     }
 
+    #[track_caller]
     pub fn unwrap(self) -> CanonAbi {
         self.into_option().unwrap()
     }


### PR DESCRIPTION
Same reason as it is on Option's.