### PR TITLE
Cache all crates for citool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,21 @@ jobs:
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           workspaces: src/ci/citool
+          cache-all-crates: true
+          key: ${{ hashFiles('src/ci/citool/**') }}
       - name: Test citool
         # Only test citool on the auto branch, to reduce latency of the calculate matrix job
         # on PR/try builds.
         if: ${{ github.ref == 'refs/heads/auto' }}
         run: |
           cd src/ci/citool
-          CARGO_INCREMENTAL=0 cargo test
+          cargo test
       - name: Calculate the CI job matrix
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd src/ci/citool
-          CARGO_INCREMENTAL=0 cargo run calculate-job-matrix >> $GITHUB_OUTPUT
+          cargo run calculate-job-matrix >> $GITHUB_OUTPUT
         id: jobs
   job:
     name: ${{ matrix.full_name }}


### PR DESCRIPTION
Even the local workspace ones, since they almost never change.

Also remove the manual `CARGO_INCREMENTAL=0` setting, it is set automatically by `rust-cache`.

r? @marcoieni