### PR TITLE
Add edition checks for some tests that had divergent output

### DIFF
--- a/tests/ui/coroutine/auto-trait-regions.rs
+++ b/tests/ui/coroutine/auto-trait-regions.rs
@@ -23,31 +23,31 @@ fn assert_foo<T: Foo>(f: T) {}
 fn main() {
     // Make sure 'static is erased for coroutine interiors so we can't match it in trait selection
     let x: &'static _ = &OnlyFooIfStaticRef(No);
-    let gen = #[coroutine] move || {
+    let generator = #[coroutine] move || {
         let x = x;
         yield;
         assert_foo(x);
     };
-    assert_foo(gen);
+    assert_foo(generator);
     //~^ ERROR implementation of `Foo` is not general enough
 
     // Allow impls which matches any lifetime
     let x = &OnlyFooIfRef(No);
-    let gen = #[coroutine] move || {
+    let generator = #[coroutine] move || {
         let x = x;
         yield;
         assert_foo(x);
     };
-    assert_foo(gen); // ok
+    assert_foo(generator); // ok
 
     // Disallow impls which relates lifetimes in the coroutine interior
-    let gen = #[coroutine] move || {
+    let generator = #[coroutine] move || {
         let a = A(&mut true, &mut true, No);
         //~^ ERROR borrow may still be in use when coroutine yields
         //~| ERROR borrow may still be in use when coroutine yields
         yield;
         assert_foo(a);
     };
-    assert_foo(gen);
+    assert_foo(generator);
     //~^ ERROR not general enough
 }

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -33,8 +33,8 @@ LL |     let gen = #[coroutine] static move || {
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:31:5
    |
-LL |     assert_foo(gen);
-   |     ^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+LL |     assert_foo(generator);
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |
    = note: `&'0 OnlyFooIfStaticRef` must implement `Foo`, for any lifetime `'0`...
    = note: ...but `Foo` is actually implemented for the type `&'static OnlyFooIfStaticRef`
@@ -42,8 +42,8 @@ LL |     assert_foo(gen);
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:51:5
    |
-LL |     assert_foo(gen);
-   |     ^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+LL |     assert_foo(generator);
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |
    = note: `Foo` would have to be implemented for the type `A<'0, '1>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Foo` is actually implemented for the type `A<'_, '2>`, for some specific lifetime `'2`

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -1,8 +1,8 @@
 error[E0626]: borrow may still be in use when coroutine yields
   --> $DIR/auto-trait-regions.rs:45:19
    |
-LL |     let gen = #[coroutine] move || {
-   |                            ------- within this coroutine
+LL |     let generator = #[coroutine] move || {
+   |                                  ------- within this coroutine
 LL |         let a = A(&mut true, &mut true, No);
    |                   ^^^^^^^^^
 ...
@@ -11,14 +11,14 @@ LL |         yield;
    |
 help: add `static` to mark this coroutine as unmovable
    |
-LL |     let gen = #[coroutine] static move || {
-   |                            ++++++
+LL |     let generator = #[coroutine] static move || {
+   |                                  ++++++
 
 error[E0626]: borrow may still be in use when coroutine yields
   --> $DIR/auto-trait-regions.rs:45:30
    |
-LL |     let gen = #[coroutine] move || {
-   |                            ------- within this coroutine
+LL |     let generator = #[coroutine] move || {
+   |                                  ------- within this coroutine
 LL |         let a = A(&mut true, &mut true, No);
    |                              ^^^^^^^^^
 ...
@@ -27,8 +27,8 @@ LL |         yield;
    |
 help: add `static` to mark this coroutine as unmovable
    |
-LL |     let gen = #[coroutine] static move || {
-   |                            ++++++
+LL |     let generator = #[coroutine] static move || {
+   |                                  ++++++
 
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:31:5

--- a/tests/ui/coroutine/clone-impl-static.rs
+++ b/tests/ui/coroutine/clone-impl-static.rs
@@ -7,13 +7,13 @@
 #![feature(coroutines, coroutine_clone, stmt_expr_attributes)]
 
 fn main() {
-    let gen = #[coroutine]
+    let generator = #[coroutine]
     static move || {
         yield;
     };
-    check_copy(&gen);
+    check_copy(&generator);
     //~^ ERROR Copy` is not satisfied
-    check_clone(&gen);
+    check_clone(&generator);
     //~^ ERROR Clone` is not satisfied
 }
 

--- a/tests/ui/coroutine/clone-impl-static.stderr
+++ b/tests/ui/coroutine/clone-impl-static.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}: Copy` is not satisfied
   --> $DIR/clone-impl-static.rs:14:16
    |
-LL |     check_copy(&gen);
-   |     ---------- ^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
+LL |     check_copy(&generator);
+   |     ---------- ^^^^^^^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -15,8 +15,8 @@ LL | fn check_copy<T: Copy>(_x: &T) {}
 error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}: Clone` is not satisfied
   --> $DIR/clone-impl-static.rs:16:17
    |
-LL |     check_clone(&gen);
-   |     ----------- ^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
+LL |     check_clone(&generator);
+   |     ----------- ^^^^^^^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -1,5 +1,5 @@
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:1:10
+  --> $DIR/bad-assoc-ty.rs:5:10
    |
 LL | type A = [u8; 4]::AssocTy;
    |          ^^^^^^^
@@ -10,7 +10,7 @@ LL | type A = <[u8; 4]>::AssocTy;
    |          +       +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:5:10
+  --> $DIR/bad-assoc-ty.rs:9:10
    |
 LL | type B = [u8]::AssocTy;
    |          ^^^^
@@ -21,7 +21,7 @@ LL | type B = <[u8]>::AssocTy;
    |          +    +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:9:10
+  --> $DIR/bad-assoc-ty.rs:13:10
    |
 LL | type C = (u8)::AssocTy;
    |          ^^^^
@@ -32,7 +32,7 @@ LL | type C = <(u8)>::AssocTy;
    |          +    +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:13:10
+  --> $DIR/bad-assoc-ty.rs:17:10
    |
 LL | type D = (u8, u8)::AssocTy;
    |          ^^^^^^^^
@@ -43,7 +43,7 @@ LL | type D = <(u8, u8)>::AssocTy;
    |          +        +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:17:10
+  --> $DIR/bad-assoc-ty.rs:21:10
    |
 LL | type E = _::AssocTy;
    |          ^
@@ -54,7 +54,7 @@ LL | type E = <_>::AssocTy;
    |          + +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:21:19
+  --> $DIR/bad-assoc-ty.rs:25:19
    |
 LL | type F = &'static (u8)::AssocTy;
    |                   ^^^^
@@ -65,7 +65,7 @@ LL | type F = &'static <(u8)>::AssocTy;
    |                   +    +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:27:10
+  --> $DIR/bad-assoc-ty.rs:31:10
    |
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL | type G = <dyn 'static + (Send)>::AssocTy;
    |          +                    +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:46:10
+  --> $DIR/bad-assoc-ty.rs:51:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^
@@ -87,7 +87,7 @@ LL | type I = <ty!()>::AssocTy;
    |          +     +
 
 error: missing angle brackets in associated item path
