### PR TITLE
Add bootstrap option to compile a tool with features

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -382,12 +382,13 @@
 #]
 
 # Specify build configuration specific for some tool, such as enabled features.
+# This option has no effect on which tools are enabled: refer to the `tools` option for that.
 #
-# For example, to build Miri with tracing support, use `tool-config.miri.features = ["tracing"]`
+# For example, to build Miri with tracing support, use `tool.miri.features = ["tracing"]`
 #
 # The default value for the `features` array is `[]`. However, please note that other flags in
 # `bootstrap.toml` might influence the features enabled for some tools.
-#tool-config.TOOL_NAME.features = [FEATURE1, FEATURE2]
+#tool.TOOL_NAME.features = [FEATURE1, FEATURE2]
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose, 3 == print environment variables on each rustc invocation
 #verbose = 0

--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -381,6 +381,14 @@
 #    "miri", "cargo-miri" # for dev/nightly channels
 #]
 
+# Specify build configuration specific for some tool, such as enabled features.
+#
+# For example, to build Miri with tracing support, use `tool-config.miri.features = ["tracing"]`
+#
+# The default value for the `features` array is `[]`. However, please note that other flags in
+# `bootstrap.toml` might influence the features enabled for some tools.
+#tool-config.TOOL_NAME.features = [FEATURE1, FEATURE2]
+
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose, 3 == print environment variables on each rustc invocation
 #verbose = 0
 

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -136,17 +136,16 @@ impl Step for ToolBuild {
             _ => panic!("unexpected Mode for tool build"),
         }
 
-        // build.tool-config.TOOL_NAME.features in bootstrap.toml allows specifying which features
-        // to enable for a specific tool. `extra_features` instead is not controlled by the toml
-        // instead provides features that are always enabled for a specific tool (e.g.
-        // "in-rust-tree" for rust-analyzer). Finally, `prepare_tool_cargo` might add more features
-        // to adapt the build to the chosen flags (e.g. "all-static" for cargo if
-        // `cargo_native_static` is true).
+        // build.tool.TOOL_NAME.features in bootstrap.toml allows specifying which features to
+        // enable for a specific tool. `extra_features` instead is not controlled by the toml and
+        // provides features that are always enabled for a specific tool (e.g. "in-rust-tree" for
+        // rust-analyzer). Finally, `prepare_tool_cargo` might add more features to adapt the build
+        // to the chosen flags (e.g. "all-static" for cargo if `cargo_native_static` is true).
         let mut features = builder
             .config
-            .tool_config
+            .tool
             .get(self.tool)
-            .and_then(|tool_config| tool_config.features.clone())
+            .and_then(|tool| tool.features.clone())
             .unwrap_or_default();
         features.extend(self.extra_features.clone());
 

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -136,6 +136,20 @@ impl Step for ToolBuild {
             _ => panic!("unexpected Mode for tool build"),
         }
 
