### PR TITLE
Fix random failure when JS code is executed when the whole file was not read yet

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -5872,6 +5872,10 @@ Lev1TParametricDescription.prototype.offsetIncrs3 = /*2 bits per value */ new In
     0xa0fc0000,0x5555ba08,0x55555555,
 ]);
 
+// ====================
+// WARNING: Nothing should be added below this comment: we need the `initSearch` function to
+// be called ONLY when the whole file has been parsed and loaded.
+
 // @ts-expect-error
 function initSearch(searchIndx) {
     rawSearchIndex = searchIndx;

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -5393,43 +5393,6 @@ function updateCrate(ev) {
     search(true);
 }
 
-// @ts-expect-error
-function initSearch(searchIndx) {
-    rawSearchIndex = searchIndx;
-    if (typeof window !== "undefined") {
-        // @ts-expect-error
-        docSearch = new DocSearch(rawSearchIndex, ROOT_PATH, searchState);
-        registerSearchEvents();
-        // If there's a search term in the URL, execute the search now.
-        if (window.searchState.getQueryStringParams().search) {
-            search();
-        }
-    } else if (typeof exports !== "undefined") {
-        // @ts-expect-error
-        docSearch = new DocSearch(rawSearchIndex, ROOT_PATH, searchState);
-        exports.docSearch = docSearch;
-        exports.parseQuery = DocSearch.parseQuery;
-    }
-}
-
-if (typeof exports !== "undefined") {
-    exports.initSearch = initSearch;
-}
-
-if (typeof window !== "undefined") {
-    // @ts-expect-error
-    window.initSearch = initSearch;
-    // @ts-expect-error
-    if (window.searchIndex !== undefined) {
-        // @ts-expect-error
-        initSearch(window.searchIndex);
-    }
-} else {
-    // Running in Node, not a browser. Run initSearch just to produce the
-    // exports.
-    initSearch(new Map());
-}
-
 // Parts of this code are based on Lucene, which is licensed under the
 // Apache/2.0 license.
 // More information found here:
@@ -5908,3 +5871,40 @@ Lev1TParametricDescription.prototype.toStates3 = /*3 bits per value */ new Int32
 Lev1TParametricDescription.prototype.offsetIncrs3 = /*2 bits per value */ new Int32Array([
     0xa0fc0000,0x5555ba08,0x55555555,
 ]);
+
+// @ts-expect-error
+function initSearch(searchIndx) {
+    rawSearchIndex = searchIndx;
+    if (typeof window !== "undefined") {
+        // @ts-expect-error
+        docSearch = new DocSearch(rawSearchIndex, ROOT_PATH, searchState);
+        registerSearchEvents();
+        // If there's a search term in the URL, execute the search now.
+        if (window.searchState.getQueryStringParams().search) {
+            search();
+        }
+    } else if (typeof exports !== "undefined") {
+        // @ts-expect-error
+        docSearch = new DocSearch(rawSearchIndex, ROOT_PATH, searchState);
+        exports.docSearch = docSearch;
+        exports.parseQuery = DocSearch.parseQuery;
+    }
+}
+
+if (typeof exports !== "undefined") {
+    exports.initSearch = initSearch;
+}
+
+if (typeof window !== "undefined") {
+    // @ts-expect-error
+    window.initSearch = initSearch;
+    // @ts-expect-error
+    if (window.searchIndex !== undefined) {
+        // @ts-expect-error
+        initSearch(window.searchIndex);
+    }
+} else {
+    // Running in Node, not a browser. Run initSearch just to produce the
+    // exports.
+    initSearch(new Map());
+}


### PR DESCRIPTION
Very randomly (and rarely), when I arrived on a page with `?search=something` in the URL, I got this error:

![Screenshot From 2025-06-14 11-27-46](https://github.com/user-attachments/assets/4b61b067-4e80-49c1-9a45-cff1509bf86a)

Moving the `initSearch` function at the bottom to ensure everything has been loaded fixes the issue.

PS: Sorry for the noise. Pushed to the wrong branch and https://github.com/rust-lang/rust/pull/142496 closed. ><