### PR TITLE
HACKY/INCOMPLETE: Add implied bounds to rustdoc-json

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2830,9 +2830,13 @@ fn clean_maybe_renamed_item<'tcx>(
                 generics: clean_generics(generics, cx),
                 fields: variant_data.fields().iter().map(|x| clean_field(x, cx)).collect(),
             }),
-            ItemKind::Struct(_, generics, variant_data) => StructItem(Struct {
+            ItemKind::Struct(_, _, variant_data) => StructItem(Struct {
                 ctor_kind: variant_data.ctor_kind(),
-                generics: clean_generics(generics, cx),
+                generics: clean_ty_generics(
+                    cx,
+                    cx.tcx.generics_of(def_id),
+                    cx.tcx.predicates_of(def_id),
+                ),
                 fields: variant_data.fields().iter().map(|x| clean_field(x, cx)).collect(),
             }),
             ItemKind::Macro(_, macro_def, MacroKind::Bang) => MacroItem(Macro {

--- a/tests/rustdoc-json/implied-bounds.rs
+++ b/tests/rustdoc-json/implied-bounds.rs
@@ -1,0 +1,19 @@
+//@ count '$.index[?(@.name=="Foo")].inner.struct.generics.params[*]' 2
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.params[0].name' \"\'a\"
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.params[0].kind.lifetime.outlives' []
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.params[1].name' '"T"'
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.params[1].kind.type.bounds' '[]'
+//@ count '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[*]' 1
+//@ count '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[*]' 1
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[0].bound_predicate.type.generic' '"T"'
+//@ count '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[0].bound_predicate.bounds[*]' 2
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.path' '"Copy"'
+//@ is    '$.index[?(@.name=="Foo")].inner.struct.generics.where_predicates[0].bound_predicate.bounds[1].outlives' \"\'a\"
+// ^^^^ The last bound donesn't exist anywhere in the source code ^^^^
+
+pub struct Foo<'a, T: Copy>(&'a T);
+// Desguars to:
+//     pub struct Foo<'a, T>(&'a T) where T: Copy + 'a;
+
+// FIXME: Needs more tests, at least
+// - Implied 'a: 'b

--- a/tests/rustdoc/assoc/normalize-assoc-item.rs
+++ b/tests/rustdoc/assoc/normalize-assoc-item.rs
@@ -49,10 +49,10 @@ impl<Inner: Trait> Trait for Generic<Inner> {
 // These can't be normalized because they depend on a generic parameter.
 // However the user can choose whether the text should be displayed as `Inner::X` or `<Inner as Trait>::X`.
 
-//@ has 'normalize_assoc_item/struct.Unknown.html' '//pre[@class="rust item-decl"]' 'pub struct Unknown<Inner: Trait>(pub <Inner as Trait>::X);'
+//@ has 'normalize_assoc_item/struct.Unknown.html' '//pre[@class="rust item-decl"]' 'pub struct Unknown<Inner>(pub <Inner as Trait>::X) where Inner: Trait;'
 pub struct Unknown<Inner: Trait>(pub <Inner as Trait>::X);
 
-//@ has 'normalize_assoc_item/struct.Unknown2.html' '//pre[@class="rust item-decl"]' 'pub struct Unknown2<Inner: Trait>(pub Inner::X);'
+//@ has 'normalize_assoc_item/struct.Unknown2.html' '//pre[@class="rust item-decl"]' 'pub struct Unknown2<Inner>(pub Inner::X) where Inner: Trait;'
 pub struct Unknown2<Inner: Trait>(pub Inner::X);
 
 trait Lifetimes<'a> {

--- a/tests/rustdoc/const-generics/generic_const_exprs.rs
+++ b/tests/rustdoc/const-generics/generic_const_exprs.rs
@@ -3,5 +3,5 @@
 #![allow(incomplete_features)]
 // make sure that `ConstEvaluatable` predicates dont cause rustdoc to ICE #77647
 //@ has foo/struct.Ice.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Ice<const N: usize> where [(); { _ }]:;'
+//      'pub struct Ice<const N: usize>;'
 pub struct Ice<const N: usize> where [(); N + 1]:;

--- a/tests/rustdoc/whitespace-after-where-clause.struct.html
+++ b/tests/rustdoc/whitespace-after-where-clause.struct.html
@@ -1,5 +1,5 @@
 <pre class="rust item-decl"><code>pub struct Struct&lt;'a, B&gt;<div class="where">where
-    B: <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;<a class="primitive" href="{{channel}}/std/primitive.unit.html">()</a>&gt; + ?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + 'a,</div>{
+    B: 'a + <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;<a class="primitive" href="{{channel}}/std/primitive.unit.html">()</a>&gt; + ?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a>,</div>{
     pub a: <a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a B</a>,
     pub b: <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>,
 }</code></pre>

--- a/tests/rustdoc/whitespace-after-where-clause.struct2.html
+++ b/tests/rustdoc/whitespace-after-where-clause.struct2.html
@@ -1,4 +1,5 @@
-<pre class="rust item-decl"><code>pub struct Struct2&lt;'a, B: ?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;<a class="primitive" href="{{channel}}/std/primitive.unit.html">()</a>&gt; + 'a&gt; {
+<pre class="rust item-decl"><code>pub struct Struct2&lt;'a, B&gt;<div class="where">where
+    B: <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;<a class="primitive" href="{{channel}}/std/primitive.unit.html">()</a>&gt; + 'a + ?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a>,</div>{
     pub a: <a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a B</a>,
     pub b: <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>,
 }</code></pre>


### PR DESCRIPTION
A hackattempt at rust-lang/rust#142226. CC @obi1kenobi @workingjubilee @fmease 

This is a meant to show it's possible. The version that lands will probably be a new PR that learns from this.

### How

Hir doesn't have implied bounds, so we need to get generics from `ty`. Rustdoc already has a codepath for that, but it's not the default because `ty` is far more normalized, so the HTML output is farther from what the user wrote.

### Limitations
- Only works on structs. Fixable by replacing all calls to `clean_generics` with calls to `clean_ty_generics`, so we only get generics from `ty`. Also would require replacing all calls to `tcx.explicit_predicates_of` to just `predicates_of`.
  
   I don't think this isn't fundamental, but should be doable with more work.
- Doesn't differentiate implied vs explicit bounds. This is necessary for json (https://github.com/rust-lang/rust/issues/142226#issuecomment-2955505816), and pretty desirable for HTML
- Makes the HTML output """worse""" (for some definition of worse)