### PR TITLE
float tests: deduplicate min, max, and rounding tests

### DIFF
--- a/library/coretests/tests/floats/f128.rs
+++ b/library/coretests/tests/floats/f128.rs
@@ -5,6 +5,8 @@ use core::ops::{Add, Div, Mul, Sub};
 use std::f128::consts;
 use std::num::FpCategory as Fp;
 
+use super::{assert_approx_eq, assert_biteq};
+
 // Note these tolerances make sense around zero, but not for more extreme exponents.
 
 /// Default tolerances. Works for values that should be near precise but not exact. Roughly

--- a/library/coretests/tests/floats/f128.rs
+++ b/library/coretests/tests/floats/f128.rs
@@ -56,34 +56,6 @@ fn test_num_f128() {
 // the intrinsics.
 
 #[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_min_nan() {
-    assert_biteq!(f128::NAN.min(2.0), 2.0);
-    assert_biteq!(2.0f128.min(f128::NAN), 2.0);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_max_nan() {
-    assert_biteq!(f128::NAN.max(2.0), 2.0);
-    assert_biteq!(2.0f128.max(f128::NAN), 2.0);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_minimum() {
-    assert!(f128::NAN.minimum(2.0).is_nan());
-    assert!(2.0f128.minimum(f128::NAN).is_nan());
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_maximum() {
-    assert!(f128::NAN.maximum(2.0).is_nan());
-    assert!(2.0f128.maximum(f128::NAN).is_nan());
-}
-
-#[test]
 fn test_nan() {
     let nan: f128 = f128::NAN;
     assert!(nan.is_nan());
@@ -232,98 +204,6 @@ fn test_classify() {
     assert_eq!(1f128.classify(), Fp::Normal);
     assert_eq!(1e-4931f128.classify(), Fp::Normal);
     assert_eq!(1e-4932f128.classify(), Fp::Subnormal);
-}
-
-#[test]
-#[cfg(target_has_reliable_f128_math)]
-fn test_floor() {
-    assert_biteq!(1.0f128.floor(), 1.0f128);
-    assert_biteq!(1.3f128.floor(), 1.0f128);
-    assert_biteq!(1.5f128.floor(), 1.0f128);
-    assert_biteq!(1.7f128.floor(), 1.0f128);
-    assert_biteq!(0.0f128.floor(), 0.0f128);
-    assert_biteq!((-0.0f128).floor(), -0.0f128);
-    assert_biteq!((-1.0f128).floor(), -1.0f128);
-    assert_biteq!((-1.3f128).floor(), -2.0f128);
-    assert_biteq!((-1.5f128).floor(), -2.0f128);
-    assert_biteq!((-1.7f128).floor(), -2.0f128);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_ceil() {
-    assert_biteq!(1.0f128.ceil(), 1.0f128);
-    assert_biteq!(1.3f128.ceil(), 2.0f128);
-    assert_biteq!(1.5f128.ceil(), 2.0f128);
-    assert_biteq!(1.7f128.ceil(), 2.0f128);
-    assert_biteq!(0.0f128.ceil(), 0.0f128);
-    assert_biteq!((-0.0f128).ceil(), -0.0f128);
-    assert_biteq!((-1.0f128).ceil(), -1.0f128);
-    assert_biteq!((-1.3f128).ceil(), -1.0f128);
-    assert_biteq!((-1.5f128).ceil(), -1.0f128);
-    assert_biteq!((-1.7f128).ceil(), -1.0f128);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_round() {
-    assert_biteq!(2.5f128.round(), 3.0f128);
-    assert_biteq!(1.0f128.round(), 1.0f128);
-    assert_biteq!(1.3f128.round(), 1.0f128);
-    assert_biteq!(1.5f128.round(), 2.0f128);
-    assert_biteq!(1.7f128.round(), 2.0f128);
-    assert_biteq!(0.0f128.round(), 0.0f128);
-    assert_biteq!((-0.0f128).round(), -0.0f128);
-    assert_biteq!((-1.0f128).round(), -1.0f128);
-    assert_biteq!((-1.3f128).round(), -1.0f128);
-    assert_biteq!((-1.5f128).round(), -2.0f128);
-    assert_biteq!((-1.7f128).round(), -2.0f128);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_round_ties_even() {
-    assert_biteq!(2.5f128.round_ties_even(), 2.0f128);
-    assert_biteq!(1.0f128.round_ties_even(), 1.0f128);
-    assert_biteq!(1.3f128.round_ties_even(), 1.0f128);
-    assert_biteq!(1.5f128.round_ties_even(), 2.0f128);
-    assert_biteq!(1.7f128.round_ties_even(), 2.0f128);
-    assert_biteq!(0.0f128.round_ties_even(), 0.0f128);
-    assert_biteq!((-0.0f128).round_ties_even(), -0.0f128);
-    assert_biteq!((-1.0f128).round_ties_even(), -1.0f128);
-    assert_biteq!((-1.3f128).round_ties_even(), -1.0f128);
-    assert_biteq!((-1.5f128).round_ties_even(), -2.0f128);
-    assert_biteq!((-1.7f128).round_ties_even(), -2.0f128);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_trunc() {
-    assert_biteq!(1.0f128.trunc(), 1.0f128);
-    assert_biteq!(1.3f128.trunc(), 1.0f128);
-    assert_biteq!(1.5f128.trunc(), 1.0f128);
-    assert_biteq!(1.7f128.trunc(), 1.0f128);
-    assert_biteq!(0.0f128.trunc(), 0.0f128);
-    assert_biteq!((-0.0f128).trunc(), -0.0f128);
-    assert_biteq!((-1.0f128).trunc(), -1.0f128);
-    assert_biteq!((-1.3f128).trunc(), -1.0f128);
-    assert_biteq!((-1.5f128).trunc(), -1.0f128);
-    assert_biteq!((-1.7f128).trunc(), -1.0f128);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f128_math))]
-fn test_fract() {
-    assert_biteq!(1.0f128.fract(), 0.0f128);
-    assert_biteq!(1.3f128.fract(), 0.300000000000000000000000000000000039f128);
-    assert_biteq!(1.5f128.fract(), 0.5f128);
-    assert_biteq!(1.7f128.fract(), 0.7f128);
-    assert_biteq!(0.0f128.fract(), 0.0f128);
-    assert_biteq!((-0.0f128).fract(), 0.0f128);
-    assert_biteq!((-1.0f128).fract(), 0.0f128);
-    assert_biteq!((-1.3f128).fract(), -0.300000000000000000000000000000000039f128);
-    assert_biteq!((-1.5f128).fract(), -0.5f128);
-    assert_biteq!((-1.7f128).fract(), -0.699999999999999999999999999999999961f128);
 }
 
 #[test]

--- a/library/coretests/tests/floats/f16.rs
+++ b/library/coretests/tests/floats/f16.rs
@@ -4,6 +4,8 @@
 use std::f16::consts;
 use std::num::FpCategory as Fp;
 
+use super::{assert_approx_eq, assert_biteq};
+
 /// Tolerance for results on the order of 10.0e-2
 #[allow(unused)]
 const TOL_N2: f16 = 0.0001;

--- a/library/coretests/tests/floats/f16.rs
+++ b/library/coretests/tests/floats/f16.rs
@@ -52,34 +52,6 @@ fn test_num_f16() {
 // the intrinsics.
 
 #[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_min_nan() {
-    assert_biteq!(f16::NAN.min(2.0), 2.0);
-    assert_biteq!(2.0f16.min(f16::NAN), 2.0);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_max_nan() {
-    assert_biteq!(f16::NAN.max(2.0), 2.0);
-    assert_biteq!(2.0f16.max(f16::NAN), 2.0);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_minimum() {
-    assert!(f16::NAN.minimum(2.0).is_nan());
-    assert!(2.0f16.minimum(f16::NAN).is_nan());
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_maximum() {
-    assert!(f16::NAN.maximum(2.0).is_nan());
-    assert!(2.0f16.maximum(f16::NAN).is_nan());
-}
-
-#[test]
 fn test_nan() {
     let nan: f16 = f16::NAN;
     assert!(nan.is_nan());
@@ -228,98 +200,6 @@ fn test_classify() {
     assert_eq!(1f16.classify(), Fp::Normal);
     assert_eq!(1e-4f16.classify(), Fp::Normal);
     assert_eq!(1e-5f16.classify(), Fp::Subnormal);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_floor() {
-    assert_biteq!(1.0f16.floor(), 1.0f16);
-    assert_biteq!(1.3f16.floor(), 1.0f16);
-    assert_biteq!(1.5f16.floor(), 1.0f16);
-    assert_biteq!(1.7f16.floor(), 1.0f16);
-    assert_biteq!(0.0f16.floor(), 0.0f16);
-    assert_biteq!((-0.0f16).floor(), -0.0f16);
-    assert_biteq!((-1.0f16).floor(), -1.0f16);
-    assert_biteq!((-1.3f16).floor(), -2.0f16);
-    assert_biteq!((-1.5f16).floor(), -2.0f16);
-    assert_biteq!((-1.7f16).floor(), -2.0f16);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_ceil() {
-    assert_biteq!(1.0f16.ceil(), 1.0f16);
-    assert_biteq!(1.3f16.ceil(), 2.0f16);
-    assert_biteq!(1.5f16.ceil(), 2.0f16);
-    assert_biteq!(1.7f16.ceil(), 2.0f16);
-    assert_biteq!(0.0f16.ceil(), 0.0f16);
-    assert_biteq!((-0.0f16).ceil(), -0.0f16);
-    assert_biteq!((-1.0f16).ceil(), -1.0f16);
-    assert_biteq!((-1.3f16).ceil(), -1.0f16);
-    assert_biteq!((-1.5f16).ceil(), -1.0f16);
-    assert_biteq!((-1.7f16).ceil(), -1.0f16);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_round() {
-    assert_biteq!(2.5f16.round(), 3.0f16);
-    assert_biteq!(1.0f16.round(), 1.0f16);
-    assert_biteq!(1.3f16.round(), 1.0f16);
-    assert_biteq!(1.5f16.round(), 2.0f16);
-    assert_biteq!(1.7f16.round(), 2.0f16);
-    assert_biteq!(0.0f16.round(), 0.0f16);
-    assert_biteq!((-0.0f16).round(), -0.0f16);
-    assert_biteq!((-1.0f16).round(), -1.0f16);
-    assert_biteq!((-1.3f16).round(), -1.0f16);
-    assert_biteq!((-1.5f16).round(), -2.0f16);
-    assert_biteq!((-1.7f16).round(), -2.0f16);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_round_ties_even() {
-    assert_biteq!(2.5f16.round_ties_even(), 2.0f16);
-    assert_biteq!(1.0f16.round_ties_even(), 1.0f16);
-    assert_biteq!(1.3f16.round_ties_even(), 1.0f16);
-    assert_biteq!(1.5f16.round_ties_even(), 2.0f16);
-    assert_biteq!(1.7f16.round_ties_even(), 2.0f16);
-    assert_biteq!(0.0f16.round_ties_even(), 0.0f16);
-    assert_biteq!((-0.0f16).round_ties_even(), -0.0f16);
-    assert_biteq!((-1.0f16).round_ties_even(), -1.0f16);
-    assert_biteq!((-1.3f16).round_ties_even(), -1.0f16);
-    assert_biteq!((-1.5f16).round_ties_even(), -2.0f16);
-    assert_biteq!((-1.7f16).round_ties_even(), -2.0f16);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_trunc() {
-    assert_biteq!(1.0f16.trunc(), 1.0f16);
-    assert_biteq!(1.3f16.trunc(), 1.0f16);
-    assert_biteq!(1.5f16.trunc(), 1.0f16);
-    assert_biteq!(1.7f16.trunc(), 1.0f16);
-    assert_biteq!(0.0f16.trunc(), 0.0f16);
-    assert_biteq!((-0.0f16).trunc(), -0.0f16);
-    assert_biteq!((-1.0f16).trunc(), -1.0f16);
-    assert_biteq!((-1.3f16).trunc(), -1.0f16);
-    assert_biteq!((-1.5f16).trunc(), -1.0f16);
-    assert_biteq!((-1.7f16).trunc(), -1.0f16);
-}
-
-#[test]
-#[cfg(any(miri, target_has_reliable_f16_math))]
-fn test_fract() {
-    assert_biteq!(1.0f16.fract(), 0.0f16);
-    assert_biteq!(1.3f16.fract(), 0.2998f16);
-    assert_biteq!(1.5f16.fract(), 0.5f16);
-    assert_biteq!(1.7f16.fract(), 0.7f16);
-    assert_biteq!(0.0f16.fract(), 0.0f16);
-    assert_biteq!((-0.0f16).fract(), 0.0f16);
-    assert_biteq!((-1.0f16).fract(), 0.0f16);
-    assert_biteq!((-1.3f16).fract(), -0.2998f16);
-    assert_biteq!((-1.5f16).fract(), -0.5f16);
-    assert_biteq!((-1.7f16).fract(), -0.7f16);
 }
 
 #[test]

--- a/library/coretests/tests/floats/f32.rs
+++ b/library/coretests/tests/floats/f32.rs
@@ -31,30 +31,6 @@ fn test_num_f32() {
 }
 
 #[test]
-fn test_min_nan() {
-    assert_biteq!(f32::NAN.min(2.0), 2.0);
-    assert_biteq!(2.0f32.min(f32::NAN), 2.0);
-}
-
-#[test]
-fn test_max_nan() {
-    assert_biteq!(f32::NAN.max(2.0), 2.0);
-    assert_biteq!(2.0f32.max(f32::NAN), 2.0);
-}
-
-#[test]
-fn test_minimum() {
-    assert!(f32::NAN.minimum(2.0).is_nan());
-    assert!(2.0f32.minimum(f32::NAN).is_nan());
-}
-
-#[test]
-fn test_maximum() {
-    assert!(f32::NAN.maximum(2.0).is_nan());
-    assert!(2.0f32.maximum(f32::NAN).is_nan());
-}
-
-#[test]
 fn test_nan() {
     let nan: f32 = f32::NAN;
     assert!(nan.is_nan());
@@ -203,92 +179,6 @@ fn test_classify() {
     assert_eq!(1f32.classify(), Fp::Normal);
     assert_eq!(1e-37f32.classify(), Fp::Normal);
     assert_eq!(1e-38f32.classify(), Fp::Subnormal);
-}
-
-#[test]
-fn test_floor() {
-    assert_biteq!(f32::math::floor(1.0f32), 1.0f32);
-    assert_biteq!(f32::math::floor(1.3f32), 1.0f32);
-    assert_biteq!(f32::math::floor(1.5f32), 1.0f32);
-    assert_biteq!(f32::math::floor(1.7f32), 1.0f32);
-    assert_biteq!(f32::math::floor(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::floor(-0.0f32), -0.0f32);
-    assert_biteq!(f32::math::floor(-1.0f32), -1.0f32);
-    assert_biteq!(f32::math::floor(-1.3f32), -2.0f32);
-    assert_biteq!(f32::math::floor(-1.5f32), -2.0f32);
-    assert_biteq!(f32::math::floor(-1.7f32), -2.0f32);
-}
-
-#[test]
-fn test_ceil() {
-    assert_biteq!(f32::math::ceil(1.0f32), 1.0f32);
-    assert_biteq!(f32::math::ceil(1.3f32), 2.0f32);
-    assert_biteq!(f32::math::ceil(1.5f32), 2.0f32);
-    assert_biteq!(f32::math::ceil(1.7f32), 2.0f32);
-    assert_biteq!(f32::math::ceil(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::ceil(-0.0f32), -0.0f32);
-    assert_biteq!(f32::math::ceil(-1.0f32), -1.0f32);
-    assert_biteq!(f32::math::ceil(-1.3f32), -1.0f32);
-    assert_biteq!(f32::math::ceil(-1.5f32), -1.0f32);
-    assert_biteq!(f32::math::ceil(-1.7f32), -1.0f32);
-}
-
-#[test]
-fn test_round() {
-    assert_biteq!(f32::math::round(2.5f32), 3.0f32);
-    assert_biteq!(f32::math::round(1.0f32), 1.0f32);
-    assert_biteq!(f32::math::round(1.3f32), 1.0f32);
-    assert_biteq!(f32::math::round(1.5f32), 2.0f32);
-    assert_biteq!(f32::math::round(1.7f32), 2.0f32);
-    assert_biteq!(f32::math::round(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::round(-0.0f32), -0.0f32);
-    assert_biteq!(f32::math::round(-1.0f32), -1.0f32);
-    assert_biteq!(f32::math::round(-1.3f32), -1.0f32);
-    assert_biteq!(f32::math::round(-1.5f32), -2.0f32);
-    assert_biteq!(f32::math::round(-1.7f32), -2.0f32);
-}
-
-#[test]
-fn test_round_ties_even() {
-    assert_biteq!(f32::math::round_ties_even(2.5f32), 2.0f32);
-    assert_biteq!(f32::math::round_ties_even(1.0f32), 1.0f32);
-    assert_biteq!(f32::math::round_ties_even(1.3f32), 1.0f32);
-    assert_biteq!(f32::math::round_ties_even(1.5f32), 2.0f32);
-    assert_biteq!(f32::math::round_ties_even(1.7f32), 2.0f32);
-    assert_biteq!(f32::math::round_ties_even(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::round_ties_even(-0.0f32), -0.0f32);
-    assert_biteq!(f32::math::round_ties_even(-1.0f32), -1.0f32);
-    assert_biteq!(f32::math::round_ties_even(-1.3f32), -1.0f32);
-    assert_biteq!(f32::math::round_ties_even(-1.5f32), -2.0f32);
-    assert_biteq!(f32::math::round_ties_even(-1.7f32), -2.0f32);
-}
-
-#[test]
-fn test_trunc() {
-    assert_biteq!(f32::math::trunc(1.0f32), 1.0f32);
-    assert_biteq!(f32::math::trunc(1.3f32), 1.0f32);
-    assert_biteq!(f32::math::trunc(1.5f32), 1.0f32);
-    assert_biteq!(f32::math::trunc(1.7f32), 1.0f32);
-    assert_biteq!(f32::math::trunc(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::trunc(-0.0f32), -0.0f32);
-    assert_biteq!(f32::math::trunc(-1.0f32), -1.0f32);
-    assert_biteq!(f32::math::trunc(-1.3f32), -1.0f32);
-    assert_biteq!(f32::math::trunc(-1.5f32), -1.0f32);
-    assert_biteq!(f32::math::trunc(-1.7f32), -1.0f32);
-}
-
-#[test]
-fn test_fract() {
-    assert_biteq!(f32::math::fract(1.0f32), 0.0f32);
-    assert_biteq!(f32::math::fract(1.3f32), 0.29999995f32);
-    assert_biteq!(f32::math::fract(1.5f32), 0.5f32);
-    assert_biteq!(f32::math::fract(1.7f32), 0.70000005f32);
-    assert_biteq!(f32::math::fract(0.0f32), 0.0f32);
-    assert_biteq!(f32::math::fract(-0.0f32), 0.0f32);
-    assert_biteq!(f32::math::fract(-1.0f32), 0.0f32);
-    assert_biteq!(f32::math::fract(-1.3f32), -0.29999995f32);
-    assert_biteq!(f32::math::fract(-1.5f32), -0.5f32);
-    assert_biteq!(f32::math::fract(-1.7f32), -0.70000005f32);
 }
 
 #[test]

--- a/library/coretests/tests/floats/f32.rs
+++ b/library/coretests/tests/floats/f32.rs
@@ -2,6 +2,8 @@ use core::f32;
 use core::f32::consts;
 use core::num::FpCategory as Fp;
 
+use super::{assert_approx_eq, assert_biteq};
+
 /// Smallest number
 const TINY_BITS: u32 = 0x1;
 

--- a/library/coretests/tests/floats/f64.rs
+++ b/library/coretests/tests/floats/f64.rs
@@ -31,18 +31,6 @@ fn test_num_f64() {
 }
 
 #[test]
-fn test_min_nan() {
-    assert_biteq!(f64::NAN.min(2.0), 2.0);
-    assert_biteq!(2.0f64.min(f64::NAN), 2.0);
-}
-
-#[test]
-fn test_max_nan() {
-    assert_biteq!(f64::NAN.max(2.0), 2.0);
-    assert_biteq!(2.0f64.max(f64::NAN), 2.0);
-}
-
-#[test]
 fn test_nan() {
     let nan: f64 = f64::NAN;
     assert!(nan.is_nan());
@@ -190,92 +178,6 @@ fn test_classify() {
     assert_eq!(neg_zero.classify(), Fp::Zero);
     assert_eq!(1e-307f64.classify(), Fp::Normal);
     assert_eq!(1e-308f64.classify(), Fp::Subnormal);
-}
-
-#[test]
-fn test_floor() {
-    assert_biteq!(f64::math::floor(1.0f64), 1.0f64);
-    assert_biteq!(f64::math::floor(1.3f64), 1.0f64);
-    assert_biteq!(f64::math::floor(1.5f64), 1.0f64);
-    assert_biteq!(f64::math::floor(1.7f64), 1.0f64);
-    assert_biteq!(f64::math::floor(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::floor(-0.0f64), -0.0f64);
-    assert_biteq!(f64::math::floor(-1.0f64), -1.0f64);
-    assert_biteq!(f64::math::floor(-1.3f64), -2.0f64);
-    assert_biteq!(f64::math::floor(-1.5f64), -2.0f64);
-    assert_biteq!(f64::math::floor(-1.7f64), -2.0f64);
-}
-
-#[test]
-fn test_ceil() {
-    assert_biteq!(f64::math::ceil(1.0f64), 1.0f64);
-    assert_biteq!(f64::math::ceil(1.3f64), 2.0f64);
-    assert_biteq!(f64::math::ceil(1.5f64), 2.0f64);
-    assert_biteq!(f64::math::ceil(1.7f64), 2.0f64);
-    assert_biteq!(f64::math::ceil(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::ceil(-0.0f64), -0.0f64);
-    assert_biteq!(f64::math::ceil(-1.0f64), -1.0f64);
-    assert_biteq!(f64::math::ceil(-1.3f64), -1.0f64);
-    assert_biteq!(f64::math::ceil(-1.5f64), -1.0f64);
-    assert_biteq!(f64::math::ceil(-1.7f64), -1.0f64);
-}
-
-#[test]
-fn test_round() {
-    assert_biteq!(f64::math::round(2.5f64), 3.0f64);
-    assert_biteq!(f64::math::round(1.0f64), 1.0f64);
-    assert_biteq!(f64::math::round(1.3f64), 1.0f64);
-    assert_biteq!(f64::math::round(1.5f64), 2.0f64);
-    assert_biteq!(f64::math::round(1.7f64), 2.0f64);
-    assert_biteq!(f64::math::round(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::round(-0.0f64), -0.0f64);
-    assert_biteq!(f64::math::round(-1.0f64), -1.0f64);
-    assert_biteq!(f64::math::round(-1.3f64), -1.0f64);
-    assert_biteq!(f64::math::round(-1.5f64), -2.0f64);
-    assert_biteq!(f64::math::round(-1.7f64), -2.0f64);
-}
-
-#[test]
-fn test_round_ties_even() {
-    assert_biteq!(f64::math::round_ties_even(2.5f64), 2.0f64);
-    assert_biteq!(f64::math::round_ties_even(1.0f64), 1.0f64);
-    assert_biteq!(f64::math::round_ties_even(1.3f64), 1.0f64);
-    assert_biteq!(f64::math::round_ties_even(1.5f64), 2.0f64);
-    assert_biteq!(f64::math::round_ties_even(1.7f64), 2.0f64);
-    assert_biteq!(f64::math::round_ties_even(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::round_ties_even(-0.0f64), -0.0f64);
-    assert_biteq!(f64::math::round_ties_even(-1.0f64), -1.0f64);
-    assert_biteq!(f64::math::round_ties_even(-1.3f64), -1.0f64);
-    assert_biteq!(f64::math::round_ties_even(-1.5f64), -2.0f64);
-    assert_biteq!(f64::math::round_ties_even(-1.7f64), -2.0f64);
-}
-
-#[test]
-fn test_trunc() {
-    assert_biteq!(f64::math::trunc(1.0f64), 1.0f64);
-    assert_biteq!(f64::math::trunc(1.3f64), 1.0f64);
-    assert_biteq!(f64::math::trunc(1.5f64), 1.0f64);
-    assert_biteq!(f64::math::trunc(1.7f64), 1.0f64);
-    assert_biteq!(f64::math::trunc(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::trunc(-0.0f64), -0.0f64);
-    assert_biteq!(f64::math::trunc(-1.0f64), -1.0f64);
-    assert_biteq!(f64::math::trunc(-1.3f64), -1.0f64);
-    assert_biteq!(f64::math::trunc(-1.5f64), -1.0f64);
-    assert_biteq!(f64::math::trunc(-1.7f64), -1.0f64);
-}
-
-#[test]
-fn test_fract() {
-    assert_biteq!(f64::math::fract(1.0f64), 0.0f64);
-    assert_biteq!(f64::math::fract(1.3f64), 0.30000000000000004f64);
-    assert_biteq!(f64::math::fract(1.5f64), 0.5f64);
-    assert_biteq!(f64::math::fract(1.7f64), 0.7f64);
-    assert_biteq!(f64::math::fract(0.0f64), 0.0f64);
-    assert_biteq!(f64::math::fract(-0.0f64), 0.0f64);
-    assert_biteq!(f64::math::fract(-1.0f64), 0.0f64);
-    assert_biteq!(f64::math::fract(-1.3f64), -0.30000000000000004f64);
-    assert_biteq!(f64::math::fract(-1.5f64), -0.5f64);
-    assert_biteq!(f64::math::fract(-1.7f64), -0.69999999999999996f64);
 }
 
 #[test]

--- a/library/coretests/tests/floats/f64.rs
+++ b/library/coretests/tests/floats/f64.rs
@@ -2,6 +2,8 @@ use core::f64;
 use core::f64::consts;
 use core::num::FpCategory as Fp;
 
+use super::{assert_approx_eq, assert_biteq};
+
 /// Smallest number
 const TINY_BITS: u64 = 0x1;
 

--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -54,7 +54,6 @@ macro_rules! assert_biteq_ {
 }
 pub(crate) use assert_biteq_ as assert_biteq;
 
-#[allow(unused)]
 mod const_asserts {
     // Shadow some assert implementations that would otherwise not compile in a const-context.
     // Every macro added here also needs to be added in the `float_test!` macro below.
@@ -503,11 +502,18 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((1.0 as Float).floor(), 1.0);
+        assert_biteq!((1.3 as Float).floor(), 1.0);
+        assert_biteq!((1.5 as Float).floor(), 1.0);
+        assert_biteq!((1.7 as Float).floor(), 1.0);
+        assert_biteq!((0.5 as Float).floor(), 0.0);
         assert_biteq!((0.0 as Float).floor(), 0.0);
         assert_biteq!((-0.0 as Float).floor(), -0.0);
-        assert_biteq!((0.5 as Float).floor(), 0.0);
         assert_biteq!((-0.5 as Float).floor(), -1.0);
-        assert_biteq!((1.5 as Float).floor(), 1.0);
+        assert_biteq!((-1.0 as Float).floor(), -1.0);
+        assert_biteq!((-1.3 as Float).floor(), -2.0);
+        assert_biteq!((-1.5 as Float).floor(), -2.0);
+        assert_biteq!((-1.7 as Float).floor(), -2.0);
         assert_biteq!(Float::MAX.floor(), Float::MAX);
         assert_biteq!(Float::MIN.floor(), Float::MIN);
         assert_biteq!(Float::MIN_POSITIVE.floor(), 0.0);
@@ -525,10 +531,18 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((1.0 as Float).ceil(), 1.0);
+        assert_biteq!((1.3 as Float).ceil(), 2.0);
+        assert_biteq!((1.5 as Float).ceil(), 2.0);
+        assert_biteq!((1.7 as Float).ceil(), 2.0);
+        assert_biteq!((0.5 as Float).ceil(), 1.0);
         assert_biteq!((0.0 as Float).ceil(), 0.0);
         assert_biteq!((-0.0 as Float).ceil(), -0.0);
-        assert_biteq!((0.5 as Float).ceil(), 1.0);
         assert_biteq!((-0.5 as Float).ceil(), -0.0);
+        assert_biteq!((-1.0 as Float).ceil(), -1.0);
+        assert_biteq!((-1.3 as Float).ceil(), -1.0);
+        assert_biteq!((-1.5 as Float).ceil(), -1.0);
+        assert_biteq!((-1.7 as Float).ceil(), -1.0);
         assert_biteq!(Float::MAX.ceil(), Float::MAX);
         assert_biteq!(Float::MIN.ceil(), Float::MIN);
         assert_biteq!(Float::MIN_POSITIVE.ceil(), 1.0);
@@ -546,10 +560,19 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((2.5 as Float).round(), 3.0);
+        assert_biteq!((1.0 as Float).round(), 1.0);
+        assert_biteq!((1.3 as Float).round(), 1.0);
+        assert_biteq!((1.5 as Float).round(), 2.0);
+        assert_biteq!((1.7 as Float).round(), 2.0);
+        assert_biteq!((0.5 as Float).round(), 1.0);
         assert_biteq!((0.0 as Float).round(), 0.0);
         assert_biteq!((-0.0 as Float).round(), -0.0);
-        assert_biteq!((0.5 as Float).round(), 1.0);
         assert_biteq!((-0.5 as Float).round(), -1.0);
+        assert_biteq!((-1.0 as Float).round(), -1.0);
+        assert_biteq!((-1.3 as Float).round(), -1.0);
+        assert_biteq!((-1.5 as Float).round(), -2.0);
+        assert_biteq!((-1.7 as Float).round(), -2.0);
         assert_biteq!(Float::MAX.round(), Float::MAX);
         assert_biteq!(Float::MIN.round(), Float::MIN);
         assert_biteq!(Float::MIN_POSITIVE.round(), 0.0);
@@ -567,10 +590,19 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((2.5 as Float).round_ties_even(), 2.0);
+        assert_biteq!((1.0 as Float).round_ties_even(), 1.0);
+        assert_biteq!((1.3 as Float).round_ties_even(), 1.0);
+        assert_biteq!((1.5 as Float).round_ties_even(), 2.0);
+        assert_biteq!((1.7 as Float).round_ties_even(), 2.0);
+        assert_biteq!((0.5 as Float).round_ties_even(), 0.0);
         assert_biteq!((0.0 as Float).round_ties_even(), 0.0);
         assert_biteq!((-0.0 as Float).round_ties_even(), -0.0);
-        assert_biteq!((0.5 as Float).round_ties_even(), 0.0);
         assert_biteq!((-0.5 as Float).round_ties_even(), -0.0);
+        assert_biteq!((-1.0 as Float).round_ties_even(), -1.0);
+        assert_biteq!((-1.3 as Float).round_ties_even(), -1.0);
+        assert_biteq!((-1.5 as Float).round_ties_even(), -2.0);
+        assert_biteq!((-1.7 as Float).round_ties_even(), -2.0);
         assert_biteq!(Float::MAX.round_ties_even(), Float::MAX);
         assert_biteq!(Float::MIN.round_ties_even(), Float::MIN);
         assert_biteq!(Float::MIN_POSITIVE.round_ties_even(), 0.0);
@@ -588,10 +620,18 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((1.0 as Float).trunc(), 1.0);
+        assert_biteq!((1.3 as Float).trunc(), 1.0);
+        assert_biteq!((1.5 as Float).trunc(), 1.0);
+        assert_biteq!((1.7 as Float).trunc(), 1.0);
+        assert_biteq!((0.5 as Float).trunc(), 0.0);
         assert_biteq!((0.0 as Float).trunc(), 0.0);
         assert_biteq!((-0.0 as Float).trunc(), -0.0);
-        assert_biteq!((0.5 as Float).trunc(), 0.0);
         assert_biteq!((-0.5 as Float).trunc(), -0.0);
+        assert_biteq!((-1.0 as Float).trunc(), -1.0);
+        assert_biteq!((-1.3 as Float).trunc(), -1.0);
+        assert_biteq!((-1.5 as Float).trunc(), -1.0);
+        assert_biteq!((-1.7 as Float).trunc(), -1.0);
         assert_biteq!(Float::MAX.trunc(), Float::MAX);
         assert_biteq!(Float::MIN.trunc(), Float::MIN);
         assert_biteq!(Float::MIN_POSITIVE.trunc(), 0.0);
@@ -609,10 +649,18 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
+        assert_biteq!((1.0 as Float).fract(), 0.0);
+        assert_approx_eq!((1.3 as Float).fract(), 0.3, 1e-3); // rounding differs between float types
+        assert_biteq!((1.5 as Float).fract(), 0.5);
+        assert_approx_eq!((1.7 as Float).fract(), 0.7);
+        assert_biteq!((0.5 as Float).fract(), 0.5);
         assert_biteq!((0.0 as Float).fract(), 0.0);
         assert_biteq!((-0.0 as Float).fract(), 0.0);
-        assert_biteq!((0.5 as Float).fract(), 0.5);
         assert_biteq!((-0.5 as Float).fract(), -0.5);
+        assert_biteq!((-1.0 as Float).fract(), 0.0);
+        assert_approx_eq!((-1.3 as Float).fract(), -0.3, 1e-3); // rounding differs between float types
+        assert_biteq!((-1.5 as Float).fract(), -0.5);
+        assert_approx_eq!((-1.7 as Float).fract(), -0.7);
         assert_biteq!(Float::MAX.fract(), 0.0);
         assert_biteq!(Float::MIN.fract(), 0.0);
         assert_biteq!(Float::MIN_POSITIVE.fract(), Float::MIN_POSITIVE);

--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
 /// Verify that floats are within a tolerance of each other, 1.0e-6 by default.
-macro_rules! assert_approx_eq {
+macro_rules! assert_approx_eq_ {
     ($a:expr, $b:expr) => {{ assert_approx_eq!($a, $b, 1.0e-6) }};
     ($a:expr, $b:expr, $lim:expr) => {{
         let (a, b) = (&$a, &$b);
@@ -14,10 +14,11 @@ macro_rules! assert_approx_eq {
         );
     }};
 }
+pub(crate) use assert_approx_eq_ as assert_approx_eq;
 
 /// Verify that floats have the same bitwise representation. Used to avoid the default `0.0 == -0.0`
 /// behavior, as well as to ensure exact NaN bitpatterns.
-macro_rules! assert_biteq {
+macro_rules! assert_biteq_ {
     (@inner $left:expr, $right:expr, $msg_sep:literal, $($tt:tt)*) => {{
         let l = $left;
         let r = $right;
@@ -41,17 +42,19 @@ macro_rules! assert_biteq {
         if !l.is_nan() && !r.is_nan() {
             // Also check that standard equality holds, since most tests use `assert_biteq` rather
             // than `assert_eq`.
-            assert_eq!(l, r)
+            assert_eq!(l, r);
         }
     }};
     ($left:expr, $right:expr , $($tt:tt)*) => {
-        assert_biteq!(@inner $left, $right, "\n", $($tt)*)
+        assert_biteq_!(@inner $left, $right, "\n", $($tt)*)
     };
     ($left:expr, $right:expr $(,)?) => {
-        assert_biteq!(@inner $left, $right, "", "")
+        assert_biteq_!(@inner $left, $right, "", "")
     };
 }
+pub(crate) use assert_biteq_ as assert_biteq;
 
+#[allow(unused)]
 mod const_asserts {
     // Shadow some assert implementations that would otherwise not compile in a const-context.
     // Every macro added here also needs to be added in the `float_test!` macro below.
@@ -63,8 +66,43 @@ mod const_asserts {
             std::assert!($left == $right, $($arg)+)
         };
     }
-
     pub(crate) use assert_eq;
+
+    macro_rules! assert_biteq {
+        (@inner $left:expr, $right:expr, $msg_sep:literal, $($tt:tt)*) => {{
+            let l = $left;
+            let r = $right;
+
+            // Hack to coerce left and right to the same type
+            let mut _eq_ty = l;
+            _eq_ty = r;
+
+            assert!(l.to_bits() == r.to_bits());
+
+            if !l.is_nan() && !r.is_nan() {
+                // Also check that standard equality holds, since most tests use `assert_biteq` rather
+                // than `assert_eq`.
+                assert!(l == r);
+            }
+        }};
+        ($left:expr, $right:expr , $($tt:tt)*) => {
+            assert_biteq!(@inner $left, $right, "\n", $($tt)*)
+        };
+        ($left:expr, $right:expr $(,)?) => {
+            assert_biteq!(@inner $left, $right, "", "")
+        };
+    }
+    pub(crate) use assert_biteq;
+
+    macro_rules! assert_approx_eq {
+        ($a:expr, $b:expr) => {{ assert_approx_eq!($a, $b, 1.0e-6) }};
+        ($a:expr, $b:expr, $lim:expr) => {{
+            let (a, b) = (&$a, &$b);
+            let diff = (*a - *b).abs();
+            assert!(diff <= $lim);
+        }};
+    }
+    pub(crate) use assert_approx_eq;
 }
 
 /// Generate float tests for all our float types, for compile-time and run-time behavior.
@@ -101,6 +139,8 @@ macro_rules! float_test {
         test<$fty:ident> $test:block
     ) => {
         mod $name {
+            use super::*;
+
             #[test]
             $( $( #[$f16_meta] )+ )?
             fn test_f16() {
@@ -131,7 +171,8 @@ macro_rules! float_test {
 
             $( $( #[$const_meta] )+ )?
             mod const_ {
-                use $crate::floats::const_asserts::assert_eq;
+                #[allow(unused)]
+                use $crate::floats::const_asserts::{assert_eq, assert_biteq, assert_approx_eq};
 
                 #[test]
                 $( $( #[$f16_const_meta] )+ )?
@@ -196,29 +237,25 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).min(0.0), 0.0);
-        assert!((0.0 as Float).min(0.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).min(-0.0), -0.0);
-        assert!((-0.0 as Float).min(-0.0).is_sign_negative());
-        assert_eq!((9.0 as Float).min(9.0), 9.0);
-        assert_eq!((-9.0 as Float).min(0.0), -9.0);
-        assert_eq!((0.0 as Float).min(9.0), 0.0);
-        assert!((0.0 as Float).min(9.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).min(9.0), -0.0);
-        assert!((-0.0 as Float).min(9.0).is_sign_negative());
-        assert_eq!((-0.0 as Float).min(-9.0), -9.0);
-        assert_eq!(Float::INFINITY.min(9.0), 9.0);
-        assert_eq!((9.0 as Float).min(Float::INFINITY), 9.0);
-        assert_eq!(Float::INFINITY.min(-9.0), -9.0);
-        assert_eq!((-9.0 as Float).min(Float::INFINITY), -9.0);
-        assert_eq!(Float::NEG_INFINITY.min(9.0), Float::NEG_INFINITY);
-        assert_eq!((9.0 as Float).min(Float::NEG_INFINITY), Float::NEG_INFINITY);
-        assert_eq!(Float::NEG_INFINITY.min(-9.0), Float::NEG_INFINITY);
-        assert_eq!((-9.0 as Float).min(Float::NEG_INFINITY), Float::NEG_INFINITY);
-        assert_eq!(Float::NAN.min(9.0), 9.0);
-        assert_eq!(Float::NAN.min(-9.0), -9.0);
-        assert_eq!((9.0 as Float).min(Float::NAN), 9.0);
-        assert_eq!((-9.0 as Float).min(Float::NAN), -9.0);
+        assert_biteq!((0.0 as Float).min(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).min(-0.0), -0.0);
+        assert_biteq!((9.0 as Float).min(9.0), 9.0);
+        assert_biteq!((-9.0 as Float).min(0.0), -9.0);
+        assert_biteq!((0.0 as Float).min(9.0), 0.0);
+        assert_biteq!((-0.0 as Float).min(9.0), -0.0);
+        assert_biteq!((-0.0 as Float).min(-9.0), -9.0);
+        assert_biteq!(Float::INFINITY.min(9.0), 9.0);
+        assert_biteq!((9.0 as Float).min(Float::INFINITY), 9.0);
+        assert_biteq!(Float::INFINITY.min(-9.0), -9.0);
+        assert_biteq!((-9.0 as Float).min(Float::INFINITY), -9.0);
+        assert_biteq!(Float::NEG_INFINITY.min(9.0), Float::NEG_INFINITY);
+        assert_biteq!((9.0 as Float).min(Float::NEG_INFINITY), Float::NEG_INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.min(-9.0), Float::NEG_INFINITY);
+        assert_biteq!((-9.0 as Float).min(Float::NEG_INFINITY), Float::NEG_INFINITY);
+        assert_biteq!(Float::NAN.min(9.0), 9.0);
+        assert_biteq!(Float::NAN.min(-9.0), -9.0);
+        assert_biteq!((9.0 as Float).min(Float::NAN), 9.0);
+        assert_biteq!((-9.0 as Float).min(Float::NAN), -9.0);
         assert!(Float::NAN.min(Float::NAN).is_nan());
     }
 }
@@ -230,32 +267,26 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).max(0.0), 0.0);
-        assert!((0.0 as Float).max(0.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).max(-0.0), -0.0);
-        assert!((-0.0 as Float).max(-0.0).is_sign_negative());
-        assert_eq!((9.0 as Float).max(9.0), 9.0);
-        assert_eq!((-9.0 as Float).max(0.0), 0.0);
-        assert!((-9.0 as Float).max(0.0).is_sign_positive());
-        assert_eq!((-9.0 as Float).max(-0.0), -0.0);
-        assert!((-9.0 as Float).max(-0.0).is_sign_negative());
-        assert_eq!((0.0 as Float).max(9.0), 9.0);
-        assert_eq!((0.0 as Float).max(-9.0), 0.0);
-        assert!((0.0 as Float).max(-9.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).max(-9.0), -0.0);
-        assert!((-0.0 as Float).max(-9.0).is_sign_negative());
-        assert_eq!(Float::INFINITY.max(9.0), Float::INFINITY);
-        assert_eq!((9.0 as Float).max(Float::INFINITY), Float::INFINITY);
-        assert_eq!(Float::INFINITY.max(-9.0), Float::INFINITY);
-        assert_eq!((-9.0 as Float).max(Float::INFINITY), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.max(9.0), 9.0);
-        assert_eq!((9.0 as Float).max(Float::NEG_INFINITY), 9.0);
-        assert_eq!(Float::NEG_INFINITY.max(-9.0), -9.0);
-        assert_eq!((-9.0 as Float).max(Float::NEG_INFINITY), -9.0);
-        assert_eq!(Float::NAN.max(9.0), 9.0);
-        assert_eq!(Float::NAN.max(-9.0), -9.0);
-        assert_eq!((9.0 as Float).max(Float::NAN), 9.0);
-        assert_eq!((-9.0 as Float).max(Float::NAN), -9.0);
+        assert_biteq!((0.0 as Float).max(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).max(-0.0), -0.0);
+        assert_biteq!((9.0 as Float).max(9.0), 9.0);
+        assert_biteq!((-9.0 as Float).max(0.0), 0.0);
+        assert_biteq!((-9.0 as Float).max(-0.0), -0.0);
+        assert_biteq!((0.0 as Float).max(9.0), 9.0);
+        assert_biteq!((0.0 as Float).max(-9.0), 0.0);
+        assert_biteq!((-0.0 as Float).max(-9.0), -0.0);
+        assert_biteq!(Float::INFINITY.max(9.0), Float::INFINITY);
+        assert_biteq!((9.0 as Float).max(Float::INFINITY), Float::INFINITY);
+        assert_biteq!(Float::INFINITY.max(-9.0), Float::INFINITY);
+        assert_biteq!((-9.0 as Float).max(Float::INFINITY), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.max(9.0), 9.0);
+        assert_biteq!((9.0 as Float).max(Float::NEG_INFINITY), 9.0);
+        assert_biteq!(Float::NEG_INFINITY.max(-9.0), -9.0);
+        assert_biteq!((-9.0 as Float).max(Float::NEG_INFINITY), -9.0);
+        assert_biteq!(Float::NAN.max(9.0), 9.0);
+        assert_biteq!(Float::NAN.max(-9.0), -9.0);
+        assert_biteq!((9.0 as Float).max(Float::NAN), 9.0);
+        assert_biteq!((-9.0 as Float).max(Float::NAN), -9.0);
         assert!(Float::NAN.max(Float::NAN).is_nan());
     }
 }
@@ -267,27 +298,22 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).minimum(0.0), 0.0);
-        assert!((0.0 as Float).minimum(0.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).minimum(0.0), -0.0);
-        assert!((-0.0 as Float).minimum(0.0).is_sign_negative());
-        assert_eq!((-0.0 as Float).minimum(-0.0), -0.0);
-        assert!((-0.0 as Float).minimum(-0.0).is_sign_negative());
-        assert_eq!((9.0 as Float).minimum(9.0), 9.0);
-        assert_eq!((-9.0 as Float).minimum(0.0), -9.0);
-        assert_eq!((0.0 as Float).minimum(9.0), 0.0);
-        assert!((0.0 as Float).minimum(9.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).minimum(9.0), -0.0);
-        assert!((-0.0 as Float).minimum(9.0).is_sign_negative());
-        assert_eq!((-0.0 as Float).minimum(-9.0), -9.0);
-        assert_eq!(Float::INFINITY.minimum(9.0), 9.0);
-        assert_eq!((9.0 as Float).minimum(Float::INFINITY), 9.0);
-        assert_eq!(Float::INFINITY.minimum(-9.0), -9.0);
-        assert_eq!((-9.0 as Float).minimum(Float::INFINITY), -9.0);
-        assert_eq!(Float::NEG_INFINITY.minimum(9.0), Float::NEG_INFINITY);
-        assert_eq!((9.0 as Float).minimum(Float::NEG_INFINITY), Float::NEG_INFINITY);
-        assert_eq!(Float::NEG_INFINITY.minimum(-9.0), Float::NEG_INFINITY);
-        assert_eq!((-9.0 as Float).minimum(Float::NEG_INFINITY), Float::NEG_INFINITY);
+        assert_biteq!((0.0 as Float).minimum(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).minimum(0.0), -0.0);
+        assert_biteq!((-0.0 as Float).minimum(-0.0), -0.0);
+        assert_biteq!((9.0 as Float).minimum(9.0), 9.0);
+        assert_biteq!((-9.0 as Float).minimum(0.0), -9.0);
+        assert_biteq!((0.0 as Float).minimum(9.0), 0.0);
+        assert_biteq!((-0.0 as Float).minimum(9.0), -0.0);
+        assert_biteq!((-0.0 as Float).minimum(-9.0), -9.0);
+        assert_biteq!(Float::INFINITY.minimum(9.0), 9.0);
+        assert_biteq!((9.0 as Float).minimum(Float::INFINITY), 9.0);
+        assert_biteq!(Float::INFINITY.minimum(-9.0), -9.0);
+        assert_biteq!((-9.0 as Float).minimum(Float::INFINITY), -9.0);
+        assert_biteq!(Float::NEG_INFINITY.minimum(9.0), Float::NEG_INFINITY);
+        assert_biteq!((9.0 as Float).minimum(Float::NEG_INFINITY), Float::NEG_INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.minimum(-9.0), Float::NEG_INFINITY);
+        assert_biteq!((-9.0 as Float).minimum(Float::NEG_INFINITY), Float::NEG_INFINITY);
         assert!(Float::NAN.minimum(9.0).is_nan());
         assert!(Float::NAN.minimum(-9.0).is_nan());
         assert!((9.0 as Float).minimum(Float::NAN).is_nan());
@@ -303,30 +329,23 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).maximum(0.0), 0.0);
-        assert!((0.0 as Float).maximum(0.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).maximum(0.0), 0.0);
-        assert!((-0.0 as Float).maximum(0.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).maximum(-0.0), -0.0);
-        assert!((-0.0 as Float).maximum(-0.0).is_sign_negative());
-        assert_eq!((9.0 as Float).maximum(9.0), 9.0);
-        assert_eq!((-9.0 as Float).maximum(0.0), 0.0);
-        assert!((-9.0 as Float).maximum(0.0).is_sign_positive());
-        assert_eq!((-9.0 as Float).maximum(-0.0), -0.0);
-        assert!((-9.0 as Float).maximum(-0.0).is_sign_negative());
-        assert_eq!((0.0 as Float).maximum(9.0), 9.0);
-        assert_eq!((0.0 as Float).maximum(-9.0), 0.0);
-        assert!((0.0 as Float).maximum(-9.0).is_sign_positive());
-        assert_eq!((-0.0 as Float).maximum(-9.0), -0.0);
-        assert!((-0.0 as Float).maximum(-9.0).is_sign_negative());
-        assert_eq!(Float::INFINITY.maximum(9.0), Float::INFINITY);
-        assert_eq!((9.0 as Float).maximum(Float::INFINITY), Float::INFINITY);
-        assert_eq!(Float::INFINITY.maximum(-9.0), Float::INFINITY);
-        assert_eq!((-9.0 as Float).maximum(Float::INFINITY), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.maximum(9.0), 9.0);
-        assert_eq!((9.0 as Float).maximum(Float::NEG_INFINITY), 9.0);
-        assert_eq!(Float::NEG_INFINITY.maximum(-9.0), -9.0);
-        assert_eq!((-9.0 as Float).maximum(Float::NEG_INFINITY), -9.0);
+        assert_biteq!((0.0 as Float).maximum(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).maximum(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).maximum(-0.0), -0.0);
+        assert_biteq!((9.0 as Float).maximum(9.0), 9.0);
+        assert_biteq!((-9.0 as Float).maximum(0.0), 0.0);
+        assert_biteq!((-9.0 as Float).maximum(-0.0), -0.0);
+        assert_biteq!((0.0 as Float).maximum(9.0), 9.0);
+        assert_biteq!((0.0 as Float).maximum(-9.0), 0.0);
+        assert_biteq!((-0.0 as Float).maximum(-9.0), -0.0);
+        assert_biteq!(Float::INFINITY.maximum(9.0), Float::INFINITY);
+        assert_biteq!((9.0 as Float).maximum(Float::INFINITY), Float::INFINITY);
+        assert_biteq!(Float::INFINITY.maximum(-9.0), Float::INFINITY);
+        assert_biteq!((-9.0 as Float).maximum(Float::INFINITY), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.maximum(9.0), 9.0);
+        assert_biteq!((9.0 as Float).maximum(Float::NEG_INFINITY), 9.0);
+        assert_biteq!(Float::NEG_INFINITY.maximum(-9.0), -9.0);
+        assert_biteq!((-9.0 as Float).maximum(Float::NEG_INFINITY), -9.0);
         assert!(Float::NAN.maximum(9.0).is_nan());
         assert!(Float::NAN.maximum(-9.0).is_nan());
         assert!((9.0 as Float).maximum(Float::NAN).is_nan());
@@ -342,38 +361,38 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.5 as Float).midpoint(0.5), 0.5);
-        assert_eq!((0.5 as Float).midpoint(2.5), 1.5);
-        assert_eq!((3.0 as Float).midpoint(4.0), 3.5);
-        assert_eq!((-3.0 as Float).midpoint(4.0), 0.5);
-        assert_eq!((3.0 as Float).midpoint(-4.0), -0.5);
-        assert_eq!((-3.0 as Float).midpoint(-4.0), -3.5);
-        assert_eq!((0.0 as Float).midpoint(0.0), 0.0);
-        assert_eq!((-0.0 as Float).midpoint(-0.0), -0.0);
-        assert_eq!((-5.0 as Float).midpoint(5.0), 0.0);
-        assert_eq!(Float::MAX.midpoint(Float::MIN), 0.0);
-        assert_eq!(Float::MIN.midpoint(Float::MAX), -0.0);
-        assert_eq!(Float::MAX.midpoint(Float::MIN_POSITIVE), Float::MAX / 2.);
-        assert_eq!((-Float::MAX).midpoint(Float::MIN_POSITIVE), -Float::MAX / 2.);
-        assert_eq!(Float::MAX.midpoint(-Float::MIN_POSITIVE), Float::MAX / 2.);
-        assert_eq!((-Float::MAX).midpoint(-Float::MIN_POSITIVE), -Float::MAX / 2.);
-        assert_eq!((Float::MIN_POSITIVE).midpoint(Float::MAX), Float::MAX / 2.);
-        assert_eq!((Float::MIN_POSITIVE).midpoint(-Float::MAX), -Float::MAX / 2.);
-        assert_eq!((-Float::MIN_POSITIVE).midpoint(Float::MAX), Float::MAX / 2.);
-        assert_eq!((-Float::MIN_POSITIVE).midpoint(-Float::MAX), -Float::MAX / 2.);
-        assert_eq!(Float::MAX.midpoint(Float::MAX), Float::MAX);
-        assert_eq!(
+        assert_biteq!((0.5 as Float).midpoint(0.5), 0.5);
+        assert_biteq!((0.5 as Float).midpoint(2.5), 1.5);
+        assert_biteq!((3.0 as Float).midpoint(4.0), 3.5);
+        assert_biteq!((-3.0 as Float).midpoint(4.0), 0.5);
+        assert_biteq!((3.0 as Float).midpoint(-4.0), -0.5);
+        assert_biteq!((-3.0 as Float).midpoint(-4.0), -3.5);
+        assert_biteq!((0.0 as Float).midpoint(0.0), 0.0);
+        assert_biteq!((-0.0 as Float).midpoint(-0.0), -0.0);
+        assert_biteq!((-5.0 as Float).midpoint(5.0), 0.0);
+        assert_biteq!(Float::MAX.midpoint(Float::MIN), 0.0);
+        assert_biteq!(Float::MIN.midpoint(Float::MAX), 0.0);
+        assert_biteq!(Float::MAX.midpoint(Float::MIN_POSITIVE), Float::MAX / 2.);
+        assert_biteq!((-Float::MAX).midpoint(Float::MIN_POSITIVE), -Float::MAX / 2.);
+        assert_biteq!(Float::MAX.midpoint(-Float::MIN_POSITIVE), Float::MAX / 2.);
+        assert_biteq!((-Float::MAX).midpoint(-Float::MIN_POSITIVE), -Float::MAX / 2.);
+        assert_biteq!((Float::MIN_POSITIVE).midpoint(Float::MAX), Float::MAX / 2.);
+        assert_biteq!((Float::MIN_POSITIVE).midpoint(-Float::MAX), -Float::MAX / 2.);
+        assert_biteq!((-Float::MIN_POSITIVE).midpoint(Float::MAX), Float::MAX / 2.);
+        assert_biteq!((-Float::MIN_POSITIVE).midpoint(-Float::MAX), -Float::MAX / 2.);
+        assert_biteq!(Float::MAX.midpoint(Float::MAX), Float::MAX);
+        assert_biteq!(
             (Float::MIN_POSITIVE).midpoint(Float::MIN_POSITIVE),
             Float::MIN_POSITIVE
         );
-        assert_eq!(
+        assert_biteq!(
             (-Float::MIN_POSITIVE).midpoint(-Float::MIN_POSITIVE),
             -Float::MIN_POSITIVE
         );
-        assert_eq!(Float::MAX.midpoint(5.0), Float::MAX / 2.0 + 2.5);
-        assert_eq!(Float::MAX.midpoint(-5.0), Float::MAX / 2.0 - 2.5);
-        assert_eq!(Float::INFINITY.midpoint(Float::INFINITY), Float::INFINITY);
-        assert_eq!(
+        assert_biteq!(Float::MAX.midpoint(5.0), Float::MAX / 2.0 + 2.5);
+        assert_biteq!(Float::MAX.midpoint(-5.0), Float::MAX / 2.0 - 2.5);
+        assert_biteq!(Float::INFINITY.midpoint(Float::INFINITY), Float::INFINITY);
+        assert_biteq!(
             Float::NEG_INFINITY.midpoint(Float::NEG_INFINITY),
             Float::NEG_INFINITY
         );
@@ -410,7 +429,7 @@ float_test! {
                 let naive = (large + small) / 2.0;
                 let midpoint = large.midpoint(small);
 
-                assert_eq!(naive, midpoint);
+                assert_biteq!(naive, midpoint);
             }
         }
     }
@@ -423,10 +442,10 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((-1.0 as Float).abs(), 1.0);
-        assert_eq!((1.0 as Float).abs(), 1.0);
-        assert_eq!(Float::NEG_INFINITY.abs(), Float::INFINITY);
-        assert_eq!(Float::INFINITY.abs(), Float::INFINITY);
+        assert_biteq!((-1.0 as Float).abs(), 1.0);
+        assert_biteq!((1.0 as Float).abs(), 1.0);
+        assert_biteq!(Float::NEG_INFINITY.abs(), Float::INFINITY);
+        assert_biteq!(Float::INFINITY.abs(), Float::INFINITY);
     }
 }
 
@@ -437,10 +456,10 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((1.0 as Float).copysign(-2.0), -1.0);
-        assert_eq!((-1.0 as Float).copysign(2.0), 1.0);
-        assert_eq!(Float::INFINITY.copysign(-0.0), Float::NEG_INFINITY);
-        assert_eq!(Float::NEG_INFINITY.copysign(0.0), Float::INFINITY);
+        assert_biteq!((1.0 as Float).copysign(-2.0), -1.0);
+        assert_biteq!((-1.0 as Float).copysign(2.0), 1.0);
+        assert_biteq!(Float::INFINITY.copysign(-0.0), Float::NEG_INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.copysign(0.0), Float::INFINITY);
     }
 }
 
@@ -453,7 +472,7 @@ float_test! {
     },
     test<Float> {
         assert!(Float::INFINITY.rem_euclid(42.0 as Float).is_nan());
-        assert_eq!((42.0 as Float).rem_euclid(Float::INFINITY), (42.0 as Float));
+        assert_biteq!((42.0 as Float).rem_euclid(Float::INFINITY), 42.0 as Float);
         assert!((42.0 as Float).rem_euclid(Float::NAN).is_nan());
         assert!(Float::INFINITY.rem_euclid(Float::INFINITY).is_nan());
         assert!(Float::INFINITY.rem_euclid(Float::NAN).is_nan());
@@ -469,7 +488,7 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((42.0 as Float).div_euclid(Float::INFINITY), 0.0);
+        assert_biteq!((42.0 as Float).div_euclid(Float::INFINITY), 0.0);
         assert!((42.0 as Float).div_euclid(Float::NAN).is_nan());
         assert!(Float::INFINITY.div_euclid(Float::INFINITY).is_nan());
         assert!(Float::INFINITY.div_euclid(Float::NAN).is_nan());
@@ -484,20 +503,18 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).floor(), 0.0);
-        assert!((0.0 as Float).floor().is_sign_positive());
-        assert_eq!((-0.0 as Float).floor(), -0.0);
-        assert!((-0.0 as Float).floor().is_sign_negative());
-        assert_eq!((0.5 as Float).floor(), 0.0);
-        assert_eq!((-0.5 as Float).floor(), -1.0);
-        assert_eq!((1.5 as Float).floor(), 1.0);
-        assert_eq!(Float::MAX.floor(), Float::MAX);
-        assert_eq!(Float::MIN.floor(), Float::MIN);
-        assert_eq!(Float::MIN_POSITIVE.floor(), 0.0);
-        assert_eq!((-Float::MIN_POSITIVE).floor(), -1.0);
+        assert_biteq!((0.0 as Float).floor(), 0.0);
+        assert_biteq!((-0.0 as Float).floor(), -0.0);
+        assert_biteq!((0.5 as Float).floor(), 0.0);
+        assert_biteq!((-0.5 as Float).floor(), -1.0);
+        assert_biteq!((1.5 as Float).floor(), 1.0);
+        assert_biteq!(Float::MAX.floor(), Float::MAX);
+        assert_biteq!(Float::MIN.floor(), Float::MIN);
+        assert_biteq!(Float::MIN_POSITIVE.floor(), 0.0);
+        assert_biteq!((-Float::MIN_POSITIVE).floor(), -1.0);
         assert!(Float::NAN.floor().is_nan());
-        assert_eq!(Float::INFINITY.floor(), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.floor(), Float::NEG_INFINITY);
+        assert_biteq!(Float::INFINITY.floor(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.floor(), Float::NEG_INFINITY);
     }
 }
 
@@ -508,19 +525,17 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).ceil(), 0.0);
-        assert!((0.0 as Float).ceil().is_sign_positive());
-        assert_eq!((-0.0 as Float).ceil(), 0.0);
-        assert!((-0.0 as Float).ceil().is_sign_negative());
-        assert_eq!((0.5 as Float).ceil(), 1.0);
-        assert_eq!((-0.5 as Float).ceil(), 0.0);
-        assert_eq!(Float::MAX.ceil(), Float::MAX);
-        assert_eq!(Float::MIN.ceil(), Float::MIN);
-        assert_eq!(Float::MIN_POSITIVE.ceil(), 1.0);
-        assert_eq!((-Float::MIN_POSITIVE).ceil(), 0.0);
+        assert_biteq!((0.0 as Float).ceil(), 0.0);
+        assert_biteq!((-0.0 as Float).ceil(), -0.0);
+        assert_biteq!((0.5 as Float).ceil(), 1.0);
+        assert_biteq!((-0.5 as Float).ceil(), -0.0);
+        assert_biteq!(Float::MAX.ceil(), Float::MAX);
+        assert_biteq!(Float::MIN.ceil(), Float::MIN);
+        assert_biteq!(Float::MIN_POSITIVE.ceil(), 1.0);
+        assert_biteq!((-Float::MIN_POSITIVE).ceil(), -0.0);
         assert!(Float::NAN.ceil().is_nan());
-        assert_eq!(Float::INFINITY.ceil(), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.ceil(), Float::NEG_INFINITY);
+        assert_biteq!(Float::INFINITY.ceil(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.ceil(), Float::NEG_INFINITY);
     }
 }
 
@@ -531,19 +546,17 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).round(), 0.0);
-        assert!((0.0 as Float).round().is_sign_positive());
-        assert_eq!((-0.0 as Float).round(), -0.0);
-        assert!((-0.0 as Float).round().is_sign_negative());
-        assert_eq!((0.5 as Float).round(), 1.0);
-        assert_eq!((-0.5 as Float).round(), -1.0);
-        assert_eq!(Float::MAX.round(), Float::MAX);
-        assert_eq!(Float::MIN.round(), Float::MIN);
-        assert_eq!(Float::MIN_POSITIVE.round(), 0.0);
-        assert_eq!((-Float::MIN_POSITIVE).round(), 0.0);
+        assert_biteq!((0.0 as Float).round(), 0.0);
+        assert_biteq!((-0.0 as Float).round(), -0.0);
+        assert_biteq!((0.5 as Float).round(), 1.0);
+        assert_biteq!((-0.5 as Float).round(), -1.0);
+        assert_biteq!(Float::MAX.round(), Float::MAX);
+        assert_biteq!(Float::MIN.round(), Float::MIN);
+        assert_biteq!(Float::MIN_POSITIVE.round(), 0.0);
+        assert_biteq!((-Float::MIN_POSITIVE).round(), -0.0);
         assert!(Float::NAN.round().is_nan());
-        assert_eq!(Float::INFINITY.round(), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.round(), Float::NEG_INFINITY);
+        assert_biteq!(Float::INFINITY.round(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.round(), Float::NEG_INFINITY);
     }
 }
 
@@ -554,21 +567,17 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).round_ties_even(), 0.0);
-        assert!((0.0 as Float).round_ties_even().is_sign_positive());
-        assert_eq!((-0.0 as Float).round_ties_even(), -0.0);
-        assert!((-0.0 as Float).round_ties_even().is_sign_negative());
-        assert_eq!((0.5 as Float).round_ties_even(), 0.0);
-        assert!((0.5 as Float).round_ties_even().is_sign_positive());
-        assert_eq!((-0.5 as Float).round_ties_even(), -0.0);
-        assert!((-0.5 as Float).round_ties_even().is_sign_negative());
-        assert_eq!(Float::MAX.round_ties_even(), Float::MAX);
-        assert_eq!(Float::MIN.round_ties_even(), Float::MIN);
-        assert_eq!(Float::MIN_POSITIVE.round_ties_even(), 0.0);
-        assert_eq!((-Float::MIN_POSITIVE).round_ties_even(), 0.0);
+        assert_biteq!((0.0 as Float).round_ties_even(), 0.0);
+        assert_biteq!((-0.0 as Float).round_ties_even(), -0.0);
+        assert_biteq!((0.5 as Float).round_ties_even(), 0.0);
+        assert_biteq!((-0.5 as Float).round_ties_even(), -0.0);
+        assert_biteq!(Float::MAX.round_ties_even(), Float::MAX);
+        assert_biteq!(Float::MIN.round_ties_even(), Float::MIN);
+        assert_biteq!(Float::MIN_POSITIVE.round_ties_even(), 0.0);
+        assert_biteq!((-Float::MIN_POSITIVE).round_ties_even(), -0.0);
         assert!(Float::NAN.round_ties_even().is_nan());
-        assert_eq!(Float::INFINITY.round_ties_even(), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.round_ties_even(), Float::NEG_INFINITY);
+        assert_biteq!(Float::INFINITY.round_ties_even(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.round_ties_even(), Float::NEG_INFINITY);
     }
 }
 
@@ -579,21 +588,17 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).trunc(), 0.0);
-        assert!((0.0 as Float).trunc().is_sign_positive());
-        assert_eq!((-0.0 as Float).trunc(), -0.0);
-        assert!((-0.0 as Float).trunc().is_sign_negative());
-        assert_eq!((0.5 as Float).trunc(), 0.0);
-        assert!((0.5 as Float).trunc().is_sign_positive());
-        assert_eq!((-0.5 as Float).trunc(), -0.0);
-        assert!((-0.5 as Float).trunc().is_sign_negative());
-        assert_eq!(Float::MAX.trunc(), Float::MAX);
-        assert_eq!(Float::MIN.trunc(), Float::MIN);
-        assert_eq!(Float::MIN_POSITIVE.trunc(), 0.0);
-        assert_eq!((-Float::MIN_POSITIVE).trunc(), 0.0);
+        assert_biteq!((0.0 as Float).trunc(), 0.0);
+        assert_biteq!((-0.0 as Float).trunc(), -0.0);
+        assert_biteq!((0.5 as Float).trunc(), 0.0);
+        assert_biteq!((-0.5 as Float).trunc(), -0.0);
+        assert_biteq!(Float::MAX.trunc(), Float::MAX);
+        assert_biteq!(Float::MIN.trunc(), Float::MIN);
+        assert_biteq!(Float::MIN_POSITIVE.trunc(), 0.0);
+        assert_biteq!((-Float::MIN_POSITIVE).trunc(), -0.0);
         assert!(Float::NAN.trunc().is_nan());
-        assert_eq!(Float::INFINITY.trunc(), Float::INFINITY);
-        assert_eq!(Float::NEG_INFINITY.trunc(), Float::NEG_INFINITY);
+        assert_biteq!(Float::INFINITY.trunc(), Float::INFINITY);
+        assert_biteq!(Float::NEG_INFINITY.trunc(), Float::NEG_INFINITY);
     }
 }
 
@@ -604,19 +609,15 @@ float_test! {
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
     test<Float> {
-        assert_eq!((0.0 as Float).fract(), 0.0);
-        assert!((0.0 as Float).fract().is_sign_positive());
-        assert_eq!((-0.0 as Float).fract(), 0.0);
-        assert!((-0.0 as Float).fract().is_sign_positive());
-        assert_eq!((0.5 as Float).fract(), 0.5);
-        assert!((0.5 as Float).fract().is_sign_positive());
-        assert_eq!((-0.5 as Float).fract(), -0.5);
-        assert!((-0.5 as Float).fract().is_sign_negative());
-        assert_eq!(Float::MAX.fract(), 0.0);
-        assert_eq!(Float::MIN.fract(), 0.0);
-        assert_eq!(Float::MIN_POSITIVE.fract(), Float::MIN_POSITIVE);
+        assert_biteq!((0.0 as Float).fract(), 0.0);
+        assert_biteq!((-0.0 as Float).fract(), 0.0);
+        assert_biteq!((0.5 as Float).fract(), 0.5);
+        assert_biteq!((-0.5 as Float).fract(), -0.5);
+        assert_biteq!(Float::MAX.fract(), 0.0);
+        assert_biteq!(Float::MIN.fract(), 0.0);
+        assert_biteq!(Float::MIN_POSITIVE.fract(), Float::MIN_POSITIVE);
         assert!(Float::MIN_POSITIVE.fract().is_sign_positive());
-        assert_eq!((-Float::MIN_POSITIVE).fract(), -Float::MIN_POSITIVE);
+        assert_biteq!((-Float::MIN_POSITIVE).fract(), -Float::MIN_POSITIVE);
         assert!((-Float::MIN_POSITIVE).fract().is_sign_negative());
         assert!(Float::NAN.fract().is_nan());
         assert!(Float::INFINITY.fract().is_nan());

--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -411,6 +411,8 @@ float_test! {
             Float::NEG_INFINITY.midpoint(Float::NEG_INFINITY),
             Float::NEG_INFINITY
         );
+        assert!(Float::NEG_INFINITY.midpoint(Float::INFINITY).is_nan());
+        assert!(Float::INFINITY.midpoint(Float::NEG_INFINITY).is_nan());
         assert!(Float::NAN.midpoint(1.0).is_nan());
         assert!((1.0 as Float).midpoint(Float::NAN).is_nan());
         assert!(Float::NAN.midpoint(Float::NAN).is_nan());


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/141726

Best reviewed commit-by-commit.

- Use `assert_biteq!` in the `mod.rs` tests. This requires some trickery to make shadowing macros with imports work.
- The min, max, minimum, maximum tests in `tests/floats/f*.rs` are entirely subsumed by what we already have in `tests/float/mod.rs`, so I just removed them.
- The rounding tests (floor etc) in `f*.rs` had more test points, so I copied them over. They didn't have `0.5` and `-0.5` though which seem like interesting points in particular regarding the sign of the resulting zero if that's what it sounds to, and they didn't max min/max/inf/nan tests, so this was really a merger of both tests.

r? @tgross35 