### PR TITLE
Key active queries by usize rather than storing raw keys

### DIFF
--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -199,6 +199,17 @@ impl<K: Eq + Hash, V> ShardedHashMap<K, V> {
             }
         }
     }
+
+    #[inline]
+    pub fn remove(&self, key: K) -> Option<V> {
+        let hash = make_hash(&key);
+        let mut shard = self.lock_shard_by_hash(hash);
+
+        match table_entry(&mut shard, hash, &key) {
+            Entry::Occupied(e) => Some(e.remove().0.1),
+            Entry::Vacant(_) => None,
+        }
+    }
 }
 
 impl<K: Eq + Hash + Copy> ShardedHashMap<K, ()> {

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -491,7 +491,7 @@ macro_rules! define_callbacks {
         #[derive(Default)]
         pub struct QueryStates<'tcx> {
             $(
-                pub $name: QueryState<$($K)*, QueryStackDeferred<'tcx>>,
+                pub $name: QueryState<QueryStackDeferred<'tcx>>,
             )*
         }
 

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -83,10 +83,7 @@ where
     }
 
     #[inline(always)]
-    fn query_state<'a>(
-        self,
-        qcx: QueryCtxt<'tcx>,
-    ) -> &'a QueryState<Self::Key, QueryStackDeferred<'tcx>>
+    fn query_state<'a>(self, qcx: QueryCtxt<'tcx>) -> &'a QueryState<QueryStackDeferred<'tcx>>
     where
         QueryCtxt<'tcx>: 'a,
     {
@@ -95,7 +92,7 @@ where
         unsafe {
             &*(&qcx.tcx.query_system.states as *const QueryStates<'tcx>)
                 .byte_add(self.dynamic.query_state)
-                .cast::<QueryState<Self::Key, QueryStackDeferred<'tcx>>>()
+                .cast::<QueryState<QueryStackDeferred<'tcx>>>()
         }
     }
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -735,9 +735,10 @@ macro_rules! define_queries {
                 tcx: TyCtxt<'tcx>,
                 qmap: &mut QueryMap<QueryStackDeferred<'tcx>>,
             ) -> Option<()> {
-                let make_query = |tcx, key| {
+                let make_query = |tcx: TyCtxt<'tcx>, key| {
                     let kind = rustc_middle::dep_graph::dep_kinds::$name;
                     let name = stringify!($name);
+                    let key = tcx.query_system.caches.$name.to_key(key);
                     $crate::plumbing::create_query_frame(tcx, rustc_middle::query::descs::$name, key, kind, name)
                 };
                 let res = tcx.query_system.states.$name.try_collect_active_jobs(

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -28,7 +28,7 @@ pub trait QueryConfig<Qcx: QueryContext>: Copy {
     fn format_value(self) -> fn(&Self::Value) -> String;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(self, tcx: Qcx) -> &'a QueryState<Self::Key, Qcx::QueryInfo>
+    fn query_state<'a>(self, tcx: Qcx) -> &'a QueryState<Qcx::QueryInfo>
     where
         Qcx: 'a;
 


### PR DESCRIPTION
Starting with perf run to evaluate impact -- my hope is that this helps somewhat with rustc compile times, since it should allow de-duplicating a bunch of `HashTable<K, ...>` codegen since it's now ~always `HashTable<usize, ...>` -- more can be done by merging the DefaultCache's active + non-active maps too.

Locally I don't really see any win from this though, so it's possible it's wasted effort -- want to see what perf says about it.

r? ghost