### PR TITLE
Implement `//@ needs-target-std` compiletest directive

### DIFF
--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -84,7 +84,7 @@ pub struct Target {
 impl Target {
     pub fn from_triple(triple: &str) -> Self {
         let mut target: Self = Default::default();
-        if triple.contains("-none") || triple.contains("nvptx") || triple.contains("switch") {
+        if !build_helper::targets::target_supports_std(triple) {
             target.no_std = true;
         }
         if triple.contains("emscripten") {

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fs;
 pub mod git;
 pub mod metrics;
 pub mod stage0_parser;
+pub mod targets;
 pub mod util;
 
 /// The default set of crates for opt-dist to collect LLVM profiles.

--- a/src/build_helper/src/targets.rs
+++ b/src/build_helper/src/targets.rs
@@ -1,0 +1,11 @@
+// FIXME(#142296): this hack is because there is no reliable way (yet) to determine whether a given
+// target supports std. In the long-term, we should try to implement a way to *reliably* determine
+// target (std) metadata.
+//
+// NOTE: this is pulled out to `build_helpers` to share this hack between `bootstrap` and
+// `compiletest`.
+pub fn target_supports_std(target_tuple: &str) -> bool {
+    !(target_tuple.contains("-none")
+        || target_tuple.contains("nvptx")
+        || target_tuple.contains("switch"))
+}

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -202,6 +202,7 @@ settings:
   `//@ needs-crate-type: cdylib, proc-macro` will cause the test to be ignored
   on `wasm32-unknown-unknown` target because the target does not support the
   `proc-macro` crate type.
+- `needs-target-std` — ignores if target platform does not have std support.
 
 The following directives will check LLVM support:
 

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -166,6 +166,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "needs-subprocess",
     "needs-symlink",
     "needs-target-has-atomic",
+    "needs-target-std",
     "needs-threads",
     "needs-unwind",
     "needs-wasmtime",

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -174,6 +174,11 @@ pub(super) fn handle_needs(
             condition: config.with_std_debug_assertions,
             ignore_reason: "ignored if std wasn't built with debug assertions",
         },
+        Need {
+            name: "needs-target-std",
+            condition: build_helper::targets::target_supports_std(&config.target),
+            ignore_reason: "ignored if target does not support std",
+        },
     ];
 
     let (name, rest) = match ln.split_once([':', ' ']) {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -945,3 +945,14 @@ fn test_ignore_auxiliary() {
     let config = cfg().build();
     assert!(check_ignore(&config, "//@ ignore-auxiliary"));
 }
+
+#[test]
+fn test_needs_target_std() {
+    // Cherry-picks two targets:
+    // 1. `x86_64-unknown-none`: Tier 2, intentionally never supports std.
+    // 2. `x86_64-unknown-linux-gnu`: Tier 1, always supports std.
+    let config = cfg().target("x86_64-unknown-none").build();
+    assert!(check_ignore(&config, "//@ needs-target-std"));
+    let config = cfg().target("x86_64-unknown-linux-gnu").build();
+    assert!(!check_ignore(&config, "//@ needs-target-std"));
+}

--- a/tests/run-make/cpp-global-destructors/rmake.rs
+++ b/tests/run-make/cpp-global-destructors/rmake.rs
@@ -6,15 +6,11 @@
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 
-//@ ignore-none
-// Reason: no-std is not supported.
 //@ ignore-wasm32
 //@ ignore-wasm64
 // Reason: compiling C++ to WASM may cause problems.
 
-// Neither of these are tested in full CI.
-//@ ignore-nvptx64-nvidia-cuda
-// Reason: can't find crate "std"
+// Not exercised in full CI, but sgx technically supports std.
 //@ ignore-sgx
 
 use run_make_support::{build_native_static_lib_cxx, run, rustc};

--- a/tests/run-make/export-executable-symbols/rmake.rs
+++ b/tests/run-make/export-executable-symbols/rmake.rs
@@ -10,8 +10,7 @@
 // (See #85673)
 //@ ignore-wasm32
 //@ ignore-wasm64
-//@ ignore-none
-// Reason: no-std is not supported
+//@ needs-target-std
 
 use run_make_support::{bin_name, llvm_readobj, rustc};
 

--- a/tests/run-make/incr-foreign-head-span/rmake.rs
+++ b/tests/run-make/incr-foreign-head-span/rmake.rs
@@ -5,10 +5,7 @@
 // source file from disk during compilation of a downstream crate.
 // See https://github.com/rust-lang/rust/issues/86480
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// Reason: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rust_lib_name, rustc};
 

--- a/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
+++ b/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
@@ -7,11 +7,7 @@
 // was hashed by rustc in addition to the span length, and the fix still
 // works.
 
-//@ ignore-none
-// reason: no-std is not supported
-
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for `std`
+//@ needs-target-std
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/incr-test-moved-file/rmake.rs
+++ b/tests/run-make/incr-test-moved-file/rmake.rs
@@ -9,10 +9,7 @@
 // for successful compilation.
 // See https://github.com/rust-lang/rust/issues/83112
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
+++ b/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
@@ -12,10 +12,7 @@
 // sessions.
 // See https://github.com/rust-lang/rust/issues/85019
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rust_lib_name, rustc};
 


### PR DESCRIPTION
Closes rust-lang/rust#141863.
Needed to unblock rust-lang/rust#139244 and rust-lang/rust#141856.

### Summary

This PR implements a `//@ needs-target-std` compiletest directive that gates test execution based on whether the target supports std or not. For some cases, this should be preferred over e.g. some combination of `//@ ignore-none`, `//@ ignore-nvptx` and more[^none-limit].

### Implementation limitation

Unfortunately, since there is currently [no reliable way to determine from metadata whether a given target supports std or not](https://github.com/rust-lang/rust/issues/142296), we have to resort to a hack. Bootstrap currently determines whether or not a target supports std by a naive target tuple substring comparison: a target supports std if its target tuple does *not* contain one of `["-none", "nvptx", "switch"]` substrings. This PR simply pulls that hack out into `build_helpers` to avoid reimplementing the same hack in compiletest, and uses that logic to inform `//@ needs-target-std`.

### Auxiliary changes

This PR additionally changes a few run-make tests to use `//@ needs-target-std` over an inconsistent combination of target-based `ignore`s. This should help with rust-lang/rust#139244.

---

r? bootstrap

[^none-limit]: Notably, `target_os = "none"` is **not** a sufficient condition for "target does not support std"