### PR TITLE
rustc_resolve: Improve `resolve_const_param_in_non_trivial_anon_const` wording

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -119,7 +119,7 @@ resolve_const_param_in_enum_discriminant =
     const parameters may not be used in enum discriminant values
 
 resolve_const_param_in_non_trivial_anon_const =
-    const parameters may only be used as standalone arguments, i.e. `{$name}`
+    const parameters may only be used as standalone arguments here, i.e. `{$name}`
 
 resolve_constructor_private_if_any_field_private =
     a constructor is private if any of the fields is private

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: [u8; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -58,7 +58,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -112,7 +112,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -166,7 +166,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
@@ -7,7 +7,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |                                   ------ in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |                                          ------ in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -30,7 +30,7 @@ error: generic parameters may not be used in const operations
 LL | fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
    |                                              ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 3 previous errors

--- a/tests/ui/const-generics/early/macro_rules-braces.stderr
+++ b/tests/ui/const-generics/early/macro_rules-braces.stderr
@@ -26,7 +26,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: foo!({{ N }});
    |                    ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -35,7 +35,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: bar!({ N });
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -44,7 +44,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: baz!({{ N }});
    |                    ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -53,7 +53,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: biz!({ N });
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 6 previous errors

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
@@ -7,7 +7,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> A<{{ y!() }}> {
    |                                  ---- in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
@@ -7,7 +7,7 @@ LL |         { N }
 LL | fn foo<const N: usize>() -> A<{ y!() }> {
    |                                 ---- in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | fn foo<const N: usize>() -> A<{ { N } }> {
    |                                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |                                                ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     arr: [u8; CFG.arr_size],
    |               ^^^ cannot perform const operation using `CFG`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `CFG`
+   = help: const parameters may only be used as standalone arguments here, i.e. `CFG`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: `Config` is forbidden as the type of a const generic parameter

--- a/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     SmallVec<{ D * 2 }>:,
    |                ^ cannot perform const operation using `D`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `D`
+   = help: const parameters may only be used as standalone arguments here, i.e. `D`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0747]: constant provided when a type was expected

--- a/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type Arr<const N: usize> = [u8; N - 1];
    |                                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     Condition<{ LHS <= RHS }>: True
    |                 ^^^ cannot perform const operation using `LHS`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `LHS`
+   = help: const parameters may only be used as standalone arguments here, i.e. `LHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     Condition<{ LHS <= RHS }>: True
    |                        ^^^ cannot perform const operation using `RHS`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `RHS`
+   = help: const parameters may only be used as standalone arguments here, i.e. `RHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                         ^ cannot perform const operation using `I`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `I`
+   = help: const parameters may only be used as standalone arguments here, i.e. `I`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -31,7 +31,7 @@ error: generic parameters may not be used in const operations
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                                    ^ cannot perform const operation using `J`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `J`
+   = help: const parameters may only be used as standalone arguments here, i.e. `J`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 4 previous errors

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.full.stderr
@@ -1,0 +1,13 @@
+error: unconstrained generic constant
+  --> $DIR/trivial-anon-const-use-cases.rs:14:12
+   |
+LL |     stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in this context.
+   |            ^^^^^^^^^^^^^^^
+   |
+help: try adding a `where` bound
+   |
+LL | struct Y<const S: usize> where [(); { S + 1 }]: {
+   |                          ++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/trivial-anon-const-use-cases.rs:14:19
+   |
+LL |     stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in this context.
+   |                   ^ cannot perform const operation using `S`
+   |
+   = help: const parameters may only be used as standalone arguments here, i.e. `S`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.rs
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.rs
@@ -1,0 +1,19 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/79429>.
+
+//@ revisions: full min
+#![cfg_attr(full, feature(generic_const_exprs))]
+#![cfg_attr(full, allow(incomplete_features))]
+
+struct X<const S: usize>;
+
+impl<const S: usize> X<S> {
+    const LEN: usize = S + 1; // `S + 1` is a valid const expression in this context.
+}
+
+struct Y<const S: usize> {
+    stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in this context.
+    //[min]~^ ERROR generic parameters may not be used in const operations
+    //[full]~^^ ERROR unconstrained generic constant
+}
+
+fn main() {}

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |                                     ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: `Option<usize>` is forbidden as the type of a const generic parameter

--- a/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
+++ b/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL | fn const_param<const N: usize>() -> [u8; N + 1] {
    |                                          ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/issues/issue-80375.stderr
+++ b/tests/ui/const-generics/issues/issue-80375.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct MyArray<const COUNT: usize>([u8; COUNT + 1]);
    |                                         ^^^^^ cannot perform const operation using `COUNT`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `COUNT`
+   = help: const parameters may only be used as standalone arguments here, i.e. `COUNT`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -16,7 +16,7 @@ error: generic parameters may not be used in const operations
 LL |     legacy_const_generics::foo(0, N + 1, 2);
    |                                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |                                      ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL | struct Break1<const N: usize>([u8; { { N } }]);
    |                                        ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: [u8; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -31,7 +31,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = [0; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     bar::<{ [1; N] }>();
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     bar::<{ [1; { N + 1 }] }>();
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
In some contexts, const expressions are OK. Add a `here` to the error message to clarify this.

Closes rust-lang/rust#79429 which has 15 x 👍 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
