### PR TITLE
ignore `run-make` tests that need `std` on targets without `std`

### DIFF
--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // ignore-tidy-linelength
 
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current

--- a/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
+++ b/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // Test that `-Awarnings` suppresses warnings for unstable APIs.
 
 use run_make_support::rustc;

--- a/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // emitting an object file is not necessary if user didn't ask for one
 //
 // This test is similar to run-make/artifact-incr-cache but it doesn't

--- a/tests/run-make/artifact-incr-cache/rmake.rs
+++ b/tests/run-make/artifact-incr-cache/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // rustc should be able to emit required files (asm, llvm-*, etc) during incremental
 // compilation on the first pass by running the code gen as well as on subsequent runs -
 // extracting them from the cache

--- a/tests/run-make/bin-emit-no-symbols/rmake.rs
+++ b/tests/run-make/bin-emit-no-symbols/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When setting the crate type as a "bin" (in app.rs),
 // this could cause a bug where some symbols would not be
 // emitted in the object files. This has been fixed, and

--- a/tests/run-make/box-struct-no-segfault/rmake.rs
+++ b/tests/run-make/box-struct-no-segfault/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The crate "foo" tied to this test executes a very specific function,
 // which involves boxing an instance of the struct Foo. However,
 // this once caused a segmentation fault in cargo release builds due to an LLVM

--- a/tests/run-make/checksum-freshness/rmake.rs
+++ b/tests/run-make/checksum-freshness/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/compiler-lookup-paths-2/rmake.rs
+++ b/tests/run-make/compiler-lookup-paths-2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that extern crate declarations in Cargo without a corresponding declaration
 // in the manifest of a dependency are NOT allowed. The last rustc call does it anyways, which
 // should result in a compilation failure.

--- a/tests/run-make/compiler-lookup-paths/rmake.rs
+++ b/tests/run-make/compiler-lookup-paths/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Since #19941, rustc can accept specifications on its library search paths.
 // This test runs Rust programs with varied library dependencies, expecting them
 // to succeed or fail depending on the situation.

--- a/tests/run-make/const-trait-stable-toolchain/rmake.rs
+++ b/tests/run-make/const-trait-stable-toolchain/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test output of const super trait errors in both stable and nightly.
 // We don't want to provide suggestions on stable that only make sense in nightly.
 

--- a/tests/run-make/crate-circular-deps-link/rmake.rs
+++ b/tests/run-make/crate-circular-deps-link/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test that previously triggered a linker failure with root cause
 // similar to one found in the issue #69368.
 //

--- a/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
+++ b/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When using the flag -C linker-plugin-lto, static libraries could lose their upstream object
 // files during compilation. This bug was fixed in #53031, and this test compiles a staticlib
 // dependent on upstream, checking that the upstream object file still exists after no LTO and

--- a/tests/run-make/cross-lang-lto/rmake.rs
+++ b/tests/run-make/cross-lang-lto/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that the object files we generate are actually
 // LLVM bitcode files (as used by linker LTO plugins) when compiling with
 // -Clinker-plugin-lto.

--- a/tests/run-make/debugger-visualizer-dep-info/rmake.rs
+++ b/tests/run-make/debugger-visualizer-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that files referenced via #[debugger_visualizer] are
 // included in `--emit dep-info` output.
 // See https://github.com/rust-lang/rust/pull/111641

--- a/tests/run-make/dep-info/rmake.rs
+++ b/tests/run-make/dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This is a simple smoke test for rustc's `--emit dep-info` feature. It prints out
 // information about dependencies in a Makefile-compatible format, as a `.d` file.
 // Note that this test does not check that the `.d` file is Makefile-compatible.

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Non-regression test for issue #132920 where multiple versions of the same crate are present in
 // the dependency graph, and an unexpected error in a dependent crate caused an ICE in the
 // unsatisfied bounds diagnostics for traits present in multiple crate versions.

--- a/tests/run-make/doctests-merge/rmake.rs
+++ b/tests/run-make/doctests-merge/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::path::Path;
 
 use run_make_support::{cwd, diff, rustc, rustdoc};

