### PR TITLE
Don't  give APITs names with macro expansion placeholder fragments in it

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1118,6 +1118,10 @@ pub trait ResolverExpand {
         trait_def_id: DefId,
         impl_def_id: LocalDefId,
     ) -> Result<Vec<(Ident, Option<Ident>)>, Indeterminate>;
+
+    /// Record the name of an opaque `Ty::ImplTrait` pre-expansion so that it can be used
+    /// to generate an item name later that does not reference placeholder macros.
+    fn insert_impl_trait_name(&mut self, id: NodeId, name: Symbol);
 }
 
 pub trait LintStoreExpand {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1778,6 +1778,16 @@ impl InvocationCollectorNode for ast::Ty {
         fragment.make_ty()
     }
     fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+        // Save the pre-expanded name of this `ImplTrait`, so that later when defining
+        // an APIT we use a name that doesn't have any placeholder fragments in it.
+        if let ast::TyKind::ImplTrait(..) = self.kind {
+            // HACK: pprust breaks strings with newlines when the type
+            // gets too long. We don't want these to show up in compiler
+            // output or built artifacts, so replace them here...
+            // Perhaps we should instead format APITs more robustly.
+            let name = Symbol::intern(&pprust::ty_to_string(self).replace('\n', " "));
+            collector.cx.resolver.insert_impl_trait_name(self.id, name);
+        }
         walk_ty(collector, self)
     }
     fn is_mac_call(&self) -> bool {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1224,6 +1224,11 @@ pub struct Resolver<'ra, 'tcx> {
     current_crate_outer_attr_insert_span: Span,
 
     mods_with_parse_errors: FxHashSet<DefId>,
+
+    // Stores pre-expansion and pre-placeholder-fragment-insertion names for `impl Trait` types
+    // that were encountered during resolution. These names are used to generate item names
+    // for APITs, so we don't want to leak details of resolution into these names.
+    impl_trait_names: FxHashMap<NodeId, Symbol>,
 }
 
 /// This provides memory for the rest of the crate. The `'ra` lifetime that is
@@ -1579,6 +1584,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             impl_binding_keys: Default::default(),
             current_crate_outer_attr_insert_span,
             mods_with_parse_errors: Default::default(),
+            impl_trait_names: Default::default(),
         };
 
         let root_parent_scope = ParentScope::module(graph_root, &resolver);

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -522,6 +522,10 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         });
         Ok(idents)
     }
+
+    fn insert_impl_trait_name(&mut self, id: NodeId, name: Symbol) {
+        self.impl_trait_names.insert(id, name);
+    }
 }
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {

--- a/tests/crashes/140333.rs
+++ b/tests/crashes/140333.rs
@@ -1,9 +1,0 @@
-//@ known-bug: #140333
-fn a() -> impl b<
-    [c; {
-        struct d {
-            #[a]
-            bar: e,
-        }
-    }],
->;

--- a/tests/ui/impl-trait/name-mentioning-macro.rs
+++ b/tests/ui/impl-trait/name-mentioning-macro.rs
@@ -1,0 +1,12 @@
+trait Foo<T> {}
+
+macro_rules! bar {
+    () => { () }
+}
+
+fn foo(x: impl Foo<bar!()>) {
+    let () = x;
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/name-mentioning-macro.stderr
+++ b/tests/ui/impl-trait/name-mentioning-macro.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/name-mentioning-macro.rs:8:9
+   |
+LL | fn foo(x: impl Foo<bar!()>) {
+   |           ---------------- expected this type parameter
+LL |     let () = x;
+   |         ^^   - this expression has type `impl Foo<bar!()>`
+   |         |
+   |         expected type parameter `impl Foo<bar!()>`, found `()`
+   |
+   = note: expected type parameter `impl Foo<bar!()>`
+                   found unit type `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/struct-field-fragment-in-name.rs
+++ b/tests/ui/impl-trait/struct-field-fragment-in-name.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+trait Trait<T> {}
+
+fn a(_: impl Trait<
+    [(); {
+        struct D {
+            #[rustfmt::skip]
+            bar: (),
+        }
+        0
+    }],
+>) {
+}
+
+fn main() {}


### PR DESCRIPTION
The `DefCollector` previously called `pprust::ty_to_string` to construct a name for APITs (arg-position impl traits). The `ast::Ty` that was being formatted however has already had its macro calls replaced with "placeholder fragments", which end up rendering like `!()` (or ICEing, in the case of rust-lang/rust#140333, since it led to a placeholder struct field with no name).

Instead, collect the name of the APIT *before* we visit its macros and replace them with placeholders in the macro expander. This makes the implementation a bit more involved, but AFAICT there's no better way to do this since we can't do a reverse mapping from placeholder fragment -> original macro call AST.

Fixes rust-lang/rust#140333