### PR TITLE
add `Cargo.lock` to CI-rustc allowed list for non-CI env

### DIFF
--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 
 use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
-use super::{Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
+use super::{Config, rustc_if_unchanged_allowed_paths};
 use crate::ChangeId;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm;
@@ -459,7 +459,7 @@ fn jobs_precedence() {
 #[test]
 fn check_rustc_if_unchanged_paths() {
     let config = parse("");
-    let normalised_allowed_paths: Vec<_> = RUSTC_IF_UNCHANGED_ALLOWED_PATHS
+    let normalised_allowed_paths: Vec<_> = rustc_if_unchanged_allowed_paths()
         .iter()
         .map(|t| {
             t.strip_prefix(":!").expect(&format!("{t} doesn't have ':!' prefix, but it should."))


### PR DESCRIPTION
Changes to dependencies usually require modifying `Cargo.toml`, which would already invalidate the CI-rustc cache if done in non-allowed paths. On non-CI environment, it should be safe to add `Cargo.lock` to the list of allowed paths as there is no real risk aside from a very rare false positive in cases like minor bumps to non-allowed path dependencies without modifying the `Cargo.toml` files.

Fixes rust-lang/rust#141986