### PR TITLE
Allow `#[must_use]` on associated types to warn on unused values in generic contexts

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -37,6 +37,7 @@ mod sealed {
 
     /// This is for compatibility with the regular `Visitor`.
     pub trait MutVisitorResult {
+        #[cfg_attr(not(bootstrap), must_use)]
         type Result: VisitorResult;
     }
 

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -130,6 +130,7 @@ pub enum LifetimeCtxt {
 pub trait Visitor<'ast>: Sized {
     /// The result type of the `visit_*` methods. Can be either `()`,
     /// or `ControlFlow<T>`.
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
 
     fn visit_ident(&mut self, _ident: &'ast Ident) -> Self::Result {
@@ -884,7 +885,7 @@ macro_rules! common_visitor_and_walkers {
                 TyKind::BareFn(function_declaration) => {
                     let BareFnTy { safety, ext: _, generic_params, decl, decl_span } =
                         &$($mut)? **function_declaration;
-                    visit_safety(vis, safety);
+                    try_visit!(visit_safety(vis, safety));
                     try_visit!(visit_generic_params(vis, generic_params));
                     try_visit!(vis.visit_fn_decl(decl));
                     try_visit!(visit_span(vis, decl_span));
@@ -1235,7 +1236,7 @@ macro_rules! common_visitor_and_walkers {
                     bounds,
                     bound_generic_params,
                 }) => {
-                    visit_generic_params(vis, bound_generic_params);
+                    try_visit!(visit_generic_params(vis, bound_generic_params));
                     try_visit!(vis.visit_ty(bounded_ty));
                     walk_list!(vis, visit_param_bound, bounds, BoundKind::Bound);
                 }
@@ -1420,7 +1421,7 @@ macro_rules! common_visitor_and_walkers {
                     let StructExpr { qself, path, fields, rest } = &$($mut)?**se;
                     try_visit!(vis.visit_qself(qself));
                     try_visit!(vis.visit_path(path));
-                    visit_expr_fields(vis, fields);
+                    try_visit!(visit_expr_fields(vis, fields));
                     match rest {
                         StructRest::Base(expr) => try_visit!(vis.visit_expr(expr)),
                         StructRest::Rest(_span) => {}

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -224,6 +224,7 @@ pub trait Visitor<'v>: Sized {
 
     /// The result type of the `visit_*` methods. Can be either `()`,
     /// or `ControlFlow<T>`.
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
 
     /// If `type NestedFilter` is set to visit nested items, this method

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1560,6 +1560,16 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             return;
         }
 
+        // `#[must_use]` can be applied to an associated type in a trait, so that it will
+        // warn on unused associated types in generic contexts.
+        if let Target::AssocTy = target
+            && let parent_def_id = self.tcx.hir_get_parent_item(hir_id).def_id
+            && let containing_item = self.tcx.hir_expect_item(parent_def_id)
+            && let hir::ItemKind::Trait(..) = containing_item.kind
+        {
+            return;
+        }
+
         let article = match target {
             Target::ExternCrate
             | Target::Enum

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -67,8 +67,11 @@ impl<'tcx> fmt::Display for LazyDefPathStr<'tcx> {
 /// manually. Second, it doesn't visit some type components like signatures of fn types, or traits
 /// in `impl Trait`, see individual comments in `DefIdVisitorSkeleton::visit_ty`.
 pub trait DefIdVisitor<'tcx> {
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
+
     const SHALLOW: bool = false;
+
     fn skip_assoc_tys(&self) -> bool {
         false
     }

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -461,6 +461,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
 
 /// The public API to interact with proof trees.
 pub trait ProofTreeVisitor<'tcx> {
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
 
     fn span(&self) -> Span;

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -9,6 +9,7 @@ use rustc_span::Span;
 use tracing::{instrument, trace};
 
 pub trait SpannedTypeVisitor<'tcx> {
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
     fn visit(&mut self, span: Span, value: impl TypeVisitable<TyCtxt<'tcx>>) -> Self::Result;
 }

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -89,6 +89,7 @@ pub trait TypeSuperVisitable<I: Interner>: TypeVisitable<I> {
 /// that recurses into the type's fields in a non-custom fashion.
 pub trait TypeVisitor<I: Interner>: Sized {
     #[cfg(feature = "nightly")]
+    #[cfg_attr(not(bootstrap), must_use)]
     type Result: VisitorResult = ();
 
     #[cfg(not(feature = "nightly"))]

--- a/tests/ui/lint/unused/unused-assoc-ty.rs
+++ b/tests/ui/lint/unused/unused-assoc-ty.rs
@@ -1,0 +1,27 @@
+#![deny(unused_must_use)]
+
+trait Foo {
+    #[must_use]
+    type Result;
+
+    fn process(arg: i32) -> Self::Result;
+}
+
+fn generic<T: Foo>() {
+    T::process(10);
+    //~^ ERROR unused `Foo::Result` that must be used
+}
+
+struct NoOp;
+impl Foo for NoOp {
+    type Result = ();
+
+    fn process(_arg: i32) { println!("did nothing"); }
+}
+
+fn noop() {
+    // Should not lint.
+    <NoOp as Foo>::process(10);
+}
+
+fn main() {}

--- a/tests/ui/lint/unused/unused-assoc-ty.stderr
+++ b/tests/ui/lint/unused/unused-assoc-ty.stderr
@@ -1,0 +1,18 @@
+error: unused `Foo::Result` that must be used
+  --> $DIR/unused-assoc-ty.rs:11:5
+   |
+LL |     T::process(10);
+   |     ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-assoc-ty.rs:1:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = T::process(10);
+   |     +++++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/unused/unused_attributes-must_use.rs
+++ b/tests/ui/lint/unused/unused_attributes-must_use.rs
@@ -67,7 +67,7 @@ fn qux<#[must_use] T>(_: T) {} //~ ERROR `#[must_use]` has no effect
 trait Use {
     #[must_use] //~ ERROR `#[must_use]` has no effect
     const ASSOC_CONST: usize = 4;
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use]
     type AssocTy;
 
     #[must_use]

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -123,12 +123,6 @@ error: `#[must_use]` has no effect when applied to an associated const
 LL |     #[must_use]
    |     ^^^^^^^^^^^
 
-error: `#[must_use]` has no effect when applied to an associated type
-  --> $DIR/unused_attributes-must_use.rs:70:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-
 error: `#[must_use]` has no effect when applied to a provided trait method
   --> $DIR/unused_attributes-must_use.rs:83:5
    |
@@ -223,5 +217,5 @@ help: use `let _ = ...` to ignore the resulting value
 LL |     let _ = ().get_four();
    |     +++++++
 
-error: aborting due to 29 previous errors
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
This PR enables `#[must_use]` on associated type definitions in traits. When the unused results visitor encounters a *rigid* associated type marked with `#[must_use]` (i.e. some `T::Result` in generic code), then it will trigger an unused warning.

This is particularly useful when users want to be generic over some `Result` associated type. In the compiler, our visitors typically return one of `()`, `ControlFlow<T>`, or `Result<T, E>`. In generic code, though, we are dealing with `T::Result`, which is a footgun since today we can't detect when a value of that rigid associated type goes unused.

```rust
trait Foo {
    #[must_use]
    type Result;

    fn process(arg: i32) -> Self::Result;
}

fn foo<T: Foo>() {
    T::process(10);
    //~^ WARNING unused value
}
```

This does not apply after an associated type can be normalized. For example, this code will not trigger the warning, since `<NoOp as Foo>::Result` is `()`, which is not `#[must_use]`:

```rust
trait Foo {
    #[must_use]
    type Result;

    fn process(arg: i32) -> Self::Result;
}

struct NoOp;
impl Foo for NoOp {
    type Result = ();

    fn process(_arg: i32) { println!("did nothing"); }
}

fn foo() {
    <NoOp as Foo>::process(10);
}
```

---

The commit 5e16f3a2a2a2496ac4e36d1594edf9dcd6a560ba demonstrates some places in the compiler that had unhandled results, and so it should make it very clear that this change is useful.