### PR TITLE
Update the stdarch submodule

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -353,7 +353,6 @@ name = "std_detect"
 version = "0.1.5"
 dependencies = [
  "cfg-if",
- "compiler_builtins",
  "libc",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
Includes the following changes:

* Add s390x z17 target features [1]
* Remove `compiler-builtins` from `rustc-dep-of-std` dependencies [2]
* Darwin AArch64 detection update [3]
* Fixes for the latest nightly [4]
* Add a lockfile [5]

[1]: https://github.com/rust-lang/stdarch/pull/1826
[2]: https://github.com/rust-lang/stdarch/pull/1825
[3]: https://github.com/rust-lang/stdarch/pull/1827
[4]: https://github.com/rust-lang/stdarch/pull/1830
[5]: https://github.com/rust-lang/stdarch/pull/1829