### PR TITLE
Make sure to propagate result from `visit_expr_fields`

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1420,7 +1420,7 @@ macro_rules! common_visitor_and_walkers {
                     let StructExpr { qself, path, fields, rest } = &$($mut)?**se;
                     try_visit!(vis.visit_qself(qself));
                     try_visit!(vis.visit_path(path));
-                    visit_expr_fields(vis, fields);
+                    try_visit!(visit_expr_fields(vis, fields));
                     match rest {
                         StructRest::Base(expr) => try_visit!(vis.visit_expr(expr)),
                         StructRest::Rest(_span) => {}

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -884,7 +884,7 @@ macro_rules! common_visitor_and_walkers {
                 TyKind::BareFn(function_declaration) => {
                     let BareFnTy { safety, ext: _, generic_params, decl, decl_span } =
                         &$($mut)? **function_declaration;
-                    visit_safety(vis, safety);
+                    try_visit!(visit_safety(vis, safety));
                     try_visit!(visit_generic_params(vis, generic_params));
                     try_visit!(vis.visit_fn_decl(decl));
                     try_visit!(visit_span(vis, decl_span));
@@ -1235,7 +1235,7 @@ macro_rules! common_visitor_and_walkers {
                     bounds,
                     bound_generic_params,
                 }) => {
-                    visit_generic_params(vis, bound_generic_params);
+                    try_visit!(visit_generic_params(vis, bound_generic_params));
                     try_visit!(vis.visit_ty(bounded_ty));
                     walk_list!(vis, visit_param_bound, bounds, BoundKind::Bound);
                 }

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
@@ -28,4 +28,11 @@ fn main() {
 
     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ());
     //~^ ERROR invalid argument to a legacy const generic
+
+    // A regression test for <https://github.com/rust-lang/rust/issues/142525>.
+    struct Struct<T> {
+        field: T,
+    }
+    std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+    //~^ ERROR invalid argument to a legacy const generic
 }

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
@@ -84,5 +84,17 @@ LL -     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ())
 LL +     std::arch::x86_64::_mm_inserti_si64::<{ || () }, { 1 + || () }>(loop {}, loop {});
    |
 
-error: aborting due to 7 previous errors
+error: invalid argument to a legacy const generic: cannot have const blocks, closures, async blocks or items
+  --> $DIR/invalid-rustc_legacy_const_generics-issue-123077.rs:36:71
+   |
+LL |     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+   |                                                                       ^^^^^
+   |
+help: try using a const generic argument instead
+   |
+LL -     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+LL +     std::arch::x86_64::_mm_blend_ps::<{ Struct { field: || () } }>(loop {}, loop {});
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
We weren't propagating the `ControlFlow::Break` out of a struct field, which means that the solution implemented in rust-lang/rust#130443 didn't work for nested fields.

Fixes rust-lang/rust#142525.