--- a/tests/run-make/doctests-runtool/rmake.rs
+++ b/tests/run-make/doctests-runtool/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Tests behavior of rustdoc `--test-runtool`.
 
 use std::path::PathBuf;

--- a/tests/run-make/dump-mono-stats/rmake.rs
+++ b/tests/run-make/dump-mono-stats/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A flag named dump-mono-stats was added to the compiler in 2022, which
 // collects stats on instantiation of items and their associated costs.
 // This test checks that the output stat file exists, and that it contains

--- a/tests/run-make/duplicate-output-flavors/rmake.rs
+++ b/tests/run-make/duplicate-output-flavors/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/embed-metadata/rmake.rs
+++ b/tests/run-make/embed-metadata/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Tests the -Zembed-metadata compiler flag.
 // Tracking issue: https://github.com/rust-lang/rust/issues/139165
 

--- a/tests/run-make/embed-source-dwarf/rmake.rs
+++ b/tests/run-make/embed-source-dwarf/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //@ ignore-windows
 //@ ignore-apple
 

--- a/tests/run-make/emit-named-files/rmake.rs
+++ b/tests/run-make/emit-named-files/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::path::Path;
 
 use run_make_support::{rfs, rustc};

--- a/tests/run-make/emit-path-unhashed/rmake.rs
+++ b/tests/run-make/emit-path-unhashed/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Specifying how rustc outputs a file can be done in different ways, such as
 // the output flag or the KIND=NAME syntax. However, some of these methods used
 // to result in different hashes on output files even though they yielded the

--- a/tests/run-make/emit-stack-sizes/rmake.rs
+++ b/tests/run-make/emit-stack-sizes/rmake.rs
@@ -6,6 +6,7 @@
 // this diagnostics information should be located.
 // See https://github.com/rust-lang/rust/pull/51946
 
+//@ needs-target-std
 //@ ignore-windows
 //@ ignore-apple
 // Reason: this feature only works when the output object format is ELF.

--- a/tests/run-make/emit-to-stdout/rmake.rs
+++ b/tests/run-make/emit-to-stdout/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //! If `-o -` or `--emit KIND=-` is provided, output should be written to stdout
 //! instead. Binary output (`obj`, `llvm-bc`, `link` and `metadata`)
 //! being written this way will result in an error if stdout is a tty.

--- a/tests/run-make/env-dep-info/rmake.rs
+++ b/tests/run-make/env-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Inside dep-info emit files, #71858 made it so all accessed environment
 // variables are usefully printed. This test checks that this feature works
 // as intended by checking if the environment variables used in compilation

--- a/tests/run-make/error-found-staticlib-instead-crate/rmake.rs
+++ b/tests/run-make/error-found-staticlib-instead-crate/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When rustc is looking for a crate but is given a staticlib instead,
 // the error message should be helpful and indicate precisely the cause
 // of the compilation failure.

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test that we exit with the correct exit code for successful / unsuccessful / ICE compilations
 
 use run_make_support::{rustc, rustdoc};

--- a/tests/run-make/export/disambiguator/rmake.rs
+++ b/tests/run-make/export/disambiguator/rmake.rs
@@ -1,12 +1,7 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "2")
-        .input("app.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "2").input("app.rs").run();
 }

--- a/tests/run-make/export/extern-opt/rmake.rs
+++ b/tests/run-make/export/extern-opt/rmake.rs
@@ -1,10 +1,8 @@
-use run_make_support::{rustc, dynamic_lib_name};
+//@ needs-target-std
+use run_make_support::{dynamic_lib_name, rustc};
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
 
     rustc()
         .env("RUSTC_FORCE_RUSTC_VERSION", "2")

--- a/tests/run-make/export/simple/rmake.rs
+++ b/tests/run-make/export/simple/rmake.rs
@@ -1,12 +1,7 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "2")
-        .input("app.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "2").input("app.rs").run();
 }

--- a/tests/run-make/extern-diff-internal-name/rmake.rs
+++ b/tests/run-make/extern-diff-internal-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In the following scenario:
 // 1. The crate foo, is referenced multiple times
 // 2. --extern foo=./path/to/libbar.rlib is specified to rustc

