### PR TITLE
Report infer ty errors during hir ty lowering

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3141,6 +3141,15 @@ pub enum TraitItemKind<'hir> {
     /// type.
     Type(GenericBounds<'hir>, Option<&'hir Ty<'hir>>),
 }
+impl TraitItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            TraitItemKind::Const(..) => "associated constant",
+            TraitItemKind::Fn(..) => "function",
+            TraitItemKind::Type(..) => "associated type",
+        }
+    }
+}
 
 // The bodies for items are stored "out of line", in a separate
 // hashmap in the `Crate`. Here we just record the hir-id of the item
@@ -3201,6 +3210,15 @@ pub enum ImplItemKind<'hir> {
     Fn(FnSig<'hir>, BodyId),
     /// An associated type.
     Type(&'hir Ty<'hir>),
+}
+impl ImplItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            ImplItemKind::Const(..) => "associated constant",
+            ImplItemKind::Fn(..) => "function",
+            ImplItemKind::Type(..) => "associated type",
+        }
+    }
 }
 
 /// A constraint on an associated item.
@@ -4525,6 +4543,16 @@ pub enum ForeignItemKind<'hir> {
     Static(&'hir Ty<'hir>, Mutability, Safety),
     /// A foreign type.
     Type,
+}
+
+impl ForeignItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            ForeignItemKind::Fn(..) => "function",
+            ForeignItemKind::Static(..) => "static variable",
+            ForeignItemKind::Type => "type",
+        }
+    }
 }
 
 /// A variable captured by a closure.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -231,7 +231,6 @@ fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) -> Result<()
         item.name = ? tcx.def_path_str(def_id)
     );
     crate::collect::lower_item(tcx, item.item_id());
-    crate::collect::reject_placeholder_type_signatures_in_item(tcx, item);
 
     let res = match item.kind {
         // Right now we check that every default trait implementation

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -29,7 +29,7 @@ use rustc_errors::{
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt, walk_generics};
+use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt};
 use rustc_hir::{self as hir, GenericParamKind, HirId, Node, PreciseCapturingArgKind};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
@@ -154,26 +154,7 @@ impl<'v> Visitor<'v> for HirPlaceholderCollector {
     }
 }
 
-/// If there are any placeholder types (`_`), emit an error explaining that this is not allowed
-/// and suggest adding type parameters in the appropriate place, taking into consideration any and
-/// all already existing generic type parameters to avoid suggesting a name that is already in use.
-pub(crate) fn placeholder_type_error<'tcx>(
-    cx: &dyn HirTyLowerer<'tcx>,
-    generics: Option<&hir::Generics<'_>>,
-    placeholder_types: Vec<Span>,
-    suggest: bool,
-    hir_ty: Option<&hir::Ty<'_>>,
-    kind: &'static str,
-) {
-    if placeholder_types.is_empty() {
-        return;
-    }
-
-    placeholder_type_error_diag(cx, generics, placeholder_types, vec![], suggest, hir_ty, kind)
-        .emit();
-}
-
-pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
+fn placeholder_type_error_diag<'cx, 'tcx>(
     cx: &'cx dyn HirTyLowerer<'tcx>,
     generics: Option<&hir::Generics<'_>>,
     placeholder_types: Vec<Span>,
@@ -245,37 +226,6 @@ pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
     err
 }
 
-pub(super) fn reject_placeholder_type_signatures_in_item<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item: &'tcx hir::Item<'tcx>,
-) {
-    let (generics, suggest) = match &item.kind {
-        hir::ItemKind::Union(_, generics, _)
-        | hir::ItemKind::Enum(_, generics, _)
-        | hir::ItemKind::TraitAlias(_, generics, _)
-        | hir::ItemKind::Trait(_, _, _, generics, ..)
-        | hir::ItemKind::Impl(hir::Impl { generics, .. })
-        | hir::ItemKind::Struct(_, generics, _) => (generics, true),
-        hir::ItemKind::TyAlias(_, generics, _) => (generics, false),
-        // `static`, `fn` and `const` are handled elsewhere to suggest appropriate type.
-        _ => return,
-    };
-
-    let mut visitor = HirPlaceholderCollector::default();
-    visitor.visit_item(item);
-
-    let icx = ItemCtxt::new(tcx, item.owner_id.def_id);
-
-    placeholder_type_error(
-        icx.lowerer(),
-        Some(generics),
-        visitor.spans,
-        suggest && !visitor.may_contain_const_infer,
-        None,
-        item.kind.descr(),
-    );
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // Utility types and common code for the above passes.
 
@@ -313,6 +263,54 @@ impl<'tcx> ItemCtxt<'tcx> {
             None => Ok(()),
         }
     }
