### PR TITLE
CI: rfl: move job forward to Linux v6.16-rc1

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-# https://github.com/Rust-for-Linux/linux/issues/1163
-LINUX_VERSION=3ca02fc80cc4fdac63aaa6796642f1e07be591d6
+LINUX_VERSION=v6.16-rc1
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
Another hopefully routine upgrade to Linux v6.16-rc1, just released.

r? @lqd @Kobzol
try-job: x86_64-rust-for-linux
@rustbot label A-rust-for-linux
@bors try