### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -22,7 +22,7 @@ pub fn alloc_error_handler_name(alloc_error_handler_kind: AllocatorKind) -> &'st
     }
 }
 
-pub const NO_ALLOC_SHIM_IS_UNSTABLE: &str = "__rust_no_alloc_shim_is_unstable";
+pub const NO_ALLOC_SHIM_IS_UNSTABLE: &str = "__rust_no_alloc_shim_is_unstable_v2";
 
 pub enum AllocatorTy {
     Layout,

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1420,7 +1420,7 @@ macro_rules! common_visitor_and_walkers {
                     let StructExpr { qself, path, fields, rest } = &$($mut)?**se;
                     try_visit!(vis.visit_qself(qself));
                     try_visit!(vis.visit_path(path));
-                    visit_expr_fields(vis, fields);
+                    try_visit!(visit_expr_fields(vis, fields));
                     match rest {
                         StructRest::Base(expr) => try_visit!(vis.visit_expr(expr)),
                         StructRest::Rest(_span) => {}

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -884,7 +884,7 @@ macro_rules! common_visitor_and_walkers {
                 TyKind::BareFn(function_declaration) => {
                     let BareFnTy { safety, ext: _, generic_params, decl, decl_span } =
                         &$($mut)? **function_declaration;
-                    visit_safety(vis, safety);
+                    try_visit!(visit_safety(vis, safety));
                     try_visit!(visit_generic_params(vis, generic_params));
                     try_visit!(vis.visit_fn_decl(decl));
                     try_visit!(visit_span(vis, decl_span));
@@ -1235,7 +1235,7 @@ macro_rules! common_visitor_and_walkers {
                     bounds,
                     bound_generic_params,
                 }) => {
-                    visit_generic_params(vis, bound_generic_params);
+                    try_visit!(visit_generic_params(vis, bound_generic_params));
                     try_visit!(vis.visit_ty(bounded_ty));
                     walk_list!(vis, visit_param_bound, bounds, BoundKind::Bound);
                 }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -224,20 +224,6 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn visit_struct_field_def(&mut self, field: &'a FieldDef) {
-        if let Some(ref ident) = field.ident
-            && ident.name == kw::Underscore
-        {
-            self.visit_vis(&field.vis);
-            self.visit_ident(ident);
-            self.visit_ty_common(&field.ty);
-            self.walk_ty(&field.ty);
-            walk_list!(self, visit_attribute, &field.attrs);
-        } else {
-            self.visit_field_def(field);
-        }
-    }
-
     fn dcx(&self) -> DiagCtxtHandle<'a> {
         self.sess.dcx()
     }
@@ -1135,8 +1121,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 VariantData::Struct { fields, .. } => {
                     self.visit_attrs_vis_ident(&item.attrs, &item.vis, ident);
                     self.visit_generics(generics);
-                    // Permit `Anon{Struct,Union}` as field type.
-                    walk_list!(self, visit_struct_field_def, fields);
+                    walk_list!(self, visit_field_def, fields);
                 }
                 _ => visit::walk_item(self, item),
             },
@@ -1148,8 +1133,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     VariantData::Struct { fields, .. } => {
                         self.visit_attrs_vis_ident(&item.attrs, &item.vis, ident);
                         self.visit_generics(generics);
-                        // Permit `Anon{Struct,Union}` as field type.
-                        walk_list!(self, visit_struct_field_def, fields);
+                        walk_list!(self, visit_field_def, fields);
                     }
                     _ => visit::walk_item(self, item),
                 }

--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -1,6 +1,7 @@
 //! Allocator shim
 // Adapted from rustc
 
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use rustc_ast::expand::allocator::{
     ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
     alloc_error_handler_name, default_fn_name, global_fn_name,
@@ -97,16 +98,31 @@ fn codegen_inner(
     data.define(Box::new([val]));
     module.define_data(data_id, &data).unwrap();
 
-    let data_id = module
-        .declare_data(
-            &mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
-            Linkage::Export,
-            false,
-            false,
-        )
-        .unwrap();
-    let mut data = DataDescription::new();
-    data.set_align(1);
-    data.define(Box::new([0]));
-    module.define_data(data_id, &data).unwrap();
+    {
+        let sig = Signature {
+            call_conv: module.target_config().default_call_conv,
+            params: vec![],
+            returns: vec![],
+        };
+        let func_id = module
+            .declare_function(
+                &mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
+                Linkage::Export,
+                &sig,
+            )
+            .unwrap();
+
+        let mut ctx = Context::new();
+        ctx.func.signature = sig;
+        let mut func_ctx = FunctionBuilderContext::new();
+        let mut bcx = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+
+        let block = bcx.create_block();
+        bcx.switch_to_block(block);
+        bcx.ins().return_(&[]);
+        bcx.seal_all_blocks();
+        bcx.finalize();
+
+        module.define_function(func_id, &mut ctx).unwrap();
+    }
 }

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -57,7 +57,7 @@ pub(crate) unsafe fn codegen(
             let from_name = mangle_internal_symbol(tcx, &global_fn_name(method.name));
             let to_name = mangle_internal_symbol(tcx, &default_fn_name(method.name));
 
-            create_wrapper_function(tcx, context, &from_name, &to_name, &types, output);
+            create_wrapper_function(tcx, context, &from_name, Some(&to_name), &types, output);
         }
     }
 
@@ -66,7 +66,7 @@ pub(crate) unsafe fn codegen(
         tcx,
         context,
         &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
-        &mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind)),
+        Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
         &[usize, usize],
         None,
     );
