### PR TITLE
Build rustc with assertions in `dist-alt` jobs

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -256,7 +256,7 @@ auto:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist-alt.sh
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-8c
 
   - name: dist-x86_64-musl
     env:

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -134,6 +134,11 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
 
   CODEGEN_BACKENDS="${CODEGEN_BACKENDS:-llvm}"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.codegen-backends=$CODEGEN_BACKENDS"
+
+  # Unless explicitly disabled, we want rustc debug assertions on the -alt builds
+  if [ "$DEPLOY_ALT" != "" ] && [ "$NO_DEBUG_ASSERTIONS" = "" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-debug-assertions"
+  fi
 else
   # We almost always want debug assertions enabled, but sometimes this takes too
   # long for too little benefit, so we just turn them off.


### PR DESCRIPTION
Revival of https://github.com/rust-lang/rust/pull/131077, to check CI times now that we don't do PGO/BOLT anymore on Linux `-alt` builds.

r? @ghost

try-job: dist-x86_64-msvc-alt
try-job: dist-x86_64-linux-alt