### PR TITLE
 Pre-install JS dependencies in tidy Dockerfile

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -41,7 +41,9 @@ RUN pip3 install --no-deps --no-cache-dir --require-hashes -r /tmp/reuse-require
 COPY host-x86_64/mingw-check-1/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check-1/validate-error-codes.sh /scripts/
 
+RUN bash -c 'npm install -g eslint@$(cat /tmp/eslint.version)'
+
 # NOTE: intentionally uses python2 for x.py so we can test it still works.
 # validate-toolstate only runs in our CI, so it's ok for it to only support python3.
-ENV SCRIPT TIDY_PRINT_DIFF=1 npm install eslint@$(head -n 1 /tmp/eslint.version) && \
- python2.7 ../x.py test --stage 0 src/tools/tidy tidyselftest --extra-checks=py,cpp
+ENV SCRIPT TIDY_PRINT_DIFF=1 python2.7 ../x.py test --stage 0 \
+    src/tools/tidy tidyselftest --extra-checks=py,cpp


### PR DESCRIPTION
Also fixes passing `TIDY_PRINT_DIFF` to tidy, which has been passed to `npm install` rather than to tidy after the latest change here.

r? @GuillaumeGomez

Fixes: https://github.com/rust-lang/rust/issues/142433