### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -158,6 +158,9 @@ pub enum AttributeKind {
     /// Represents `#[allow_internal_unstable]`.
     AllowInternalUnstable(ThinVec<(Symbol, Span)>),
 
+    /// Represents `#[rustc_as_ptr]` (used by the `dangling_pointers_from_temporaries` lint).
+    AsPtr(Span),
+
     /// Represents `#[rustc_default_body_unstable]`.
     BodyStability {
         stability: DefaultBodyStability,

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -1,0 +1,21 @@
+use rustc_attr_data_structures::AttributeKind;
+use rustc_span::{Symbol, sym};
+
+use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::context::{AcceptContext, Stage};
+use crate::parser::ArgParser;
+
+pub(crate) struct AsPtrParser;
+
+impl<S: Stage> SingleAttributeParser<S> for AsPtrParser {
+    const PATH: &[Symbol] = &[sym::rustc_as_ptr];
+
+    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepFirst;
+
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, _args: &ArgParser<'_>) -> Option<AttributeKind> {
+        // FIXME: check that there's no args (this is currently checked elsewhere)
+        Some(AttributeKind::AsPtr(cx.attr_span))
+    }
+}

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod allow_unstable;
 pub(crate) mod cfg;
 pub(crate) mod confusables;
 pub(crate) mod deprecation;
