### PR TITLE
Run `calculate_matrix` job on `master` to cache citool builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ name: CI
 on:
   push:
     branches:
+      # CI on master only serves for caching citool builds for the `calculate_matrix` job.
+      # In order to use GHA cache on PR CI (and auto/try) jobs, we need to write to it
+      # from the default branch.
+      - master
       - auto
       - try
       - try-perf

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -47,6 +47,7 @@ impl GitHubContext {
                 Some(RunType::TryJob { job_patterns: patterns })
             }
             ("push", "refs/heads/auto") => Some(RunType::AutoJob),
+            ("push", "refs/heads/master") => Some(RunType::MasterJob),
             _ => None,
         }
     }

--- a/src/ci/citool/tests/jobs.rs
+++ b/src/ci/citool/tests/jobs.rs
@@ -46,16 +46,21 @@ fn pr_jobs() {
 }
 
 fn get_matrix(event_name: &str, commit_msg: &str, branch_ref: &str) -> String {
-    let output = Command::new("cargo")
-        .args(["run", "-q", "calculate-job-matrix", "--jobs-file", TEST_JOBS_YML_PATH])
+    let path = std::env::var("PATH");
+    let mut cmd = Command::new("cargo");
+    cmd.args(["run", "-q", "calculate-job-matrix", "--jobs-file", TEST_JOBS_YML_PATH])
+        .env_clear()
         .env("GITHUB_EVENT_NAME", event_name)
         .env("COMMIT_MESSAGE", commit_msg)
         .env("GITHUB_REF", branch_ref)
         .env("GITHUB_RUN_ID", "123")
         .env("GITHUB_RUN_ATTEMPT", "1")
-        .stdout(Stdio::piped())
-        .output()
-        .expect("Failed to execute command");
+        .stdout(Stdio::piped());
+    if let Ok(path) = path {
+        cmd.env("PATH", path);
+    }
+
+    let output = cmd.output().expect("Failed to execute command");
 
     let stdout = String::from_utf8(output.stdout).unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();

--- a/src/ci/citool/tests/jobs.rs
+++ b/src/ci/citool/tests/jobs.rs
@@ -45,6 +45,15 @@ fn pr_jobs() {
     "#);
 }
 
+#[test]
+fn master_jobs() {
+    let stdout = get_matrix("push", "commit", "refs/heads/master");
+    insta::assert_snapshot!(stdout, @r#"
+    jobs=[]
+    run_type=master
+    "#);
+}
+
 fn get_matrix(event_name: &str, commit_msg: &str, branch_ref: &str) -> String {
     let path = std::env::var("PATH");
     let mut cmd = Command::new("cargo");


### PR DESCRIPTION
As discussed in https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/PR.20ci.20seems.20much.20to.20slow/with/523028903, the current `rust-cache` solution for `citool` doesn't work, because we don't ever write to the cache from `master`, so the cache is empty on PR CI jobs.

This PR runs the `calculate_matrix` job on `master`, with the only motivation to actually prime the cache.

r? @marcoieni