### PR TITLE
tests: Minicore `extern "gpu-kernel"` feature test

### DIFF
--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.AMDGPU.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.AMDGPU.stderr
@@ -1,0 +1,73 @@
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:8
+   |
+LL | extern "gpu-kernel" fn f1(_: ()) {}
+   |        ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:21:12
+   |
+LL |     extern "gpu-kernel" fn m1(_: ());
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:23:12
+   |
+LL |     extern "gpu-kernel" fn dm1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:31:12
+   |
+LL |     extern "gpu-kernel" fn m1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:12
+   |
+LL |     extern "gpu-kernel" fn im1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:18
+   |
+LL | type A1 = extern "gpu-kernel" fn(_: ());
+   |                  ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:47:8
+   |
+LL | extern "gpu-kernel" {}
+   |        ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.HOST.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.HOST.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:11:8
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:8
    |
 LL | extern "gpu-kernel" fn f1(_: ()) {}
    |        ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "gpu-kernel" fn f1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:21:12
    |
 LL |     extern "gpu-kernel" fn m1(_: ());
    |            ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "gpu-kernel" fn m1(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:18:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:23:12
    |
 LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:26:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:31:12
    |
 LL |     extern "gpu-kernel" fn m1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "gpu-kernel" fn m1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:32:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:12
    |
 LL |     extern "gpu-kernel" fn im1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "gpu-kernel" fn im1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:18
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:18
    |
 LL | type A1 = extern "gpu-kernel" fn(_: ());
    |                  ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type A1 = extern "gpu-kernel" fn(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:8
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:47:8
    |
 LL | extern "gpu-kernel" {}
    |        ^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL | extern "gpu-kernel" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: the calling convention "gpu-kernel" is not supported on this target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:11
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:11
    |
 LL | type A1 = extern "gpu-kernel" fn(_: ());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,31 +79,31 @@ LL | type A1 = extern "gpu-kernel" fn(_: ());
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:1
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:47:1
    |
 LL | extern "gpu-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:11:1
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:1
    |
 LL | extern "gpu-kernel" fn f1(_: ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:18:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:23:5
    |
 LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:26:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:31:5
    |
 LL |     extern "gpu-kernel" fn m1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:32:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:5
    |
 LL |     extern "gpu-kernel" fn im1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ Some errors have detailed explanations: E0570, E0658.
 For more information about an error, try `rustc --explain E0570`.
 Future incompatibility report: Future breakage diagnostic:
 warning: the calling convention "gpu-kernel" is not supported on this target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:11
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:11
    |
 LL | type A1 = extern "gpu-kernel" fn(_: ());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.NVPTX.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.NVPTX.stderr
@@ -1,0 +1,73 @@
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:8
+   |
+LL | extern "gpu-kernel" fn f1(_: ()) {}
+   |        ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:21:12
+   |
+LL |     extern "gpu-kernel" fn m1(_: ());
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:23:12
+   |
+LL |     extern "gpu-kernel" fn dm1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:31:12
+   |
+LL |     extern "gpu-kernel" fn m1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:12
+   |
+LL |     extern "gpu-kernel" fn im1(_: ()) {}
+   |            ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:18
+   |
+LL | type A1 = extern "gpu-kernel" fn(_: ());
+   |                  ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:47:8
+   |
+LL | extern "gpu-kernel" {}
+   |        ^^^^^^^^^^^^
+   |
+   = note: see issue #135467 <https://github.com/rust-lang/rust/issues/135467> for more information
+   = help: add `#![feature(abi_gpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.rs
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.rs
@@ -1,5 +1,10 @@
+//@ revisions: HOST AMDGPU NVPTX
 //@ add-core-stubs
 //@ compile-flags: --crate-type=rlib
+//@[AMDGPU] compile-flags: --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx1100
+//@[AMDGPU] needs-llvm-components: amdgpu
+//@[NVPTX]  compile-flags: --target nvptx64-nvidia-cuda
+//@[NVPTX] needs-llvm-components: nvptx
 
 #![feature(no_core, lang_items)]
 #![no_core]
@@ -9,14 +14,14 @@ use minicore::*;
 
 // Functions
 extern "gpu-kernel" fn f1(_: ()) {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-//~^ ERROR is not a supported ABI
+//[HOST]~^ ERROR is not a supported ABI
 
 // Methods in trait definition
 trait Tr {
     extern "gpu-kernel" fn m1(_: ()); //~ ERROR "gpu-kernel" ABI is experimental and subject to change
 
     extern "gpu-kernel" fn dm1(_: ()) {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-    //~^ ERROR is not a supported ABI
+    //[HOST]~^ ERROR is not a supported ABI
 }
 
 struct S;
@@ -24,20 +29,20 @@ struct S;
 // Methods in trait impl
 impl Tr for S {
     extern "gpu-kernel" fn m1(_: ()) {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-    //~^ ERROR is not a supported ABI
+    //[HOST]~^ ERROR is not a supported ABI
 }
 
 // Methods in inherent impl
 impl S {
     extern "gpu-kernel" fn im1(_: ()) {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-    //~^ ERROR is not a supported ABI
+    //[HOST]~^ ERROR is not a supported ABI
 }
 
 // Function pointer types
 type A1 = extern "gpu-kernel" fn(_: ()); //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-//~^ WARN the calling convention "gpu-kernel" is not supported on this target
-//~^^ WARN this was previously accepted by the compiler but is being phased out
+//[HOST]~^ WARNING the calling convention "gpu-kernel" is not supported on this target [unsupported_fn_ptr_calling_conventions]
+//[HOST]~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 // Foreign modules
 extern "gpu-kernel" {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change
-//~^ ERROR is not a supported ABI
+//[HOST]~^ ERROR is not a supported ABI


### PR DESCRIPTION
Explicitly cross-build it for GPU targets and check it errors on hosts. A relatively minor cleanup from my other ABI-related PRs that I got tired of rebasing.