+pub(crate) mod lint_helpers;
 pub(crate) mod repr;
 pub(crate) mod stability;
 pub(crate) mod transparency;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -18,6 +18,7 @@ use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
 use crate::attributes::allow_unstable::{AllowConstFnUnstableParser, AllowInternalUnstableParser};
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
+use crate::attributes::lint_helpers::AsPtrParser;
 use crate::attributes::repr::ReprParser;
 use crate::attributes::stability::{
     BodyStabilityParser, ConstStabilityIndirectParser, ConstStabilityParser, StabilityParser,
@@ -102,6 +103,7 @@ attribute_parsers!(
         // tidy-alphabetical-end
 
         // tidy-alphabetical-start
+        Single<AsPtrParser>,
         Single<ConstStabilityIndirectParser>,
         Single<DeprecationParser>,
         Single<TransparencyParser>,

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -626,7 +626,7 @@ impl<'gcc, 'tcx> ArgAbiExt<'gcc, 'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 bx.lifetime_start(llscratch, scratch_size);
 
                 // ... where we first store the value...
-                bx.store(val, llscratch, scratch_align);
+                rustc_codegen_ssa::mir::store_cast(bx, cast, val, llscratch, scratch_align);
 
                 // ... and then memcpy it to the intended destination.
                 bx.memcpy(

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -229,7 +229,7 @@ impl<'ll, 'tcx> ArgAbiExt<'ll, 'tcx> for ArgAbi<'tcx, Ty<'tcx>> {
                 let llscratch = bx.alloca(scratch_size, scratch_align);
                 bx.lifetime_start(llscratch, scratch_size);
                 // ...store the value...
-                bx.store(val, llscratch, scratch_align);
+                rustc_codegen_ssa::mir::store_cast(bx, cast, val, llscratch, scratch_align);
                 // ... and then memcpy it to the intended destination.
                 bx.memcpy(
                     dst.val.llval,

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -26,6 +26,7 @@ pub mod place;
 mod rvalue;
 mod statement;
 
+pub use self::block::store_cast;
 use self::debuginfo::{FunctionDebugContext, PerLocalVarDebugInfo};
 use self::operand::{OperandRef, OperandValue};
 use self::place::PlaceRef;
@@ -259,7 +260,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                     }
                     PassMode::Cast { ref cast, .. } => {
                         debug!("alloc: {:?} (return place) -> place", local);
-                        let size = cast.size(&start_bx);
+                        let size = cast.size(&start_bx).max(layout.size);
                         return LocalRef::Place(PlaceRef::alloca_size(&mut start_bx, size, layout));
                     }
                     _ => {}

--- a/compiler/rustc_lint/src/dangling.rs
+++ b/compiler/rustc_lint/src/dangling.rs
@@ -1,4 +1,5 @@
 use rustc_ast::visit::{visit_opt, walk_list};
+use rustc_attr_data_structures::{AttributeKind, find_attr};
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{FnKind, Visitor, walk_expr};
 use rustc_hir::{Block, Body, Expr, ExprKind, FnDecl, LangItem};
@@ -133,7 +134,7 @@ fn lint_expr(cx: &LateContext<'_>, expr: &Expr<'_>) {
         && let ty = cx.typeck_results().expr_ty(receiver)
         && owns_allocation(cx.tcx, ty)
         && let Some(fn_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
-        && cx.tcx.has_attr(fn_id, sym::rustc_as_ptr)
+        && find_attr!(cx.tcx.get_all_attrs(fn_id), AttributeKind::AsPtr(_))
     {
         // FIXME: use `emit_node_lint` when `#[primary_span]` is added.
         cx.tcx.emit_node_span_lint(

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -170,12 +170,12 @@ impl TypoCandidate {
     }
 }
 
-impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
+impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn make_base_error(
         &mut self,
         path: &[Segment],
         span: Span,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         res: Option<Res>,
     ) -> BaseError {
         // Make the base error.
@@ -421,7 +421,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         res: Option<Res>,
         qself: Option<&QSelf>,
     ) -> (Diag<'tcx>, Vec<ImportSuggestion>) {
@@ -539,7 +539,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         res: Option<Res>,
         qself: Option<&QSelf>,
     ) {
@@ -650,7 +650,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn try_lookup_name_relaxed(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
@@ -940,7 +940,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_trait_and_bounds(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         res: Option<Res>,
         span: Span,
         base_error: &BaseError,
@@ -1017,7 +1017,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_typo(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
@@ -1063,7 +1063,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_shadowed(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
@@ -1096,7 +1096,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn err_code_special_cases(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         span: Span,
     ) {
@@ -1141,7 +1141,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_self_ty(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         span: Span,
     ) -> bool {
@@ -1164,7 +1164,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_self_value(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         span: Span,
     ) -> bool {
@@ -1332,7 +1332,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_swapping_misplaced_self_ty_and_trait(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         res: Option<Res>,
         span: Span,
     ) {
@@ -1361,7 +1361,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         &mut self,
         err: &mut Diag<'_>,
         res: Option<Res>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
     ) {
         let PathSource::TupleStruct(_, _) = source else { return };
         let Some(Res::Def(DefKind::Fn, _)) = res else { return };
@@ -1373,7 +1373,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         &mut self,
         err: &mut Diag<'_>,
         res: Option<Res>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         span: Span,
     ) {
         let PathSource::Trait(_) = source else { return };
@@ -1422,7 +1422,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_pattern_match_with_let(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         span: Span,
     ) -> bool {
         if let PathSource::Expr(_) = source
@@ -1448,7 +1448,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn get_single_associated_item(
         &mut self,
         path: &[Segment],
-        source: &PathSource<'_, '_>,
+        source: &PathSource<'_, '_, '_>,
         filter_fn: &impl Fn(Res) -> bool,
     ) -> Option<TypoSuggestion> {
         if let crate::PathSource::TraitItem(_, _) = source {
@@ -1556,7 +1556,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
     /// Check if the source is call expression and the first argument is `self`. If true,
     /// return the span of whole call and the span for all arguments expect the first one (`self`).
-    fn call_has_self_arg(&self, source: PathSource<'_, '_>) -> Option<(Span, Option<Span>)> {
+    fn call_has_self_arg(&self, source: PathSource<'_, '_, '_>) -> Option<(Span, Option<Span>)> {
         let mut has_self_arg = None;
         if let PathSource::Expr(Some(parent)) = source
             && let ExprKind::Call(_, args) = &parent.kind
@@ -1614,7 +1614,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         &mut self,
         err: &mut Diag<'_>,
         span: Span,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         path: &[Segment],
         res: Res,
         path_str: &str,
@@ -1666,7 +1666,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             }
         };
 
-        let find_span = |source: &PathSource<'_, '_>, err: &mut Diag<'_>| {
+        let find_span = |source: &PathSource<'_, '_, '_>, err: &mut Diag<'_>| {
             match source {
                 PathSource::Expr(Some(Expr { span, kind: ExprKind::Call(_, _), .. }))
                 | PathSource::TupleStruct(span, _) => {
@@ -2699,7 +2699,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_using_enum_variant(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
         def_id: DefId,
         span: Span,
     ) {
@@ -2877,7 +2877,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     pub(crate) fn suggest_adding_generic_parameter(
         &self,
         path: &[Segment],
-        source: PathSource<'_, '_>,
+        source: PathSource<'_, '_, '_>,
     ) -> Option<(Span, &'static str, String, Applicability)> {
         let (ident, span) = match path {
             [segment]

--- a/compiler/rustc_target/src/callconv/mips64.rs
+++ b/compiler/rustc_target/src/callconv/mips64.rs
@@ -2,9 +2,7 @@ use rustc_abi::{
     BackendRepr, FieldsShape, Float, HasDataLayout, Primitive, Reg, Size, TyAbiInterface,
 };
 
-use crate::callconv::{
-    ArgAbi, ArgAttribute, ArgAttributes, ArgExtension, CastTarget, FnAbi, PassMode, Uniform,
-};
+use crate::callconv::{ArgAbi, ArgExtension, CastTarget, FnAbi, PassMode, Uniform};
 
 fn extend_integer_width_mips<Ty>(arg: &mut ArgAbi<'_, Ty>, bits: u64) {
     // Always sign extend u32 values on 64-bit mips
@@ -140,16 +138,7 @@ where
 
     // Extract first 8 chunks as the prefix
     let rest_size = size - Size::from_bytes(8) * prefix_index as u64;
-    arg.cast_to(CastTarget {
-        prefix,
-        rest: Uniform::new(Reg::i64(), rest_size),
-        attrs: ArgAttributes {
-            regular: ArgAttribute::default(),
-            arg_ext: ArgExtension::None,
-            pointee_size: Size::ZERO,
-            pointee_align: None,
-        },
-    });
+    arg.cast_to(CastTarget::prefixed(prefix, Uniform::new(Reg::i64(), rest_size)));
 }
 
 pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -5,9 +5,7 @@ use rustc_abi::{
     TyAndLayout,
 };
 
-use crate::callconv::{
-    ArgAbi, ArgAttribute, ArgAttributes, ArgExtension, CastTarget, FnAbi, Uniform,
-};
+use crate::callconv::{ArgAbi, ArgAttribute, CastTarget, FnAbi, Uniform};
 use crate::spec::HasTargetSpec;
 
 #[derive(Clone, Debug)]
@@ -197,16 +195,10 @@ where
                     rest_size = rest_size - Reg::i32().size;
                 }
 
-                arg.cast_to(CastTarget {
-                    prefix: data.prefix,
-                    rest: Uniform::new(Reg::i64(), rest_size),
-                    attrs: ArgAttributes {
-                        regular: data.arg_attribute,
-                        arg_ext: ArgExtension::None,
-                        pointee_size: Size::ZERO,
-                        pointee_align: None,
-                    },
-                });
+                arg.cast_to(
+                    CastTarget::prefixed(data.prefix, Uniform::new(Reg::i64(), rest_size))
+                        .with_attrs(data.arg_attribute.into()),
+                );
                 return;
             }
         }

--- a/tests/assembly/naked-functions/wasm32.rs
+++ b/tests/assembly/naked-functions/wasm32.rs
@@ -1,10 +1,10 @@
-// FIXME: add wasm32-unknown when the wasm32-unknown-unknown ABI is fixed
-// see https://github.com/rust-lang/rust/issues/115666
-//@ revisions: wasm64-unknown wasm32-wasip1
+//@ revisions: wasm32-unknown wasm64-unknown wasm32-wasip1
 //@ add-core-stubs
 //@ assembly-output: emit-asm
+//@ [wasm32-unknown] compile-flags: --target wasm32-unknown-unknown
 //@ [wasm64-unknown] compile-flags: --target wasm64-unknown-unknown
 //@ [wasm32-wasip1] compile-flags: --target wasm32-wasip1
+//@ [wasm32-unknown] needs-llvm-components: webassembly
 //@ [wasm64-unknown] needs-llvm-components: webassembly
 //@ [wasm32-wasip1] needs-llvm-components: webassembly
 
@@ -97,6 +97,7 @@ extern "C" fn fn_i64_i64(num: i64) -> i64 {
 }
 
 // CHECK-LABEL: fn_i128_i128:
+// wasm32-unknown: .functype fn_i128_i128 (i32, i64, i64) -> ()
 // wasm32-wasip1: .functype fn_i128_i128 (i32, i64, i64) -> ()
 // wasm64-unknown: .functype fn_i128_i128 (i64, i64, i64) -> ()
 #[allow(improper_ctypes_definitions)]
@@ -114,6 +115,7 @@ extern "C" fn fn_i128_i128(num: i128) -> i128 {
 }
 
 // CHECK-LABEL: fn_f128_f128:
+// wasm32-unknown: .functype fn_f128_f128 (i32, i64, i64) -> ()
 // wasm32-wasip1: .functype fn_f128_f128 (i32, i64, i64) -> ()
 // wasm64-unknown: .functype fn_f128_f128 (i64, i64, i64) -> ()
 #[no_mangle]
@@ -136,6 +138,7 @@ struct Compound {
 }
 
 // CHECK-LABEL: fn_compound_compound:
+// wasm32-unknown: .functype fn_compound_compound (i32, i32) -> ()
 // wasm32-wasip1: .functype fn_compound_compound (i32, i32) -> ()
 // wasm64-unknown: .functype fn_compound_compound (i64, i64) -> ()
 #[no_mangle]

--- a/tests/assembly/riscv-float-struct-abi.rs
+++ b/tests/assembly/riscv-float-struct-abi.rs
@@ -1,0 +1,177 @@
+//@ add-core-stubs
+//@ assembly-output: emit-asm
+//@ compile-flags: -Copt-level=3 --target riscv64gc-unknown-linux-gnu
+//@ needs-llvm-components: riscv
+
+#![feature(no_core, lang_items)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(C, align(64))]
+struct Aligned(f64);
+
+#[repr(C)]
+struct Padded(u8, Aligned);
+
+#[repr(C, packed)]
+struct Packed(u8, f32);
+
+impl Copy for Aligned {}
+impl Copy for Padded {}
+impl Copy for Packed {}
+
+extern "C" {
+    fn take_padded(x: Padded);
+    fn get_padded() -> Padded;
+    fn take_packed(x: Packed);
+    fn get_packed() -> Packed;
+}
+
+// CHECK-LABEL: pass_padded
+#[unsafe(no_mangle)]
+extern "C" fn pass_padded(out: &mut Padded, x: Padded) {
+    // CHECK: sb a1, 0(a0)
+    // CHECK-NEXT: fsd fa0, 64(a0)
+    // CHECK-NEXT: ret
+    *out = x;
+}
+
+// CHECK-LABEL: ret_padded
+#[unsafe(no_mangle)]
+extern "C" fn ret_padded(x: &Padded) -> Padded {
+    // CHECK: fld fa0, 64(a0)
+    // CHECK-NEXT: lbu a0, 0(a0)
+    // CHECK-NEXT: ret
+    *x
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn call_padded(x: &Padded) {
+    // CHECK: fld fa0, 64(a0)
+    // CHECK-NEXT: lbu a0, 0(a0)
+    // CHECK-NEXT: tail take_padded
+    unsafe {
+        take_padded(*x);
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn receive_padded(out: &mut Padded) {
+    // CHECK: addi sp, sp, -16
+    // CHECK-NEXT: .cfi_def_cfa_offset 16
+    // CHECK-NEXT: sd ra, [[#%d,RA_SPILL:]](sp)
+    // CHECK-NEXT: sd [[TEMP:.*]], [[#%d,TEMP_SPILL:]](sp)
+    // CHECK-NEXT: .cfi_offset ra, [[#%d,RA_SPILL - 16]]
+    // CHECK-NEXT: .cfi_offset [[TEMP]], [[#%d,TEMP_SPILL - 16]]
+    // CHECK-NEXT: mv [[TEMP]], a0
+    // CHECK-NEXT: call get_padded
+    // CHECK-NEXT: sb a0, 0([[TEMP]])
+    // CHECK-NEXT: fsd fa0, 64([[TEMP]])
+    // CHECK-NEXT: ld ra, [[#%d,RA_SPILL]](sp)
+    // CHECK-NEXT: ld [[TEMP]], [[#%d,TEMP_SPILL]](sp)
+    // CHECK: addi sp, sp, 16
+    // CHECK: ret
+    unsafe {
+        *out = get_padded();
+    }
+}
+
+// CHECK-LABEL: pass_packed
+#[unsafe(no_mangle)]
+extern "C" fn pass_packed(out: &mut Packed, x: Packed) {
+    // CHECK: addi sp, sp, -16
+    // CHECK-NEXT: .cfi_def_cfa_offset 16
+    // CHECK-NEXT: sb a1, 0(a0)
+    // CHECK-NEXT: fsw fa0, 8(sp)
+    // CHECK-NEXT: lw [[VALUE:.*]], 8(sp)
+    // CHECK-DAG: srli [[BYTE4:.*]], [[VALUE]], 24
+    // CHECK-DAG: srli [[BYTE3:.*]], [[VALUE]], 16
+    // CHECK-DAG: srli [[BYTE2:.*]], [[VALUE]], 8
+    // CHECK-DAG: sb [[VALUE]], 1(a0)
+    // CHECK-DAG: sb [[BYTE2]], 2(a0)
+    // CHECK-DAG: sb [[BYTE3]], 3(a0)
+    // CHECK-DAG: sb [[BYTE4]], 4(a0)
+    // CHECK-NEXT: addi sp, sp, 16
+    // CHECK: ret
+    *out = x;
+}
+
+// CHECK-LABEL: ret_packed
+#[unsafe(no_mangle)]
+extern "C" fn ret_packed(x: &Packed) -> Packed {
+    // CHECK: addi sp, sp, -16
+    // CHECK-NEXT: .cfi_def_cfa_offset 16
+    // CHECK-NEXT: lbu [[BYTE2:.*]], 2(a0)
+    // CHECK-NEXT: lbu [[BYTE1:.*]], 1(a0)
+    // CHECK-NEXT: lbu [[BYTE3:.*]], 3(a0)
+    // CHECK-NEXT: lbu [[BYTE4:.*]], 4(a0)
+    // CHECK-NEXT: slli [[SHIFTED2:.*]], [[BYTE2]], 8
+    // CHECK-NEXT: or [[BYTE12:.*]], [[SHIFTED2]], [[BYTE1]]
+    // CHECK-NEXT: slli [[SHIFTED3:.*]], [[BYTE3]], 16
+    // CHECK-NEXT: slli [[SHIFTED4:.*]], [[BYTE4]], 24
+    // CHECK-NEXT: or [[BYTE34:.*]], [[SHIFTED3]], [[SHIFTED4]]
+    // CHECK-NEXT: or [[VALUE:.*]], [[BYTE12]], [[BYTE34]]
+    // CHECK-NEXT: sw [[VALUE]], 8(sp)
+    // CHECK-NEXT: flw fa0, 8(sp)
+    // CHECK-NEXT: lbu a0, 0(a0)
+    // CHECK-NEXT: addi sp, sp, 16
+    // CHECK: ret
+    *x
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn call_packed(x: &Packed) {
+    // CHECK: addi sp, sp, -16
+    // CHECK-NEXT: .cfi_def_cfa_offset 16
+    // CHECK-NEXT: lbu [[BYTE2:.*]], 2(a0)
+    // CHECK-NEXT: lbu [[BYTE1:.*]], 1(a0)
+    // CHECK-NEXT: lbu [[BYTE3:.*]], 3(a0)
+    // CHECK-NEXT: lbu [[BYTE4:.*]], 4(a0)
+    // CHECK-NEXT: slli [[SHIFTED2:.*]], [[BYTE2]], 8
+    // CHECK-NEXT: or [[BYTE12:.*]], [[SHIFTED2]], [[BYTE1]]
+    // CHECK-NEXT: slli [[SHIFTED3:.*]], [[BYTE3]], 16
+    // CHECK-NEXT: slli [[SHIFTED4:.*]], [[BYTE4]], 24
+    // CHECK-NEXT: or [[BYTE34:.*]], [[SHIFTED3]], [[SHIFTED4]]
+    // CHECK-NEXT: or [[VALUE:.*]], [[BYTE12]], [[BYTE34]]
+    // CHECK-NEXT: sw [[VALUE]], 8(sp)
+    // CHECK-NEXT: flw fa0, 8(sp)
+    // CHECK-NEXT: lbu a0, 0(a0)
+    // CHECK-NEXT: addi sp, sp, 16
+    // CHECK: tail take_packed
+    unsafe {
+        take_packed(*x);
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn receive_packed(out: &mut Packed) {
+    // CHECK: addi sp, sp, -32
+    // CHECK-NEXT: .cfi_def_cfa_offset 32
+    // CHECK-NEXT: sd ra, [[#%d,RA_SPILL:]](sp)
+    // CHECK-NEXT: sd [[TEMP:.*]], [[#%d,TEMP_SPILL:]](sp)
+    // CHECK-NEXT: .cfi_offset ra, [[#%d,RA_SPILL - 32]]
+    // CHECK-NEXT: .cfi_offset [[TEMP]], [[#%d,TEMP_SPILL - 32]]
+    // CHECK-NEXT: mv [[TEMP]], a0
+    // CHECK-NEXT: call get_packed
+    // CHECK-NEXT: sb a0, 0([[TEMP]])
+    // CHECK-NEXT: fsw fa0, [[FLOAT_SPILL:.*]](sp)
+    // CHECK-NEXT: lw [[VALUE:.*]], [[FLOAT_SPILL]](sp)
+    // CHECK-DAG: srli [[BYTE4:.*]], [[VALUE]], 24
+    // CHECK-DAG: srli [[BYTE3:.*]], [[VALUE]], 16
+    // CHECK-DAG: srli [[BYTE2:.*]], [[VALUE]], 8
+    // CHECK-DAG: sb [[VALUE]], 1([[TEMP]])
+    // CHECK-DAG: sb [[BYTE2]], 2([[TEMP]])
+    // CHECK-DAG: sb [[BYTE3]], 3([[TEMP]])
+    // CHECK-DAG: sb [[BYTE4]], 4([[TEMP]])
+    // CHECK-NEXT: ld ra, [[#%d,RA_SPILL]](sp)
+    // CHECK-NEXT: ld [[TEMP]], [[#%d,TEMP_SPILL]](sp)
+    // CHECK: addi sp, sp, 32
+    // CHECK: ret
+    unsafe {
+        *out = get_packed();
+    }
+}

--- a/tests/codegen/riscv-abi/cast-local-large-enough.rs
+++ b/tests/codegen/riscv-abi/cast-local-large-enough.rs
@@ -1,0 +1,44 @@
+//@ add-core-stubs
+//@ compile-flags: -Copt-level=0 -Cdebuginfo=0 --target riscv64gc-unknown-linux-gnu
+//@ needs-llvm-components: riscv
+
+#![feature(no_core, lang_items)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(C, align(64))]
+struct Aligned(f64);
+
+#[repr(C, align(64))]
+struct AlignedPair(f32, f64);
+
+impl Copy for Aligned {}
+impl Copy for AlignedPair {}
+
+// CHECK-LABEL: define double @read_aligned
+#[unsafe(no_mangle)]
+pub extern "C" fn read_aligned(x: &Aligned) -> Aligned {
+    // CHECK: %[[TEMP:.*]] = alloca [64 x i8], align 64
+    // CHECK-NEXT: call void @llvm.memcpy.p0.p0.i64(ptr align 64 %[[TEMP]], ptr align 64 %[[PTR:.*]], i64 64, i1 false)
+    // CHECK-NEXT: %[[RES:.*]] = load double, ptr %[[TEMP]], align 64
+    // CHECK-NEXT: ret double %[[RES]]
+    *x
+}
+
+// CHECK-LABEL: define { float, double } @read_aligned_pair
+#[unsafe(no_mangle)]
+pub extern "C" fn read_aligned_pair(x: &AlignedPair) -> AlignedPair {
+    // CHECK: %[[TEMP:.*]] = alloca [64 x i8], align 64
+    // CHECK-NEXT: call void @llvm.memcpy.p0.p0.i64(ptr align 64 %[[TEMP]], ptr align 64 %[[PTR:.*]], i64 64, i1 false)
+    // CHECK-NEXT: %[[FIRST:.*]] = load float, ptr %[[TEMP]], align 64
+    // CHECK-NEXT: %[[SECOND_PTR:.*]] = getelementptr inbounds i8, ptr %[[TEMP]], i64 8
+    // CHECK-NEXT: %[[SECOND:.*]] = load double, ptr %[[SECOND_PTR]], align 8
+    // CHECK-NEXT: %[[RES1:.*]] = insertvalue { float, double } poison, float %[[FIRST]], 0
+    // CHECK-NEXT: %[[RES2:.*]] = insertvalue { float, double } %[[RES1]], double %[[SECOND]], 1
+    // CHECK-NEXT: ret { float, double } %[[RES2]]
+    *x
+}

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // ignore-tidy-linelength
 
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current

--- a/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
+++ b/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // Test that `-Awarnings` suppresses warnings for unstable APIs.
 
 use run_make_support::rustc;

--- a/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
+++ b/tests/run-make/artifact-incr-cache-no-obj/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // emitting an object file is not necessary if user didn't ask for one
 //
 // This test is similar to run-make/artifact-incr-cache but it doesn't

--- a/tests/run-make/artifact-incr-cache/rmake.rs
+++ b/tests/run-make/artifact-incr-cache/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // rustc should be able to emit required files (asm, llvm-*, etc) during incremental
 // compilation on the first pass by running the code gen as well as on subsequent runs -
 // extracting them from the cache

--- a/tests/run-make/bin-emit-no-symbols/rmake.rs
+++ b/tests/run-make/bin-emit-no-symbols/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When setting the crate type as a "bin" (in app.rs),
 // this could cause a bug where some symbols would not be
 // emitted in the object files. This has been fixed, and

--- a/tests/run-make/box-struct-no-segfault/rmake.rs
+++ b/tests/run-make/box-struct-no-segfault/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The crate "foo" tied to this test executes a very specific function,
 // which involves boxing an instance of the struct Foo. However,
 // this once caused a segmentation fault in cargo release builds due to an LLVM

--- a/tests/run-make/checksum-freshness/rmake.rs
+++ b/tests/run-make/checksum-freshness/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/compiler-lookup-paths-2/rmake.rs
+++ b/tests/run-make/compiler-lookup-paths-2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that extern crate declarations in Cargo without a corresponding declaration
 // in the manifest of a dependency are NOT allowed. The last rustc call does it anyways, which
 // should result in a compilation failure.

--- a/tests/run-make/compiler-lookup-paths/rmake.rs
+++ b/tests/run-make/compiler-lookup-paths/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Since #19941, rustc can accept specifications on its library search paths.
 // This test runs Rust programs with varied library dependencies, expecting them
 // to succeed or fail depending on the situation.

--- a/tests/run-make/const-trait-stable-toolchain/rmake.rs
+++ b/tests/run-make/const-trait-stable-toolchain/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test output of const super trait errors in both stable and nightly.
 // We don't want to provide suggestions on stable that only make sense in nightly.
 

--- a/tests/run-make/crate-circular-deps-link/rmake.rs
+++ b/tests/run-make/crate-circular-deps-link/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test that previously triggered a linker failure with root cause
 // similar to one found in the issue #69368.
 //

--- a/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
+++ b/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When using the flag -C linker-plugin-lto, static libraries could lose their upstream object
 // files during compilation. This bug was fixed in #53031, and this test compiles a staticlib
 // dependent on upstream, checking that the upstream object file still exists after no LTO and

--- a/tests/run-make/cross-lang-lto/rmake.rs
+++ b/tests/run-make/cross-lang-lto/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that the object files we generate are actually
 // LLVM bitcode files (as used by linker LTO plugins) when compiling with
 // -Clinker-plugin-lto.

--- a/tests/run-make/debugger-visualizer-dep-info/rmake.rs
+++ b/tests/run-make/debugger-visualizer-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks that files referenced via #[debugger_visualizer] are
 // included in `--emit dep-info` output.
 // See https://github.com/rust-lang/rust/pull/111641

--- a/tests/run-make/dep-info/rmake.rs
+++ b/tests/run-make/dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This is a simple smoke test for rustc's `--emit dep-info` feature. It prints out
 // information about dependencies in a Makefile-compatible format, as a `.d` file.
 // Note that this test does not check that the `.d` file is Makefile-compatible.

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Non-regression test for issue #132920 where multiple versions of the same crate are present in
 // the dependency graph, and an unexpected error in a dependent crate caused an ICE in the
 // unsatisfied bounds diagnostics for traits present in multiple crate versions.

--- a/tests/run-make/doctests-merge/rmake.rs
+++ b/tests/run-make/doctests-merge/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::path::Path;
 
 use run_make_support::{cwd, diff, rustc, rustdoc};

--- a/tests/run-make/doctests-runtool/rmake.rs
+++ b/tests/run-make/doctests-runtool/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Tests behavior of rustdoc `--test-runtool`.
 
 use std::path::PathBuf;

--- a/tests/run-make/dump-mono-stats/rmake.rs
+++ b/tests/run-make/dump-mono-stats/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A flag named dump-mono-stats was added to the compiler in 2022, which
 // collects stats on instantiation of items and their associated costs.
 // This test checks that the output stat file exists, and that it contains

--- a/tests/run-make/duplicate-output-flavors/rmake.rs
+++ b/tests/run-make/duplicate-output-flavors/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/embed-metadata/rmake.rs
+++ b/tests/run-make/embed-metadata/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Tests the -Zembed-metadata compiler flag.
 // Tracking issue: https://github.com/rust-lang/rust/issues/139165
 

--- a/tests/run-make/embed-source-dwarf/rmake.rs
+++ b/tests/run-make/embed-source-dwarf/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //@ ignore-windows
 //@ ignore-apple
 

--- a/tests/run-make/emit-named-files/rmake.rs
+++ b/tests/run-make/emit-named-files/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::path::Path;
 
 use run_make_support::{rfs, rustc};

--- a/tests/run-make/emit-path-unhashed/rmake.rs
+++ b/tests/run-make/emit-path-unhashed/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Specifying how rustc outputs a file can be done in different ways, such as
 // the output flag or the KIND=NAME syntax. However, some of these methods used
 // to result in different hashes on output files even though they yielded the

--- a/tests/run-make/emit-stack-sizes/rmake.rs
+++ b/tests/run-make/emit-stack-sizes/rmake.rs
@@ -6,6 +6,7 @@
 // this diagnostics information should be located.
 // See https://github.com/rust-lang/rust/pull/51946
 
+//@ needs-target-std
 //@ ignore-windows
 //@ ignore-apple
 // Reason: this feature only works when the output object format is ELF.

--- a/tests/run-make/emit-to-stdout/rmake.rs
+++ b/tests/run-make/emit-to-stdout/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //! If `-o -` or `--emit KIND=-` is provided, output should be written to stdout
 //! instead. Binary output (`obj`, `llvm-bc`, `link` and `metadata`)
 //! being written this way will result in an error if stdout is a tty.

--- a/tests/run-make/env-dep-info/rmake.rs
+++ b/tests/run-make/env-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Inside dep-info emit files, #71858 made it so all accessed environment
 // variables are usefully printed. This test checks that this feature works
 // as intended by checking if the environment variables used in compilation

--- a/tests/run-make/error-found-staticlib-instead-crate/rmake.rs
+++ b/tests/run-make/error-found-staticlib-instead-crate/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When rustc is looking for a crate but is given a staticlib instead,
 // the error message should be helpful and indicate precisely the cause
 // of the compilation failure.

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Test that we exit with the correct exit code for successful / unsuccessful / ICE compilations
 
 use run_make_support::{rustc, rustdoc};

--- a/tests/run-make/export/disambiguator/rmake.rs
+++ b/tests/run-make/export/disambiguator/rmake.rs
@@ -1,12 +1,7 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "2")
-        .input("app.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "2").input("app.rs").run();
 }

--- a/tests/run-make/export/extern-opt/rmake.rs
+++ b/tests/run-make/export/extern-opt/rmake.rs
@@ -1,10 +1,8 @@
-use run_make_support::{rustc, dynamic_lib_name};
+//@ needs-target-std
+use run_make_support::{dynamic_lib_name, rustc};
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
 
     rustc()
         .env("RUSTC_FORCE_RUSTC_VERSION", "2")

--- a/tests/run-make/export/simple/rmake.rs
+++ b/tests/run-make/export/simple/rmake.rs
@@ -1,12 +1,7 @@
+//@ needs-target-std
 use run_make_support::rustc;
 
 fn main() {
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "1")
-        .input("libr.rs")
-        .run();
-    rustc()
-        .env("RUSTC_FORCE_RUSTC_VERSION", "2")
-        .input("app.rs")
-        .run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "1").input("libr.rs").run();
+    rustc().env("RUSTC_FORCE_RUSTC_VERSION", "2").input("app.rs").run();
 }

--- a/tests/run-make/extern-diff-internal-name/rmake.rs
+++ b/tests/run-make/extern-diff-internal-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In the following scenario:
 // 1. The crate foo, is referenced multiple times
 // 2. --extern foo=./path/to/libbar.rlib is specified to rustc

--- a/tests/run-make/extern-flag-fun/rmake.rs
+++ b/tests/run-make/extern-flag-fun/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The --extern flag can override the default crate search of
 // the compiler and directly fetch a given path. There are a few rules
 // to follow: for example, there can't be more than one rlib, the crates must

--- a/tests/run-make/extern-flag-rename-transitive/rmake.rs
+++ b/tests/run-make/extern-flag-rename-transitive/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, baz.rs is looking for an extern crate "a" which
 // does not exist, and can only run through the --extern rustc flag
 // defining that the "a" crate is in fact just "foo". This test

--- a/tests/run-make/extern-multiple-copies/rmake.rs
+++ b/tests/run-make/extern-multiple-copies/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the rust library foo1 exists in two different locations, but only one
 // is required by the --extern flag. This test checks that the copy is ignored (as --extern
 // demands fetching only the original instance of foo1) and that no error is emitted, resulting

--- a/tests/run-make/extern-multiple-copies2/rmake.rs
+++ b/tests/run-make/extern-multiple-copies2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Almost identical to `extern-multiple-copies`, but with a variation in the --extern calls
 // and the addition of #[macro_use] in the rust code files, which used to break --extern
 // until #33625.

--- a/tests/run-make/ice-static-mir/rmake.rs
+++ b/tests/run-make/ice-static-mir/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Trying to access mid-level internal representation (MIR) in statics
 // used to cause an internal compiler error (ICE), now handled as a proper
 // error since #100211. This test checks that the correct error is printed

--- a/tests/run-make/include-all-symbols-linking/rmake.rs
+++ b/tests/run-make/include-all-symbols-linking/rmake.rs
@@ -7,6 +7,7 @@
 // See https://github.com/rust-lang/rust/pull/95604
 // See https://github.com/rust-lang/rust/issues/47384
 
+//@ needs-target-std
 //@ ignore-wasm differences in object file formats causes errors in the llvm_objdump step.
 //@ ignore-windows differences in object file formats causes errors in the llvm_objdump step.
 

--- a/tests/run-make/include-bytes-deps/rmake.rs
+++ b/tests/run-make/include-bytes-deps/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // include_bytes! and include_str! in `main.rs`
 // should register the included file as of #24423,
 // and this test checks that this is still the case.

--- a/tests/run-make/incremental-debugger-visualizer/rmake.rs
+++ b/tests/run-make/incremental-debugger-visualizer/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test ensures that changes to files referenced via #[debugger_visualizer]
 // (in this case, foo.py and foo.natvis) are picked up when compiling incrementally.
 // See https://github.com/rust-lang/rust/pull/111641

--- a/tests/run-make/inline-always-many-cgu/rmake.rs
+++ b/tests/run-make/inline-always-many-cgu/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use std::ffi::OsStr;
 
 use run_make_support::regex::Regex;

--- a/tests/run-make/invalid-so/rmake.rs
+++ b/tests/run-make/invalid-so/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When a fake library was given to the compiler, it would
 // result in an obscure and unhelpful error message. This test
 // creates a false "foo" dylib, and checks that the standard error

--- a/tests/run-make/invalid-staticlib/rmake.rs
+++ b/tests/run-make/invalid-staticlib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // If the static library provided is not valid (in this test,
 // created as an empty file),
 // rustc should print a normal error message and not throw

--- a/tests/run-make/invalid-symlink-search-path/rmake.rs
+++ b/tests/run-make/invalid-symlink-search-path/rmake.rs
@@ -5,6 +5,7 @@
 //
 // See https://github.com/rust-lang/rust/issues/26006
 
+//@ needs-target-std
 //@ needs-symlink
 //Reason: symlink requires elevated permission in Windows
 

--- a/tests/run-make/invalid-tmpdir-env-var/rmake.rs
+++ b/tests/run-make/invalid-tmpdir-env-var/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When the TMP (on Windows) or TMPDIR (on Unix) variable is set to an invalid
 // or non-existing directory, this used to cause an internal compiler error (ICE). After the
 // addition of proper error handling in #28430, this test checks that the expected message is

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;

--- a/tests/run-make/issue-125484-used-dependencies/rmake.rs
+++ b/tests/run-make/issue-125484-used-dependencies/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Non-regression test for issues #125474, #125484, #125646, with the repro taken from #125484. Some
 // queries use "used dependencies" while others use "speculatively loaded dependencies", and an
 // indexing ICE appeared in some cases when these were unexpectedly used in the same context.

--- a/tests/run-make/json-error-no-offset/rmake.rs
+++ b/tests/run-make/json-error-no-offset/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The byte positions in json format error logging used to have a small, difficult
 // to predict offset. This was changed to be the top of the file every time in #42973,
 // and this test checks that the measurements appearing in the standard error are correct.

--- a/tests/run-make/lib-trait-for-trait-no-ice/rmake.rs
+++ b/tests/run-make/lib-trait-for-trait-no-ice/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Inside a library, implementing a trait for another trait
 // with a lifetime used to cause an internal compiler error (ICE).
 // This test checks that this bug does not make a resurgence -

--- a/tests/run-make/link-arg/rmake.rs
+++ b/tests/run-make/link-arg/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In 2016, the rustc flag "-C link-arg" was introduced - it can be repeatedly used
 // to add single arguments to the linker. This test passes 2 arguments to the linker using it,
 // then checks that the compiler's output contains the arguments passed to it.

--- a/tests/run-make/link-args-order/rmake.rs
+++ b/tests/run-make/link-args-order/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Passing linker arguments to the compiler used to be lost or reordered in a messy way
 // as they were passed further to the linker. This was fixed in #70665, and this test
 // checks that linker arguments remain intact and in the order they were originally passed in.

--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When native libraries are passed to the linker, there used to be an annoyance
 // where multiple instances of the same library in a row would cause duplication in
 // outputs. This has been fixed, and this test checks that it stays fixed.

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{Rustc, diff, regex, rustc};
 
 fn run_rustc() -> Rustc {

--- a/tests/run-make/llvm-outputs/rmake.rs
+++ b/tests/run-make/llvm-outputs/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 // test that directories get created when emitting llvm bitcode and IR
 
 use std::path::PathBuf;

--- a/tests/run-make/lto-avoid-object-duplication/rmake.rs
+++ b/tests/run-make/lto-avoid-object-duplication/rmake.rs
@@ -8,6 +8,7 @@
 // This test makes sure that functions defined in the upstream crates do not
 // appear twice in the final staticlib when listing all the symbols from it.
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: `llvm-objdump`'s output looks different on windows than on other platforms.
 // Only checking on Unix platforms should suffice.

--- a/tests/run-make/manual-crate-name/rmake.rs
+++ b/tests/run-make/manual-crate-name/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{path, rustc};
 
 fn main() {

--- a/tests/run-make/many-crates-but-no-match/rmake.rs
+++ b/tests/run-make/many-crates-but-no-match/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // An extended version of the ui/changing-crates.rs test, this test puts
 // multiple mismatching crates into the search path of crateC (A2 and A3)
 // and checks that the standard error contains helpful messages to indicate

--- a/tests/run-make/metadata-dep-info/rmake.rs
+++ b/tests/run-make/metadata-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Emitting dep-info alongside metadata would present subtle discrepancies
 // in the output file, such as the filename transforming underscores_ into hyphens-.
 // After the fix in #114750, this test checks that the emitted files are identical

--- a/tests/run-make/metadata-only-crate-no-ice/rmake.rs
+++ b/tests/run-make/metadata-only-crate-no-ice/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In a dependency hierarchy, metadata-only crates could cause an Internal
 // Compiler Error (ICE) due to a compiler bug - not correctly fetching sources for
 // metadata-only crates. This test is a minimal reproduction of a program that triggered

--- a/tests/run-make/missing-crate-dependency/rmake.rs
+++ b/tests/run-make/missing-crate-dependency/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A simple smoke test to check that rustc fails compilation
 // and outputs a helpful message when a dependency is missing
 // in a dependency chain.

--- a/tests/run-make/multiple-emits/rmake.rs
+++ b/tests/run-make/multiple-emits/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{path, rustc};
 
 fn main() {

--- a/tests/run-make/native-lib-alt-naming/rmake.rs
+++ b/tests/run-make/native-lib-alt-naming/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // On MSVC the alternative naming format for static libraries (`libfoo.a`) is accepted in addition
 // to the default format (`foo.lib`).
 

--- a/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
@@ -3,6 +3,7 @@
 // This test is the same as native-link-modifier-rustc, but without rlibs.
 // See https://github.com/rust-lang/rust/issues/99425
 
+//@ needs-target-std
 //@ ignore-apple
 // Reason: linking fails due to the unusual ".ext" staticlib name.
 

--- a/tests/run-make/native-link-modifier-verbatim-rustc/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-rustc/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `verbatim` is a native link modifier that forces rustc to only accept libraries with
 // a specified name. This test checks that this modifier works as intended.
 // This test is the same as native-link-modifier-linker, but with rlibs.

--- a/tests/run-make/no-builtins-attribute/rmake.rs
+++ b/tests/run-make/no-builtins-attribute/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `no_builtins` is an attribute related to LLVM's optimizations. In order to ensure that it has an
 // effect on link-time optimizations (LTO), it should be added to function declarations in a crate.
 // This test uses the `llvm-filecheck` tool to determine that this attribute is successfully

--- a/tests/run-make/no-builtins-lto/rmake.rs
+++ b/tests/run-make/no-builtins-lto/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The rlib produced by a no_builtins crate should be explicitly linked
 // during compilation, and as a result be present in the linker arguments.
 // See the comments inside this file for more details.

--- a/tests/run-make/non-unicode-env/rmake.rs
+++ b/tests/run-make/non-unicode-env/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/notify-all-emit-artifacts/rmake.rs
+++ b/tests/run-make/notify-all-emit-artifacts/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // rust should produce artifact notifications about files it was asked to --emit.
 //
 // It should work in incremental mode both on the first pass where files are generated as well

--- a/tests/run-make/optimization-remarks-dir/rmake.rs
+++ b/tests/run-make/optimization-remarks-dir/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the function `bar` has #[inline(never)] and the function `foo`
 // does not. This test outputs LLVM optimization remarks twice - first for all
 // functions (including `bar`, and the `inline` mention), and then for only `foo`

--- a/tests/run-make/overwrite-input/rmake.rs
+++ b/tests/run-make/overwrite-input/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // An attempt to set the output `-o` into a directory or a file we cannot write into should indeed
 // be an error; but not an ICE (Internal Compiler Error). This test attempts both and checks
 // that the standard error matches what is expected.

--- a/tests/run-make/parallel-rustc-no-overwrite/rmake.rs
+++ b/tests/run-make/parallel-rustc-no-overwrite/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When two instances of rustc are invoked in parallel, they
 // can conflict on their temporary files and overwrite each others',
 // leading to unsuccessful compilation. The -Z temps-dir flag adds

--- a/tests/run-make/pass-linker-flags-from-dep/rmake.rs
+++ b/tests/run-make/pass-linker-flags-from-dep/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A similar test to pass-linker-flags, testing that the `-l link-arg` flag
 // respects the order relative to other `-l` flags, but this time, the flags
 // are passed on the compilation of a dependency. This test checks that the

--- a/tests/run-make/pass-linker-flags/rmake.rs
+++ b/tests/run-make/pass-linker-flags/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks the proper function of `-l link-arg=NAME`, which, unlike
 // -C link-arg, is supposed to guarantee that the order relative to other -l
 // options will be respected. In this test, compilation fails (because none of the

--- a/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
+++ b/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // LLVM's profiling instrumentation adds a few symbols that are used by the profiler runtime.
 // Since these show up as globals in the LLVM IR, the compiler generates dllimport-related
 // __imp_ stubs for them. This can lead to linker errors because the instrumentation

--- a/tests/run-make/pretty-print-with-dep-file/rmake.rs
+++ b/tests/run-make/pretty-print-with-dep-file/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Passing --emit=dep-info to the Rust compiler should create a .d file...
 // but it failed to do so in Rust 1.69.0 when combined with -Z unpretty=expanded
 // due to a bug. This test checks that -Z unpretty=expanded does not prevent the

--- a/tests/run-make/proc-macro-three-crates/rmake.rs
+++ b/tests/run-make/proc-macro-three-crates/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A compiler bug caused the following issue:
 // If a crate A depends on crate B, and crate B
 // depends on crate C, and crate C contains a procedural

--- a/tests/run-make/remap-path-prefix-dwarf/rmake.rs
+++ b/tests/run-make/remap-path-prefix-dwarf/rmake.rs
@@ -4,6 +4,7 @@
 // It tests several cases, each of them has a detailed description attached to it.
 // See https://github.com/rust-lang/rust/pull/96867
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: the remap path prefix is not printed in the dwarf dump.
 

--- a/tests/run-make/remap-path-prefix/rmake.rs
+++ b/tests/run-make/remap-path-prefix/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Generating metadata alongside remap-path-prefix would fail to actually remap the path
 // in the metadata. After this was fixed in #85344, this test checks that "auxiliary" is being
 // successfully remapped to "/the/aux" in the rmeta files.

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //@ ignore-windows
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 

--- a/tests/run-make/reproducible-build-2/rmake.rs
+++ b/tests/run-make/reproducible-build-2/rmake.rs
@@ -6,6 +6,7 @@
 // Outputs should be identical.
 // See https://github.com/rust-lang/rust/issues/34902
 
+//@ needs-target-std
 //@ ignore-windows
 // Reasons:
 // 1. The object files are reproducible, but their paths are not, which causes

--- a/tests/run-make/resolve-rename/rmake.rs
+++ b/tests/run-make/resolve-rename/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // If a library is compiled with -C extra-filename, the rust compiler
 // will take this into account when searching for libraries. However,
 // if that library is then renamed, the rust compiler should fall back

--- a/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
+++ b/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // `-Z packed_bundled_libs` is an unstable rustc flag that makes the compiler
 // only require a native library and no supplementary object files to compile.
 // This test simply checks that this flag can be passed alongside verbatim syntax

--- a/tests/run-make/rustc-macro-dep-files/rmake.rs
+++ b/tests/run-make/rustc-macro-dep-files/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // --emit dep-info used to print all macro-generated code it could
 // find as if it was part of a nonexistent file named "proc-macro source",
 // which is not a valid path. After this was fixed in #36776, this test checks

--- a/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-invalid-expr/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-multiple/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-ordering/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 mod scrape;
 
 fn main() {

--- a/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-test/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-whitespace/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 #[path = "../rustdoc-scrape-examples-remap/scrape.rs"]
 mod scrape;
 

--- a/tests/run-make/rustdoc-with-short-out-dir-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-short-out-dir-option/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 use run_make_support::{htmldocck, rustdoc};
 
 fn main() {

--- a/tests/run-make/share-generics-dylib/rmake.rs
+++ b/tests/run-make/share-generics-dylib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test makes sure all generic instances get re-exported from Rust dylibs for use by
 // `-Zshare-generics`. There are two rlibs (`instance_provider_a` and `instance_provider_b`)
 // which both provide an instance of `Cell<i32>::set`. There is `instance_user_dylib` which is

--- a/tests/run-make/short-ice/rmake.rs
+++ b/tests/run-make/short-ice/rmake.rs
@@ -4,6 +4,7 @@
 // was shortened down to an appropriate length.
 // See https://github.com/rust-lang/rust/issues/107910
 
+//@ needs-target-std
 //@ ignore-windows
 // Reason: the assert_eq! on line 32 fails, as error output on Windows is different.
 

--- a/tests/run-make/stable-symbol-names/rmake.rs
+++ b/tests/run-make/stable-symbol-names/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // A typo in rustc caused generic symbol names to be non-deterministic -
 // that is, it was possible to compile the same file twice with no changes
 // and get outputs with different symbol names.

--- a/tests/run-make/staticlib-blank-lib/rmake.rs
+++ b/tests/run-make/staticlib-blank-lib/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // In this test, the static library foo is made blank, which used to cause
 // a compilation error. As the compiler now returns Ok upon encountering a blank
 // staticlib as of #12379, this test checks that compilation is successful despite

--- a/tests/run-make/staticlib-broken-bitcode/rmake.rs
+++ b/tests/run-make/staticlib-broken-bitcode/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Regression test for https://github.com/rust-lang/rust/issues/128955#issuecomment-2657811196
 // which checks that rustc can read an archive containing LLVM bitcode with a
 // newer version from the one rustc links against.

--- a/tests/run-make/staticlib-thin-archive/rmake.rs
+++ b/tests/run-make/staticlib-thin-archive/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Regression test for https://github.com/rust-lang/rust/issues/107407 which
 // checks that rustc can read thin archive. Before the object crate added thin
 // archive support rustc would add emit object files to the staticlib and after

--- a/tests/run-make/stdin-rustc/rmake.rs
+++ b/tests/run-make/stdin-rustc/rmake.rs
@@ -1,3 +1,4 @@
+//@ needs-target-std
 //! This test checks rustc `-` (stdin) support
 
 use std::path::PathBuf;

--- a/tests/run-make/symbol-visibility/rmake.rs
+++ b/tests/run-make/symbol-visibility/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Dynamic libraries on Rust used to export a very high amount of symbols,
 // going as far as filling the output with mangled names and generic function
 // names. After the rework of #38117, this test checks that no mangled Rust symbols

--- a/tests/run-make/symbols-include-type-name/rmake.rs
+++ b/tests/run-make/symbols-include-type-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Method names used to be obfuscated when exported into symbols,
 // leaving only an obscure `<impl>`. After the fix in #30328,
 // this test checks that method names are successfully saved in the symbol list.

--- a/tests/run-make/track-path-dep-info/rmake.rs
+++ b/tests/run-make/track-path-dep-info/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test checks the functionality of `tracked_path::path`, a procedural macro
 // feature that adds a dependency to another file inside the procmacro. In this case,
 // the text file is added through this method, and the test checks that the compilation

--- a/tests/run-make/type-mismatch-same-crate-name/rmake.rs
+++ b/tests/run-make/type-mismatch-same-crate-name/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // When a compilation failure deals with seemingly identical types, some helpful
 // errors should be printed.
 // The main use case of this error is when there are two crates

--- a/tests/run-make/unknown-mod-stdin/rmake.rs
+++ b/tests/run-make/unknown-mod-stdin/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // Rustc displays a compilation error when it finds a `mod` (module)
 // statement referencing a file that does not exist. However, a bug from 2019
 // caused invalid `mod` statements to silently insert empty inline modules

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -10,6 +10,7 @@
 //! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
 //! those will be present in this test as well on the same platform
 
+//@ needs-target-std
 //@ ignore-windows
 //FIXME(#128911): still flakey on i686-mingw.
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -10,6 +10,7 @@
 //! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
 //! those will be present in this test as well on the same platform
 
+//@ needs-target-std
 //@ ignore-windows
 //FIXME(#128911): still flakey on i686-mingw.
 

--- a/tests/run-make/use-suggestions-rust-2018/rmake.rs
+++ b/tests/run-make/use-suggestions-rust-2018/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // The compilation error caused by calling on an unimported crate
 // should have a suggestion to write, say, crate::bar::Foo instead
 // of just bar::Foo. However, this suggestion used to only appear for

--- a/tests/run-make/used/rmake.rs
+++ b/tests/run-make/used/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+//
 // This test ensures that the compiler is keeping static variables, even if not referenced
 // by another part of the program, in the output object file.
 //

--- a/tests/ui/abi/numbers-arithmetic/float-struct.rs
+++ b/tests/ui/abi/numbers-arithmetic/float-struct.rs
@@ -1,0 +1,44 @@
+//@ run-pass
+
+use std::fmt::Debug;
+use std::hint::black_box;
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct Regular(f32, f64);
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct Packed(f32, f64);
+
+#[repr(C, align(64))]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct AlignedF32(f32);
+
+#[repr(C)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+struct Aligned(f64, AlignedF32);
+
+#[inline(never)]
+extern "C" fn read<T: Copy>(x: &T) -> T {
+    *black_box(x)
+}
+
+#[inline(never)]
+extern "C" fn write<T: Copy>(x: T, dest: &mut T) {
+    *dest = black_box(x)
+}
+
+#[track_caller]
+fn check<T: Copy + PartialEq + Debug + Default>(x: T) {
+    assert_eq!(read(&x), x);
+    let mut out = T::default();
+    write(x, &mut out);
+    assert_eq!(out, x);
+}
+
+fn main() {
+    check(Regular(1.0, 2.0));
+    check(Packed(3.0, 4.0));
+    check(Aligned(5.0, AlignedF32(6.0)));
+}

--- a/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.rs
+++ b/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.rs
@@ -1,0 +1,34 @@
+//! Check that if the parser suggests converting `///` to a regular comment
+//! when it appears after a missing comma in an list (e.g. `enum` variants).
+//!
+//! Related issue
+//! - https://github.com/rust-lang/rust/issues/142311
+
+enum Foo {
+    /// Like the noise a sheep makes
+    Bar
+    /// Like where people drink
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `/// Like where people drink`
+    Baa///xxxxxx
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+    Baz///xxxxxx
+    //~^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+}
+
+fn foo() {
+    let a = [
+        1///xxxxxx
+        //~^ ERROR expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+        2
+    ];
+}
+
+fn bar() {
+    let a = [
+        1,
+        2///xxxxxx
+        //~^ ERROR expected one of `,`, `.`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+    ];
+}
+
+fn main() {}

--- a/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.stderr
+++ b/tests/ui/parser/doc-comment-after-missing-comma-issue-142311.stderr
@@ -1,0 +1,43 @@
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `/// Like where people drink`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:10:5
+   |
+LL |     Bar
+   |        -
+   |        |
+   |        expected one of `(`, `,`, `=`, `{`, or `}`
+   |        help: missing `,`
+LL |     /// Like where people drink
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unexpected token
+
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:12:8
+   |
+LL |     Baa///xxxxxx
+   |        -^^^^^^^^
+   |        |
+   |        expected one of `(`, `,`, `=`, `{`, or `}`
+   |        help: missing `,`
+
+error: expected one of `(`, `,`, `=`, `{`, or `}`, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:14:8
+   |
+LL |     Baz///xxxxxx
+   |        ^^^^^^^^^ expected one of `(`, `,`, `=`, `{`, or `}`
+   |
+   = help: doc comments must come before what they document, if a comment was intended use `//`
+   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+
+error: expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:20:10
+   |
+LL |         1///xxxxxx
+   |          ^^^^^^^^^ expected one of `,`, `.`, `;`, `?`, `]`, or an operator
+
+error: expected one of `,`, `.`, `?`, `]`, or an operator, found doc comment `///xxxxxx`
+  --> $DIR/doc-comment-after-missing-comma-issue-142311.rs:29:10
+   |
+LL |         2///xxxxxx
+   |          ^^^^^^^^^ expected one of `,`, `.`, `?`, `]`, or an operator
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#139340 (Fix RISC-V C function ABI when passing/returning structs containing floats)
 - rust-lang/rust#142341 (Don't suggest converting `///` to `//` when expecting `,`)
 - rust-lang/rust#142414 (ignore `run-make` tests that need `std` on targets without `std`)
 - rust-lang/rust#142498 (Port `#[rustc_as_ptr]` to the new attribute system)
 - rust-lang/rust#142554 (Fix `PathSource` lifetimes.)
 - rust-lang/rust#142562 (Update the `backtrace` submodule)
 - rust-lang/rust#142565 (Test naked asm for wasm32-unknown-unknown)
 - rust-lang/rust#142573 (`fn candidate_is_applicable` to method)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139340,142341,142414,142498,142554,142562,142565,142573)
<!-- homu-ignore:end -->