### PR TITLE
Avoid a gratuitous 10s wait in a stress test

### DIFF
--- a/library/std/tests/sync/mpmc.rs
+++ b/library/std/tests/sync/mpmc.rs
@@ -462,8 +462,8 @@ fn oneshot_single_thread_recv_timeout() {
 #[test]
 fn stress_recv_timeout_two_threads() {
     let (tx, rx) = channel();
-    let stress = stress_factor() + 100;
-    let timeout = Duration::from_millis(100);
+    let stress = stress_factor() + 50;
+    let timeout = Duration::from_millis(5);
 
     thread::spawn(move || {
         for i in 0..stress {
@@ -475,18 +475,23 @@ fn stress_recv_timeout_two_threads() {
     });
 
     let mut recv_count = 0;
+    let mut got_timeout = false;
     loop {
         match rx.recv_timeout(timeout) {
             Ok(n) => {
                 assert_eq!(n, 1usize);
                 recv_count += 1;
             }
-            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Timeout) => {
+                got_timeout = true;
+                continue;
+            }
             Err(RecvTimeoutError::Disconnected) => break,
         }
     }
 
     assert_eq!(recv_count, stress);
+    assert!(got_timeout);
 }
 
 #[test]

--- a/library/std/tests/sync/mpsc.rs
+++ b/library/std/tests/sync/mpsc.rs
@@ -425,8 +425,8 @@ fn oneshot_single_thread_recv_timeout() {
 #[test]
 fn stress_recv_timeout_two_threads() {
     let (tx, rx) = channel();
-    let stress = stress_factor() + 100;
-    let timeout = Duration::from_millis(100);
+    let stress = stress_factor() + 50;
+    let timeout = Duration::from_millis(5);
 
     thread::spawn(move || {
         for i in 0..stress {
@@ -438,18 +438,23 @@ fn stress_recv_timeout_two_threads() {
     });
 
     let mut recv_count = 0;
+    let mut got_timeout = false;
     loop {
         match rx.recv_timeout(timeout) {
             Ok(n) => {
                 assert_eq!(n, 1usize);
                 recv_count += 1;
             }
-            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Timeout) => {
+                got_timeout = true;
+                continue;
+            }
             Err(RecvTimeoutError::Disconnected) => break,
         }
     }
 
     assert_eq!(recv_count, stress);
+    assert!(got_timeout);
 }
 
 #[test]


### PR DESCRIPTION
`stress_recv_timeout_two_threads`, in the mpmc and mpsc testsuites, is a stress test of the `recv_timeout` function. This test processes and ignores timeouts, and just ensures that every sent value gets received. As such, the exact length of the timeouts is not critical, only that the timeout and sleep durations ensure that at least one timeout occurred.

The current tests have 100 iterations, half of which sleep for 200ms, causing the test to take 10s. This represents around 2/3rds of the *total* runtime of the `library/std` testsuite, and is the only standard library test that takes more than a second.

Reduce this to 50 iterations where half of them sleep for 10ms, causing the test to take 0.25s.

Add a check that at least one timeout occurred.