### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,18 @@ jobs:
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           workspaces: src/ci/citool
+      - name: Test citool
+        # Only test citool on the auto branch, to reduce latency of the calculate matrix job
+        # on PR/try builds.
+        if: ${{ github.ref == 'refs/heads/auto' }}
+        run: |
+          cd src/ci/citool
+          CARGO_INCREMENTAL=0 cargo test
       - name: Calculate the CI job matrix
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd src/ci/citool
-          CARGO_INCREMENTAL=0 cargo test
           CARGO_INCREMENTAL=0 cargo run calculate-job-matrix >> $GITHUB_OUTPUT
         id: jobs
   job:

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -389,6 +389,7 @@ tcx_lifetime! {
     rustc_middle::ty::layout::FnAbiError,
     rustc_middle::ty::layout::LayoutError,
     rustc_middle::ty::ParamEnv,
+    rustc_middle::ty::TypingEnv,
     rustc_middle::ty::Predicate,
     rustc_middle::ty::SymbolName,
     rustc_middle::ty::TraitRef,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1571,7 +1571,7 @@ rustc_queries! {
     /// Like `param_env`, but returns the `ParamEnv` after all opaque types have been
     /// replaced with their hidden type. This is used in the old trait solver
     /// when in `PostAnalysis` mode and should not be called directly.
-    query param_env_normalized_for_post_analysis(def_id: DefId) -> ty::ParamEnv<'tcx> {
+    query typing_env_normalized_for_post_analysis(def_id: DefId) -> ty::TypingEnv<'tcx> {
         desc { |tcx| "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1116,10 +1116,7 @@ impl<'tcx> TypingEnv<'tcx> {
     }
 
     pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryParam<DefId>) -> TypingEnv<'tcx> {
-        TypingEnv {
-            typing_mode: TypingMode::PostAnalysis,
-            param_env: tcx.param_env_normalized_for_post_analysis(def_id),
-        }
+        tcx.typing_env_normalized_for_post_analysis(def_id)
     }
 
     /// Modify the `typing_mode` to `PostAnalysis` and eagerly reveal all
@@ -1133,7 +1130,7 @@ impl<'tcx> TypingEnv<'tcx> {
         // No need to reveal opaques with the new solver enabled,
         // since we have lazy norm.
         let param_env = if tcx.next_trait_solver_globally() {
-            ParamEnv::new(param_env.caller_bounds())
+            param_env
         } else {
             ParamEnv::new(tcx.reveal_opaque_types_in_bounds(param_env.caller_bounds()))
         };

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -7,7 +7,7 @@ use rustc_ast::{
 use rustc_ast_pretty::pprust;
 use rustc_attr_data_structures::{self as attr, Stability};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_data_structures::unord::UnordSet;
+use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, MultiSpan, SuggestionStyle,
@@ -1054,6 +1054,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 false,
                                 false,
                                 None,
+                                None,
                             ) else {
                                 continue;
                             };
@@ -1482,7 +1483,35 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         parent_scope: &ParentScope<'ra>,
         ident: Ident,
         krate: &Crate,
+        sugg_span: Option<Span>,
     ) {
+        // Bring imported but unused `derive` macros into `macro_map` so we ensure they can be used
+        // for suggestions.
+        self.visit_scopes(
+            ScopeSet::Macro(MacroKind::Derive),
+            &parent_scope,
+            ident.span.ctxt(),
+            |this, scope, _use_prelude, _ctxt| {
+                let Scope::Module(m, _) = scope else {
+                    return None;
+                };
+                for (_, resolution) in this.resolutions(m).borrow().iter() {
+                    let Some(binding) = resolution.borrow().binding else {
+                        continue;
+                    };
+                    let Res::Def(DefKind::Macro(MacroKind::Derive | MacroKind::Attr), def_id) =
+                        binding.res()
+                    else {
+                        continue;
+                    };
+                    // By doing this all *imported* macros get added to the `macro_map` even if they
+                    // are *unused*, which makes the later suggestions find them and work.
+                    let _ = this.get_macro_by_def_id(def_id);
+                }
+                None::<()>
+            },
+        );
+
         let is_expected = &|res: Res| res.macro_kind() == Some(macro_kind);
         let suggestion = self.early_lookup_typo_candidate(
             ScopeSet::Macro(macro_kind),
@@ -1490,7 +1519,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ident,
             is_expected,
         );
-        self.add_typo_suggestion(err, suggestion, ident.span);
+        if !self.add_typo_suggestion(err, suggestion, ident.span) {
+            self.detect_derive_attribute(err, ident, parent_scope, sugg_span);
+        }
 
         let import_suggestions =
             self.lookup_import_candidates(ident, Namespace::MacroNS, parent_scope, is_expected);
@@ -1620,6 +1651,108 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             };
             err.subdiagnostic(note);
             return;
