### PR TITLE
Do not free disk space in the `mingw-check-tidy` job

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -128,6 +128,7 @@ pr:
     <<: *job-linux-4c
   - name: mingw-check-tidy
     continue_on_error: true
+    free_disk: false
     <<: *job-linux-4c
   - name: x86_64-gnu-llvm-19
     env:


### PR DESCRIPTION
It's not needed an it slows down the job considerably. It took ~2 minutes out of the total 8-9 minutes of running `mingw-check-tidy`.