### PR TITLE
compiler: Use -T instead of --script for linker scripts

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1894,7 +1894,9 @@ fn add_link_script(cmd: &mut dyn Linker, sess: &Session, tmpdir: &Path, crate_ty
                 sess.dcx().emit_fatal(errors::LinkScriptWriteFailure { path, error });
             }
 
-            cmd.link_arg("--script").link_arg(path);
+            // "--script" feels nice and explicit, but -T is supported by gcc **and clang**.
+            // Amusingly, lld supports --script just fine, it's only clang that doesn't.
+            cmd.link_arg("-T").link_arg(path);
         }
         _ => {}
     }


### PR DESCRIPTION
Note that our run-make test suite uses `-T` and not `--script`, interestingly enough:
```
run-make/rust-lld-link-script-provide/rmake.rs
2:// when the symbols in the `PROVIDE` of the link script can be eliminated.
16:        .link_arg("-Tscript.t")
```

<!-- homu-ignore:start -->
Fixes https://github.com/rust-lang/rust/issues/127183
<!-- homu-ignore:end -->