### PR TITLE
Refine run-make test ignores due to unpredictable `i686-pc-windows-gnu` unwind mechanism

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -17,14 +17,14 @@
 //!
 //! # Test history
 //!
-//! - The previous rmake.rs iteration of this test was flakey for unknown reason on `i686-mingw`
-//!   *specifically*, so assertion failures in this test was made extremely verbose to help
-//!   diagnose why the ICE messages was different *specifically* on `i686-mingw`.
-//! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
-//!   this test is still flakey, please restore the `ignore-windows` directive.
+//! The previous rmake.rs iteration of this test was flaky for unknown reason on
+//! `i686-pc-windows-gnu` *specifically*, so assertion failures in this test was made extremely
+//! verbose to help diagnose why the ICE messages was different. It appears that backtraces on
+//! `i686-pc-windows-gnu` specifically are quite unpredictable in how many backtrace frames are
+//! involved.
 
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercising ICE dump on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -86,9 +86,7 @@ fn test_metrics_errors() {
             .env("RUST_BACKTRACE", "short")
             .arg("-Zmetrics-dir=invaliddirectorythatdefinitelydoesntexist")
             .run_fail()
-            .assert_stderr_contains(
-                "error: cannot dump feature usage metrics: No such file or directory",
-            )
+            .assert_stderr_contains("error: cannot dump feature usage metrics")
             .assert_stdout_not_contains("internal compiler error");
     });
 }

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -7,12 +7,11 @@
 //!
 //! # Test history
 //!
-//! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
-//! those will be present in this test as well on the same platform
+//! - Forked from `dump-ice-to-disk` test, which previously had backtrace unpredictability on
+//! `i686-pc-windows-gnu`.
 
-//@ needs-target-std
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercises metrics incremental on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::path::{Path, PathBuf};
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -7,12 +7,10 @@
 //!
 //! # Test history
 //!
-//! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
-//! those will be present in this test as well on the same platform
+//! - Forked from `dump-ice-to-disk` test, where `i686-pc-windows-gnu` has unpredictable backtraces.
 
-//@ needs-target-std
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercises metrics dump on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::path::{Path, PathBuf};
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -83,9 +83,7 @@ fn test_metrics_errors() {
             .env("RUST_BACKTRACE", "short")
             .arg("-Zmetrics-dir=invaliddirectorythatdefinitelydoesntexist")
             .run_fail()
-            .assert_stderr_contains(
-                "error: cannot dump feature usage metrics: No such file or directory",
-            )
+            .assert_stderr_contains("error: cannot dump feature usage metrics")
             .assert_stdout_not_contains("internal compiler error");
     });
 }


### PR DESCRIPTION
Closes rust-lang/rust#128911. This PR *re-enables* the `dump-ice-to-disk` test and the unstable feature usage metrics tests for {x86_64,i686} Windows MSVC hosts and x86_64 Windows GNU host. I'll keep an eye out for these tests, and will broaden the ignores if this test is still flaky on not just `i686-pc-windows-gnu`.

r? mati865

try-job: x86_64-msvc-1
try-job: i686-msvc-1
try-job: x86_64-mingw-1
