### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1420,7 +1420,7 @@ macro_rules! common_visitor_and_walkers {
                     let StructExpr { qself, path, fields, rest } = &$($mut)?**se;
                     try_visit!(vis.visit_qself(qself));
                     try_visit!(vis.visit_path(path));
-                    visit_expr_fields(vis, fields);
+                    try_visit!(visit_expr_fields(vis, fields));
                     match rest {
                         StructRest::Base(expr) => try_visit!(vis.visit_expr(expr)),
                         StructRest::Rest(_span) => {}

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -884,7 +884,7 @@ macro_rules! common_visitor_and_walkers {
                 TyKind::BareFn(function_declaration) => {
                     let BareFnTy { safety, ext: _, generic_params, decl, decl_span } =
                         &$($mut)? **function_declaration;
-                    visit_safety(vis, safety);
+                    try_visit!(visit_safety(vis, safety));
                     try_visit!(visit_generic_params(vis, generic_params));
                     try_visit!(vis.visit_fn_decl(decl));
                     try_visit!(visit_span(vis, decl_span));
@@ -1235,7 +1235,7 @@ macro_rules! common_visitor_and_walkers {
                     bounds,
                     bound_generic_params,
                 }) => {
-                    visit_generic_params(vis, bound_generic_params);
+                    try_visit!(visit_generic_params(vis, bound_generic_params));
                     try_visit!(vis.visit_ty(bounded_ty));
                     walk_list!(vis, visit_param_bound, bounds, BoundKind::Bound);
                 }

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -179,6 +179,8 @@ ast_lowering_underscore_expr_lhs_assign =
     in expressions, `_` can only be used on the left-hand side of an assignment
     .label = `_` not allowed here
 
+ast_lowering_union_default_field_values = unions cannot have default field values
+
 ast_lowering_unstable_inline_assembly = inline assembly is not stable yet on this architecture
 ast_lowering_unstable_inline_assembly_label_operand_with_outputs =
     using both label and output operands for inline assembly is unstable

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -475,3 +475,10 @@ pub(crate) struct UseConstGenericArg {
     #[suggestion_part(code = "{other_args}")]
     pub call_args: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(ast_lowering_union_default_field_values)]
+pub(crate) struct UnionWithDefault {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -224,20 +224,6 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn visit_struct_field_def(&mut self, field: &'a FieldDef) {
-        if let Some(ref ident) = field.ident
-            && ident.name == kw::Underscore
-        {
-            self.visit_vis(&field.vis);
-            self.visit_ident(ident);
-            self.visit_ty_common(&field.ty);
-            self.walk_ty(&field.ty);
-            walk_list!(self, visit_attribute, &field.attrs);
-        } else {
-            self.visit_field_def(field);
-        }
-    }
-
     fn dcx(&self) -> DiagCtxtHandle<'a> {
         self.sess.dcx()
     }
@@ -1135,8 +1121,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 VariantData::Struct { fields, .. } => {
                     self.visit_attrs_vis_ident(&item.attrs, &item.vis, ident);
                     self.visit_generics(generics);
-                    // Permit `Anon{Struct,Union}` as field type.
-                    walk_list!(self, visit_struct_field_def, fields);
+                    walk_list!(self, visit_field_def, fields);
                 }
                 _ => visit::walk_item(self, item),
             },
@@ -1148,8 +1133,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     VariantData::Struct { fields, .. } => {
                         self.visit_attrs_vis_ident(&item.attrs, &item.vis, ident);
                         self.visit_generics(generics);
-                        // Permit `Anon{Struct,Union}` as field type.
-                        walk_list!(self, visit_struct_field_def, fields);
+                        walk_list!(self, visit_field_def, fields);
                     }
                     _ => visit::walk_item(self, item),
                 }

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -342,10 +342,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
                                 }
                             }
                         } else if let LocalInfo::BlockTailTemp(info) = local_decl.local_info() {
-                            let sp = info
-                                .span
-                                .find_ancestor_in_same_ctxt(local_decl.source_info.span)
-                                .unwrap_or(info.span);
+                            let sp = info.span.find_oldest_ancestor_in_same_ctxt();
                             if info.tail_result_is_ignored {
                                 // #85581: If the first mutable borrow's scope contains
                                 // the second borrow, this suggestion isn't helpful.

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -69,23 +69,6 @@ pub fn ensure_removed(dcx: DiagCtxtHandle<'_>, path: &Path) {
     }
 }
 
-fn check_link_info_print_request(sess: &Session, crate_types: &[CrateType]) {
-    let print_native_static_libs =
-        sess.opts.prints.iter().any(|p| p.kind == PrintKind::NativeStaticLibs);
-    let has_staticlib = crate_types.iter().any(|ct| *ct == CrateType::Staticlib);
-    if print_native_static_libs {
-        if !has_staticlib {
-            sess.dcx()
-                .warn(format!("cannot output linkage information without staticlib crate-type"));
-            sess.dcx()
-                .note(format!("consider `--crate-type staticlib` to print linkage information"));
-        } else if !sess.opts.output_types.should_link() {
-            sess.dcx()
-                .warn(format!("cannot output linkage information when --emit link is not passed"));
-        }
-    }
-}
-
 /// Performs the linkage portion of the compilation phase. This will generate all
 /// of the requested outputs for this compilation session.
 pub fn link_binary(
@@ -207,8 +190,6 @@ pub fn link_binary(
             }
         }
     }