+
+    fn report_placeholder_type_error(
+        &self,
+        placeholder_types: Vec<Span>,
+        infer_replacements: Vec<(Span, String)>,
+    ) -> ErrorGuaranteed {
+        let node = self.tcx.hir_node_by_def_id(self.item_def_id);
+        let generics = node.generics();
+        let kind_id = match node {
+            Node::GenericParam(_) | Node::WherePredicate(_) | Node::Field(_) => {
+                self.tcx.local_parent(self.item_def_id)
+            }
+            _ => self.item_def_id,
+        };
+        // FIXME: just invoke `tcx.def_descr` instead of going through the HIR
+        // Can also remove most `descr` methods then.
+        let kind = match self.tcx.hir_node_by_def_id(kind_id) {
+            Node::Item(it) => it.kind.descr(),
+            Node::ImplItem(it) => it.kind.descr(),
+            Node::TraitItem(it) => it.kind.descr(),
+            Node::ForeignItem(it) => it.kind.descr(),
+            Node::OpaqueTy(_) => "opaque type",
+            Node::Synthetic => self.tcx.def_descr(kind_id.into()),
+            node => todo!("{node:#?}"),
+        };
+        let mut diag = placeholder_type_error_diag(
+            self,
+            generics,
+            placeholder_types,
+            infer_replacements.iter().map(|&(span, _)| span).collect(),
+            false,
+            None,
+            kind,
+        );
+        if !infer_replacements.is_empty() {
+            diag.multipart_suggestion(
+                format!(
+                    "try replacing `_` with the type{} in the corresponding trait method \
+                        signature",
+                    rustc_errors::pluralize!(infer_replacements.len()),
+                ),
+                infer_replacements,
+                Applicability::MachineApplicable,
+            );
+        }
+
+        diag.emit()
+    }
 }
 
 impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
@@ -346,10 +344,14 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     }
 
     fn ty_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Ty<'tcx> {
+        if !self.tcx.dcx().has_stashed_diagnostic(span, StashKey::ItemNoType) {
+            self.report_placeholder_type_error(vec![span], vec![]);
+        }
         Ty::new_error_with_message(self.tcx(), span, "bad placeholder type")
     }
 
     fn ct_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Const<'tcx> {
+        self.report_placeholder_type_error(vec![span], vec![]);
         ty::Const::new_error_with_message(self.tcx(), span, "bad placeholder constant")
     }
 
@@ -524,18 +526,13 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     fn lower_fn_sig(
         &self,
         decl: &hir::FnDecl<'tcx>,
-        generics: Option<&hir::Generics<'_>>,
+        _generics: Option<&hir::Generics<'_>>,
         hir_id: rustc_hir::HirId,
-        hir_ty: Option<&hir::Ty<'_>>,
+        _hir_ty: Option<&hir::Ty<'_>>,
     ) -> (Vec<Ty<'tcx>>, Ty<'tcx>) {
         let tcx = self.tcx();
-        // We proactively collect all the inferred type params to emit a single error per fn def.
-        let mut visitor = HirPlaceholderCollector::default();
-        let mut infer_replacements = vec![];
 
-        if let Some(generics) = generics {
-            walk_generics(&mut visitor, generics);
-        }
+        let mut infer_replacements = vec![];
 
         let input_tys = decl
             .inputs
@@ -551,8 +548,6 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                     }
                 }
 
-                // Only visit the type looking for `_` if we didn't fix the type above
-                visitor.visit_ty_unambig(a);
                 self.lowerer().lower_ty(a)
             })
             .collect();
@@ -566,42 +561,15 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                     infer_replacements.push((output.span, suggested_ty.to_string()));
                     Ty::new_error_with_message(tcx, output.span, suggested_ty.to_string())
                 } else {
-                    visitor.visit_ty_unambig(output);
                     self.lower_ty(output)
                 }
             }
             hir::FnRetTy::DefaultReturn(..) => tcx.types.unit,
         };
 
-        if !(visitor.spans.is_empty() && infer_replacements.is_empty()) {
-            // We check for the presence of
-            // `ident_span` to not emit an error twice when we have `fn foo(_: fn() -> _)`.
-
-            let mut diag = crate::collect::placeholder_type_error_diag(
-                self,
-                generics,
-                visitor.spans,
-                infer_replacements.iter().map(|(s, _)| *s).collect(),
-                !visitor.may_contain_const_infer,
-                hir_ty,
-                "function",
-            );
-
-            if !infer_replacements.is_empty() {
-                diag.multipart_suggestion(
-                    format!(
-                        "try replacing `_` with the type{} in the corresponding trait method \
-                         signature",
-                        rustc_errors::pluralize!(infer_replacements.len()),
-                    ),
-                    infer_replacements,
-                    Applicability::MachineApplicable,
-                );
-            }
-
-            diag.emit();
+        if !infer_replacements.is_empty() {
+            self.report_placeholder_type_error(vec![], infer_replacements);
         }
-
         (input_tys, output_ty)
     }
 
@@ -652,7 +620,6 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
     let it = tcx.hir_item(item_id);
     debug!(item = ?it.kind.ident(), id = %it.hir_id());
     let def_id = item_id.owner_id.def_id;
-    let icx = ItemCtxt::new(tcx, def_id);
 
     match &it.kind {
         // These don't define types.
@@ -678,16 +645,6 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                     }
                     hir::ForeignItemKind::Static(..) => {
                         tcx.ensure_ok().codegen_fn_attrs(item.owner_id);
-                        let mut visitor = HirPlaceholderCollector::default();
-                        visitor.visit_foreign_item(item);
-                        placeholder_type_error(
-                            icx.lowerer(),
-                            None,
-                            visitor.spans,
-                            false,
-                            None,
-                            "static variable",
-                        );
                     }
                     _ => (),
                 }
@@ -741,22 +698,10 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             tcx.ensure_ok().predicates_of(def_id);
         }
 
-        hir::ItemKind::Static(_, _, ty, _) | hir::ItemKind::Const(_, _, ty, _) => {
+        hir::ItemKind::Static(..) | hir::ItemKind::Const(..) => {
             tcx.ensure_ok().generics_of(def_id);
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().predicates_of(def_id);
-            if !ty.is_suggestable_infer_ty() {
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_item(it);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    it.kind.descr(),
-                );
-            }
         }
 
         hir::ItemKind::Fn { .. } => {
@@ -773,7 +718,6 @@ pub(crate) fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId)
     let trait_item = tcx.hir_trait_item(trait_item_id);
     let def_id = trait_item_id.owner_id;
     tcx.ensure_ok().generics_of(def_id);