-  --> $DIR/bad-assoc-ty.rs:39:19
+  --> $DIR/bad-assoc-ty.rs:44:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^
@@ -102,7 +102,7 @@ LL |     ($ty: ty) => (<$ty>::AssocTy);
    |                   +   +
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:1:10
+  --> $DIR/bad-assoc-ty.rs:5:10
    |
 LL | type A = [u8; 4]::AssocTy;
    |          ^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL + type A = <[u8; 4] as Example>::AssocTy;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:5:10
+  --> $DIR/bad-assoc-ty.rs:9:10
    |
 LL | type B = [u8]::AssocTy;
    |          ^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL + type B = <[u8] as Example>::AssocTy;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:9:10
+  --> $DIR/bad-assoc-ty.rs:13:10
    |
 LL | type C = (u8)::AssocTy;
    |          ^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL + type C = <u8 as Example>::AssocTy;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:13:10
+  --> $DIR/bad-assoc-ty.rs:17:10
    |
 LL | type D = (u8, u8)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^
@@ -150,13 +150,13 @@ LL + type D = <(u8, u8) as Example>::AssocTy;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/bad-assoc-ty.rs:17:10
+  --> $DIR/bad-assoc-ty.rs:21:10
    |
 LL | type E = _::AssocTy;
    |          ^ not allowed in type signatures
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:21:19
+  --> $DIR/bad-assoc-ty.rs:25:19
    |
 LL | type F = &'static (u8)::AssocTy;
    |                   ^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ LL + type F = &'static <u8 as Example>::AssocTy;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:27:10
