### PR TITLE
remove ice group pings from `triagebot.toml`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -44,29 +44,6 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
-[ping.icebreakers-llvm]
-message = """\
-Hey LLVM ICE-breakers! This bug has been identified as a good
-"LLVM ICE-breaking candidate". In case it's useful, here are some
-[instructions] for tackling these sorts of bugs. Maybe take a look?
-Thanks! <3
-
-[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/llvm.html
-"""
-label = "ICEBreaker-LLVM"
-
-[ping.icebreakers-cleanup-crew]
-alias = ["cleanup", "cleanups", "cleanup-crew", "shrink", "reduce", "bisect"]
-message = """\
-Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
-"Cleanup ICE-breaking candidate". In case it's useful, here are some
-[instructions] for tackling these sorts of bugs. Maybe take a look?
-Thanks! <3
-
-[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/cleanup-crew.html
-"""
-label = "ICEBreaker-Cleanup-Crew"
-
 [ping.windows]
 message = """\
 Hey Windows Group! This bug has been identified as a good "Windows candidate".


### PR DESCRIPTION
Followup to rust-lang/team#1860.

Question: should the https://github.com/rust-lang/rust/labels/ICEBreaker-Cleanup-Crew and https://github.com/rust-lang/rust/labels/ICEBreaker-LLVM labels be deleted too or not?