+        // build.tool-config.TOOL_NAME.features in bootstrap.toml allows specifying which features
+        // to enable for a specific tool. `extra_features` instead is not controlled by the toml
+        // instead provides features that are always enabled for a specific tool (e.g.
+        // "in-rust-tree" for rust-analyzer). Finally, `prepare_tool_cargo` might add more features
+        // to adapt the build to the chosen flags (e.g. "all-static" for cargo if
+        // `cargo_native_static` is true).
+        let mut features = builder
+            .config
+            .tool_config
+            .get(self.tool)
+            .and_then(|tool_config| tool_config.features.clone())
+            .unwrap_or_default();
+        features.extend(self.extra_features.clone());
+
         let mut cargo = prepare_tool_cargo(
             builder,
             self.compiler,
@@ -144,7 +158,7 @@ impl Step for ToolBuild {
             Kind::Build,
             path,
             self.source_type,
-            &self.extra_features,
+            &features,
         );
 
         // The stage0 compiler changes infrequently and does not directly depend on code

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -35,7 +35,7 @@ pub use crate::core::config::flags::Subcommand;
 use crate::core::config::flags::{Color, Flags};
 use crate::core::config::target_selection::TargetSelectionList;
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::toml::build::{Build, ToolConfig};
+use crate::core::config::toml::build::{Build, Tool};
 use crate::core::config::toml::change_id::ChangeId;
 use crate::core::config::toml::rust::{
     LldMode, RustOptimize, check_incompatible_options_for_ci_rustc,
@@ -114,7 +114,9 @@ pub struct Config {
     pub bootstrap_cache_path: Option<PathBuf>,
     pub extended: bool,
     pub tools: Option<HashSet<String>>,
-    pub tool_config: HashMap<String, ToolConfig>,
+    /// Specify build configuration specific for some tool, such as enabled features, see [Tool].
+    /// The key in the map is the name of the tool, and the value is tool-specific configuration.
+    pub tool: HashMap<String, Tool>,
     pub sanitizers: bool,
     pub profiler: bool,
     pub omit_git_hash: bool,
@@ -690,7 +692,7 @@ impl Config {
             bootstrap_cache_path,
             extended,
             tools,
-            tool_config,
+            tool,
             verbose,
             sanitizers,
             profiler,
@@ -837,7 +839,7 @@ impl Config {
         set(&mut config.full_bootstrap, full_bootstrap);
         set(&mut config.extended, extended);
         config.tools = tools;
-        set(&mut config.tool_config, tool_config);
+        set(&mut config.tool, tool);
         set(&mut config.verbose, verbose);
         set(&mut config.sanitizers, sanitizers);
         set(&mut config.profiler, profiler);

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -35,7 +35,7 @@ pub use crate::core::config::flags::Subcommand;
 use crate::core::config::flags::{Color, Flags};
 use crate::core::config::target_selection::TargetSelectionList;
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::toml::build::Build;
+use crate::core::config::toml::build::{Build, ToolConfig};
 use crate::core::config::toml::change_id::ChangeId;
 use crate::core::config::toml::rust::{
     LldMode, RustOptimize, check_incompatible_options_for_ci_rustc,
@@ -114,6 +114,7 @@ pub struct Config {
     pub bootstrap_cache_path: Option<PathBuf>,
     pub extended: bool,
     pub tools: Option<HashSet<String>>,
+    pub tool_config: HashMap<String, ToolConfig>,
     pub sanitizers: bool,
     pub profiler: bool,
     pub omit_git_hash: bool,
@@ -689,6 +690,7 @@ impl Config {
             bootstrap_cache_path,
             extended,
             tools,
+            tool_config,
             verbose,
             sanitizers,
             profiler,
@@ -835,6 +837,7 @@ impl Config {
         set(&mut config.full_bootstrap, full_bootstrap);
         set(&mut config.extended, extended);
         config.tools = tools;
+        set(&mut config.tool_config, tool_config);
         set(&mut config.verbose, verbose);
         set(&mut config.sanitizers, sanitizers);
         set(&mut config.profiler, profiler);

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -44,7 +44,7 @@ define_config! {
         bootstrap_cache_path: Option<PathBuf> = "bootstrap-cache-path",
         extended: Option<bool> = "extended",
         tools: Option<HashSet<String>> = "tools",
-        tool_config: Option<HashMap<String, ToolConfig>> = "tool-config",
+        tool: Option<HashMap<String, Tool>> = "tool",
         verbose: Option<usize> = "verbose",
         sanitizers: Option<bool> = "sanitizers",
         profiler: Option<bool> = "profiler",
@@ -75,8 +75,9 @@ define_config! {
 }
 
 define_config! {
+    /// Configuration specific for some tool, e.g. which features to enable during build.
     #[derive(Default, Clone)]
-    struct ToolConfig {
+    struct Tool {
         features: Option<Vec<String>> = "features",
     }
 }

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -6,6 +6,8 @@
 //! various feature flags. These options apply across different stages and components
 //! unless specifically overridden by other configuration sections or command-line flags.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::toml::ReplaceOpt;
@@ -42,6 +44,7 @@ define_config! {
         bootstrap_cache_path: Option<PathBuf> = "bootstrap-cache-path",
         extended: Option<bool> = "extended",
         tools: Option<HashSet<String>> = "tools",
+        tool_config: Option<HashMap<String, ToolConfig>> = "tool-config",
         verbose: Option<usize> = "verbose",
         sanitizers: Option<bool> = "sanitizers",
         profiler: Option<bool> = "profiler",
@@ -68,5 +71,12 @@ define_config! {
         compiletest_use_stage0_libtest: Option<bool> = "compiletest-use-stage0-libtest",
         ccache: Option<StringOrBool> = "ccache",
         exclude: Option<Vec<PathBuf>> = "exclude",
+    }
+}
+
+define_config! {
+    #[derive(Default, Clone)]
+    struct ToolConfig {
+        features: Option<Vec<String>> = "features",
     }
 }

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -424,6 +424,6 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
     ChangeInfo {
         change_id: 142379,
         severity: ChangeSeverity::Info,
-        summary: "Added new option `tool-config.TOOL_NAME.features` to specify the features to compile a tool with",
+        summary: "Added new option `tool.TOOL_NAME.features` to specify the features to compile a tool with",
     },
 ];

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -421,4 +421,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Added new bootstrap flag `--skip-std-check-if-no-download-rustc` that skips std checks when download-rustc is unavailable. Mainly intended for developers to reduce RA overhead.",
     },
+    ChangeInfo {
+        change_id: 142379,
+        severity: ChangeSeverity::Info,
+        summary: "Added new option `tool-config.TOOL_NAME.features` to specify the features to compile a tool with",
+    },
 ];


### PR DESCRIPTION
Add an option to specify which features to build a tool with, e.g. it will be useful to build Miri with tracing enabled:
```toml
tool-config.miri.features = ["tracing"]
```

See [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Passing.20--features.20to.20Miri.20build.20using.20.2E.2Fx.2Epy/with/523564773) for the options considered. If the final decision will be different than what I wrote now, I will update the code as needed. The reason why the option is `tool-config.miri.features` instead of something like `tool-features.miri` is to possibly allow adding more tool-specific configurations in the future.

I didn't do any validation of the keys of the `tool-config` hashmap, since I saw that no validation is done on the `tools` hashset either.

I don't like much the fact that features can be chosen by various places of the codebase: `Step`s can have some fixed `extra_features`, `prepare_tool_cargo` will add features depending on some bootstrapping options, and the newly added option can also contribute features to tools. However I think it is out of scope of this PR to try to refactor all of that (if it even is refactorable), so I left a comment in the codebase explaining all of the sources of features I could find.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
