### PR TITLE
`rustdoc-json-types`: Intern `Type`s to deduplicate and flatten

### DIFF
--- a/src/librustdoc/json/ids.rs
+++ b/src/librustdoc/json/ids.rs
@@ -14,7 +14,7 @@ use rustdoc_json_types as types;
 use super::JsonRenderer;
 use crate::clean;
 
-pub(super) type IdInterner = FxHashMap<FullItemId, types::Id>;
+pub(super) type IdInterner = FxHashMap<FullItemId, types::ItemId>;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 /// An uninterned id.
@@ -66,7 +66,7 @@ pub(super) struct FullItemId {
 }
 
 impl JsonRenderer<'_> {
-    pub(crate) fn id_from_item_default(&self, item_id: clean::ItemId) -> types::Id {
+    pub(crate) fn id_from_item_default(&self, item_id: clean::ItemId) -> types::ItemId {
         self.id_from_item_inner(item_id, None, None)
     }
 
@@ -75,7 +75,7 @@ impl JsonRenderer<'_> {
         item_id: clean::ItemId,
         name: Option<Symbol>,
         imported_id: Option<DefId>,
-    ) -> types::Id {
+    ) -> types::ItemId {
         let (def_id, extra_id) = match item_id {
             clean::ItemId::DefId(did) => (did, imported_id),
             clean::ItemId::Blanket { for_, impl_id } => (for_, Some(impl_id)),
@@ -107,10 +107,10 @@ impl JsonRenderer<'_> {
         let len = interner.len();
         *interner
             .entry(key)
-            .or_insert_with(|| types::Id(len.try_into().expect("too many items in a crate")))
+            .or_insert_with(|| types::ItemId(len.try_into().expect("too many items in a crate")))
     }
 
-    pub(crate) fn id_from_item(&self, item: &clean::Item) -> types::Id {
+    pub(crate) fn id_from_item(&self, item: &clean::Item) -> types::ItemId {
         match item.kind {
             clean::ItemKind::ImportItem(ref import) => {
                 let imported_id = import.source.did;

--- a/src/librustdoc/json/ids.rs
+++ b/src/librustdoc/json/ids.rs
@@ -1,6 +1,6 @@
 //! Id handling for rustdoc-json.
 //!
-//! Manages the creation of [`rustdoc_json_types::Id`] and the
+//! Manages the creation of [`rustdoc_json_types::ItemId`] and the
 //! fact that these don't correspond exactly to [`DefId`], because
 //! [`rustdoc_json_types::Item`] doesn't correspond exactly to what
 //! other phases think of as an "item".
@@ -21,7 +21,7 @@ pub(super) type IdInterner = FxHashMap<FullItemId, types::ItemId>;
 ///
 /// Each one corresponds to exactly one of both:
 /// 1. [`rustdoc_json_types::Item`].
-/// 2. [`rustdoc_json_types::Id`] transitively (as each `Item` has an `Id`).
+/// 2. [`rustdoc_json_types::ItemId`] transitively (as each `Item` has an `Id`).
 ///
 /// It's *broadly* equivalent to a [`DefId`], but needs slightly more information
 /// to fully disambiguate items, because sometimes we choose to split a single HIR

--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -19,7 +19,7 @@ impl Cache {
         // `filename` needs to replace `-` with `_` to be sure the JSON path will always be valid.
         let filename =
             Path::new(&config.template).file_stem().unwrap().to_str().unwrap().replace('-', "_");
-        let file_path = root.join(&Path::with_extension(Path::new(&filename), "json"));
+        let file_path = root.join(Path::with_extension(Path::new(&filename), "json"));
         let content = fs::read_to_string(&file_path).expect("failed to read JSON file");
 
         Cache {

--- a/src/tools/jsondoclint/src/main.rs
+++ b/src/tools/jsondoclint/src/main.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, bail};
 use clap::Parser;
 use fs_err as fs;
-use rustdoc_json_types::{Crate, FORMAT_VERSION, Id};
+use rustdoc_json_types::{Crate, FORMAT_VERSION, ItemId};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -15,7 +15,7 @@ mod validator;
 #[derive(Debug, PartialEq, Eq, Serialize, Clone)]
 struct Error {
     kind: ErrorKind,
-    id: Id,
+    id: ItemId,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Clone)]
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
                     [sel] => eprintln!(
                         "{} not in index or paths, but referred to at '{}'",
                         err.id.0,
-                        json_find::to_jsonpath(&sel)
+                        json_find::to_jsonpath(sel)
                     ),
                     [sel, ..] => {
                         if verbose {
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
                             eprintln!(
                                 "{} not in index or paths, but referred to at '{}' and {} more",
                                 err.id.0,
-                                json_find::to_jsonpath(&sel),
+                                json_find::to_jsonpath(sel),
                                 sels.len() - 1,
                             )
                         }

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -18,19 +18,19 @@ fn check(krate: &Crate, errs: &[Error]) {
 #[test]
 fn errors_on_missing_links() {
     let k = Crate {
-        root: Id(0),
+        root: ItemId(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([(
-            Id(0),
+            ItemId(0),
             Item {
                 name: Some("root".to_owned()),
-                id: Id(0),
+                id: ItemId(0),
                 crate_id: 0,
                 span: None,
                 visibility: Visibility::Public,
                 docs: None,
-                links: FxHashMap::from_iter([("Not Found".to_owned(), Id(1))]),
+                links: FxHashMap::from_iter([("Not Found".to_owned(), ItemId(1))]),
                 attrs: vec![],
                 deprecation: None,
                 inner: ItemEnum::Module(Module {
@@ -40,6 +40,7 @@ fn errors_on_missing_links() {
                 }),
             },
         )]),
+        types: vec![],
         paths: FxHashMap::default(),
         external_crates: FxHashMap::default(),
         target: rustdoc_json_types::Target { triple: "".to_string(), target_features: vec![] },
@@ -55,7 +56,7 @@ fn errors_on_missing_links() {
                 SelectorPart::Field("links".to_owned()),
                 SelectorPart::Field("Not Found".to_owned()),
             ]]),
-            id: Id(1),
+            id: ItemId(1),
         }],
     );
 }
@@ -65,33 +66,33 @@ fn errors_on_missing_links() {
 #[test]
 fn errors_on_local_in_paths_and_not_index() {
     let krate = Crate {
-        root: Id(0),
+        root: ItemId(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([
             (
-                Id(0),
+                ItemId(0),
                 Item {
-                    id: Id(0),
+                    id: ItemId(0),
                     crate_id: 0,
                     name: Some("microcore".to_owned()),
                     span: None,
                     visibility: Visibility::Public,
                     docs: None,
-                    links: FxHashMap::from_iter([(("prim@i32".to_owned(), Id(2)))]),
+                    links: FxHashMap::from_iter([(("prim@i32".to_owned(), ItemId(2)))]),
                     attrs: Vec::new(),
                     deprecation: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
-                        items: vec![Id(1)],
+                        items: vec![ItemId(1)],
                         is_stripped: false,
                     }),
                 },
             ),
             (
-                Id(1),
+                ItemId(1),
                 Item {
-                    id: Id(1),
+                    id: ItemId(1),
                     crate_id: 0,
                     name: Some("i32".to_owned()),
                     span: None,
@@ -104,8 +105,9 @@ fn errors_on_local_in_paths_and_not_index() {
                 },
             ),
         ]),
+        types: vec![],
         paths: FxHashMap::from_iter([(
-            Id(2),
+            ItemId(2),
             ItemSummary {
                 crate_id: 0,
                 path: vec!["microcore".to_owned(), "i32".to_owned()],
@@ -120,7 +122,7 @@ fn errors_on_local_in_paths_and_not_index() {
     check(
         &krate,
         &[Error {
-            id: Id(2),
+            id: ItemId(2),
             kind: ErrorKind::Custom("Id for local item in `paths` but not in `index`".to_owned()),
         }],
     );
@@ -137,14 +139,14 @@ fn errors_on_missing_path() {
     let generics = Generics { params: vec![], where_predicates: vec![] };
 
     let krate = Crate {
-        root: Id(0),
+        root: ItemId(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([
             (
-                Id(0),
+                ItemId(0),
                 Item {
-                    id: Id(0),
+                    id: ItemId(0),
                     crate_id: 0,
                     name: Some("foo".to_owned()),
                     span: None,
@@ -155,15 +157,15 @@ fn errors_on_missing_path() {
                     deprecation: None,
                     inner: ItemEnum::Module(Module {
                         is_crate: true,
-                        items: vec![Id(1), Id(2)],
+                        items: vec![ItemId(1), ItemId(2)],
                         is_stripped: false,
                     }),
                 },
             ),
             (
-                Id(1),
+                ItemId(1),
                 Item {
-                    id: Id(0),
+                    id: ItemId(0),
                     crate_id: 0,
                     name: Some("Bar".to_owned()),
                     span: None,
@@ -180,9 +182,9 @@ fn errors_on_missing_path() {
                 },
             ),
             (
-                Id(2),
+                ItemId(2),
                 Item {
-                    id: Id(0),
+                    id: ItemId(0),
                     crate_id: 0,
                     name: Some("mk_bar".to_owned()),
                     span: None,
@@ -194,11 +196,7 @@ fn errors_on_missing_path() {
                     inner: ItemEnum::Function(Function {
                         sig: FunctionSignature {
                             inputs: vec![],
-                            output: Some(Type::ResolvedPath(Path {
-                                path: "Bar".to_owned(),
-                                id: Id(1),
-                                args: None,
-                            })),
+                            output: Some(0),
                             is_c_variadic: false,
                         },
                         generics,
@@ -213,8 +211,9 @@ fn errors_on_missing_path() {
                 },
             ),
         ]),
+        types: vec![Type::ResolvedPath(Path { path: "Bar".to_owned(), id: ItemId(1), args: None })],
         paths: FxHashMap::from_iter([(
-            Id(0),
+            ItemId(0),
             ItemSummary { crate_id: 0, path: vec!["foo".to_owned()], kind: ItemKind::Module },
         )]),
         external_crates: FxHashMap::default(),
@@ -226,10 +225,10 @@ fn errors_on_missing_path() {
         &krate,
         &[Error {
             kind: ErrorKind::Custom(
-                r#"No entry in '$.paths' for Path { path: "Bar", id: Id(1), args: None }"#
+                r#"No entry in '$.paths' for Path { path: "Bar", id: ItemId(1), args: None }"#
                     .to_owned(),
             ),
-            id: Id(1),
+            id: ItemId(1),
         }],
     );
 }
@@ -238,13 +237,13 @@ fn errors_on_missing_path() {
 #[should_panic = "LOCAL_CRATE_ID is wrong"]
 fn checks_local_crate_id_is_correct() {
     let krate = Crate {
-        root: Id(0),
+        root: ItemId(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([(
-            Id(0),
+            ItemId(0),
             Item {
-                id: Id(0),
+                id: ItemId(0),
                 crate_id: LOCAL_CRATE_ID.wrapping_add(1),
                 name: Some("irrelavent".to_owned()),
                 span: None,
@@ -260,6 +259,7 @@ fn checks_local_crate_id_is_correct() {
                 }),
             },
         )]),
+        types: vec![],
         paths: FxHashMap::default(),
         external_crates: FxHashMap::default(),
         target: rustdoc_json_types::Target { triple: "".to_string(), target_features: vec![] },

--- a/tests/run-make/rustdoc-types-depth/rmake.rs
+++ b/tests/run-make/rustdoc-types-depth/rmake.rs
@@ -1,0 +1,28 @@
+use run_make_support::rustdoc;
+use run_make_support::serde_json::{self, Value};
+
+const REPEAT: usize = 150;
+
+fn main() {
+    let deeply_nested_code =
+        format!("pub type Foo = {}u128{};", "Box<".repeat(REPEAT), ">".repeat(REPEAT));
+    let output = rustdoc()
+        .stdin_buf(deeply_nested_code)
+        .args(["-", "-Zunstable-options", "-wjson", "-o-"])
+        .run()
+        .stdout();
+    let parsed = serde_json::from_slice::<Value>(&output).expect("failed to parse JSON");
+
+    assert!(max_depth(&parsed) < 15);
+}
+
+fn max_depth(v: &Value) -> usize {
+    match v {
+        Value::Null => 1,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 1,
+        Value::String(_) => 1,
+        Value::Array(a) => a.iter().map(max_depth).max().unwrap_or(0) + 1,
+        Value::Object(o) => o.values().map(max_depth).max().unwrap_or(0) + 1,
+    }
+}

--- a/tests/rustdoc-json/assoc_items.rs
+++ b/tests/rustdoc-json/assoc_items.rs
@@ -15,19 +15,20 @@ pub trait EasyToImpl {
     type ToDeclare;
     //@ has "$.index[?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const"
     //@ is "$.index[?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.value" null
-    //@ is "$.index[?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.type.primitive" '"usize"'
+    //@ is "$.index[?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.type" 0
+    //@ is "$.types[0].primitive" '"usize"'
     /// AN_ATTRIBUTE trait
     const AN_ATTRIBUTE: usize;
 }
 
 impl EasyToImpl for Simple {
     //@ has "$.index[?(@.docs=='ToDeclare impl')].inner.assoc_type"
-    //@ is "$.index[?(@.docs=='ToDeclare impl')].inner.assoc_type.type.primitive" \"usize\"
+    //@ is "$.index[?(@.docs=='ToDeclare impl')].inner.assoc_type.type" 0
     /// ToDeclare impl
     type ToDeclare = usize;
 
     //@ has "$.index[?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const"
-    //@ is "$.index[?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.type.primitive" \"usize\"
+    //@ is "$.index[?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.type" 0
     //@ is "$.index[?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.value" \"12\"
     /// AN_ATTRIBUTE impl
     const AN_ATTRIBUTE: usize = 12;

--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -9,5 +9,8 @@ impl Default for Manual {
     }
 }
 
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'
+//@ is '$.types[0].resolved_path.path' '"Derive"'
+//@ is '$.types[14].resolved_path.path' '"Manual"'
+
+//@ is '$.index[?(@.inner.impl.for == 0 && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
+//@ is '$.index[?(@.inner.impl.for == 14 && @.inner.impl.trait.path == "Default")].attrs' '[]'

--- a/tests/rustdoc-json/blanket_impls.rs
+++ b/tests/rustdoc-json/blanket_impls.rs
@@ -3,6 +3,7 @@
 #![no_std]
 
 //@ has "$.index[?(@.name=='Error')].inner.assoc_type"
-//@ has "$.index[?(@.name=='Error')].inner.assoc_type.type.resolved_path"
-//@ has "$.index[?(@.name=='Error')].inner.assoc_type.type.resolved_path.path" \"Infallible\"
+//@ has "$.index[?(@.name=='Error')].inner.assoc_type.type" 10
+//@ has "$.types[10].resolved_path"
+//@ has "$.types[10].resolved_path.path" \"Infallible\"
 pub struct ForBlanketTryFromImpl;

--- a/tests/rustdoc-json/enums/tuple_fields_hidden.rs
+++ b/tests/rustdoc-json/enums/tuple_fields_hidden.rs
@@ -67,14 +67,16 @@ pub enum EnumWithStrippedTupleVariants {
 //@ is "$.index[?(@.docs=='3.3.0')].name" '"0"'
 //@ is "$.index[?(@.docs=='3.3.1')].name" '"1"'
 
-//@ is "$.index[?(@.docs=='1.1.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.1.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.1.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.2.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.3.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.1.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.1.2')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.2.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.2.2')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.3.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.3.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ is "$.types[0].primitive" '"bool"'
+
+//@ is "$.index[?(@.docs=='1.1.0')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='2.1.0')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='2.1.1')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='2.2.1')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='2.3.0')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.1.1')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.1.2')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.2.0')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.2.2')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.3.0')].inner.struct_field" 0
+//@ is "$.index[?(@.docs=='3.3.1')].inner.struct_field" 0

--- a/tests/rustdoc-json/fn_pointer/abi.rs
+++ b/tests/rustdoc-json/fn_pointer/abi.rs
@@ -1,22 +1,29 @@
 #![feature(abi_vectorcall)]
 
-//@ is "$.index[?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"
+//@ is "$.index[?(@.name=='AbiRust')].inner.type_alias.type" 0
+//@ is "$.types[0].function_pointer.header.abi" \"Rust\"
 pub type AbiRust = fn();
 
-//@ is "$.index[?(@.name=='AbiC')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": false}}'
+//@ is "$.index[?(@.name=='AbiC')].inner.type_alias.type" 1
+//@ is "$.types[1].function_pointer.header.abi" '{"C": {"unwind": false}}'
 pub type AbiC = extern "C" fn();
 
-//@ is "$.index[?(@.name=='AbiSystem')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": false}}'
+//@ is "$.index[?(@.name=='AbiSystem')].inner.type_alias.type" 2
+//@ is "$.types[2].function_pointer.header.abi" '{"System": {"unwind": false}}'
 pub type AbiSystem = extern "system" fn();
 
-//@ is "$.index[?(@.name=='AbiCUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": true}}'
+//@ is "$.index[?(@.name=='AbiCUnwind')].inner.type_alias.type" 3
+//@ is "$.types[3].function_pointer.header.abi" '{"C": {"unwind": true}}'
 pub type AbiCUnwind = extern "C-unwind" fn();
 
-//@ is "$.index[?(@.name=='AbiSystemUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": true}}'
+//@ is "$.index[?(@.name=='AbiSystemUnwind')].inner.type_alias.type" 4
+//@ is "$.types[4].function_pointer.header.abi" '{"System": {"unwind": true}}'
 pub type AbiSystemUnwind = extern "system-unwind" fn();
 
-//@ is "$.index[?(@.name=='AbiVecorcall')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall\""'
+//@ is "$.index[?(@.name=='AbiVecorcall')].inner.type_alias.type" 5
+//@ is "$.types[5].function_pointer.header.abi.Other" '"\"vectorcall\""'
 pub type AbiVecorcall = extern "vectorcall" fn();
 
-//@ is "$.index[?(@.name=='AbiVecorcallUnwind')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
+//@ is "$.index[?(@.name=='AbiVecorcallUnwind')].inner.type_alias.type" 6
+//@ is "$.types[6].function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
 pub type AbiVecorcallUnwind = extern "vectorcall-unwind" fn();

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,8 +1,11 @@
-//@ count "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][0]" '"val"'
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.output.primitive" \"i32\"
-//@ count "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[*]" 1
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].name" \"\'c\"
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type" 2
+//@ count "$.types[2].function_pointer.sig.inputs[*]" 1
+//@ is "$.types[2].function_pointer.sig.inputs[0][0]" '"val"'
+//@ is "$.types[2].function_pointer.sig.inputs[0][1]" 1
+//@ is "$.types[1].borrowed_ref.lifetime" \"\'c\"
+//@ is "$.types[2].function_pointer.sig.output" 0
+//@ is "$.types[0].primitive" \"i32\"
+//@ count "$.types[2].function_pointer.generic_params[*]" 1
+//@ is "$.types[2].function_pointer.generic_params[0].name" \"\'c\"
+//@ is "$.types[2].function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
 pub type WithHigherRankTraitBounds = for<'c> fn(val: &'c i32) -> i32;

--- a/tests/rustdoc-json/fn_pointer/qualifiers.rs
+++ b/tests/rustdoc-json/fn_pointer/qualifiers.rs
@@ -1,9 +1,11 @@
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_unsafe" false
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_const" false
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_async" false
+//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type" 0
+//@ is "$.types[0].function_pointer.header.is_unsafe" false
+//@ is "$.types[0].function_pointer.header.is_const" false
+//@ is "$.types[0].function_pointer.header.is_async" false
 pub type FnPointer = fn();
 
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_unsafe" true
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_const" false
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_async" false
+//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type" 1
+//@ is "$.types[1].function_pointer.header.is_unsafe" true
+//@ is "$.types[1].function_pointer.header.is_const" false
+//@ is "$.types[1].function_pointer.header.is_async" false
 pub type UnsafePointer = unsafe fn();

--- a/tests/rustdoc-json/fns/async_return.rs
+++ b/tests/rustdoc-json/fns/async_return.rs
@@ -4,29 +4,30 @@
 
 use std::future::Future;
 
-//@ is "$.index[?(@.name=='get_int')].inner.function.sig.output.primitive" \"i32\"
+//@ is "$.types[0].primitive" \"i32\"
+
+//@ is "$.index[?(@.name=='get_int')].inner.function.sig.output" 0
 //@ is "$.index[?(@.name=='get_int')].inner.function.header.is_async" false
 pub fn get_int() -> i32 {
     42
 }
 
-//@ is "$.index[?(@.name=='get_int_async')].inner.function.sig.output.primitive" \"i32\"
+//@ is "$.index[?(@.name=='get_int_async')].inner.function.sig.output" 0
 //@ is "$.index[?(@.name=='get_int_async')].inner.function.header.is_async" true
 pub async fn get_int_async() -> i32 {
     42
 }
 
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.path" '"Future"'
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive"  \"i32\"
+//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output" 1
+//@ is "$.types[1].impl_trait[0].trait_bound.trait.path" '"Future"'
+//@ is "$.types[1].impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
+//@ is "$.types[1].impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type" 0
 //@ is "$.index[?(@.name=='get_int_future')].inner.function.header.is_async" false
 pub fn get_int_future() -> impl Future<Output = i32> {
     async { 42 }
 }
 
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.path" '"Future"'
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive" \"i32\"
+//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output" 1
 //@ is "$.index[?(@.name=='get_int_future_async')].inner.function.header.is_async" true
 pub async fn get_int_future_async() -> impl Future<Output = i32> {
     async { 42 }

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -12,7 +12,8 @@ pub trait GenericFoo<'a> {}
 //@ is "$.index[?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
 //@ count "$.index[?(@.name=='generics')].inner.function.sig.inputs[*]" 1
 //@ is "$.index[?(@.name=='generics')].inner.function.sig.inputs[0][0]" '"f"'
-//@ is "$.index[?(@.name=='generics')].inner.function.sig.inputs[0][1].generic" '"F"'
+//@ is "$.index[?(@.name=='generics')].inner.function.sig.inputs[0][1]" 0
+//@ is "$.types[0].generic" '"F"'
 pub fn generics<F: Foo>(f: F) {}
 
 //@ is "$.index[?(@.name=='impl_trait')].inner.function.generics.where_predicates" "[]"
@@ -21,8 +22,9 @@ pub fn generics<F: Foo>(f: F) {}
 //@ is "$.index[?(@.name=='impl_trait')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
 //@ count "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[*]" 1
 //@ is "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][0]" '"f"'
-//@ count "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[*]" 1
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
+//@ is "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][1]" 1
+//@ count "$.types[1].impl_trait[*]" 1
+//@ is "$.types[1].impl_trait[0].trait_bound.trait.id" $foo
 pub fn impl_trait(f: impl Foo) {}
 
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.params[*]" 3
@@ -30,14 +32,15 @@ pub fn impl_trait(f: impl Foo) {}
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "is_synthetic": false}}'
 //@ count "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[*]" 3
 //@ is "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[0][0]" '"f"'
-//@ is "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[0][1].generic" '"F"'
+//@ is "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[0][1]" 0
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[*]" 3
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type.generic" \"F\"
+//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type" 0
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]" 1
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.id" $foo
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.type.generic" \"G\"
+//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.type" 2
+//@ is "$.types[2].generic" \"G\"
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[*]" 1
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.id" $generic_foo
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
@@ -45,8 +48,10 @@ pub fn impl_trait(f: impl Foo) {}
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind.lifetime.outlives" "[]"
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.generic_params" "[]"
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.lifetime" \"\'b\"
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.type.generic" \"H\"
+//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type" 4
+//@ is "$.types[4].borrowed_ref.lifetime" \"\'b\"
+//@ is "$.types[4].borrowed_ref.type" 3
+//@ is "$.types[3].generic" \"H\"
 //@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[*]" 1
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.id" $foo
 //@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -4,8 +4,9 @@
 pub trait Foo {}
 
 //@ is "$.index[?(@.name=='get_foo')].inner.function.sig.inputs" []
-//@ count "$.index[?(@.name=='get_foo')].inner.function.sig.output.impl_trait[*]" 1
-//@ is "$.index[?(@.name=='get_foo')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $foo
+//@ is "$.index[?(@.name=='get_foo')].inner.function.sig.output" 0
+//@ count "$.types[0].impl_trait[*]" 1
+//@ is "$.types[0].impl_trait[0].trait_bound.trait.id" $foo
 pub fn get_foo() -> impl Foo {
     Fooer {}
 }

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -6,7 +6,8 @@ pub trait Wham {}
 //@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].name" '"T"'
 //@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.is_synthetic" false
 //@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.sig.inputs" '[["w", {"generic": "T"}]]'
+//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.sig.inputs" '[["w", 0]]'
+//@ is    "$.types[0].generic" '"T"'
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
 //@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.where_predicates" []
@@ -16,5 +17,6 @@ pub fn one_generic_param_fn<T: Wham>(w: T) {}
 //@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
 //@ count "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[*]" 1
 //@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][0]" '"w"'
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
+//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][1]" 1
+//@ is    "$.types[1].impl_trait[0].trait_bound.trait.id" $wham_id
 pub fn one_synthetic_generic_param_fn(w: impl Wham) {}

--- a/tests/rustdoc-json/fns/return_type_alias.rs
+++ b/tests/rustdoc-json/fns/return_type_alias.rs
@@ -3,7 +3,8 @@
 //@ set foo = "$.index[?(@.name=='Foo')].id"
 pub type Foo = i32;
 
-//@ is "$.index[?(@.name=='demo')].inner.function.sig.output.resolved_path.id" $foo
+//@ is "$.index[?(@.name=='demo')].inner.function.sig.output" 1
+//@ is "$.types[1].resolved_path.id" $foo
 pub fn demo() -> Foo {
     42
 }

--- a/tests/rustdoc-json/generic-associated-types/gats.rs
+++ b/tests/rustdoc-json/generic-associated-types/gats.rs
@@ -4,17 +4,19 @@ pub trait LendingIterator {
     //@ count "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.params[*]" 1
     //@ is "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.params[*].name" \"\'a\"
     //@ count "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*]" 1
-    //@ is "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.type.generic" \"Self\"
+    //@ is "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.type" 0
+    //@ is "$.types[0].generic" \"Self\"
     //@ is "$.index[?(@.name=='LendingItem')].inner.assoc_type.generics.where_predicates[*].bound_predicate.bounds[*].outlives" \"\'a\"
     //@ count "$.index[?(@.name=='LendingItem')].inner.assoc_type.bounds[*]" 1
     type LendingItem<'a>: Display
     where
         Self: 'a;
 
-    //@ count "$.index[?(@.name=='lending_next')].inner.function.sig.output.qualified_path.args.angle_bracketed.args[*]" 1
-    //@ count "$.index[?(@.name=='lending_next')].inner.function.sig.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    //@ is "$.index[?(@.name=='lending_next')].inner.function.sig.output.qualified_path.self_type.generic" \"Self\"
-    //@ is "$.index[?(@.name=='lending_next')].inner.function.sig.output.qualified_path.name" \"LendingItem\"
+    //@ is "$.index[?(@.name=='lending_next')].inner.function.sig.output" 2
+    //@ count "$.types[2].qualified_path.args.angle_bracketed.args[*]" 1
+    //@ count "$.types[2].qualified_path.args.angle_bracketed.bindings[*]" 0
+    //@ is "$.types[2].qualified_path.self_type" 0
+    //@ is "$.types[2].qualified_path.name" \"LendingItem\"
     fn lending_next<'a>(&'a self) -> Self::LendingItem<'a>;
 }
 
@@ -26,7 +28,8 @@ pub trait Iterator {
 
     //@ count "$.index[?(@.name=='next')].inner.function.sig.output.qualified_path.args.angle_bracketed.args[*]" 0
     //@ count "$.index[?(@.name=='next')].inner.function.sig.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    //@ is "$.index[?(@.name=='next')].inner.function.sig.output.qualified_path.self_type.generic" \"Self\"
-    //@ is "$.index[?(@.name=='next')].inner.function.sig.output.qualified_path.name" \"Item\"
+    //@ is "$.index[?(@.name=='next')].inner.function.sig.output" 3
+    //@ is "$.types[3].qualified_path.self_type" 0
+    //@ is "$.types[3].qualified_path.name" \"Item\"
     fn next<'a>(&'a self) -> Self::Item;
 }

--- a/tests/rustdoc-json/impl-trait-in-assoc-type.rs
+++ b/tests/rustdoc-json/impl-trait-in-assoc-type.rs
@@ -8,11 +8,13 @@ impl IntoIterator for AlwaysTrue {
     /// type Item
     type Item = bool;
 
-    //@ count '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[*]' 1
-    //@ is    '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.path' '"Iterator"'
-    //@ count '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[*]' 1
-    //@ is    '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name' '"Item"'
-    //@ is    '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive' '"bool"'
+    //@ is    '$.index[?(@.docs=="type IntoIter")].inner.assoc_type.type' 15
+    //@ count '$.types[15].impl_trait[*]' 1
+    //@ is    '$.types[15].impl_trait[0].trait_bound.trait.path' '"Iterator"'
+    //@ count '$.types[15].impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[*]' 1
+    //@ is    '$.types[15].impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name' '"Item"'
+    //@ is    '$.types[15].impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type' 14
+    //@ is    '$.types[14].primitive' '"bool"'
 
     //@ set IntoIter = '$.index[?(@.docs=="type IntoIter")].id'
     /// type IntoIter

--- a/tests/rustdoc-json/impl-trait-precise-capturing.rs
+++ b/tests/rustdoc-json/impl-trait-precise-capturing.rs
@@ -1,4 +1,5 @@
-//@ is "$.index[?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[0].lifetime" \"\'a\"
-//@ is "$.index[?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[1].param" \"T\"
-//@ is "$.index[?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[2].param" \"N\"
+//@ is "$.index[?(@.name=='hello')].inner.function.sig.output" 0
+//@ is "$.types[0].impl_trait[1].use[0].lifetime" \"\'a\"
+//@ is "$.types[0].impl_trait[1].use[1].param" \"T\"
+//@ is "$.types[0].impl_trait[1].use[2].param" \"N\"
 pub fn hello<'a, T, const N: usize>() -> impl Sized + use<'a, T, N> {}

--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -19,6 +19,7 @@ impl Foo {
 //@ is "$.index[?(@.docs=='has span')].span.end" "[15, 2]"
 //@ is "$.index[?(@.docs=='has span')].inner.impl.is_synthetic" false
 //@ is "$.index[?(@.inner.impl.is_synthetic==true)].span" null
-//@ is "$.index[?(@.inner.impl.is_synthetic==true)].inner.impl.for.resolved_path.path" '"Foo"'
+//@ is "$.index[?(@.inner.impl.is_synthetic==true)].inner.impl.for" 0
+//@ is "$.types[0].resolved_path.path" '"Foo"'
 //@ is "$.index[?(@.inner.impl.is_synthetic==true)].inner.impl.trait.path" '"Bar"'
 pub struct Foo;

--- a/tests/rustdoc-json/impls/foreign_for_local.rs
+++ b/tests/rustdoc-json/impls/foreign_for_local.rs
@@ -12,7 +12,8 @@ pub struct LocalStruct;
 impl foreign_trait::ForeignTrait for LocalStruct {}
 
 //@ set impl = "$.index[?(@.docs=='foreign for local')].id"
-//@ is "$.index[?(@.docs=='foreign for local')].inner.impl.for.resolved_path.id" $LocalStruct
+//@ is "$.index[?(@.docs=='foreign for local')].inner.impl.for" 0
+//@ is "$.types[0].resolved_path.id" $LocalStruct
 //@ is "$.index[?(@.docs=='foreign for local')].inner.impl.trait.id" $ForeignTrait
 
 //@ has "$.index[?(@.name=='LocalStruct')].inner.struct.impls[*]" $impl

--- a/tests/rustdoc-json/impls/local_for_foreign.rs
+++ b/tests/rustdoc-json/impls/local_for_foreign.rs
@@ -13,6 +13,7 @@ impl LocalTrait for foreign_struct::ForeignStruct {}
 
 //@ set impl = "$.index[?(@.docs=='local for foreign')].id"
 //@ is "$.index[?(@.docs=='local for foreign')].inner.impl.trait.id" $LocalTrait
-//@ is "$.index[?(@.docs=='local for foreign')].inner.impl.for.resolved_path.id" $ForeignStruct
+//@ is "$.index[?(@.docs=='local for foreign')].inner.impl.for" 0
+//@ is "$.types[0].resolved_path.id" $ForeignStruct
 
 //@ is "$.index[?(@.name=='LocalTrait')].inner.trait.implementations[*]" $impl

--- a/tests/rustdoc-json/impls/local_for_local.rs
+++ b/tests/rustdoc-json/impls/local_for_local.rs
@@ -9,4 +9,5 @@ impl Trait for Struct {}
 //@ has "$.index[?(@.name=='Struct')].inner.struct.impls[*]" $impl
 //@ is "$.index[?(@.name=='Trait')].inner.trait.implementations[*]" $impl
 //@ is "$.index[?(@.docs=='impl')].inner.impl.trait.id" $trait
-//@ is "$.index[?(@.docs=='impl')].inner.impl.for.resolved_path.id" $struct
+//@ is "$.index[?(@.docs=='impl')].inner.impl.for" 0
+//@ is "$.types[0].resolved_path.id" $struct

--- a/tests/rustdoc-json/impls/local_for_local_primitive.rs
+++ b/tests/rustdoc-json/impls/local_for_local_primitive.rs
@@ -4,7 +4,8 @@
 pub trait Local {}
 
 //@ is "$.index[?(@.docs=='Local for bool')].inner.impl.trait.id" $Local
-//@ is "$.index[?(@.docs=='Local for bool')].inner.impl.for.primitive" '"bool"'
+//@ is "$.index[?(@.docs=='Local for bool')].inner.impl.for" 0
+//@ is "$.types[0].primitive" '"bool"'
 /// Local for bool
 impl Local for bool {}
 

--- a/tests/rustdoc-json/impls/trait-for-dyn-trait.rs
+++ b/tests/rustdoc-json/impls/trait-for-dyn-trait.rs
@@ -12,4 +12,5 @@ impl T1 for dyn T2 {}
 //@ is '$.index[?(@.name=="T2")].inner.trait.implementations' []
 
 //@ is '$.index[?(@.docs=="Fun impl")].inner.impl.trait.id' $t1
-//@ is '$.index[?(@.docs=="Fun impl")].inner.impl.for.dyn_trait.traits[*].trait.id' $t2
+//@ is '$.index[?(@.docs=="Fun impl")].inner.impl.for' 0
+//@ is '$.types[0].dyn_trait.traits[*].trait.id' $t2

--- a/tests/rustdoc-json/lifetime/longest.rs
+++ b/tests/rustdoc-json/lifetime/longest.rs
@@ -8,17 +8,14 @@
 //@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[0][0]" '"l"'
 //@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[1][0]" '"r"'
 
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable" false
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[0][1]" 1
+//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[1][1]" 1
+//@ is "$.index[?(@.name=='longest')].inner.function.sig.output" 1
 
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.is_mutable" false
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.type.primitive" \"str\"
-
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.output.borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.output.borrowed_ref.is_mutable" false
-//@ is "$.index[?(@.name=='longest')].inner.function.sig.output.borrowed_ref.type.primitive" \"str\"
+//@ is "$.types[1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.types[1].borrowed_ref.is_mutable" false
+//@ is "$.types[1].borrowed_ref.type" 0
+//@ is "$.types[0].primitive" \"str\"
 
 pub fn longest<'a>(l: &'a str, r: &'a str) -> &'a str {
     if l.len() > r.len() { l } else { r }

--- a/tests/rustdoc-json/lifetime/outlives.rs
+++ b/tests/rustdoc-json/lifetime/outlives.rs
@@ -8,9 +8,12 @@
 //@ is "$.index[?(@.name=='foo')].inner.function.generics.params[2].kind.type.default" null
 //@ count "$.index[?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[*]" 1
 //@ is "$.index[?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[0].outlives" \"\'b\"
-//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable" false
-//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.lifetime" \"\'b\"
-//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.is_mutable" false
-//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.type.generic" \"T\"
+//@ is "$.index[?(@.name=='foo')].inner.function.sig.inputs[0][1]" 2
+//@ is "$.types[2].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.types[2].borrowed_ref.is_mutable" false
+//@ is "$.types[2].borrowed_ref.type" 1
+//@ is "$.types[1].borrowed_ref.lifetime" \"\'b\"
+//@ is "$.types[1].borrowed_ref.is_mutable" false
+//@ is "$.types[1].borrowed_ref.type" 0
+//@ is "$.types[0].generic" \"T\"
 pub fn foo<'a, 'b: 'a, T: 'b>(_: &'a &'b T) {}

--- a/tests/rustdoc-json/lifetime/outlives_in_where.rs
+++ b/tests/rustdoc-json/lifetime/outlives_in_where.rs
@@ -12,7 +12,8 @@ where
 //@ is    '$.index[?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
 //@ is    '$.index[?(@.name=="on_trait")].inner.function.generics.params[1].kind.type.bounds' []
 //@ count '$.index[?(@.name=="on_trait")].inner.function.generics.where_predicates[*]' 1
-//@ is    '$.index[?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.type.generic' '"T"'
+//@ is    '$.index[?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.type' 0
+//@ is    '$.types[0].generic' '"T"'
 //@ count '$.index[?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]' 1
 //@ is    '$.index[?(@.name=="on_trait")].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].outlives' \"\'a\"
 pub fn on_trait<'a, T>()

--- a/tests/rustdoc-json/path_name.rs
+++ b/tests/rustdoc-json/path_name.rs
@@ -19,22 +19,28 @@ pub use priv_mod::{InPrivMod, InPrivMod as InPrivMod2};
 use pub_mod::InPubMod as InPubMod3;
 pub use pub_mod::{InPubMod, InPubMod as InPubMod2};
 
-//@ is "$.index[?(@.name=='T0')].inner.type_alias.type.resolved_path.path" '"priv_mod::InPrivMod"'
+//@ is "$.index[?(@.name=='T0')].inner.type_alias.type" 15
+//@ is "$.types[15].resolved_path.path" '"priv_mod::InPrivMod"'
 pub type T0 = priv_mod::InPrivMod;
-//@ is "$.index[?(@.name=='T1')].inner.type_alias.type.resolved_path.path" '"InPrivMod"'
+//@ is "$.index[?(@.name=='T1')].inner.type_alias.type" 0
+//@ is "$.types[0].resolved_path.path" '"InPrivMod"'
 pub type T1 = InPrivMod;
-//@ is "$.index[?(@.name=='T2')].inner.type_alias.type.resolved_path.path" '"InPrivMod2"'
+//@ is "$.index[?(@.name=='T2')].inner.type_alias.type" 16
+//@ is "$.types[16].resolved_path.path" '"InPrivMod2"'
 pub type T2 = InPrivMod2;
-//@ is "$.index[?(@.name=='T3')].inner.type_alias.type.resolved_path.path" '"priv_mod::InPrivMod"'
+//@ is "$.index[?(@.name=='T3')].inner.type_alias.type" 15
 pub type T3 = InPrivMod3;
 
-//@ is "$.index[?(@.name=='U0')].inner.type_alias.type.resolved_path.path" '"pub_mod::InPubMod"'
+//@ is "$.index[?(@.name=='U0')].inner.type_alias.type" 17
+//@ is "$.types[17].resolved_path.path" '"pub_mod::InPubMod"'
 pub type U0 = pub_mod::InPubMod;
-//@ is "$.index[?(@.name=='U1')].inner.type_alias.type.resolved_path.path" '"InPubMod"'
+//@ is "$.index[?(@.name=='U1')].inner.type_alias.type" 14
+//@ is "$.types[14].resolved_path.path" '"InPubMod"'
 pub type U1 = InPubMod;
-//@ is "$.index[?(@.name=='U2')].inner.type_alias.type.resolved_path.path" '"InPubMod2"'
+//@ is "$.index[?(@.name=='U2')].inner.type_alias.type" 18
+//@ is "$.types[18].resolved_path.path" '"InPubMod2"'
 pub type U2 = InPubMod2;
-//@ is "$.index[?(@.name=='U3')].inner.type_alias.type.resolved_path.path" '"pub_mod::InPubMod"'
+//@ is "$.index[?(@.name=='U3')].inner.type_alias.type" 17
 pub type U3 = InPubMod3;
 
 // Check we only have paths for structs at their original path
@@ -43,25 +49,32 @@ pub type U3 = InPubMod3;
 pub use defines_and_reexports::{InPrivMod as XPrivMod, InPubMod as XPubMod};
 use defines_and_reexports::{InPrivMod as XPrivMod2, InPubMod as XPubMod2};
 
-//@ is "$.index[?(@.name=='X0')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::m1::InPubMod"'
+//@ is "$.index[?(@.name=='X0')].inner.type_alias.type" 19
+//@ is "$.types[19].resolved_path.path" '"defines_and_reexports::m1::InPubMod"'
 pub type X0 = defines_and_reexports::m1::InPubMod;
-//@ is "$.index[?(@.name=='X1')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPubMod"'
+//@ is "$.index[?(@.name=='X1')].inner.type_alias.type" 20
+//@ is "$.types[20].resolved_path.path" '"defines_and_reexports::InPubMod"'
 pub type X1 = defines_and_reexports::InPubMod;
-//@ is "$.index[?(@.name=='X2')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPubMod2"'
+//@ is "$.index[?(@.name=='X2')].inner.type_alias.type" 21
+//@ is "$.types[21].resolved_path.path" '"defines_and_reexports::InPubMod2"'
 pub type X2 = defines_and_reexports::InPubMod2;
-//@ is "$.index[?(@.name=='X3')].inner.type_alias.type.resolved_path.path" '"XPubMod"'
+//@ is "$.index[?(@.name=='X3')].inner.type_alias.type" 22
+//@ is "$.types[22].resolved_path.path" '"XPubMod"'
 pub type X3 = XPubMod;
 // N.B. This isn't the path as used *or* the original path!
-//@ is "$.index[?(@.name=='X4')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPubMod"'
+//@ is "$.index[?(@.name=='X4')].inner.type_alias.type" 20
 pub type X4 = XPubMod2;
 
-//@ is "$.index[?(@.name=='Y1')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPrivMod"'
+//@ is "$.index[?(@.name=='Y1')].inner.type_alias.type" 23
+//@ is "$.types[23].resolved_path.path" '"defines_and_reexports::InPrivMod"'
 pub type Y1 = defines_and_reexports::InPrivMod;
-//@ is "$.index[?(@.name=='Y2')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPrivMod2"'
+//@ is "$.index[?(@.name=='Y2')].inner.type_alias.type" 24
+//@ is "$.types[24].resolved_path.path" '"defines_and_reexports::InPrivMod2"'
 pub type Y2 = defines_and_reexports::InPrivMod2;
-//@ is "$.index[?(@.name=='Y3')].inner.type_alias.type.resolved_path.path" '"XPrivMod"'
+//@ is "$.index[?(@.name=='Y3')].inner.type_alias.type" 25
+//@ is "$.types[25].resolved_path.path" '"XPrivMod"'
 pub type Y3 = XPrivMod;
-//@ is "$.index[?(@.name=='Y4')].inner.type_alias.type.resolved_path.path" '"defines_and_reexports::InPrivMod"'
+//@ is "$.index[?(@.name=='Y4')].inner.type_alias.type" 23
 pub type Y4 = XPrivMod2;
 
 // For foreign items, $.paths contains the *origional* path, even if it's not publicly
@@ -74,9 +87,12 @@ pub type Y4 = XPrivMod2;
 
 // Tests for the example in the docs of Path::name.
 // If these change, chage the docs.
-//@ is "$.index[?(@.name=='Vec1')].inner.type_alias.type.resolved_path.path" '"std::vec::Vec"'
+//@ is "$.index[?(@.name=='Vec1')].inner.type_alias.type" 27
+//@ is "$.types[27].resolved_path.path" '"std::vec::Vec"'
 pub type Vec1 = std::vec::Vec<i32>;
-//@ is "$.index[?(@.name=='Vec2')].inner.type_alias.type.resolved_path.path" '"Vec"'
+//@ is "$.index[?(@.name=='Vec2')].inner.type_alias.type" 28
+//@ is "$.types[28].resolved_path.path" '"Vec"'
 pub type Vec2 = Vec<i32>;
-//@ is "$.index[?(@.name=='Vec3')].inner.type_alias.type.resolved_path.path" '"std::prelude::v1::Vec"'
+//@ is "$.index[?(@.name=='Vec3')].inner.type_alias.type" 29
+//@ is "$.types[29].resolved_path.path" '"std::prelude::v1::Vec"'
 pub type Vec3 = std::prelude::v1::Vec<i32>;

--- a/tests/rustdoc-json/primitives/primitive_type.rs
+++ b/tests/rustdoc-json/primitives/primitive_type.rs
@@ -1,17 +1,22 @@
 #![feature(never_type)]
 
 //@ is "$.index[?(@.name=='PrimNever')].visibility" \"public\"
-//@ is "$.index[?(@.name=='PrimNever')].inner.type_alias.type.primitive" \"never\"
+//@ is "$.index[?(@.name=='PrimNever')].inner.type_alias.type" 0
+//@ is "$.types[0].primitive" \"never\"
 pub type PrimNever = !;
 
-//@ is "$.index[?(@.name=='PrimStr')].inner.type_alias.type.primitive" \"str\"
+//@ is "$.index[?(@.name=='PrimStr')].inner.type_alias.type" 1
+//@ is "$.types[1].primitive" \"str\"
 pub type PrimStr = str;
 
-//@ is "$.index[?(@.name=='PrimBool')].inner.type_alias.type.primitive" \"bool\"
+//@ is "$.index[?(@.name=='PrimBool')].inner.type_alias.type" 2
+//@ is "$.types[2].primitive" \"bool\"
 pub type PrimBool = bool;
 
-//@ is "$.index[?(@.name=='PrimChar')].inner.type_alias.type.primitive" \"char\"
+//@ is "$.index[?(@.name=='PrimChar')].inner.type_alias.type" 3
+//@ is "$.types[3].primitive" \"char\"
 pub type PrimChar = char;
 
-//@ is "$.index[?(@.name=='PrimU8')].inner.type_alias.type.primitive" \"u8\"
+//@ is "$.index[?(@.name=='PrimU8')].inner.type_alias.type" 4
+//@ is "$.types[4].primitive" \"u8\"
 pub type PrimU8 = u8;

--- a/tests/rustdoc-json/return-type-notation.rs
+++ b/tests/rustdoc-json/return-type-notation.rs
@@ -9,7 +9,8 @@ pub trait Foo {
 }
 
 //@ is "$.index[?(@.name=='foo')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.args.angle_bracketed.constraints[0].args" '"return_type_notation"'
-//@ ismany "$.index[?(@.name=='foo')].inner.function.generics.where_predicates[*].bound_predicate.type.qualified_path.args" '"return_type_notation"' '"return_type_notation"'
+//@ ismany "$.index[?(@.name=='foo')].inner.function.generics.where_predicates[*].bound_predicate.type" 1 2
+//@ ismany "$.types[1, 2].qualified_path.args" '"return_type_notation"' '"return_type_notation"'
 pub fn foo<T: Foo<bar(..): Send>>()
 where
     <T as Foo>::bar(..): 'static,

--- a/tests/rustdoc-json/return_private.rs
+++ b/tests/rustdoc-json/return_private.rs
@@ -6,8 +6,9 @@ mod secret {
 }
 
 //@ has "$.index[?(@.name=='get_secret')].inner.function"
-//@ is "$.index[?(@.name=='get_secret')].inner.function.sig.output.resolved_path.path" '"secret::Secret"'
-//@ is "$.index[?(@.name=='get_secret')].inner.function.sig.output.resolved_path.id" $struct_secret
+//@ is "$.index[?(@.name=='get_secret')].inner.function.sig.output" 0
+//@ is "$.types[0].resolved_path.path" '"secret::Secret"'
+//@ is "$.types[0].resolved_path.id" $struct_secret
 pub fn get_secret() -> secret::Secret {
     secret::Secret
 }

--- a/tests/rustdoc-json/statics/extern.rs
+++ b/tests/rustdoc-json/statics/extern.rs
@@ -35,4 +35,5 @@ unsafe extern "C" {
 }
 
 //@ ismany '$.index[?(@.inner.static)].inner.static.expr' '""' '""' '""' '""' '""' '""' '""' '""'
-//@ ismany '$.index[?(@.inner.static)].inner.static.type.primitive' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"'
+//@ is '$.types[0].primitive' '"i32"'
+//@ ismany '$.index[?(@.inner.static)].inner.static.type' 0 0 0 0 0 0 0 0

--- a/tests/rustdoc-json/statics/statics.rs
+++ b/tests/rustdoc-json/statics/statics.rs
@@ -1,10 +1,12 @@
-//@ is '$.index[?(@.name=="A")].inner.static.type.primitive' '"i32"'
+//@ is '$.index[?(@.name=="A")].inner.static.type' 0
+//@ is '$.types[0].primitive' '"i32"'
 //@ is '$.index[?(@.name=="A")].inner.static.is_mutable' false
 //@ is '$.index[?(@.name=="A")].inner.static.expr' '"5"'
 //@ is '$.index[?(@.name=="A")].inner.static.is_unsafe' false
 pub static A: i32 = 5;
 
-//@ is '$.index[?(@.name=="B")].inner.static.type.primitive' '"u32"'
+//@ is '$.index[?(@.name=="B")].inner.static.type' 1
+//@ is '$.types[1].primitive' '"u32"'
 //@ is '$.index[?(@.name=="B")].inner.static.is_mutable' true
 // Expr value isn't gaurenteed, it'd be fine to change it.
 //@ is '$.index[?(@.name=="B")].inner.static.expr' '"_"'

--- a/tests/rustdoc-json/trait_alias.rs
+++ b/tests/rustdoc-json/trait_alias.rs
@@ -6,12 +6,14 @@
 //@ is "$.index[?(@.name=='StrLike')].span.filename" $FILE
 pub trait StrLike = AsRef<str>;
 
-//@ is "$.index[?(@.name=='f')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ is "$.index[?(@.name=='f')].inner.function.sig.output" 1
+//@ is "$.types[1].impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn f() -> impl StrLike {
     "heya"
 }
 
-//@ !is "$.index[?(@.name=='g')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ is "$.index[?(@.name=='g')].inner.function.sig.output" 2
+//@ !is "$.types[2].impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn g() -> impl AsRef<str> {
     "heya"
 }

--- a/tests/rustdoc-json/traits/implementors.rs
+++ b/tests/rustdoc-json/traits/implementors.rs
@@ -15,4 +15,5 @@ impl Wham for GeorgeMichael {}
 
 // Impl points to both struct and trait.
 //@ is "$.index[?(@.docs == 'Wham for George Michael')].inner.impl.trait.id" $wham
-//@ is "$.index[?(@.docs == 'Wham for George Michael')].inner.impl.for.resolved_path.id" $gm
+//@ is "$.index[?(@.docs == 'Wham for George Michael')].inner.impl.for" 0
+//@ is "$.types[0].resolved_path.id" $gm

--- a/tests/rustdoc-json/traits/self.rs
+++ b/tests/rustdoc-json/traits/self.rs
@@ -8,28 +8,32 @@ pub struct Foo;
 
 impl Foo {
     //@ ismany '$.index[?(@.name=="by_ref")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' null null null
-    //@ ismany '$.index[?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' false false false
+    //@ ismany '$.index[?(@.name=="by_ref")].inner.function.sig.inputs[0][1]' 1 1 1
+    //@ is '$.types[1].borrowed_ref.type' 0
+    //@ is '$.types[0].generic' '"Self"'
+    //@ is '$.types[1].borrowed_ref.lifetime' null
+    //@ is '$.types[1].borrowed_ref.is_mutable' false
     pub fn by_ref(&self) {}
 
     //@ ismany '$.index[?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' null null null
-    //@ ismany '$.index[?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' true true true
+    //@ ismany '$.index[?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1]' 2 2 2
+    //@ is '$.types[2].borrowed_ref.type' 0
+    //@ is '$.types[2].borrowed_ref.lifetime' null
+    //@ is '$.types[2].borrowed_ref.is_mutable' true
     pub fn by_exclusive_ref(&mut self) {}
 
     //@ ismany '$.index[?(@.name=="by_value")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[?(@.name=="by_value")].inner.function.sig.inputs[0][1].generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[?(@.name=="by_value")].inner.function.sig.inputs[0][1]' 0 0 0
     pub fn by_value(self) {}
 
     //@ ismany '$.index[?(@.name=="with_lifetime")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' \"\'a\" \"\'a\" \"\'a\"
-    //@ ismany '$.index[?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' false false false
+    //@ ismany '$.index[?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1]' 3 3 3
+    //@ is '$.types[3].borrowed_ref.type' 0
+    //@ is '$.types[3].borrowed_ref.lifetime' \"\'a\"
+    //@ is '$.types[3].borrowed_ref.is_mutable' false
     pub fn with_lifetime<'a>(&'a self) {}
 
-    //@ ismany '$.index[?(@.name=="build")].inner.function.sig.output.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[?(@.name=="build")].inner.function.sig.output' 0 0 0
     pub fn build() -> Self {
         Self
     }

--- a/tests/rustdoc-json/traits/trait_alias.rs
+++ b/tests/rustdoc-json/traits/trait_alias.rs
@@ -11,15 +11,17 @@ pub trait Orig<T> {}
 //@ is "$.index[?(@.name == 'Alias')].inner.trait_alias.generics" '{"params": [], "where_predicates": []}'
 //@ count "$.index[?(@.name == 'Alias')].inner.trait_alias.params[*]" 1
 //@ is "$.index[?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.id" $Orig
-//@ is "$.index[?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.args.angle_bracketed.args[0].type.primitive" '"i32"'
+//@ is "$.index[?(@.name == 'Alias')].inner.trait_alias.params[0].trait_bound.trait.args.angle_bracketed.args[0].type" 0
+//@ is "$.types[0].primitive" '"i32"'
 pub trait Alias = Orig<i32>;
 
 pub struct Struct;
 
 impl Orig<i32> for Struct {}
 
-//@ has "$.index[?(@.name=='takes_alias')].inner.function.sig.inputs[0][1].impl_trait"
-//@ is "$.index[?(@.name=='takes_alias')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $Alias
+//@ is "$.index[?(@.name=='takes_alias')].inner.function.sig.inputs[0][1]" 15
+//@ has "$.types[15].impl_trait"
+//@ is "$.types[15].impl_trait[0].trait_bound.trait.id" $Alias
 //@ is "$.index[?(@.name=='takes_alias')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $Alias
 pub fn takes_alias(_: impl Alias) {}
 // FIXME: Should the trait be mentioned in both the decl and generics?

--- a/tests/rustdoc-json/type/dyn.rs
+++ b/tests/rustdoc-json/type/dyn.rs
@@ -6,40 +6,47 @@ use std::fmt::Debug;
 //@ set weird_order  = "$.index[?(@.name=='WeirdOrder')].id"
 //@ ismany "$.index[?(@.name=='dyn')].inner.module.items[*]" $sync_int_gen $ref_fn $weird_order
 
-//@ has    "$.index[?(@.name=='SyncIntGen')].inner.type_alias"
+//@ has   "$.index[?(@.name=='SyncIntGen')].inner.type_alias"
 //@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.generics" '{"params": [], "where_predicates": []}'
-//@ has    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path"
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.path" \"Box\"
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.constraints" []
-//@ count "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args" 1
-//@ has    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait"
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.lifetime" \"\'static\"
-//@ count "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[*]" 3
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].generic_params" []
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].generic_params" []
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].generic_params" []
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.path" '"Fn"'
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.path" '"Send"'
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[2].trait.path" '"Sync"'
-//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.args" '{"parenthesized": {"inputs": [],"output": {"primitive": "i32"}}}'
+//@ is    "$.index[?(@.name=='SyncIntGen')].inner.type_alias.type" 2
+//@ has   "$.types[2].resolved_path"
+//@ is    "$.types[2].resolved_path.path" \"Box\"
+//@ is    "$.types[2].resolved_path.args.angle_bracketed.constraints" []
+//@ count "$.types[2].resolved_path.args.angle_bracketed.args" 1
+//@ is    "$.types[2].resolved_path.args.angle_bracketed.args[0].type" 1
+//@ has   "$.types[1].dyn_trait"
+//@ is    "$.types[1].dyn_trait.lifetime" \"\'static\"
+//@ count "$.types[1].dyn_trait.traits[*]" 3
+//@ is    "$.types[1].dyn_trait.traits[0].generic_params" []
+//@ is    "$.types[1].dyn_trait.traits[1].generic_params" []
+//@ is    "$.types[1].dyn_trait.traits[2].generic_params" []
+//@ is    "$.types[1].dyn_trait.traits[0].trait.path" '"Fn"'
+//@ is    "$.types[1].dyn_trait.traits[1].trait.path" '"Send"'
+//@ is    "$.types[1].dyn_trait.traits[2].trait.path" '"Sync"'
+//@ is    "$.types[0].primitive" '"i32"'
+//@ is    "$.types[1].dyn_trait.traits[0].trait.args" '{"parenthesized": {"inputs": [],"output": 0}}'
 pub type SyncIntGen = Box<dyn Fn() -> i32 + Send + Sync + 'static>;
 
 //@ has "$.index[?(@.name=='RefFn')].inner.type_alias"
 //@ is "$.index[?(@.name=='RefFn')].inner.type_alias.generics" '{"params": [{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"}],"where_predicates": []}'
-//@ has "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref"
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.is_mutable" 'false'
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.lifetime" "\"'a\""
-//@ has "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait"
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.lifetime" null
-//@ count "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[*]" 1
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.path" '"Fn"'
-//@ has "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref"
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.inputs[0].borrowed_ref.lifetime" "\"'b\""
-//@ has "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref"
-//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.traits[0].trait.args.parenthesized.output.borrowed_ref.lifetime" "\"'b\""
+//@ is "$.index[?(@.name=='RefFn')].inner.type_alias.type" 5
+//@ has "$.types[5].borrowed_ref"
+//@ is "$.types[5].borrowed_ref.is_mutable" 'false'
+//@ is "$.types[5].borrowed_ref.lifetime" "\"'a\""
+//@ is "$.types[5].borrowed_ref.type" 4
+//@ has "$.types[4].dyn_trait"
+//@ is "$.types[4].dyn_trait.lifetime" null
+//@ count "$.types[4].dyn_trait.traits[*]" 1
+//@ is "$.types[4].dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.types[4].dyn_trait.traits[0].trait.path" '"Fn"'
+//@ is "$.types[4].dyn_trait.traits[0].trait.args.parenthesized.inputs[0]" 3
+//@ has "$.types[3].borrowed_ref"
+//@ is "$.types[3].borrowed_ref.lifetime" "\"'b\""
+//@ is "$.types[4].dyn_trait.traits[0].trait.args.parenthesized.output" 3
 pub type RefFn<'a> = &'a dyn for<'b> Fn(&'b i32) -> &'b i32;
 
-//@ is    "$.index[?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[0].trait.path" '"Send"'
-//@ is    "$.index[?(@.name=='WeirdOrder')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.traits[1].trait.path" '"Debug"'
+//@ is "$.index[?(@.name=='WeirdOrder')].inner.type_alias.type" 7
+//@ is "$.types[7].resolved_path.args.angle_bracketed.args[0].type" 6
+//@ is "$.types[6].dyn_trait.traits[0].trait.path" '"Send"'
+//@ is "$.types[6].dyn_trait.traits[1].trait.path" '"Debug"'
 pub type WeirdOrder = Box<dyn Send + Debug>;

--- a/tests/rustdoc-json/type/fn_lifetime.rs
+++ b/tests/rustdoc-json/type/fn_lifetime.rs
@@ -5,20 +5,23 @@
 //@ count  "$.index[?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime.outlives[*]" 0
 //@ count  "$.index[?(@.name=='GenericFn')].inner.type_alias.generics.where_predicates[*]" 0
 //@ count  "$.index[?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.generic_params[*]" 0
-//@ count  "$.index[?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
-//@ is     "$.index[?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-//@ is     "$.index[?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.output.borrowed_ref.lifetime" \"\'a\"
+//@ is     "$.index[?(@.name=='GenericFn')].inner.type_alias.type" 2
+//@ count  "$.types[2].function_pointer.sig.inputs[*]" 1
+//@ is     "$.types[2].function_pointer.sig.inputs[*][1]" 1
+//@ is     "$.types[1].borrowed_ref.lifetime" \"\'a\"
+//@ is     "$.types[2].function_pointer.sig.output" 1
 
 pub type GenericFn<'a> = fn(&'a i32) -> &'a i32;
 
 //@ has    "$.index[?(@.name=='ForAll')].inner.type_alias"
 //@ count "$.index[?(@.name=='ForAll')].inner.type_alias.generics.params[*]" 0
 //@ count "$.index[?(@.name=='ForAll')].inner.type_alias.generics.where_predicates[*]" 0
-//@ count "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*]" 1
-//@ is    "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].name" \"\'a\"
-//@ has   "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime"
-//@ count "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime.outlives[*]" 0
-//@ count "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
-//@ is    "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-//@ is    "$.index[?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.output.borrowed_ref.lifetime" \"\'a\"
+//@ is    "$.index[?(@.name=='ForAll')].inner.type_alias.type" 3
+//@ count "$.types[3].function_pointer.generic_params[*]" 1
+//@ is    "$.types[3].function_pointer.generic_params[*].name" \"\'a\"
+//@ has   "$.types[3].function_pointer.generic_params[*].kind.lifetime"
+//@ count "$.types[3].function_pointer.generic_params[*].kind.lifetime.outlives[*]" 0
+//@ count "$.types[3].function_pointer.sig.inputs[*]" 1
+//@ is    "$.types[3].function_pointer.sig.inputs[*][1]" 1
+//@ is    "$.types[3].function_pointer.sig.output" 1
 pub type ForAll = for<'a> fn(&'a i32) -> &'a i32;

--- a/tests/rustdoc-json/type/generic_default.rs
+++ b/tests/rustdoc-json/type/generic_default.rs
@@ -7,7 +7,7 @@ pub enum Result<T, E> {
 //@ set my_error = "$.index[?(@.name=='MyError')].id"
 pub struct MyError {}
 
-//@ has    "$.index[?(@.name=='MyResult')].inner.type_alias"
+//@ has   "$.index[?(@.name=='MyResult')].inner.type_alias"
 //@ count "$.index[?(@.name=='MyResult')].inner.type_alias.generics.where_predicates[*]" 0
 //@ count "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[*]" 2
 //@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[0].name" \"T\"
@@ -17,15 +17,19 @@ pub struct MyError {}
 //@ count "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.bounds[*]" 0
 //@ count "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.bounds[*]" 0
 //@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[0].kind.type.default" null
-//@ has    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path"
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.id" $my_error
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default.resolved_path.path" \"MyError\"
-//@ has    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path"
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.id" $result
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.path" \"Result\"
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.constraints" []
-//@ has    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic"
-//@ has    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic"
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic" \"T\"
-//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic" \"E\"
+//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.generics.params[1].kind.type.default" 15
+//@ has   "$.types[15].resolved_path"
+//@ is    "$.types[15].resolved_path.id" $my_error
+//@ is    "$.types[15].resolved_path.path" \"MyError\"
+//@ is    "$.index[?(@.name=='MyResult')].inner.type_alias.type" 2
+//@ has   "$.types[2].resolved_path"
+//@ is    "$.types[2].resolved_path.id" $result
+//@ is    "$.types[2].resolved_path.path" \"Result\"
+//@ is    "$.types[2].resolved_path.args.angle_bracketed.constraints" []
+//@ is    "$.types[2].resolved_path.args.angle_bracketed.args[0].type" 0
+//@ is    "$.types[2].resolved_path.args.angle_bracketed.args[1].type" 1
+//@ has   "$.types[0].generic"
+//@ has   "$.types[1].generic"
+//@ is    "$.types[0].generic" \"T\"
+//@ is    "$.types[1].generic" \"E\"
 pub type MyResult<T, E = MyError> = Result<T, E>;

--- a/tests/rustdoc-json/type/hrtb.rs
+++ b/tests/rustdoc-json/type/hrtb.rs
@@ -1,4 +1,5 @@
-//@ is "$.index[?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.type" '{"generic": "F"}'
+//@ is "$.index[?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.type" 0
+//@ is "$.types[0].generic" '"F"'
 //@ is "$.index[?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
 pub fn genfn<F>(f: F)
 where
@@ -10,10 +11,12 @@ where
 
 //@ is "$.index[?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
 //@ is "$.index[?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
-//@ is "$.index[?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.lifetime" null
-//@ count "$.index[?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[*]" 1
-//@ is "$.index[?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-//@ is "$.index[?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].trait.path" '"Fn"'
+//@ is "$.index[?(@.name=='dynfn')].inner.function.sig.inputs[0][1]" 5
+//@ is "$.types[5].borrowed_ref.type" 4
+//@ is "$.types[4].dyn_trait.lifetime" null
+//@ count "$.types[4].dyn_trait.traits[*]" 1
+//@ is "$.types[4].dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.types[4].dyn_trait.traits[0].trait.path" '"Fn"'
 pub fn dynfn(f: &dyn for<'a, 'b> Fn(&'a i32, &'b i32)) {
     let zero = 0;
     f(&zero, &zero);

--- a/tests/rustdoc-json/type/inherent_associated_type.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type.rs
@@ -9,9 +9,11 @@ pub struct Owner;
 pub fn create() -> Owner::Metadata {
     OwnerMetadata
 }
-//@ is '$.index[?(@.name=="create")].inner.function.sig.output.qualified_path.name' '"Metadata"'
-//@ is '$.index[?(@.name=="create")].inner.function.sig.output.qualified_path.trait' null
-//@ is '$.index[?(@.name=="create")].inner.function.sig.output.qualified_path.self_type.resolved_path.id' $Owner
+//@ is '$.index[?(@.name=="create")].inner.function.sig.output' 15
+//@ is '$.types[15].qualified_path.name' '"Metadata"'
+//@ is '$.types[15].qualified_path.trait' null
+//@ is '$.types[15].qualified_path.self_type' 14
+//@ is '$.types[14].resolved_path.id' $Owner
 
 /// impl
 impl Owner {
@@ -20,4 +22,5 @@ impl Owner {
 }
 //@ set iat = '$.index[?(@.docs=="iat")].id'
 //@ is '$.index[?(@.docs=="impl")].inner.impl.items[*]' $iat
-//@ is '$.index[?(@.docs=="iat")].inner.assoc_type.type.resolved_path.id' $OwnerMetadata
+//@ is '$.index[?(@.docs=="iat")].inner.assoc_type.type' 0
+//@ is '$.types[0].resolved_path.id' $OwnerMetadata

--- a/tests/rustdoc-json/type/inherent_associated_type_bound.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_bound.rs
@@ -6,12 +6,16 @@ pub struct Carrier<'a>(&'a ());
 
 //@ count "$.index[?(@.name=='user')].inner.function.sig.inputs[*]" 1
 //@ is "$.index[?(@.name=='user')].inner.function.sig.inputs[0][0]" '"_"'
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.generic_params[*].name' \""'b"\"
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.self_type.resolved_path.id' $Carrier
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.name' '"Focus"'
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.trait' null
-//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.args.angle_bracketed.args[0].type.primitive' '"i32"'
+//@ is '$.index[?(@.name=="user")].inner.function.sig.inputs[0][1]' 18
+//@ is '$.types[18].function_pointer.generic_params[*].name' \""'b"\"
+//@ is '$.types[18].function_pointer.sig.inputs[0][1]' 17
+//@ is '$.types[17].qualified_path.self_type' 16
+//@ is '$.types[16].resolved_path.id' $Carrier
+//@ is '$.types[16].resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
+//@ is '$.types[17].qualified_path.name' '"Focus"'
+//@ is '$.types[17].qualified_path.trait' null
+//@ is '$.types[17].qualified_path.args.angle_bracketed.args[0].type' 15
+//@ is '$.types[15].primitive' '"i32"'
 pub fn user(_: for<'b> fn(Carrier<'b>::Focus<i32>)) {}
 
 impl<'a> Carrier<'a> {

--- a/tests/rustdoc-json/type/inherent_associated_type_projections.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_projections.rs
@@ -6,10 +6,13 @@ pub struct Parametrized<T>(T);
 
 //@ count "$.index[?(@.name=='test')].inner.function.sig.inputs[*]" 1
 //@ is "$.index[?(@.name=='test')].inner.function.sig.inputs[0][0]" '"_"'
-//@ is '$.index[?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.self_type.resolved_path.id' $Parametrized
-//@ is '$.index[?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].type.primitive' \"i32\"
-//@ is '$.index[?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.name' '"Proj"'
-//@ is '$.index[?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.trait' null
+//@ is '$.index[?(@.name=="test")].inner.function.sig.inputs[0][1]' 20
+//@ is '$.types[20].qualified_path.self_type' 5
+//@ is '$.types[5].resolved_path.id' $Parametrized
+//@ is '$.types[5].resolved_path.args.angle_bracketed.args[0].type' 4
+//@ is '$.types[4].primitive' \"i32\"
+//@ is '$.types[20].qualified_path.name' '"Proj"'
+//@ is '$.types[20].qualified_path.trait' null
 pub fn test(_: Parametrized<i32>::Proj) {}
 
 /// param_bool

--- a/tests/rustdoc-json/type_alias.rs
+++ b/tests/rustdoc-json/type_alias.rs
@@ -4,12 +4,14 @@
 //@ is "$.index[?(@.name=='IntVec')].span.filename" $FILE
 pub type IntVec = Vec<u32>;
 
-//@ is "$.index[?(@.name=='f')].inner.function.sig.output.resolved_path.id" $IntVec
+//@ is "$.index[?(@.name=='f')].inner.function.sig.output" 2
+//@ is "$.types[2].resolved_path.id" $IntVec
 pub fn f() -> IntVec {
     vec![0; 32]
 }
 
-//@ !is "$.index[?(@.name=='g')].inner.function.sig.output.resolved_path.id" $IntVec
+//@ is "$.index[?(@.name=='g')].inner.function.sig.output" 1
+//@ !is "$.types[1].resolved_path.id" $IntVec
 pub fn g() -> Vec<u32> {
     vec![0; 32]
 }

--- a/tests/rustdoc-json/unions/union.rs
+++ b/tests/rustdoc-json/unions/union.rs
@@ -1,14 +1,15 @@
 //@ has "$.index[?(@.name=='Union')].visibility" \"public\"
 //@ has "$.index[?(@.name=='Union')].inner.union"
-//@ !has "$.index[?(@.name=='Union')].inner.union.struct_type"
+//@ !has "$.index[?(@.name=='Union')].inner.union.kind"
 //@ set Union = "$.index[?(@.name=='Union')].id"
 pub union Union {
     int: i32,
     float: f32,
 }
 
-//@ has "$.index[?(@.name=='make_int_union')].inner.function.sig.output.resolved_path"
-//@ is "$.index[?(@.name=='make_int_union')].inner.function.sig.output.resolved_path.id" $Union
+//@ is "$.index[?(@.name=='make_int_union')].inner.function.sig.output" 0
+//@ has "$.types[0].resolved_path"
+//@ is "$.types[0].resolved_path.id" $Union
 pub fn make_int_union(int: i32) -> Union {
     Union { int }
 }


### PR DESCRIPTION
The current format of `rustdoc-types` has a problem that potentially prevents it from being parsed by the majority of JSON parsers, including `serde_json`. Generally, they're implemented via recursion meaning that they'll hit their depth limit or invoke a stack overflow if a JSON blob has too deeply nested data. This creates issues like https://github.com/obi1kenobi/cargo-semver-checks/issues/108. I don't think that the problem has anything to do with parsers' limitations. Instead, I consider it as a format design flaw. `rustdoc-types` implements [`Type`][type] as a recursive structure by using `Box`es. I've removed them and added the `types` field to [`Crate`](https://docs.rs/rustdoc-types/0.46/rustdoc_types/struct.Crate.html) that can be indexed akin to [`Crate::index`](https://docs.rs/rustdoc-types/latest/rustdoc_types/struct.Crate.html#structfield.index). This eliminated the recursive property of [`Type`][type] making `rustdoc-types` parseable with much more deeply nested crates like [`diesel`](https://github.com/diesel-rs/diesel).

I've also added a test that demonstrates that `rustdoc-types` doesn't grow in depth anymore. Thanks to @weiznich for [this snippet](https://gist.github.com/weiznich/78a541904ea08c0375c64f2cf7a96eb0).

The only known to me problem with these changes is that the current testing approach for `rustdoc-types` ostensibly makes everything to stop you from using indexes from the same JSON blob it's querying. I've fixed all broken tests by just hardcoding type identifiers, though something tells me this isn't really deterministic, but I have no idea about other options, so I'll really appreciate any help here.

As for other improvements, due to hashing of types at the render stage, there are no more duplicated types in a resulted JSON blob, i.e. resulted JSON blobs are much smaller now. I've done a test with [`diesel`](https://github.com/diesel-rs/diesel/tree/2be8b97080a067b3c55f9c5888fa409bbc33a1a3/diesel) by generating 2 JSON blobs with `cargo rustdoc -Zunstable-options --lib --output-format=json -F extras,128-column-tables -p diesel -- --document-private-items`. `rustdoc` 1.87 generated 231 MB, the PR's `rustdoc` generated 76 MB (3x smaller). This should drastically improve the speed of tools that use `rustdoc-types`.

[type]: https://docs.rs/rustdoc-types/0.46/rustdoc_types/enum.Type.html