### PR TITLE
`rustc_const_eval`: respect `target.min_global_align`

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -893,7 +893,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         // # Global allocations
         if let Some(global_alloc) = self.tcx.try_get_global_alloc(id) {
-            let (size, align) = global_alloc.size_and_align(*self.tcx, self.typing_env);
+            let (size, mut align) = global_alloc.size_and_align(*self.tcx, self.typing_env);
+            if let Some(min_global_align) = self.tcx.sess.target.min_global_align {
+                align = Ord::max(align, min_global_align);
+            }
             let mutbl = global_alloc.mutability(*self.tcx, self.typing_env);
             let kind = match global_alloc {
                 GlobalAlloc::Static { .. } | GlobalAlloc::Memory { .. } => AllocKind::LiveData,

--- a/src/tools/miri/tests/pass/static_align.rs
+++ b/src/tools/miri/tests/pass/static_align.rs
@@ -1,0 +1,37 @@
+// Test that miri respects the `target.min_global_align` value for the target.
+//
+// The only way to observe its effect currently is to test for the alignment of statics with a
+// natural alignment of 1 on s390x. On that target, the `min_global_align` is 2 bytes.
+
+fn main() {
+    let min_align = if cfg!(target_arch = "s390x") { 2 } else { 1 };
+
+    macro_rules! check {
+        ($x:ident, $v:expr) => {
+            static $x: bool = $v;
+            assert!(core::ptr::from_ref(&$x).addr().is_multiple_of(min_align));
+        };
+    }
+
+    check!(T0, true);
+    check!(T1, true);
+    check!(T2, true);
+    check!(T3, true);
+    check!(T4, true);
+    check!(T5, true);
+    check!(T6, true);
+    check!(T7, true);
+    check!(T8, true);
+    check!(T9, true);
+
+    check!(F0, false);
+    check!(F1, false);
+    check!(F2, false);
+    check!(F3, false);
+    check!(F4, false);
+    check!(F5, false);
+    check!(F6, false);
+    check!(F7, false);
+    check!(F8, false);
+    check!(F9, false);
+}


### PR DESCRIPTION
Currently different backends handle the `target.min_global_align` option inconsistently: llvm and gcc respect it, but miri/`rustc_const_eval` does not. I believe that `rustc_codegen_cranelift` can't yet support per-item alignment.

The only rust target that sets `min_global_align` today is `s390x`. In LLVM the only other target that also specifies a `min_global_align` is `larai`, which rust does not support. The `nvptx` targets inherit the `min_global_align` from their host.

## Proposal

The `min_global_align` target option becomes a language guarantee: If the target specifies `min_global_align` (i.e. it is not `None`), all globals will have an alignment of at least the `min_global_align` specified by the target.

This allows unsafe code authors to write inline assembly and other code that relies on the alignment of globals.

## Background

Issue https://github.com/rust-lang/rust/issues/44411 describes a correctness problem on s390x, where a static is not sufficiently aligned: the `larl` instruction that LLVM generates assumes an even address, but e.g. a static containing a `bool` may have an odd address. Clang and gcc make sure that globals are always aligned properly, even if their type does not require it. A language guarantee is required to justify inline assembly using the same instruction.

See also [#miri > alignment of globals on s390x](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/alignment.20of.20globals.20on.20s390x/with/522919662)

r? @RalfJung  
@rustbot label +I-lang-nominated