### PR TITLE
Revert overeager warning for misuse of `--print native-static-libs`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -69,23 +69,6 @@ pub fn ensure_removed(dcx: DiagCtxtHandle<'_>, path: &Path) {
     }
 }
 
-fn check_link_info_print_request(sess: &Session, crate_types: &[CrateType]) {
-    let print_native_static_libs =
-        sess.opts.prints.iter().any(|p| p.kind == PrintKind::NativeStaticLibs);
-    let has_staticlib = crate_types.iter().any(|ct| *ct == CrateType::Staticlib);
-    if print_native_static_libs {
-        if !has_staticlib {
-            sess.dcx()
-                .warn(format!("cannot output linkage information without staticlib crate-type"));
-            sess.dcx()
-                .note(format!("consider `--crate-type staticlib` to print linkage information"));
-        } else if !sess.opts.output_types.should_link() {
-            sess.dcx()
-                .warn(format!("cannot output linkage information when --emit link is not passed"));
-        }
-    }
-}
-
 /// Performs the linkage portion of the compilation phase. This will generate all
 /// of the requested outputs for this compilation session.
 pub fn link_binary(
@@ -207,8 +190,6 @@ pub fn link_binary(
             }
         }
     }
-
-    check_link_info_print_request(sess, &codegen_results.crate_info.crate_types);
 
     // Remove the temporary object file and metadata if we aren't saving temps.
     sess.time("link_binary_remove_temps", || {

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
@@ -1,5 +1,0 @@
-//@ compile-flags: --print native-static-libs
-//@ check-pass
-//~? WARN cannot output linkage information without staticlib crate-type
-
-fn main() {}

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
@@ -1,6 +1,0 @@
-warning: cannot output linkage information without staticlib crate-type
-
-note: consider `--crate-type staticlib` to print linkage information
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
@@ -1,3 +1,0 @@
-//@ compile-flags: --print native-static-libs --crate-type staticlib  --emit metadata
-//@ check-pass
-//~? WARN cannot output linkage information when --emit link is not passed

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
@@ -1,4 +1,0 @@
-warning: cannot output linkage information when --emit link is not passed
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/stability.rs
+++ b/tests/ui/print-request/stability.rs
@@ -110,4 +110,3 @@ fn main() {}
 //[check_cfg]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `check-cfg` print option
 //[supported_crate_types]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `supported-crate-types` print option
 //[target_spec_json]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `target-spec-json` print option
-//[native_static_libs]~? WARNING cannot output linkage information without staticlib crate-type


### PR DESCRIPTION
In a PR to emit warnings on misuse of `--print native-static-libs`, we did not consider the matter of composing parts of build systems. If you are not directly invoking rustc, it can be difficult to know when you will in fact compile a staticlib, so making sure uses `--print native-static-lib` correctly can be just a nuisance.

Next cycle we can reland a slightly more narrowly focused variant or one that focuses on `--emit` instead of `--print native-static-libs`. But in its current state, I am not sure the warning is very useful.

<!-- homu-ignore:start -->
Reverts rust-lang/rust#138139
Fixes rust-lang/rust#142582

r? @ChrisDenton
<!-- homu-ignore:end -->
