### PR TITLE
compiler: remove AIX's `uses_power_alignment` lint

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -1063,7 +1063,5 @@ lint_useless_ptr_null_checks_fn_ret = returned pointer of `{$fn_name}` call is n
 lint_useless_ptr_null_checks_ref = references are not nullable, so checking them for null will always return false
     .label = expression has type `{$orig_ty}`
 
-lint_uses_power_alignment = repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1776,10 +1776,6 @@ pub(crate) struct TooLargeCharCast {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_uses_power_alignment)]
-pub(crate) struct UsesPowerAlignment;
-
-#[derive(LintDiagnostic)]
 #[diag(lint_unused_comparisons)]
 pub(crate) struct UnusedComparisons;
 

--- a/tests/ui/layout/reprc-power-alignment.rs
+++ b/tests/ui/layout/reprc-power-alignment.rs
@@ -1,9 +1,8 @@
-//@ check-pass
 //@ compile-flags: --target powerpc64-ibm-aix
 //@ needs-llvm-components: powerpc
 //@ add-minicore
 //@ ignore-backends: gcc
-#![feature(no_core)]
+#![feature(no_core, rustc_attrs)]
 #![no_core]
 #![no_std]
 #![crate_type = "lib"]
@@ -11,182 +10,217 @@
 extern crate minicore;
 use minicore::*;
 
