### PR TITLE
Test binary size of share generics

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1401,7 +1401,7 @@ impl Options {
         match self.unstable_opts.share_generics {
             Some(setting) => setting,
             None => match self.optimize {
-                OptLevel::No | OptLevel::Less | OptLevel::Size | OptLevel::SizeMin => true,
+                OptLevel::No | OptLevel::Less | OptLevel::Size | OptLevel::SizeMin => false,
                 OptLevel::More | OptLevel::Aggressive => false,
             },
         }


### PR DESCRIPTION
maybe we have some opt-level=s or opt-level=z crates in here? :D

cc rust-lang/rust#142164

r? ghost