### PR TITLE
tests: Add `RUST_BACKTRACE` and `-Cpanic` revisions to `panic-main.rs` test

### DIFF
--- a/tests/ui/panics/panic-main.rs
+++ b/tests/ui/panics/panic-main.rs
@@ -1,3 +1,26 @@
+//@ revisions: default abort-zero abort-one abort-full unwind-zero unwind-one unwind-full
+
+//@[abort-zero] compile-flags: -Cpanic=abort
+//@[abort-zero] no-prefer-dynamic
+//@[abort-zero] exec-env:RUST_BACKTRACE=0
+
+//@[abort-one] compile-flags: -Cpanic=abort
+//@[abort-one] no-prefer-dynamic
+//@[abort-one] exec-env:RUST_BACKTRACE=1
+
+//@[abort-full] compile-flags: -Cpanic=abort
+//@[abort-full] no-prefer-dynamic
+//@[abort-full] exec-env:RUST_BACKTRACE=full
+
+//@[unwind-zero] compile-flags: -Cpanic=unwind
+//@[unwind-zero] exec-env:RUST_BACKTRACE=0
+
+//@[unwind-one] compile-flags: -Cpanic=unwind
+//@[unwind-one] exec-env:RUST_BACKTRACE=1
+
+//@[unwind-full] compile-flags: -Cpanic=unwind
+//@[unwind-full] exec-env:RUST_BACKTRACE=full
+
 //@ run-fail
 //@ error-pattern:moop
 //@ needs-subprocess


### PR DESCRIPTION
This is a regression test for rust-lang/rust#123733 (**P-high** and **regression-from-stable-to-stable**) which was [fixed by accident without a regression test](https://github.com/rust-lang/rust/issues/123733#issuecomment-2929091266).


Edit 2025-06-23:

Closes https://github.com/rust-lang/rust/issues/123733