### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3229,8 +3229,20 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                                     Applicability::MaybeIncorrect,
                                 );
                             }
+
+                            let mutability = if matches!(borrow.kind(), BorrowKind::Mut { .. }) {
+                                "mut "
+                            } else {
+                                ""
+                            };
+
                             if !is_format_arguments_item {
-                                let addition = format!("let binding = {};\n{}", s, " ".repeat(p));
+                                let addition = format!(
+                                    "let {}binding = {};\n{}",
+                                    mutability,
+                                    s,
+                                    " ".repeat(p)
+                                );
                                 err.multipart_suggestion_verbose(
                                     msg,
                                     vec![

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -494,7 +494,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
 
                 // Only visit the type looking for `_` if we didn't fix the type above
                 visitor.visit_ty_unambig(a);
-                self.lowerer().lower_arg_ty(a, None)
+                self.lowerer().lower_ty(a)
             })
             .collect();
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2708,16 +2708,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
-    pub fn lower_arg_ty(&self, ty: &hir::Ty<'tcx>, expected_ty: Option<Ty<'tcx>>) -> Ty<'tcx> {
-        match ty.kind {
-            hir::TyKind::Infer(()) if let Some(expected_ty) = expected_ty => {
-                self.record_ty(ty.hir_id, expected_ty, ty.span);
-                expected_ty
-            }
-            _ => self.lower_ty(ty),
-        }
-    }
-
     /// Lower a function type from the HIR to our internal notion of a function signature.
     #[instrument(level = "debug", skip(self, hir_id, safety, abi, decl, generics, hir_ty), ret)]
     pub fn lower_fn_ty(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -382,7 +382,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
         _hir_id: rustc_hir::HirId,
         _hir_ty: Option<&hir::Ty<'_>>,
     ) -> (Vec<Ty<'tcx>>, Ty<'tcx>) {
-        let input_tys = decl.inputs.iter().map(|a| self.lowerer().lower_arg_ty(a, None)).collect();
+        let input_tys = decl.inputs.iter().map(|a| self.lowerer().lower_ty(a)).collect();
 
         let output_ty = match decl.output {
             hir::FnRetTy::Return(output) => self.lowerer().lower_ty(output),

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -196,7 +196,8 @@ declare_lint! {
     /// same address after being merged together.
     UNPREDICTABLE_FUNCTION_POINTER_COMPARISONS,
     Warn,
-    "detects unpredictable function pointer comparisons"
+    "detects unpredictable function pointer comparisons",
+    report_in_external_macro
 }
 
 #[derive(Copy, Clone, Default)]

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -290,6 +290,9 @@ passes_duplicate_lang_item_crate_depends =
     .first_definition_path = first definition in `{$orig_crate_name}` loaded from {$orig_path}
     .second_definition_path = second definition in `{$crate_name}` loaded from {$path}
 
+passes_enum_variant_same_name =
+    it is impossible to refer to the {$descr} `{$dead_name}` because it is shadowed by this enum variant with the same name
+
 passes_export_name =
     attribute should be applied to a free function, impl method or static
     .label = not a free function, impl method or static

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1478,6 +1478,9 @@ pub(crate) enum MultipleDeadCodes<'tcx> {
         participle: &'tcx str,
         name_list: DiagSymbolList,
         #[subdiagnostic]
+        // only on DeadCodes since it's never a problem for tuple struct fields
+        enum_variants_with_same_name: Vec<EnumVariantSameName<'tcx>>,
+        #[subdiagnostic]
         parent_info: Option<ParentInfo<'tcx>>,
         #[subdiagnostic]
         ignored_derived_impls: Option<IgnoredDerivedImpls>,
@@ -1496,6 +1499,15 @@ pub(crate) enum MultipleDeadCodes<'tcx> {
         #[subdiagnostic]
         ignored_derived_impls: Option<IgnoredDerivedImpls>,
     },
+}
+
+#[derive(Subdiagnostic)]
+#[note(passes_enum_variant_same_name)]
+pub(crate) struct EnumVariantSameName<'tcx> {
+    #[primary_span]
+    pub variant_span: Span,
+    pub dead_name: Symbol,
+    pub descr: &'tcx str,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -133,7 +133,9 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
                 .field("target", target)
                 .field("id", id)
                 .finish(),