@@ -81,21 +81,21 @@ pub(crate) unsafe fn codegen(
     let value = context.new_rvalue_from_int(i8, value as i32);
     global.global_set_initializer_rvalue(value);
 
-    let name = mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE);
-    let global = context.new_global(None, GlobalKind::Exported, i8, name);
-    #[cfg(feature = "master")]
-    global.add_attribute(VarAttribute::Visibility(symbol_visibility_to_gcc(
-        tcx.sess.default_visibility(),
-    )));
-    let value = context.new_rvalue_from_int(i8, 0);
-    global.global_set_initializer_rvalue(value);
+    create_wrapper_function(
+        tcx,
+        context,
+        &mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
+        None,
+        &[],
+        None,
+    );
 }
 
 fn create_wrapper_function(
     tcx: TyCtxt<'_>,
     context: &Context<'_>,
     from_name: &str,
-    to_name: &str,
+    to_name: Option<&str>,
     types: &[Type<'_>],
     output: Option<Type<'_>>,
 ) {
@@ -124,34 +124,40 @@ fn create_wrapper_function(
         // TODO(antoyo): emit unwind tables.
     }
 
-    let args: Vec<_> = types
-        .iter()
-        .enumerate()
-        .map(|(index, typ)| context.new_parameter(None, *typ, format!("param{}", index)))
-        .collect();
-    let callee = context.new_function(
-        None,
-        FunctionType::Extern,
-        output.unwrap_or(void),
-        &args,
-        to_name,
-        false,
-    );
-    #[cfg(feature = "master")]
-    callee.add_attribute(FnAttribute::Visibility(gccjit::Visibility::Hidden));
-
     let block = func.new_block("entry");
 
-    let args = args
-        .iter()
-        .enumerate()
-        .map(|(i, _)| func.get_param(i as i32).to_rvalue())
-        .collect::<Vec<_>>();
-    let ret = context.new_call(None, callee, &args);
-    //llvm::LLVMSetTailCall(ret, True);
-    if output.is_some() {
-        block.end_with_return(None, ret);
+    if let Some(to_name) = to_name {
+        let args: Vec<_> = types
+            .iter()
+            .enumerate()
+            .map(|(index, typ)| context.new_parameter(None, *typ, format!("param{}", index)))
+            .collect();
+        let callee = context.new_function(
+            None,
+            FunctionType::Extern,
+            output.unwrap_or(void),
+            &args,
+            to_name,
+            false,
+        );
+        #[cfg(feature = "master")]
+        callee.add_attribute(FnAttribute::Visibility(gccjit::Visibility::Hidden));
+
+        let args = args
+            .iter()
+            .enumerate()
+            .map(|(i, _)| func.get_param(i as i32).to_rvalue())
+            .collect::<Vec<_>>();
+        let ret = context.new_call(None, callee, &args);
+        //llvm::LLVMSetTailCall(ret, True);
+        if output.is_some() {
+            block.end_with_return(None, ret);
+        } else {
+            block.add_eval(None, ret);
+            block.end_with_void_return(None);
+        }
     } else {
+        assert!(output.is_none());
         block.end_with_void_return(None);
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -69,23 +69,6 @@ pub fn ensure_removed(dcx: DiagCtxtHandle<'_>, path: &Path) {
     }
 }
 
-fn check_link_info_print_request(sess: &Session, crate_types: &[CrateType]) {
-    let print_native_static_libs =
-        sess.opts.prints.iter().any(|p| p.kind == PrintKind::NativeStaticLibs);
-    let has_staticlib = crate_types.iter().any(|ct| *ct == CrateType::Staticlib);
-    if print_native_static_libs {
-        if !has_staticlib {
-            sess.dcx()
-                .warn(format!("cannot output linkage information without staticlib crate-type"));
-            sess.dcx()
-                .note(format!("consider `--crate-type staticlib` to print linkage information"));
-        } else if !sess.opts.output_types.should_link() {
-            sess.dcx()
-                .warn(format!("cannot output linkage information when --emit link is not passed"));
-        }
-    }
-}
-
 /// Performs the linkage portion of the compilation phase. This will generate all
 /// of the requested outputs for this compilation session.
 pub fn link_binary(
@@ -207,8 +190,6 @@ pub fn link_binary(
             }
         }
     }
-
-    check_link_info_print_request(sess, &codegen_results.crate_info.crate_types);
 
     // Remove the temporary object file and metadata if we aren't saving temps.
     sess.time("link_binary_remove_temps", || {

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -219,6 +219,7 @@ fn exported_symbols_provider_local<'tcx>(
             .chain([
                 mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
                 mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
+                mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
             ])
         {
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(tcx, &symbol_name));
@@ -232,19 +233,6 @@ fn exported_symbols_provider_local<'tcx>(
                 },
             ));
         }