-
-    check_link_info_print_request(sess, &codegen_results.crate_info.crate_types);
 
     // Remove the temporary object file and metadata if we aren't saving temps.
     sess.time("link_binary_remove_temps", || {

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -74,7 +74,9 @@ impl SimplifyCfg {
 }
 
 pub(super) fn simplify_cfg<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-    CfgSimplifier::new(tcx, body).simplify();
+    if CfgSimplifier::new(tcx, body).simplify() {
+        body.basic_blocks.invalidate_cfg_cache();
+    }
     remove_dead_blocks(body);
 
     // FIXME: Should probably be moved into some kind of pass manager
@@ -121,12 +123,15 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
         // Preserve `SwitchInt` reads on built and analysis MIR, or if `-Zmir-preserve-ub`.
         let preserve_switch_reads = matches!(body.phase, MirPhase::Built | MirPhase::Analysis(_))
             || tcx.sess.opts.unstable_opts.mir_preserve_ub;
-        let basic_blocks = body.basic_blocks_mut();
+        let basic_blocks = body.basic_blocks.as_mut_preserves_cfg();
 
         CfgSimplifier { preserve_switch_reads, basic_blocks, pred_count }
     }
 
-    fn simplify(mut self) {
+    /// Returns whether we actually simplified anything. In that case, the caller *must* invalidate
+    /// the CFG caches of the MIR body.
+    #[must_use]
+    fn simplify(mut self) -> bool {
         self.strip_nops();
 
         // Vec of the blocks that should be merged. We store the indices here, instead of the
@@ -134,6 +139,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
         // We do not push the statements directly into the target block (`bb`) as that is slower
         // due to additional reallocations
         let mut merged_blocks = Vec::new();
+        let mut outer_changed = false;
         loop {
             let mut changed = false;
 
@@ -177,7 +183,11 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
             if !changed {
                 break;
             }
+
+            outer_changed = true;
         }
+
+        outer_changed
     }
 
     /// This function will return `None` if

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-freebsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv1".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
@@ -12,6 +12,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-musl".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-openbsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv1".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-freebsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-linux-musl".into(),

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1489,10 +1489,11 @@ impl String {
         Some(ch)
     }
 
-    /// Removes a [`char`] from this `String` at a byte position and returns it.
+    /// Removes a [`char`] from this `String` at byte position `idx` and returns it.
     ///
-    /// This is an *O*(*n*) operation, as it requires copying every element in the
-    /// buffer.
+    /// Copies all bytes after the removed char to new positions.
+    ///
+    /// Note that calling this in a loop can result in quadratic behavior.
     ///
     /// # Panics
     ///
@@ -1678,10 +1679,13 @@ impl String {
         drop(guard);
     }
 
-    /// Inserts a character into this `String` at a byte position.
+    /// Inserts a character into this `String` at byte position `idx`.
     ///
-    /// This is an *O*(*n*) operation as it requires copying every element in the
-    /// buffer.
+    /// Reallocates if `self.capacity()` is insufficient, which may involve copying all
+    /// `self.capacity()` bytes. Makes space for the insertion by copying all bytes of
+    /// `&self[idx..]` to new positions.
+    ///
+    /// Note that calling this in a loop can result in quadratic behavior.
     ///
     /// # Panics
     ///
@@ -1733,10 +1737,13 @@ impl String {
         }
     }
 
-    /// Inserts a string slice into this `String` at a byte position.
+    /// Inserts a string slice into this `String` at byte position `idx`.
     ///
-    /// This is an *O*(*n*) operation as it requires copying every element in the
-    /// buffer.
+    /// Reallocates if `self.capacity()` is insufficient, which may involve copying all
+    /// `self.capacity()` bytes. Makes space for the insertion by copying all bytes of
+    /// `&self[idx..]` to new positions.
+    ///
+    /// Note that calling this in a loop can result in quadratic behavior.
     ///
     /// # Panics
     ///

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,6 +30,14 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
+//
+// WARNING: When you update `FORMAT_VERSION`, please also update the "Latest feature" line with a
+// description of the change. This minimizes the risk of two concurrent PRs changing
+// `FORMAT_VERSION` from N to N+1 and git merging them without conflicts; the "Latest feature" line
+// will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
+// are deliberately not in a doc comment, because they need not be in public docs.)
+//
+// Latest feature: rustdoc JSON: Don't apply #[repr] privacy heuristics
 pub const FORMAT_VERSION: u32 = 46;
 
 /// The root of the emitted JSON blob.

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -17,14 +17,14 @@
 //!
 //! # Test history
 //!
-//! - The previous rmake.rs iteration of this test was flakey for unknown reason on `i686-mingw`
-//!   *specifically*, so assertion failures in this test was made extremely verbose to help
-//!   diagnose why the ICE messages was different *specifically* on `i686-mingw`.
-//! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
-//!   this test is still flakey, please restore the `ignore-windows` directive.
+//! The previous rmake.rs iteration of this test was flaky for unknown reason on
+//! `i686-pc-windows-gnu` *specifically*, so assertion failures in this test was made extremely
+//! verbose to help diagnose why the ICE messages was different. It appears that backtraces on
+//! `i686-pc-windows-gnu` specifically are quite unpredictable in how many backtrace frames are
+//! involved.
 
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercising ICE dump on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -86,9 +86,7 @@ fn test_metrics_errors() {
             .env("RUST_BACKTRACE", "short")
             .arg("-Zmetrics-dir=invaliddirectorythatdefinitelydoesntexist")
             .run_fail()
-            .assert_stderr_contains(
-                "error: cannot dump feature usage metrics: No such file or directory",
-            )
+            .assert_stderr_contains("error: cannot dump feature usage metrics")
             .assert_stdout_not_contains("internal compiler error");
     });
 }