-            MacroUse { .. } => f.debug_struct("MacroUse").finish(),
+            MacroUse { warn_private } => {
+                f.debug_struct("MacroUse").field("warn_private", warn_private).finish()
+            }
             MacroExport => f.debug_struct("MacroExport").finish(),
         }
     }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -239,7 +239,6 @@ macro_rules! int_impl {
         /// Basic usage:
         ///
         /// ```
-        ///
         #[doc = concat!("let n = -1", stringify!($SelfT), ";")]
         ///
         #[doc = concat!("assert_eq!(n.cast_unsigned(), ", stringify!($UnsignedT), "::MAX);")]

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1053,7 +1053,6 @@ impl u8 {
     /// # Examples
     ///
     /// ```
-    ///
     /// assert_eq!("0", b'0'.escape_ascii().to_string());
     /// assert_eq!("\\t", b'\t'.escape_ascii().to_string());
     /// assert_eq!("\\r", b'\r'.escape_ascii().to_string());

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -128,7 +128,6 @@ impl [u8] {
     /// # Examples
     ///
     /// ```
-    ///
     /// let s = b"0\t\r\n'\"\\\x9d";
     /// let escaped = s.escape_ascii().to_string();
     /// assert_eq!(escaped, "0\\t\\r\\n\\'\\\"\\\\\\x9d");

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -104,6 +104,7 @@ impl RawWaker {
 /// synchronization. This is because [`LocalWaker`] is not thread safe itself, so it cannot
 /// be sent across threads.
 #[stable(feature = "futures_api", since = "1.36.0")]
+#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct RawWakerVTable {
     /// This function will be called when the [`RawWaker`] gets cloned, e.g. when

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -11,7 +11,7 @@ LL |         assert_foo(a);
    |
 help: consider using a `let` binding to create a longer lived value
    |
-LL ~         let binding = true;
+LL ~         let mut binding = true;
 LL ~         let a = A(&mut binding, &mut true, No);
    |
 
@@ -28,7 +28,7 @@ LL |         assert_foo(a);
    |
 help: consider using a `let` binding to create a longer lived value
    |
-LL ~         let binding = true;
+LL ~         let mut binding = true;
 LL ~         let a = A(&mut true, &mut binding, No);
    |
 

--- a/tests/ui/enum/dead-code-associated-function.rs
+++ b/tests/ui/enum/dead-code-associated-function.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+#![warn(dead_code)]
+
+enum E {
+    F(),
+    C(),
+}
+
+impl E {
+    #[expect(non_snake_case)]
+    fn F() {}
+    //~^ WARN: associated items `F` and `C` are never used
+
+    const C: () = ();
+}
+
+fn main() {
+    let _: E = E::F();
+    let _: E = E::C();
+}

--- a/tests/ui/enum/dead-code-associated-function.stderr
+++ b/tests/ui/enum/dead-code-associated-function.stderr
@@ -1,0 +1,20 @@
+warning: associated items `F` and `C` are never used
+  --> $DIR/dead-code-associated-function.rs:11:8
+   |
+LL | impl E {
+   | ------ associated items in this implementation
+LL |     #[expect(non_snake_case)]
+LL |     fn F() {}
+   |        ^
+...
+LL |     const C: () = ();
+   |           ^
+   |
+note: the lint level is defined here
+  --> $DIR/dead-code-associated-function.rs:2:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/tests/ui/enum/dead-code-associated-function.stderr
+++ b/tests/ui/enum/dead-code-associated-function.stderr
@@ -10,6 +10,16 @@ LL |     fn F() {}
 LL |     const C: () = ();
    |           ^
    |
+note: it is impossible to refer to the associated function `F` because it is shadowed by this enum variant with the same name
+  --> $DIR/dead-code-associated-function.rs:5:5
+   |
+LL |     F(),
+   |     ^
+note: it is impossible to refer to the associated constant `C` because it is shadowed by this enum variant with the same name
+  --> $DIR/dead-code-associated-function.rs:6:5
+   |
+LL |     C(),
+   |     ^
 note: the lint level is defined here
   --> $DIR/dead-code-associated-function.rs:2:9
    |

--- a/tests/ui/issues/issue-28561.rs
+++ b/tests/ui/issues/issue-28561.rs
@@ -37,6 +37,7 @@ struct Array<T> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[allow(unpredictable_function_pointer_comparisons)]
 struct Fn<A, B, C, D, E, F, G, H, I, J, K, L> {
     f00: fn(),
     f01: fn(A),

--- a/tests/ui/lint/fn-ptr-comparisons-some.rs
+++ b/tests/ui/lint/fn-ptr-comparisons-some.rs
@@ -12,6 +12,6 @@ fn main() {
     let _ = Some::<FnPtr>(func) == Some(func as unsafe extern "C" fn());
     //~^ WARN function pointer comparisons
 
-    // Undecided as of https://github.com/rust-lang/rust/pull/134536
     assert_eq!(Some::<FnPtr>(func), Some(func as unsafe extern "C" fn()));
+    //~^ WARN function pointer comparisons
 }

--- a/tests/ui/lint/fn-ptr-comparisons-some.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons-some.stderr
@@ -9,5 +9,16 @@ LL |     let _ = Some::<FnPtr>(func) == Some(func as unsafe extern "C" fn());
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
    = note: `#[warn(unpredictable_function_pointer_comparisons)]` on by default
 
-warning: 1 warning emitted
+warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
+  --> $DIR/fn-ptr-comparisons-some.rs:15:5
+   |
+LL |     assert_eq!(Some::<FnPtr>(func), Some(func as unsafe extern "C" fn()));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the address of the same function can vary between different codegen units
+   = note: furthermore, different functions could have the same address after being merged together
+   = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
+   = note: this warning originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 2 warnings emitted
 

--- a/tests/ui/lint/fn-ptr-comparisons-weird.rs
+++ b/tests/ui/lint/fn-ptr-comparisons-weird.rs
@@ -1,5 +1,23 @@
 //@ check-pass
 
+#[derive(PartialEq, Eq)]
+struct A {
+    f: fn(),
+    //~^ WARN function pointer comparisons
+}
+
+#[allow(unpredictable_function_pointer_comparisons)]
+#[derive(PartialEq, Eq)]
+struct AllowedAbove {
+    f: fn(),
+}
+
+#[derive(PartialEq, Eq)]
+#[allow(unpredictable_function_pointer_comparisons)]
+struct AllowedBelow {
+    f: fn(),
+}
+
 fn main() {
     let f: fn() = main;
     let g: fn() = main;
@@ -11,5 +29,9 @@ fn main() {
     let _ = f <= g;
     //~^ WARN function pointer comparisons
     let _ = f < g;
+    //~^ WARN function pointer comparisons
+    let _ = assert_eq!(g, g);
+    //~^ WARN function pointer comparisons
+    let _ = assert_ne!(g, g);
     //~^ WARN function pointer comparisons
 }

--- a/tests/ui/lint/fn-ptr-comparisons-weird.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons-weird.stderr
@@ -1,8 +1,11 @@
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons-weird.rs:7:13
+  --> $DIR/fn-ptr-comparisons-weird.rs:5:5
    |
-LL |     let _ = f > g;
-   |             ^^^^^
+LL | #[derive(PartialEq, Eq)]
+   |          --------- in this derive macro expansion
+LL | struct A {
+LL |     f: fn(),
+   |     ^^^^^^^
    |
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
@@ -10,7 +13,17 @@ LL |     let _ = f > g;
    = note: `#[warn(unpredictable_function_pointer_comparisons)]` on by default
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons-weird.rs:9:13
+  --> $DIR/fn-ptr-comparisons-weird.rs:25:13
+   |
+LL |     let _ = f > g;
+   |             ^^^^^
+   |
+   = note: the address of the same function can vary between different codegen units
+   = note: furthermore, different functions could have the same address after being merged together
+   = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
+
+warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
+  --> $DIR/fn-ptr-comparisons-weird.rs:27:13
    |
 LL |     let _ = f >= g;
    |             ^^^^^^
@@ -20,7 +33,7 @@ LL |     let _ = f >= g;
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons-weird.rs:11:13
+  --> $DIR/fn-ptr-comparisons-weird.rs:29:13
    |
 LL |     let _ = f <= g;
    |             ^^^^^^
@@ -30,7 +43,7 @@ LL |     let _ = f <= g;
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons-weird.rs:13:13
+  --> $DIR/fn-ptr-comparisons-weird.rs:31:13
    |
 LL |     let _ = f < g;
    |             ^^^^^
@@ -39,5 +52,27 @@ LL |     let _ = f < g;
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
 
-warning: 4 warnings emitted
+warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
+  --> $DIR/fn-ptr-comparisons-weird.rs:33:13
+   |
+LL |     let _ = assert_eq!(g, g);
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: the address of the same function can vary between different codegen units
+   = note: furthermore, different functions could have the same address after being merged together
+   = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
+   = note: this warning originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
+  --> $DIR/fn-ptr-comparisons-weird.rs:35:13
+   |
+LL |     let _ = assert_ne!(g, g);
+   |             ^^^^^^^^^^^^^^^^
+   |
+   = note: the address of the same function can vary between different codegen units
+   = note: furthermore, different functions could have the same address after being merged together
+   = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
+   = note: this warning originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 7 warnings emitted
 

--- a/tests/ui/lint/fn-ptr-comparisons.fixed
+++ b/tests/ui/lint/fn-ptr-comparisons.fixed
@@ -11,7 +11,6 @@ extern "C" fn c() {}
 
 extern "C" fn args(_a: i32) -> i32 { 0 }
 
-#[derive(PartialEq, Eq)]
 struct A {
     f: fn(),
 }
@@ -52,7 +51,6 @@ fn main() {
     let _ = std::ptr::fn_addr_eq(t, test as unsafe extern "C" fn());
     //~^ WARN function pointer comparisons
 
-    let _ = a1 == a2; // should not warn
     let _ = std::ptr::fn_addr_eq(a1.f, a2.f);
     //~^ WARN function pointer comparisons
 }

--- a/tests/ui/lint/fn-ptr-comparisons.rs
+++ b/tests/ui/lint/fn-ptr-comparisons.rs
@@ -11,7 +11,6 @@ extern "C" fn c() {}
 
 extern "C" fn args(_a: i32) -> i32 { 0 }
 
-#[derive(PartialEq, Eq)]
 struct A {
     f: fn(),
 }
@@ -52,7 +51,6 @@ fn main() {
     let _ = t == test;
     //~^ WARN function pointer comparisons
 
-    let _ = a1 == a2; // should not warn
     let _ = a1.f == a2.f;
     //~^ WARN function pointer comparisons
 }

--- a/tests/ui/lint/fn-ptr-comparisons.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons.stderr
@@ -1,5 +1,5 @@
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:26:13
+  --> $DIR/fn-ptr-comparisons.rs:25:13
    |
 LL |     let _ = f == a;
    |             ^^^^^^
@@ -15,7 +15,7 @@ LL +     let _ = std::ptr::fn_addr_eq(f, a as fn());
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:28:13
+  --> $DIR/fn-ptr-comparisons.rs:27:13
    |
 LL |     let _ = f != a;
    |             ^^^^^^
@@ -30,7 +30,7 @@ LL +     let _ = !std::ptr::fn_addr_eq(f, a as fn());
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:30:13
+  --> $DIR/fn-ptr-comparisons.rs:29:13
    |
 LL |     let _ = f == g;
    |             ^^^^^^
@@ -45,7 +45,7 @@ LL +     let _ = std::ptr::fn_addr_eq(f, g);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:32:13
+  --> $DIR/fn-ptr-comparisons.rs:31:13
    |
 LL |     let _ = f == f;
    |             ^^^^^^
@@ -60,7 +60,7 @@ LL +     let _ = std::ptr::fn_addr_eq(f, f);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:34:13
+  --> $DIR/fn-ptr-comparisons.rs:33:13
    |
 LL |     let _ = g == g;
    |             ^^^^^^
@@ -75,7 +75,7 @@ LL +     let _ = std::ptr::fn_addr_eq(g, g);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:36:13
+  --> $DIR/fn-ptr-comparisons.rs:35:13
    |
 LL |     let _ = g == g;
    |             ^^^^^^
@@ -90,7 +90,7 @@ LL +     let _ = std::ptr::fn_addr_eq(g, g);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:38:13
+  --> $DIR/fn-ptr-comparisons.rs:37:13
    |
 LL |     let _ = &g == &g;
    |             ^^^^^^^^
@@ -105,7 +105,7 @@ LL +     let _ = std::ptr::fn_addr_eq(g, g);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:40:13
+  --> $DIR/fn-ptr-comparisons.rs:39:13
    |
 LL |     let _ = a as fn() == g;
    |             ^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL +     let _ = std::ptr::fn_addr_eq(a as fn(), g);
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:44:13
+  --> $DIR/fn-ptr-comparisons.rs:43:13
    |
 LL |     let _ = cfn == c;
    |             ^^^^^^^^
@@ -135,7 +135,7 @@ LL +     let _ = std::ptr::fn_addr_eq(cfn, c as extern "C" fn());
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:48:13
+  --> $DIR/fn-ptr-comparisons.rs:47:13
    |
 LL |     let _ = argsfn == args;
    |             ^^^^^^^^^^^^^^
@@ -150,7 +150,7 @@ LL +     let _ = std::ptr::fn_addr_eq(argsfn, args as extern "C" fn(i32) -> i32)
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:52:13
+  --> $DIR/fn-ptr-comparisons.rs:51:13
    |
 LL |     let _ = t == test;
    |             ^^^^^^^^^
@@ -165,7 +165,7 @@ LL +     let _ = std::ptr::fn_addr_eq(t, test as unsafe extern "C" fn());
    |
 
 warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
-  --> $DIR/fn-ptr-comparisons.rs:56:13
+  --> $DIR/fn-ptr-comparisons.rs:54:13
    |
 LL |     let _ = a1.f == a2.f;
    |             ^^^^^^^^^^^^

--- a/tests/ui/methods/missing-bound-on-tuple.rs
+++ b/tests/ui/methods/missing-bound-on-tuple.rs
@@ -1,0 +1,39 @@
+trait WorksOnDefault {
+    fn do_something() {}
+}
+
+impl<T: Default> WorksOnDefault for T {}
+//~^ NOTE the following trait bounds were not satisfied
+//~| NOTE unsatisfied trait bound introduced here
+
+trait Foo {}
+
+trait WorksOnFoo {
+    fn do_be_do() {}
+}
+
+impl<T: Foo> WorksOnFoo for T {}
+//~^ NOTE the following trait bounds were not satisfied
+//~| NOTE unsatisfied trait bound introduced here
+
+impl<A: Foo, B: Foo, C: Foo> Foo for (A, B, C) {}
+//~^ NOTE `Foo` is implemented for `(i32, u32, String)`
+impl Foo for i32 {}
+impl Foo for &i32 {}
+impl Foo for u32 {}
+impl Foo for String {}
+
+fn main() {
+    let _success = <(i32, u32, String)>::do_something();
+    let _failure = <(i32, &u32, String)>::do_something(); //~ ERROR E0599
+    //~^ NOTE `Default` is implemented for `(i32, u32, String)`
+    //~| NOTE function or associated item cannot be called on
+    let _success = <(i32, u32, String)>::do_be_do();
+    let _failure = <(i32, &u32, String)>::do_be_do(); //~ ERROR E0599
+    //~^ NOTE function or associated item cannot be called on
+    let _success = <(i32, u32, String)>::default();
+    let _failure = <(i32, &u32, String)>::default(); //~ ERROR E0599
+    //~^ NOTE `Default` is implemented for `(i32, u32, String)`
+    //~| NOTE function or associated item cannot be called on
+    //~| NOTE the following trait bounds were not satisfied
+}

--- a/tests/ui/methods/missing-bound-on-tuple.stderr
+++ b/tests/ui/methods/missing-bound-on-tuple.stderr
@@ -1,0 +1,58 @@
+error[E0599]: the function or associated item `do_something` exists for tuple `(i32, &u32, String)`, but its trait bounds were not satisfied
+  --> $DIR/missing-bound-on-tuple.rs:28:43
+   |
+LL |     let _failure = <(i32, &u32, String)>::do_something();
+   |                                           ^^^^^^^^^^^^ function or associated item cannot be called on `(i32, &u32, String)` due to unsatisfied trait bounds
+   |
+note: the following trait bounds were not satisfied:
+      `&(i32, &u32, String): Default`
+      `&mut (i32, &u32, String): Default`
+      `(i32, &u32, String): Default`
+  --> $DIR/missing-bound-on-tuple.rs:5:9
+   |
+LL | impl<T: Default> WorksOnDefault for T {}
+   |         ^^^^^^^  --------------     -
+   |         |
+   |         unsatisfied trait bound introduced here
+note: `Default` is implemented for `(i32, u32, String)` but not for `(i32, &u32, String)`
+  --> $SRC_DIR/core/src/tuple.rs:LL:COL
+   = note: this error originates in the macro `tuple_impls` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: the function or associated item `do_be_do` exists for tuple `(i32, &u32, String)`, but its trait bounds were not satisfied
+  --> $DIR/missing-bound-on-tuple.rs:32:43
+   |
+LL |     let _failure = <(i32, &u32, String)>::do_be_do();
+   |                                           ^^^^^^^^ function or associated item cannot be called on `(i32, &u32, String)` due to unsatisfied trait bounds
+   |
+note: the following trait bounds were not satisfied:
+      `&(i32, &u32, String): Foo`
+      `&mut (i32, &u32, String): Foo`
+      `(i32, &u32, String): Foo`
+  --> $DIR/missing-bound-on-tuple.rs:15:9
+   |
+LL | impl<T: Foo> WorksOnFoo for T {}
+   |         ^^^  ----------     -
+   |         |
+   |         unsatisfied trait bound introduced here
+note: `Foo` is implemented for `(i32, u32, String)` but not for `(i32, &u32, String)`
+  --> $DIR/missing-bound-on-tuple.rs:19:1
+   |
+LL | impl<A: Foo, B: Foo, C: Foo> Foo for (A, B, C) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: the function or associated item `default` exists for tuple `(i32, &u32, String)`, but its trait bounds were not satisfied
+  --> $DIR/missing-bound-on-tuple.rs:35:43
+   |
+LL |     let _failure = <(i32, &u32, String)>::default();
+   |                                           ^^^^^^^ function or associated item cannot be called on `(i32, &u32, String)` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `&u32: Default`
+           which is required by `(i32, &u32, String): Default`
+note: `Default` is implemented for `(i32, u32, String)` but not for `(i32, &u32, String)`
+  --> $SRC_DIR/core/src/tuple.rs:LL:COL
+   = note: this error originates in the macro `tuple_impls` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/mir/mir_refs_correct.rs
+++ b/tests/ui/mir/mir_refs_correct.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 //@ aux-build:mir_external_refs.rs
 
+#![allow(unpredictable_function_pointer_comparisons)]
+
 extern crate mir_external_refs as ext;
 
 struct S(#[allow(dead_code)] u8);

--- a/tests/ui/nll/sugg-mut-for-binding-issue-137486.fixed
+++ b/tests/ui/nll/sugg-mut-for-binding-issue-137486.fixed
@@ -1,0 +1,23 @@
+//@ run-rustfix
+#![allow(unused_assignments)]
+
+use std::pin::Pin;
+fn main() {
+    let mut s = String::from("hello");
+    let mut ref_s = &mut s;
+
+    let mut binding = String::from("world");
+    ref_s = &mut binding; //~ ERROR temporary value dropped while borrowed [E0716]
+
+    print!("r1 = {}", ref_s);
+
+    let mut val: u8 = 5;
+    let mut s = Pin::new(&mut val);
+    let mut ref_s = &mut s;
+
+    let mut val2: u8 = 10;
+    let mut binding = Pin::new(&mut val2);
+    ref_s = &mut binding; //~ ERROR temporary value dropped while borrowed [E0716]
+
+    print!("r1 = {}", ref_s);
+}

--- a/tests/ui/nll/sugg-mut-for-binding-issue-137486.rs
+++ b/tests/ui/nll/sugg-mut-for-binding-issue-137486.rs
@@ -1,0 +1,21 @@
+//@ run-rustfix
+#![allow(unused_assignments)]
+
+use std::pin::Pin;
+fn main() {
+    let mut s = String::from("hello");
+    let mut ref_s = &mut s;
+
+    ref_s = &mut String::from("world"); //~ ERROR temporary value dropped while borrowed [E0716]
+
+    print!("r1 = {}", ref_s);
+
+    let mut val: u8 = 5;
+    let mut s = Pin::new(&mut val);
+    let mut ref_s = &mut s;
+
+    let mut val2: u8 = 10;
+    ref_s = &mut Pin::new(&mut val2); //~ ERROR temporary value dropped while borrowed [E0716]
+
+    print!("r1 = {}", ref_s);
+}

--- a/tests/ui/nll/sugg-mut-for-binding-issue-137486.stderr
+++ b/tests/ui/nll/sugg-mut-for-binding-issue-137486.stderr
@@ -1,0 +1,37 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/sugg-mut-for-binding-issue-137486.rs:9:18
+   |
+LL |     ref_s = &mut String::from("world");
+   |                  ^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |                  |
+   |                  creates a temporary value which is freed while still in use
+LL |
+LL |     print!("r1 = {}", ref_s);
+   |                       ----- borrow later used here
+   |
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let mut binding = String::from("world");
+LL ~     ref_s = &mut binding;
+   |
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/sugg-mut-for-binding-issue-137486.rs:18:18
+   |
+LL |     ref_s = &mut Pin::new(&mut val2);
+   |                  ^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |                  |
+   |                  creates a temporary value which is freed while still in use
+LL |
+LL |     print!("r1 = {}", ref_s);
+   |                       ----- borrow later used here
+   |
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let mut binding = Pin::new(&mut val2);
+LL ~     ref_s = &mut binding;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/nullable-pointer-iotareduction.rs
+++ b/tests/ui/nullable-pointer-iotareduction.rs
@@ -8,6 +8,8 @@
 // trying to get assert failure messages that at least identify which case
 // failed.
 
+#![allow(unpredictable_function_pointer_comparisons)]
+
 enum E<T> { Thing(isize, T), #[allow(dead_code)] Nothing((), ((), ()), [i8; 0]) }
 impl<T> E<T> {
     fn is_none(&self) -> bool {

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1229,6 +1229,7 @@ compiler = [
     "@oli-obk",
     "@petrochenkov",
     "@SparrowLii",
+    "@WaffleLapkin",
     "@wesleywiser",
 ]
 libs = [
@@ -1266,6 +1267,7 @@ codegen = [
     "@dianqk",
     "@saethlin",
     "@workingjubilee",
+    "@WaffleLapkin",
 ]
 query-system = [
     "@oli-obk",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1240,13 +1240,6 @@ libs = [
     "@thomcc",
     "@ibraheemdev",
 ]
-bootstrap = [
-    "@Mark-Simulacrum",
-    "@albertlarsan68",
-    "@kobzol",
-    "@jieyouxu",
-    "@clubby789",
-]
 infra-ci = [
     "@Mark-Simulacrum",
     "@Kobzol",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#134536 (Lint on fn pointers comparisons in external macros)
 - rust-lang/rust#141069 (Suggest mut when possbile for temporary value dropped while borrowed)
 - rust-lang/rust#141934 (resolve: Tweak `private_macro_use` lint to be compatible with upcoming macro prelude changes)
 - rust-lang/rust#142034 (Detect method not being present that is present in other tuple types)
 - rust-lang/rust#142402 (chore(doctest): Remove redundant blank lines)
 - rust-lang/rust#142406 (Note when enum variants shadow an associated function)
 - rust-lang/rust#142407 (Remove bootstrap adhoc group)
 - rust-lang/rust#142408 (Add myself (WaffleLapkin) to review rotation)
 - rust-lang/rust#142418 (Remove lower_arg_ty as all callers were passing `None`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134536,141069,141934,142034,142402,142406,142407,142408,142418)
<!-- homu-ignore:end -->