### PR TITLE
Windows: make `read_dir` stop iterating after the first error is encountered

### DIFF
--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -132,6 +132,7 @@ impl Iterator for ReadDir {
             let mut wfd = mem::zeroed();
             loop {
                 if c::FindNextFileW(handle.0, &mut wfd) == 0 {
+                    self.handle = None;
                     match api::get_last_error() {
                         WinError::NO_MORE_FILES => return None,
                         WinError { code } => {


### PR DESCRIPTION
This also essentially makes the `ReadDir` iterator fused. Which I think is pretty much what people expect anyway.

[`FindNextFileW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilew) doesn't document what happens if you call it after iteration ends or after an error so we're probably in implementation defined territory at that point.

<!-- homu-ignore:start -->
Fixes rust-lang/rust#142411
<!-- homu-ignore:end -->
