### PR TITLE
Run `mingw-check-tidy` on auto builds

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -305,6 +305,10 @@ auto:
   - name: mingw-check-2
     <<: *job-linux-4c
 
+  - name: mingw-check-tidy
+    free_disk: false
+    <<: *job-linux-4c
+
   - name: test-various
     <<: *job-linux-4c
 


### PR DESCRIPTION
This has two advantages:
- It moves `auto` builds closer to being a superset of PR CI builds
- It allows us to reuse the Docker cache for the job in PR CI, thus speeding up the job in PR CI considerably

Discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/PR.20ci.20seems.20much.20to.20slow).

r? @Mark-Simulacrum