--- a/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics-incremental/rmake.rs
@@ -7,12 +7,11 @@
 //!
 //! # Test history
 //!
-//! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
-//! those will be present in this test as well on the same platform
+//! - Forked from `dump-ice-to-disk` test, which previously had backtrace unpredictability on
+//! `i686-pc-windows-gnu`.
 
-//@ needs-target-std
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercises metrics incremental on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::path::{Path, PathBuf};
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -7,12 +7,10 @@
 //!
 //! # Test history
 //!
-//! - forked from dump-ice-to-disk test, which has flakeyness issues on i686-mingw, I'm assuming
-//! those will be present in this test as well on the same platform
+//! - Forked from `dump-ice-to-disk` test, where `i686-pc-windows-gnu` has unpredictable backtraces.
 
-//@ needs-target-std
-//@ ignore-windows
-//FIXME(#128911): still flakey on i686-mingw.
+//@ ignore-cross-compile (exercises metrics dump on host)
+//@ ignore-i686-pc-windows-gnu (unwind mechanism produces unpredictable backtraces)
 
 use std::path::{Path, PathBuf};
 

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -83,9 +83,7 @@ fn test_metrics_errors() {
             .env("RUST_BACKTRACE", "short")
             .arg("-Zmetrics-dir=invaliddirectorythatdefinitelydoesntexist")
             .run_fail()
-            .assert_stderr_contains(
-                "error: cannot dump feature usage metrics: No such file or directory",
-            )
+            .assert_stderr_contains("error: cannot dump feature usage metrics")
             .assert_stdout_not_contains("internal compiler error");
     });
 }

