### PR TITLE
Don't suggest converting `///` to `//` when expecting `,`

### DIFF
--- a/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.rs
+++ b/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.rs
@@ -1,0 +1,34 @@
+//! Check that if the parser suggests converting `///` to a regular comment
+//! when it appears after a missing comma in an list (e.g. `enum` variants).
+//!
+//! Related issue
+//! - https://github.com/rust-lang/rust/issues/142311
+
+enum Foo {
+    /// Like the noise a sheep makes
+    Bar
+    /// Like where people drink
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `/// Like where people drink`
+    Baa///xxxxxx
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+    Baz///xxxxxx
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+}
+
+fn foo() {
+    let a = [
+        1///xxxxxx
+        //~^ ERROR expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+        2
+    ];
+}
+
+fn bar() {
+    let a = [
+        1,
+        2///xxxxxx
+        //~^ ERROR expected one of `,`, `.`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+    ];
+}
+
+fn main() {}

--- a/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.stderr
+++ b/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.stderr
@@ -1,0 +1,43 @@
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `/// Like where people drink`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:10:5
+   |
+LL |     Bar
+   |        -
+   |        |
+   |        expected one of `(`, `,`, `=`, `{`, or `}`
+   |        help: missing `,`
+LL |     /// Like where people drink
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected token
+
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:12:8
+   |
+LL |     Baa///xxxxxx
+   |        -^^^^^^^^
+   |        |
+   |        expected one of `(`, `,`, `=`, `{`, or `}`
+   |        help: missing `,`
+
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:14:8
+   |
+LL |     Baz///xxxxxx
+   |        ^^^^^^^^^ expected one of `(`, `,`, `=`, `{`, or `}`
+   |
+   = help: doc comments must come before what they document, if a comment was intended use `//`
+   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+
+error: expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:20:10
+   |
+LL |         1///xxxxxx
+   |          ^^^^^^^^^ expected one of `,`, `.`, `;`, `?`, `]`, or an operator
+
+error: expected one of `,`, `.`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:29:10
+   |
+LL |         2///xxxxxx
+   |          ^^^^^^^^^ expected one of `,`, `.`, `?`, `]`, or an operator
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#142311
