### PR TITLE
Ensure copy* intrinsics also perform the static self-init checks

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1412,8 +1412,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let src_alloc = self.get_alloc_raw(src_alloc_id)?;
         let src_range = alloc_range(src_offset, size);
         assert!(!self.memory.validation_in_progress.get(), "we can't be copying during validation");
-        // For the overlapping case, it is crucial that we trigger the read hook
+
+        // Trigger read hooks.
+        // For the overlapping case, it is crucial that we trigger the read hooks
         // before the write hook -- the aliasing model cares about the order.
+        if let Ok((alloc_id, ..)) = self.ptr_try_get_alloc_id(src, size.bytes() as i64) {
+            M::before_alloc_read(self, alloc_id)?;
+        }
         M::before_memory_read(
             tcx,
             &self.machine,

--- a/tests/ui/statics/read_before_init.rs
+++ b/tests/ui/statics/read_before_init.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+
+use std::mem::MaybeUninit;
+
+pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0));
+
+const fn foo(x: &i32) -> MaybeUninit<i32> {
+    let mut temp = MaybeUninit::<i32>::uninit();
+    unsafe {
+        std::ptr::copy(x, temp.as_mut_ptr(), 1);
+    }
+    temp
+}
+
+fn main() {}

--- a/tests/ui/statics/read_before_init.rs
+++ b/tests/ui/statics/read_before_init.rs
@@ -1,8 +1,15 @@
-//@ check-pass
+//! This test checks the one code path that does not go through
+//! the regular CTFE memory access (as an optimization). We forgot
+//! to duplicate the static item self-initialization check, allowing
+//! reading from the uninitialized static memory before it was
+//! initialized at the end of the static initializer.
+//!
+//! https://github.com/rust-lang/rust/issues/142532
 
 use std::mem::MaybeUninit;
 
 pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0));
+//~^ ERROR: encountered static that tried to initialize itself with itself
 
 const fn foo(x: &i32) -> MaybeUninit<i32> {
     let mut temp = MaybeUninit::<i32>::uninit();

--- a/tests/ui/statics/read_before_init.stderr
+++ b/tests/ui/statics/read_before_init.stderr
@@ -1,0 +1,17 @@
+error[E0080]: encountered static that tried to initialize itself with itself
+  --> $DIR/read_before_init.rs:11:45
+   |
+LL | pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0));
+   |                                             ^^^^^^^^^ evaluation of `X` failed inside this call
+   |
+note: inside `foo`
+  --> $DIR/read_before_init.rs:17:9
+   |
+LL |         std::ptr::copy(x, temp.as_mut_ptr(), 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: inside `std::ptr::copy::<i32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
fixes rust-lang/rust#142532

r? @RalfJung 