--- a/tests/ui/borrowck/span-semicolon-issue-139049.fixed
+++ b/tests/ui/borrowck/span-semicolon-issue-139049.fixed
@@ -1,52 +1,25 @@
-// Make sure the generated suggestion suggest editing the user
-// code instead of the std macro implementation
+// Make sure the generated suggestion suggest editing the user code instead of
+// the macro implementation (which might come from an external crate).
+// issue: <https://github.com/rust-lang/rust/issues/139049>
 
 //@ run-rustfix
 
 #![allow(dead_code)]
 
-use std::fmt::{self, Display};
-
-struct Mutex;
-
-impl Mutex {
-    fn lock(&self) -> MutexGuard<'_> {
-        MutexGuard(self)
-    }
-}
-
-struct MutexGuard<'a>(&'a Mutex);
-
-impl<'a> Drop for MutexGuard<'a> {
-    fn drop(&mut self) {}
-}
-
-struct Out;
-
-impl Out {
-    fn write_fmt(&self, _args: fmt::Arguments) {}
-}
-
-impl<'a> Display for MutexGuard<'a> {
-    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-        Ok(())
-    }
-}
+// You could assume that this comes from an extern crate (it doesn't
+// because an aux crate would be overkill for this test).
+macro_rules! perform { ($e:expr) => { D(&$e).end() } }
+//~^ ERROR does not live long enough
+//~| ERROR does not live long enough
 
 fn main() {
-    let _write = {
-        let mutex = Mutex;
-        write!(Out, "{}", mutex.lock());
-        //~^ ERROR `mutex` does not live long enough
-        //~| SUGGESTION ;
-    };
+    { let l = (); perform!(l); };
+    //~^ SUGGESTION ;
 
-    let _write = {
-        use std::io::Write as _;
-
-        let mutex = Mutex;
-        let x = write!(std::io::stdout(), "{}", mutex.lock()); x
-        //~^ ERROR `mutex` does not live long enough
-        //~| SUGGESTION let x
-    };
+    let _x = { let l = (); let x = perform!(l); x };
+    //~^ SUGGESTION let x
 }
+
+struct D<T>(T);
+impl<T> Drop for D<T> { fn drop(&mut self) {} }
+impl<T> D<T> { fn end(&self) -> String { String::new() } }

--- a/tests/ui/borrowck/span-semicolon-issue-139049.stderr
+++ b/tests/ui/borrowck/span-semicolon-issue-139049.stderr
@@ -1,46 +1,48 @@
-error[E0597]: `mutex` does not live long enough
-  --> $DIR/span-semicolon-issue-139049.rs:39:27
+error[E0597]: `l` does not live long enough
+  --> $DIR/span-semicolon-issue-139049.rs:11:41
    |
-LL |         let mutex = Mutex;
-   |             ----- binding `mutex` declared here
-LL |         write!(Out, "{}", mutex.lock())
-   |                           ^^^^^-------
-   |                           |
-   |                           borrowed value does not live long enough
-   |                           a temporary with access to the borrow is created here ...
+LL | macro_rules! perform { ($e:expr) => { D(&$e).end() } }
+   |                                       --^^^-
+   |                                       | |
+   |                                       | borrowed value does not live long enough
+   |                                       a temporary with access to the borrow is created here ...
 ...
-LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
-   |     |
-   |     `mutex` dropped here while still borrowed
+LL |     { let l = (); perform!(l) };
+   |           -       ----------- -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |           |       |           |
+   |           |       |           `l` dropped here while still borrowed
+   |           |       in this macro invocation
+   |           binding `l` declared here
    |
+   = note: this error originates in the macro `perform` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |
-LL |         write!(Out, "{}", mutex.lock());
-   |                                        +
+LL |     { let l = (); perform!(l); };
+   |                              +
 
-error[E0597]: `mutex` does not live long enough
-  --> $DIR/span-semicolon-issue-139049.rs:48:41
+error[E0597]: `l` does not live long enough
+  --> $DIR/span-semicolon-issue-139049.rs:11:41
    |
-LL |         let mutex = Mutex;
-   |             ----- binding `mutex` declared here
-LL |         write!(std::io::stdout(), "{}", mutex.lock())
-   |                                         ^^^^^-------
-   |                                         |
-   |                                         borrowed value does not live long enough
-   |                                         a temporary with access to the borrow is created here ...
+LL | macro_rules! perform { ($e:expr) => { D(&$e).end() } }
+   |                                       --^^^-
+   |                                       | |
+   |                                       | borrowed value does not live long enough
+   |                                       a temporary with access to the borrow is created here ...
 ...
-LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
-   |     |
-   |     `mutex` dropped here while still borrowed
+LL |     let _x = { let l = (); perform!(l) };
+   |                    -       ----------- -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                    |       |           |
+   |                    |       |           `l` dropped here while still borrowed
+   |                    |       in this macro invocation
+   |                    binding `l` declared here
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
+   = note: this error originates in the macro `perform` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
    |
-LL |         let x = write!(std::io::stdout(), "{}", mutex.lock()); x
-   |         +++++++                                              +++
+LL |     let _x = { let l = (); let x = perform!(l); x };
+   |                            +++++++            +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -129,7 +129,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -129,7 +129,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/feature-gates/feature-gate-default-field-values.rs
+++ b/tests/ui/feature-gates/feature-gate-default-field-values.rs
@@ -58,6 +58,16 @@ pub enum OptEnum {
     }
 }
 
