### PR TITLE
Revert "add `Cargo.lock` to CI-rustc allowed list for non-CI env"

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -52,39 +52,26 @@ use crate::utils::execution_context::ExecutionContext;
 use crate::utils::helpers::exe;
 use crate::{GitInfo, OnceLock, TargetSelection, check_ci_llvm, helpers, t};
 
-/// Each path from this function is considered "allowed" in the `download-rustc="if-unchanged"` logic.
+/// Each path in this list is considered "allowed" in the `download-rustc="if-unchanged"` logic.
 /// This means they can be modified and changes to these paths should never trigger a compiler build
 /// when "if-unchanged" is set.
-pub fn rustc_if_unchanged_allowed_paths() -> Vec<&'static str> {
-    // NOTE: Paths must have the ":!" prefix to tell git to ignore changes in those paths during
-    // the diff check.
-    //
-    // WARNING: Be cautious when adding paths to this list. If a path that influences the compiler build
-    // is added here, it will cause bootstrap to skip necessary rebuilds, which may lead to risky results.
-    // For example, "src/bootstrap" should never be included in this list as it plays a crucial role in the
-    // final output/compiler, which can be significantly affected by changes made to the bootstrap sources.
-    let mut paths = vec![
-        ":!library",
-        ":!src/tools",
-        ":!src/librustdoc",
-        ":!src/rustdoc-json-types",
-        ":!tests",
-        ":!triagebot.toml",
-    ];
-
-    if !CiEnv::is_ci() {
-        // When a dependency is added/updated/removed in the library tree (or in some tools),
-        // `Cargo.lock` will be updated by `cargo`. This update will incorrectly invalidate the
-        // `download-rustc=if-unchanged` cache.
-        //
-        // To prevent this, add `Cargo.lock` to the list of allowed paths when not running on CI.
-        // This is generally safe because changes to dependencies typically involve modifying
-        // `Cargo.toml`, which would already invalidate the CI-rustc cache on non-allowed paths.
-        paths.push(":!Cargo.lock");
-    }
-
-    paths
-}
+///
+/// NOTE: Paths must have the ":!" prefix to tell git to ignore changes in those paths during
+/// the diff check.
+///
+/// WARNING: Be cautious when adding paths to this list. If a path that influences the compiler build
+/// is added here, it will cause bootstrap to skip necessary rebuilds, which may lead to risky results.
+/// For example, "src/bootstrap" should never be included in this list as it plays a crucial role in the
+/// final output/compiler, which can be significantly affected by changes made to the bootstrap sources.
+#[rustfmt::skip] // We don't want rustfmt to oneline this list
+pub const RUSTC_IF_UNCHANGED_ALLOWED_PATHS: &[&str] = &[
+    ":!library",
+    ":!src/tools",
+    ":!src/librustdoc",
+    ":!src/rustdoc-json-types",
+    ":!tests",
+    ":!triagebot.toml",
+];
 
 /// Global configuration for the entire build and/or bootstrap.
 ///
@@ -1516,7 +1503,7 @@ impl Config {
         let commit = if self.rust_info.is_managed_git_subrepository() {
             // Look for a version to compare to based on the current commit.
             // Only commits merged by bors will have CI artifacts.
-            let freshness = self.check_path_modifications(&rustc_if_unchanged_allowed_paths());
+            let freshness = self.check_path_modifications(RUSTC_IF_UNCHANGED_ALLOWED_PATHS);
             self.verbose(|| {
                 eprintln!("rustc freshness: {freshness:?}");
             });

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 
 use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
-use super::{Config, rustc_if_unchanged_allowed_paths};
+use super::{Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
 use crate::ChangeId;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm;
@@ -459,7 +459,7 @@ fn jobs_precedence() {
 #[test]
 fn check_rustc_if_unchanged_paths() {
     let config = parse("");
-    let normalised_allowed_paths: Vec<_> = rustc_if_unchanged_allowed_paths()
+    let normalised_allowed_paths: Vec<_> = RUSTC_IF_UNCHANGED_ALLOWED_PATHS
         .iter()
         .map(|t| {
             t.strip_prefix(":!").expect(&format!("{t} doesn't have ':!' prefix, but it should."))


### PR DESCRIPTION
This reverts commit c3de813944873940b8e1a7734991f3c9f3f55156 (https://github.com/rust-lang/rust/pull/142232).

r? @RalfJung

Fixes: https://github.com/rust-lang/rust/issues/142338
Unfixes: https://github.com/rust-lang/rust/issues/141986