### PR TITLE
Rustdoc js: even more typechecking improvements

### DIFF
--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -4,6 +4,8 @@
 
 /* eslint-disable */
 declare global {
+    /** Search engine data used by main.js and search.js */
+    declare var searchState: rustdoc.SearchState;
     /** Defined and documented in `storage.js` */
     declare function nonnull(x: T|null, msg: string|undefined);
     /** Defined and documented in `storage.js` */
@@ -17,8 +19,6 @@ declare global {
         RUSTDOC_TOOLTIP_HOVER_MS: number;
         /** Used by the popover tooltip code. */
         RUSTDOC_TOOLTIP_HOVER_EXIT_MS: number;
-        /** Search engine data used by main.js and search.js */
-        searchState: rustdoc.SearchState;
         /** Global option, with a long list of "../"'s */
         rootPath: string|null;
         /**
@@ -102,20 +102,22 @@ declare namespace rustdoc {
         currentTab: number;
         focusedByTab: [number|null, number|null, number|null];
         clearInputTimeout: function;
-        outputElement: function(): HTMLElement|null;
-        focus: function();
-        defocus: function();
-        showResults: function(HTMLElement|null|undefined);
-        removeQueryParameters: function();
-        hideResults: function();
-        getQueryStringParams: function(): Object.<any, string>;
+        outputElement(): HTMLElement|null;
+        focus();
+        defocus();
+        // note: an optional param is not the same as
+        // a nullable/undef-able param.
+        showResults(elem?: HTMLElement|null);
+        removeQueryParameters();
+        hideResults();
+        getQueryStringParams(): Object.<any, string>;
         origPlaceholder: string;
         setup: function();
-        setLoadingSearch: function();
+        setLoadingSearch();
         descShards: Map<string, SearchDescShard[]>;
         loadDesc: function({descShard: SearchDescShard, descIndex: number}): Promise<string|null>;
-        loadedDescShard: function(string, number, string);
-        isDisplayed: function(): boolean,
+        loadedDescShard(string, number, string);
+        isDisplayed(): boolean,
     }
 
     interface SearchDescShard {
@@ -237,7 +239,7 @@ declare namespace rustdoc {
         query: ParsedQuery,
     }
 
-    type Results = Map<String, ResultObject>;
+    type Results = { max_dist?: number } & Map<number, ResultObject>
 
     /**
      * An annotated `Row`, used in the viewmodel.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I noticed some oddities when I went to start working on type aliases, so I've gone and cleaned up a bunch of stuff.  Notably `fullId` was nearly always an integer in practice, but tsc was being told it should be a string.

r? @notriddle 
