### PR TITLE
Fix Typos in Documentation and Comments

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3097,7 +3097,7 @@ pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
 /// On UNIX-like systems, this function will update the permission bits
 /// of the file pointed to by the symlink.
 ///
-/// Note that this behavior can lead to privalage escalation vulnerabilites,
+/// Note that this behavior can lead to privalage escalation vulnerabilities,
 /// where the ability to create a symlink in one directory allows you to
 /// cause the permissions of another file or directory to be modified.
 ///

--- a/library/std/src/thread/spawnhook.rs
+++ b/library/std/src/thread/spawnhook.rs
@@ -6,7 +6,7 @@ use crate::thread::Thread;
 crate::thread_local! {
     /// A thread local linked list of spawn hooks.
     ///
-    /// It is a linked list of Arcs, such that it can very cheaply be inhereted by spawned threads.
+    /// It is a linked list of Arcs, such that it can very cheaply be inherited by spawned threads.
     ///
     /// (That technically makes it a set of linked lists with shared tails, so a linked tree.)
     static SPAWN_HOOKS: Cell<SpawnHooks> = const { Cell::new(SpawnHooks { first: None }) };

--- a/tests/ui/lifetimes/issue-77175.rs
+++ b/tests/ui/lifetimes/issue-77175.rs
@@ -6,7 +6,7 @@
 // once. This was obviously wrong since the lifetime is used twice: For the s3
 // parameter and the return type. The issue was caused by the compiler
 // desugaring the async function into a coroutine that uses only a single
-// lifetime, which then the validator complained about becauase of the
+// lifetime, which then the validator complained about because of the
 // single_use_lifetimes constraints.
 async fn bar<'a>(s1: String, s2: &'_ str, s3: &'a str) -> &'a str {
     s3


### PR DESCRIPTION


Description:  
This pull request corrects several typographical errors in documentation and comments across the codebase. Specifically, it fixes the spelling of "vulnerabilities," "inherited," and "because" in the relevant files. These changes improve the clarity and professionalism of the code documentation without affecting any functionality.