### PR TITLE
rust: library: Add `setsid` method to `CommandExt` trait

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -210,6 +210,9 @@ pub trait CommandExt: Sealed {
     /// intentional difference from the underlying `chroot` system call.)
     #[unstable(feature = "process_chroot", issue = "141298")]
     fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command;
+
+    #[unstable(feature = "process_setsid", issue = "105376")]
+    fn setsid(&mut self, setsid: bool) -> &mut process::Command;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -258,6 +261,11 @@ impl CommandExt for process::Command {
 
     fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command {
         self.as_inner_mut().chroot(dir.as_ref());
+        self
+    }
+
+    fn setsid(&mut self, setsid: bool) -> &mut process::Command {
+        self.as_inner_mut().setsid(setsid);
         self
     }
 }

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -98,6 +98,7 @@ pub struct Command {
     #[cfg(target_os = "linux")]
     create_pidfd: bool,
     pgroup: Option<pid_t>,
+    setsid: bool,
 }
 
 // passed back to std::process with the pipes connected to the child, if any
@@ -185,6 +186,7 @@ impl Command {
             #[cfg(target_os = "linux")]
             create_pidfd: false,
             pgroup: None,
+            setsid: false,
         }
     }
 
@@ -219,6 +221,9 @@ impl Command {
         if self.cwd.is_none() {
             self.cwd(&OsStr::new("/"));
         }
+    }
+    pub fn setsid(&mut self, setsid: bool) {
+        self.setsid = setsid;
     }
 
     #[cfg(target_os = "linux")]
@@ -297,6 +302,10 @@ impl Command {
     #[allow(dead_code)]
     pub fn get_chroot(&self) -> Option<&CStr> {
         self.chroot.as_deref()
+    }
+    #[allow(dead_code)]
+    pub fn get_setsid(&self) -> bool {
+        self.setsid
     }
 
     pub fn get_closures(&mut self) -> &mut Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>> {


### PR DESCRIPTION
Add a setsid method to the CommandExt trait so that callers can create a process in a new session and process group whilst still using the POSIX spawn fast path.

Tracking issue: rust-lang/rust#105376

ACP: https://github.com/rust-lang/libs-team/issues/184

This PR was previously submitted by @HarveyHunt (whom I marked as Co-Author in the commit message) in rust-lang/rust#105377. However that PR went stale.

I applied the [suggestion](https://github.com/rust-lang/rust/pull/105377/files/231d19fcbfe155b2e85116865adae4253380ff1f#r1893457943) to change the function signature to `fn setsid(&mut self, setsid: bool) -> &mut Command`.