+// Default field values may not be used on `union`s (at least, this is not described in the accepted
+// RFC, and it's not currently clear how to extend the design to do so). We emit a feature gate
+// error when the feature is not enabled, but syntactically reject default field values when used
+// with unions when the feature is enabled. This can be adjusted if there's an acceptable design
+// extension, or just unconditionally reject always.
+union U {
+    x: i32 = 0,   //~ ERROR default values on fields are experimental
+    y: f32 = 0.0, //~ ERROR default values on fields are experimental
+}
+
 fn main () {
     let x = Foo { .. }; //~ ERROR base expression required after `..`
     let y = Foo::default();

--- a/tests/ui/feature-gates/feature-gate-default-field-values.stderr
+++ b/tests/ui/feature-gates/feature-gate-default-field-values.stderr
@@ -124,8 +124,28 @@ LL |         optional: () = (),
    = help: add `#![feature(default_field_values)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: default values on fields are experimental
+  --> $DIR/feature-gate-default-field-values.rs:67:11
+   |
+LL |     x: i32 = 0,
+   |           ^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: default values on fields are experimental
+  --> $DIR/feature-gate-default-field-values.rs:68:11
+   |
+LL |     y: f32 = 0.0,
+   |           ^^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:62:21
+  --> $DIR/feature-gate-default-field-values.rs:72:21
    |
 LL |     let x = Foo { .. };
    |                     ^
@@ -140,7 +160,7 @@ LL |     let x = Foo { ../* expr */ };
    |                     ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:64:29
+  --> $DIR/feature-gate-default-field-values.rs:74:29
    |
 LL |     let z = Foo { baz: 1, .. };
    |                             ^
@@ -155,7 +175,7 @@ LL |     let z = Foo { baz: 1, ../* expr */ };
    |                             ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:70:26
+  --> $DIR/feature-gate-default-field-values.rs:80:26
    |
 LL |     let x = Bar::Foo { .. };
    |                          ^
@@ -170,7 +190,7 @@ LL |     let x = Bar::Foo { ../* expr */ };
    |                          ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:72:34
+  --> $DIR/feature-gate-default-field-values.rs:82:34
    |
 LL |     let z = Bar::Foo { baz: 1, .. };
    |                                  ^
@@ -185,7 +205,7 @@ LL |     let z = Bar::Foo { baz: 1, ../* expr */ };
    |                                  ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:78:31
+  --> $DIR/feature-gate-default-field-values.rs:88:31
    |
 LL |     let x = Qux::<i32, 4> { .. };
    |                               ^
@@ -200,7 +220,7 @@ LL |     let x = Qux::<i32, 4> { ../* expr */ };
    |                               ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:79:73
+  --> $DIR/feature-gate-default-field-values.rs:89:73
    |
 LL |     assert!(matches!(Qux::<i32, 4> { bar: S, baz: 42, bat: 2, bay: 4, .. }, x));
    |                                                                         ^
@@ -215,7 +235,7 @@ LL |     assert!(matches!(Qux::<i32, 4> { bar: S, baz: 42, bat: 2, bay: 4, ../* 
    |                                                                         ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:82:38
+  --> $DIR/feature-gate-default-field-values.rs:92:38
    |
 LL |     let y = Opt { mandatory: None, .. };
    |                                      ^
@@ -230,7 +250,7 @@ LL |     let y = Opt { mandatory: None, ../* expr */ };
    |                                      ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:86:47
+  --> $DIR/feature-gate-default-field-values.rs:96:47
    |
 LL |     assert!(matches!(Opt { mandatory: None, .. }, z));
    |                                               ^
@@ -245,7 +265,7 @@ LL |     assert!(matches!(Opt { mandatory: None, ../* expr */ }, z));
    |                                               ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:88:30
+  --> $DIR/feature-gate-default-field-values.rs:98:30
    |
 LL |     assert!(matches!(Opt { .. }, z));
    |                              ^
@@ -256,7 +276,7 @@ LL |     assert!(matches!(Opt { ../* expr */ }, z));
    |                              ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:90:44
+  --> $DIR/feature-gate-default-field-values.rs:100:44
    |
 LL |     assert!(matches!(Opt { optional: (), .. }, z));
    |                                            ^
@@ -267,7 +287,7 @@ LL |     assert!(matches!(Opt { optional: (), ../* expr */ }, z));
    |                                            ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:92:61
+  --> $DIR/feature-gate-default-field-values.rs:102:61
    |
 LL |     assert!(matches!(Opt { optional: (), mandatory: None, .. }, z));
    |                                                             ^
@@ -279,7 +299,7 @@ LL +     assert!(matches!(Opt { optional: (), mandatory: None,  }, z));
    |
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:94:51
+  --> $DIR/feature-gate-default-field-values.rs:104:51
    |
 LL |     let y = OptEnum::Variant { mandatory: None, .. };
    |                                                   ^
@@ -294,7 +314,7 @@ LL |     let y = OptEnum::Variant { mandatory: None, ../* expr */ };
    |                                                   ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:98:60
+  --> $DIR/feature-gate-default-field-values.rs:108:60
    |
 LL |     assert!(matches!(OptEnum::Variant { mandatory: None, .. }, z));
    |                                                            ^
@@ -309,7 +329,7 @@ LL |     assert!(matches!(OptEnum::Variant { mandatory: None, ../* expr */ }, z)
    |                                                            ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:100:43
+  --> $DIR/feature-gate-default-field-values.rs:110:43
    |
 LL |     assert!(matches!(OptEnum::Variant { .. }, z));
    |                                           ^
@@ -320,7 +340,7 @@ LL |     assert!(matches!(OptEnum::Variant { ../* expr */ }, z));
    |                                           ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:102:57
+  --> $DIR/feature-gate-default-field-values.rs:112:57
    |
 LL |     assert!(matches!(OptEnum::Variant { optional: (), .. }, z));
    |                                                         ^
@@ -331,7 +351,7 @@ LL |     assert!(matches!(OptEnum::Variant { optional: (), ../* expr */ }, z));
    |                                                         ++++++++++
 
 error[E0797]: base expression required after `..`
-  --> $DIR/feature-gate-default-field-values.rs:104:74
+  --> $DIR/feature-gate-default-field-values.rs:114:74
    |
 LL |     assert!(matches!(OptEnum::Variant { optional: (), mandatory: None, .. }, z));
    |                                                                          ^
@@ -342,7 +362,7 @@ LL -     assert!(matches!(OptEnum::Variant { optional: (), mandatory: None, .. }
 LL +     assert!(matches!(OptEnum::Variant { optional: (), mandatory: None,  }, z));
    |
 
-error: aborting due to 29 previous errors
+error: aborting due to 31 previous errors
 
 Some errors have detailed explanations: E0658, E0797.
 For more information about an error, try `rustc --explain E0658`.

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
@@ -28,4 +28,11 @@ fn main() {
 
     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ());
     //~^ ERROR invalid argument to a legacy const generic
+
+    // A regression test for <https://github.com/rust-lang/rust/issues/142525>.
+    struct Struct<T> {
+        field: T,
+    }
+    std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+    //~^ ERROR invalid argument to a legacy const generic
 }

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
@@ -84,5 +84,17 @@ LL -     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ())
 LL +     std::arch::x86_64::_mm_inserti_si64::<{ || () }, { 1 + || () }>(loop {}, loop {});
    |
 
-error: aborting due to 7 previous errors
+error: invalid argument to a legacy const generic: cannot have const blocks, closures, async blocks or items
+  --> $DIR/invalid-rustc_legacy_const_generics-issue-123077.rs:36:71
+   |
+LL |     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+   |                                                                       ^^^^^
+   |
+help: try using a const generic argument instead
+   |
+LL -     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+LL +     std::arch::x86_64::_mm_blend_ps::<{ Struct { field: || () } }>(loop {}, loop {});
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
@@ -1,5 +1,0 @@
-//@ compile-flags: --print native-static-libs
-//@ check-pass
-//~? WARN cannot output linkage information without staticlib crate-type
-
-fn main() {}

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
@@ -1,6 +1,0 @@
-warning: cannot output linkage information without staticlib crate-type
-
-note: consider `--crate-type staticlib` to print linkage information
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
@@ -1,3 +1,0 @@
-//@ compile-flags: --print native-static-libs --crate-type staticlib  --emit metadata
-//@ check-pass
-//~? WARN cannot output linkage information when --emit link is not passed

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
@@ -1,4 +1,0 @@
-warning: cannot output linkage information when --emit link is not passed
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/stability.rs
+++ b/tests/ui/print-request/stability.rs
@@ -110,4 +110,3 @@ fn main() {}
 //[check_cfg]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `check-cfg` print option
 //[supported_crate_types]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `supported-crate-types` print option
 //[target_spec_json]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `target-spec-json` print option
-//[native_static_libs]~? WARNING cannot output linkage information without staticlib crate-type

--- a/tests/ui/structs/default-field-values/failures.rs
+++ b/tests/ui/structs/default-field-values/failures.rs
@@ -49,6 +49,12 @@ enum E {
     Variant {} //~ ERROR the `#[default]` attribute may only be used on unit enum variants
 }
 
