### PR TITLE
Lint about `console` calls in rustdoc JS

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -91,5 +91,6 @@ module.exports = {
         "no-script-url": "error",
         "no-sequences": "error",
         "no-div-regex": "error",
+        "no-console": "error",
     }
 };

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1133,6 +1133,7 @@ class RoaringBitmap {
         }
         for (let j = 0; j < size; ++j) {
             if (offsets && offsets[j] !== i) {
+                // eslint-disable-next-line no-console
                 console.log(this.containers);
                 throw new Error(`corrupt bitmap ${j}: ${i} / ${offsets[j]}`);
             }


### PR DESCRIPTION
As discussed [here](https://github.com/rust-lang/rust/pull/142100#discussion_r2151764395), this PR enforces that `console` is not used in rustdoc JS by default.

cc @lolbinarycat 