--- a/tests/run-make/extern-flag-fun/rmake.rs
+++ b/tests/run-make/extern-flag-fun/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The --extern flag can override the default crate search of
 // the compiler and directly fetch a given path. There are a few rules
 // to follow: for example, there can't be more than one rlib, the crates must

--- a/tests/run-make/extern-flag-rename-transitive/rmake.rs
+++ b/tests/run-make/extern-flag-rename-transitive/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, baz.rs is looking for an extern crate "a" which
 // does not exist, and can only run through the --extern rustc flag
 // defining that the "a" crate is in fact just "foo". This test

--- a/tests/run-make/extern-multiple-copies/rmake.rs
+++ b/tests/run-make/extern-multiple-copies/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the rust library foo1 exists in two different locations, but only one
 // is required by the --extern flag. This test checks that the copy is ignored (as --extern
 // demands fetching only the original instance of foo1) and that no error is emitted, resulting

--- a/tests/run-make/extern-multiple-copies2/rmake.rs
+++ b/tests/run-make/extern-multiple-copies2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Almost identical to `extern-multiple-copies`, but with a variation in the --extern calls
 // and the addition of #[macro_use] in the rust code files, which used to break --extern
 // until #33625.

--- a/tests/run-make/ice-static-mir/rmake.rs
+++ b/tests/run-make/ice-static-mir/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Trying to access mid-level internal representation (MIR) in statics
 // used to cause an internal compiler error (ICE), now handled as a proper
 // error since #100211. This test checks that the correct error is printed

--- a/tests/run-make/include-all-symbols-linking/rmake.rs
+++ b/tests/run-make/include-all-symbols-linking/rmake.rs
@@ -7,6 +7,7 @@
 // See https://github.com/rust-lang/rust/pull/95604
 // See https://github.com/rust-lang/rust/issues/47384
 
+//@ needs-target-std
 //@ ignore-wasm differences in object file formats causes errors in the llvm_objdump step.
 //@ ignore-windows differences in object file formats causes errors in the llvm_objdump step.
 

--- a/tests/run-make/include-bytes-deps/rmake.rs
+++ b/tests/run-make/include-bytes-deps/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // include_bytes! and include_str! in `main.rs`
 // should register the included file as of #24423,
 // and this test checks that this is still the case.

--- a/tests/run-make/incremental-debugger-visualizer/rmake.rs
+++ b/tests/run-make/incremental-debugger-visualizer/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test ensures that changes to files referenced via #[debugger_visualizer]
 // (in this case, foo.py and foo.natvis) are picked up when compiling incrementally.
 // See https://github.com/rust-lang/rust/pull/111641

--- a/tests/run-make/inline-always-many-cgu/rmake.rs
+++ b/tests/run-make/inline-always-many-cgu/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::ffi::OsStr;
 
 use run_make_support::regex::Regex;

--- a/tests/run-make/invalid-so/rmake.rs
+++ b/tests/run-make/invalid-so/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When a fake library was given to the compiler, it would
 // result in an obscure and unhelpful error message. This test
 // creates a false "foo" dylib, and checks that the standard error

--- a/tests/run-make/invalid-staticlib/rmake.rs
+++ b/tests/run-make/invalid-staticlib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // If the static library provided is not valid (in this test,
 // created as an empty file),
 // rustc should print a normal error message and not throw

--- a/tests/run-make/invalid-symlink-search-path/rmake.rs
+++ b/tests/run-make/invalid-symlink-search-path/rmake.rs
@@ -5,6 +5,7 @@
 //
 // See https://github.com/rust-lang/rust/issues/26006
 
+//@ needs-target-std
 //@ needs-symlink
 //Reason: symlink requires elevated permission in Windows
 

--- a/tests/run-make/invalid-tmpdir-env-var/rmake.rs
+++ b/tests/run-make/invalid-tmpdir-env-var/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When the TMP (on Windows) or TMPDIR (on Unix) variable is set to an invalid
 // or non-existing directory, this used to cause an internal compiler error (ICE). After the
 // addition of proper error handling in #28430, this test checks that the expected message is

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;