-    let icx = ItemCtxt::new(tcx, def_id.def_id);
 
     match trait_item.kind {
         hir::TraitItemKind::Fn(..) => {
@@ -782,58 +726,19 @@ pub(crate) fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId)
             tcx.ensure_ok().fn_sig(def_id);
         }
 
-        hir::TraitItemKind::Const(ty, body_id) => {
+        hir::TraitItemKind::Const(..) => {
             tcx.ensure_ok().type_of(def_id);
-            if !tcx.dcx().has_stashed_diagnostic(ty.span, StashKey::ItemNoType)
-                && !(ty.is_suggestable_infer_ty() && body_id.is_some())
-            {
-                // Account for `const C: _;`.
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_trait_item(trait_item);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    "associated constant",
-                );
-            }
         }
 
         hir::TraitItemKind::Type(_, Some(_)) => {
             tcx.ensure_ok().item_bounds(def_id);
             tcx.ensure_ok().item_self_bounds(def_id);
             tcx.ensure_ok().type_of(def_id);
-            // Account for `type T = _;`.
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_trait_item(trait_item);
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
         }
 
         hir::TraitItemKind::Type(_, None) => {
             tcx.ensure_ok().item_bounds(def_id);
             tcx.ensure_ok().item_self_bounds(def_id);
-            // #74612: Visit and try to find bad placeholders
-            // even if there is no concrete type.
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_trait_item(trait_item);
-
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
         }
     };
 
@@ -846,41 +751,13 @@ pub(super) fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
     tcx.ensure_ok().type_of(def_id);
     tcx.ensure_ok().predicates_of(def_id);
     let impl_item = tcx.hir_impl_item(impl_item_id);
