### PR TITLE
Rework how the disallowed qualifier in function type diagnostics are generated

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -299,10 +299,12 @@ parse_float_literal_unsupported_base = {$base} float literal is not supported
 parse_fn_pointer_cannot_be_async = an `fn` pointer type cannot be `async`
     .label = `async` because of this
     .suggestion = remove the `async` qualifier
+    .note = allowed qualifiers are: `unsafe` and `extern`
 
 parse_fn_pointer_cannot_be_const = an `fn` pointer type cannot be `const`
     .label = `const` because of this
     .suggestion = remove the `const` qualifier
+    .note = allowed qualifiers are: `unsafe` and `extern`
 
 parse_fn_ptr_with_generics = function pointer types may not have generic parameters
     .suggestion = consider moving the lifetime {$arity ->

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2938,22 +2938,22 @@ pub(crate) struct DynAfterMut {
 
 #[derive(Diagnostic)]
 #[diag(parse_fn_pointer_cannot_be_const)]
+#[note]
 pub(crate) struct FnPointerCannotBeConst {
     #[primary_span]
-    pub span: Span,
     #[label]
-    pub qualifier: Span,
+    pub span: Span,
     #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(parse_fn_pointer_cannot_be_async)]
+#[note]
 pub(crate) struct FnPointerCannotBeAsync {
     #[primary_span]
-    pub span: Span,
     #[label]
-    pub qualifier: Span,
+    pub span: Span,
     #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub suggestion: Span,
 }

--- a/tests/ui/parser/bad-fn-ptr-qualifier.fixed
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.fixed
@@ -23,4 +23,12 @@ pub type FTT6 = for<'a> unsafe extern "C" fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
 //~| ERROR an `fn` pointer type cannot be `async`
 
+// Tests with qualifiers in the wrong order
+pub type W1 = unsafe fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+pub type W2 = unsafe fn();
+//~^ ERROR an `fn` pointer type cannot be `async`
+pub type W3 = for<'a> unsafe fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+
 fn main() {}

--- a/tests/ui/parser/bad-fn-ptr-qualifier.rs
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.rs
@@ -23,4 +23,15 @@ pub type FTT6 = for<'a> const async unsafe extern "C" fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
 //~| ERROR an `fn` pointer type cannot be `async`
 
+// Tests with qualifiers in the wrong order
+pub type W1 = unsafe const fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR expected one of `extern` or `fn`, found keyword `const`
+pub type W2 = unsafe async fn();
+//~^ ERROR an `fn` pointer type cannot be `async`
+//~| ERROR expected one of `extern` or `fn`, found keyword `async`
+pub type W3 = for<'a> unsafe const fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR expected one of `extern` or `fn`, found keyword `const`
+
 fn main() {}

--- a/tests/ui/parser/bad-fn-ptr-qualifier.rs
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.rs
@@ -26,12 +26,9 @@ pub type FTT6 = for<'a> const async unsafe extern "C" fn();
 // Tests with qualifiers in the wrong order
 pub type W1 = unsafe const fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
-//~| ERROR expected one of `extern` or `fn`, found keyword `const`
 pub type W2 = unsafe async fn();
 //~^ ERROR an `fn` pointer type cannot be `async`
-//~| ERROR expected one of `extern` or `fn`, found keyword `async`
 pub type W3 = for<'a> unsafe const fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
-//~| ERROR expected one of `extern` or `fn`, found keyword `const`
 
 fn main() {}

--- a/tests/ui/parser/bad-fn-ptr-qualifier.stderr
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.stderr
@@ -2,10 +2,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:5:15
    |
 LL | pub type T0 = const fn();
-   |               -----^^^^^
-   |               |
-   |               `const` because of this
+   |               ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type T0 = const fn();
@@ -16,10 +15,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:6:15
    |
 LL | pub type T1 = const extern "C" fn();
-   |               -----^^^^^^^^^^^^^^^^
-   |               |
-   |               `const` because of this
+   |               ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type T1 = const extern "C" fn();
@@ -30,10 +28,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:7:15
    |
 LL | pub type T2 = const unsafe extern "C" fn();
-   |               -----^^^^^^^^^^^^^^^^^^^^^^^
-   |               |
-   |               `const` because of this
+   |               ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type T2 = const unsafe extern "C" fn();
@@ -44,10 +41,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:8:15
    |
 LL | pub type T3 = async fn();
-   |               -----^^^^^
-   |               |
-   |               `async` because of this
+   |               ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type T3 = async fn();
@@ -58,10 +54,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:9:15
    |
 LL | pub type T4 = async extern "C" fn();
-   |               -----^^^^^^^^^^^^^^^^
-   |               |
-   |               `async` because of this
+   |               ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type T4 = async extern "C" fn();
@@ -72,10 +67,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/bad-fn-ptr-qualifier.rs:10:15
    |
 LL | pub type T5 = async unsafe extern "C" fn();
-   |               -----^^^^^^^^^^^^^^^^^^^^^^^
-   |               |
-   |               `async` because of this
+   |               ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type T5 = async unsafe extern "C" fn();
@@ -86,10 +80,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:11:15
    |
 LL | pub type T6 = const async unsafe extern "C" fn();
-   |               -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |               |
-   |               `const` because of this
+   |               ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type T6 = const async unsafe extern "C" fn();
@@ -97,13 +90,12 @@ LL + pub type T6 = async unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:11:15
+  --> $DIR/bad-fn-ptr-qualifier.rs:11:21
    |
 LL | pub type T6 = const async unsafe extern "C" fn();
-   |               ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                     |
-   |                     `async` because of this
+   |                     ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type T6 = const async unsafe extern "C" fn();
@@ -111,13 +103,12 @@ LL + pub type T6 = const unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:15:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:15:25
    |
 LL | pub type FTT0 = for<'a> const fn();
-   |                 ^^^^^^^^-----^^^^^
-   |                         |
-   |                         `const` because of this
+   |                         ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type FTT0 = for<'a> const fn();
@@ -125,13 +116,12 @@ LL + pub type FTT0 = for<'a> fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:16:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:16:25
    |
 LL | pub type FTT1 = for<'a> const extern "C" fn();
-   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^
-   |                         |
-   |                         `const` because of this
+   |                         ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type FTT1 = for<'a> const extern "C" fn();
@@ -139,13 +129,12 @@ LL + pub type FTT1 = for<'a> extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:17:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:17:25
    |
 LL | pub type FTT2 = for<'a> const unsafe extern "C" fn();
-   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                         |
-   |                         `const` because of this
+   |                         ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type FTT2 = for<'a> const unsafe extern "C" fn();
@@ -153,13 +142,12 @@ LL + pub type FTT2 = for<'a> unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:18:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:18:25
    |
 LL | pub type FTT3 = for<'a> async fn();
-   |                 ^^^^^^^^-----^^^^^
-   |                         |
-   |                         `async` because of this
+   |                         ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type FTT3 = for<'a> async fn();
@@ -167,13 +155,12 @@ LL + pub type FTT3 = for<'a> fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:19:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:19:25
    |
 LL | pub type FTT4 = for<'a> async extern "C" fn();
-   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^
-   |                         |
-   |                         `async` because of this
+   |                         ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type FTT4 = for<'a> async extern "C" fn();
@@ -181,13 +168,12 @@ LL + pub type FTT4 = for<'a> extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:20:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:20:25
    |
 LL | pub type FTT5 = for<'a> async unsafe extern "C" fn();
-   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                         |
-   |                         `async` because of this
+   |                         ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type FTT5 = for<'a> async unsafe extern "C" fn();
@@ -195,13 +181,12 @@ LL + pub type FTT5 = for<'a> unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:22:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:22:25
    |
 LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
-   |                 ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                         |
-   |                         `const` because of this
+   |                         ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type FTT6 = for<'a> const async unsafe extern "C" fn();
@@ -209,93 +194,56 @@ LL + pub type FTT6 = for<'a> async unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:22:17
+  --> $DIR/bad-fn-ptr-qualifier.rs:22:31
    |
 LL | pub type FTT6 = for<'a> const async unsafe extern "C" fn();
-   |                 ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                               |
-   |                               `async` because of this
+   |                               ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type FTT6 = for<'a> const async unsafe extern "C" fn();
 LL + pub type FTT6 = for<'a> const unsafe extern "C" fn();
    |
 
-error: expected one of `extern` or `fn`, found keyword `const`
+error: an `fn` pointer type cannot be `const`
   --> $DIR/bad-fn-ptr-qualifier.rs:27:22
    |
 LL | pub type W1 = unsafe const fn();
-   |               -------^^^^^
-   |               |      |
-   |               |      expected one of `extern` or `fn`
-   |               help: `const` must come before `unsafe`: `const unsafe`
+   |                      ^^^^^ `const` because of this
    |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
-
-error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:27:15
-   |
-LL | pub type W1 = unsafe const fn();
-   |               ^^^^^^^-----^^^^^
-   |                      |
-   |                      `const` because of this
-   |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type W1 = unsafe const fn();
-LL + pub type W1 = const fn();
+LL + pub type W1 = unsafe fn();
    |
-
-error: expected one of `extern` or `fn`, found keyword `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:30:22
-   |
-LL | pub type W2 = unsafe async fn();
-   |               -------^^^^^
-   |               |      |
-   |               |      expected one of `extern` or `fn`
-   |               help: `async` must come before `unsafe`: `async unsafe`
-   |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/bad-fn-ptr-qualifier.rs:30:15
+  --> $DIR/bad-fn-ptr-qualifier.rs:29:22
    |
 LL | pub type W2 = unsafe async fn();
-   |               ^^^^^^^-----^^^^^
-   |                      |
-   |                      `async` because of this
+   |                      ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - pub type W2 = unsafe async fn();
-LL + pub type W2 = async fn();
+LL + pub type W2 = unsafe fn();
    |
-
-error: expected one of `extern` or `fn`, found keyword `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:33:30
-   |
-LL | pub type W3 = for<'a> unsafe const fn();
-   |                       -------^^^^^
-   |                       |      |
-   |                       |      expected one of `extern` or `fn`
-   |                       help: `const` must come before `unsafe`: `const unsafe`
-   |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/bad-fn-ptr-qualifier.rs:33:15
+  --> $DIR/bad-fn-ptr-qualifier.rs:31:30
    |
 LL | pub type W3 = for<'a> unsafe const fn();
-   |               ^^^^^^^^^^^^^^^-----^^^^^
-   |                              |
-   |                              `const` because of this
+   |                              ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - pub type W3 = for<'a> unsafe const fn();
-LL + pub type W3 = for<'a> const fn();
+LL + pub type W3 = for<'a> unsafe fn();
    |
 
-error: aborting due to 22 previous errors
+error: aborting due to 19 previous errors
 

--- a/tests/ui/parser/bad-fn-ptr-qualifier.stderr
+++ b/tests/ui/parser/bad-fn-ptr-qualifier.stderr
@@ -222,5 +222,80 @@ LL - pub type FTT6 = for<'a> const async unsafe extern "C" fn();
 LL + pub type FTT6 = for<'a> const unsafe extern "C" fn();
    |
 
-error: aborting due to 16 previous errors
+error: expected one of `extern` or `fn`, found keyword `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:27:22
+   |
+LL | pub type W1 = unsafe const fn();
+   |               -------^^^^^
+   |               |      |
+   |               |      expected one of `extern` or `fn`
+   |               help: `const` must come before `unsafe`: `const unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:27:15
+   |
+LL | pub type W1 = unsafe const fn();
+   |               ^^^^^^^-----^^^^^
+   |                      |
+   |                      `const` because of this
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type W1 = unsafe const fn();
+LL + pub type W1 = const fn();
+   |
+
+error: expected one of `extern` or `fn`, found keyword `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:30:22
+   |
+LL | pub type W2 = unsafe async fn();
+   |               -------^^^^^
+   |               |      |
+   |               |      expected one of `extern` or `fn`
+   |               help: `async` must come before `unsafe`: `async unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/bad-fn-ptr-qualifier.rs:30:15
+   |
+LL | pub type W2 = unsafe async fn();
+   |               ^^^^^^^-----^^^^^
+   |                      |
+   |                      `async` because of this
+   |
+help: remove the `async` qualifier
+   |
+LL - pub type W2 = unsafe async fn();
+LL + pub type W2 = async fn();
+   |
+
+error: expected one of `extern` or `fn`, found keyword `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:33:30
+   |
+LL | pub type W3 = for<'a> unsafe const fn();
+   |                       -------^^^^^
+   |                       |      |
+   |                       |      expected one of `extern` or `fn`
+   |                       help: `const` must come before `unsafe`: `const unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/bad-fn-ptr-qualifier.rs:33:15
+   |
+LL | pub type W3 = for<'a> unsafe const fn();
+   |               ^^^^^^^^^^^^^^^-----^^^^^
+   |                              |
+   |                              `const` because of this
+   |
+help: remove the `const` qualifier
+   |
+LL - pub type W3 = for<'a> unsafe const fn();
+LL + pub type W3 = for<'a> const fn();
+   |
+
+error: aborting due to 22 previous errors
 

--- a/tests/ui/parser/recover/recover-const-async-fn-ptr.rs
+++ b/tests/ui/parser/recover/recover-const-async-fn-ptr.rs
@@ -23,13 +23,10 @@ type FT6 = for<'a> const async unsafe extern "C" fn();
 // Tests with qualifiers in the wrong order
 type W1 = unsafe const fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
-//~| ERROR expected one of `extern` or `fn`, found keyword `const`
 type W2 = unsafe async fn();
 //~^ ERROR an `fn` pointer type cannot be `async`
-//~| ERROR expected one of `extern` or `fn`, found keyword `async`
 type W3 = for<'a> unsafe const fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
-//~| ERROR expected one of `extern` or `fn`, found keyword `const`
 
 fn main() {
     let _recovery_witness: () = 0; //~ ERROR mismatched types

--- a/tests/ui/parser/recover/recover-const-async-fn-ptr.rs
+++ b/tests/ui/parser/recover/recover-const-async-fn-ptr.rs
@@ -20,6 +20,17 @@ type FT6 = for<'a> const async unsafe extern "C" fn();
 //~^ ERROR an `fn` pointer type cannot be `const`
 //~| ERROR an `fn` pointer type cannot be `async`
 
+// Tests with qualifiers in the wrong order
+type W1 = unsafe const fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR expected one of `extern` or `fn`, found keyword `const`
+type W2 = unsafe async fn();
+//~^ ERROR an `fn` pointer type cannot be `async`
+//~| ERROR expected one of `extern` or `fn`, found keyword `async`
+type W3 = for<'a> unsafe const fn();
+//~^ ERROR an `fn` pointer type cannot be `const`
+//~| ERROR expected one of `extern` or `fn`, found keyword `const`
+
 fn main() {
     let _recovery_witness: () = 0; //~ ERROR mismatched types
 }

--- a/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
+++ b/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
@@ -2,10 +2,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:3:11
    |
 LL | type T0 = const fn();
-   |           -----^^^^^
-   |           |
-   |           `const` because of this
+   |           ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type T0 = const fn();
@@ -16,10 +15,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:4:11
    |
 LL | type T1 = const extern "C" fn();
-   |           -----^^^^^^^^^^^^^^^^
-   |           |
-   |           `const` because of this
+   |           ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type T1 = const extern "C" fn();
@@ -30,10 +28,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:5:11
    |
 LL | type T2 = const unsafe extern "C" fn();
-   |           -----^^^^^^^^^^^^^^^^^^^^^^^
-   |           |
-   |           `const` because of this
+   |           ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type T2 = const unsafe extern "C" fn();
@@ -44,10 +41,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:6:11
    |
 LL | type T3 = async fn();
-   |           -----^^^^^
-   |           |
-   |           `async` because of this
+   |           ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type T3 = async fn();
@@ -58,10 +54,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:7:11
    |
 LL | type T4 = async extern "C" fn();
-   |           -----^^^^^^^^^^^^^^^^
-   |           |
-   |           `async` because of this
+   |           ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type T4 = async extern "C" fn();
@@ -72,10 +67,9 @@ error: an `fn` pointer type cannot be `async`
   --> $DIR/recover-const-async-fn-ptr.rs:8:11
    |
 LL | type T5 = async unsafe extern "C" fn();
-   |           -----^^^^^^^^^^^^^^^^^^^^^^^
-   |           |
-   |           `async` because of this
+   |           ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type T5 = async unsafe extern "C" fn();
@@ -86,10 +80,9 @@ error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:9:11
    |
 LL | type T6 = const async unsafe extern "C" fn();
-   |           -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |           |
-   |           `const` because of this
+   |           ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type T6 = const async unsafe extern "C" fn();
@@ -97,13 +90,12 @@ LL + type T6 = async unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:9:11
+  --> $DIR/recover-const-async-fn-ptr.rs:9:17
    |
 LL | type T6 = const async unsafe extern "C" fn();
-   |           ^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                 |
-   |                 `async` because of this
+   |                 ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type T6 = const async unsafe extern "C" fn();
@@ -111,13 +103,12 @@ LL + type T6 = const unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:13:12
+  --> $DIR/recover-const-async-fn-ptr.rs:13:20
    |
 LL | type FT0 = for<'a> const fn();
-   |            ^^^^^^^^-----^^^^^
-   |                    |
-   |                    `const` because of this
+   |                    ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type FT0 = for<'a> const fn();
@@ -125,13 +116,12 @@ LL + type FT0 = for<'a> fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:14:12
+  --> $DIR/recover-const-async-fn-ptr.rs:14:20
    |
 LL | type FT1 = for<'a> const extern "C" fn();
-   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^
-   |                    |
-   |                    `const` because of this
+   |                    ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type FT1 = for<'a> const extern "C" fn();
@@ -139,13 +129,12 @@ LL + type FT1 = for<'a> extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:15:12
+  --> $DIR/recover-const-async-fn-ptr.rs:15:20
    |
 LL | type FT2 = for<'a> const unsafe extern "C" fn();
-   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    `const` because of this
+   |                    ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type FT2 = for<'a> const unsafe extern "C" fn();
@@ -153,13 +142,12 @@ LL + type FT2 = for<'a> unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:16:12
+  --> $DIR/recover-const-async-fn-ptr.rs:16:20
    |
 LL | type FT3 = for<'a> async fn();
-   |            ^^^^^^^^-----^^^^^
-   |                    |
-   |                    `async` because of this
+   |                    ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type FT3 = for<'a> async fn();
@@ -167,13 +155,12 @@ LL + type FT3 = for<'a> fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:17:12
+  --> $DIR/recover-const-async-fn-ptr.rs:17:20
    |
 LL | type FT4 = for<'a> async extern "C" fn();
-   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^
-   |                    |
-   |                    `async` because of this
+   |                    ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type FT4 = for<'a> async extern "C" fn();
@@ -181,13 +168,12 @@ LL + type FT4 = for<'a> extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:18:12
+  --> $DIR/recover-const-async-fn-ptr.rs:18:20
    |
 LL | type FT5 = for<'a> async unsafe extern "C" fn();
-   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    `async` because of this
+   |                    ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type FT5 = for<'a> async unsafe extern "C" fn();
@@ -195,13 +181,12 @@ LL + type FT5 = for<'a> unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:19:12
+  --> $DIR/recover-const-async-fn-ptr.rs:19:20
    |
 LL | type FT6 = for<'a> const async unsafe extern "C" fn();
-   |            ^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                    |
-   |                    `const` because of this
+   |                    ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type FT6 = for<'a> const async unsafe extern "C" fn();
@@ -209,102 +194,65 @@ LL + type FT6 = for<'a> async unsafe extern "C" fn();
    |
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:19:12
+  --> $DIR/recover-const-async-fn-ptr.rs:19:26
    |
 LL | type FT6 = for<'a> const async unsafe extern "C" fn();
-   |            ^^^^^^^^^^^^^^-----^^^^^^^^^^^^^^^^^^^^^^^
-   |                          |
-   |                          `async` because of this
+   |                          ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type FT6 = for<'a> const async unsafe extern "C" fn();
 LL + type FT6 = for<'a> const unsafe extern "C" fn();
    |
 
-error: expected one of `extern` or `fn`, found keyword `const`
+error: an `fn` pointer type cannot be `const`
   --> $DIR/recover-const-async-fn-ptr.rs:24:18
    |
 LL | type W1 = unsafe const fn();
-   |           -------^^^^^
-   |           |      |
-   |           |      expected one of `extern` or `fn`
-   |           help: `const` must come before `unsafe`: `const unsafe`
+   |                  ^^^^^ `const` because of this
    |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
-
-error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:24:11
-   |
-LL | type W1 = unsafe const fn();
-   |           ^^^^^^^-----^^^^^
-   |                  |
-   |                  `const` because of this
-   |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type W1 = unsafe const fn();
-LL + type W1 = const fn();
+LL + type W1 = unsafe fn();
    |
-
-error: expected one of `extern` or `fn`, found keyword `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:27:18
-   |
-LL | type W2 = unsafe async fn();
-   |           -------^^^^^
-   |           |      |
-   |           |      expected one of `extern` or `fn`
-   |           help: `async` must come before `unsafe`: `async unsafe`
-   |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: an `fn` pointer type cannot be `async`
-  --> $DIR/recover-const-async-fn-ptr.rs:27:11
+  --> $DIR/recover-const-async-fn-ptr.rs:26:18
    |
 LL | type W2 = unsafe async fn();
-   |           ^^^^^^^-----^^^^^
-   |                  |
-   |                  `async` because of this
+   |                  ^^^^^ `async` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `async` qualifier
    |
 LL - type W2 = unsafe async fn();
-LL + type W2 = async fn();
+LL + type W2 = unsafe fn();
    |
-
-error: expected one of `extern` or `fn`, found keyword `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:30:26
-   |
-LL | type W3 = for<'a> unsafe const fn();
-   |                   -------^^^^^
-   |                   |      |
-   |                   |      expected one of `extern` or `fn`
-   |                   help: `const` must come before `unsafe`: `const unsafe`
-   |
-   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: an `fn` pointer type cannot be `const`
-  --> $DIR/recover-const-async-fn-ptr.rs:30:11
+  --> $DIR/recover-const-async-fn-ptr.rs:28:26
    |
 LL | type W3 = for<'a> unsafe const fn();
-   |           ^^^^^^^^^^^^^^^-----^^^^^
-   |                          |
-   |                          `const` because of this
+   |                          ^^^^^ `const` because of this
    |
+   = note: allowed qualifiers are: `unsafe` and `extern`
 help: remove the `const` qualifier
    |
 LL - type W3 = for<'a> unsafe const fn();
-LL + type W3 = for<'a> const fn();
+LL + type W3 = for<'a> unsafe fn();
    |
 
 error[E0308]: mismatched types
-  --> $DIR/recover-const-async-fn-ptr.rs:35:33
+  --> $DIR/recover-const-async-fn-ptr.rs:32:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer
    |                            |
    |                            expected due to this
 
-error: aborting due to 23 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
+++ b/tests/ui/parser/recover/recover-const-async-fn-ptr.stderr
@@ -222,14 +222,89 @@ LL - type FT6 = for<'a> const async unsafe extern "C" fn();
 LL + type FT6 = for<'a> const unsafe extern "C" fn();
    |
 
+error: expected one of `extern` or `fn`, found keyword `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:24:18
+   |
+LL | type W1 = unsafe const fn();
+   |           -------^^^^^
+   |           |      |
+   |           |      expected one of `extern` or `fn`
+   |           help: `const` must come before `unsafe`: `const unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:24:11
+   |
+LL | type W1 = unsafe const fn();
+   |           ^^^^^^^-----^^^^^
+   |                  |
+   |                  `const` because of this
+   |
+help: remove the `const` qualifier
+   |
+LL - type W1 = unsafe const fn();
+LL + type W1 = const fn();
+   |
+
+error: expected one of `extern` or `fn`, found keyword `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:27:18
+   |
+LL | type W2 = unsafe async fn();
+   |           -------^^^^^
+   |           |      |
+   |           |      expected one of `extern` or `fn`
+   |           help: `async` must come before `unsafe`: `async unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `async`
+  --> $DIR/recover-const-async-fn-ptr.rs:27:11
+   |
+LL | type W2 = unsafe async fn();
+   |           ^^^^^^^-----^^^^^
+   |                  |
+   |                  `async` because of this
+   |
+help: remove the `async` qualifier
+   |
+LL - type W2 = unsafe async fn();
+LL + type W2 = async fn();
+   |
+
+error: expected one of `extern` or `fn`, found keyword `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:30:26
+   |
+LL | type W3 = for<'a> unsafe const fn();
+   |                   -------^^^^^
+   |                   |      |
+   |                   |      expected one of `extern` or `fn`
+   |                   help: `const` must come before `unsafe`: `const unsafe`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+error: an `fn` pointer type cannot be `const`
+  --> $DIR/recover-const-async-fn-ptr.rs:30:11
+   |
+LL | type W3 = for<'a> unsafe const fn();
+   |           ^^^^^^^^^^^^^^^-----^^^^^
+   |                          |
+   |                          `const` because of this
+   |
+help: remove the `const` qualifier
+   |
+LL - type W3 = for<'a> unsafe const fn();
+LL + type W3 = for<'a> const fn();
+   |
+
 error[E0308]: mismatched types
-  --> $DIR/recover-const-async-fn-ptr.rs:24:33
+  --> $DIR/recover-const-async-fn-ptr.rs:35:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer
    |                            |
    |                            expected due to this
 
-error: aborting due to 17 previous errors
+error: aborting due to 23 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This pull request fixes two independent issues:
1. When qualifiers of a function type ptr are in the wrong order and one of them is async/const (not permitted on function types), the diagnostic suggests removing the incorrect qualifier.  Fixes https://github.com/rust-lang/rust/issues/142268, which is an issue created by https://github.com/rust-lang/rust/pull/133151. This is fixed by moving the check into `parse_fn_front_matter`, where better span information is available to generate the right suggestions. 
2. When qualifiers of a function type ptr are in the wrong order and one of them is async/const (not permitted on function types), `cargo fix` crashes because "cannot replace slice of data that was already replaced". This is fixed by not generating a suggestion for the "wrong order" diagnostic if the "disallowed qualifier" diagnostic is triggered.

There is a commit with failing tests so the test diff is clearer
r? @jdonszelmann 

