### PR TITLE
Always consider `const _` items as live for dead code analysis

### DIFF
--- a/tests/ui/lint/dead-code/const-underscore-issue-142104.rs
+++ b/tests/ui/lint/dead-code/const-underscore-issue-142104.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+
+// This test makes sure we always considers `const _` items as live for dead code analysis.
+
+#![deny(dead_code)]
+
+const fn is_nonzero(x: u8) -> bool {
+    x != 0
+}
+
+const _: () = {
+    assert!(is_nonzero(2));
+};
+
+fn main() {}


### PR DESCRIPTION
This PR alters dead code analysis to always consider `const _: () = { ... };` to be live.

This doesn't address the `_name` pattern from https://github.com/rust-lang/rust/issues/142075.

Fixes https://github.com/rust-lang/rust/issues/142104