### PR TITLE
use `#[align]` attribute for `fn_align`

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -182,6 +182,9 @@ impl Deprecation {
 #[derive(Clone, Debug, HashStable_Generic, Encodable, Decodable, PrintAttribute)]
 pub enum AttributeKind {
     // tidy-alphabetical-start
+    /// Represents `#[align(N)]`.
+    Align { align: Align, span: Span },
+
     /// Represents `#[rustc_allow_const_fn_unstable]`.
     AllowConstFnUnstable(ThinVec<Symbol>),
 

--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -44,6 +44,9 @@ attr_parsing_incorrect_repr_format_packed_expect_integer =
 attr_parsing_incorrect_repr_format_packed_one_or_zero_arg =
     incorrect `repr(packed)` attribute format: `packed` takes exactly one parenthesized argument, or no parentheses at all
 
+attr_parsing_invalid_alignment_value =
+    invalid alignment value: {$error_part}
+
 attr_parsing_invalid_issue_string =
     `issue` must be a non-zero numeric string or "none"
     .must_not_be_zero = `issue` must not be "0", use "none" instead

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -19,7 +19,7 @@ use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
 use crate::attributes::inline::{InlineParser, RustcForceInlineParser};
 use crate::attributes::lint_helpers::AsPtrParser;
-use crate::attributes::repr::ReprParser;
+use crate::attributes::repr::{AlignParser, ReprParser};
 use crate::attributes::stability::{
     BodyStabilityParser, ConstStabilityIndirectParser, ConstStabilityParser, StabilityParser,
 };
@@ -90,6 +90,7 @@ macro_rules! attribute_parsers {
 attribute_parsers!(
     pub(crate) static ATTRIBUTE_PARSERS = [
         // tidy-alphabetical-start
+        AlignParser,
         BodyStabilityParser,
         ConfusablesParser,
         ConstStabilityParser,

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -451,6 +451,14 @@ pub(crate) struct EmptyConfusables {
 }
 
 #[derive(Diagnostic)]
+#[diag(attr_parsing_invalid_alignment_value, code = E0589)]
+pub(crate) struct InvalidAlignmentValue {
+    #[primary_span]
+    pub span: Span,
+    pub error_part: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(attr_parsing_repr_ident, code = E0565)]
 pub(crate) struct ReprIdent {
     #[primary_span]

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 use rustc_abi::ExternAbi;
 use rustc_ast::expand::autodiff_attrs::{AutoDiffAttrs, DiffActivity, DiffMode};
 use rustc_ast::{LitKind, MetaItem, MetaItemInner, attr};
-use rustc_attr_data_structures::ReprAttr::ReprAlign;
 use rustc_attr_data_structures::{
     AttributeKind, InlineAttr, InstructionSetAttr, OptimizeAttr, find_attr,
 };
@@ -110,17 +109,8 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             }
         };
 
-        if let hir::Attribute::Parsed(p) = attr {
-            match p {
-                AttributeKind::Repr(reprs) => {
-                    codegen_fn_attrs.alignment = reprs
-                        .iter()
-                        .filter_map(|(r, _)| if let ReprAlign(x) = r { Some(*x) } else { None })
-                        .max();
-                }
-
-                _ => {}
-            }
+        if let hir::Attribute::Parsed(AttributeKind::Align { align, .. }) = attr {
+            codegen_fn_attrs.alignment = Some(*align);
         }
 
         let Some(Ident { name, .. }) = attr.ident() else {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -495,6 +495,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(no_link, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No),
     ungated!(repr, Normal, template!(List: "C"), DuplicatesOk, EncodeCrossCrate::No),
+    gated!(align, Normal, template!(List: "alignment"), DuplicatesOk, EncodeCrossCrate::No, fn_align, experimental!(align)),
     ungated!(unsafe(Edition2024) export_name, Normal, template!(NameValueStr: "name"), FutureWarnPreceding, EncodeCrossCrate::No),
     ungated!(unsafe(Edition2024) link_section, Normal, template!(NameValueStr: "name"), FutureWarnPreceding, EncodeCrossCrate::No),
     ungated!(unsafe(Edition2024) no_mangle, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No),

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -47,8 +47,7 @@ pub struct CodegenFnAttrs {
     /// be generated against a specific instruction set. Only usable on architectures which allow
     /// switching between multiple instruction sets.
     pub instruction_set: Option<InstructionSetAttr>,
-    /// The `#[repr(align(...))]` attribute. Indicates the value of which the function should be
-    /// aligned to.
+    /// The `#[align(...)]` attribute. Determines the alignment of the function body.
     pub alignment: Option<Align>,
     /// The `#[patchable_function_entry(...)]` attribute. Indicates how many nops should be around
     /// the function entry.

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -289,6 +289,7 @@ fn emit_malformed_attribute(
             | sym::rustc_force_inline
             | sym::rustc_confusables
             | sym::repr
+            | sym::align
             | sym::deprecated
     ) {
         return;

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -13,6 +13,10 @@ passes_abi_ne =
 passes_abi_of =
     fn_abi_of({$fn_name}) = {$fn_abi}
 
+passes_align_should_be_repr_align =
+    `#[align(...)]` is not supported on {$item} items
+    .suggestion = use `#[repr(align(...))]` instead
+
 passes_allow_incoherent_impl =
     `rustc_allow_incoherent_impl` attribute should be applied to impl items
     .label = the only currently supported targets are inherent methods
@@ -28,10 +32,6 @@ passes_attr_application_enum =
 passes_attr_application_struct =
     attribute should be applied to a struct
     .label = not a struct
-
-passes_attr_application_struct_enum_function_method_union =
-    attribute should be applied to a struct, enum, function, associated function, or union
-    .label = not a struct, enum, function, associated function, or union
 
 passes_attr_application_struct_enum_union =
     attribute should be applied to a struct, enum, or union
@@ -583,12 +583,13 @@ passes_remove_fields =
      *[other] fields
     }
 
-passes_repr_align_function =
-    `repr(align)` attributes on functions are unstable
-
 passes_repr_align_greater_than_target_max =
     alignment must not be greater than `isize::MAX` bytes
     .note = `isize::MAX` is {$size} for the current target
+
+passes_repr_align_should_be_align =
+    `#[repr(align(...))]` is not supported on {$item} items
+    .help = use `#[align(...)]` instead
 
 passes_repr_conflicting =
     conflicting representation hints

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1308,13 +1308,6 @@ pub(crate) enum AttrApplication {
         #[label]
         span: Span,
     },
-    #[diag(passes_attr_application_struct_enum_function_method_union, code = E0517)]
-    StructEnumFunctionMethodUnion {
-        #[primary_span]
-        hint_span: Span,
-        #[label]
-        span: Span,
-    },
 }
 
 #[derive(Diagnostic)]
@@ -1815,4 +1808,27 @@ pub(crate) enum UnexportableItem<'a> {
         vis_note: Span,
         field_name: &'a str,
     },
+}
+
+#[derive(Diagnostic)]
+#[diag(passes_repr_align_should_be_align)]
+pub(crate) struct ReprAlignShouldBeAlign {
+    #[primary_span]
+    #[help]
+    pub span: Span,
+    pub item: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(passes_align_should_be_repr_align)]
+pub(crate) struct AlignShouldBeReprAlign {
+    #[primary_span]
+    #[suggestion(
+        style = "verbose",
+        applicability = "machine-applicable",
+        code = "#[repr(align({align_bytes}))]"
+    )]
+    pub span: Span,
+    pub item: &'static str,
+    pub align_bytes: u64,
 }

--- a/src/tools/miri/tests/pass/fn_align.rs
+++ b/src/tools/miri/tests/pass/fn_align.rs
@@ -1,21 +1,21 @@
 //@compile-flags: -Zmin-function-alignment=8
 #![feature(fn_align)]
 
-// When a function uses `repr(align(N))`, the function address should be a multiple of `N`.
+// When a function uses `align(N)`, the function address should be a multiple of `N`.
 
-#[repr(align(256))]
+#[align(256)]
 fn foo() {}
 
-#[repr(align(16))]
+#[align(16)]
 fn bar() {}
 
-#[repr(align(4))]
+#[align(4)]
 fn baz() {}
 
 fn main() {
     assert!((foo as usize).is_multiple_of(256));
     assert!((bar as usize).is_multiple_of(16));
 
-    // The maximum of `repr(align(N))` and `-Zmin-function-alignment=N` is used.
+    // The maximum of `align(N)` and `-Zmin-function-alignment=N` is used.
     assert!((baz as usize).is_multiple_of(8));
 }

--- a/tests/assembly/naked-functions/wasm32.rs
+++ b/tests/assembly/naked-functions/wasm32.rs
@@ -37,7 +37,7 @@ extern "C" fn nop() {
 #[unsafe(naked)]
 #[linkage = "weak"]
 // wasm functions cannot be aligned, so this has no effect
-#[repr(align(32))]
+#[align(32)]
 extern "C" fn weak_aligned_nop() {
     naked_asm!("nop")
 }

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -5,7 +5,7 @@
 
 // CHECK: align 16
 #[no_mangle]
-#[repr(align(16))]
+#[align(16)]
 pub fn fn_align() {}
 
 pub struct A;
@@ -13,12 +13,12 @@ pub struct A;
 impl A {
     // CHECK: align 16
     #[no_mangle]
-    #[repr(align(16))]
+    #[align(16)]
     pub fn method_align(self) {}
 
     // CHECK: align 16
     #[no_mangle]
-    #[repr(align(16))]
+    #[align(16)]
     pub fn associated_fn() {}
 }
 
@@ -26,19 +26,19 @@ trait T: Sized {
     fn trait_fn() {}
 
     // CHECK: align 32
-    #[repr(align(32))]
+    #[align(32)]
     fn trait_method(self) {}
 }
 
 impl T for A {
     // CHECK: align 16
     #[no_mangle]
-    #[repr(align(16))]
+    #[align(16)]
     fn trait_fn() {}
 
     // CHECK: align 16
     #[no_mangle]
-    #[repr(align(16))]
+    #[align(16)]
     fn trait_method(self) {}
 }
 
@@ -51,18 +51,20 @@ pub fn foo() {
 // CHECK-LABEL: align_specified_twice_1
 // CHECK-SAME: align 64
 #[no_mangle]
-#[repr(align(32), align(64))]
+#[align(32)]
+#[align(64)]
 pub fn align_specified_twice_1() {}
 
 // CHECK-LABEL: align_specified_twice_2
 // CHECK-SAME: align 128
 #[no_mangle]
-#[repr(align(128), align(32))]
+#[align(128)]
+#[align(32)]
 pub fn align_specified_twice_2() {}
 
 // CHECK-LABEL: align_specified_twice_3
 // CHECK-SAME: align 256
 #[no_mangle]
-#[repr(align(32))]
-#[repr(align(256))]
+#[align(32)]
+#[align(256)]
 pub fn align_specified_twice_3() {}

--- a/tests/codegen/min-function-alignment.rs
+++ b/tests/codegen/min-function-alignment.rs
@@ -18,16 +18,16 @@ pub fn no_explicit_align() {}
 // align16: align 16
 // align1024: align 1024
 #[no_mangle]
-#[repr(align(8))]
+#[align(8)]
 pub fn lower_align() {}
 
-// the higher value of min-function-alignment and repr(align) wins out
+// the higher value of min-function-alignment and the align attribute wins out
 //
 // CHECK-LABEL: @higher_align
 // align16: align 32
 // align1024: align 1024
 #[no_mangle]
-#[repr(align(32))]
+#[align(32)]
 pub fn higher_align() {}
 
 // cold functions follow the same rules as other functions

--- a/tests/codegen/naked-fn/aligned.rs
+++ b/tests/codegen/naked-fn/aligned.rs
@@ -8,7 +8,7 @@ use std::arch::naked_asm;
 
 // CHECK: .balign 16
 // CHECK-LABEL: naked_empty:
-#[repr(align(16))]
+#[align(16)]
 #[no_mangle]
 #[unsafe(naked)]
 pub extern "C" fn naked_empty() {

--- a/tests/codegen/naked-fn/min-function-alignment.rs
+++ b/tests/codegen/naked-fn/min-function-alignment.rs
@@ -16,7 +16,7 @@ pub extern "C" fn naked_no_explicit_align() {
 
 // CHECK: .balign 16
 #[no_mangle]
-#[repr(align(8))]
+#[align(8)]
 #[unsafe(naked)]
 pub extern "C" fn naked_lower_align() {
     core::arch::naked_asm!("ret")
@@ -24,7 +24,7 @@ pub extern "C" fn naked_lower_align() {
 
 // CHECK: .balign 32
 #[no_mangle]
-#[repr(align(32))]
+#[align(32)]
 #[unsafe(naked)]
 pub extern "C" fn naked_higher_align() {
     core::arch::naked_asm!("ret")

--- a/tests/ui/asm/naked-with-invalid-repr-attr.rs
+++ b/tests/ui/asm/naked-with-invalid-repr-attr.rs
@@ -19,8 +19,9 @@ extern "C" fn example2() {
     naked_asm!("")
 }
 
-#[repr(align(16), C)]
+#[repr(C)]
 //~^ ERROR attribute should be applied to a struct, enum, or union [E0517]
+#[align(16)]
 #[unsafe(naked)]
 extern "C" fn example3() {
     //~^ NOTE not a struct, enum, or union

--- a/tests/ui/asm/naked-with-invalid-repr-attr.stderr
+++ b/tests/ui/asm/naked-with-invalid-repr-attr.stderr
@@ -23,10 +23,10 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/naked-with-invalid-repr-attr.rs:22:19
+  --> $DIR/naked-with-invalid-repr-attr.rs:22:8
    |
-LL |   #[repr(align(16), C)]
-   |                     ^
+LL |   #[repr(C)]
+   |          ^
 ...
 LL | / extern "C" fn example3() {
 LL | |
@@ -35,7 +35,7 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/naked-with-invalid-repr-attr.rs:31:8
+  --> $DIR/naked-with-invalid-repr-attr.rs:32:8
    |
 LL |   #[repr(C, packed)]
    |          ^
@@ -48,7 +48,7 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct or union
-  --> $DIR/naked-with-invalid-repr-attr.rs:31:11
+  --> $DIR/naked-with-invalid-repr-attr.rs:32:11
    |
 LL |   #[repr(C, packed)]
    |             ^^^^^^
@@ -61,7 +61,7 @@ LL | | }
    | |_- not a struct or union
 
 error[E0517]: attribute should be applied to an enum
-  --> $DIR/naked-with-invalid-repr-attr.rs:41:8
+  --> $DIR/naked-with-invalid-repr-attr.rs:42:8
    |
 LL |   #[repr(u8)]
    |          ^^

--- a/tests/ui/attributes/arg-error-issue-121425.stderr
+++ b/tests/ui/attributes/arg-error-issue-121425.stderr
@@ -1,9 +1,3 @@
-error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
-  --> $DIR/arg-error-issue-121425.rs:16:8
-   |
-LL | #[repr(align())]
-   |        ^^^^^^^
-
 error[E0693]: incorrect `repr(align)` attribute format: `align` expects a literal integer as argument
   --> $DIR/arg-error-issue-121425.rs:4:14
    |
@@ -21,6 +15,12 @@ error[E0589]: invalid `repr(align)` attribute: not an unsuffixed integer
    |
 LL | #[repr(align("str"))]
    |              ^^^^^
+
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/arg-error-issue-121425.rs:16:8
+   |
+LL | #[repr(align())]
+   |        ^^^^^^^
 
 error[E0552]: incorrect `repr(packed)` attribute format: `packed` expects a literal integer as argument
   --> $DIR/arg-error-issue-121425.rs:21:15

--- a/tests/ui/attributes/invalid-repr.rs
+++ b/tests/ui/attributes/invalid-repr.rs
@@ -1,5 +1,5 @@
 #[repr(align(16))]
-//~^ ERROR attribute should be applied to a struct, enum, function, associated function, or union
+//~^ ERROR attribute should be applied to a struct, enum, or union
 pub type Foo = i32;
 
 fn main() {}

--- a/tests/ui/attributes/invalid-repr.stderr
+++ b/tests/ui/attributes/invalid-repr.stderr
@@ -1,11 +1,11 @@
-error[E0517]: attribute should be applied to a struct, enum, function, associated function, or union
+error[E0517]: attribute should be applied to a struct, enum, or union
   --> $DIR/invalid-repr.rs:1:8
    |
 LL | #[repr(align(16))]
    |        ^^^^^^^^^
 LL |
 LL | pub type Foo = i32;
-   | ------------------- not a struct, enum, function, associated function, or union
+   | ------------------- not a struct, enum, or union
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/malformed-fn-align.rs
+++ b/tests/ui/attributes/malformed-fn-align.rs
@@ -2,6 +2,21 @@
 #![crate_type = "lib"]
 
 trait MyTrait {
-    #[repr(align)] //~ ERROR invalid `repr(align)` attribute: `align` needs an argument
+    #[align] //~ ERROR malformed `align` attribute input
     fn myfun();
 }
+
+#[align = 16] //~ ERROR malformed `align` attribute input
+fn f1() {}
+
+#[align("hello")] //~ ERROR invalid alignment value: not an unsuffixed integer
+fn f2() {}
+
+#[align(0)] //~ ERROR invalid alignment value: not a power of two
+fn f3() {}
+
+#[repr(align(16))] //~ ERROR `#[repr(align(...))]` is not supported on function items
+fn f4() {}
+
+#[align(16)] //~ ERROR `#[align(...)]` is not supported on struct items
+struct S1;

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -1,9 +1,66 @@
-error[E0589]: invalid `repr(align)` attribute: `align` needs an argument
-  --> $DIR/malformed-fn-align.rs:5:12
+error[E0539]: malformed `align` attribute input
+  --> $DIR/malformed-fn-align.rs:5:5
    |
-LL |     #[repr(align)]
-   |            ^^^^^ help: supply an argument here: `align(...)`
+LL |     #[align]
+   |     ^^^^^^^^ expected this to be a list
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL |     #[align(<alignment in bytes>)]
+   |            ++++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0539]: malformed `align` attribute input
+  --> $DIR/malformed-fn-align.rs:9:1
+   |
+LL | #[align = 16]
+   | ^^^^^^^^^^^^^ expected this to be a list
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[align = 16]
+LL + #[align(<alignment in bytes>)]
+   |
+LL - #[align = 16]
+LL + #[align]
+   |
 
-For more information about this error, try `rustc --explain E0589`.
+error[E0589]: invalid alignment value: not an unsuffixed integer
+  --> $DIR/malformed-fn-align.rs:12:9
+   |
+LL | #[align("hello")]
+   |         ^^^^^^^
+
+error[E0589]: invalid alignment value: not a power of two
+  --> $DIR/malformed-fn-align.rs:15:9
+   |
+LL | #[align(0)]
+   |         ^
+
+error: `#[repr(align(...))]` is not supported on function items
+  --> $DIR/malformed-fn-align.rs:18:8
+   |
+LL | #[repr(align(16))]
+   |        ^^^^^^^^^
+   |
+help: use `#[align(...)]` instead
+  --> $DIR/malformed-fn-align.rs:18:8
+   |
+LL | #[repr(align(16))]
+   |        ^^^^^^^^^
+
+error: `#[align(...)]` is not supported on struct items
+  --> $DIR/malformed-fn-align.rs:21:1
+   |
+LL | #[align(16)]
+   | ^^^^^^^^^^^^
+   |
+help: use `#[repr(align(...))]` instead
+   |
+LL - #[align(16)]
+LL + #[repr(align(16))]
+   |
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0539, E0589.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/feature-gates/feature-gate-fn_align.rs
+++ b/tests/ui/feature-gates/feature-gate-fn_align.rs
@@ -1,9 +1,12 @@
 #![crate_type = "lib"]
 
-#[repr(align(16))] //~ ERROR `repr(align)` attributes on functions are unstable
+#[align(16)]
+//~^ ERROR the `#[align]` attribute is an experimental feature
 fn requires_alignment() {}
 
 trait MyTrait {
-    #[repr(align)] //~ ERROR invalid `repr(align)` attribute: `align` needs an argument
+    #[align]
+    //~^ ERROR the `#[align]` attribute is an experimental feature
+    //~| ERROR malformed `align` attribute input
     fn myfun();
 }

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -1,20 +1,35 @@
-error[E0589]: invalid `repr(align)` attribute: `align` needs an argument
-  --> $DIR/feature-gate-fn_align.rs:7:12
+error[E0658]: the `#[align]` attribute is an experimental feature
+  --> $DIR/feature-gate-fn_align.rs:3:1
    |
-LL |     #[repr(align)]
-   |            ^^^^^ help: supply an argument here: `align(...)`
-
-error[E0658]: `repr(align)` attributes on functions are unstable
-  --> $DIR/feature-gate-fn_align.rs:3:8
-   |
-LL | #[repr(align(16))]
-   |        ^^^^^^^^^
+LL | #[align(16)]
+   | ^^^^^^^^^^^^
    |
    = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
    = help: add `#![feature(fn_align)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0658]: the `#[align]` attribute is an experimental feature
+  --> $DIR/feature-gate-fn_align.rs:8:5
+   |
+LL |     #[align]
+   |     ^^^^^^^^
+   |
+   = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
+   = help: add `#![feature(fn_align)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-Some errors have detailed explanations: E0589, E0658.
-For more information about an error, try `rustc --explain E0589`.
+error[E0539]: malformed `align` attribute input
+  --> $DIR/feature-gate-fn_align.rs:8:5
+   |
+LL |     #[align]
+   |     ^^^^^^^^ expected this to be a list
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL |     #[align(<alignment in bytes>)]
+   |            ++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0539, E0658.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/repr/attr-usage-repr.rs
+++ b/tests/ui/repr/attr-usage-repr.rs
@@ -45,7 +45,7 @@ enum EInt {
     B,
 }
 
-#[repr()] //~ ERROR attribute should be applied to a struct, enum, function, associated function, or union [E0517]
+#[repr()] //~ ERROR attribute should be applied to a struct, enum, or union [E0517]
 type SirThisIsAType = i32;
 
 #[repr()]

--- a/tests/ui/repr/attr-usage-repr.stderr
+++ b/tests/ui/repr/attr-usage-repr.stderr
@@ -36,13 +36,13 @@ LL | |     B,
 LL | | }
    | |_- not a struct
 
-error[E0517]: attribute should be applied to a struct, enum, function, associated function, or union
+error[E0517]: attribute should be applied to a struct, enum, or union
   --> $DIR/attr-usage-repr.rs:48:1
    |
 LL | #[repr()]
    | ^^^^^^^^^
 LL | type SirThisIsAType = i32;
-   | -------------------------- not a struct, enum, function, associated function, or union
+   | -------------------------- not a struct, enum, or union
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/repr/malformed-repr-hints.stderr
+++ b/tests/ui/repr/malformed-repr-hints.stderr
@@ -1,15 +1,3 @@
-error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
-  --> $DIR/malformed-repr-hints.rs:14:8
-   |
-LL | #[repr(align(2, 4))]
-   |        ^^^^^^^^^^^
-
-error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
-  --> $DIR/malformed-repr-hints.rs:18:8
-   |
-LL | #[repr(align())]
-   |        ^^^^^^^
-
 error[E0552]: incorrect `repr(packed)` attribute format: `packed` takes exactly one parenthesized argument, or no parentheses at all
   --> $DIR/malformed-repr-hints.rs:6:8
    |
@@ -21,6 +9,18 @@ error[E0589]: invalid `repr(align)` attribute: `align` needs an argument
    |
 LL | #[repr(align)]
    |        ^^^^^ help: supply an argument here: `align(...)`
+
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/malformed-repr-hints.rs:14:8
+   |
+LL | #[repr(align(2, 4))]
+   |        ^^^^^^^^^^^
+
+error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
+  --> $DIR/malformed-repr-hints.rs:18:8
+   |
+LL | #[repr(align())]
+   |        ^^^^^^^
 
 error[E0552]: invalid representation hint: `Rust` does not take a parenthesized argument list
   --> $DIR/malformed-repr-hints.rs:23:8


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/82232

https://github.com/rust-lang/rfcs/pull/3806 decides to add the `#[align]` attribute for alignment of various items. Right now it's used for functions with `fn_align`, in the future it will get more uses (statics, struct fields, etc.)

(the RFC finishes FCP today)

r? @ghost