--- a/tests/run-make/issue-125484-used-dependencies/rmake.rs
+++ b/tests/run-make/issue-125484-used-dependencies/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Non-regression test for issues #125474, #125484, #125646, with the repro taken from #125484. Some
 // queries use "used dependencies" while others use "speculatively loaded dependencies", and an
 // indexing ICE appeared in some cases when these were unexpectedly used in the same context.

--- a/tests/run-make/json-error-no-offset/rmake.rs
+++ b/tests/run-make/json-error-no-offset/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The byte positions in json format error logging used to have a small, difficult
 // to predict offset. This was changed to be the top of the file every time in #42973,
 // and this test checks that the measurements appearing in the standard error are correct.

--- a/tests/run-make/lib-trait-for-trait-no-ice/rmake.rs
+++ b/tests/run-make/lib-trait-for-trait-no-ice/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Inside a library, implementing a trait for another trait
 // with a lifetime used to cause an internal compiler error (ICE).
 // This test checks that this bug does not make a resurgence -

--- a/tests/run-make/link-arg/rmake.rs
+++ b/tests/run-make/link-arg/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In 2016, the rustc flag "-C link-arg" was introduced - it can be repeatedly used
 // to add single arguments to the linker. This test passes 2 arguments to the linker using it,
 // then checks that the compiler's output contains the arguments passed to it.

--- a/tests/run-make/link-args-order/rmake.rs
+++ b/tests/run-make/link-args-order/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Passing linker arguments to the compiler used to be lost or reordered in a messy way
 // as they were passed further to the linker. This was fixed in #70665, and this test
 // checks that linker arguments remain intact and in the order they were originally passed in.