+union U
+{
+    x: i32 = 1,
+    y: f32 = 2.,
+}
+
 fn main () {
     let _ = Foo { .. }; // ok
     let _ = Foo::default(); // ok

--- a/tests/ui/structs/default-field-values/failures.rs
+++ b/tests/ui/structs/default-field-values/failures.rs
@@ -51,8 +51,8 @@ enum E {
 
 union U
 {
-    x: i32 = 1,
-    y: f32 = 2.,
+    x: i32 = 1,  //~ ERROR unions cannot have default field values
+    y: f32 = 2., //~ ERROR unions cannot have default field values
 }
 
 fn main () {

--- a/tests/ui/structs/default-field-values/failures.stderr
+++ b/tests/ui/structs/default-field-values/failures.stderr
@@ -28,19 +28,19 @@ LL | pub struct S;
    |
 
 error: missing field `bar` in initializer
-  --> $DIR/failures.rs:55:19
+  --> $DIR/failures.rs:61:19
    |
 LL |     let _ = Bar { .. };
    |                   ^ fields that do not have a defaulted value must be provided explicitly
 
 error: missing field `bar` in initializer
-  --> $DIR/failures.rs:56:27
+  --> $DIR/failures.rs:62:27
    |
 LL |     let _ = Bar { baz: 0, .. };
    |                           ^ fields that do not have a defaulted value must be provided explicitly
 
 error[E0308]: mismatched types
-  --> $DIR/failures.rs:60:17
+  --> $DIR/failures.rs:66:17
    |
 LL |     let _ = Rak(..);
    |             --- ^^ expected `i32`, found `RangeFull`
@@ -53,19 +53,19 @@ note: tuple struct defined here
 LL | pub struct Rak(i32 = 42);
    |            ^^^
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:60:17
+  --> $DIR/failures.rs:66:17
    |
 LL |     let _ = Rak(..);
    |                 ^^
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
-  --> $DIR/failures.rs:62:13
+  --> $DIR/failures.rs:68:13
    |
 LL |     let _ = Rak(0, ..);
    |             ^^^    -- unexpected argument #2 of type `RangeFull`
    |
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:62:20
+  --> $DIR/failures.rs:68:20
    |
 LL |     let _ = Rak(0, ..);
    |                    ^^
@@ -81,13 +81,13 @@ LL +     let _ = Rak(0);
    |
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
-  --> $DIR/failures.rs:64:13
+  --> $DIR/failures.rs:70:13
    |
 LL |     let _ = Rak(.., 0);
    |             ^^^ -- unexpected argument #1 of type `RangeFull`
    |
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:64:17
+  --> $DIR/failures.rs:70:17
    |
 LL |     let _ = Rak(.., 0);
    |                 ^^

--- a/tests/ui/structs/default-field-values/failures.stderr
+++ b/tests/ui/structs/default-field-values/failures.stderr
@@ -12,6 +12,18 @@ error: default fields are not supported in tuple structs
 LL | pub struct Rak(i32 = 42);
    |                      ^^ default fields are only supported on structs
 
+error: unions cannot have default field values
+  --> $DIR/failures.rs:54:14
+   |
+LL |     x: i32 = 1,
+   |              ^
+
+error: unions cannot have default field values
+  --> $DIR/failures.rs:55:14
+   |
+LL |     y: f32 = 2.,
+   |              ^^
+
 error[E0277]: the trait bound `S: Default` is not satisfied
   --> $DIR/failures.rs:16:5
    |
@@ -102,7 +114,7 @@ LL -     let _ = Rak(.., 0);
 LL +     let _ = Rak(0);
    |
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0061, E0277, E0308.
 For more information about an error, try `rustc --explain E0061`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#138538 (Make performance description of String::{insert,insert_str,remove} more precise)
 - rust-lang/rust#141946 (std: refactor explanation of `NonNull`)
 - rust-lang/rust#142216 (Miscellaneous RefCell cleanups)
 - rust-lang/rust#142542 (Manually invalidate caches in SimplifyCfg.)
 - rust-lang/rust#142563 (Refine run-make test ignores due to unpredictable `i686-pc-windows-gnu` unwind mechanism)
 - rust-lang/rust#142570 (Reject union default field values)
 - rust-lang/rust#142584 (Handle same-crate macro for borrowck semicolon suggestion)
 - rust-lang/rust#142585 (Update books)
 - rust-lang/rust#142586 (Fold unnecessary `visit_struct_field_def` in AstValidator)
 - rust-lang/rust#142587 (Make sure to propagate result from `visit_expr_fields`)
 - rust-lang/rust#142595 (Revert overeager warning for misuse of `--print native-static-libs`)
 - rust-lang/rust#142598 (Set elf e_flags on ppc64 targets according to abi)
 - rust-lang/rust#142601 (Add a comment to `FORMAT_VERSION`.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=138538,141946,142216,142542,142563,142570,142584,142585,142586,142587,142595,142598,142601)
<!-- homu-ignore:end -->