### PR TITLE
Fix incorrect suggestion when calling an associated type with a type anchor

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -724,7 +724,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             {
                 let def_path = tcx.def_path_str(adt_def.did());
                 err.span_suggestion(
-                    ty.span.to(item_ident.span),
+                    sugg_span,
                     format!("to construct a value of type `{}`, use the explicit path", def_path),
                     def_path,
                     Applicability::MachineApplicable,

--- a/tests/ui/associated-types/associated-type-call.fixed
+++ b/tests/ui/associated-types/associated-type-call.fixed
@@ -14,7 +14,7 @@ impl Trait for () {
     type Assoc = T;
 
     fn f() {
-        <T();
+        T();
         //~^ ERROR no associated item named `Assoc` found for unit type `()` in the current scope
     }
 }

--- a/tests/ui/associated-types/associated-type-call.fixed
+++ b/tests/ui/associated-types/associated-type-call.fixed
@@ -1,0 +1,22 @@
+// issue: <https://github.com/rust-lang/rust/issues/142473>
+//
+//@ run-rustfix
+#![allow(unused)]
+struct T();
+
+trait Trait {
+    type Assoc;
+
+    fn f();
+}
+
+impl Trait for () {
+    type Assoc = T;
+
+    fn f() {
+        <T();
+        //~^ ERROR no associated item named `Assoc` found for unit type `()` in the current scope
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/associated-type-call.rs
+++ b/tests/ui/associated-types/associated-type-call.rs
@@ -1,0 +1,22 @@
+// issue: <https://github.com/rust-lang/rust/issues/142473>
+//
+//@ run-rustfix
+#![allow(unused)]
+struct T();
+
+trait Trait {
+    type Assoc;
+
+    fn f();
+}
+
+impl Trait for () {
+    type Assoc = T;
+
+    fn f() {
+        <Self>::Assoc();
+        //~^ ERROR no associated item named `Assoc` found for unit type `()` in the current scope
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/associated-type-call.stderr
+++ b/tests/ui/associated-types/associated-type-call.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no associated item named `Assoc` found for unit type `()` in the current scope
+  --> $DIR/associated-type-call.rs:17:17
+   |
+LL |         <Self>::Assoc();
+   |                 ^^^^^ associated item not found in `()`
+   |
+help: to construct a value of type `T`, use the explicit path
+   |
+LL -         <Self>::Assoc();
+LL +         <T();
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/associated-types/associated-type-call.stderr
+++ b/tests/ui/associated-types/associated-type-call.stderr
@@ -7,7 +7,7 @@ LL |         <Self>::Assoc();
 help: to construct a value of type `T`, use the explicit path
    |
 LL -         <Self>::Assoc();
-LL +         <T();
+LL +         T();
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
`sugg_span` here is the span of the call expression.
That span here is the `<Self>::Assoc`, which is exactly what we need here (even though I would expect it to include the arguments, but I guess it doesn't)

r? @WaffleLapkin 
One commit with failing tests and one that fixes it for reviewability

closes rust-lang/rust#142473 