### PR TITLE
Add expectation for `{` when parsing lone coroutine qualifiers

### DIFF
--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -44,22 +44,22 @@ note: while trying to match `r#async`
 LL |     (r#async) => (1)
    |      ^^^^^^^
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2015.rs:27:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
   ::: $DIR/edition-keywords-2018-2015-parsing.rs:22:8
    |
 LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:24:24
    |
 LL |     if passes_tt!(async) == 1 {}
-   |                        ^ expected one of `move`, `use`, `|`, or `||`
+   |                        ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
 error[E0308]: mismatched types
   --> $DIR/edition-keywords-2018-2015-parsing.rs:29:33

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -44,34 +44,34 @@ note: while trying to match `r#async`
 LL |     (r#async) => (1)
    |      ^^^^^^^
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2018.rs:27:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
   ::: $DIR/edition-keywords-2018-2018-parsing.rs:29:8
    |
 LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:31:24
    |
 LL |     if passes_tt!(async) == 1 {}
-   |                        ^ expected one of `move`, `use`, `|`, or `||`
+   |                        ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:14:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:35:30
    |
 LL |     if local_passes_tt!(async) == 1 {}
-   |                              ^ expected one of `move`, `use`, `|`, or `||`
+   |                              ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
 error[E0308]: mismatched types
   --> $DIR/edition-keywords-2018-2018-parsing.rs:40:33

--- a/tests/ui/parser/block-no-opening-brace.rs
+++ b/tests/ui/parser/block-no-opening-brace.rs
@@ -27,10 +27,10 @@ fn in_try() {
         let x = 0;
 }
 
-// FIXME(#80931)
 fn in_async() {
     async
-        let x = 0; //~ ERROR expected one of `move`, `use`, `|`, or `||`, found keyword `let`
+        let x = 0;
+    //~^ ERROR expected one of `move`, `use`, `{`, `|`, or `||`, found keyword `let`
 }
 
 // FIXME(#78168)

--- a/tests/ui/parser/block-no-opening-brace.stderr
+++ b/tests/ui/parser/block-no-opening-brace.stderr
@@ -43,11 +43,11 @@ error: expected expression, found reserved keyword `try`
 LL |     try
    |     ^^^ expected expression
 
-error: expected one of `move`, `use`, `|`, or `||`, found keyword `let`
-  --> $DIR/block-no-opening-brace.rs:33:9
+error: expected one of `move`, `use`, `{`, `|`, or `||`, found keyword `let`
+  --> $DIR/block-no-opening-brace.rs:32:9
    |
 LL |     async
-   |          - expected one of `move`, `use`, `|`, or `||`
+   |          - expected one of `move`, `use`, `{`, `|`, or `||`
 LL |         let x = 0;
    |         ^^^ unexpected token
 

--- a/tests/ui/parser/misspelled-keywords/async-move.stderr
+++ b/tests/ui/parser/misspelled-keywords/async-move.stderr
@@ -1,8 +1,8 @@
-error: expected one of `move`, `use`, `|`, or `||`, found `Move`
+error: expected one of `move`, `use`, `{`, `|`, or `||`, found `Move`
   --> $DIR/async-move.rs:4:11
    |
 LL |     async Move {}
-   |           ^^^^ expected one of `move`, `use`, `|`, or `||`
+   |           ^^^^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
 help: write keyword `move` in lowercase
    |


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/80931