### PR TITLE
Fix enter_trace_span!() using wrong $crate paths

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -58,9 +58,9 @@ pub enum MaybeEnteredSpan {
 macro_rules! enter_trace_span {
     ($machine:ident, $($tt:tt)*) => {
         if $machine::TRACING_ENABLED {
-            $crate::interpret::tracing_utils::MaybeEnteredSpan::Some(tracing::info_span!($($tt)*).entered())
+            $crate::interpret::util::MaybeEnteredSpan::Some(tracing::info_span!($($tt)*).entered())
         } else {
-            $crate::interpret::tracing_utils::MaybeEnteredSpan::None
+            $crate::interpret::util::MaybeEnteredSpan::None
         }
     }
 }


### PR DESCRIPTION
This is a followup to rust-lang/rust#140972, where I made a silly mistake and forgot to update `$crate::interpret::tracing_utils::...` to `$crate::interpret::util::...` inside the macro after moving the referenced code from `tracing_utils.rs` to `util.rs`. Sorry about this.

r? @RalfJung 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

