### PR TITLE
Remove unneeded lifetime bound from signature of BTreeSet::extract_if

### DIFF
--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1220,11 +1220,11 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// assert_eq!(high.into_iter().collect::<Vec<_>>(), [4, 5, 6, 7]);
     /// ```
     #[unstable(feature = "btree_extract_if", issue = "70530")]
-    pub fn extract_if<'a, F, R>(&'a mut self, range: R, pred: F) -> ExtractIf<'a, T, R, F, A>
+    pub fn extract_if<F, R>(&mut self, range: R, pred: F) -> ExtractIf<'_, T, R, F, A>
     where
         T: Ord,
         R: RangeBounds<T>,
-        F: 'a + FnMut(&T) -> bool,
+        F: FnMut(&T) -> bool,
     {
         let (inner, alloc) = self.map.extract_if_inner(range);
         ExtractIf { pred, inner, alloc }
@@ -1585,11 +1585,11 @@ where
 }
 
 #[unstable(feature = "btree_extract_if", issue = "70530")]
-impl<'a, T, R, F, A: Allocator + Clone> Iterator for ExtractIf<'_, T, R, F, A>
+impl<T, R, F, A: Allocator + Clone> Iterator for ExtractIf<'_, T, R, F, A>
 where
     T: PartialOrd,
     R: RangeBounds<T>,
-    F: 'a + FnMut(&T) -> bool,
+    F: FnMut(&T) -> bool,
 {
     type Item = T;
 


### PR DESCRIPTION
One way to observe the difference between these signatures, using 0 explicit lifetimes and 0 contrived where-clauses:

```rust
use std::collections::btree_set::{BTreeSet, ExtractIf};
use std::ops::RangeFull;

fn repro(
    set: &mut BTreeSet<i32>,
    predicate: impl Fn(i32) -> bool,
) -> ExtractIf<i32, RangeFull, impl FnMut(&i32) -> bool> {
    set.extract_if(.., move |x| predicate(*x))
}
```

**Before:**

```console
error[E0311]: the parameter type `impl Fn(i32) -> bool` may not live long enough
 --> src/lib.rs:8:5
  |
5 |     set: &mut BTreeSet<i32>,
  |          ------------------ the parameter type `impl Fn(i32) -> bool` must be valid for the anonymous lifetime defined here...
...
8 |     set.extract_if(.., move |x| predicate(*x))
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `impl Fn(i32) -> bool` will meet its required lifetime bounds
  |
help: consider adding an explicit lifetime bound
  |
4 ~ fn repro<'a>(
5 ~     set: &'a mut BTreeSet<i32>,
6 ~     predicate: impl Fn(i32) -> bool + 'a,
7 ~ ) -> ExtractIf<'a, i32, RangeFull, impl FnMut(&i32) -> bool> {
  |
```

**After:** compiles successfully.

- Tracking issue: https://github.com/rust-lang/rust/issues/70530