### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -51,6 +51,9 @@ type AcceptMapping<T> = &'static [(&'static [Symbol], AcceptFn<T>)];
 /// whether it has seen the attribute it has been looking for.
 ///
 /// The state machine is automatically reset to parse attributes on the next item.
+///
+/// For a simpler attribute parsing interface, consider using [`SingleAttributeParser`]
+/// or [`CombineAttributeParser`] instead.
 pub(crate) trait AttributeParser: Default + 'static {
     /// The symbols for the attributes that this parser is interested in.
     ///
@@ -59,6 +62,12 @@ pub(crate) trait AttributeParser: Default + 'static {
 
     /// The parser has gotten a chance to accept the attributes on an item,
     /// here it can produce an attribute.
+    ///
+    /// All finalize methods of all parsers are unconditionally called.
+    /// This means you can't unconditionally return `Some` here,
+    /// that'd be equivalent to unconditionally applying an attribute to
+    /// every single syntax item that could have attributes applied to it.
+    /// Your accept mappings should determine whether this returns something.
     fn finalize(self, cx: &FinalizeContext<'_>) -> Option<AttributeKind>;
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -12,7 +12,7 @@
 //! - [`CombineAttributeParser`]: makes it easy to implement an attribute which should combine the
 //! contents of attributes, if an attribute appear multiple times in a list
 //!
-//! Attributes should be added to [`ATTRIBUTE_MAPPING`](crate::context::ATTRIBUTE_MAPPING) to be parsed.
+//! Attributes should be added to [`ATTRIBUTE_PARSERS`](crate::context::ATTRIBUTE_PARSERS) to be parsed.
 
 use std::marker::PhantomData;
 

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -58,9 +58,9 @@ pub enum MaybeEnteredSpan {
 macro_rules! enter_trace_span {
     ($machine:ident, $($tt:tt)*) => {
         if $machine::TRACING_ENABLED {
-            $crate::interpret::tracing_utils::MaybeEnteredSpan::Some(tracing::info_span!($($tt)*).entered())
+            $crate::interpret::util::MaybeEnteredSpan::Some(tracing::info_span!($($tt)*).entered())
         } else {
-            $crate::interpret::tracing_utils::MaybeEnteredSpan::None
+            $crate::interpret::util::MaybeEnteredSpan::None
         }
     }
 }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -136,7 +136,6 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
         // the AST struct that they wrap (e.g. an item)
         self.with_lint_attrs(s.id, s.attrs(), |cx| {
             lint_callback!(cx, check_stmt, s);
-            cx.check_id(s.id);
         });
         // The visitor for the AST struct wrapped
         // by the statement (e.g. `Item`) will call
@@ -147,7 +146,6 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
 
     fn visit_fn(&mut self, fk: ast_visit::FnKind<'ast>, span: Span, id: ast::NodeId) {
         lint_callback!(self, check_fn, fk, span, id);
-        self.check_id(id);
         ast_visit::walk_fn(self, fk);
     }
 

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1402,7 +1402,8 @@ impl Config {
                 // If there is a tag named after the current branch, git will try to disambiguate by prepending `heads/` to the branch name.
                 // This syntax isn't accepted by `branch.{branch}`. Strip it.
                 let branch = current_branch.stdout();
-                let branch = branch.strip_prefix("heads/").unwrap_or(&branch);
+                let branch = branch.trim();
+                let branch = branch.strip_prefix("heads/").unwrap_or(branch);
                 git.arg("-c").arg(format!("branch.{branch}.remote=origin"));
             }
             git.args(["submodule", "update", "--init", "--recursive", "--depth=1"]);

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -321,11 +321,11 @@ pub fn check_incompatible_options_for_ci_rustc(
         rpath,
         channel,
         description,
-        incremental,
         default_linker,
         std_features,
 
         // Rest of the options can simply be ignored.
+        incremental: _,
         debug: _,
         codegen_units: _,
         codegen_units_std: _,
@@ -389,7 +389,6 @@ pub fn check_incompatible_options_for_ci_rustc(
 
     warn!(current_rust_config.channel, channel, "rust");
     warn!(current_rust_config.description, description, "rust");
-    warn!(current_rust_config.incremental, incremental, "rust");
 
     Ok(())
 }

--- a/src/bootstrap/src/utils/execution_context.rs
+++ b/src/bootstrap/src/utils/execution_context.rs
@@ -6,6 +6,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::core::config::DryRun;
+#[cfg(feature = "tracing")]
+use crate::trace_cmd;
 use crate::{BehaviorOnFailure, BootstrapCommand, CommandOutput, OutputMode, exit};
 
 #[derive(Clone, Default)]

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,7 +27,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        python3 ../x.py check && \
+        BOOTSTRAP_TRACING=bootstrap=TRACE python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,7 +27,9 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        BOOTSTRAP_TRACING=bootstrap=TRACE python3 ../x.py check && \
+        # The BOOTSTRAP_TRACING flag is added to verify whether the 
+        # bootstrap process compiles successfully with this flag enabled.
+        BOOTSTRAP_TRACING=1 python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \

--- a/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-2/Dockerfile
@@ -27,9 +27,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
-        # The BOOTSTRAP_TRACING flag is added to verify whether the 
-        # bootstrap process compiles successfully with this flag enabled.
-        BOOTSTRAP_TRACING=1 python3 ../x.py check && \
+        python3 ../x.py check && \
         python3 ../x.py clippy ci && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py doc --stage 0 bootstrap && \
@@ -38,4 +36,7 @@ ENV SCRIPT \
         RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library && \
         mkdir -p /checkout/obj/staging/doc && \
         cp -r build/x86_64-unknown-linux-gnu/doc /checkout/obj/staging && \
-        RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library/test
+        RUSTDOCFLAGS=\"--document-private-items --document-hidden-items\" python3 ../x.py doc --stage 1 library/test && \
+        # The BOOTSTRAP_TRACING flag is added to verify whether the 
+        # bootstrap process compiles successfully with this flag enabled.
+        BOOTSTRAP_TRACING=1 python3 ../x.py --help

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -44,22 +44,22 @@ note: while trying to match `r#async`
 LL |     (r#async) => (1)
    |      ^^^^^^^
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2015.rs:27:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
   ::: $DIR/edition-keywords-2018-2015-parsing.rs:22:8
    |
 LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:24:24
    |
 LL |     if passes_tt!(async) == 1 {}
-   |                        ^ expected one of `move`, `use`, `|`, or `||`
+   |                        ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
 error[E0308]: mismatched types
   --> $DIR/edition-keywords-2018-2015-parsing.rs:29:33

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -44,34 +44,34 @@ note: while trying to match `r#async`
 LL |     (r#async) => (1)
    |      ^^^^^^^
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/auxiliary/edition-kw-macro-2018.rs:27:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
   ::: $DIR/edition-keywords-2018-2018-parsing.rs:29:8
    |
 LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:31:24
    |
 LL |     if passes_tt!(async) == 1 {}
-   |                        ^ expected one of `move`, `use`, `|`, or `||`
+   |                        ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:14:23
    |
 LL |     ($i: ident) => ($i)
-   |                       ^ expected one of `move`, `use`, `|`, or `||`
+   |                       ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `|`, or `||`
+error: macro expansion ends with an incomplete expression: expected one of `move`, `use`, `{`, `|`, or `||`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:35:30
    |
 LL |     if local_passes_tt!(async) == 1 {}
-   |                              ^ expected one of `move`, `use`, `|`, or `||`
+   |                              ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
 error[E0308]: mismatched types
   --> $DIR/edition-keywords-2018-2018-parsing.rs:40:33

--- a/tests/ui/parser/block-no-opening-brace.rs
+++ b/tests/ui/parser/block-no-opening-brace.rs
@@ -27,10 +27,10 @@ fn in_try() {
         let x = 0;
 }
 
-// FIXME(#80931)
 fn in_async() {
     async
-        let x = 0; //~ ERROR expected one of `move`, `use`, `|`, or `||`, found keyword `let`
+        let x = 0;
+    //~^ ERROR expected one of `move`, `use`, `{`, `|`, or `||`, found keyword `let`
 }
 
 // FIXME(#78168)

--- a/tests/ui/parser/block-no-opening-brace.stderr
+++ b/tests/ui/parser/block-no-opening-brace.stderr
@@ -43,11 +43,11 @@ error: expected expression, found reserved keyword `try`
 LL |     try
    |     ^^^ expected expression
 
-error: expected one of `move`, `use`, `|`, or `||`, found keyword `let`
-  --> $DIR/block-no-opening-brace.rs:33:9
+error: expected one of `move`, `use`, `{`, `|`, or `||`, found keyword `let`
+  --> $DIR/block-no-opening-brace.rs:32:9
    |
 LL |     async
-   |          - expected one of `move`, `use`, `|`, or `||`
+   |          - expected one of `move`, `use`, `{`, `|`, or `||`
 LL |         let x = 0;
    |         ^^^ unexpected token
 

--- a/tests/ui/parser/misspelled-keywords/async-move.stderr
+++ b/tests/ui/parser/misspelled-keywords/async-move.stderr
@@ -1,8 +1,8 @@
-error: expected one of `move`, `use`, `|`, or `||`, found `Move`
+error: expected one of `move`, `use`, `{`, `|`, or `||`, found `Move`
   --> $DIR/async-move.rs:4:11
    |
 LL |     async Move {}
-   |           ^^^^ expected one of `move`, `use`, `|`, or `||`
+   |           ^^^^ expected one of `move`, `use`, `{`, `|`, or `||`
    |
 help: write keyword `move` in lowercase
    |

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -44,29 +44,6 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
-[ping.icebreakers-llvm]
-message = """\
-Hey LLVM ICE-breakers! This bug has been identified as a good
-"LLVM ICE-breaking candidate". In case it's useful, here are some
-[instructions] for tackling these sorts of bugs. Maybe take a look?
-Thanks! <3
-
-[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/llvm.html
-"""
-label = "ICEBreaker-LLVM"
-
-[ping.icebreakers-cleanup-crew]
-alias = ["cleanup", "cleanups", "cleanup-crew", "shrink", "reduce", "bisect"]
-message = """\
-Hey Cleanup Crew ICE-breakers! This bug has been identified as a good
-"Cleanup ICE-breaking candidate". In case it's useful, here are some
-[instructions] for tackling these sorts of bugs. Maybe take a look?
-Thanks! <3
-
-[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/cleanup-crew.html
-"""
-label = "ICEBreaker-Cleanup-Crew"
-
 [ping.windows]
 message = """\
 Hey Windows Group! This bug has been identified as a good "Windows candidate".

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1231,7 +1231,6 @@ libs = [
 bootstrap = [
     "@Mark-Simulacrum",
     "@albertlarsan68",
-    "@onur-ozkan",
     "@kobzol",
     "@jieyouxu",
     "@clubby789",
@@ -1424,8 +1423,8 @@ compiletest = [
 "/src/tools/rustdoc-themes" =                            ["rustdoc"]
 "/src/tools/tidy" =                                      ["bootstrap"]
 "/src/tools/x" =                                         ["bootstrap"]
-"/src/tools/rustdoc-gui-test" =                          ["bootstrap", "@onur-ozkan"]
-"/src/tools/libcxx-version" =                            ["@onur-ozkan"]
+"/src/tools/rustdoc-gui-test" =                          ["bootstrap"]
+"/src/tools/libcxx-version" =                            ["bootstrap"]
 
 # Enable review queue tracking
 # Documentation at: https://forge.rust-lang.org/triagebot/review-queue-tracking.html


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#142305 (Remove unneeded `check_id` calls as they are already called in `visit_id` in `EarlyContextAndPass` type)
 - rust-lang/rust#142314 (remove ice group pings from `triagebot.toml`)
 - rust-lang/rust#142343 (remove myself from the project)
 - rust-lang/rust#142346 (Add tracing import to execution context)
 - rust-lang/rust#142356 (Fix enter_trace_span!() using wrong $crate paths)
 - rust-lang/rust#142362 (Add expectation for `{` when parsing lone coroutine qualifiers)
 - rust-lang/rust#142364 (Do not warn on `rust.incremental` when using download CI rustc)
 - rust-lang/rust#142369 (Improve some attribute docs and rename groups)
 - rust-lang/rust#142374 (Fix missing newline trim in bootstrap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=142305,142314,142343,142346,142356,142362,142364,142369,142374)
<!-- homu-ignore:end -->