### PR TITLE
Do not suggest compatible variants inside macro

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2707,12 +2707,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     Some(CtorKind::Const) => unreachable!("unit variants don't have fields"),
                 };
 
-                // Suggest constructor as deep into the block tree as possible.
-                // This fixes https://github.com/rust-lang/rust/issues/101065,
-                // and also just helps make the most minimal suggestions.
+                // Suggest constructor as deep into the block tree as possible,
+                // but don't cross macro contexts. This fixes #101065 while
+                // keeping suggestions out of macro definitions (#142359).
                 let mut expr = expr;
                 while let hir::ExprKind::Block(block, _) = &expr.kind
                     && let Some(expr_) = &block.expr
+                    && expr_.span.eq_ctxt(expr.span)
                 {
                     expr = expr_
                 }

--- a/tests/ui/typeck/suggestions/auxiliary/suggest-compatible-variants-macro-issue-142359.rs
+++ b/tests/ui/typeck/suggestions/auxiliary/suggest-compatible-variants-macro-issue-142359.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! unit {
+    () => {{
+        ()
+    }};
+}

--- a/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.rs
+++ b/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.rs
@@ -1,0 +1,16 @@
+// Make sure we don't suggest compatible variants cross macro context. (issue #142359)
+//@ aux-crate:ext=suggest-compatible-variants-macro-issue-142359.rs
+
+extern crate ext;
+
+use std::ops::ControlFlow;
+
+fn main() {
+    let x: Result<i32, i32> = Err(1);
+
+    let _ = match x {
+        Err(r) => ControlFlow::Break(r),
+        Ok(r) => { ext::unit!() } //~ ERROR `match` arms have incompatible types [E0308]
+
+    };
+}

--- a/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.stderr
+++ b/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.stderr
@@ -1,0 +1,25 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/suggest-compatible-variants-macro-issue-142359.rs:13:19
+   |
+LL |       let _ = match x {
+   |  _____________-
+LL | |         Err(r) => ControlFlow::Break(r),
+   | |                   --------------------- this is found to be of type `ControlFlow<i32, _>`
+LL | |         Ok(r) => {ext::unit!()}
+   | |                   ^^^^^^^^^^^^ expected `ControlFlow<i32, _>`, found `()`
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note:   expected enum `ControlFlow<i32, _>`
+           found unit type `()`
+   = note: this error originates in the macro `ext::unit` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try wrapping the expression in `std::ops::ControlFlow::Continue`
+  --> $DIR/auxiliary/suggest-compatible-variants-macro-issue-142359.rs:4:9
+   |
+LL |         std::ops::ControlFlow::Continue(())
+   |         ++++++++++++++++++++++++++++++++  +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.stderr
+++ b/tests/ui/typeck/suggestions/suggest-compatible-variants-macro-issue-142359.stderr
@@ -1,12 +1,12 @@
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/suggest-compatible-variants-macro-issue-142359.rs:13:19
+  --> $DIR/suggest-compatible-variants-macro-issue-142359.rs:13:20
    |
 LL |       let _ = match x {
    |  _____________-
 LL | |         Err(r) => ControlFlow::Break(r),
    | |                   --------------------- this is found to be of type `ControlFlow<i32, _>`
-LL | |         Ok(r) => {ext::unit!()}
-   | |                   ^^^^^^^^^^^^ expected `ControlFlow<i32, _>`, found `()`
+LL | |         Ok(r) => { ext::unit!() }
+   | |                    ^^^^^^^^^^^^ expected `ControlFlow<i32, _>`, found `()`
 LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
@@ -15,10 +15,9 @@ LL | |     };
            found unit type `()`
    = note: this error originates in the macro `ext::unit` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: try wrapping the expression in `std::ops::ControlFlow::Continue`
-  --> $DIR/auxiliary/suggest-compatible-variants-macro-issue-142359.rs:4:9
    |
-LL |         std::ops::ControlFlow::Continue(())
-   |         ++++++++++++++++++++++++++++++++  +
+LL |         Ok(r) => std::ops::ControlFlow::Continue({ ext::unit!() })
+   |                  ++++++++++++++++++++++++++++++++                +
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes rust-lang/rust#142359

r? compiler
