### PR TITLE
early linting: avoid redundant calls to `check_id`

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1700,7 +1700,8 @@ fn visit_nested_use_tree<'a, V: Visitor<'a>>(
 }
 
 pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) -> V::Result {
-    let Stmt { id: _, kind, span: _ } = statement;
+    let Stmt { id, kind, span: _ } = statement;
+    try_visit!(visit_id(visitor, id));
     match kind {
         StmtKind::Let(local) => try_visit!(visitor.visit_local(local)),
         StmtKind::Item(item) => try_visit!(visitor.visit_item(item)),

--- a/tests/ui/label/label_misspelled.stderr
+++ b/tests/ui/label/label_misspelled.stderr
@@ -78,6 +78,14 @@ LL |         break for_loop;
    |               not found in this scope
    |               help: use the similarly named label: `'for_loop`
 
+warning: denote infinite loops with `loop { ... }`
+  --> $DIR/label_misspelled.rs:4:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
+   |
+   = note: `#[warn(while_true)]` on by default
+
 warning: unused label
   --> $DIR/label_misspelled.rs:4:5
    |
@@ -89,14 +97,6 @@ note: the lint level is defined here
    |
 LL | #![warn(unused_labels)]
    |         ^^^^^^^^^^^^^
-
-warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:4:5
-   |
-LL |     'while_loop: while true {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
-   |
-   = note: `#[warn(while_true)]` on by default
 
 warning: unused label
   --> $DIR/label_misspelled.rs:9:5
@@ -122,17 +122,17 @@ warning: denote infinite loops with `loop { ... }`
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
-warning: unused label
-  --> $DIR/label_misspelled.rs:47:5
-   |
-LL |     'while_loop: while true {
-   |     ^^^^^^^^^^^
-
 warning: denote infinite loops with `loop { ... }`
   --> $DIR/label_misspelled.rs:47:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:47:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^
 
 warning: unused label
   --> $DIR/label_misspelled.rs:52:5


### PR DESCRIPTION
An attempt to address the regression at https://github.com/rust-lang/rust/pull/142240#issuecomment-2964425460

r? @oli-obk

cc @nnethercote who might have a better understanding of the performance implications