### PR TITLE
Don't unwrap in enzyme builds in case of missing llvm-config

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2105,19 +2105,20 @@ impl Step for Assemble {
         if builder.config.llvm_enzyme && !builder.config.dry_run() {
             debug!("`llvm_enzyme` requested");
             let enzyme_install = builder.ensure(llvm::Enzyme { target: build_compiler.host });
-            let llvm_config = builder.llvm_config(builder.config.host_target).unwrap();
-            let llvm_version_major = llvm::get_llvm_version_major(builder, &llvm_config);
-            let lib_ext = std::env::consts::DLL_EXTENSION;
-            let libenzyme = format!("libEnzyme-{llvm_version_major}");
-            let src_lib =
-                enzyme_install.join("build/Enzyme").join(&libenzyme).with_extension(lib_ext);
-            let libdir = builder.sysroot_target_libdir(build_compiler, build_compiler.host);
-            let target_libdir =
-                builder.sysroot_target_libdir(target_compiler, target_compiler.host);
-            let dst_lib = libdir.join(&libenzyme).with_extension(lib_ext);
-            let target_dst_lib = target_libdir.join(&libenzyme).with_extension(lib_ext);
-            builder.copy_link(&src_lib, &dst_lib, FileType::NativeLibrary);
-            builder.copy_link(&src_lib, &target_dst_lib, FileType::NativeLibrary);
+            if let Some(llvm_config) = builder.llvm_config(builder.config.host_target) {
+                let llvm_version_major = llvm::get_llvm_version_major(builder, &llvm_config);
+                let lib_ext = std::env::consts::DLL_EXTENSION;
+                let libenzyme = format!("libEnzyme-{llvm_version_major}");
+                let src_lib =
+                    enzyme_install.join("build/Enzyme").join(&libenzyme).with_extension(lib_ext);
+                let libdir = builder.sysroot_target_libdir(build_compiler, build_compiler.host);
+                let target_libdir =
+                    builder.sysroot_target_libdir(target_compiler, target_compiler.host);
+                let dst_lib = libdir.join(&libenzyme).with_extension(lib_ext);
+                let target_dst_lib = target_libdir.join(&libenzyme).with_extension(lib_ext);
+                builder.copy_link(&src_lib, &dst_lib, FileType::NativeLibrary);
+                builder.copy_link(&src_lib, &target_dst_lib, FileType::NativeLibrary);
+            }
         }
 
         // Build the libraries for this compiler to link to (i.e., the libraries


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @onur-ozkan 

For some reason x.py was now panicking in this location, so I also removed the unwrap here.
part 2 of https://github.com/rust-lang/rust/pull/140000, there shouldn't be other locations where we check for llvm-config.