### PR TITLE
Only traverse reachable blocks in JumpThreading.

### DIFF
--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -89,7 +89,7 @@ impl<'tcx> crate::MirPass<'tcx> for JumpThreading {
             opportunities: Vec::new(),
         };
 
-        for bb in body.basic_blocks.indices() {
+        for (bb, _) in traversal::preorder(body) {
             finder.start_from_switch(bb);
         }
 

--- a/tests/ui/mir/unreachable-loop-jump-threading.rs
+++ b/tests/ui/mir/unreachable-loop-jump-threading.rs
@@ -1,9 +1,10 @@
-//@ known-bug: #131451
+//@ build-pass
 //@ needs-rustc-debug-assertions
 //@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+JumpThreading --crate-type=lib
 
 pub fn fun(terminate: bool) {
     while true {}
+    //~^ WARN denote infinite loops with `loop { ... }`
 
     while !terminate {}
 }

--- a/tests/ui/mir/unreachable-loop-jump-threading.stderr
+++ b/tests/ui/mir/unreachable-loop-jump-threading.stderr
@@ -1,0 +1,10 @@
+warning: denote infinite loops with `loop { ... }`
+  --> $DIR/unreachable-loop-jump-threading.rs:6:5
+   |
+LL |     while true {}
+   |     ^^^^^^^^^^ help: use `loop`
+   |
+   = note: `#[warn(while_true)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/131451

We only compute loop headers for reachable blocks. We shouldn't try to perform an opt on unreachable blocks anyway.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
