### PR TITLE
Require generic params for const generic params

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2147,7 +2147,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 ty_id,
                 &None,
                 path,
-                ParamMode::Optional,
+                ParamMode::Explicit,
                 AllowReturnTypeNotation::No,
                 // FIXME(mgca): update for `fn foo() -> Bar<FOO<impl Trait>>` support
                 ImplTraitContext::Disallowed(ImplTraitPosition::Path),
@@ -2219,7 +2219,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 expr.id,
                 qself,
                 path,
-                ParamMode::Optional,
+                ParamMode::Explicit,
                 AllowReturnTypeNotation::No,
                 // FIXME(mgca): update for `fn foo() -> Bar<FOO<impl Trait>>` support
                 ImplTraitContext::Disallowed(ImplTraitPosition::Path),

--- a/tests/crashes/137188.rs
+++ b/tests/crashes/137188.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #137188
-#![feature(min_generic_const_args)]
-trait Trait {}
-impl Trait for [(); N] {}
-fn N<T>() {}
-pub fn main() {}

--- a/tests/crashes/138166.rs
+++ b/tests/crashes/138166.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #138166
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
-struct a(Box<[u8; Box::b]>);
-impl a {
-  fn c(self) { self.0.d() }
-}
-fn main() {}

--- a/tests/crashes/138240.rs
+++ b/tests/crashes/138240.rs
@@ -1,9 +1,0 @@
-//@ known-bug: #138240
-//@edition:2024
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
-async fn _CF() -> Box<[u8; Box::b]> {
-    Box::new(true)
-}
-
-fn main() {}

--- a/tests/crashes/138266.rs
+++ b/tests/crashes/138266.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #138266
-//@compile-flags: --crate-type=lib
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
-pub fn f(mut x: [u8; Box::b]) {
-    x[72] = 1;
-}

--- a/tests/crashes/138359.rs
+++ b/tests/crashes/138359.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #138359
-#![feature(min_generic_const_args)]
-#![feature(inherent_associated_types)]
-struct a(Box<[u8; Box::b]>);
-impl a {
-  fn c(self) { self.0.da }
-}
-fn main() {}

--- a/tests/ui/const-generics/mgca/missing_generic_params.rs
+++ b/tests/ui/const-generics/mgca/missing_generic_params.rs
@@ -1,0 +1,16 @@
+// This used to ICE: #137188
+// The missing parameter list on `N` was set to
+// "infer from use site" in ast lowering, which
+// caused later code to not emit a missing generic
+// param error. The missing param was then attempted
+// to be inferred, but inference of generic params
+// is only possible within bodies. So a delayed
+// bug was generated with no error ever reported.
+
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+trait Trait {}
+impl Trait for [(); N] {}
+//~^ ERROR: missing generics for function `N`
+fn N<T>() {}
+pub fn main() {}

--- a/tests/ui/const-generics/mgca/missing_generic_params.stderr
+++ b/tests/ui/const-generics/mgca/missing_generic_params.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for function `N`
+  --> $DIR/missing_generic_params.rs:13:21
+   |
+LL | impl Trait for [(); N] {}
+   |                     ^ expected 1 generic argument
+   |
+note: function defined here, with 1 generic parameter: `T`
+  --> $DIR/missing_generic_params.rs:15:4
+   |
+LL | fn N<T>() {}
+   |    ^ -
+help: add missing generic argument
+   |
+LL | impl Trait for [(); N<T>] {}
+   |                      +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
I think that was just an oversight when the support for them was added

r? @BoxyUwU or @camelid 

fixes rust-lang/rust#137188
fixes rust-lang/rust#138166
fixes rust-lang/rust#138240 
fixes rust-lang/rust#138266 
fixes rust-lang/rust#138359 