### PR TITLE
promote_consts experiment: do not promote !Freeze shared references

### DIFF
--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -192,7 +192,7 @@ impl<'p, Cx: PatCx> PatOrWild<'p, Cx> {
     }
     pub(crate) fn ctor(self) -> &'p Constructor<Cx> {
         match self {
-            PatOrWild::Wild => &Wildcard,
+            PatOrWild::Wild => const { &Wildcard },
             PatOrWild::Pat(pat) => pat.ctor(),
         }
     }


### PR DESCRIPTION
This is a crater experiment to measure the fallout from not promoting shared references to `!Freeze` types. IOW, this switches promotion from value-based reasoning to type-based reasoning about interior mutability.

Landing this PR would fix https://github.com/rust-lang/unsafe-code-guidelines/issues/493 but I doubt we can get away with that.