+  --> $DIR/bad-assoc-ty.rs:31:10
    |
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,7 +180,7 @@ LL + type G = <(dyn Send + 'static) as Example>::AssocTy;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bad-assoc-ty.rs:33:10
+  --> $DIR/bad-assoc-ty.rs:37:10
    |
 LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^
@@ -194,7 +194,7 @@ LL | type H = <dyn Fn(u8) -> (u8)>::Output;
    |          ++++               +
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:33:10
+  --> $DIR/bad-assoc-ty.rs:37:10
    |
 LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ LL + type H = <(dyn Fn(u8) -> u8 + 'static) as IntoFuture>::Output;
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:39:19
+  --> $DIR/bad-assoc-ty.rs:44:19
    |
 LL |     ($ty: ty) => ($ty::AssocTy);
    |                   ^^^^^^^^^^^^
@@ -225,7 +225,7 @@ LL +     ($ty: ty) => (<u8 as Example>::AssocTy);
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/bad-assoc-ty.rs:46:10
+  --> $DIR/bad-assoc-ty.rs:51:10
    |
 LL | type I = ty!()::AssocTy;
    |          ^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL + type I = <u8 as Example>::AssocTy;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:51:13
+  --> $DIR/bad-assoc-ty.rs:56:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
    |             ^  ^ not allowed in type signatures
@@ -245,7 +245,7 @@ LL | fn foo<X: K<_, _>>(x: X) {}
    |             not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:54:34
+  --> $DIR/bad-assoc-ty.rs:59:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
@@ -257,7 +257,7 @@ LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:57:19
+  --> $DIR/bad-assoc-ty.rs:62:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
@@ -269,7 +269,7 @@ LL + fn baz<F: Fn() -> T, T>(_: F) {}
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:60:33
+  --> $DIR/bad-assoc-ty.rs:65:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
@@ -281,7 +281,7 @@ LL + struct L<F, T>(F) where F: Fn() -> T;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:82:38
+  --> $DIR/bad-assoc-ty.rs:87:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
    |                                      ^ not allowed in type signatures
@@ -293,7 +293,7 @@ LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:62:30
+  --> $DIR/bad-assoc-ty.rs:67:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
@@ -305,7 +305,7 @@ LL + struct M<F, T> where F: Fn() -> T {
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:66:28
+  --> $DIR/bad-assoc-ty.rs:71:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
@@ -317,7 +317,7 @@ LL + enum N<F, T> where F: Fn() -> T {
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:71:29
+  --> $DIR/bad-assoc-ty.rs:76:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -329,7 +329,7 @@ LL + union O<F, T> where F: Fn() -> T {
    |
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/bad-assoc-ty.rs:73:5
+  --> $DIR/bad-assoc-ty.rs:78:5
    |
 LL |     foo: F,
    |     ^^^^^^
@@ -341,7 +341,7 @@ LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:77:29
+  --> $DIR/bad-assoc-ty.rs:82:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
@@ -1,0 +1,340 @@
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:5:10
+   |
+LL | type A = [u8; 4]::AssocTy;
+   |          ^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type A = <[u8; 4]>::AssocTy;
+   |          +       +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:9:10
+   |
+LL | type B = [u8]::AssocTy;
+   |          ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type B = <[u8]>::AssocTy;
+   |          +    +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:13:10
+   |
+LL | type C = (u8)::AssocTy;
+   |          ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type C = <(u8)>::AssocTy;
+   |          +    +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:17:10
+   |
+LL | type D = (u8, u8)::AssocTy;
+   |          ^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type D = <(u8, u8)>::AssocTy;
+   |          +        +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:21:10
+   |
+LL | type E = _::AssocTy;
+   |          ^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type E = <_>::AssocTy;
+   |          + +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:25:19
+   |
+LL | type F = &'static (u8)::AssocTy;
+   |                   ^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type F = &'static <(u8)>::AssocTy;
+   |                   +    +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:31:10
+   |
+LL | type G = dyn 'static + (Send)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type G = <dyn 'static + (Send)>::AssocTy;
+   |          +                    +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:51:10
+   |
+LL | type I = ty!()::AssocTy;
+   |          ^^^^^
+   |
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL | type I = <ty!()>::AssocTy;
+   |          +     +
+
+error: missing angle brackets in associated item path
+  --> $DIR/bad-assoc-ty.rs:44:19
+   |
+LL |     ($ty: ty) => ($ty::AssocTy);
+   |                   ^^^
+...
+LL | type J = ty!(u8);
+   |          ------- in this macro invocation
+   |
+   = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: types that don't start with an identifier need to be surrounded with angle brackets in qualified paths
+   |
+LL |     ($ty: ty) => (<$ty>::AssocTy);
+   |                   +   +
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:5:10
+   |
+LL | type A = [u8; 4]::AssocTy;
+   |          ^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `[u8; 4]`, you could use the fully-qualified path
+   |
+LL - type A = [u8; 4]::AssocTy;
+LL + type A = <[u8; 4] as Example>::AssocTy;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:9:10
+   |
+LL | type B = [u8]::AssocTy;
+   |          ^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `[u8]`, you could use the fully-qualified path
+   |
+LL - type B = [u8]::AssocTy;
+LL + type B = <[u8] as Example>::AssocTy;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:13:10
+   |
+LL | type C = (u8)::AssocTy;
+   |          ^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `u8`, you could use the fully-qualified path
+   |
+LL - type C = (u8)::AssocTy;
+LL + type C = <u8 as Example>::AssocTy;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:17:10
+   |
+LL | type D = (u8, u8)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `(u8, u8)`, you could use the fully-qualified path
+   |
+LL - type D = (u8, u8)::AssocTy;
+LL + type D = <(u8, u8) as Example>::AssocTy;
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
+  --> $DIR/bad-assoc-ty.rs:21:10
+   |
+LL | type E = _::AssocTy;
+   |          ^ not allowed in type signatures
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:25:19
+   |
+LL | type F = &'static (u8)::AssocTy;
+   |                   ^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `u8`, you could use the fully-qualified path
+   |
+LL - type F = &'static (u8)::AssocTy;
+LL + type F = &'static <u8 as Example>::AssocTy;
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:31:10
+   |
+LL | type G = dyn 'static + (Send)::AssocTy;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `(dyn Send + 'static)`, you could use the fully-qualified path
+   |
+LL - type G = dyn 'static + (Send)::AssocTy;
+LL + type G = <(dyn Send + 'static) as Example>::AssocTy;
+   |
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/bad-assoc-ty.rs:37:10
+   |
+LL | type H = Fn(u8) -> (u8)::Output;
+   |          ^^^^^^^^^^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | type H = <dyn Fn(u8) -> (u8)>::Output;
+   |          ++++               +
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:44:19
+   |
+LL |     ($ty: ty) => ($ty::AssocTy);
+   |                   ^^^^^^^^^^^^
+...
+LL | type J = ty!(u8);
+   |          ------- in this macro invocation
+   |
+   = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `u8`, you could use the fully-qualified path
+   |
+LL -     ($ty: ty) => ($ty::AssocTy);
+LL +     ($ty: ty) => (<u8 as Example>::AssocTy);
+   |
+
+error[E0223]: ambiguous associated type
+  --> $DIR/bad-assoc-ty.rs:51:10
+   |
+LL | type I = ty!()::AssocTy;
+   |          ^^^^^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `u8`, you could use the fully-qualified path
+   |
+LL - type I = ty!()::AssocTy;
+LL + type I = <u8 as Example>::AssocTy;
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:56:13
+   |
+LL | fn foo<X: K<_, _>>(x: X) {}
+   |             ^  ^ not allowed in type signatures
+   |             |
+   |             not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:59:34
+   |
+LL | fn bar<F>(_: F) where F: Fn() -> _ {}
+   |                                  ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - fn bar<F>(_: F) where F: Fn() -> _ {}
+LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:62:19
+   |
+LL | fn baz<F: Fn() -> _>(_: F) {}
+   |                   ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - fn baz<F: Fn() -> _>(_: F) {}
+LL + fn baz<F: Fn() -> T, T>(_: F) {}
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/bad-assoc-ty.rs:65:33
+   |
+LL | struct L<F>(F) where F: Fn() -> _;
+   |                                 ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - struct L<F>(F) where F: Fn() -> _;
+LL + struct L<F, T>(F) where F: Fn() -> T;
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:87:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL -     fn foo<F>(_: F) where F: Fn() -> _ {}
+LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/bad-assoc-ty.rs:67:30
+   |
+LL | struct M<F> where F: Fn() -> _ {
+   |                              ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - struct M<F> where F: Fn() -> _ {
+LL + struct M<F, T> where F: Fn() -> T {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
+  --> $DIR/bad-assoc-ty.rs:71:28
+   |
+LL | enum N<F> where F: Fn() -> _ {
+   |                            ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - enum N<F> where F: Fn() -> _ {
+LL + enum N<F, T> where F: Fn() -> T {
+   |
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
+  --> $DIR/bad-assoc-ty.rs:76:29
+   |
+LL | union O<F> where F: Fn() -> _ {
+   |                             ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - union O<F> where F: Fn() -> _ {
+LL + union O<F, T> where F: Fn() -> T {
+   |
+
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/bad-assoc-ty.rs:78:5
+   |
+LL |     foo: F,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     foo: std::mem::ManuallyDrop<F>,
+   |          +++++++++++++++++++++++ +
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
+  --> $DIR/bad-assoc-ty.rs:82:29
+   |
+LL | trait P<F> where F: Fn() -> _ {
+   |                             ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL - trait P<F> where F: Fn() -> _ {
+LL + trait P<F, T> where F: Fn() -> T {
+   |
+
+error: aborting due to 29 previous errors
+
+Some errors have detailed explanations: E0121, E0223, E0740, E0782.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -1,3 +1,7 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
+
 type A = [u8; 4]::AssocTy;
 //~^ ERROR missing angle brackets in associated item path
 //~| ERROR ambiguous associated type
@@ -31,9 +35,10 @@ type G = dyn 'static + (Send)::AssocTy;
 // This is actually a legal path with fn-like generic arguments in the middle!
 // Recovery should not apply in this context.
 type H = Fn(u8) -> (u8)::Output;
-//~^ ERROR ambiguous associated type
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
+//[edition2015]~^ ERROR ambiguous associated type
+//[edition2015]~| WARN trait objects without an explicit `dyn` are deprecated
+//[edition2015]~| WARN this is accepted in the current edition
+//[edition2021]~^^^^ ERROR expected a type, found a trait
 
 macro_rules! ty {
     ($ty: ty) => ($ty::AssocTy);

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2015.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2015.stderr
@@ -1,0 +1,61 @@
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/feature-gate-unsized_fn_params.rs:20:11
+   |
+LL | fn foo(x: dyn Foo) {
+   |           ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL - fn foo(x: dyn Foo) {
+LL + fn foo(x: impl Foo) {
+   |
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn foo(x: &dyn Foo) {
+   |           +
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/feature-gate-unsized_fn_params.rs:24:11
+   |
+LL | fn bar(x: Foo) {
+   |           ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn bar(x: impl Foo) {
+   |           ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(x: &dyn Foo) {
+   |           ++++
+
+error[E0277]: the size for values of type `[()]` cannot be known at compilation time
+  --> $DIR/feature-gate-unsized_fn_params.rs:30:11
+   |
+LL | fn qux(_: [()]) {}
+   |           ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[()]`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed slices always have a known size
+   |
+LL | fn qux(_: &[()]) {}
+   |           +
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/feature-gate-unsized_fn_params.rs:34:9
+   |
+LL |     foo(*x);
+   |         ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = note: all function arguments must have a statically known size
+   = help: unsized fn params are gated as an unstable feature
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2021.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2021.stderr
@@ -1,5 +1,25 @@
+error[E0782]: expected a type, found a trait
+  --> $DIR/feature-gate-unsized_fn_params.rs:24:11
+   |
+LL | fn bar(x: Foo) {
+   |           ^^^
+   |
+help: use a new generic type parameter, constrained by `Foo`
+   |
+LL - fn bar(x: Foo) {
+LL + fn bar<T: Foo>(x: T) {
+   |
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL | fn bar(x: impl Foo) {
+   |           ++++
+help: alternatively, use a trait object to accept any type that implements `Foo`, accessing its methods at runtime using dynamic dispatch
+   |
+LL | fn bar(x: &dyn Foo) {
+   |           ++++
+
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:17:11
+  --> $DIR/feature-gate-unsized_fn_params.rs:20:11
    |
 LL | fn foo(x: dyn Foo) {
    |           ^^^^^^^ doesn't have a size known at compile-time
@@ -16,25 +36,8 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn foo(x: &dyn Foo) {
    |           +
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:21:11
-   |
-LL | fn bar(x: Foo) {
-   |           ^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
-   = help: unsized fn params are gated as an unstable feature
-help: you can use `impl Trait` as the argument type
-   |
-LL | fn bar(x: impl Foo) {
-   |           ++++
-help: function arguments must have a statically known size, borrowed types always have a known size
-   |
-LL | fn bar(x: &dyn Foo) {
-   |           ++++
-
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:25:11
+  --> $DIR/feature-gate-unsized_fn_params.rs:30:11
    |
 LL | fn qux(_: [()]) {}
    |           ^^^^ doesn't have a size known at compile-time
@@ -47,7 +50,7 @@ LL | fn qux(_: &[()]) {}
    |           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:29:9
+  --> $DIR/feature-gate-unsized_fn_params.rs:34:9
    |
 LL |     foo(*x);
    |         ^^ doesn't have a size known at compile-time
@@ -58,4 +61,5 @@ LL |     foo(*x);
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.rs
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
 #![allow(unused, bare_trait_objects)]
 #[repr(align(256))]
 struct A {
@@ -18,7 +21,9 @@ fn foo(x: dyn Foo) { //~ ERROR [E0277]
     x.foo()
 }
 
-fn bar(x: Foo) { //~ ERROR [E0277]
+fn bar(x: Foo) {
+//[edition2015]~^ ERROR [E0277]
+//[edition2021]~^^ ERROR expected a type, found a trait
     x.foo()
 }
 

--- a/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.edition2015.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Sized + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/rpit-hidden-erased-unsoundness.rs:16:5
+  --> $DIR/rpit-hidden-erased-unsoundness.rs:19:5
    |
 LL | fn step2<'a, 'b: 'a>() -> impl Sized + 'a {
    |              --           --------------- opaque type defined here

--- a/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.edition2024.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.edition2024.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/rpit-hidden-erased-unsoundness.rs:24:5
+   |
+LL | fn step3<'a, 'b: 'a>() -> impl Send + 'a {
+   |              -- lifetime `'b` defined here
+LL |     step2::<'a, 'b>()
+   |     ^^^^^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'static`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.rs
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hidden-erased-unsoundness.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 // This test should never pass!
 
 #![feature(type_alias_impl_trait)]
@@ -14,11 +17,12 @@ fn step1<'a, 'b: 'a>() -> impl Sized + Captures<'b> + 'a {
 
 fn step2<'a, 'b: 'a>() -> impl Sized + 'a {
     step1::<'a, 'b>()
-    //~^ ERROR hidden type for `impl Sized + 'a` captures lifetime that does not appear in bounds
+    //[edition2015]~^ ERROR hidden type for `impl Sized + 'a` captures lifetime that does not appear in bounds
 }
 
 fn step3<'a, 'b: 'a>() -> impl Send + 'a {
     step2::<'a, 'b>()
+    //[edition2024]~^ ERROR lifetime may not live long enough
     // This should not be Send unless `'b: 'static`
 }
 

--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/rpit-hide-lifetime-for-swap.rs:17:5
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:20:5
    |
 LL | fn hide<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |             --                                            -------------- opaque type defined here

--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.edition2024.stderr
@@ -1,0 +1,17 @@
+error[E0597]: `x` does not live long enough
+  --> $DIR/rpit-hide-lifetime-for-swap.rs:27:38
+   |
+LL |     let x = [1, 2, 3];
+   |         - binding `x` declared here
+LL |     let short = Rc::new(RefCell::new(&x));
+   |                                      ^^ borrowed value does not live long enough
+...
+LL |     let res: &'static [i32; 3] = *long.borrow();
+   |              ----------------- type annotation requires that `x` is borrowed for `'static`
+LL |     res
+LL | }
+   | - `x` dropped here while still borrowed
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.rs
+++ b/tests/ui/impl-trait/alias-liveness/rpit-hide-lifetime-for-swap.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 // This test should never pass!
 
 use std::cell::RefCell;
@@ -15,13 +18,14 @@ impl<T> Swap for Rc<RefCell<T>> {
 
 fn hide<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
     x
-    //~^ ERROR hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
+    //[edition2015]~^ ERROR hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
 }
 
 fn dangle() -> &'static [i32; 3] {
     let long = Rc::new(RefCell::new(&[4, 5, 6]));
     let x = [1, 2, 3];
     let short = Rc::new(RefCell::new(&x));
+    //[edition2024]~^ ERROR `x` does not live long enough
     hide(long.clone()).swap(hide(short));
     let res: &'static [i32; 3] = *long.borrow();
     res

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2015.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2015.stderr
@@ -1,0 +1,327 @@
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:13
+   |
+LL | fn fuz() -> (usize, Trait) { (42, Struct) }
+   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: the return type of a function must have a statically known size
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
+   |
+LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
+   |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: the return type of a function must have a statically known size
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
+   |
+LL | fn bap() -> Trait { Struct }
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bap() -> impl Trait { Struct }
+   |             ++++
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
+   |             +++++++      +   +++++++++      +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:22:13
+   |
+LL | fn ban() -> dyn Trait { Struct }
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn ban() -> dyn Trait { Struct }
+LL + fn ban() -> impl Trait { Struct }
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
+   |             ++++         +   +++++++++      +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:24:13
+   |
+LL | fn bak() -> dyn Trait { unimplemented!() }
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bak() -> dyn Trait { unimplemented!() }
+LL + fn bak() -> impl Trait { unimplemented!() }
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
+   |             ++++         +   +++++++++                +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:26:13
+   |
+LL | fn bal() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bal() -> dyn Trait {
+LL + fn bal() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bal() -> Box<dyn Trait> {
+LL |     if true {
+LL ~         return Box::new(Struct);
+LL |     }
+LL ~     Box::new(42)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:32:13
+   |
+LL | fn bax() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bax() -> dyn Trait {
+LL + fn bax() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bax() -> Box<dyn Trait> {
+LL |     if true {
+LL ~         Box::new(Struct)
+LL |     } else {
+LL ~         Box::new(42)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:67:13
+   |
+LL | fn bat() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bat() -> dyn Trait {
+LL + fn bat() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bat() -> Box<dyn Trait> {
+LL |     if true {
+LL ~         return Box::new(0);
+LL |     }
+LL ~     Box::new(42)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:73:13
+   |
+LL | fn bay() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bay() -> dyn Trait {
+LL + fn bay() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bay() -> Box<dyn Trait> {
+LL |     if true {
+LL ~         Box::new(0)
+LL |     } else {
+LL ~         Box::new(42)
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:35
+   |
+LL | fn fuz() -> (usize, Trait) { (42, Struct) }
+   |                                   ^^^^^^ expected `dyn Trait`, found `Struct`
+   |
+   = note: expected trait object `(dyn Trait + 'static)`
+                    found struct `Struct`
+   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:30
+   |
+LL | fn fuz() -> (usize, Trait) { (42, Struct) }
+   |                              ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: tuples must have a statically known size to be initialized
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:39
+   |
+LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
+   |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
+   |
+   = note: expected trait object `(dyn Trait + 'static)`
+                    found struct `Struct`
+   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:34
+   |
+LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
+   |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: tuples must have a statically known size to be initialized
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:41:16
+   |
+LL | fn bam() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         return Struct;
+   |                ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+              found struct `Struct`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         return Box::new(Struct);
+   |                +++++++++      +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:43:5
+   |
+LL | fn bam() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |     42
+   |     ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     Box::new(42)
+   |     +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:47:16
+   |
+LL | fn baq() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         return 0;
+   |                ^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         return Box::new(0);
+   |                +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:49:5
+   |
+LL | fn baq() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |     42
+   |     ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     Box::new(42)
+   |     +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:53:9
+   |
+LL | fn baz() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         Struct
+   |         ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+              found struct `Struct`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(Struct)
+   |         +++++++++      +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
+   |
+LL | fn baz() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |         42
+   |         ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(42)
+   |         +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:60:9
+   |
+LL | fn baw() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         0
+   |         ^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(0)
+   |         +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:9
+   |
+LL | fn baw() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |         42
+   |         ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(42)
+   |         +++++++++  +
+
+error: aborting due to 21 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0746.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2021.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2021.stderr
@@ -1,15 +1,16 @@
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:13
+error[E0782]: expected a type, found a trait
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:21
    |
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^^^^^
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
-   = note: the return type of a function must have a statically known size
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | fn fuz() -> (usize, dyn Trait) { (42, Struct) }
+   |                     +++
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -18,23 +19,23 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 
-error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
+error[E0782]: expected a type, found a trait
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
    |
 LL | fn bap() -> Trait { Struct }
-   |             ^^^^^ doesn't have a size known at compile-time
+   |             ^^^^^
    |
-help: consider returning an `impl Trait` instead of a `dyn Trait`
+help: use `impl Trait` to return an opaque type, as long as you return a single underlying type
    |
 LL | fn bap() -> impl Trait { Struct }
    |             ++++
-help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+help: alternatively, you can return an owned trait object
    |
-LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
-   |             +++++++      +   +++++++++      +
+LL | fn bap() -> Box<dyn Trait> { Struct }
+   |             +++++++      +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:22:13
    |
 LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -50,7 +51,7 @@ LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:24:13
    |
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -66,7 +67,7 @@ LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
    |             ++++         +   +++++++++                +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:26:13
    |
 LL | fn bal() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -86,7 +87,7 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:27:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:32:13
    |
 LL | fn bax() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -106,7 +107,7 @@ LL ~         Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:67:13
    |
 LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -126,7 +127,7 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:68:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:73:13
    |
 LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -146,27 +147,7 @@ LL ~         Box::new(42)
    |
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:35
-   |
-LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |                                   ^^^^^^ expected `dyn Trait`, found `Struct`
-   |
-   = note: expected trait object `(dyn Trait + 'static)`
-                    found struct `Struct`
-   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
-
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:30
-   |
-LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |                              ^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
-   = note: tuples must have a statically known size to be initialized
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:39
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:39
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
@@ -176,7 +157,7 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:34
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:34
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -186,7 +167,7 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = note: tuples must have a statically known size to be initialized
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:36:16
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:41:16
    |
 LL | fn bam() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -203,7 +184,7 @@ LL |         return Box::new(Struct);
    |                +++++++++      +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:38:5
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:43:5
    |
 LL | fn bam() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -220,7 +201,7 @@ LL |     Box::new(42)
    |     +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:42:16
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:47:16
    |
 LL | fn baq() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -237,7 +218,7 @@ LL |         return Box::new(0);
    |                +++++++++ +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:44:5
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:49:5
    |
 LL | fn baq() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -254,7 +235,7 @@ LL |     Box::new(42)
    |     +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:48:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:53:9
    |
 LL | fn baz() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -271,7 +252,7 @@ LL |         Box::new(Struct)
    |         +++++++++      +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:50:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
    |
 LL | fn baz() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -288,7 +269,7 @@ LL |         Box::new(42)
    |         +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:60:9
    |
 LL | fn baw() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -305,7 +286,7 @@ LL |         Box::new(0)
    |         +++++++++ +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:57:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:9
    |
 LL | fn baw() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -321,7 +302,7 @@ help: store this in the heap by calling `Box::new`
 LL |         Box::new(42)
    |         +++++++++  +
 
-error: aborting due to 21 previous errors
+error: aborting due to 19 previous errors
 
-Some errors have detailed explanations: E0277, E0308, E0746.
+Some errors have detailed explanations: E0277, E0308, E0746, E0782.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2021
+//@[edition2015] edition:2015
+//@[edition2021] edition:2021
 #![allow(bare_trait_objects)]
 struct Struct;
 trait Trait {}
@@ -5,15 +8,17 @@ impl Trait for Struct {}
 impl Trait for u32 {}
 
 fn fuz() -> (usize, Trait) { (42, Struct) }
-//~^ ERROR E0277
-//~| ERROR E0277
-//~| ERROR E0308
+//[edition2015]~^ ERROR E0277
+//[edition2015]~| ERROR E0277
+//[edition2015]~| ERROR E0308
+//[edition2021]~^^^^ ERROR expected a type, found a trait
 fn bar() -> (usize, dyn Trait) { (42, Struct) }
 //~^ ERROR E0277
 //~| ERROR E0277
 //~| ERROR E0308
 fn bap() -> Trait { Struct }
-//~^ ERROR E0746
+//[edition2015]~^ ERROR E0746
+//[edition2021]~^^ ERROR expected a type, found a trait
 fn ban() -> dyn Trait { Struct }
 //~^ ERROR E0746
 fn bak() -> dyn Trait { unimplemented!() } //~ ERROR E0746

--- a/tests/ui/impl-trait/hidden-lifetimes.edition2015.stderr
+++ b/tests/ui/impl-trait/hidden-lifetimes.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-lifetimes.rs:29:5
+  --> $DIR/hidden-lifetimes.rs:33:5
    |
 LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a {
    |                 --                                   -------------- opaque type defined here
@@ -14,7 +14,7 @@ LL | fn hide_ref<'a, 'b, T: 'static>(x: &'a mut &'b T) -> impl Swap + 'a + use<'
    |                                                                     ++++++++++++++++
 
 error[E0700]: hidden type for `impl Swap + 'a` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-lifetimes.rs:46:5
+  --> $DIR/hidden-lifetimes.rs:50:5
    |
 LL | fn hide_rc_refcell<'a, 'b: 'a, T: 'static>(x: Rc<RefCell<&'b T>>) -> impl Swap + 'a {
    |                        --                                            -------------- opaque type defined here

--- a/tests/ui/impl-trait/hidden-lifetimes.edition2024.stderr
+++ b/tests/ui/impl-trait/hidden-lifetimes.edition2024.stderr
@@ -1,0 +1,26 @@
+error[E0515]: cannot return value referencing local variable `x`
+  --> $DIR/hidden-lifetimes.rs:41:5
+   |
+LL |     hide_ref(&mut res).swap(hide_ref(&mut &x));
+   |                                           -- `x` is borrowed here
+LL |     res
+   |     ^^^ returns a value referencing data owned by the current function
+
+error[E0597]: `x` does not live long enough
+  --> $DIR/hidden-lifetimes.rs:57:38
+   |
+LL |     let x = [1, 2, 3];
+   |         - binding `x` declared here
+LL |     let short = Rc::new(RefCell::new(&x));
+   |                                      ^^ borrowed value does not live long enough
+LL |     hide_rc_refcell(long.clone()).swap(hide_rc_refcell(short));
+LL |     let res: &'static [i32; 3] = *long.borrow();
+   |              ----------------- type annotation requires that `x` is borrowed for `'static`
+LL |     res
+LL | }
+   | - `x` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0515, E0597.
+For more information about an error, try `rustc --explain E0515`.

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.edition2015.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Debug` captures lifetime that does not appear in bounds
-  --> $DIR/impl-fn-hrtb-bounds-2.rs:5:9
+  --> $DIR/impl-fn-hrtb-bounds-2.rs:8:9
    |
 LL | fn a() -> impl Fn(&u8) -> impl Debug {
    |                           ---------- opaque type defined here

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.edition2024.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.edition2024.stderr
@@ -1,0 +1,15 @@
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+  --> $DIR/impl-fn-hrtb-bounds-2.rs:7:27
+   |
+LL | fn a() -> impl Fn(&u8) -> impl Debug {
+   |                           ^^^^^^^^^^ `impl Trait` implicitly captures all lifetimes in scope
+   |
+note: lifetime declared here
+  --> $DIR/impl-fn-hrtb-bounds-2.rs:7:19
+   |
+LL | fn a() -> impl Fn(&u8) -> impl Debug {
+   |                   ^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds-2.rs
@@ -1,8 +1,11 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 #![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 
-fn a() -> impl Fn(&u8) -> impl Debug {
-    |x| x //~ ERROR hidden type for `impl Debug` captures lifetime that does not appear in bounds
+fn a() -> impl Fn(&u8) -> impl Debug { //[edition2024]~ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+    |x| x //[edition2015]~ ERROR hidden type for `impl Debug` captures lifetime that does not appear in bounds
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/impl-fn-predefined-lifetimes.edition2015.stderr
+++ b/tests/ui/impl-trait/impl-fn-predefined-lifetimes.edition2015.stderr
@@ -1,0 +1,11 @@
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/impl-fn-predefined-lifetimes.rs:8:9
+   |
+LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
+   |                                                -- this generic parameter must be used with a generic lifetime parameter
+LL |     |x| x
+   |         ^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/impl-trait/impl-fn-predefined-lifetimes.edition2024.stderr
+++ b/tests/ui/impl-trait/impl-fn-predefined-lifetimes.edition2024.stderr
@@ -1,8 +1,8 @@
 error[E0792]: expected generic lifetime parameter, found `'_`
-  --> $DIR/impl-fn-predefined-lifetimes.rs:5:9
+  --> $DIR/impl-fn-predefined-lifetimes.rs:8:9
    |
 LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
-   |                                                -- this generic parameter must be used with a generic lifetime parameter
+   |      -- this generic parameter must be used with a generic lifetime parameter
 LL |     |x| x
    |         ^
 

--- a/tests/ui/impl-trait/impl-fn-predefined-lifetimes.rs
+++ b/tests/ui/impl-trait/impl-fn-predefined-lifetimes.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 #![feature(impl_trait_in_fn_trait_return)]
 use std::fmt::Debug;
 

--- a/tests/ui/impl-trait/issues/issue-54895.edition2015.stderr
+++ b/tests/ui/impl-trait/issues/issue-54895.edition2015.stderr
@@ -1,11 +1,11 @@
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
-  --> $DIR/issue-54895.rs:15:53
+  --> $DIR/issue-54895.rs:18:53
    |
 LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
    |                                                     ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-54895.rs:15:20
+  --> $DIR/issue-54895.rs:18:20
    |
 LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
    |                    ^^

--- a/tests/ui/impl-trait/issues/issue-54895.edition2024.stderr
+++ b/tests/ui/impl-trait/issues/issue-54895.edition2024.stderr
@@ -1,0 +1,27 @@
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+  --> $DIR/issue-54895.rs:18:40
+   |
+LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+   |                                        ^^^^^^^^^^^^^^^ `impl Trait` implicitly captures all lifetimes in scope
+   |
+note: lifetime declared here
+  --> $DIR/issue-54895.rs:18:20
+   |
+LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+   |                    ^^
+
+error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+  --> $DIR/issue-54895.rs:18:53
+   |
+LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+   |                                                     ^^
+   |
+note: lifetime declared here
+  --> $DIR/issue-54895.rs:18:20
+   |
+LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+   |                    ^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/issues/issue-54895.rs
+++ b/tests/ui/impl-trait/issues/issue-54895.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 trait Trait<'a> {
     type Out;
     fn call(&'a self) -> Self::Out;
@@ -14,6 +17,7 @@ impl<'a> Trait<'a> for X {
 
 fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
     //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
+    //[edition2024]~^^ ERROR `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
     X(())
 }
 

--- a/tests/ui/impl-trait/issues/issue-79099.edition2015.stderr
+++ b/tests/ui/impl-trait/issues/issue-79099.edition2015.stderr
@@ -1,0 +1,25 @@
+error: expected identifier, found `1`
+  --> $DIR/issue-79099.rs:6:65
+   |
+LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
+   |                                                         -----   ^ expected identifier
+   |                                                         |
+   |                                                         `async` blocks are only allowed in Rust 2018 or later
+   |
+   = help: pass `--edition 2024` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error[E0562]: `impl Trait` is not allowed in the type of variable bindings
+  --> $DIR/issue-79099.rs:6:16
+   |
+LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0562`.

--- a/tests/ui/impl-trait/issues/issue-79099.edition2024.stderr
+++ b/tests/ui/impl-trait/issues/issue-79099.edition2024.stderr
@@ -1,16 +1,5 @@
-error: expected identifier, found `1`
-  --> $DIR/issue-79099.rs:3:65
-   |
-LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
-   |                                                         -----   ^ expected identifier
-   |                                                         |
-   |                                                         `async` blocks are only allowed in Rust 2018 or later
-   |
-   = help: pass `--edition 2024` to `rustc`
-   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
-
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/issue-79099.rs:3:16
+  --> $DIR/issue-79099.rs:6:16
    |
 LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,6 +9,6 @@ LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0562`.

--- a/tests/ui/impl-trait/issues/issue-79099.rs
+++ b/tests/ui/impl-trait/issues/issue-79099.rs
@@ -1,8 +1,11 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 struct Bug {
     V1: [(); {
         let f: impl core::future::Future<Output = u8> = async { 1 };
         //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
-        //~| ERROR expected identifier
+        //[edition2015]~| ERROR expected identifier
         1
     }],
 }

--- a/tests/ui/impl-trait/precise-capturing/dyn-use.edition2015.stderr
+++ b/tests/ui/impl-trait/precise-capturing/dyn-use.edition2015.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `(`, `::`, `<`, `where`, or `{`, found keyword `use`
-  --> $DIR/dyn-use.rs:1:26
+  --> $DIR/dyn-use.rs:4:26
    |
 LL | fn dyn() -> &'static dyn use<> { &() }
    |                          ^^^ expected one of `!`, `(`, `::`, `<`, `where`, or `{`

--- a/tests/ui/impl-trait/precise-capturing/dyn-use.edition2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/dyn-use.edition2024.stderr
@@ -1,0 +1,26 @@
+error: expected identifier, found keyword `dyn`
+  --> $DIR/dyn-use.rs:4:4
+   |
+LL | fn dyn() -> &'static dyn use<> { &() }
+   |    ^^^ expected identifier, found keyword
+   |
+help: escape `dyn` to use it as an identifier
+   |
+LL | fn r#dyn() -> &'static dyn use<> { &() }
+   |    ++
+
+error: `use<...>` precise capturing syntax not allowed in `dyn` trait object bounds
+  --> $DIR/dyn-use.rs:4:26
+   |
+LL | fn dyn() -> &'static dyn use<> { &() }
+   |                          ^^^^^
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/dyn-use.rs:4:22
+   |
+LL | fn dyn() -> &'static dyn use<> { &() }
+   |                      ^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0224`.

--- a/tests/ui/impl-trait/precise-capturing/dyn-use.rs
+++ b/tests/ui/impl-trait/precise-capturing/dyn-use.rs
@@ -1,2 +1,10 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 fn dyn() -> &'static dyn use<> { &() }
-//~^ ERROR expected one of `!`, `(`, `::`, `<`, `where`, or `{`, found keyword `use`
+//[edition2015]~^ ERROR expected one of `!`, `(`, `::`, `<`, `where`, or `{`, found keyword `use`
+//[edition2024]~^^ ERROR expected identifier, found keyword `dyn`
+//[edition2024]~| ERROR `use<...>` precise capturing syntax not allowed in `dyn` trait object bounds
+//[edition2024]~| ERROR at least one trait is required for an object type
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.edition2015.stderr
+++ b/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:3:5
+  --> $DIR/hidden-type-suggestion.rs:6:5
    |
 LL | fn lifetime<'a, 'b>(x: &'a ()) -> impl Sized + use<'b> {
    |             --                    -------------------- opaque type defined here
@@ -15,7 +15,7 @@ LL | fn lifetime<'a, 'b>(x: &'a ()) -> impl Sized + use<'b, 'a> {
    |                                                      ++++
 
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:9:5
+  --> $DIR/hidden-type-suggestion.rs:12:5
    |
 LL | fn param<'a, T>(x: &'a ()) -> impl Sized + use<T> {
    |          --                   ------------------- opaque type defined here
@@ -31,7 +31,7 @@ LL | fn param<'a, T>(x: &'a ()) -> impl Sized + use<'a, T> {
    |                                                +++
 
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:15:5
+  --> $DIR/hidden-type-suggestion.rs:18:5
    |
 LL | fn empty<'a>(x: &'a ()) -> impl Sized + use<> {
    |          --                ------------------ opaque type defined here
@@ -47,7 +47,7 @@ LL | fn empty<'a>(x: &'a ()) -> impl Sized + use<'a> {
    |                                             ++
 
 error[E0700]: hidden type for `impl Captures<'captured>` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:24:5
+  --> $DIR/hidden-type-suggestion.rs:27:5
    |
 LL | fn missing<'a, 'captured, 'not_captured, Captured>(x: &'a ()) -> impl Captures<'captured> {
    |            --                                                    ------------------------ opaque type defined here
@@ -63,7 +63,7 @@ LL | fn missing<'a, 'captured, 'not_captured, Captured>(x: &'a ()) -> impl Captu
    |                                                                                           ++++++++++++++++++++++++++++++
 
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:30:5
+  --> $DIR/hidden-type-suggestion.rs:33:5
    |
 LL | fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
    |                                    ---     ---------- opaque type defined here
@@ -74,7 +74,7 @@ LL |     y
    |     ^
    |
 note: you could use a `use<...>` bound to explicitly capture `'_`, but argument-position `impl Trait`s are not nameable
-  --> $DIR/hidden-type-suggestion.rs:28:21
+  --> $DIR/hidden-type-suggestion.rs:31:21
    |
 LL | fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
    |                     ^^^^^^^^^^
@@ -85,7 +85,7 @@ LL + fn no_params_yet<T: Sized>(_: T, y: &()) -> impl Sized + use<'_, T> {
    |
 
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/hidden-type-suggestion.rs:36:5
+  --> $DIR/hidden-type-suggestion.rs:39:5
    |
 LL | fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
    |                   --                                  ---------- opaque type defined here
@@ -96,7 +96,7 @@ LL |     y
    |     ^
    |
 note: you could use a `use<...>` bound to explicitly capture `'a`, but argument-position `impl Trait`s are not nameable
-  --> $DIR/hidden-type-suggestion.rs:34:29
+  --> $DIR/hidden-type-suggestion.rs:37:29
    |
 LL | fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
    |                             ^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.edition2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.edition2024.stderr
@@ -1,0 +1,51 @@
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/hidden-type-suggestion.rs:6:5
+   |
+LL | fn lifetime<'a, 'b>(x: &'a ()) -> impl Sized + use<'b> {
+   |             --                    -------------------- opaque type defined here
+   |             |
+   |             hidden type `&'a ()` captures the lifetime `'a` as defined here
+LL |
+LL |     x
+   |     ^
+   |
+help: add `'a` to the `use<...>` bound to explicitly capture it
+   |
+LL | fn lifetime<'a, 'b>(x: &'a ()) -> impl Sized + use<'b, 'a> {
+   |                                                      ++++
+
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/hidden-type-suggestion.rs:12:5
+   |
+LL | fn param<'a, T>(x: &'a ()) -> impl Sized + use<T> {
+   |          --                   ------------------- opaque type defined here
+   |          |
+   |          hidden type `&'a ()` captures the lifetime `'a` as defined here
+LL |
+LL |     x
+   |     ^
+   |
+help: add `'a` to the `use<...>` bound to explicitly capture it
+   |
+LL | fn param<'a, T>(x: &'a ()) -> impl Sized + use<'a, T> {
+   |                                                +++
+
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/hidden-type-suggestion.rs:18:5
+   |
+LL | fn empty<'a>(x: &'a ()) -> impl Sized + use<> {
+   |          --                ------------------ opaque type defined here
+   |          |
+   |          hidden type `&'a ()` captures the lifetime `'a` as defined here
+LL |
+LL |     x
+   |     ^
+   |
+help: add `'a` to the `use<...>` bound to explicitly capture it
+   |
+LL | fn empty<'a>(x: &'a ()) -> impl Sized + use<'a> {
+   |                                             ++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0700`.

--- a/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.rs
+++ b/tests/ui/impl-trait/precise-capturing/hidden-type-suggestion.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 fn lifetime<'a, 'b>(x: &'a ()) -> impl Sized + use<'b> {
 //~^ HELP add `'a` to the `use<...>` bound
     x
@@ -20,21 +23,21 @@ trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
 fn missing<'a, 'captured, 'not_captured, Captured>(x: &'a ()) -> impl Captures<'captured> {
-//~^ HELP add a `use<...>` bound
+//[edition2015]~^ HELP add a `use<...>` bound
     x
-//~^ ERROR hidden type for
+//[edition2015]~^ ERROR hidden type for
 }
 
 fn no_params_yet(_: impl Sized, y: &()) -> impl Sized {
-//~^ HELP add a `use<...>` bound
+//[edition2015]~^ HELP add a `use<...>` bound
     y
-//~^ ERROR hidden type for
+//[edition2015]~^ ERROR hidden type for
 }
 
 fn yes_params_yet<'a, T>(_: impl Sized, y: &'a ()) -> impl Sized {
-//~^ HELP add a `use<...>` bound
+//[edition2015]~^ HELP add a `use<...>` bound
     y
-//~^ ERROR hidden type for
+//[edition2015]~^ ERROR hidden type for
 }
 
 fn main() {}

--- a/tests/ui/imports/import-from-missing-star-2.edition2015.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.edition2015.stderr
@@ -1,0 +1,14 @@
+error[E0432]: unresolved import `spam`
+  --> $DIR/import-from-missing-star-2.rs:6:9
+   |
+LL |     use spam::*;
+   |         ^^^^ use of unresolved module or unlinked crate `spam`
+   |
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
+   |
+LL + extern crate spam;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/import-from-missing-star-2.edition2024.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.edition2024.stderr
@@ -1,13 +1,10 @@
 error[E0432]: unresolved import `spam`
-  --> $DIR/import-from-missing-star-2.rs:2:9
+  --> $DIR/import-from-missing-star-2.rs:6:9
    |
 LL |     use spam::*;
    |         ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: you might be missing a crate named `spam`, add it to your project and import it in your code
-   |
-LL + extern crate spam;
-   |
+   = help: you might be missing a crate named `spam`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-from-missing-star-2.rs
+++ b/tests/ui/imports/import-from-missing-star-2.rs
@@ -1,5 +1,10 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 mod foo {
+//[edition2015]~^ HELP you might be missing a crate named `spam`, add it to your project and import it in your code
     use spam::*; //~ ERROR unresolved import `spam` [E0432]
+    //[edition2024]~^ HELP you might be missing a crate named `spam`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2015.stderr
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2015.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
-  --> $DIR/imply_bounds_from_bounds_param.rs:26:5
+  --> $DIR/imply_bounds_from_bounds_param.rs:29:5
    |
 LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne {
    |         --                     ------------ opaque type defined here

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2024.stderr
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.edition2024.stderr
@@ -1,0 +1,91 @@
+error[E0499]: cannot borrow `z` as mutable more than once at a time
+  --> $DIR/imply_bounds_from_bounds_param.rs:36:27
+   |
+LL |     let mut thing = test(&mut z);
+   |                          ------ first mutable borrow occurs here
+LL |     let mut thing2 = test(&mut z);
+   |                           ^^^^^^ second mutable borrow occurs here
+LL |     thing.plus_one();
+   |     ----- first borrow later used here
+   |
+note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
+  --> $DIR/imply_bounds_from_bounds_param.rs:35:21
+   |
+LL |     let mut thing = test(&mut z);
+   |                     ^^^^^^^^^^^^
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
+   |                                             +++++++
+
+error[E0502]: cannot borrow `z` as immutable because it is also borrowed as mutable
+  --> $DIR/imply_bounds_from_bounds_param.rs:38:5
+   |
+LL |     let mut thing = test(&mut z);
+   |                          ------ mutable borrow occurs here
+...
+LL |     assert_eq!(z, 43);
+   |     ^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+...
+LL |     thing.plus_one();
+   |     ----- mutable borrow later used here
+   |
+note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
+  --> $DIR/imply_bounds_from_bounds_param.rs:35:21
+   |
+LL |     let mut thing = test(&mut z);
+   |                     ^^^^^^^^^^^^
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
+   |                                             +++++++
+
+error[E0502]: cannot borrow `z` as immutable because it is also borrowed as mutable
+  --> $DIR/imply_bounds_from_bounds_param.rs:40:5
+   |
+LL |     let mut thing = test(&mut z);
+   |                          ------ mutable borrow occurs here
+...
+LL |     assert_eq!(z, 44);
+   |     ^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+LL |     thing.plus_one();
+   |     ----- mutable borrow later used here
+   |
+note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
+  --> $DIR/imply_bounds_from_bounds_param.rs:35:21
+   |
+LL |     let mut thing = test(&mut z);
+   |                     ^^^^^^^^^^^^
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
+   |                                             +++++++
+
+error[E0502]: cannot borrow `z` as immutable because it is also borrowed as mutable
+  --> $DIR/imply_bounds_from_bounds_param.rs:42:5
+   |
+LL |     let mut thing = test(&mut z);
+   |                          ------ mutable borrow occurs here
+...
+LL |     assert_eq!(z, 45);
+   |     ^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+LL | }
+   | - mutable borrow might be used here, when `thing` is dropped and runs the destructor for type `impl PlusOne`
+   |
+note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
+  --> $DIR/imply_bounds_from_bounds_param.rs:35:21
+   |
+LL |     let mut thing = test(&mut z);
+   |                     ^^^^^^^^^^^^
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | fn test<'a>(y: &'a mut i32) -> impl PlusOne + use<> {
+   |                                             +++++++
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0499, E0502.
+For more information about an error, try `rustc --explain E0499`.

--- a/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.rs
+++ b/tests/ui/type-alias-impl-trait/imply_bounds_from_bounds_param.rs
@@ -1,3 +1,6 @@
+//@revisions: edition2015 edition2024
+//@[edition2015] edition:2015
+//@[edition2024] edition:2024
 #![feature(impl_trait_in_assoc_type)]
 
 trait Callable {
@@ -24,17 +27,17 @@ impl<T: PlusOne> Callable for T {
 
 fn test<'a>(y: &'a mut i32) -> impl PlusOne {
     <&'a mut i32 as Callable>::call(y)
-    //~^ ERROR hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
+    //[edition2015]~^ ERROR hidden type for `impl PlusOne` captures lifetime that does not appear in bounds
 }
 
 fn main() {
     let mut z = 42;
     let mut thing = test(&mut z);
-    let mut thing2 = test(&mut z);
+    let mut thing2 = test(&mut z); //[edition2024]~ ERROR cannot borrow `z` as mutable more than once
     thing.plus_one();
-    assert_eq!(z, 43);
+    assert_eq!(z, 43); //[edition2024]~ ERROR cannot borrow `z` as immutable
     thing2.plus_one();
-    assert_eq!(z, 44);
+    assert_eq!(z, 44); //[edition2024]~ ERROR cannot borrow `z` as immutable
     thing.plus_one();
-    assert_eq!(z, 45);
+    assert_eq!(z, 45); //[edition2024]~ ERROR cannot borrow `z` as immutable
 }


### PR DESCRIPTION
In order to expose edition dependent divergences in some tests in the test suite, add explicit `edition` annotations. Some of these tests might require additional work to *avoid* the divergences, as they might have been unintentional. These are not exhaustive changes, purely opportunistic while I was looking at something else.