+        }
+    }
+
+    /// Given an attribute macro that failed to be resolved, look for `derive` macros that could
+    /// provide it, either as-is or with small typos.
+    fn detect_derive_attribute(
+        &self,
+        err: &mut Diag<'_>,
+        ident: Ident,
+        parent_scope: &ParentScope<'ra>,
+        sugg_span: Option<Span>,
+    ) {
+        // Find all of the `derive`s in scope and collect their corresponding declared
+        // attributes.
+        // FIXME: this only works if the crate that owns the macro that has the helper_attr
+        // has already been imported.
+        let mut derives = vec![];
+        let mut all_attrs: UnordMap<Symbol, Vec<_>> = UnordMap::default();
+        // We're collecting these in a hashmap, and handle ordering the output further down.
+        #[allow(rustc::potential_query_instability)]
+        for (def_id, data) in &self.macro_map {
+            for helper_attr in &data.ext.helper_attrs {
+                let item_name = self.tcx.item_name(*def_id);
+                all_attrs.entry(*helper_attr).or_default().push(item_name);
+                if helper_attr == &ident.name {
+                    derives.push(item_name);
+                }
+            }
+        }
+        let kind = MacroKind::Derive.descr();
+        if !derives.is_empty() {
+            // We found an exact match for the missing attribute in a `derive` macro. Suggest it.
+            derives.sort();
+            derives.dedup();
+            let msg = match &derives[..] {
+                [derive] => format!(" `{derive}`"),
+                [start @ .., last] => format!(
+                    "s {} and `{last}`",
+                    start.iter().map(|d| format!("`{d}`")).collect::<Vec<_>>().join(", ")
+                ),
+                [] => unreachable!("we checked for this to be non-empty 10 lines above!?"),
+            };
+            let msg = format!(
+                "`{}` is an attribute that can be used by the {kind}{msg}, you might be \
+                     missing a `derive` attribute",
+                ident.name,
+            );
+            let sugg_span = if let ModuleKind::Def(DefKind::Enum, id, _) = parent_scope.module.kind
+            {
+                let span = self.def_span(id);
+                if span.from_expansion() {
+                    None
+                } else {
+                    // For enum variants sugg_span is empty but we can get the enum's Span.
+                    Some(span.shrink_to_lo())
+                }
+            } else {
+                // For items this `Span` will be populated, everything else it'll be None.
+                sugg_span
+            };
+            match sugg_span {
+                Some(span) => {
+                    err.span_suggestion_verbose(
+                        span,
+                        msg,
+                        format!(
+                            "#[derive({})]\n",
+                            derives
+                                .iter()
+                                .map(|d| d.to_string())
+                                .collect::<Vec<String>>()
+                                .join(", ")
+                        ),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                None => {
+                    err.note(msg);
+                }
+            }
+        } else {
+            // We didn't find an exact match. Look for close matches. If any, suggest fixing typo.
+            let all_attr_names = all_attrs.keys().map(|s| *s).into_sorted_stable_ord();
+            if let Some(best_match) = find_best_match_for_name(&all_attr_names, ident.name, None)
+                && let Some(macros) = all_attrs.get(&best_match)
+            {
+                let msg = match &macros[..] {
+                    [] => return,
+                    [name] => format!(" `{name}` accepts"),
+                    [start @ .., end] => format!(
+                        "s {} and `{end}` accept",
+                        start.iter().map(|m| format!("`{m}`")).collect::<Vec<_>>().join(", "),
+                    ),
+                };
+                let msg = format!("the {kind}{msg} the similarly named `{best_match}` attribute");
+                err.span_suggestion_verbose(
+                    ident.span,
+                    msg,
+                    best_match,
+                    Applicability::MaybeIncorrect,
+                );
+            }
         }
     }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -460,6 +460,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 true,
                                 force,
                                 ignore_import,
+                                None,
                             ) {
                                 Ok((Some(ext), _)) => {
                                     if ext.helper_attrs.contains(&ident.name) {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4509,7 +4509,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             let path_seg = |seg: &Segment| PathSegment::from_ident(seg.ident);
             let path = Path { segments: path.iter().map(path_seg).collect(), span, tokens: None };
             if let Ok((_, res)) =
-                self.r.resolve_macro_path(&path, None, &self.parent_scope, false, false, None)
+                self.r.resolve_macro_path(&path, None, &self.parent_scope, false, false, None, None)
             {
                 return Ok(Some(PartialRes::new(res)));
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1139,7 +1139,7 @@ pub struct Resolver<'ra, 'tcx> {
     proc_macro_stubs: FxHashSet<LocalDefId>,
     /// Traces collected during macro resolution and validated when it's complete.
     single_segment_macro_resolutions:
-        Vec<(Ident, MacroKind, ParentScope<'ra>, Option<NameBinding<'ra>>)>,
+        Vec<(Ident, MacroKind, ParentScope<'ra>, Option<NameBinding<'ra>>, Option<Span>)>,
     multi_segment_macro_resolutions:
         Vec<(Vec<Segment>, Span, MacroKind, ParentScope<'ra>, Option<Res>, Namespace)>,
     builtin_attrs: Vec<(Ident, ParentScope<'ra>)>,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -12,7 +12,8 @@ use rustc_attr_data_structures::StabilityLevel;
 use rustc_data_structures::intern::Interned;
 use rustc_errors::{Applicability, DiagCtxtHandle, StashKey};
 use rustc_expand::base::{
-    DeriveResolution, Indeterminate, ResolverExpand, SyntaxExtension, SyntaxExtensionKind,
+    Annotatable, DeriveResolution, Indeterminate, ResolverExpand, SyntaxExtension,
+    SyntaxExtensionKind,
 };
 use rustc_expand::compile_declarative_macro;
 use rustc_expand::expand::{
@@ -294,6 +295,14 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                     && self.tcx.def_kind(mod_def_id) == DefKind::Mod
             })
             .map(|&InvocationParent { parent_def: mod_def_id, .. }| mod_def_id);
+        let sugg_span = match &invoc.kind {
+            InvocationKind::Attr { item: Annotatable::Item(item), .. }
+                if !item.span.from_expansion() =>
+            {
+                Some(item.span.shrink_to_lo())
+            }
+            _ => None,
+        };
         let (ext, res) = self.smart_resolve_macro_path(
             path,
             kind,
@@ -304,6 +313,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             force,
             deleg_impl,
             looks_like_invoc_in_mod_inert_attr,
+            sugg_span,
         )?;
 
         let span = invoc.span();
@@ -385,6 +395,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                         &parent_scope,
                         true,
                         force,
+                        None,
                         None,
                     ) {
                         Ok((Some(ext), _)) => {
@@ -528,6 +539,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         force: bool,
         deleg_impl: Option<LocalDefId>,
         invoc_in_mod_inert_attr: Option<LocalDefId>,
+        suggestion_span: Option<Span>,
     ) -> Result<(Arc<SyntaxExtension>, Res), Indeterminate> {
         let (ext, res) = match self.resolve_macro_or_delegation_path(
             path,
@@ -538,6 +550,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             deleg_impl,
             invoc_in_mod_inert_attr.map(|def_id| (def_id, node_id)),
             None,
+            suggestion_span,
         ) {
             Ok((Some(ext), res)) => (ext, res),
             Ok((None, res)) => (self.dummy_ext(kind), res),
@@ -681,6 +694,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         trace: bool,
         force: bool,
         ignore_import: Option<Import<'ra>>,
+        suggestion_span: Option<Span>,
     ) -> Result<(Option<Arc<SyntaxExtension>>, Res), Determinacy> {
         self.resolve_macro_or_delegation_path(
             path,
@@ -691,6 +705,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             None,
             None,
             ignore_import,
+            suggestion_span,
         )
     }
 
@@ -704,6 +719,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         deleg_impl: Option<LocalDefId>,
         invoc_in_mod_inert_attr: Option<(LocalDefId, NodeId)>,
         ignore_import: Option<Import<'ra>>,
+        suggestion_span: Option<Span>,
     ) -> Result<(Option<Arc<SyntaxExtension>>, Res), Determinacy> {
         let path_span = ast_path.span;
         let mut path = Segment::from_path(ast_path);
@@ -768,6 +784,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     kind,
                     *parent_scope,
                     binding.ok(),
+                    suggestion_span,
                 ));
             }
 
@@ -905,7 +922,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         let macro_resolutions = mem::take(&mut self.single_segment_macro_resolutions);
-        for (ident, kind, parent_scope, initial_binding) in macro_resolutions {
+        for (ident, kind, parent_scope, initial_binding, sugg_span) in macro_resolutions {
             match self.early_resolve_ident_in_lexical_scope(
                 ident,
                 ScopeSet::Macro(kind),
@@ -946,7 +963,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         expected,
                         ident,
                     });
-                    self.unresolved_macro_suggestions(&mut err, kind, &parent_scope, ident, krate);
+                    self.unresolved_macro_suggestions(
+                        &mut err,
+                        kind,
+                        &parent_scope,
+                        ident,
+                        krate,
+                        sugg_span,
+                    );
                     err.emit();
                 }
             }

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -445,12 +445,9 @@ impl<'tcx> SmirCtxt<'tcx> {
     pub fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
         let mut tables = self.0.borrow_mut();
         let tcx = tables.tcx;
-
-        let discr = adt
-            .internal(&mut *tables, tcx)
-            .discriminant_for_variant(tcx, variant.internal(&mut *tables, tcx));
-
-        Discr { val: discr.val, ty: discr.ty.stable(&mut *tables) }
+        let adt = adt.internal(&mut *tables, tcx);
+        let variant = variant.internal(&mut *tables, tcx);
+        adt.discriminant_for_variant(tcx, variant).stable(&mut *tables)
     }
 
     /// Discriminant for a given variand index and args of a coroutine
@@ -462,14 +459,10 @@ impl<'tcx> SmirCtxt<'tcx> {
     ) -> Discr {
         let mut tables = self.0.borrow_mut();
         let tcx = tables.tcx;
-
-        let discr = args.internal(&mut *tables, tcx).as_coroutine().discriminant_for_variant(
-            coroutine.def_id().internal(&mut *tables, tcx),
-            tcx,
-            variant.internal(&mut *tables, tcx),
-        );
-
-        Discr { val: discr.val, ty: discr.ty.stable(&mut *tables) }
+        let coroutine = coroutine.def_id().internal(&mut *tables, tcx);
+        let args = args.internal(&mut *tables, tcx);
+        let variant = variant.internal(&mut *tables, tcx);
+        args.as_coroutine().discriminant_for_variant(coroutine, tcx, variant).stable(&mut *tables)
     }
 
     /// The name of a variant.

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -12,7 +12,8 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::print::{with_forced_trimmed_paths, with_no_trimmed_paths};
 use rustc_middle::ty::{
-    GenericPredicates, Instance, List, ScalarInt, TyCtxt, TypeVisitableExt, ValTree,
+    CoroutineArgsExt, GenericPredicates, Instance, List, ScalarInt, TyCtxt, TypeVisitableExt,
+    ValTree,
 };
 use rustc_middle::{mir, ty};
 use rustc_span::def_id::LOCAL_CRATE;
@@ -22,9 +23,9 @@ use stable_mir::mir::mono::{InstanceDef, StaticDef};
 use stable_mir::mir::{BinOp, Body, Place, UnOp};
 use stable_mir::target::{MachineInfo, MachineSize};
 use stable_mir::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Discr, FieldDef, FnDef, ForeignDef,
-    ForeignItemKind, GenericArgs, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy, Span, Ty,
-    TyConst, TyKind, UintTy, VariantDef, VariantIdx,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, CoroutineDef, Discr, FieldDef, FnDef,
+    ForeignDef, ForeignItemKind, GenericArgs, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy,
+    Span, Ty, TyConst, TyKind, UintTy, VariantDef, VariantIdx,
 };
 use stable_mir::{Crate, CrateDef, CrateItem, CrateNum, DefId, Error, Filename, ItemKind, Symbol};
 
@@ -448,6 +449,25 @@ impl<'tcx> SmirCtxt<'tcx> {
         let discr = adt
             .internal(&mut *tables, tcx)
             .discriminant_for_variant(tcx, variant.internal(&mut *tables, tcx));
+
+        Discr { val: discr.val, ty: discr.ty.stable(&mut *tables) }
+    }
+
+    /// Discriminant for a given variand index and args of a coroutine
+    pub fn coroutine_discr_for_variant(
+        &self,
+        coroutine: CoroutineDef,
+        args: &GenericArgs,
+        variant: VariantIdx,
+    ) -> Discr {
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+
+        let discr = args.internal(&mut *tables, tcx).as_coroutine().discriminant_for_variant(
+            coroutine.def_id().internal(&mut *tables, tcx),
+            tcx,
+            variant.internal(&mut *tables, tcx),
+        );
 
         Discr { val: discr.val, ty: discr.ty.stable(&mut *tables) }
     }

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -22,9 +22,9 @@ use stable_mir::mir::mono::{InstanceDef, StaticDef};
 use stable_mir::mir::{BinOp, Body, Place, UnOp};
 use stable_mir::target::{MachineInfo, MachineSize};
 use stable_mir::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, FieldDef, FnDef, ForeignDef,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Discr, FieldDef, FnDef, ForeignDef,
     ForeignItemKind, GenericArgs, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy, Span, Ty,
-    TyConst, TyKind, UintTy, VariantDef,
+    TyConst, TyKind, UintTy, VariantDef, VariantIdx,
 };
 use stable_mir::{Crate, CrateDef, CrateItem, CrateNum, DefId, Error, Filename, ItemKind, Symbol};
 
@@ -438,6 +438,18 @@ impl<'tcx> SmirCtxt<'tcx> {
         let mut tables = self.0.borrow_mut();
         let tcx = tables.tcx;
         def.internal(&mut *tables, tcx).variants().len()
+    }
+
+    /// Discriminant for a given variant index of AdtDef
+    pub fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+
+        let discr = adt
+            .internal(&mut *tables, tcx)
+            .discriminant_for_variant(tcx, variant.internal(&mut *tables, tcx));
+
+        Discr { val: discr.val, ty: discr.ty.stable(&mut *tables) }
     }
 
     /// The name of a variant.

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -959,3 +959,11 @@ impl<'tcx> Stable<'tcx> for ty::ImplTraitInTraitData {
         }
     }
 }
+
+impl<'tcx> Stable<'tcx> for rustc_middle::ty::util::Discr<'tcx> {
+    type T = stable_mir::ty::Discr;
+
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
+        stable_mir::ty::Discr { val: self.val, ty: self.ty.stable(tables) }
+    }
+}

--- a/compiler/rustc_smir/src/stable_mir/compiler_interface.rs
+++ b/compiler/rustc_smir/src/stable_mir/compiler_interface.rs
@@ -13,10 +13,10 @@ use stable_mir::mir::mono::{Instance, InstanceDef, StaticDef};
 use stable_mir::mir::{BinOp, Body, Place, UnOp};
 use stable_mir::target::MachineInfo;
 use stable_mir::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Discr, FieldDef, FnDef, ForeignDef,
