### PR TITLE
compiletest: Clarify that `--no-capture` is needed with `--verbose`

### DIFF
--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -29,6 +29,7 @@ fn path_div() -> &'static str {
 pub fn logv(config: &Config, s: String) {
     debug!("{}", s);
     if config.verbose {
+        // Note: `./x test ... --verbose --no-capture` is needed to see this print.
         println!("{}", s);
     }
 }


### PR DESCRIPTION
Confusingly, this does not make compile test print what command is used to run a ui test:

    ./x test tests/ui/panics/abort-on-panic.rs --verbose

It is also necessary to pass `--no-capture`, like this:

    ./x test tests/ui/panics/abort-on-panic.rs --verbose --no-capture

Then you will see prints like this:

    executing cd "/rust/build/x86_64-unknown-linux-gnu/test/ui/panics/abort-on-panic.next" && \
        RUSTC="/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc" \
        RUST_TEST_THREADS="32" \
        "/rust/build/x86_64-unknown-linux-gnu/test/ui/panics/abort-on-panic.next/a"

Add a hint in the code for this that would have helped me figure this out.

(See https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/compiltest.20show.20rustc.20commands.3F for some more context.)
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
