### PR TITLE
small iter.intersperse.fold() optimization

### DIFF
--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -223,7 +223,16 @@ where
 {
     let mut accum = init;
 
-    let first = if started { next_item.take() } else { iter.next() };
+    let first = if started {
+        next_item.take()
+    } else {
+        let n = iter.next();
+        // skip invoking fold() for empty iterators
+        if n.is_none() {
+            return accum;
+        }
+        n
+    };
     if let Some(x) = first {
         accum = f(accum, x);
     }


### PR DESCRIPTION
No need to call into fold when the first item is already None, this avoids some redundant work for empty iterators.

"But it uses Fuse" one might want to protest, but Fuse is specialized and may call into the inner iterator anyway.
