### PR TITLE
Fix `-nopt` CI jobs

### DIFF
--- a/src/ci/docker/host-x86_64/i686-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/i686-gnu-nopt/Dockerfile
@@ -22,10 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN mkdir -p /config
-RUN echo "[rust]" > /config/nopt-std-config.toml
-RUN echo "optimize = false" >> /config/nopt-std-config.toml
-
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu --disable-optimize-tests
 ARG SCRIPT_ARG
 COPY scripts/stage_2_test_set1.sh /scripts/

--- a/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-nopt/Dockerfile
@@ -22,12 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN mkdir -p /config
-RUN echo "[rust]" > /config/nopt-std-config.toml
-RUN echo "optimize = false" >> /config/nopt-std-config.toml
-
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
   --set rust.test-compare-mode
-ENV SCRIPT python3 ../x.py test --stage 1 --config /config/nopt-std-config.toml library/std \
+ENV SCRIPT python3 ../x.py test --stage 1 --set rust.optimize=false library/std \
   && python3 ../x.py --stage 2 test

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -300,7 +300,7 @@ auto:
     env:
       IMAGE: i686-gnu-nopt
       DOCKER_SCRIPT: >-
-        python3 ../x.py test --stage 1 --config /config/nopt-std-config.toml library/std &&
+        python3 ../x.py test --stage 1 --set rust.optimize=false library/std &&
         /scripts/stage_2_test_set2.sh
     <<: *job-linux-4c
 


### PR DESCRIPTION
They were using `--config` instead of `--set`, which overrides too much stuff after recent changes to config merging.

Should hopefully unblock https://github.com/rust-lang/rust/pull/142447.

r? @jieyouxu