-    ForeignItemKind, ForeignModule, ForeignModuleDef, GenericArgs, GenericPredicates, Generics,
-    ImplDef, ImplTrait, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy, Span, TraitDecl,
-    TraitDef, Ty, TyConst, TyConstId, TyKind, UintTy, VariantDef, VariantIdx,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, CoroutineDef, Discr, FieldDef, FnDef,
+    ForeignDef, ForeignItemKind, ForeignModule, ForeignModuleDef, GenericArgs, GenericPredicates,
+    Generics, ImplDef, ImplTrait, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy, Span,
+    TraitDecl, TraitDef, Ty, TyConst, TyConstId, TyKind, UintTy, VariantDef, VariantIdx,
 };
 use stable_mir::{
     AssocItems, Crate, CrateItem, CrateItems, CrateNum, DefId, Error, Filename, ImplTraitDecls,
@@ -228,6 +228,16 @@ impl<'tcx> SmirInterface<'tcx> {
     /// Discriminant for a given variant index of AdtDef
     pub(crate) fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
         self.cx.adt_discr_for_variant(adt, variant)
+    }
+
+    /// Discriminant for a given variand index and args of a coroutine
+    pub(crate) fn coroutine_discr_for_variant(
+        &self,
+        coroutine: CoroutineDef,
+        args: &GenericArgs,
+        variant: VariantIdx,
+    ) -> Discr {
+        self.cx.coroutine_discr_for_variant(coroutine, args, variant)
     }
 
     /// The name of a variant.

--- a/compiler/rustc_smir/src/stable_mir/compiler_interface.rs
+++ b/compiler/rustc_smir/src/stable_mir/compiler_interface.rs
@@ -13,10 +13,10 @@ use stable_mir::mir::mono::{Instance, InstanceDef, StaticDef};
 use stable_mir::mir::{BinOp, Body, Place, UnOp};
 use stable_mir::target::MachineInfo;
 use stable_mir::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, FieldDef, FnDef, ForeignDef,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Discr, FieldDef, FnDef, ForeignDef,
     ForeignItemKind, ForeignModule, ForeignModuleDef, GenericArgs, GenericPredicates, Generics,
     ImplDef, ImplTrait, IntrinsicDef, LineInfo, MirConst, PolyFnSig, RigidTy, Span, TraitDecl,
-    TraitDef, Ty, TyConst, TyConstId, TyKind, UintTy, VariantDef,
+    TraitDef, Ty, TyConst, TyConstId, TyKind, UintTy, VariantDef, VariantIdx,
 };
 use stable_mir::{
     AssocItems, Crate, CrateItem, CrateItems, CrateNum, DefId, Error, Filename, ImplTraitDecls,
@@ -223,6 +223,11 @@ impl<'tcx> SmirInterface<'tcx> {
     /// The number of variants in this ADT.
     pub(crate) fn adt_variants_len(&self, def: AdtDef) -> usize {
         self.cx.adt_variants_len(def)
+    }
+
+    /// Discriminant for a given variant index of AdtDef
+    pub(crate) fn adt_discr_for_variant(&self, adt: AdtDef, variant: VariantIdx) -> Discr {
+        self.cx.adt_discr_for_variant(adt, variant)
     }
 
     /// The name of a variant.

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -747,6 +747,12 @@ crate_def! {
     pub CoroutineDef;
 }
 
+impl CoroutineDef {
+    pub fn discriminant_for_variant(&self, args: &GenericArgs, idx: VariantIdx) -> Discr {
+        with(|cx| cx.coroutine_discr_for_variant(*self, args, idx))
+    }
+}
+
 crate_def! {
     #[derive(Serialize)]
     pub CoroutineClosureDef;

--- a/compiler/rustc_smir/src/stable_mir/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/ty.rs
@@ -818,6 +818,15 @@ impl AdtDef {
     pub fn variant(&self, idx: VariantIdx) -> Option<VariantDef> {
         (idx.to_index() < self.num_variants()).then_some(VariantDef { idx, adt_def: *self })
     }
+
+    pub fn discriminant_for_variant(&self, idx: VariantIdx) -> Discr {
+        with(|cx| cx.adt_discr_for_variant(*self, idx))
+    }
+}
+
+pub struct Discr {
+    pub val: u128,
+    pub ty: Ty,
 }
 
 /// Definition of a variant, which can be either a struct / union field or an enum variant.

--- a/compiler/rustc_target/src/asm/loongarch.rs
+++ b/compiler/rustc_target/src/asm/loongarch.rs
@@ -34,11 +34,13 @@ impl LoongArchInlineAsmRegClass {
 
     pub fn supported_types(
         self,
-        _arch: InlineAsmArch,
+        arch: InlineAsmArch,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
-        match self {
-            Self::reg => types! { _: I8, I16, I32, I64, F32, F64; },
-            Self::freg => types! { f: F32; d: F64; },
+        match (self, arch) {
+            (Self::reg, InlineAsmArch::LoongArch64) => types! { _: I8, I16, I32, I64, F32, F64; },
+            (Self::reg, InlineAsmArch::LoongArch32) => types! { _: I8, I16, I32, F32; },
+            (Self::freg, _) => types! { f: F32; d: F64; },
+            _ => unreachable!("unsupported register class"),
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -759,7 +759,8 @@ pub enum ExplicitLifetimeRequired<'a> {
         #[suggestion(
             trait_selection_explicit_lifetime_required_sugg_with_ident,
             code = "{new_ty}",
-            applicability = "unspecified"
+            applicability = "unspecified",
+            style = "verbose"
         )]
         new_ty_span: Span,
         #[skip_arg]
@@ -774,7 +775,8 @@ pub enum ExplicitLifetimeRequired<'a> {
         #[suggestion(
             trait_selection_explicit_lifetime_required_sugg_with_param_type,
             code = "{new_ty}",
-            applicability = "unspecified"
+            applicability = "unspecified",
+            style = "verbose"
         )]
         new_ty_span: Span,
         #[skip_arg]
@@ -1462,7 +1464,8 @@ pub enum SuggestAccessingField<'a> {
     #[suggestion(
         trait_selection_suggest_accessing_field,
         code = "{snippet}.{name}",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     Safe {
         #[primary_span]
@@ -1474,7 +1477,8 @@ pub enum SuggestAccessingField<'a> {
     #[suggestion(
         trait_selection_suggest_accessing_field,
         code = "unsafe {{ {snippet}.{name} }}",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     Unsafe {
         #[primary_span]

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -255,10 +255,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
     }
 }
 
-fn param_env_normalized_for_post_analysis(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
-    // This is a bit ugly but the easiest way to avoid code duplication.
-    let typing_env = ty::TypingEnv::non_body_analysis(tcx, def_id);
-    typing_env.with_post_analysis_normalized(tcx).param_env
+fn typing_env_normalized_for_post_analysis(tcx: TyCtxt<'_>, def_id: DefId) -> ty::TypingEnv<'_> {
+    ty::TypingEnv::non_body_analysis(tcx, def_id).with_post_analysis_normalized(tcx)
 }
 
 /// Check if a function is async.
@@ -374,7 +372,7 @@ pub(crate) fn provide(providers: &mut Providers) {
         asyncness,
         adt_sized_constraint,
         param_env,
-        param_env_normalized_for_post_analysis,
+        typing_env_normalized_for_post_analysis,
         defaultness,
         unsizing_params_for_adt,
         impl_self_is_guaranteed_unsized,

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -213,6 +213,30 @@ macro_rules! uint_impl {
             (!self).trailing_zeros()
         }
 
+        /// Returns the minimum number of bits required to represent `self`.
+        ///
+        /// This method returns zero if `self` is zero.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(uint_bit_width)]
+        ///
+        #[doc = concat!("assert_eq!(0_", stringify!($SelfT), ".bit_width(), 0);")]
+        #[doc = concat!("assert_eq!(0b111_", stringify!($SelfT), ".bit_width(), 3);")]
+        #[doc = concat!("assert_eq!(0b1110_", stringify!($SelfT), ".bit_width(), 4);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.bit_width(), ", stringify!($BITS), ");")]
+        /// ```
+        #[unstable(feature = "uint_bit_width", issue = "142326")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn bit_width(self) -> u32 {
+            Self::BITS - self.leading_zeros()
+        }
+
         /// Returns `self` with only the most significant bit set, or `0` if
         /// the input is `0`.
         ///

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -94,6 +94,7 @@
 #![feature(try_blocks)]
 #![feature(try_find)]
 #![feature(try_trait_v2)]
+#![feature(uint_bit_width)]
 #![feature(unsize)]
 #![feature(unwrap_infallible)]
 // tidy-alphabetical-end

--- a/library/coretests/tests/num/uint_macros.rs
+++ b/library/coretests/tests/num/uint_macros.rs
@@ -72,6 +72,14 @@ macro_rules! uint_module {
                 assert_eq_const_safe!(u32: X.trailing_ones(), 0);
             }
 
+            fn test_bit_width() {
+                assert_eq_const_safe!(u32: A.bit_width(), 6);
+                assert_eq_const_safe!(u32: B.bit_width(), 6);
+                assert_eq_const_safe!(u32: C.bit_width(), 7);
+                assert_eq_const_safe!(u32: _0.bit_width(), 0);
+                assert_eq_const_safe!(u32: _1.bit_width(), $T::BITS);
+            }
+
             fn test_rotate() {
                 assert_eq_const_safe!($T: A.rotate_left(6).rotate_right(2).rotate_right(4), A);
                 assert_eq_const_safe!($T: B.rotate_left(3).rotate_left(2).rotate_right(5), B);

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -84,7 +84,7 @@ pub struct Target {
 impl Target {
     pub fn from_triple(triple: &str) -> Self {
         let mut target: Self = Default::default();
-        if triple.contains("-none") || triple.contains("nvptx") || triple.contains("switch") {
+        if !build_helper::targets::target_supports_std(triple) {
             target.no_std = true;
         }
         if triple.contains("emscripten") {

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -6,6 +6,7 @@ pub mod fs;
 pub mod git;
 pub mod metrics;
 pub mod stage0_parser;
+pub mod targets;
 pub mod util;
 
 /// The default set of crates for opt-dist to collect LLVM profiles.

--- a/src/build_helper/src/targets.rs
+++ b/src/build_helper/src/targets.rs
@@ -1,0 +1,11 @@
+// FIXME(#142296): this hack is because there is no reliable way (yet) to determine whether a given
+// target supports std. In the long-term, we should try to implement a way to *reliably* determine
+// target (std) metadata.
+//
+// NOTE: this is pulled out to `build_helpers` to share this hack between `bootstrap` and
+// `compiletest`.
+pub fn target_supports_std(target_tuple: &str) -> bool {
+    !(target_tuple.contains("-none")
+        || target_tuple.contains("nvptx")
+        || target_tuple.contains("switch"))
+}

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -202,6 +202,7 @@ settings:
   `//@ needs-crate-type: cdylib, proc-macro` will cause the test to be ignored
   on `wasm32-unknown-unknown` target because the target does not support the
   `proc-macro` crate type.
+- `needs-target-std` — ignores if target platform does not have std support.
 
 The following directives will check LLVM support:
 

--- a/src/doc/rustc/src/platform-support/loongarch-none.md
+++ b/src/doc/rustc/src/platform-support/loongarch-none.md
@@ -11,8 +11,8 @@ Freestanding/bare-metal LoongArch binaries in ELF format: firmware, kernels, etc
 
 ## Target maintainers
 
-- [@heiher](https://github.com/heiher)
-- [@xen0n](https://github.com/xen0n)
+[@heiher](https://github.com/heiher)
+[@xen0n](https://github.com/xen0n)
 
 ## Requirements
 

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -19,6 +19,7 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 - M68k
 - CSKY
 - SPARC
+- LoongArch32
 
 ## Register classes
 
@@ -53,6 +54,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`         | `f[0-31]`                          | `f`                  |
 | SPARC        | `reg`          | `r[2-29]`                          | `r`                  |
 | SPARC        | `yreg`         | `y`                                | Only clobbers        |
+| LoongArch32  | `reg`          | `$r1`, `$r[4-20]`, `$r[23,30]`     | `r`                  |
+| LoongArch32  | `freg`         | `$f[0-31]`                         | `f`                  |
 
 > **Notes**:
 > - NVPTX doesn't have a fixed register set, so named registers are not supported.
@@ -91,6 +94,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`                          | None           | `f32`,                                  |
 | SPARC        | `reg`                           | None           | `i8`, `i16`, `i32`, `i64` (SPARC64 only) |
 | SPARC        | `yreg`                          | N/A            | Only clobbers                           |
+| LoongArch32  | `reg`                           | None           | `i8`, `i16`, `i32`, `f32`               |
+| LoongArch32  | `freg`                          | None           | `f32`, `f64`                            |
 
 ## Register aliases
 

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -166,6 +166,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "needs-subprocess",
     "needs-symlink",
     "needs-target-has-atomic",
+    "needs-target-std",
     "needs-threads",
     "needs-unwind",
     "needs-wasmtime",

--- a/src/tools/compiletest/src/header/needs.rs
+++ b/src/tools/compiletest/src/header/needs.rs
@@ -174,6 +174,11 @@ pub(super) fn handle_needs(
             condition: config.with_std_debug_assertions,
             ignore_reason: "ignored if std wasn't built with debug assertions",
         },
+        Need {
+            name: "needs-target-std",
+            condition: build_helper::targets::target_supports_std(&config.target),
+            ignore_reason: "ignored if target does not support std",
+        },
     ];
 
     let (name, rest) = match ln.split_once([':', ' ']) {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -945,3 +945,14 @@ fn test_ignore_auxiliary() {
     let config = cfg().build();
     assert!(check_ignore(&config, "//@ ignore-auxiliary"));
 }
+
+#[test]
+fn test_needs_target_std() {
+    // Cherry-picks two targets:
+    // 1. `x86_64-unknown-none`: Tier 2, intentionally never supports std.
+    // 2. `x86_64-unknown-linux-gnu`: Tier 1, always supports std.
+    let config = cfg().target("x86_64-unknown-none").build();
+    assert!(check_ignore(&config, "//@ needs-target-std"));
+    let config = cfg().target("x86_64-unknown-linux-gnu").build();
+    assert!(!check_ignore(&config, "//@ needs-target-std"));
+}

--- a/tests/codegen/autovec/dont-shuffle-bswaps-opt2.rs
+++ b/tests/codegen/autovec/dont-shuffle-bswaps-opt2.rs
@@ -1,11 +1,4 @@
-//@ revisions: OPT2 OPT3 OPT3_S390X
-//@[OPT2] compile-flags: -Copt-level=2
-//@[OPT3] compile-flags: -C opt-level=3
-// some targets don't do the opt we are looking for
-//@[OPT3] only-64bit
-//@[OPT3] ignore-s390x
-//@[OPT3_S390X] compile-flags: -C opt-level=3 -C target-cpu=z13
-//@[OPT3_S390X] only-s390x
+//@ compile-flags: -Copt-level=2
 
 #![crate_type = "lib"]
 #![no_std]
@@ -13,17 +6,9 @@
 // The code is from https://github.com/rust-lang/rust/issues/122805.
 // Ensure we do not generate the shufflevector instruction
 // to avoid complicating the code.
+
 // CHECK-LABEL: define{{.*}}void @convert(
 // CHECK-NOT: shufflevector
-// On higher opt levels, this should just be a bswap:
-// OPT3: load <8 x i16>
-// OPT3-NEXT: call <8 x i16> @llvm.bswap
-// OPT3-NEXT: store <8 x i16>
-// OPT3-NEXT: ret void
-// OPT3_S390X: load <8 x i16>
-// OPT3_S390X-NEXT: call <8 x i16> @llvm.bswap
-// OPT3_S390X-NEXT: store <8 x i16>
-// OPT3_S390X-NEXT: ret void
 #[no_mangle]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
     #[cfg(target_endian = "little")]

--- a/tests/codegen/autovec/dont-shuffle-bswaps-opt2.rs
+++ b/tests/codegen/autovec/dont-shuffle-bswaps-opt2.rs
@@ -3,6 +3,8 @@
 #![crate_type = "lib"]
 #![no_std]
 
+// This test is paired with the arch-specific -opt3.rs test.
+
 // The code is from https://github.com/rust-lang/rust/issues/122805.
 // Ensure we do not generate the shufflevector instruction
 // to avoid complicating the code.

--- a/tests/codegen/autovec/dont-shuffle-bswaps-opt3.rs
+++ b/tests/codegen/autovec/dont-shuffle-bswaps-opt3.rs
@@ -1,0 +1,43 @@
+//@ revisions: OPT3 OPT3_S390X
+//@[OPT3] compile-flags: -C opt-level=3
+// some targets don't do the opt we are looking for
+//@[OPT3] only-64bit
+//@[OPT3] ignore-s390x
+//@[OPT3_S390X] compile-flags: -C opt-level=3 -C target-cpu=z13
+//@[OPT3_S390X] only-s390x
+
+#![crate_type = "lib"]
+#![no_std]
+
+// The code is from https://github.com/rust-lang/rust/issues/122805.
+// Ensure we do not generate the shufflevector instruction
+// to avoid complicating the code.
+// CHECK-LABEL: define{{.*}}void @convert(
+// CHECK-NOT: shufflevector
+// On higher opt levels, this should just be a bswap:
+// OPT3: load <8 x i16>
+// OPT3-NEXT: call <8 x i16> @llvm.bswap
+// OPT3-NEXT: store <8 x i16>
+// OPT3-NEXT: ret void
+// OPT3_S390X: load <8 x i16>
+// OPT3_S390X-NEXT: call <8 x i16> @llvm.bswap
+// OPT3_S390X-NEXT: store <8 x i16>
+// OPT3_S390X-NEXT: ret void
+#[no_mangle]
+pub fn convert(value: [u16; 8]) -> [u8; 16] {
+    #[cfg(target_endian = "little")]
+    let bswap = u16::to_be;
+    #[cfg(target_endian = "big")]
+    let bswap = u16::to_le;
+    let addr16 = [
+        bswap(value[0]),
+        bswap(value[1]),
+        bswap(value[2]),
+        bswap(value[3]),
+        bswap(value[4]),
+        bswap(value[5]),
+        bswap(value[6]),
+        bswap(value[7]),
+    ];
+    unsafe { core::mem::transmute::<_, [u8; 16]>(addr16) }
+}

--- a/tests/codegen/autovec/dont-shuffle-bswaps-opt3.rs
+++ b/tests/codegen/autovec/dont-shuffle-bswaps-opt3.rs
@@ -1,28 +1,27 @@
-//@ revisions: OPT3 OPT3_S390X
-//@[OPT3] compile-flags: -C opt-level=3
-// some targets don't do the opt we are looking for
-//@[OPT3] only-64bit
-//@[OPT3] ignore-s390x
-//@[OPT3_S390X] compile-flags: -C opt-level=3 -C target-cpu=z13
-//@[OPT3_S390X] only-s390x
+//@ revisions: AARCH64 X86_64 Z13
+//@ compile-flags: -Copt-level=3
+//@[AARCH64] only-aarch64
+//@[X86_64] only-x86_64
+//@[Z13] only-s390x
+//@[Z13] compile-flags: -Ctarget-cpu=z13
 
 #![crate_type = "lib"]
 #![no_std]
 
+// This test is paired with the arch-neutral -opt2.rs test
+
 // The code is from https://github.com/rust-lang/rust/issues/122805.
 // Ensure we do not generate the shufflevector instruction
 // to avoid complicating the code.
+
 // CHECK-LABEL: define{{.*}}void @convert(
 // CHECK-NOT: shufflevector
+
 // On higher opt levels, this should just be a bswap:
-// OPT3: load <8 x i16>
-// OPT3-NEXT: call <8 x i16> @llvm.bswap
-// OPT3-NEXT: store <8 x i16>
-// OPT3-NEXT: ret void
-// OPT3_S390X: load <8 x i16>
-// OPT3_S390X-NEXT: call <8 x i16> @llvm.bswap
-// OPT3_S390X-NEXT: store <8 x i16>
-// OPT3_S390X-NEXT: ret void
+// CHECK: load <8 x i16>
+// CHECK-NEXT: call <8 x i16> @llvm.bswap
+// CHECK-NEXT: store <8 x i16>
+// CHECK-NEXT: ret void
 #[no_mangle]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
     #[cfg(target_endian = "little")]

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -19,7 +19,7 @@
 // gdb-check:type = type_names::GenericStruct<type_names::mod1::Struct2, type_names::mod1::mod2::Struct3>
 
 // gdb-command:whatis generic_struct2
-// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "fastcall" fn(isize) -> usize>
+// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "system" fn(isize) -> usize>
 
 // gdb-command:whatis mod_struct
 // gdb-check:type = type_names::mod1::Struct2
@@ -379,7 +379,7 @@ fn main() {
     let simple_struct = Struct1;
     let generic_struct1: GenericStruct<mod1::Struct2, mod1::mod2::Struct3> =
         GenericStruct(PhantomData);
-    let generic_struct2: GenericStruct<Struct1, extern "fastcall" fn(isize) -> usize> =
+    let generic_struct2: GenericStruct<Struct1, extern "system" fn(isize) -> usize> =
         GenericStruct(PhantomData);
     let mod_struct = mod1::Struct2;
 

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -440,7 +440,7 @@ trait TraitAddExternModifier {
 
 // Change extern "C" to extern "stdcall"
 #[cfg(any(cfail1,cfail4))]
-trait TraitChangeExternCToRustIntrinsic {
+trait TraitChangeExternCToExternSystem {
     // --------------------------------------------------------------
     // -------------------------
     // --------------------------------------------------------------
@@ -458,7 +458,7 @@ trait TraitChangeExternCToRustIntrinsic {
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
-    extern "stdcall" fn method();
+    extern "system" fn method();
 }
 
 

--- a/tests/run-make/cpp-global-destructors/rmake.rs
+++ b/tests/run-make/cpp-global-destructors/rmake.rs
@@ -6,15 +6,11 @@
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 
-//@ ignore-none
-// Reason: no-std is not supported.
 //@ ignore-wasm32
 //@ ignore-wasm64
 // Reason: compiling C++ to WASM may cause problems.
 
-// Neither of these are tested in full CI.
-//@ ignore-nvptx64-nvidia-cuda
-// Reason: can't find crate "std"
+// Not exercised in full CI, but sgx technically supports std.
 //@ ignore-sgx
 
 use run_make_support::{build_native_static_lib_cxx, run, rustc};

--- a/tests/run-make/export-executable-symbols/rmake.rs
+++ b/tests/run-make/export-executable-symbols/rmake.rs
@@ -10,8 +10,7 @@
 // (See #85673)
 //@ ignore-wasm32
 //@ ignore-wasm64
-//@ ignore-none
-// Reason: no-std is not supported
+//@ needs-target-std
 
 use run_make_support::{bin_name, llvm_readobj, rustc};
 

--- a/tests/run-make/incr-foreign-head-span/rmake.rs
+++ b/tests/run-make/incr-foreign-head-span/rmake.rs
@@ -5,10 +5,7 @@
 // source file from disk during compilation of a downstream crate.
 // See https://github.com/rust-lang/rust/issues/86480
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// Reason: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rust_lib_name, rustc};
 

--- a/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
+++ b/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
@@ -7,11 +7,7 @@
 // was hashed by rustc in addition to the span length, and the fix still
 // works.
 
-//@ ignore-none
-// reason: no-std is not supported
-
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for `std`
+//@ needs-target-std
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/incr-test-moved-file/rmake.rs
+++ b/tests/run-make/incr-test-moved-file/rmake.rs
@@ -9,10 +9,7 @@
 // for successful compilation.
 // See https://github.com/rust-lang/rust/issues/83112
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
+++ b/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
@@ -12,10 +12,7 @@
 // sessions.
 // See https://github.com/rust-lang/rust/issues/85019
 
-//@ ignore-none
-// Reason: no-std is not supported
-//@ ignore-nvptx64-nvidia-cuda
-// FIXME: can't find crate for 'std'
+//@ needs-target-std
 
 use run_make_support::{rfs, rust_lib_name, rustc};
 

--- a/tests/rustdoc-json/fn_pointer/abi.rs
+++ b/tests/rustdoc-json/fn_pointer/abi.rs
@@ -1,4 +1,4 @@
-#![feature(abi_vectorcall)]
+#![feature(rust_cold_cc)]
 
 //@ is "$.index[?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"
 pub type AbiRust = fn();
@@ -15,8 +15,5 @@ pub type AbiCUnwind = extern "C-unwind" fn();
 //@ is "$.index[?(@.name=='AbiSystemUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": true}}'
 pub type AbiSystemUnwind = extern "system-unwind" fn();
 
-//@ is "$.index[?(@.name=='AbiVecorcall')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall\""'
-pub type AbiVecorcall = extern "vectorcall" fn();
-
-//@ is "$.index[?(@.name=='AbiVecorcallUnwind')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
-pub type AbiVecorcallUnwind = extern "vectorcall-unwind" fn();
+//@ is "$.index[?(@.name=='AbiRustCold')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"rust-cold\""'
+pub type AbiRustCold = extern "rust-cold" fn();

--- a/tests/rustdoc-json/fns/abi.rs
+++ b/tests/rustdoc-json/fns/abi.rs
@@ -1,4 +1,4 @@
-#![feature(abi_vectorcall)]
+#![feature(rust_cold_cc)]
 
 //@ is "$.index[?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
 pub fn abi_rust() {}
@@ -15,8 +15,5 @@ pub extern "C-unwind" fn abi_c_unwind() {}
 //@ is "$.index[?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
 pub extern "system-unwind" fn abi_system_unwind() {}
 
-//@ is "$.index[?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
-pub extern "vectorcall" fn abi_vectorcall() {}
-
-//@ is "$.index[?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
-pub extern "vectorcall-unwind" fn abi_vectorcall_unwind() {}
+//@ is "$.index[?(@.name=='abi_rust_cold')].inner.function.header.abi.Other" '"\"rust-cold\""'
+pub extern "rust-cold" fn abi_rust_cold() {}

--- a/tests/rustdoc-json/methods/abi.rs
+++ b/tests/rustdoc-json/methods/abi.rs
@@ -1,5 +1,4 @@
-#![feature(abi_vectorcall)]
-
+#![feature(rust_cold_cc)]
 //@ has "$.index[?(@.name=='Foo')]"
 pub struct Foo;
 
@@ -19,11 +18,8 @@ impl Foo {
     //@ is "$.index[?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
     pub extern "system-unwind" fn abi_system_unwind() {}
 
-    //@ is "$.index[?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
-    pub extern "vectorcall" fn abi_vectorcall() {}
-
-    //@ is "$.index[?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
-    pub extern "vectorcall-unwind" fn abi_vectorcall_unwind() {}
+    //@ is "$.index[?(@.name=='abi_rust_cold')].inner.function.header.abi.Other" '"\"rust-cold\""'
+    pub extern "rust-cold" fn abi_rust_cold() {}
 }
 
 pub trait Bar {
@@ -42,9 +38,6 @@ pub trait Bar {
     //@ is "$.index[?(@.name=='trait_abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
     extern "system-unwind" fn trait_abi_system_unwind() {}
 
-    //@ is "$.index[?(@.name=='trait_abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
-    extern "vectorcall" fn trait_abi_vectorcall() {}
-
-    //@ is "$.index[?(@.name=='trait_abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
-    extern "vectorcall-unwind" fn trait_abi_vectorcall_unwind() {}
+    //@ is "$.index[?(@.name=='trait_abi_rust_cold')].inner.function.header.abi.Other" '"\"rust-cold\""'
+    extern "rust-cold" fn trait_abi_rust_cold() {}
 }

--- a/tests/rustdoc-json/vectorcall.rs
+++ b/tests/rustdoc-json/vectorcall.rs
@@ -1,0 +1,27 @@
+#![feature(abi_vectorcall)]
+//@ only-x86_64
+
+//@ is "$.index[?(@.name=='AbiVectorcall')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall\""'
+pub type AbiVectorcall = extern "vectorcall" fn();
+
+//@ is "$.index[?(@.name=='AbiVectorcallUnwind')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"vectorcall-unwind\""'
+pub type AbiVectorcallUnwind = extern "vectorcall-unwind" fn();
+
+//@ has "$.index[?(@.name=='Foo')]"
+pub struct Foo;
+
+impl Foo {
+    //@ is "$.index[?(@.name=='abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
+    pub extern "vectorcall" fn abi_vectorcall() {}
+
+    //@ is "$.index[?(@.name=='abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
+    pub extern "vectorcall-unwind" fn abi_vectorcall_unwind() {}
+}
+
+pub trait Bar {
+    //@ is "$.index[?(@.name=='trait_abi_vectorcall')].inner.function.header.abi.Other" '"\"vectorcall\""'
+    extern "vectorcall" fn trait_abi_vectorcall() {}
+
+    //@ is "$.index[?(@.name=='trait_abi_vectorcall_unwind')].inner.function.header.abi.Other" '"\"vectorcall-unwind\""'
+    extern "vectorcall-unwind" fn trait_abi_vectorcall_unwind() {}
+}

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -583,18 +583,32 @@ error: cannot find attribute `multipart_suggestion` in this scope
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
+   |
+help: `multipart_suggestion` is an attribute that can be used by the derive macro `Subdiagnostic`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Subdiagnostic)]
+LL | struct MultipartSuggestion {
+   |
 
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive.rs:647:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
+   |
+help: `multipart_suggestion` is an attribute that can be used by the derive macro `Subdiagnostic`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Subdiagnostic)]
+LL | struct MultipartSuggestion {
+   |
 
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive.rs:651:7
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `multipart_suggestion` is an attribute that can be used by the derive macro `Subdiagnostic`, you might be missing a `derive` attribute
 
 error[E0425]: cannot find value `nonsense` in module `crate::fluent_generated`
   --> $DIR/diagnostic-derive.rs:75:8

--- a/tests/ui-fulldeps/stable-mir/check_variant.rs
+++ b/tests/ui-fulldeps/stable-mir/check_variant.rs
@@ -1,6 +1,6 @@
 //@ run-pass
-//! Test that users are able to use stable mir APIs to retrieve type information from a crate item
-//! definition.
+//! Test that users are able to use stable mir APIs to retrieve
+//! discriminant value and type for AdtDef and Coroutine variants
 
 //@ ignore-stage1
 //@ ignore-cross-compile

--- a/tests/ui-fulldeps/stable-mir/check_variant.rs
+++ b/tests/ui-fulldeps/stable-mir/check_variant.rs
@@ -1,0 +1,154 @@
+//@ run-pass
+//! Test that users are able to use stable mir APIs to retrieve type information from a crate item
+//! definition.
+
+//@ ignore-stage1
+//@ ignore-cross-compile
+//@ ignore-remote
+//@ edition: 2024
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+
+extern crate rustc_middle;
+#[macro_use]
+extern crate rustc_smir;
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate stable_mir;
+
+use std::io::Write;
+use std::ops::ControlFlow;
+
+use stable_mir::CrateItem;
+use stable_mir::crate_def::CrateDef;
+use stable_mir::mir::{AggregateKind, Rvalue, Statement, StatementKind};
+use stable_mir::ty::{IntTy, RigidTy, Ty};
+
+const CRATE_NAME: &str = "crate_variant_ty";
+
+/// Test if we can retrieve discriminant info for different types.
+fn test_def_tys() -> ControlFlow<()> {
+    check_adt_mono();
+    check_adt_poly();
+
+    ControlFlow::Continue(())
+}
+
+fn check_adt_mono() {
+    let mono = get_fn("mono").expect_body();
+
+    check_statement_is_aggregate_assign(
+        &mono.blocks[0].statements[0],
+        0,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &mono.blocks[1].statements[0],
+        1,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &mono.blocks[2].statements[0],
+        2,
+        RigidTy::Int(IntTy::Isize),
+    );
+}
+
+fn check_adt_poly() {
+    let poly = get_fn("poly").expect_body();
+
+    check_statement_is_aggregate_assign(
+        &poly.blocks[0].statements[0],
+        0,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &poly.blocks[1].statements[0],
+        1,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &poly.blocks[2].statements[0],
+        2,
+        RigidTy::Int(IntTy::Isize),
+    );
+}
+
+fn get_fn(name: &str) -> CrateItem {
+    stable_mir::all_local_items().into_iter().find(|it| it.name().eq(name)).unwrap()
+}
+
+fn check_statement_is_aggregate_assign(
+    statement: &Statement,
+    expected_discr_val: u128,
+    expected_discr_ty: RigidTy,
+) {
+    if let Statement { kind: StatementKind::Assign(_, rvalue), .. } = statement
+        && let Rvalue::Aggregate(aggregate, _) = rvalue
+        && let AggregateKind::Adt(adt_def, variant_idx, ..) = aggregate
+    {
+        let discr = adt_def.discriminant_for_variant(*variant_idx);
+
+        assert_eq!(discr.val, expected_discr_val);
+        assert_eq!(discr.ty, Ty::from_rigid_kind(expected_discr_ty));
+    } else {
+        unreachable!("Unexpected statement");
+    }
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "defs_ty_input.rs";
+    generate_input(&path).unwrap();
+    let args = &[
+        "rustc".to_string(),
+        "-Cpanic=abort".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, test_def_tys).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+        use std::hint::black_box;
+
+        enum Mono {{
+            A,
+            B(i32),
+            C {{ a: i32, b: u32 }},
+        }}
+
+        enum Poly<T> {{
+            A,
+            B(T),
+            C {{ t: T }},
+        }}
+
+        pub fn main() {{
+            mono();
+        }}
+
+        fn mono() {{
+            black_box(Mono::A);
+            black_box(Mono::B(6));
+            black_box(Mono::C {{a: 1, b: 10 }});
+        }}
+
+        fn poly() {{
+            black_box(Poly::<i32>::A);
+            black_box(Poly::B(1i32));
+            black_box(Poly::C {{ t: 1i32 }});
+        }}
+    "#
+    )?;
+    Ok(())
+}

--- a/tests/ui-fulldeps/stable-mir/check_variant.rs
+++ b/tests/ui-fulldeps/stable-mir/check_variant.rs
@@ -31,6 +31,7 @@ const CRATE_NAME: &str = "crate_variant_ty";
 fn test_def_tys() -> ControlFlow<()> {
     check_adt_mono();
     check_adt_poly();
+    check_adt_poly2();
 
     ControlFlow::Continue(())
 }
@@ -57,6 +58,26 @@ fn check_adt_mono() {
 
 fn check_adt_poly() {
     let poly = get_fn("poly").expect_body();
+
+    check_statement_is_aggregate_assign(
+        &poly.blocks[0].statements[0],
+        0,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &poly.blocks[1].statements[0],
+        1,
+        RigidTy::Int(IntTy::Isize),
+    );
+    check_statement_is_aggregate_assign(
+        &poly.blocks[2].statements[0],
+        2,
+        RigidTy::Int(IntTy::Isize),
+    );
+}
+
+fn check_adt_poly2() {
+    let poly = get_fn("poly2").expect_body();
 
     check_statement_is_aggregate_assign(
         &poly.blocks[0].statements[0],
@@ -135,6 +156,8 @@ fn generate_input(path: &str) -> std::io::Result<()> {
 
         pub fn main() {{
             mono();
+            poly();
+            poly2::<i32>(1);
         }}
 
         fn mono() {{
@@ -147,6 +170,12 @@ fn generate_input(path: &str) -> std::io::Result<()> {
             black_box(Poly::<i32>::A);
             black_box(Poly::B(1i32));
             black_box(Poly::C {{ t: 1i32 }});
+        }}
+
+        fn poly2<T: Copy>(t: T) {{
+            black_box(Poly::<T>::A);
+            black_box(Poly::B(t));
+            black_box(Poly::C {{ t: t }});
         }}
     "#
     )?;

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -106,11 +106,13 @@ LL | }
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/without-precise-captures-we-are-powerless.rs:38:5
    |
-LL | fn through_field_and_ref<'a>(x: &S<'a>) {
-   |                                 ------ help: add explicit lifetime `'a` to the type of `x`: `&'a S<'a>`
-...
 LL |     outlives::<'a>(call_once(c));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn through_field_and_ref<'a>(x: &'a S<'a>) {
+   |                                  ++
 
 error[E0597]: `c` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:43:20
@@ -131,11 +133,13 @@ LL | }
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/without-precise-captures-we-are-powerless.rs:44:5
    |
-LL | fn through_field_and_ref_move<'a>(x: &S<'a>) {
-   |                                      ------ help: add explicit lifetime `'a` to the type of `x`: `&'a S<'a>`
-...
 LL |     outlives::<'a>(call_once(c));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn through_field_and_ref_move<'a>(x: &'a S<'a>) {
+   |                                       ++
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/async-await/issues/issue-63388-1.stderr
+++ b/tests/ui/async-await/issues/issue-63388-1.stderr
@@ -1,11 +1,14 @@
 error[E0621]: explicit lifetime required in the type of `foo`
   --> $DIR/issue-63388-1.rs:14:9
    |
-LL |         &'a self, foo: &dyn Foo
-   |                        -------- help: add explicit lifetime `'a` to the type of `foo`: `&'a (dyn Foo + 'a)`
-...
 LL |         foo
    |         ^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `foo`
+   |
+LL -         &'a self, foo: &dyn Foo
+LL +         &'a self, foo: &'a (dyn Foo + 'a)
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -65,9 +65,12 @@ error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/must_outlive_least_region_or_bound.rs:15:41
    |
 LL | fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
-   |               ----                      ^ lifetime `'a` required
-   |               |
-   |               help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
+   |                                         ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn foo<'a>(x: &'a i32) -> impl Copy + 'a { x }
+   |                ++
 
 error: lifetime may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:30:55

--- a/tests/ui/issues/issue-13058.stderr
+++ b/tests/ui/issues/issue-13058.stderr
@@ -1,11 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `cont`
   --> $DIR/issue-13058.rs:14:21
    |
-LL | fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &T) -> bool
-   |                                                                     -- help: add explicit lifetime `'r` to the type of `cont`: `&'r T`
-LL | {
 LL |     let cont_iter = cont.iter();
    |                     ^^^^^^^^^^^ lifetime `'r` required
+   |
+help: add explicit lifetime `'r` to the type of `cont`
+   |
+LL | fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &'r T) -> bool
+   |                                                                      ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-14285.stderr
+++ b/tests/ui/issues/issue-14285.stderr
@@ -1,10 +1,14 @@
 error[E0621]: explicit lifetime required in the type of `a`
   --> $DIR/issue-14285.rs:12:5
    |
-LL | fn foo<'a>(a: &dyn Foo) -> B<'a> {
-   |               -------- help: add explicit lifetime `'a` to the type of `a`: `&'a (dyn Foo + 'a)`
 LL |     B(a)
    |     ^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `a`
+   |
+LL - fn foo<'a>(a: &dyn Foo) -> B<'a> {
+LL + fn foo<'a>(a: &'a (dyn Foo + 'a)) -> B<'a> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-15034.stderr
+++ b/tests/ui/issues/issue-15034.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `lexer`
   --> $DIR/issue-15034.rs:17:9
    |
-LL |     pub fn new(lexer: &'a mut Lexer) -> Parser<'a> {
-   |                       ------------- help: add explicit lifetime `'a` to the type of `lexer`: `&'a mut Lexer<'a>`
 LL |         Parser { lexer: lexer }
    |         ^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `lexer`
+   |
+LL |     pub fn new(lexer: &'a mut Lexer<'a>) -> Parser<'a> {
+   |                                    ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-3154.stderr
+++ b/tests/ui/issues/issue-3154.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/issue-3154.rs:6:5
    |
-LL | fn thing<'a,Q>(x: &Q) -> Thing<'a,Q> {
-   |                   -- help: add explicit lifetime `'a` to the type of `x`: `&'a Q`
 LL |     Thing { x: x }
    |     ^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn thing<'a,Q>(x: &'a Q) -> Thing<'a,Q> {
+   |                    ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-40288-2.stderr
+++ b/tests/ui/issues/issue-40288-2.stderr
@@ -1,20 +1,24 @@
 error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/issue-40288-2.rs:9:5
    |
-LL | fn lifetime_transmute_slice<'a, T: ?Sized>(x: &'a T, y: &T) -> &'a T {
-   |                                                         -- help: add explicit lifetime `'a` to the type of `y`: `&'a T`
-...
 LL |     out[0]
    |     ^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `y`
+   |
+LL | fn lifetime_transmute_slice<'a, T: ?Sized>(x: &'a T, y: &'a T) -> &'a T {
+   |                                                          ++
 
 error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/issue-40288-2.rs:24:5
    |
-LL | fn lifetime_transmute_struct<'a, T: ?Sized>(x: &'a T, y: &T) -> &'a T {
-   |                                                          -- help: add explicit lifetime `'a` to the type of `y`: `&'a T`
-...
 LL |     out.head
    |     ^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `y`
+   |
+LL | fn lifetime_transmute_struct<'a, T: ?Sized>(x: &'a T, y: &'a T) -> &'a T {
+   |                                                           ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/lifetime-errors/42701_one_named_and_one_anonymous.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/42701_one_named_and_one_anonymous.stderr
@@ -1,11 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/42701_one_named_and_one_anonymous.rs:10:9
    |
-LL | fn foo2<'a>(a: &'a Foo, x: &i32) -> &'a i32 {
-   |                            ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
-...
 LL |         &*x
    |         ^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn foo2<'a>(a: &'a Foo, x: &'a i32) -> &'a i32 {
+   |                             ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-early-bound-in-struct.stderr
@@ -1,11 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `other`
   --> $DIR/ex1-return-one-existing-name-early-bound-in-struct.rs:11:21
    |
-LL |     fn bar(&self, other: Foo) -> Foo<'a> {
-   |                          --- help: add explicit lifetime `'a` to the type of `other`: `Foo<'a>`
-...
 LL |                     other
    |                     ^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `other`
+   |
+LL |     fn bar(&self, other: Foo<'a>) -> Foo<'a> {
+   |                             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-2.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex1-return-one-existing-name-if-else-2.rs:2:16
    |
-LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
-   |               ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL |     if x > y { x } else { y }
    |                ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+   |                ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-3.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in parameter type
   --> $DIR/ex1-return-one-existing-name-if-else-3.rs:2:27
    |
-LL | fn foo<'a>((x, y): (&'a i32, &i32)) -> &'a i32 {
-   |                    --------------- help: add explicit lifetime `'a` to type: `(&'a i32, &'a i32)`
 LL |     if x > y { x } else { y }
    |                           ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to type
+   |
+LL | fn foo<'a>((x, y): (&'a i32, &'a i32)) -> &'a i32 {
+   |                               ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-2.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex1-return-one-existing-name-if-else-using-impl-2.rs:4:15
    |
-LL | fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
-   |               ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL |    if x > y { x } else { y }
    |               ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+   |                ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:7:36
    |
-LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
-   |                           ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 LL |     if true { &self.field } else { x }
    |                                    ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL |   fn foo<'a>(&'a self, x: &'a i32) -> &i32 {
+   |                            ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/ex1-return-one-existing-name-if-else.rs:2:27
    |
-LL | fn foo<'a>(x: &'a i32, y: &i32) -> &'a i32 {
-   |                           ---- help: add explicit lifetime `'a` to the type of `y`: `&'a i32`
 LL |     if x > y { x } else { y }
    |                           ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `y`
+   |
+LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+   |                            ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-2.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex2a-push-one-existing-name-2.rs:6:5
    |
-LL | fn foo<'a>(x: Ref<i32>, y: &mut Vec<Ref<'a, i32>>) {
-   |               -------- help: add explicit lifetime `'a` to the type of `x`: `Ref<'a, i32>`
 LL |     y.push(x);
    |     ^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `x`
+   |
+LL | fn foo<'a>(x: Ref<'a, i32>, y: &mut Vec<Ref<'a, i32>>) {
+   |                   +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-early-bound.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name-early-bound.stderr
@@ -1,11 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/ex2a-push-one-existing-name-early-bound.rs:8:5
    |
-LL | fn baz<'a, 'b, T>(x: &mut Vec<&'a T>, y: &T)
-   |                                          -- help: add explicit lifetime `'a` to the type of `y`: `&'a T`
-...
 LL |     x.push(y);
    |     ^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `y`
+   |
+LL | fn baz<'a, 'b, T>(x: &mut Vec<&'a T>, y: &'a T)
+   |                                           ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex2a-push-one-existing-name.stderr
@@ -1,10 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `y`
   --> $DIR/ex2a-push-one-existing-name.rs:6:5
    |
-LL | fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<i32>) {
-   |                                          -------- help: add explicit lifetime `'a` to the type of `y`: `Ref<'a, i32>`
 LL |     x.push(y);
    |     ^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `y`
+   |
+LL | fn foo<'a>(x: &mut Vec<Ref<'a, i32>>, y: Ref<'a, i32>) {
+   |                                              +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/noisy-follow-up-erro.stderr
+++ b/tests/ui/lifetimes/noisy-follow-up-erro.stderr
@@ -15,11 +15,14 @@ LL | struct Foo<'c, 'd>(&'c (), &'d ());
 error[E0621]: explicit lifetime required in the type of `foo`
   --> $DIR/noisy-follow-up-erro.rs:14:9
    |
-LL |     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
-   |                         -------------------- help: add explicit lifetime `'a` to the type of `foo`: `&mut Foo<'_, 'a>`
-LL |
 LL |         self.bar().map_err(|()| foo.acc(self))?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `foo`
+   |
+LL -     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
+LL +     fn boom(&self, foo: &mut Foo<'_, 'a>) -> Result<(), &'a ()> {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/auxiliary/serde.rs
+++ b/tests/ui/macros/auxiliary/serde.rs
@@ -1,0 +1,19 @@
+//@ force-host
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(proc_macro_quote)]
+
+extern crate proc_macro;
+
+use proc_macro::*;
+
+#[proc_macro_derive(Serialize, attributes(serde))]
+pub fn serialize(ts: TokenStream) -> TokenStream {
+    quote!{}
+}
+
+#[proc_macro_derive(Deserialize, attributes(serde))]
+pub fn deserialize(ts: TokenStream) -> TokenStream {
+    quote!{}
+}

--- a/tests/ui/macros/missing-derive-1.rs
+++ b/tests/ui/macros/missing-derive-1.rs
@@ -1,0 +1,33 @@
+//@aux-build:serde.rs
+
+// derive macros imported and used
+
+extern crate serde;
+use serde::{Serialize, Deserialize};
+
+#[serde(untagged)] //~ ERROR cannot find attribute `serde`
+enum A { //~ HELP `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`
+    A,
+    B,
+}
+
+enum B { //~ HELP `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`
+    A,
+    #[serde(untagged)] //~ ERROR cannot find attribute `serde`
+    B,
+}
+
+enum C {
+    A,
+    #[sede(untagged)] //~ ERROR cannot find attribute `sede`
+    B, //~^ HELP the derive macros `Deserialize` and `Serialize` accept the similarly named `serde` attribute
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum D {
+    A,
+    B,
+}
+
+fn main() {}

--- a/tests/ui/macros/missing-derive-1.stderr
+++ b/tests/ui/macros/missing-derive-1.stderr
@@ -1,0 +1,47 @@
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-1.rs:8:3
+   |
+LL | #[serde(untagged)]
+   |   ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-1.rs:5:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+help: `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Serialize, Deserialize)]
+LL | enum A {
+   |
+
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-1.rs:16:7
+   |
+LL |     #[serde(untagged)]
+   |       ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-1.rs:5:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+help: `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Serialize, Deserialize)]
+LL | enum B {
+   |
+
+error: cannot find attribute `sede` in this scope
+  --> $DIR/missing-derive-1.rs:22:7
+   |
+LL |     #[sede(untagged)]
+   |       ^^^^
+   |
+help: the derive macros `Deserialize` and `Serialize` accept the similarly named `serde` attribute
+   |
+LL |     #[serde(untagged)]
+   |         +
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/missing-derive-2.rs
+++ b/tests/ui/macros/missing-derive-2.rs
@@ -1,0 +1,26 @@
+//@aux-build:serde.rs
+
+// derive macros imported but unused
+
+extern crate serde;
+use serde::{Serialize, Deserialize};
+
+#[serde(untagged)] //~ ERROR cannot find attribute `serde`
+enum A { //~ HELP `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`
+    A,
+    B,
+}
+
+enum B { //~ HELP `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`
+    A,
+    #[serde(untagged)] //~ ERROR cannot find attribute `serde`
+    B,
+}
+
+enum C {
+    A,
+    #[sede(untagged)] //~ ERROR cannot find attribute `sede`
+    B, //~^ HELP the derive macros `Deserialize` and `Serialize` accept the similarly named `serde` attribute
+}
+
+fn main() {}

--- a/tests/ui/macros/missing-derive-2.stderr
+++ b/tests/ui/macros/missing-derive-2.stderr
@@ -1,0 +1,47 @@
+error: cannot find attribute `sede` in this scope
+  --> $DIR/missing-derive-2.rs:22:7
+   |
+LL |     #[sede(untagged)]
+   |       ^^^^
+   |
+help: the derive macros `Deserialize` and `Serialize` accept the similarly named `serde` attribute
+   |
+LL |     #[serde(untagged)]
+   |         +
+
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-2.rs:16:7
+   |
+LL |     #[serde(untagged)]
+   |       ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-2.rs:5:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+help: `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Serialize, Deserialize)]
+LL | enum B {
+   |
+
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-2.rs:8:3
+   |
+LL | #[serde(untagged)]
+   |   ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-2.rs:5:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+help: `serde` is an attribute that can be used by the derive macros `Serialize` and `Deserialize`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Serialize, Deserialize)]
+LL | enum A {
+   |
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/missing-derive-3.rs
+++ b/tests/ui/macros/missing-derive-3.rs
@@ -1,0 +1,24 @@
+//@aux-build:serde.rs
+
+// derive macros not imported, but namespace imported. Not yet handled.
+extern crate serde;
+
+#[serde(untagged)] //~ ERROR cannot find attribute `serde`
+enum A {
+    A,
+    B,
+}
+
+enum B {
+    A,
+    #[serde(untagged)] //~ ERROR cannot find attribute `serde`
+    B,
+}
+
+enum C {
+    A,
+    #[sede(untagged)] //~ ERROR cannot find attribute `sede`
+    B,
+}
+
+fn main() {}

--- a/tests/ui/macros/missing-derive-3.stderr
+++ b/tests/ui/macros/missing-derive-3.stderr
@@ -1,0 +1,32 @@
+error: cannot find attribute `sede` in this scope
+  --> $DIR/missing-derive-3.rs:20:7
+   |
+LL |     #[sede(untagged)]
+   |       ^^^^
+
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-3.rs:14:7
+   |
+LL |     #[serde(untagged)]
+   |       ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-3.rs:4:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: cannot find attribute `serde` in this scope
+  --> $DIR/missing-derive-3.rs:6:3
+   |
+LL | #[serde(untagged)]
+   |   ^^^^^
+   |
+note: `serde` is imported here, but it is a crate, not an attribute
+  --> $DIR/missing-derive-3.rs:4:1
+   |
+LL | extern crate serde;
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/object-lifetime/object-lifetime-default-from-box-error.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-from-box-error.stderr
@@ -21,11 +21,13 @@ LL |     ss.r
 error[E0621]: explicit lifetime required in the type of `ss`
   --> $DIR/object-lifetime-default-from-box-error.rs:33:5
    |
-LL | fn store1<'b>(ss: &mut SomeStruct, b: Box<dyn SomeTrait+'b>) {
-   |                   --------------- help: add explicit lifetime `'b` to the type of `ss`: `&mut SomeStruct<'b>`
-...
 LL |     ss.r = b;
    |     ^^^^ lifetime `'b` required
+   |
+help: add explicit lifetime `'b` to the type of `ss`
+   |
+LL | fn store1<'b>(ss: &mut SomeStruct<'b>, b: Box<dyn SomeTrait+'b>) {
+   |                                  ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/derive-helper-legacy-limits.stderr
+++ b/tests/ui/proc-macro/derive-helper-legacy-limits.stderr
@@ -3,6 +3,12 @@ error: cannot find attribute `empty_helper` in this scope
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^
+   |
+help: `empty_helper` is an attribute that can be used by the derive macro `Empty`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Empty)]
+LL | struct S2;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -16,6 +16,7 @@ error: cannot find attribute `empty_helper` in this scope
 LL |             #[derive(GenHelperUse)]
    |                      ^^^^^^^^^^^^
    |
+   = note: `empty_helper` is an attribute that can be used by the derive macro `Empty`, you might be missing a `derive` attribute
    = note: this error originates in the derive macro `GenHelperUse` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this attribute macro through its public re-export
    |
@@ -31,6 +32,7 @@ LL |         #[empty_helper]
 LL |             gen_helper_use!();
    |             ----------------- in this macro invocation
    |
+   = note: `empty_helper` is an attribute that can be used by the derive macro `Empty`, you might be missing a `derive` attribute
    = note: this error originates in the macro `gen_helper_use` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this attribute macro through its public re-export
    |

--- a/tests/ui/proc-macro/disappearing-resolution.stderr
+++ b/tests/ui/proc-macro/disappearing-resolution.stderr
@@ -3,6 +3,12 @@ error: cannot find attribute `empty_helper` in this scope
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^
+   |
+help: `empty_helper` is an attribute that can be used by the derive macro `Empty`, you might be missing a `derive` attribute
+   |
+LL + #[derive(Empty)]
+LL | struct S;
+   |
 
 error[E0603]: derive macro import `Empty` is private
   --> $DIR/disappearing-resolution.rs:11:8

--- a/tests/ui/regions/regions-glb-free-free.stderr
+++ b/tests/ui/regions/regions-glb-free-free.stderr
@@ -1,8 +1,6 @@
 error[E0621]: explicit lifetime required in the type of `s`
   --> $DIR/regions-glb-free-free.rs:15:13
    |
-LL |           pub fn set_desc(self, s: &str) -> Flag<'a> {
-   |                                    ---- help: add explicit lifetime `'a` to the type of `s`: `&'a str`
 LL | /             Flag {
 LL | |                 name: self.name,
 LL | |                 desc: s,
@@ -10,6 +8,11 @@ LL | |                 max_count: self.max_count,
 LL | |                 value: self.value
 LL | |             }
    | |_____________^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `s`
+   |
+LL |         pub fn set_desc(self, s: &'a str) -> Flag<'a> {
+   |                                   ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-infer-at-fn-not-param.stderr
+++ b/tests/ui/regions/regions-infer-at-fn-not-param.stderr
@@ -2,9 +2,12 @@ error[E0621]: explicit lifetime required in the type of `p`
   --> $DIR/regions-infer-at-fn-not-param.rs:13:57
    |
 LL | fn take1<'a>(p: Parameterized1) -> Parameterized1<'a> { p }
-   |                 --------------                          ^ lifetime `'a` required
-   |                 |
-   |                 help: add explicit lifetime `'a` to the type of `p`: `Parameterized1<'a>`
+   |                                                         ^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `p`
+   |
+LL | fn take1<'a>(p: Parameterized1<'a>) -> Parameterized1<'a> { p }
+   |                               ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -101,15 +101,17 @@ LL + fn bat<'b, 'a, G: 'a + 'b, T>(g: G, dest: &'b mut T) -> impl FnOnce() + 'b 
 error[E0621]: explicit lifetime required in the type of `dest`
   --> $DIR/missing-lifetimes-in-signature.rs:73:5
    |
-LL |   fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-   |                                    ------ help: add explicit lifetime `'a` to the type of `dest`: `&'a mut T`
-...
 LL | /     move || {
 LL | |
 LL | |
 LL | |         *dest = g.get();
 LL | |     }
    | |_____^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `dest`
+   |
+LL | fn bat<'a, G: 'a, T>(g: G, dest: &'a mut T) -> impl FnOnce() + '_ + 'a
+   |                                   ++
 
 error[E0309]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:85:5

--- a/tests/ui/variance/variance-trait-matching.stderr
+++ b/tests/ui/variance/variance-trait-matching.stderr
@@ -1,11 +1,13 @@
 error[E0621]: explicit lifetime required in the type of `get`
   --> $DIR/variance-trait-matching.rs:24:5
    |
-LL | fn get<'a, G>(get: &G) -> i32
-   |                    -- help: add explicit lifetime `'a` to the type of `get`: `&'a G`
-...
 LL |     pick(get, &22)
    |     ^^^^^^^^^^^^^^ lifetime `'a` required
+   |
+help: add explicit lifetime `'a` to the type of `get`
+   |
+LL | fn get<'a, G>(get: &'a G) -> i32
+   |                     ++
 
 error: aborting due to 1 previous error
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -729,6 +729,41 @@ don't know
 ]
 message_on_remove = "PR #{number}'s stable-nomination has been removed."
 
+[notify-zulip."beta-nominated".bootstrap]
+required_labels = ["T-bootstrap"]
+zulip_stream = 507486 # #t-infra/bootstrap/backports
+topic = "#{number}: beta-nominated"
+message_on_add = [
+    """\
+@*T-bootstrap* PR #{number} "{title}" has been nominated for beta backport.
+""",
+    """\
+/poll Approve beta backport of #{number}?
+approve
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s beta-nomination has been removed."
+
+[notify-zulip."stable-nominated".bootstrap]
+required_labels = ["T-bootstrap"]
+zulip_stream = 507486 # #t-infra/bootstrap/backports
+topic = "#{number}: stable-nominated"
+message_on_add = [
+    """\
+@*T-bootstrap* PR #{number} "{title}" has been nominated for stable backport.
+""",
+    """\
+/poll Approve stable backport of #{number}?
+approve
+approve (but does not justify new dot release on its own)
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s stable-nomination has been removed."
+
 [notify-zulip."A-edition-2021"]
 required_labels = ["C-bug"]
 zulip_stream = 268952 # #edition


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#134841 (Look at proc-macro attributes when encountering unknown attribute)
 - rust-lang/rust#141639 (Expose discriminant values in stable_mir)
 - rust-lang/rust#141967 (Configure bootstrap backport nominations through triagebot)
 - rust-lang/rust#142042 (Make E0621 missing lifetime suggestion verbose)
 - rust-lang/rust#142176 (tests: Split dont-shuffle-bswaps along opt-levels and arches)
 - rust-lang/rust#142248 (Add supported asm types for LoongArch32)
 - rust-lang/rust#142272 (tests: Change ABIs in tests to more future-resilient ones)
 - rust-lang/rust#142282 (Only run `citool` tests on the `auto` branch)
 - rust-lang/rust#142297 (Implement `//@ needs-target-std` compiletest directive)
 - rust-lang/rust#142298 (Make loongarch-none target maintainers more easily pingable)
 - rust-lang/rust#142306 (Dont unwrap and re-wrap typing envs)
 - rust-lang/rust#142324 (Remove unneeded `FunctionCx` from some codegen methods)
 - rust-lang/rust#142328 (feat: Add `bit_width` for unsigned integer types)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134841,141639,141967,142042,142176,142248,142272,142282,142297,142298,142306,142324,142328)
<!-- homu-ignore:end -->