--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When native libraries are passed to the linker, there used to be an annoyance
 // where multiple instances of the same library in a row would cause duplication in
 // outputs. This has been fixed, and this test checks that it stays fixed.

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{Rustc, diff, regex, rustc};
 
 fn run_rustc() -> Rustc {

--- a/tests/run-make/llvm-outputs/rmake.rs
+++ b/tests/run-make/llvm-outputs/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // test that directories get created when emitting llvm bitcode and IR
 
 use std::path::PathBuf;

--- a/tests/run-make/lto-avoid-object-duplication/rmake.rs
+++ b/tests/run-make/lto-avoid-object-duplication/rmake.rs
@@ -8,6 +8,7 @@
 // This test makes sure that functions defined in the upstream crates do not
 // appear twice in the final staticlib when listing all the symbols from it.
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: `llvm-objdump`'s output looks different on windows than on other platforms.
 // Only checking on Unix platforms should suffice.

--- a/tests/run-make/manual-crate-name/rmake.rs
+++ b/tests/run-make/manual-crate-name/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{path, rustc};
 
 fn main() {

--- a/tests/run-make/many-crates-but-no-match/rmake.rs
+++ b/tests/run-make/many-crates-but-no-match/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // An extended version of the ui/changing-crates.rs test, this test puts
 // multiple mismatching crates into the search path of crateC (A2 and A3)
 // and checks that the standard error contains helpful messages to indicate

--- a/tests/run-make/metadata-dep-info/rmake.rs
+++ b/tests/run-make/metadata-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Emitting dep-info alongside metadata would present subtle discrepancies
 // in the output file, such as the filename transforming underscores_ into hyphens-.
 // After the fix in #114750, this test checks that the emitted files are identical

--- a/tests/run-make/metadata-only-crate-no-ice/rmake.rs
+++ b/tests/run-make/metadata-only-crate-no-ice/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In a dependency hierarchy, metadata-only crates could cause an Internal
 // Compiler Error (ICE) due to a compiler bug - not correctly fetching sources for
 // metadata-only crates. This test is a minimal reproduction of a program that triggered

--- a/tests/run-make/missing-crate-dependency/rmake.rs
+++ b/tests/run-make/missing-crate-dependency/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A simple smoke test to check that rustc fails compilation
 // and outputs a helpful message when a dependency is missing
 // in a dependency chain.

--- a/tests/run-make/multiple-emits/rmake.rs
+++ b/tests/run-make/multiple-emits/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{path, rustc};
 
 fn main() {

--- a/tests/run-make/native-lib-alt-naming/rmake.rs
+++ b/tests/run-make/native-lib-alt-naming/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // On MSVC the alternative naming format for static libraries (`libfoo.a`) is accepted in addition
 // to the default format (`foo.lib`).
 

--- a/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
@@ -3,6 +3,7 @@
 // This test is the same as native-link-modifier-rustc, but without rlibs.
 // See https://github.com/rust-lang/rust/issues/99425
 
+//@ needs-target-std
 //@ ignore-apple
 // Reason: linking fails due to the unusual ".ext" staticlib name.
 

--- a/tests/run-make/native-link-modifier-verbatim-rustc/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-rustc/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `verbatim` is a native link modifier that forces rustc to only accept libraries with
 // a specified name. This test checks that this modifier works as intended.
 // This test is the same as native-link-modifier-linker, but with rlibs.

--- a/tests/run-make/no-builtins-attribute/rmake.rs
+++ b/tests/run-make/no-builtins-attribute/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `no_builtins` is an attribute related to LLVM's optimizations. In order to ensure that it has an
 // effect on link-time optimizations (LTO), it should be added to function declarations in a crate.
 // This test uses the `llvm-filecheck` tool to determine that this attribute is successfully

--- a/tests/run-make/no-builtins-lto/rmake.rs
+++ b/tests/run-make/no-builtins-lto/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The rlib produced by a no_builtins crate should be explicitly linked
 // during compilation, and as a result be present in the linker arguments.
 // See the comments inside this file for more details.

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/notify-all-emit-artifacts/rmake.rs
+++ b/tests/run-make/notify-all-emit-artifacts/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // rust should produce artifact notifications about files it was asked to --emit.
 //
 // It should work in incremental mode both on the first pass where files are generated as well

--- a/tests/run-make/optimization-remarks-dir/rmake.rs
+++ b/tests/run-make/optimization-remarks-dir/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the function `bar` has #[inline(never)] and the function `foo`
 // does not. This test outputs LLVM optimization remarks twice - first for all
 // functions (including `bar`, and the `inline` mention), and then for only `foo`

--- a/tests/run-make/overwrite-input/rmake.rs
+++ b/tests/run-make/overwrite-input/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // An attempt to set the output `-o` into a directory or a file we cannot write into should indeed
 // be an error; but not an ICE (Internal Compiler Error). This test attempts both and checks
 // that the standard error matches what is expected.

--- a/tests/run-make/parallel-rustc-no-overwrite/rmake.rs
+++ b/tests/run-make/parallel-rustc-no-overwrite/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When two instances of rustc are invoked in parallel, they
 // can conflict on their temporary files and overwrite each others',
 // leading to unsuccessful compilation. The -Z temps-dir flag adds

--- a/tests/run-make/pass-linker-flags-from-dep/rmake.rs
+++ b/tests/run-make/pass-linker-flags-from-dep/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A similar test to pass-linker-flags, testing that the `-l link-arg` flag
 // respects the order relative to other `-l` flags, but this time, the flags
 // are passed on the compilation of a dependency. This test checks that the

--- a/tests/run-make/pass-linker-flags/rmake.rs
+++ b/tests/run-make/pass-linker-flags/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks the proper function of `-l link-arg=NAME`, which, unlike
 // -C link-arg, is supposed to guarantee that the order relative to other -l
 // options will be respected. In this test, compilation fails (because none of the

--- a/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
+++ b/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // LLVM's profiling instrumentation adds a few symbols that are used by the profiler runtime.
 // Since these show up as globals in the LLVM IR, the compiler generates dllimport-related
 // __imp_ stubs for them. This can lead to linker errors because the instrumentation

--- a/tests/run-make/pretty-print-with-dep-file/rmake.rs
+++ b/tests/run-make/pretty-print-with-dep-file/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Passing --emit=dep-info to the Rust compiler should create a .d file...
 // but it failed to do so in Rust 1.69.0 when combined with -Z unpretty=expanded
 // due to a bug. This test checks that -Z unpretty=expanded does not prevent the

--- a/tests/run-make/proc-macro-three-crates/rmake.rs
+++ b/tests/run-make/proc-macro-three-crates/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A compiler bug caused the following issue:
 // If a crate A depends on crate B, and crate B
 // depends on crate C, and crate C contains a procedural

--- a/tests/run-make/remap-path-prefix-dwarf/rmake.rs
+++ b/tests/run-make/remap-path-prefix-dwarf/rmake.rs
@@ -4,6 +4,7 @@
 // It tests several cases, each of them has a detailed description attached to it.
 // See https://github.com/rust-lang/rust/pull/96867
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: the remap path prefix is not printed in the dwarf dump.
 

--- a/tests/run-make/remap-path-prefix/rmake.rs
+++ b/tests/run-make/remap-path-prefix/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Generating metadata alongside remap-path-prefix would fail to actually remap the path
 // in the metadata. After this was fixed in #85344, this test checks that "auxiliary" is being
 // successfully remapped to "/the/aux" in the rmeta files.

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //@ ignore-windows
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 

--- a/tests/run-make/reproducible-build-2/rmake.rs
+++ b/tests/run-make/reproducible-build-2/rmake.rs
@@ -6,6 +6,7 @@
 // Outputs should be identical.
 // See https://github.com/rust-lang/rust/issues/34902
 
+//@ needs-target-std
 //@ ignore-windows
 // Reasons:
 // 1. The object files are reproducible, but their paths are not, which causes

--- a/tests/run-make/resolve-rename/rmake.rs
+++ b/tests/run-make/resolve-rename/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // If a library is compiled with -C extra-filename, the rust compiler
 // will take this into account when searching for libraries. However,
 // if that library is then renamed, the rust compiler should fall back

--- a/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
+++ b/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `-Z packed_bundled_libs` is an unstable rustc flag that makes the compiler
 // only require a native library and no supplementary object files to compile.
 // This test simply checks that this flag can be passed alongside verbatim syntax

--- a/tests/run-make/rustc-macro-dep-files/rmake.rs
+++ b/tests/run-make/rustc-macro-dep-files/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // --emit dep-info used to print all macro-generated code it could
 // find as if it was part of a nonexistent file named "proc-macro source",
 // which is not a valid path. After this was fixed in #36776, this test checks

--- a/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 mod scrape;
 
 fn main() {

--- a/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-with-short-out-dir-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-short-out-dir-option/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{htmldocck, rustdoc};
 
 fn main() {

--- a/tests/run-make/share-generics-dylib/rmake.rs
+++ b/tests/run-make/share-generics-dylib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test makes sure all generic instances get re-exported from Rust dylibs for use by
 // `-Zshare-generics`. There are two rlibs (`instance_provider_a` and `instance_provider_b`)
 // which both provide an instance of `Cell<i32>::set`. There is `instance_user_dylib` which is

--- a/tests/run-make/short-ice/rmake.rs
+++ b/tests/run-make/short-ice/rmake.rs
@@ -4,6 +4,7 @@
 // was shortened down to an appropriate length.
 // See https://github.com/rust-lang/rust/issues/107910
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: the assert_eq! on line 32 fails, as error output on Windows is different.
 

--- a/tests/run-make/stable-symbol-names/rmake.rs
+++ b/tests/run-make/stable-symbol-names/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A typo in rustc caused generic symbol names to be non-deterministic -
 // that is, it was possible to compile the same file twice with no changes
 // and get outputs with different symbol names.

--- a/tests/run-make/staticlib-blank-lib/rmake.rs
+++ b/tests/run-make/staticlib-blank-lib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the static library foo is made blank, which used to cause
 // a compilation error. As the compiler now returns Ok upon encountering a blank
 // staticlib as of #12379, this test checks that compilation is successful despite

--- a/tests/run-make/staticlib-broken-bitcode/rmake.rs
+++ b/tests/run-make/staticlib-broken-bitcode/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Regression test for https://github.com/rust-lang/rust/issues/128955#issuecomment-2657811196
 // which checks that rustc can read an archive containing LLVM bitcode with a
 // newer version from the one rustc links against.

--- a/tests/run-make/staticlib-thin-archive/rmake.rs
+++ b/tests/run-make/staticlib-thin-archive/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Regression test for https://github.com/rust-lang/rust/issues/107407 which
 // checks that rustc can read thin archive. Before the object crate added thin
 // archive support rustc would add emit object files to the staticlib and after

--- a/tests/run-make/stdin-rustc/rmake.rs
+++ b/tests/run-make/stdin-rustc/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //! This test checks rustc `-` (stdin) support
 
 use std::path::PathBuf;

--- a/tests/run-make/symbol-visibility/rmake.rs
+++ b/tests/run-make/symbol-visibility/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Dynamic libraries on Rust used to export a very high amount of symbols,
 // going as far as filling the output with mangled names and generic function
 // names. After the rework of #38117, this test checks that no mangled Rust symbols

--- a/tests/run-make/symbols-include-type-name/rmake.rs
+++ b/tests/run-make/symbols-include-type-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Method names used to be obfuscated when exported into symbols,
 // leaving only an obscure `<impl>`. After the fix in #30328,
 // this test checks that method names are successfully saved in the symbol list.

--- a/tests/run-make/track-path-dep-info/rmake.rs
+++ b/tests/run-make/track-path-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks the functionality of `tracked_path::path`, a procedural macro
 // feature that adds a dependency to another file inside the procmacro. In this case,
 // the text file is added through this method, and the test checks that the compilation

--- a/tests/run-make/type-mismatch-same-crate-name/rmake.rs
+++ b/tests/run-make/type-mismatch-same-crate-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When a compilation failure deals with seemingly identical types, some helpful
 // errors should be printed.
 // The main use case of this error is when there are two crates

--- a/tests/run-make/unknown-mod-stdin/rmake.rs
+++ b/tests/run-make/unknown-mod-stdin/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Rustc displays a compilation error when it finds a `mod` (module)
 // statement referencing a file that does not exist. However, a bug from 2019
 // caused invalid `mod` statements to silently insert empty inline modules

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -10,6 +10,7 @@
 //! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
 //! those will be present in this test as well on the same platform
 
+//@ needs-target-std
 //@ ignore-windows
 //FIXME(#128911): still flakey on i686-mingw.
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -10,6 +10,7 @@
 //! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
 //! those will be present in this test as well on the same platform
 
+//@ needs-target-std
 //@ ignore-windows
 //FIXME(#128911): still flakey on i686-mingw.
 

--- a/tests/run-make/use-suggestions-rust-2018/rmake.rs
+++ b/tests/run-make/use-suggestions-rust-2018/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The compilation error caused by calling on an unimported crate
 // should have a suggestion to write, say, crate::bar::Foo instead
 // of just bar::Foo. However, this suggestion used to only appear for

--- a/tests/run-make/used/rmake.rs
+++ b/tests/run-make/used/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test ensures that the compiler is keeping static variables, even if not referenced
 // by another part of the program, in the output object file.
 //


### PR DESCRIPTION
In particular, anything that includes `none` in the target triple, and `nvptx64-nvidia-cuda`. Right now we don't cross-compile the `run-make` tests, but we want to in the future.

This uses `//@ needs-target-std` introduced in https://github.com/rust-lang/rust/pull/142297.

Useful for https://github.com/rust-lang/rust/pull/139244 and https://github.com/rust-lang/rust/pull/141856.

The modified files are based on running https://github.com/rust-lang/rust/pull/141856 locally. It might be that https://github.com/rust-lang/rust/pull/139244 uncovers some additional files, but that PR needs to be rebased (though actually I'd advice to rebase the non-test changes onto this PR, probably faster that way).

r? @jieyouxu 



<details>
  <summary>vim notes for future me</summary>

Make a file with lines like this

```
/home/folkertdev/rust/rust/tests/run-make/export/disambiguator/rmake.rs:1:1
/home/folkertdev/rust/rust/tests/run-make/invalid-so/rmake.rs:1:1
/home/folkertdev/rust/rust/tests/run-make/no-builtins-attribute/rmake.rs:1:1
/home/folkertdev/rust/rust/tests/run-make/export/extern-opt/rmake.rs:1:1
/home/folkertdev/rust/rust/tests/run-make/link-dedup/rmake.rs:1:1
```

then

```
:set errorformat=%f:%l:%c
:cfile /tmp/files-to-fix.txt
```
```
:copen
:cnext
:cprev
```

are your friends  

</details>



