### PR TITLE
Apply `mismatched-lifetime-syntaxes` to trait and extern functions

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-1.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-1.rs
@@ -20,7 +20,7 @@ where
     Self: Sized,
 {
     type I: for<'a> FamilyLt<'a>;
-    fn inject(_: &()) -> <Self::I as FamilyLt>::Out;
+    fn inject(_: &()) -> <Self::I as FamilyLt<'_>>::Out;
 }
 
 impl<T: 'static> Inject for RefMutFamily<T> {

--- a/tests/ui/lifetimes/mismatched-lifetime-syntaxes.rs
+++ b/tests/ui/lifetimes/mismatched-lifetime-syntaxes.rs
@@ -220,6 +220,45 @@ mod diagnostic_output {
     }
 }
 
+/// Trait functions are represented differently in the HIR. Make sure
+/// we visit them.
+mod trait_functions {
+    #[derive(Copy, Clone)]
+    struct ContainsLifetime<'a>(&'a u8);
+
+    trait TheTrait {
+        fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime;
+        //~^ ERROR lifetime flowing from input to output with different syntax
+
+        fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime;
+        //~^ ERROR lifetime flowing from input to output with different syntax
+    }
+
+    impl TheTrait for &u8 {
+        fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime {
+            //~^ ERROR lifetime flowing from input to output with different syntax
+            ContainsLifetime(v)
+        }
+
+        fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime {
+            //~^ ERROR lifetime flowing from input to output with different syntax
+            ContainsLifetime(self)
+        }
+    }
+}
+
+/// Extern functions are represented differently in the HIR. Make sure
+/// we visit them.
+mod foreign_functions {
+    #[derive(Copy, Clone)]
+    struct ContainsLifetime<'a>(&'a u8);
+
+    extern "Rust" {
+        fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime;
+        //~^ ERROR lifetime flowing from input to output with different syntax
+    }
+}
+
 /// These usages are expected to **not** trigger the lint
 mod acceptable_uses {
     #[derive(Copy, Clone)]

--- a/tests/ui/lifetimes/mismatched-lifetime-syntaxes.stderr
+++ b/tests/ui/lifetimes/mismatched-lifetime-syntaxes.stderr
@@ -469,5 +469,70 @@ help: one option is to consistently use `'a`
 LL |     fn multiple_outputs<'a>(v: &'a u8) -> (&'a u8, &'a u8) {
    |                                             ++      ++
 
-error: aborting due to 34 previous errors
+error: lifetime flowing from input to output with different syntax can be confusing
+  --> $DIR/mismatched-lifetime-syntaxes.rs:230:45
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime;
+   |                                             ^^^     ---------------- the lifetime gets resolved as `'_`
+   |                                             |
+   |                                             this lifetime flows to the output
+   |
+help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime<'_>;
+   |                                                                     ++++
+
+error: lifetime flowing from input to output with different syntax can be confusing
+  --> $DIR/mismatched-lifetime-syntaxes.rs:233:49
+   |
+LL |         fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime;
+   |                                                 ^^^^^     ---------------- the lifetime gets resolved as `'_`
+   |                                                 |
+   |                                                 this lifetime flows to the output
+   |
+help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
+   |
+LL |         fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime<'_>;
+   |                                                                           ++++
+
+error: lifetime flowing from input to output with different syntax can be confusing
+  --> $DIR/mismatched-lifetime-syntaxes.rs:238:45
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime {
+   |                                             ^^^     ---------------- the lifetime gets resolved as `'_`
+   |                                             |
+   |                                             this lifetime flows to the output
+   |
+help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime<'_> {
+   |                                                                     ++++
+
+error: lifetime flowing from input to output with different syntax can be confusing
+  --> $DIR/mismatched-lifetime-syntaxes.rs:243:49
+   |
+LL |         fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime {
+   |                                                 ^^^^^     ---------------- the lifetime gets resolved as `'_`
+   |                                                 |
+   |                                                 this lifetime flows to the output
+   |
+help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
+   |
+LL |         fn method_implicit_ref_to_implicit_path(&self) -> ContainsLifetime<'_> {
+   |                                                                           ++++
+
+error: lifetime flowing from input to output with different syntax can be confusing
+  --> $DIR/mismatched-lifetime-syntaxes.rs:257:45
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime;
+   |                                             ^^^     ---------------- the lifetime gets resolved as `'_`
+   |                                             |
+   |                                             this lifetime flows to the output
+   |
+help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
+   |
+LL |         fn implicit_ref_to_implicit_path(v: &u8) -> ContainsLifetime<'_>;
+   |                                                                     ++++
+
+error: aborting due to 39 previous errors
 

--- a/tests/ui/traits/associated_type_bound/hrtb-associated.rs
+++ b/tests/ui/traits/associated_type_bound/hrtb-associated.rs
@@ -10,7 +10,7 @@ pub trait Provides<'a> {
 pub trait Selector: for<'a> Provides<'a> {
     type Namespace: PartialEq + for<'a> PartialEq<<Self as Provides<'a>>::Item>;
 
-    fn get_namespace(&self) -> <Self as Provides>::Item;
+    fn get_namespace(&self) -> <Self as Provides<'_>>::Item;
 }
 
 pub struct MySelector;


### PR DESCRIPTION
r? @jieyouxu 