### PR TITLE
small iter.intersperse.fold() optimization

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -226,11 +226,13 @@ where
     let first = if started { next_item.take() } else { iter.next() };
     if let Some(x) = first {
         accum = f(accum, x);
-    }
 
-    iter.fold(accum, |mut accum, x| {
-        accum = f(accum, separator());
-        accum = f(accum, x);
+        iter.fold(accum, |mut accum, x| {
+            accum = f(accum, separator());
+            accum = f(accum, x);
+            accum
+        })
+    } else {
         accum
-    })
+    }
 }


### PR DESCRIPTION
No need to call into `fold` when the first item is already `None`, this avoids some redundant work for empty iterators.

"But it uses Fuse" one might want to protest, but Fuse is specialized and may call into the inner iterator anyway.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
