### PR TITLE
compiler: Treat ForceWarning as a Warning for diagnostic level

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1529,7 +1529,7 @@ impl DiagCtxtInner {
             // Future breakages aren't emitted if they're `Level::Allow` or
             // `Level::Expect`, but they still need to be constructed and
             // stashed below, so they'll trigger the must_produce_diag check.
-            assert_matches!(diagnostic.level, Error | Warning | Allow | Expect);
+            assert_matches!(diagnostic.level, Error | ForceWarning | Warning | Allow | Expect);
             self.future_breakage_diagnostics.push(diagnostic.clone());
         }
 

--- a/tests/ui/lint/force-warn/ice-free.rs
+++ b/tests/ui/lint/force-warn/ice-free.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: --force-warn pub_use_of_private_extern_crate
+//@ check-pass
+
+extern crate core;
+pub use core as reexported_core;
+//~^ warning: extern crate `core` is private
+//~| warning: this was previously accepted by the compiler
+
+fn main() {}

--- a/tests/ui/lint/force-warn/ice-free.stderr
+++ b/tests/ui/lint/force-warn/ice-free.stderr
@@ -1,0 +1,32 @@
+warning[E0365]: extern crate `core` is private and cannot be re-exported
+  --> $DIR/ice-free.rs:5:9
+   |
+LL | pub use core as reexported_core;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
+   = note: requested on the command line with `--force-warn pub-use-of-private-extern-crate`
+help: consider making the `extern crate` item publicly accessible
+   |
+LL | pub extern crate core;
+   | +++
+
+warning: 1 warning emitted
+
+For more information about this error, try `rustc --explain E0365`.
+Future incompatibility report: Future breakage diagnostic:
+warning[E0365]: extern crate `core` is private and cannot be re-exported
+  --> $DIR/ice-free.rs:5:9
+   |
+LL | pub use core as reexported_core;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #127909 <https://github.com/rust-lang/rust/issues/127909>
+   = note: requested on the command line with `--force-warn pub-use-of-private-extern-crate`
+help: consider making the `extern crate` item publicly accessible
+   |
+LL | pub extern crate core;
+   | +++
+


### PR DESCRIPTION
This silences an ICE.

No idea if this is the correct solution though tbh.

Fixes rust-lang/rust#142144