-    let icx = ItemCtxt::new(tcx, def_id.def_id);
     match impl_item.kind {
         hir::ImplItemKind::Fn(..) => {
             tcx.ensure_ok().codegen_fn_attrs(def_id);
             tcx.ensure_ok().fn_sig(def_id);
         }
-        hir::ImplItemKind::Type(_) => {
-            // Account for `type T = _;`
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_impl_item(impl_item);
-
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
-        }
-        hir::ImplItemKind::Const(ty, _) => {
-            // Account for `const T: _ = ..;`
-            if !ty.is_suggestable_infer_ty() {
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_impl_item(impl_item);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    "associated constant",
-                );
-            }
-        }
+        hir::ImplItemKind::Type(_) => {}
+        hir::ImplItemKind::Const(..) => {}
     }
 }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -768,6 +768,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn def_kind_descr(self, def_kind: DefKind, def_id: DefId) -> &'static str {
         match def_kind {
             DefKind::AssocFn if self.associated_item(def_id).is_method() => "method",
+            DefKind::AssocTy if self.opt_rpitit_info(def_id).is_some() => "opaque type",
             DefKind::Closure if let Some(coroutine_kind) = self.coroutine_kind(def_id) => {
                 match coroutine_kind {
                     hir::CoroutineKind::Desugared(

--- a/tests/ui/async-await/issues/issue-95307.rs
+++ b/tests/ui/async-await/issues/issue-95307.rs
@@ -5,7 +5,10 @@
 
 pub trait C {
     async fn new() -> [u8; _];
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
 }
 
 fn main() {}

--- a/tests/ui/async-await/issues/issue-95307.stderr
+++ b/tests/ui/async-await/issues/issue-95307.stderr
@@ -1,9 +1,33 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
   --> $DIR/issue-95307.rs:7:28
    |
 LL |     async fn new() -> [u8; _];
    |                            ^ not allowed in type signatures
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.rs
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.rs
@@ -41,6 +41,7 @@ trait TyAssocConst {
 trait TyAssocConstMixed {
     const ARR: Bar<_, _>;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 trait AssocTy {
@@ -57,4 +58,5 @@ impl AssocTy for i16 {
 impl AssocTy for i32 {
     type Assoc = Bar<_, _>;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -103,24 +103,28 @@ LL + static TY_STATIC_MIXED: Bar<i32, 3> = Bar::<i32, 3>(0);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:50:23
+  --> $DIR/in-signature.rs:51:23
    |
 LL |     type Assoc = [u8; _];
    |                       ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:54:27
+  --> $DIR/in-signature.rs:55:27
    |
 LL |     type Assoc = Bar<i32, _>;
    |                           ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:58:22
+  --> $DIR/in-signature.rs:59:22
    |
 LL |     type Assoc = Bar<_, _>;
-   |                      ^  ^ not allowed in type signatures
-   |                      |
-   |                      not allowed in type signatures
+   |                      ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/in-signature.rs:59:25
+   |
+LL |     type Assoc = Bar<_, _>;
+   |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/in-signature.rs:34:21
@@ -138,10 +142,14 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/in-signature.rs:42:20
    |
 LL |     const ARR: Bar<_, _>;
-   |                    ^  ^ not allowed in type signatures
-   |                    |
-   |                    not allowed in type signatures
+   |                    ^ not allowed in type signatures
 
-error: aborting due to 15 previous errors
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/in-signature.rs:42:23
+   |
+LL |     const ARR: Bar<_, _>;
+   |                       ^ not allowed in type signatures
+
+error: aborting due to 17 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -240,96 +240,52 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/bad-assoc-ty.rs:56:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:59:34
+  --> $DIR/bad-assoc-ty.rs:56:16
+   |
+LL | fn foo<X: K<_, _>>(x: X) {}
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:60:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn bar<F>(_: F) where F: Fn() -> _ {}
-LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:62:19
+  --> $DIR/bad-assoc-ty.rs:63:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn baz<F: Fn() -> _>(_: F) {}
-LL + fn baz<F: Fn() -> T, T>(_: F) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:65:33
+  --> $DIR/bad-assoc-ty.rs:66:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct L<F>(F) where F: Fn() -> _;
-LL + struct L<F, T>(F) where F: Fn() -> T;
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:87:38
-   |
-LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
-   |                                      ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn foo<F>(_: F) where F: Fn() -> _ {}
-LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:67:30
+  --> $DIR/bad-assoc-ty.rs:68:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct M<F> where F: Fn() -> _ {
-LL + struct M<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:71:28
+  --> $DIR/bad-assoc-ty.rs:72:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - enum N<F> where F: Fn() -> _ {
-LL + enum N<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - union O<F> where F: Fn() -> _ {
-LL + union O<F, T> where F: Fn() -> T {
-   |
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/bad-assoc-ty.rs:78:5
+  --> $DIR/bad-assoc-ty.rs:79:5
    |
 LL |     foo: F,
    |     ^^^^^^
@@ -341,18 +297,18 @@ LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:82:29
+  --> $DIR/bad-assoc-ty.rs:83:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - trait P<F> where F: Fn() -> _ {
-LL + trait P<F, T> where F: Fn() -> T {
-   |
 
-error: aborting due to 29 previous errors; 1 warning emitted
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:88:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+
+error: aborting due to 30 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0121, E0223, E0740.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
@@ -222,96 +222,52 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/bad-assoc-ty.rs:56:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:59:34
+  --> $DIR/bad-assoc-ty.rs:56:16
+   |
+LL | fn foo<X: K<_, _>>(x: X) {}
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:60:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn bar<F>(_: F) where F: Fn() -> _ {}
-LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:62:19
+  --> $DIR/bad-assoc-ty.rs:63:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn baz<F: Fn() -> _>(_: F) {}
-LL + fn baz<F: Fn() -> T, T>(_: F) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:65:33
+  --> $DIR/bad-assoc-ty.rs:66:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct L<F>(F) where F: Fn() -> _;
-LL + struct L<F, T>(F) where F: Fn() -> T;
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:87:38
-   |
-LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
-   |                                      ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn foo<F>(_: F) where F: Fn() -> _ {}
-LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:67:30
+  --> $DIR/bad-assoc-ty.rs:68:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct M<F> where F: Fn() -> _ {
-LL + struct M<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:71:28
+  --> $DIR/bad-assoc-ty.rs:72:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - enum N<F> where F: Fn() -> _ {
-LL + enum N<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - union O<F> where F: Fn() -> _ {
-LL + union O<F, T> where F: Fn() -> T {
-   |
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/bad-assoc-ty.rs:78:5
+  --> $DIR/bad-assoc-ty.rs:79:5
    |
 LL |     foo: F,
    |     ^^^^^^
@@ -323,18 +279,18 @@ LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:82:29
+  --> $DIR/bad-assoc-ty.rs:83:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - trait P<F> where F: Fn() -> _ {
-LL + trait P<F, T> where F: Fn() -> T {
-   |
 
-error: aborting due to 29 previous errors
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:88:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+
+error: aborting due to 30 previous errors
 
 Some errors have detailed explanations: E0121, E0223, E0740, E0782.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -55,6 +55,7 @@ type I = ty!()::AssocTy;
 trait K<A, B> {}
 fn foo<X: K<_, _>>(x: X) {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 fn bar<F>(_: F) where F: Fn() -> _ {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions

--- a/tests/ui/fn/error-recovery-mismatch.stderr
+++ b/tests/ui/fn/error-recovery-mismatch.stderr
@@ -34,12 +34,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn fold<T>(&self, _: T, &self._) {}
    |                                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fold<T>(&self, _: T, &self._) {}
-LL +     fn fold<T, U>(&self, _: T, &self.U) {}
-   |
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
+++ b/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
@@ -30,12 +30,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn mainIterator<_ = _> {}
    |                     ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn mainIterator<_ = _> {}
-LL + fn mainIterator<T = T> {}
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
+++ b/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
@@ -5,7 +5,7 @@ LL |     ().publish_typed();
    |        ^^^^^^^^^^^^^ cannot infer type of the type parameter `F` declared on the method `publish_typed`
    |
    = note: cannot satisfy `_: Clone`
-   = note: associated types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   = note: opaque types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
 note: required by a bound in `TypedClient::publish_typed::{anon_assoc#0}`
   --> $DIR/not-inferred-generic.rs:4:12
    |

--- a/tests/ui/macros/issue-118048.rs
+++ b/tests/ui/macros/issue-118048.rs
@@ -6,5 +6,6 @@ macro_rules! foo {
 
 foo!(_);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 fn main() {}

--- a/tests/ui/macros/issue-118048.stderr
+++ b/tests/ui/macros/issue-118048.stderr
@@ -2,20 +2,16 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-118048.rs:7:6
    |
 LL | foo!(_);
-   |      ^
-   |      |
-   |      not allowed in type signatures
-   |      not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~         fn foo<T>(_: $ty, _: $ty) {}
-LL |     }
-LL | }
-LL |
-LL ~ foo!(T);
-   |
+   |      ^ not allowed in type signatures
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/issue-118048.rs:7:6
+   |
+LL | foo!(_);
+   |      ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/macros/macro-span-issue-116502.rs
+++ b/tests/ui/macros/macro-span-issue-116502.rs
@@ -5,6 +5,8 @@ fn bug() {
     macro_rules! m {
         () => {
             _ //~ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+            //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+            //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
         };
     }
     struct S<T = m!()>(m!(), T)

--- a/tests/ui/macros/macro-span-issue-116502.stderr
+++ b/tests/ui/macros/macro-span-issue-116502.stderr
@@ -2,22 +2,35 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/macro-span-issue-116502.rs:7:13
    |
 LL |             _
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             not allowed in type signatures
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 ...
-LL |     struct S<T = m!()>(m!(), T)
-   |                  ----  ---- in this macro invocation
-   |                  |
-   |                  in this macro invocation
-LL |     where
 LL |         T: Trait<m!()>;
    |                  ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
+   |                        ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
+   |                  ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/self/self-infer.stderr
+++ b/tests/ui/self/self-infer.stderr
@@ -3,24 +3,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn f(self: _) {}
    |                ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn f(self: _) {}
-LL +     fn f<T>(self: T) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/self-infer.rs:5:17
    |
 LL |     fn g(self: &_) {}
    |                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn g(self: &_) {}
-LL +     fn g<T>(self: &T) {}
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -3,12 +3,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn bar(s: _) {}
    |               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn bar(s: _) {}
-LL +     fn bar<T>(s: T) {}
-   |
 
 error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 0
   --> $DIR/bad-infer-in-trait-impl.rs:6:15

--- a/tests/ui/typeck/issue-74086.rs
+++ b/tests/ui/typeck/issue-74086.rs
@@ -1,5 +1,4 @@
 fn main() {
     static BUG: fn(_) -> u8 = |_| 8;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR the placeholder `_` is not allowed within types on item signatures for static items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static items
 }

--- a/tests/ui/typeck/issue-74086.stderr
+++ b/tests/ui/typeck/issue-74086.stderr
@@ -1,15 +1,9 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-74086.rs:2:20
-   |
-LL |     static BUG: fn(_) -> u8 = |_| 8;
-   |                    ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
   --> $DIR/issue-74086.rs:2:20
    |
 LL |     static BUG: fn(_) -> u8 = |_| 8;
    |                    ^ not allowed in type signatures
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/issue-81885.rs
+++ b/tests/ui/typeck/issue-81885.rs
@@ -1,9 +1,7 @@
 const TEST4: fn() -> _ = 42;
-                  //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-                  //~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 
 fn main() {
     const TEST5: fn() -> _ = 42;
-                      //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-                      //~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 }

--- a/tests/ui/typeck/issue-81885.stderr
+++ b/tests/ui/typeck/issue-81885.stderr
@@ -1,27 +1,15 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-81885.rs:1:22
-   |
-LL | const TEST4: fn() -> _ = 42;
-   |                      ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
   --> $DIR/issue-81885.rs:1:22
    |
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-81885.rs:6:26
-   |
-LL |     const TEST5: fn() -> _ = 42;
-   |                          ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
-  --> $DIR/issue-81885.rs:6:26
+  --> $DIR/issue-81885.rs:5:26
    |
 LL |     const TEST5: fn() -> _ = 42;
    |                          ^ not allowed in type signatures
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/type-placeholder-fn-in-const.rs
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.rs
@@ -2,14 +2,12 @@ struct MyStruct;
 
 trait Test {
     const TEST: fn() -> _;
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 impl Test for MyStruct {
     const TEST: fn() -> _ = 42;
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 fn main() {}

--- a/tests/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -1,17 +1,5 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
-   |
-LL |     const TEST: fn() -> _ = 42;
-   |                         ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:4:25
-   |
-LL |     const TEST: fn() -> _;
-   |                         ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+  --> $DIR/type-placeholder-fn-in-const.rs:9:25
    |
 LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
@@ -22,6 +10,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -33,7 +33,6 @@ fn test7(x: _) { let _x: usize = x; }
 
 fn test8(_f: fn() -> _) { }
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-//~^^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 struct Test9;
 
@@ -67,6 +66,8 @@ struct Test10 {
     a: _,
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
     b: (_, _),
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
 }
 
 pub fn main() {
@@ -99,7 +100,6 @@ pub fn main() {
 
     fn fn_test8(_f: fn() -> _) { }
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-    //~^^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
     struct FnTest9;
 
@@ -123,6 +123,8 @@ pub fn main() {
         a: _,
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
         b: (_, _),
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+        //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
     }
 
     fn fn_test11(_: _) -> (_, _) { panic!() }
@@ -141,12 +143,14 @@ trait T {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn method_test2(&self, x: _) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn method_test3(&self) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test1(x: _);
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test2(x: _) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test3() -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 }
@@ -158,9 +162,11 @@ trait BadTrait<_> {}
 //~^ ERROR expected identifier, found reserved identifier `_`
 impl BadTrait<_> for BadStruct<_> {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for implementations
 
 fn impl_trait() -> impl BadTrait<_> {
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
     unimplemented!()
 }
 
@@ -180,7 +186,8 @@ struct Struct;
 trait Trait<T> {}
 impl Trait<usize> for Struct {}
 type Y = impl Trait<_>;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for type aliases
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
 #[define_opaque(Y)]
 fn foo() -> Y {
     Struct
@@ -197,6 +204,7 @@ trait Qux {
     // type E: _; // FIXME: make the parser propagate the existence of `B`
     type F: std::ops::Fn(_);
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
     //~^ ERROR not all trait items implemented, missing: `F`

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -1,35 +1,35 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:154:18
+  --> $DIR/typeck_type_placeholder_item.rs:158:18
    |
 LL | struct BadStruct<_>(_);
    |                  ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:157:16
+  --> $DIR/typeck_type_placeholder_item.rs:161:16
    |
 LL | trait BadTrait<_> {}
    |                ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:167:19
+  --> $DIR/typeck_type_placeholder_item.rs:173:19
    |
 LL | struct BadStruct1<_, _>(_);
    |                   ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:167:22
+  --> $DIR/typeck_type_placeholder_item.rs:173:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                      ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:172:19
+  --> $DIR/typeck_type_placeholder_item.rs:178:19
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:207:5
+  --> $DIR/typeck_type_placeholder_item.rs:215:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -37,7 +37,7 @@ LL |     const C: _;
    |               help: provide a definition for the constant: `= <expr>;`
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/typeck_type_placeholder_item.rs:167:22
+  --> $DIR/typeck_type_placeholder_item.rs:173:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                   -  ^ already used
@@ -106,72 +106,87 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn test6(_: _) { }
    |             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6(_: _) { }
-LL + fn test6<T>(_: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:25:18
    |
 LL | fn test6_b<T>(_: _, _: T) { }
    |                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6_b<T>(_: _, _: T) { }
-LL + fn test6_b<T, U>(_: U, _: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:28:30
    |
 LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
-LL + fn test6_c<T, K, L, A, B, U>(_: U, _: (T, K, L, A, B)) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:31:13
    |
 LL | fn test7(x: _) { let _x: usize = x; }
    |             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test7(x: _) { let _x: usize = x; }
-LL + fn test7<T>(x: T) { let _x: usize = x; }
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:34:22
-   |
-LL | fn test8(_f: fn() -> _) { }
-   |                      ^
-   |                      |
-   |                      not allowed in type signatures
-   |                      help: use type parameters instead: `T`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:34:22
    |
 LL | fn test8(_f: fn() -> _) { }
    |                      ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:66:8
    |
-help: use type parameters instead
+LL |     a: _,
+   |        ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:9
    |
-LL - fn test8(_f: fn() -> _) { }
-LL + fn test8<T>(_f: fn() -> T) { }
+LL |     b: (_, _),
+   |         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:12
    |
+LL |     b: (_, _),
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:123:12
+   |
+LL |         a: _,
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:13
+   |
+LL |         b: (_, _),
+   |             ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:16
+   |
+LL |         b: (_, _),
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:158:21
+   |
+LL | struct BadStruct<_>(_);
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:173:25
+   |
+LL | struct BadStruct1<_, _>(_);
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:178:25
+   |
+LL | struct BadStruct2<_, T>(_, T);
+   |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:48:26
+  --> $DIR/typeck_type_placeholder_item.rs:47:26
    |
 LL | fn test11(x: &usize) -> &_ {
    |                         -^
@@ -180,7 +195,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         help: replace with the correct return type: `&&usize`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:53:52
+  --> $DIR/typeck_type_placeholder_item.rs:52:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      --------------^
@@ -189,7 +204,7 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      help: replace with the correct return type: `*const *const usize`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:59:24
+  --> $DIR/typeck_type_placeholder_item.rs:58:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
    |                        ^ not allowed in type signatures
@@ -201,7 +216,7 @@ LL +     fn clone(&self) -> Test9 { Test9 }
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:62:37
+  --> $DIR/typeck_type_placeholder_item.rs:61:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
    |                                     ^ not allowed in type signatures
@@ -212,33 +227,14 @@ LL -     fn clone_from(&mut self, other: _) { *self = Test9; }
 LL +     fn clone_from(&mut self, other: &Test9) { *self = Test9; }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:67:8
-   |
-LL |     a: _,
-   |        ^ not allowed in type signatures
-LL |
-LL |     b: (_, _),
-   |         ^  ^ not allowed in type signatures
-   |         |
-   |         not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~ struct Test10<T> {
-LL ~     a: T,
-LL |
-LL ~     b: (T, T),
-   |
-
 error: missing type for `static` item
-  --> $DIR/typeck_type_placeholder_item.rs:73:13
+  --> $DIR/typeck_type_placeholder_item.rs:74:13
    |
 LL |     static A = 42;
    |             ^ help: provide a type for the static variable: `: i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:75:15
+  --> $DIR/typeck_type_placeholder_item.rs:76:15
    |
 LL |     static B: _ = 42;
    |               ^ not allowed in type signatures
@@ -250,7 +246,7 @@ LL +     static B: i32 = 42;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:77:22
+  --> $DIR/typeck_type_placeholder_item.rs:78:22
    |
 LL |     static C: Option<_> = Some(42);
    |                      ^ not allowed in type signatures
@@ -262,7 +258,7 @@ LL +     static C: Option<i32> = Some(42);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:79:21
+  --> $DIR/typeck_type_placeholder_item.rs:80:21
    |
 LL |     fn fn_test() -> _ { 5 }
    |                     ^
@@ -271,7 +267,7 @@ LL |     fn fn_test() -> _ { 5 }
    |                     help: replace with the correct return type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:82:23
+  --> $DIR/typeck_type_placeholder_item.rs:83:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      -^--^-
@@ -281,7 +277,7 @@ LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:85:22
+  --> $DIR/typeck_type_placeholder_item.rs:86:22
    |
 LL |     static FN_TEST3: _ = "test";
    |                      ^ not allowed in type signatures
@@ -293,7 +289,7 @@ LL +     static FN_TEST3: &str = "test";
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:88:22
+  --> $DIR/typeck_type_placeholder_item.rs:89:22
    |
 LL |     static FN_TEST4: _ = 145;
    |                      ^ not allowed in type signatures
@@ -305,7 +301,7 @@ LL +     static FN_TEST4: i32 = 145;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:91:23
+  --> $DIR/typeck_type_placeholder_item.rs:92:23
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
    |                       ^  ^ not allowed in type signatures
@@ -319,49 +315,22 @@ LL +     static FN_TEST5: (i32, i32) = (1, 2);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:94:20
+  --> $DIR/typeck_type_placeholder_item.rs:95:20
    |
 LL |     fn fn_test6(_: _) { }
    |                    ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test6(_: _) { }
-LL +     fn fn_test6<T>(_: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:97:20
+  --> $DIR/typeck_type_placeholder_item.rs:98:20
    |
 LL |     fn fn_test7(x: _) { let _x: usize = x; }
    |                    ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test7(x: _) { let _x: usize = x; }
-LL +     fn fn_test7<T>(x: T) { let _x: usize = x; }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:100:29
-   |
-LL |     fn fn_test8(_f: fn() -> _) { }
-   |                             ^
-   |                             |
-   |                             not allowed in type signatures
-   |                             help: use type parameters instead: `T`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:100:29
+  --> $DIR/typeck_type_placeholder_item.rs:101:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test8(_f: fn() -> _) { }
-LL +     fn fn_test8<T>(_f: fn() -> T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:115:28
@@ -387,33 +356,14 @@ LL -         fn clone_from(&mut self, other: _) { *self = FnTest9; }
 LL +         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:123:12
-   |
-LL |         a: _,
-   |            ^ not allowed in type signatures
-LL |
-LL |         b: (_, _),
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~     struct FnTest10<T> {
-LL ~         a: T,
-LL |
-LL ~         b: (T, T),
-   |
-
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:128:21
+  --> $DIR/typeck_type_placeholder_item.rs:130:21
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                     ^ cannot infer type
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:128:28
+  --> $DIR/typeck_type_placeholder_item.rs:130:28
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            ^  ^ not allowed in type signatures
@@ -421,7 +371,7 @@ LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:132:30
+  --> $DIR/typeck_type_placeholder_item.rs:134:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             -^--^-
@@ -431,7 +381,7 @@ LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:135:33
+  --> $DIR/typeck_type_placeholder_item.rs:137:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           ------^-
@@ -439,152 +389,116 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:154:21
-   |
-LL | struct BadStruct<_>(_);
-   |                     ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct<_>(_);
-LL + struct BadStruct<T>(T);
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:140:31
-   |
-LL |     fn method_test1(&self, x: _);
-   |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test1(&self, x: _);
-LL +     fn method_test1<T>(&self, x: T);
-   |
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:142:31
    |
-LL |     fn method_test2(&self, x: _) -> _;
-   |                               ^     ^ not allowed in type signatures
-   |                               |
-   |                               not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test2(&self, x: _) -> _;
-LL +     fn method_test2<T>(&self, x: T) -> T;
-   |
+LL |     fn method_test1(&self, x: _);
+   |                               ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:144:31
    |
-LL |     fn method_test3(&self) -> _;
+LL |     fn method_test2(&self, x: _) -> _;
    |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test3(&self) -> _;
-LL +     fn method_test3<T>(&self) -> T;
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:146:26
+  --> $DIR/typeck_type_placeholder_item.rs:144:37
+   |
+LL |     fn method_test2(&self, x: _) -> _;
+   |                                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:147:31
+   |
+LL |     fn method_test3(&self) -> _;
+   |                               ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:149:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test1(x: _);
-LL +     fn assoc_fn_test1<T>(x: T);
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:148:26
+  --> $DIR/typeck_type_placeholder_item.rs:151:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
-   |                          ^     ^ not allowed in type signatures
-   |                          |
-   |                          not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test2(x: _) -> _;
-LL +     fn assoc_fn_test2<T>(x: T) -> T;
-   |
+   |                          ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:150:28
+  --> $DIR/typeck_type_placeholder_item.rs:151:32
+   |
+LL |     fn assoc_fn_test2(x: _) -> _;
+   |                                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:154:28
    |
 LL |     fn assoc_fn_test3() -> _;
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test3() -> _;
-LL +     fn assoc_fn_test3<T>() -> T;
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
-  --> $DIR/typeck_type_placeholder_item.rs:159:15
+  --> $DIR/typeck_type_placeholder_item.rs:163:32
    |
 LL | impl BadTrait<_> for BadStruct<_> {}
-   |               ^                ^ not allowed in type signatures
-   |               |
-   |               not allowed in type signatures
+   |                                ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:162:34
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/typeck_type_placeholder_item.rs:163:15
+   |
+LL | impl BadTrait<_> for BadStruct<_> {}
+   |               ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:167:34
    |
 LL | fn impl_trait() -> impl BadTrait<_> {
    |                                  ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:167:25
-   |
-LL | struct BadStruct1<_, _>(_);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct1<_, _>(_);
-LL + struct BadStruct1<T, _>(T);
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:172:25
-   |
-LL | struct BadStruct2<_, T>(_, T);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct2<_, T>(_, T);
-LL + struct BadStruct2<U, T>(U, T);
-   |
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/typeck_type_placeholder_item.rs:176:14
+  --> $DIR/typeck_type_placeholder_item.rs:182:14
    |
 LL | type X = Box<_>;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/typeck_type_placeholder_item.rs:182:21
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:188:21
    |
 LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:198:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:211:14
+   |
+LL |     type A = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:213:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:207:14
+  --> $DIR/typeck_type_placeholder_item.rs:200:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:195:14
+  --> $DIR/typeck_type_placeholder_item.rs:215:14
+   |
+LL |     const C: _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     const D: _ = 42;
    |              ^ not allowed in type signatures
@@ -596,13 +510,13 @@ LL +     const D: i32 = 42;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:210:14
+  --> $DIR/typeck_type_placeholder_item.rs:218:14
    |
 LL |     const D: _ = 42;
    |              ^ not allowed in type signatures
 
 error[E0046]: not all trait items implemented, missing: `F`
-  --> $DIR/typeck_type_placeholder_item.rs:201:1
+  --> $DIR/typeck_type_placeholder_item.rs:209:1
    |
 LL |     type F: std::ops::Fn(_);
    |     ----------------------- `F` from trait
@@ -611,7 +525,7 @@ LL | impl Qux for Struct {
    | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:218:31
+  --> $DIR/typeck_type_placeholder_item.rs:226:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -620,7 +534,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:223:17
+  --> $DIR/typeck_type_placeholder_item.rs:231:17
    |
 LL | const _: Option<_> = map(value);
    |                 ^ not allowed in type signatures
@@ -632,7 +546,7 @@ LL + const _: Option<u8> = map(value);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:227:31
+  --> $DIR/typeck_type_placeholder_item.rs:235:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -641,19 +555,19 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:10
+  --> $DIR/typeck_type_placeholder_item.rs:240:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:232:29}>, {closure@typeck_type_placeholder_item.rs:232:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:232:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:240:29}>, {closure@typeck_type_placeholder_item.rs:240:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:240:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:41:24
+  --> $DIR/typeck_type_placeholder_item.rs:40:24
    |
 LL |     fn test9(&self) -> _ { () }
    |                        ^
@@ -662,16 +576,10 @@ LL |     fn test9(&self) -> _ { () }
    |                        help: replace with the correct return type: `()`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:44:27
+  --> $DIR/typeck_type_placeholder_item.rs:43:27
    |
 LL |     fn test10(&self, _x : _) { }
    |                           ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn test10(&self, _x : _) { }
-LL +     fn test10<T>(&self, _x : T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:107:31
@@ -687,68 +595,62 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |         fn fn_test10(&self, _x : _) { }
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -         fn fn_test10(&self, _x : _) { }
-LL +         fn fn_test10<T>(&self, _x : T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
-   |
-LL |     type A = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:191:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:193:14
-   |
-LL |     const C: _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:198:26
+  --> $DIR/typeck_type_placeholder_item.rs:205:26
    |
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:205:26
+   |
+LL |     type F: std::ops::Fn(_);
+   |                          ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:167:34
+   |
+LL | fn impl_trait() -> impl BadTrait<_> {
+   |                                  ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:188:21
+   |
+LL | type Y = impl Trait<_>;
+   |                     ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0015]: cannot call non-const function `map::<u8>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:223:22
+  --> $DIR/typeck_type_placeholder_item.rs:231:22
    |
 LL | const _: Option<_> = map(value);
    |                      ^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:232:29: 232:32}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:22
+error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:240:22
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:232:29: 232:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:232:49: 232:52}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:45
+error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:240:49: 240:52}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:240:45
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                                             ^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to 75 previous errors
+error: aborting due to 83 previous errors
 
 Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -11,8 +11,7 @@ const TEST3: _ = Some(42);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 
 const TEST4: fn() -> _ = 42;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-//~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 
 trait Test5 {
     const TEST5: _ = 42;

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -31,12 +31,6 @@ LL - const TEST3: _ = Some(42);
 LL + const TEST3: Option<i32> = Some(42);
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item_help.rs:13:22
-   |
-LL | const TEST4: fn() -> _ = 42;
-   |                      ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
    |
@@ -44,7 +38,7 @@ LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:25:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:24:18
    |
 LL |     const TEST6: _ = 13;
    |                  ^ not allowed in type signatures
@@ -56,7 +50,7 @@ LL +     const TEST6: i32 = 13;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:18:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:17:18
    |
 LL |     const TEST5: _ = 42;
    |                  ^ not allowed in type signatures
@@ -68,7 +62,7 @@ LL +     const TEST5: i32 = 42;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_item_help.rs:30:28
+  --> $DIR/typeck_type_placeholder_item_help.rs:29:28
    |
 LL |     let _: Option<usize> = test1();
    |            -------------   ^^^^^^^ expected `Option<usize>`, found `Option<i32>`
@@ -79,7 +73,7 @@ LL |     let _: Option<usize> = test1();
               found enum `Option<i32>`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_item_help.rs:31:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:30:18
    |
 LL |     let _: f64 = test1();
    |            ---   ^^^^^^^ expected `f64`, found `Option<i32>`
@@ -89,7 +83,7 @@ LL |     let _: f64 = test1();
    = note: expected type `f64`
               found enum `Option<i32>`
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0121, E0308.
 For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
This centralizes the placeholder type error reporting in one location, but it also exposes the granularity at which we convert things from hir to ty more. E.g. previously infer types in where bounds were errored together with the function signature, but now they are independent.

r? @compiler-errors 