-
-        let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(
-            tcx,
-            &mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
-        ));
-        symbols.push((
-            exported_symbol,
-            SymbolExportInfo {
-                level: SymbolExportLevel::Rust,
-                kind: SymbolExportKind::Data,
-                used: false,
-            },
-        ))
     }
 
     if tcx.sess.instrument_coverage() || tcx.sess.opts.cg.profile_generate.enabled() {

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -85,10 +85,6 @@ pub fn mangle_internal_symbol<'tcx>(tcx: TyCtxt<'tcx>, item_name: &str) -> Strin
     if item_name == "rust_eh_personality" {
         // rust_eh_personality must not be renamed as LLVM hard-codes the name
         return "rust_eh_personality".to_owned();
-    } else if item_name == "__rust_no_alloc_shim_is_unstable" {
-        // Temporary back compat hack to give people the chance to migrate to
-        // include #[rustc_std_internal_symbol].
-        return "__rust_no_alloc_shim_is_unstable".to_owned();
     }
 
     let prefix = "_R";

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-freebsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv1".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
@@ -12,6 +12,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-musl".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64-unknown-openbsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv1".into();
 
     Target {
         llvm_target: "powerpc64-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-freebsd".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-linux-gnu".into(),

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.llvm_abiname = "elfv2".into();
 
     Target {
         llvm_target: "powerpc64le-unknown-linux-musl".into(),

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -31,8 +31,9 @@ unsafe extern "Rust" {
     #[rustc_std_internal_symbol]
     fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8;
 
+    #[rustc_nounwind]
     #[rustc_std_internal_symbol]
-    static __rust_no_alloc_shim_is_unstable: u8;
+    fn __rust_no_alloc_shim_is_unstable_v2();
 }
 
 /// The global memory allocator.
@@ -88,7 +89,7 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     unsafe {
         // Make sure we don't accidentally allow omitting the allocator shim in
         // stable code until it is actually stabilized.
-        core::ptr::read_volatile(&__rust_no_alloc_shim_is_unstable);
+        __rust_no_alloc_shim_is_unstable_v2();
 
         __rust_alloc(layout.size(), layout.align())
     }
@@ -171,7 +172,7 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
     unsafe {
         // Make sure we don't accidentally allow omitting the allocator shim in
         // stable code until it is actually stabilized.
-        core::ptr::read_volatile(&__rust_no_alloc_shim_is_unstable);
+        __rust_no_alloc_shim_is_unstable_v2();
 
         __rust_alloc_zeroed(layout.size(), layout.align())
     }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,6 +30,14 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
+//
+// WARNING: When you update `FORMAT_VERSION`, please also update the "Latest feature" line with a
+// description of the change. This minimizes the risk of two concurrent PRs changing
+// `FORMAT_VERSION` from N to N+1 and git merging them without conflicts; the "Latest feature" line
+// will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
+// are deliberately not in a doc comment, because they need not be in public docs.)
+//
+// Latest feature: rustdoc JSON: Don't apply #[repr] privacy heuristics
 pub const FORMAT_VERSION: u32 = 46;
 
 /// The root of the emitted JSON blob.

--- a/src/tools/miri/src/shims/extern_static.rs
+++ b/src/tools/miri/src/shims/extern_static.rs
@@ -45,10 +45,6 @@ impl<'tcx> MiriMachine<'tcx> {
 
     /// Sets up the "extern statics" for this machine.
     pub fn init_extern_statics(ecx: &mut MiriInterpCx<'tcx>) -> InterpResult<'tcx> {
-        // "__rust_no_alloc_shim_is_unstable"
-        let val = ImmTy::from_int(0, ecx.machine.layouts.u8); // always 0, value does not matter
-        Self::alloc_extern_static(ecx, "__rust_no_alloc_shim_is_unstable", val)?;
-
         // "__rust_alloc_error_handler_should_panic"
         let val = ecx.tcx.sess.opts.unstable_opts.oom.should_panic();
         let val = ImmTy::from_int(val, ecx.machine.layouts.u8);

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -611,6 +611,10 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_pointer(new_ptr, dest)
                 });
             }
+            name if name == this.mangle_internal_symbol("__rust_no_alloc_shim_is_unstable_v2") => {
+                // This is a no-op shim that only exists to prevent making the allocator shims instantly stable.
+                let [] = this.check_shim(abi, CanonAbi::Rust, link_name, args)?;
+            }
 
             // C memory handling functions
             "memcmp" => {

--- a/src/tools/miri/tests/pass/alloc-access-tracking.rs
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
-//@compile-flags: -Zmiri-track-alloc-id=20 -Zmiri-track-alloc-accesses -Cpanic=abort
-//@normalize-stderr-test: "id 20" -> "id $$ALLOC"
+//@compile-flags: -Zmiri-track-alloc-id=19 -Zmiri-track-alloc-accesses -Cpanic=abort
+//@normalize-stderr-test: "id 19" -> "id $$ALLOC"
 //@only-target: linux # alloc IDs differ between OSes (due to extern static allocations)
 
 extern "Rust" {

--- a/tests/codegen/alloc-optimisation.rs
+++ b/tests/codegen/alloc-optimisation.rs
@@ -5,7 +5,8 @@
 pub fn alloc_test(data: u32) {
     // CHECK-LABEL: @alloc_test
     // CHECK-NEXT: start:
-    // CHECK-NEXT: {{.*}} load volatile i8, ptr @{{.*}}__rust_no_alloc_shim_is_unstable, align 1
+    // CHECK-NEXT: ; call __rustc::__rust_no_alloc_shim_is_unstable_v2
+    // CHECK-NEXT: tail call void @_R{{.+}}__rust_no_alloc_shim_is_unstable_v2()
     // CHECK-NEXT: ret void
     let x = Box::new(data);
     drop(x);

--- a/tests/codegen/unwind-landingpad-inline.rs
+++ b/tests/codegen/unwind-landingpad-inline.rs
@@ -10,8 +10,10 @@
 // See https://github.com/rust-lang/rust/issues/46515
 // CHECK-LABEL: @check_no_escape_in_landingpad
 // CHECK: start:
-// CHECK-NEXT: __rust_no_alloc_shim_is_unstable
-// CHECK-NEXT: __rust_no_alloc_shim_is_unstable
+// CHECK-NEXT: ; call __rustc::__rust_no_alloc_shim_is_unstable_v2
+// CHECK-NEXT: tail call void @[[NO_ALLOC_SHIM:_R.+__rust_no_alloc_shim_is_unstable_v2]]()
+// CHECK-NEXT: ; call __rustc::__rust_no_alloc_shim_is_unstable_v2
+// CHECK-NEXT: tail call void @[[NO_ALLOC_SHIM]]()
 // CHECK-NEXT: ret void
 #[no_mangle]
 pub fn check_no_escape_in_landingpad(f: fn()) {

--- a/tests/codegen/vec-iter-collect-len.rs
+++ b/tests/codegen/vec-iter-collect-len.rs
@@ -4,7 +4,9 @@
 #[no_mangle]
 pub fn get_len() -> usize {
     // CHECK-LABEL: @get_len
-    // CHECK-NOT: call
-    // CHECK-NOT: invoke
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ; call __rustc::__rust_no_alloc_shim_is_unstable_v2
+    // CHECK-NEXT: tail call void @_R{{.+}}__rust_no_alloc_shim_is_unstable_v2()
+    // CHECK-NEXT: ret i{{[0-9]+}} 3
     [1, 2, 3].iter().collect::<Vec<_>>().len()
 }

--- a/tests/codegen/vec-optimizes-away.rs
+++ b/tests/codegen/vec-optimizes-away.rs
@@ -5,7 +5,8 @@
 pub fn sum_me() -> i32 {
     // CHECK-LABEL: @sum_me
     // CHECK-NEXT: {{^.*:$}}
-    // CHECK-NEXT: {{.*}} load volatile i8, ptr @{{.*}}__rust_no_alloc_shim_is_unstable, align 1
+    // CHECK-NEXT: ; call __rustc::__rust_no_alloc_shim_is_unstable_v2
+    // CHECK-NEXT: tail call void @_R{{.+}}__rust_no_alloc_shim_is_unstable_v2()
     // CHECK-NEXT: ret i32 6
     vec![1, 2, 3].iter().sum::<i32>()
 }

--- a/tests/run-make/no-alloc-shim/foo.rs
+++ b/tests/run-make/no-alloc-shim/foo.rs
@@ -1,4 +1,4 @@
-#![feature(default_alloc_error_handler)]
+#![feature(rustc_attrs)]
 #![no_std]
 #![no_main]
 
@@ -31,8 +31,8 @@ unsafe impl GlobalAlloc for Alloc {
 }
 
 #[cfg(not(check_feature_gate))]
-#[no_mangle]
-static __rust_no_alloc_shim_is_unstable: u8 = 0;
+#[rustc_std_internal_symbol]
+fn __rust_no_alloc_shim_is_unstable_v2() {}
 
 #[no_mangle]
 extern "C" fn main(_argc: core::ffi::c_int, _argv: *const *const i8) -> i32 {

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -35,10 +35,6 @@ fn symbols_check_archive(path: &str) {
             continue; // All compiler-builtins symbols must remain unmangled
         }
 
-        if name == "__rust_no_alloc_shim_is_unstable" {
-            continue; // FIXME remove exception once we mangle this symbol
-        }
-
         if name.contains("rust_eh_personality") {
             continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
         }
@@ -73,10 +69,6 @@ fn symbols_check(path: &str) {
             // be wrong, but even if so symbol_check_archive will likely
             // catch it.
             continue;
-        }
-
-        if name == "__rust_no_alloc_shim_is_unstable" {
-            continue; // FIXME remove exception once we mangle this symbol
         }
 
         if name.contains("rust_eh_personality") {

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -129,7 +129,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -129,7 +129,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
@@ -28,4 +28,11 @@ fn main() {
 
     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ());
     //~^ ERROR invalid argument to a legacy const generic
+
+    // A regression test for <https://github.com/rust-lang/rust/issues/142525>.
+    struct Struct<T> {
+        field: T,
+    }
+    std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+    //~^ ERROR invalid argument to a legacy const generic
 }

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.stderr
@@ -84,5 +84,17 @@ LL -     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ())
 LL +     std::arch::x86_64::_mm_inserti_si64::<{ || () }, { 1 + || () }>(loop {}, loop {});
    |
 
-error: aborting due to 7 previous errors
+error: invalid argument to a legacy const generic: cannot have const blocks, closures, async blocks or items
+  --> $DIR/invalid-rustc_legacy_const_generics-issue-123077.rs:36:71
+   |
+LL |     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+   |                                                                       ^^^^^
+   |
+help: try using a const generic argument instead
+   |
+LL -     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, Struct { field: || () });
+LL +     std::arch::x86_64::_mm_blend_ps::<{ Struct { field: || () } }>(loop {}, loop {});
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
@@ -1,5 +1,0 @@
-//@ compile-flags: --print native-static-libs
-//@ check-pass
-//~? WARN cannot output linkage information without staticlib crate-type
-
-fn main() {}

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
@@ -1,6 +1,0 @@
-warning: cannot output linkage information without staticlib crate-type
-
-note: consider `--crate-type staticlib` to print linkage information
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
@@ -1,3 +1,0 @@
-//@ compile-flags: --print native-static-libs --crate-type staticlib  --emit metadata
-//@ check-pass
-//~? WARN cannot output linkage information when --emit link is not passed

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
@@ -1,4 +1,0 @@
-warning: cannot output linkage information when --emit link is not passed
-
-warning: 1 warning emitted
-

--- a/tests/ui/print-request/stability.rs
+++ b/tests/ui/print-request/stability.rs
@@ -110,4 +110,3 @@ fn main() {}
 //[check_cfg]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `check-cfg` print option
 //[supported_crate_types]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `supported-crate-types` print option
 //[target_spec_json]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `target-spec-json` print option
-//[native_static_libs]~? WARNING cannot output linkage information without staticlib crate-type

--- a/tests/ui/sanitizer/dataflow-abilist.txt
+++ b/tests/ui/sanitizer/dataflow-abilist.txt
@@ -503,3 +503,4 @@ fun:__rust_realloc=uninstrumented
 fun:_ZN4core*=uninstrumented
 fun:_ZN3std*=uninstrumented
 fun:rust_eh_personality=uninstrumented
+fun:_R*__rustc*=uninstrumented


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141061 (Change __rust_no_alloc_shim_is_unstable to be a function)
 - rust-lang/rust#142585 (Update books)
 - rust-lang/rust#142586 (Fold unnecessary `visit_struct_field_def` in AstValidator)
 - rust-lang/rust#142587 (Make sure to propagate result from `visit_expr_fields`)
 - rust-lang/rust#142595 (Revert overeager warning for misuse of `--print native-static-libs`)
 - rust-lang/rust#142598 (Set elf e_flags on ppc64 targets according to abi)
 - rust-lang/rust#142601 (Add a comment to `FORMAT_VERSION`.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141061,142585,142586,142587,142595,142598,142601)
<!-- homu-ignore:end -->