### PR TITLE
Insert parentheses around binary operation with attribute

### DIFF
--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -92,6 +92,15 @@ static EXPRS: &[&str] = &[
     "#[attr] loop {}.field",
     "(#[attr] loop {}).field",
     "loop { #![attr] }.field",
+    // Attributes on a Binary, Cast, Assign, AssignOp, and Range expression
+    // require parentheses. Without parentheses `#[attr] lo..hi` means
+    // `(#[attr] lo)..hi`, and `#[attr] ..hi` is invalid syntax.
+    "#[attr] (1 + 1)",
+    "#[attr] (1 as T)",
+    "#[attr] (x = 1)",
+    "#[attr] (x += 1)",
+    "#[attr] (lo..hi)",
+    "#[attr] (..hi)",
     // Grammar restriction: break value starting with a labeled loop is not
     // allowed, except if the break is also labeled.
     "break 'outer 'inner: loop {} + 2",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -101,6 +101,12 @@ static EXPRS: &[&str] = &[
     "#[attr] (x += 1)",
     "#[attr] (lo..hi)",
     "#[attr] (..hi)",
+    // If the attribute were not present on the binary operation, it would be
+    // legal to render this without not just the inner parentheses, but also the
+    // outer ones. `return x + .. .field` (Yes, really.) Currently the
+    // pretty-printer does not take advantage of this edge case.
+    "(return #[attr] (x + ..)).field",
+    "(return x + ..).field",
     // Grammar restriction: break value starting with a labeled loop is not
     // allowed, except if the break is also labeled.
     "break 'outer 'inner: loop {} + 2",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -158,7 +158,12 @@ struct Unparenthesize;
 impl MutVisitor for Unparenthesize {
     fn visit_expr(&mut self, e: &mut Expr) {
         while let ExprKind::Paren(paren) = &mut e.kind {
+            let paren_attrs = mem::take(&mut e.attrs);
             *e = mem::replace(paren, Expr::dummy());
+            if !paren_attrs.is_empty() {
+                assert!(e.attrs.is_empty());
+                e.attrs = paren_attrs;
+            }
         }
         mut_visit::walk_expr(self, e);
     }


### PR DESCRIPTION
Fixes the bug found by @fmease in https://github.com/rust-lang/rust/pull/134661#pullrequestreview-2538983253.

Previously, `-Zunpretty=expanded` would expand this program as follows:

```rust
#![feature(stmt_expr_attributes)]
#![allow(unused_attributes)]

macro_rules! group {
    ($e:expr) => {
        $e
    };
}

macro_rules! extra {
    ($e:expr) => {
        #[allow()] $e
    };
}

fn main() {
    let _ = #[allow()] 1 + 1;
    let _ = group!(#[allow()] 1) + 1;
    let _ = 1 + group!(#[allow()] 1);
    let _ = extra!({ 0 }) + 1;
    let _ = extra!({ 0 } + 1);
}
```

```console
let _ = #[allow()] 1 + 1;
let _ = #[allow()] 1 + 1;
let _ = 1 + #[allow()] 1;
let _ = #[allow()] { 0 } + 1;
let _ = #[allow()] { 0 } + 1;
```

The first 4 statements are the correct expansion, but the last one is not. The attribute is supposed to apply to the entire binary operation, not only to the left operand.

After this PR, the 5th statement will expand to:

```console
let _ = #[allow()] ({ 0 } + 1);
```

In the future, as some subset of `stmt_expr_attributes` approaches stabilization, it is possible that we will need to do parenthesization for a number of additional cases depending on the outcome of https://github.com/rust-lang/rust/issues/127436. But for now, at least this PR makes the pretty-printer align with the current behavior of the parser.

r? fmease