### PR TITLE
Remove unneeded `check_id` calls as they are already called in `visit_id` in `EarlyContextAndPass` type

### DIFF
--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -136,7 +136,6 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
         // the AST struct that they wrap (e.g. an item)
         self.with_lint_attrs(s.id, s.attrs(), |cx| {
             lint_callback!(cx, check_stmt, s);
-            cx.check_id(s.id);
         });
         // The visitor for the AST struct wrapped
         // by the statement (e.g. `Item`) will call
@@ -147,7 +146,6 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
 
     fn visit_fn(&mut self, fk: ast_visit::FnKind<'ast>, span: Span, id: ast::NodeId) {
         lint_callback!(self, check_fn, fk, span, id);
-        self.check_id(id);
         ast_visit::walk_fn(self, fk);
     }
 


### PR DESCRIPTION
Follow-up from [this message](https://github.com/rust-lang/rust/pull/142240/files#r2137474724).

Since `check_id` is already called in `visit_id` which is supposed to be called for each item with an ID, we don't need to manually call `check_id`.

r? @oli-obk 