### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/library/compiler-builtins/builtins-test/tests/misc.rs
+++ b/library/compiler-builtins/builtins-test/tests/misc.rs
@@ -3,7 +3,7 @@
 
 use builtins_test::*;
 
-/// Make sure that the the edge case tester and randomized tester don't break, and list examples of
+/// Make sure that the edge case tester and randomized tester don't break, and list examples of
 /// fuzz values for documentation purposes.
 #[test]
 fn fuzz_values() {

--- a/library/compiler-builtins/compiler-builtins/src/int/specialized_div_rem/binary_long.rs
+++ b/library/compiler-builtins/compiler-builtins/src/int/specialized_div_rem/binary_long.rs
@@ -325,7 +325,7 @@ macro_rules! impl_binary_long {
             // ________________
             //       0b00101110
             //              ^^^
-            // `duo` is now back in the `duo_shl1` state it was at in the the third step, with an
+            // `duo` is now back in the `duo_shl1` state it was at in the third step, with an
             // unset quotient bit.
             //
             // final step (`shl` was 4, so exactly 4 steps must be taken)

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -66,7 +66,7 @@ impl<T, const N: usize> IntoIterator for [T; N] {
         // FIXME: If normal `transmute` ever gets smart enough to allow this
         // directly, use it instead of `transmute_unchecked`.
         let data: [MaybeUninit<T>; N] = unsafe { transmute_unchecked(self) };
-        // SAFETY: The original array was entirely initialized and the the alive
+        // SAFETY: The original array was entirely initialized and the alive
         // range we're passing here represents that fact.
         let inner = unsafe { InnerSized::new_unchecked(IndexRange::zero_to(N), data) };
         IntoIter { inner }


### PR DESCRIPTION
remove redundant word in comment