-#[warn(uses_power_alignment)]
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct Floats {
+pub struct Floats { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: f64,
     b: u8,
-    c: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    c: f64,
     d: f32,
 }
 
-pub struct Floats2 {
+#[rustc_layout(align)]
+pub struct Floats2 { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: f64,
     b: u32,
     c: f64,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct Floats3 {
+pub struct Floats3 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     a: f32,
     b: f32,
     c: i64,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct Floats4 {
+pub struct Floats4 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     a: u64,
     b: u32,
     c: f32,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct Floats5 {
+pub struct Floats5 { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: f32,
-    b: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    b: f64,
     c: f32,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg1 {
+pub struct FloatAgg1 { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     x: Floats,
-    y: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: f64,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg2 {
+pub struct FloatAgg2 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: i64,
-    y: Floats, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: Floats,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg3 {
+pub struct FloatAgg3 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: FloatAgg1,
-    // NOTE: the "power" alignment rule is infectious to nested struct fields.
-    y: FloatAgg2, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-    z: FloatAgg2, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: FloatAgg2,
+    z: FloatAgg2,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg4 {
+pub struct FloatAgg4 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: FloatAgg1,
-    y: FloatAgg2, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: FloatAgg2,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg5 {
+pub struct FloatAgg5 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: FloatAgg1,
-    y: FloatAgg2, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-    z: FloatAgg3, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: FloatAgg2,
+    z: FloatAgg3,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg6 {
+pub struct FloatAgg6 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: i64,
-    y: Floats, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: Floats,
     z: u8,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct FloatAgg7 {
+pub struct FloatAgg7 { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     x: i64,
-    y: Floats, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    y: Floats,
     z: u8,
     zz: f32,
 }
 
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct A {
+pub struct A { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     d: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct B {
+pub struct B { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: A,
     f: f32,
-    d: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    d: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct C {
+pub struct C { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     c: u8,
-    b: B, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    b: B,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct D {
+pub struct D { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     x: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct E {
+pub struct E { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     x: i32,
-    d: D, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    d: D,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct F {
+pub struct F { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: u8,
-    b: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    b: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct G {
+pub struct G { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: u8,
     b: u8,
-    c: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    c: f64,
     d: f32,
-    e: f64, //~ WARNING repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
+    e: f64,
 }
-// Should not warn on #[repr(packed)].
+
+#[rustc_layout(align)]
 #[repr(packed)]
-pub struct H {
+pub struct H { //~ ERROR: align: AbiAlign { abi: Align(1 bytes) }
     a: u8,
     b: u8,
     c: f64,
     d: f32,
     e: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C, packed)]
-pub struct I {
+pub struct I { //~ ERROR: align: AbiAlign { abi: Align(1 bytes) }
     a: u8,
     b: u8,
     c: f64,
     d: f32,
     e: f64,
 }
+
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct J {
+pub struct J { //~ ERROR: align: AbiAlign { abi: Align(1 bytes) }
     a: u8,
     b: I,
 }
-// The lint also ignores diagnosing #[repr(align(n))].
+
+#[rustc_layout(align)]
 #[repr(C, align(8))]
-pub struct K {
+pub struct K { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     a: u8,
     b: u8,
     c: f64,
     d: f32,
     e: f64,
 }
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub struct L {
+pub struct L { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     a: u8,
     b: K,
 }
+
+#[rustc_layout(align)]
 #[repr(C, align(8))]
-pub struct M {
+pub struct M { //~ ERROR: align: AbiAlign { abi: Align(8 bytes) }
     a: u8,
     b: K,
     c: L,
 }
 
-// The lint ignores unions
+#[rustc_layout(align)]
 #[repr(C)]
-pub union Union {
+pub union Union { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     a: f64,
     b: u8,
     c: f64,
     d: f32,
 }
 
-// The lint ignores enums
+
+#[rustc_layout(align)]
 #[repr(C)]
-pub enum Enum {
+pub enum Enum { //~ ERROR: align: AbiAlign { abi: Align(4 bytes) }
     A { a: f64, b: u8, c: f64, d: f32 },
     B,
 }

--- a/tests/ui/layout/reprc-power-alignment.stderr
+++ b/tests/ui/layout/reprc-power-alignment.stderr
@@ -1,112 +1,164 @@
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:19:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:15:1
    |
-LL |     c: f64,
-   |     ^^^^^^
-   |
-note: the lint level is defined here
-  --> $DIR/reprc-power-alignment.rs:14:8
-   |
-LL | #[warn(uses_power_alignment)]
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | pub struct Floats {
+   | ^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:46:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:23:1
    |
-LL |     b: f64,
-   |     ^^^^^^
-   |
-   = note: `#[warn(uses_power_alignment)]` on by default
+LL | pub struct Floats2 {
+   | ^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:53:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:31:1
    |
-LL |     y: f64,
-   |     ^^^^^^
+LL | pub struct Floats3 {
+   | ^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:59:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:39:1
    |
-LL |     y: Floats,
-   |     ^^^^^^^^^
+LL | pub struct Floats4 {
+   | ^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:66:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:47:1
    |
-LL |     y: FloatAgg2,
-   |     ^^^^^^^^^^^^
+LL | pub struct Floats5 {
+   | ^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:67:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:55:1
    |
-LL |     z: FloatAgg2,
-   |     ^^^^^^^^^^^^
+LL | pub struct FloatAgg1 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:73:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:62:1
    |
-LL |     y: FloatAgg2,
-   |     ^^^^^^^^^^^^
+LL | pub struct FloatAgg2 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:79:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:69:1
    |
-LL |     y: FloatAgg2,
-   |     ^^^^^^^^^^^^
+LL | pub struct FloatAgg3 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:80:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:77:1
    |
-LL |     z: FloatAgg3,
-   |     ^^^^^^^^^^^^
+LL | pub struct FloatAgg4 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:86:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:84:1
    |
-LL |     y: Floats,
-   |     ^^^^^^^^^
+LL | pub struct FloatAgg5 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:93:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:92:1
    |
-LL |     y: Floats,
-   |     ^^^^^^^^^
+LL | pub struct FloatAgg6 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:106:5
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:100:1
    |
-LL |     d: f64,
-   |     ^^^^^^
+LL | pub struct FloatAgg7 {
+   | ^^^^^^^^^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:111:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:109:1
    |
-LL |     b: B,
-   |     ^^^^
+LL | pub struct A {
+   | ^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:120:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:115:1
    |
-LL |     d: D,
-   |     ^^^^
+LL | pub struct B {
+   | ^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:125:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:123:1
    |
-LL |     b: f64,
-   |     ^^^^^^
+LL | pub struct C {
+   | ^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:131:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:130:1
    |
-LL |     c: f64,
-   |     ^^^^^^
+LL | pub struct D {
+   | ^^^^^^^^^^^^
 
-warning: repr(C) does not follow the power alignment rule. This may affect platform C ABI compatibility for this type
-  --> $DIR/reprc-power-alignment.rs:133:5
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:136:1
    |
-LL |     e: f64,
-   |     ^^^^^^
+LL | pub struct E {
+   | ^^^^^^^^^^^^
 
-warning: 17 warnings emitted
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:143:1
+   |
+LL | pub struct F {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:150:1
+   |
+LL | pub struct G {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(1 bytes) }
+  --> $DIR/reprc-power-alignment.rs:160:1
+   |
+LL | pub struct H {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(1 bytes) }
+  --> $DIR/reprc-power-alignment.rs:170:1
+   |
+LL | pub struct I {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(1 bytes) }
+  --> $DIR/reprc-power-alignment.rs:181:1
+   |
+LL | pub struct J {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:188:1
+   |
+LL | pub struct K {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:198:1
+   |
+LL | pub struct L {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(8 bytes) }
+  --> $DIR/reprc-power-alignment.rs:205:1
+   |
+LL | pub struct M {
+   | ^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:213:1
+   |
+LL | pub union Union {
+   | ^^^^^^^^^^^^^^^
+
+error: align: AbiAlign { abi: Align(4 bytes) }
+  --> $DIR/reprc-power-alignment.rs:223:1
+   |
+LL | pub enum Enum {
+   | ^^^^^^^^^^^^^
+
+error: aborting due to 27 previous errors
 

--- a/tests/ui/lint/clashing-extern-fn.rs
+++ b/tests/ui/lint/clashing-extern-fn.rs
@@ -248,7 +248,6 @@ mod sameish_members {
 
 mod same_sized_members_clash {
     mod a {
-        #[allow(uses_power_alignment)]
         #[repr(C)]
         struct Point3 {
             x: f32,

--- a/tests/ui/lint/clashing-extern-fn.stderr
+++ b/tests/ui/lint/clashing-extern-fn.stderr
@@ -1,5 +1,5 @@
 warning: `extern` block uses type `Option<TransparentNoNiche>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:483:55
+  --> $DIR/clashing-extern-fn.rs:482:55
    |
 LL |             fn hidden_niche_transparent_no_niche() -> Option<TransparentNoNiche>;
    |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -9,7 +9,7 @@ LL |             fn hidden_niche_transparent_no_niche() -> Option<TransparentNoN
    = note: `#[warn(improper_ctypes)]` on by default
 
 warning: `extern` block uses type `Option<UnsafeCell<NonZero<usize>>>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:487:46
+  --> $DIR/clashing-extern-fn.rs:486:46
    |
 LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usize>>>;
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -18,7 +18,7 @@ LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usiz
    = note: enum has no representation hint
 
 warning: `extern` block uses type `Option<(usize) is 0..>`, which is not FFI-safe
-  --> $DIR/clashing-extern-fn.rs:502:54
+  --> $DIR/clashing-extern-fn.rs:501:54
    |
 LL |             fn pt_non_zero_usize_opt_full_range() -> Option<pattern_type!(usize is 0..)>;
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -160,7 +160,7 @@ LL |             fn draw_point(p: Point);
               found `unsafe extern "C" fn(sameish_members::b::Point)`
 
 warning: `origin` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:270:13
+  --> $DIR/clashing-extern-fn.rs:269:13
    |
 LL |             fn origin() -> Point3;
    |             ---------------------- `origin` previously declared here
@@ -172,7 +172,7 @@ LL |             fn origin() -> Point3;
               found `unsafe extern "C" fn() -> same_sized_members_clash::b::Point3`
 
 warning: `transparent_incorrect` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:293:13
+  --> $DIR/clashing-extern-fn.rs:292:13
    |
 LL |             fn transparent_incorrect() -> T;
    |             -------------------------------- `transparent_incorrect` previously declared here
@@ -184,7 +184,7 @@ LL |             fn transparent_incorrect() -> isize;
               found `unsafe extern "C" fn() -> isize`
 
 warning: `missing_return_type` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:311:13
+  --> $DIR/clashing-extern-fn.rs:310:13
    |
 LL |             fn missing_return_type() -> usize;
    |             ---------------------------------- `missing_return_type` previously declared here
@@ -196,7 +196,7 @@ LL |             fn missing_return_type();
               found `unsafe extern "C" fn()`
 
 warning: `non_zero_usize` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:329:13
+  --> $DIR/clashing-extern-fn.rs:328:13
    |
 LL |             fn non_zero_usize() -> core::num::NonZero<usize>;
    |             ------------------------------------------------- `non_zero_usize` previously declared here
@@ -208,7 +208,7 @@ LL |             fn non_zero_usize() -> usize;
               found `unsafe extern "C" fn() -> usize`
 
 warning: `non_null_ptr` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:331:13
+  --> $DIR/clashing-extern-fn.rs:330:13
    |
 LL |             fn non_null_ptr() -> core::ptr::NonNull<usize>;
    |             ----------------------------------------------- `non_null_ptr` previously declared here
@@ -220,7 +220,7 @@ LL |             fn non_null_ptr() -> *const usize;
               found `unsafe extern "C" fn() -> *const usize`
 
 warning: `option_non_zero_usize_incorrect` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:425:13
+  --> $DIR/clashing-extern-fn.rs:424:13
    |
 LL |             fn option_non_zero_usize_incorrect() -> usize;
    |             ---------------------------------------------- `option_non_zero_usize_incorrect` previously declared here
@@ -232,7 +232,7 @@ LL |             fn option_non_zero_usize_incorrect() -> isize;
               found `unsafe extern "C" fn() -> isize`
 
 warning: `option_non_null_ptr_incorrect` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:427:13
+  --> $DIR/clashing-extern-fn.rs:426:13
    |
 LL |             fn option_non_null_ptr_incorrect() -> *const usize;
    |             --------------------------------------------------- `option_non_null_ptr_incorrect` previously declared here
@@ -244,7 +244,7 @@ LL |             fn option_non_null_ptr_incorrect() -> *const isize;
               found `unsafe extern "C" fn() -> *const isize`
 
 warning: `hidden_niche_transparent_no_niche` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:483:13
+  --> $DIR/clashing-extern-fn.rs:482:13
    |
 LL |             fn hidden_niche_transparent_no_niche() -> usize;
    |             ------------------------------------------------ `hidden_niche_transparent_no_niche` previously declared here
@@ -256,7 +256,7 @@ LL |             fn hidden_niche_transparent_no_niche() -> Option<TransparentNoN
               found `unsafe extern "C" fn() -> Option<TransparentNoNiche>`
 
 warning: `hidden_niche_unsafe_cell` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:487:13
+  --> $DIR/clashing-extern-fn.rs:486:13
    |
 LL |             fn hidden_niche_unsafe_cell() -> usize;
    |             --------------------------------------- `hidden_niche_unsafe_cell` previously declared here
@@ -268,7 +268,7 @@ LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usiz
               found `unsafe extern "C" fn() -> Option<UnsafeCell<NonZero<usize>>>`
 
 warning: `pt_non_null_ptr` redeclared with a different signature
-  --> $DIR/clashing-extern-fn.rs:516:13
+  --> $DIR/clashing-extern-fn.rs:515:13
    |
 LL |             fn pt_non_null_ptr() -> pattern_type!(usize is 1..);
    |             ---------------------------------------------------- `pt_non_null_ptr` previously declared here


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/142310)*
<!-- homu-ignore:end -->

In https://github.com/rust-lang/rust/pull/149880 we changed the data layout for AIX to use the corrected, reduced alignment for `f64` (AKA "double"). Because the `uses_power_alignment` lint was based on the premise that our previous alignment was correct, which is wrong, we should now simply remove it. This greatly simplifies the surrounding code handling types that are "improper" for FFI.

Some `repr(C)` structs are still not given the proper layout for FFI compatibility. This will involve a future migration plan involving either a new lint or language changes. The current lint remains incorrect and is not very useful to rewrite into possible revised lints that address this need.