### PR TITLE
Remove bootstrap adhoc group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1240,13 +1240,6 @@ libs = [
     "@thomcc",
     "@ibraheemdev",
 ]
-bootstrap = [
-    "@Mark-Simulacrum",
-    "@albertlarsan68",
-    "@kobzol",
-    "@jieyouxu",
-    "@clubby789",
-]
 infra-ci = [
     "@Mark-Simulacrum",
     "@Kobzol",


### PR DESCRIPTION
It corresponds 1:1 to the current bootstrap team, and with the new review preferences we shouldn't need it.

Discussed on Zulip.

r? @davidtwco