### PR TITLE
Make `lto` and `linker-plugin-lto` work the same for `compiler_builtins`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -147,23 +147,12 @@ impl ModuleConfig {
 
         let emit_obj = if !should_emit_obj {
             EmitObj::None
-        } else if sess.target.obj_is_bitcode
-            || (sess.opts.cg.linker_plugin_lto.enabled() && !no_builtins)
-        {
+        } else if sess.target.obj_is_bitcode || sess.opts.cg.linker_plugin_lto.enabled() {
             // This case is selected if the target uses objects as bitcode, or
             // if linker plugin LTO is enabled. In the linker plugin LTO case
             // the assumption is that the final link-step will read the bitcode
             // and convert it to object code. This may be done by either the
             // native linker or rustc itself.
-            //
-            // Note, however, that the linker-plugin-lto requested here is
-            // explicitly ignored for `#![no_builtins]` crates. These crates are
-            // specifically ignored by rustc's LTO passes and wouldn't work if
-            // loaded into the linker. These crates define symbols that LLVM
-            // lowers intrinsics to, and these symbol dependencies aren't known
-            // until after codegen. As a result any crate marked
-            // `#![no_builtins]` is assumed to not participate in LTO and
-            // instead goes on to generate object code.
             EmitObj::Bitcode
         } else if need_bitcode_in_object(tcx) {
             EmitObj::ObjectCode(BitcodeSection::Full)

--- a/tests/ui/sanitizer/cfi/no_builtins.rs
+++ b/tests/ui/sanitizer/cfi/no_builtins.rs
@@ -1,0 +1,22 @@
+// Verifies that `#![no_builtins]` crates can be built with linker-plugin-lto and CFI.
+// See Issue #142284
+//
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Clinker-plugin-lto -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static
+//@ compile-flags: --crate-type rlib
+//@ build-pass
+
+#![no_builtins]
+#![no_std]
+
+pub static FUNC: fn() = initializer;
+
+pub fn initializer() {
+    call(fma_with_fma);
+}
+
+pub fn call(fn_ptr: fn()) {
+    fn_ptr();
+}
+
+pub fn fma_with_fma() {}


### PR DESCRIPTION
Fixes: rust-lang/rust#142284

This still needs more testing to make sure it doesn't bring back rust-lang/rust#118609 