### PR TITLE
Add tracing import to execution context

### DIFF
--- a/src/bootstrap/src/utils/execution_context.rs
+++ b/src/bootstrap/src/utils/execution_context.rs
@@ -6,6 +6,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::core::config::DryRun;
+#[cfg(feature = "tracing")]
+use crate::trace_cmd;
 use crate::{BehaviorOnFailure, BootstrapCommand, CommandOutput, OutputMode, exit};
 
 #[derive(Clone, Default)]

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,7 +27,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        python3 ../x.py check && \
+        BOOTSTRAP_TRACING=bootstrap=TRACE python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,7 +27,9 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        BOOTSTRAP_TRACING=bootstrap=TRACE python3 ../x.py check && \
+        # The BOOTSTRAP_TRACING flag is added to verify whether the 
+        # bootstrap process compiles successfully with this flag enabled.
+        BOOTSTRAP_TRACING=1 python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,9 +27,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        # The BOOTSTRAP_TRACING flag is added to verify whether the 
-        # bootstrap process compiles successfully with this flag enabled.
-        BOOTSTRAP_TRACING=1 python3 ../x.py check && \
+        python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \
@@ -38,4 +36,7 @@ ENV SCRIPT \
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library && \
         mkdir -p /checkout/obj/staging/doc && \
         cp -r build/x86_64-unknown-linux-gnu/doc /checkout/obj/staging && \
-        RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library/test
+        RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library/test && \
+        # The BOOTSTRAP_TRACING flag is added to verify whether the 
+        # bootstrap process compiles successfully with this flag enabled.
+        BOOTSTRAP_TRACING=1 python3 ../x.py --help


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/141909, we missed adding the trace_cmd import in the execution context module. This PR fixes that. Additionally, we are updating the mingw-check-2 check command to include BOOTSTRAP_TRACING=1 to help ensure we don't miss such cases in future PRs.



r? @Kobzol 