### PR TITLE
Mark `core::slice::memchr` as `#[doc(hidden)]`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -21,6 +21,7 @@ use crate::{fmt, hint, ptr, range, slice};
     issue = "none",
     reason = "exposed from core to be reused in std; use the memchr crate"
 )]
+#[doc(hidden)]
 /// Pure Rust memchr implementation, taken from rust-memchr
 pub mod memchr;
 


### PR DESCRIPTION
It's purely internal, and not intended to be a public API, even on nightly. This stops it showing up and being misleading in rustdoc search.

It also mirrors the (also internal) `core::slice::sort` module.