### PR TITLE
Reduce confusion of some drop order tests

### DIFF
--- a/tests/ui/drop/issue-2735-2.rs
+++ b/tests/ui/drop/issue-2735-2.rs
@@ -1,27 +1,24 @@
 //@ run-pass
-#![allow(non_camel_case_types)]
 
 use std::cell::Cell;
 
 // This test should behave exactly like issue-2735-3
-struct defer<'a> {
+struct Defer<'a> {
     b: &'a Cell<bool>,
 }
 
-impl<'a> Drop for defer<'a> {
+impl<'a> Drop for Defer<'a> {
     fn drop(&mut self) {
         self.b.set(true);
     }
 }
 
-fn defer(b: &Cell<bool>) -> defer<'_> {
-    defer {
-        b: b
-    }
+fn defer(b: &Cell<bool>) -> Defer<'_> {
+    Defer { b }
 }
 
 pub fn main() {
     let dtor_ran = &Cell::new(false);
-    let _  = defer(dtor_ran);
+    let _ = defer(dtor_ran);
     assert!(dtor_ran.get());
 }

--- a/tests/ui/drop/issue-2735-3.rs
+++ b/tests/ui/drop/issue-2735-3.rs
@@ -1,23 +1,20 @@
 //@ run-pass
-#![allow(non_camel_case_types)]
 
 use std::cell::Cell;
 
 // This test should behave exactly like issue-2735-2
-struct defer<'a> {
+struct Defer<'a> {
     b: &'a Cell<bool>,
 }
 
-impl<'a> Drop for defer<'a> {
+impl<'a> Drop for Defer<'a> {
     fn drop(&mut self) {
         self.b.set(true);
     }
 }
 
-fn defer(b: &Cell<bool>) -> defer<'_> {
-    defer {
-        b: b
-    }
+fn defer(b: &Cell<bool>) -> Defer<'_> {
+    Defer { b }
 }
 
 pub fn main() {

--- a/tests/ui/drop/issue-2735.rs
+++ b/tests/ui/drop/issue-2735.rs
@@ -1,15 +1,13 @@
 //@ run-pass
 #![allow(dead_code)]
-#![allow(non_camel_case_types)]
 
-
-trait hax {
-    fn dummy(&self) { }
+trait Hax {
+    fn dummy(&self) {}
 }
-impl<A> hax for A { }
+impl<A> Hax for A {}
 
-fn perform_hax<T: 'static>(x: Box<T>) -> Box<dyn hax+'static> {
-    Box::new(x) as Box<dyn hax+'static>
+fn perform_hax<T: 'static>(x: Box<T>) -> Box<dyn Hax + 'static> {
+    Box::new(x) as Box<dyn Hax + 'static>
 }
 
 fn deadcode() {

--- a/tests/ui/drop/issue-979.rs
+++ b/tests/ui/drop/issue-979.rs
@@ -1,22 +1,19 @@
 //@ run-pass
-#![allow(non_camel_case_types)]
 
 use std::cell::Cell;
 
-struct r<'a> {
+struct R<'a> {
     b: &'a Cell<isize>,
 }
 
-impl<'a> Drop for r<'a> {
+impl<'a> Drop for R<'a> {
     fn drop(&mut self) {
         self.b.set(self.b.get() + 1);
     }
 }
 
-fn r(b: &Cell<isize>) -> r<'_> {
-    r {
-        b: b
-    }
+fn r(b: &Cell<isize>) -> R<'_> {
+    R { b }
 }
 
 pub fn main() {


### PR DESCRIPTION
In addition to adhering to normal Rust casing idioms, I ran `rustfmt`.

Closes rust-lang/rust#141604

r? @jieyouxu 