### PR TITLE
Disable `tests/run-make/mte-ffi` because no CI runners have MTE extensions enabled

### DIFF
--- a/tests/run-make/mte-ffi/bar.h
+++ b/tests/run-make/mte-ffi/bar.h
@@ -1,5 +1,3 @@
-// FIXME(#141600) the mte-ffi test doesn't fail in aarch64-gnu
-
 #ifndef __BAR_H
 #define __BAR_H
 

--- a/tests/run-make/mte-ffi/bar_float.c
+++ b/tests/run-make/mte-ffi/bar_float.c
@@ -3,9 +3,9 @@
 #include <stdint.h>
 #include "bar.h"
 
-extern void foo(float*);
+extern void foo(char*);
 
-void bar(float *ptr) {
+void bar(char *ptr) {
     if (((uintptr_t)ptr >> 56) != 0x1f) {
         fprintf(stderr, "Top byte corrupted on Rust -> C FFI boundary!\n");
         exit(1);

--- a/tests/run-make/mte-ffi/bar_int.c
+++ b/tests/run-make/mte-ffi/bar_int.c
@@ -5,7 +5,7 @@
 
 extern void foo(unsigned int *);
 
-void bar(unsigned int *ptr) {
+void bar(char *ptr) {
     if (((uintptr_t)ptr >> 56) != 0x1f) {
         fprintf(stderr, "Top byte corrupted on Rust -> C FFI boundary!\n");
         exit(1);

--- a/tests/run-make/mte-ffi/bar_string.c
+++ b/tests/run-make/mte-ffi/bar_string.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <string.h>
 #include "bar.h"
 
 extern void foo(char*);
@@ -33,7 +32,7 @@ int main(void)
 
     // Store an arbitrary tag in bits 56-59 of the pointer (where an MTE tag may be),
     // and a different value in the ignored top 4 bits.
-    ptr = (char *)((uintptr_t)ptr | 0x1fl << 56);
+    ptr = (unsigned int *)((uintptr_t)ptr | 0x1fl << 56);
 
     if (mte_enabled()) {
         set_tag(ptr);

--- a/tests/run-make/mte-ffi/rmake.rs
+++ b/tests/run-make/mte-ffi/rmake.rs
@@ -2,6 +2,13 @@
 //! FFI boundaries (C <-> Rust). This test does not require MTE: whilst the test will use MTE if
 //! available, if it is not, arbitrary tag bits are set using TBI.
 
+//@ ignore-test (FIXME #141600)
+//
+// FIXME(#141600): this test is broken in two ways:
+// 1. This test triggers `-Wincompatible-pointer-types` on GCC 14.
+// 2. This test requires ARMv8.5+ w/ MTE extensions enabled, but GHA CI runner hardware do not have
+//    this enabled.
+
 //@ only-aarch64-unknown-linux-gnu
 // Reason: this test is only valid for AArch64 with `gcc`. The linker must be explicitly specified
 // when cross-compiling, so it is limited to `aarch64-unknown-linux-gnu`.


### PR DESCRIPTION
This PR disables the `tests/run-make/mte-ffi` run-make test because it is (1) broken, and (2) no CI runners have suitable MTE extensions enabled to run it correctly. This test being broken is tracked by https://github.com/rust-lang/rust/issues/141600.

The first commit also reverts `mte-ffi` changes introduced in rust-lang/rust#141576, as those fixes potentially changes the meaning of the test.

cc @dheaton-arm (as this test was introduced in https://github.com/rust-lang/rust/pull/128384)

### Context

In https://github.com/rust-lang/rust/pull/141576 when converting PR CI runners from x86_64 to aarch64 runners, it was noticed that this test failed on `aarch64-gnu-llvm-19-1` but not `aarch64-gnu`. It turns out that:

- `aarch64-gnu-llvm-19-1`
	- Uses `gcc version 14.2.0 (Ubuntu 14.2.0-4ubuntu2)`
	- Based on `lscpu` output, the hardware that was used for this runner does not have MTE enabled.
- `aarch64-gnu`
	- Uses `gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)`
	- Based on `lscpu` output, the hardware that was used for this runner does not have MTE enabled.

Based on [this comment](https://github.com/rust-lang/rust/pull/141576#issuecomment-2964179035), it seems like the test *requires* hardware with MTE extensions enabled to run properly (on ARMv8.5 or higher).

Furthermore, I believe this test does indeed have mismatched pointer type issues, i.e.

```
bar_string.c: In function ‘main’:
bar_string.c:36:9: error: assignment to ‘char *’ from incompatible pointer type ‘unsigned int *’ [-Wincompatible-pointer-types]
   36 |     ptr = (unsigned int *)((uintptr_t)ptr | 0x1fl << 56);
      |         ^
```

Which is only exposed by `aarch64-gnu-llvm-19-1` because `aarch64-gnu-llvm-19-1` uses **gcc 14.2.0** whereas `aarch64-gnu` uses **gcc 11.14.0**.

### Details

<details>
<summary>aarch64-gnu-llvm-19-1</summary>

```
gcc_version: Using built-in specs.
COLLECT_GCC=aarch64-linux-gnu-gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/aarch64-linux-gnu/14/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: aarch64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 14.2.0-4ubuntu2' --with-bugurl=file:///usr/share/doc/gcc-14/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --prefix=/usr --with-gcc-major-version-only --program-suffix=-14 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/libexec --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-libstdcxx-backtrace --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-fix-cortex-a53-843419 --disable-werror --enable-offload-targets=nvptx-none=/build/gcc-14-T7YiXd/gcc-14-14.2.0/debian/tmp-nvptx/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-serialization=2
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.2.0 (Ubuntu 14.2.0-4ubuntu2) 
 
lscpu: Architecture:                         aarch64
CPU op-mode(s):                       32-bit, 64-bit
Byte Order:                           Little Endian
CPU(s):                               4
On-line CPU(s) list:                  0-3
Vendor ID:                            ARM
Model name:                           Neoverse-N2
Model:                                0
Thread(s) per core:                   1
Core(s) per socket:                   4
Socket(s):                            1
Stepping:                             r0p0
BogoMIPS:                             2000.00
Flags:                                fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm uscat ilrcpc flagm sb paca pacg dcpodp sve2 sveaes svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bf16
L1d cache:                            256 KiB (4 instances)
L1i cache:                            256 KiB (4 instances)
L2 cache:                             4 MiB (4 instances)
L3 cache:                             128 MiB (1 instance)
NUMA node(s):                         1
NUMA node0 CPU(s):                    0-3
Vulnerability Gather data sampling:   Not affected
Vulnerability Itlb multihit:          Not affected
Vulnerability L1tf:                   Not affected
Vulnerability Mds:                    Not affected
Vulnerability Meltdown:               Not affected
Vulnerability Mmio stale data:        Not affected
Vulnerability Reg file data sampling: Not affected
Vulnerability Retbleed:               Not affected
Vulnerability Spec rstack overflow:   Not affected
Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:             Mitigation; __user pointer sanitization
Vulnerability Spectre v2:             Mitigation; CSV2, BHB
Vulnerability Srbds:                  Not affected
Vulnerability Tsx async abort:        Not affected
```
</details>

<details>
<summary>aarch64-gnu</summary>

```
gcc_version: Using built-in specs.
COLLECT_GCC=aarch64-linux-gnu-gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/aarch64-linux-gnu/11/lto-wrapper
Target: aarch64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 11.4.0-1ubuntu1~22.04' --with-bugurl=file:///usr/share/doc/gcc-11/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-11 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --enable-fix-cortex-a53-843419 --disable-werror --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-build-config=bootstrap-lto-lean --enable-link-serialization=2
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04) 

lscpu: Architecture:                         aarch64
CPU op-mode(s):                       32-bit, 64-bit
Byte Order:                           Little Endian
CPU(s):                               4
On-line CPU(s) list:                  0-3
Vendor ID:                            ARM
Model:                                0
Thread(s) per core:                   1
Core(s) per socket:                   4
Socket(s):                            1
Stepping:                             r0p0
BogoMIPS:                             2000.00
Flags:                                fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm uscat ilrcpc flagm sb paca pacg dcpodp sve2 sveaes svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bf16
L1d cache:                            256 KiB (4 instances)
L1i cache:                            256 KiB (4 instances)
L2 cache:                             4 MiB (4 instances)
L3 cache:                             128 MiB (1 instance)
NUMA node(s):                         1
NUMA node0 CPU(s):                    0-3
Vulnerability Gather data sampling:   Not affected
Vulnerability Itlb multihit:          Not affected
Vulnerability L1tf:                   Not affected
Vulnerability Mds:                    Not affected
Vulnerability Meltdown:               Not affected
Vulnerability Mmio stale data:        Not affected
Vulnerability Reg file data sampling: Not affected
Vulnerability Retbleed:               Not affected
Vulnerability Spec rstack overflow:   Not affected
Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:             Mitigation; __user pointer sanitization
Vulnerability Spectre v2:             Mitigation; CSV2, BHB
Vulnerability Srbds:                  Not affected
Vulnerability Tsx async abort:        Not affected
```
</details>

### References

- https://www.kernel.org/doc/html/v5.10/arm64/memory-tagging-extension.html

---

cc @marcoieni as this PR reverts the `tests/run-make/mte-ffi` changes from rust-lang/rust#141576.