### PR TITLE
Move placeholder error handling to before region inference

### DIFF
--- a/compiler/rustc_data_structures/src/graph/scc/tests.rs
+++ b/compiler/rustc_data_structures/src/graph/scc/tests.rs
@@ -32,12 +32,12 @@ impl Maxes {
 }
 
 impl Annotation for MaxReached {
-    fn merge_scc(self, other: Self) -> Self {
-        Self(std::cmp::max(other.0, self.0))
+    fn update_scc(&mut self, other: &Self) {
+        self.0 = self.0.max(other.0);
     }
 
-    fn merge_reached(self, other: Self) -> Self {
-        Self(std::cmp::max(other.0, self.0))
+    fn update_reachable(&mut self, other: &Self) {
+        self.0 = self.0.max(other.0);
     }
 }
 
@@ -75,13 +75,12 @@ impl Annotations<usize> for MinMaxes {
 }
 
 impl Annotation for MinMaxIn {
-    fn merge_scc(self, other: Self) -> Self {
-        Self { min: std::cmp::min(self.min, other.min), max: std::cmp::max(self.max, other.max) }
+    fn update_scc(&mut self, other: &Self) {
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
     }
 
-    fn merge_reached(self, _other: Self) -> Self {
-        self
-    }
+    fn update_reachable(&mut self, _other: &Self) {}
 }
 
 #[test]

--- a/tests/ui/associated-types/associated-types-eq-hr.rs
+++ b/tests/ui/associated-types/associated-types-eq-hr.rs
@@ -96,15 +96,11 @@ pub fn call_tuple_one() {
     tuple_one::<Tuple>();
     //~^ ERROR not general enough
     //~| ERROR not general enough
-    //~| ERROR not general enough
-    //~| ERROR not general enough
 }
 
 pub fn call_tuple_two() {
     tuple_two::<Tuple>();
     //~^ ERROR not general enough
-    //~| ERROR not general enough
-    //~| ERROR mismatched types
     //~| ERROR mismatched types
 }
 
@@ -115,7 +111,6 @@ pub fn call_tuple_three() {
 pub fn call_tuple_four() {
     tuple_four::<Tuple>();
     //~^ ERROR not general enough
-    //~| ERROR not general enough
 }
 
 fn main() {}

--- a/tests/ui/associated-types/associated-types-eq-hr.stderr
+++ b/tests/ui/associated-types/associated-types-eq-hr.stderr
@@ -62,46 +62,16 @@ LL |     tuple_one::<Tuple>();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:96:5
-   |
-LL |     tuple_one::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
-   |
-   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:96:5
-   |
-LL |     tuple_one::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
-   |
-   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:104:5
+  --> $DIR/associated-types-eq-hr.rs:102:5
    |
 LL |     tuple_two::<Tuple>();
    |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
    |
    = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-
-error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:104:5
-   |
-LL |     tuple_two::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
-   |
-   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
-  --> $DIR/associated-types-eq-hr.rs:104:5
+  --> $DIR/associated-types-eq-hr.rs:102:5
    |
 LL |     tuple_two::<Tuple>();
    |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
@@ -114,23 +84,8 @@ note: the lifetime requirement is introduced here
 LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
    |                                                     ^^^^^^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/associated-types-eq-hr.rs:104:5
-   |
-LL |     tuple_two::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected reference `&'x _`
-              found reference `&'y _`
-note: the lifetime requirement is introduced here
-  --> $DIR/associated-types-eq-hr.rs:66:53
-   |
-LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
-   |                                                     ^^^^^^^^^^^^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:116:5
+  --> $DIR/associated-types-eq-hr.rs:112:5
    |
 LL |     tuple_four::<Tuple>();
    |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
@@ -138,17 +93,7 @@ LL |     tuple_four::<Tuple>();
    = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
 
-error: implementation of `TheTrait` is not general enough
-  --> $DIR/associated-types-eq-hr.rs:116:5
-   |
-LL |     tuple_four::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
-   |
-   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 12 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0271, E0308.
 For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/async-await/drop-tracking-unresolved-typeck-results.no_assumptions.stderr
+++ b/tests/ui/async-await/drop-tracking-unresolved-typeck-results.no_assumptions.stderr
@@ -9,17 +9,5 @@ LL | |     });
    = note: `fn(&'0 ()) -> std::future::Ready<&'0 ()> {std::future::ready::<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&(),)>`
 
-error: implementation of `FnOnce` is not general enough
-  --> $DIR/drop-tracking-unresolved-typeck-results.rs:102:5
-   |
-LL | /     send(async {
-LL | |         Next(&Buffered(Map(Empty(PhantomData), ready::<&()>), FuturesOrdered(PhantomData), 0)).await
-LL | |     });
-   | |______^ implementation of `FnOnce` is not general enough
-   |
-   = note: `fn(&'0 ()) -> std::future::Ready<&'0 ()> {std::future::ready::<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `FnOnce<(&(),)>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-1.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-1.no_assumptions.stderr
@@ -15,24 +15,6 @@ LL | |     }
    = note: no two async blocks, even if identical, have the same type
    = help: consider pinning your async block and casting it to a trait object
 
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-auto-trait-1.rs:37:5
-   |
-LL | /     async {
-LL | |         let _y = &();
-LL | |         let _x = filter(FilterMap {
-LL | |             f: || async move { *_y },
-...  |
-LL | |         drop(_x);
-LL | |     }
-   | |_____^ one type is more general than the other
-   |
-   = note: expected `async` block `{async block@$DIR/higher-ranked-auto-trait-1.rs:40:19: 40:29}`
-              found `async` block `{async block@$DIR/higher-ranked-auto-trait-1.rs:40:19: 40:29}`
-   = note: no two async blocks, even if identical, have the same type
-   = help: consider pinning your async block and casting it to a trait object
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/higher-ranked-auto-trait-10.assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-10.assumptions.stderr
@@ -7,15 +7,5 @@ LL |     Box::new(async move { get_foo(x).await })
    = note: `Foo<'1>` would have to be implemented for the type `&'0 str`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Foo<'2>` is actually implemented for the type `&'2 str`, for some specific lifetime `'2`
 
-error: implementation of `Foo` is not general enough
-  --> $DIR/higher-ranked-auto-trait-10.rs:32:5
-   |
-LL |     Box::new(async move { get_foo(x).await })
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
-   |
-   = note: `Foo<'1>` would have to be implemented for the type `&'0 str`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Foo<'2>` is actually implemented for the type `&'2 str`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-10.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-10.no_assumptions.stderr
@@ -7,15 +7,5 @@ LL |     Box::new(async move { get_foo(x).await })
    = note: `Foo<'1>` would have to be implemented for the type `&'0 str`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Foo<'2>` is actually implemented for the type `&'2 str`, for some specific lifetime `'2`
 
-error: implementation of `Foo` is not general enough
-  --> $DIR/higher-ranked-auto-trait-10.rs:32:5
-   |
-LL |     Box::new(async move { get_foo(x).await })
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
-   |
-   = note: `Foo<'1>` would have to be implemented for the type `&'0 str`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Foo<'2>` is actually implemented for the type `&'2 str`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-13.assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-13.assumptions.stderr
@@ -4,7 +4,7 @@ error: implementation of `Getter` is not general enough
 LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
    |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
+   = note: `Getter<'_>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'1>>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
 
 error: implementation of `Getter` is not general enough
@@ -13,29 +13,9 @@ error: implementation of `Getter` is not general enough
 LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
    |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
+   = note: `Getter<'_>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'1>>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: implementation of `Getter` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
-   |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: implementation of `Getter` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
-   |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-13.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-13.no_assumptions.stderr
@@ -4,7 +4,7 @@ error: implementation of `Getter` is not general enough
 LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
    |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
+   = note: `Getter<'_>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'1>>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
 
 error: implementation of `Getter` is not general enough
@@ -13,48 +13,9 @@ error: implementation of `Getter` is not general enough
 LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
    |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
+   = note: `Getter<'_>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'1>>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: implementation of `Callable` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Callable` is not general enough
-   |
-   = note: `Callable<'_>` would have to be implemented for the type `ConstructableImpl<'0>`, for any lifetime `'0`...
-   = note: ...but `Callable<'1>` is actually implemented for the type `ConstructableImpl<'1>`, for some specific lifetime `'1`
-
-error: implementation of `Getter` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
-   |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: implementation of `Getter` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Getter` is not general enough
-   |
-   = note: `Getter<'1>` would have to be implemented for the type `GetterImpl<'0, ConstructableImpl<'_>>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Getter<'2>` is actually implemented for the type `GetterImpl<'2, ConstructableImpl<'_>>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: implementation of `Callable` is not general enough
-  --> $DIR/higher-ranked-auto-trait-13.rs:65:5
-   |
-LL |     assert_send(my_send_async_method(struct_with_lifetime, data));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Callable` is not general enough
-   |
-   = note: `Callable<'_>` would have to be implemented for the type `ConstructableImpl<'0>`, for any lifetime `'0`...
-   = note: ...but `Callable<'1>` is actually implemented for the type `ConstructableImpl<'1>`, for some specific lifetime `'1`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-15.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-15.no_assumptions.stderr
@@ -7,15 +7,5 @@ LL |     require_send(future);
    = note: closure with signature `fn(&'0 Vec<i32>) -> std::slice::Iter<'_, i32>` must implement `FnOnce<(&'1 Vec<i32>,)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&Vec<i32>,)>`
 
-error: implementation of `FnOnce` is not general enough
-  --> $DIR/higher-ranked-auto-trait-15.rs:20:5
-   |
-LL |     require_send(future);
-   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
-   |
-   = note: closure with signature `fn(&'0 Vec<i32>) -> std::slice::Iter<'_, i32>` must implement `FnOnce<(&'1 Vec<i32>,)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `FnOnce<(&Vec<i32>,)>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-17.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-17.no_assumptions.stderr
@@ -11,19 +11,5 @@ LL | |     }
    = note: closure with signature `fn(&'0 ())` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&(),)>`
 
-error: implementation of `FnOnce` is not general enough
-  --> $DIR/higher-ranked-auto-trait-17.rs:12:5
-   |
-LL | /     async move {
-LL | |         let iter = Adaptor::new(a.iter().map(|_: &()| {}));
-LL | |         std::future::pending::<()>().await;
-LL | |         drop(iter);
-LL | |     }
-   | |_____^ implementation of `FnOnce` is not general enough
-   |
-   = note: closure with signature `fn(&'0 ())` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `FnOnce<(&(),)>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-6.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-6.no_assumptions.stderr
@@ -9,18 +9,6 @@ LL |     Box::new(async { new(|| async { f().await }).await })
    = note: no two async blocks, even if identical, have the same type
    = help: consider pinning your async block and casting it to a trait object
 
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-auto-trait-6.rs:16:5
-   |
-LL |     Box::new(async { new(|| async { f().await }).await })
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-              found `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-   = note: no two async blocks, even if identical, have the same type
-   = help: consider pinning your async block and casting it to a trait object
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.no_assumptions.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.no_assumptions.stderr
@@ -12,20 +12,5 @@ LL | |     });
    = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>(..) }`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>(..) }`, for some specific lifetime `'2`
 
-error: implementation of `Send` is not general enough
-  --> $DIR/issue-110963-early.rs:17:5
-   |
-LL | /     spawn(async move {
-LL | |         let mut hc = hc;
-LL | |         if !hc.check().await {
-LL | |             log_health_check_failure().await;
-LL | |         }
-LL | |     });
-   | |______^ implementation of `Send` is not general enough
-   |
-   = note: `Send` would have to be implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'0>(..) }`, for any two lifetimes `'0` and `'1`...
-   = note: ...but `Send` is actually implemented for the type `impl Future<Output = bool> { <HC as HealthCheck>::check<'2>(..) }`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/opaque-types-patterns-subtyping-ice-104779.rs
+++ b/tests/ui/borrowck/opaque-types-patterns-subtyping-ice-104779.rs
@@ -14,10 +14,8 @@ fn foo() -> impl Sized {
     loop {
         match foo() {
         //~^ ERROR higher-ranked subtype error
-        //~^^ ERROR higher-ranked subtype error
             Subtype::Bar => (),
             //~^ ERROR higher-ranked subtype error
-            //~^^ ERROR higher-ranked subtype error
             Supertype::Var(x) => {}
         }
     }

--- a/tests/ui/borrowck/opaque-types-patterns-subtyping-ice-104779.stderr
+++ b/tests/ui/borrowck/opaque-types-patterns-subtyping-ice-104779.stderr
@@ -17,26 +17,10 @@ LL |         match foo() {
    |               ^^^^^
 
 error: higher-ranked subtype error
-  --> $DIR/opaque-types-patterns-subtyping-ice-104779.rs:15:15
-   |
-LL |         match foo() {
-   |               ^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: higher-ranked subtype error
-  --> $DIR/opaque-types-patterns-subtyping-ice-104779.rs:18:13
+  --> $DIR/opaque-types-patterns-subtyping-ice-104779.rs:17:13
    |
 LL |             Subtype::Bar => (),
    |             ^^^^^^^^^^^^
 
-error: higher-ranked subtype error
-  --> $DIR/opaque-types-patterns-subtyping-ice-104779.rs:18:13
-   |
-LL |             Subtype::Bar => (),
-   |             ^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/coroutine/auto-trait-regions.rs
+++ b/tests/ui/coroutine/auto-trait-regions.rs
@@ -20,6 +20,19 @@ impl<'a> Foo for &'a OnlyFooIfRef {}
 
 fn assert_foo<T: Foo>(f: T) {}
 
+fn other_assertion() {
+    // Disallow impls which relates lifetimes in the coroutine interior
+    let generator = #[coroutine] move || {
+        let a = A(&mut true, &mut true, No);
+        //~^ ERROR borrow may still be in use when coroutine yields
+        //~| ERROR borrow may still be in use when coroutine yields
+        yield;
+        assert_foo(a);
+    };
+    assert_foo(generator);
+    //~^ ERROR not general enough
+}
+
 fn main() {
     // Make sure 'static is erased for coroutine interiors so we can't match it in trait selection
     let x: &'static _ = &OnlyFooIfStaticRef(No);
@@ -39,15 +52,4 @@ fn main() {
         assert_foo(x);
     };
     assert_foo(generator); // ok
-
-    // Disallow impls which relates lifetimes in the coroutine interior
-    let generator = #[coroutine] move || {
-        let a = A(&mut true, &mut true, No);
-        //~^ ERROR borrow may still be in use when coroutine yields
-        //~| ERROR borrow may still be in use when coroutine yields
-        yield;
-        assert_foo(a);
-    };
-    assert_foo(generator);
-    //~^ ERROR not general enough
 }

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -1,5 +1,5 @@
 error[E0626]: borrow may still be in use when coroutine yields
-  --> $DIR/auto-trait-regions.rs:45:19
+  --> $DIR/auto-trait-regions.rs:26:19
    |
 LL |     let generator = #[coroutine] move || {
    |                                  ------- within this coroutine
@@ -15,7 +15,7 @@ LL |     let generator = #[coroutine] static move || {
    |                                  ++++++
 
 error[E0626]: borrow may still be in use when coroutine yields
-  --> $DIR/auto-trait-regions.rs:45:30
+  --> $DIR/auto-trait-regions.rs:26:30
    |
 LL |     let generator = #[coroutine] move || {
    |                                  ------- within this coroutine
@@ -31,22 +31,22 @@ LL |     let generator = #[coroutine] static move || {
    |                                  ++++++
 
 error: implementation of `Foo` is not general enough
-  --> $DIR/auto-trait-regions.rs:31:5
-   |
-LL |     assert_foo(generator);
-   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
-   |
-   = note: `&'0 OnlyFooIfStaticRef` must implement `Foo`, for any lifetime `'0`...
-   = note: ...but `Foo` is actually implemented for the type `&'static OnlyFooIfStaticRef`
-
-error: implementation of `Foo` is not general enough
-  --> $DIR/auto-trait-regions.rs:51:5
+  --> $DIR/auto-trait-regions.rs:32:5
    |
 LL |     assert_foo(generator);
    |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |
    = note: `Foo` would have to be implemented for the type `A<'0, '1>`, for any two lifetimes `'0` and `'1`...
    = note: ...but `Foo` is actually implemented for the type `A<'_, '2>`, for some specific lifetime `'2`
+
+error: implementation of `Foo` is not general enough
+  --> $DIR/auto-trait-regions.rs:44:5
+   |
+LL |     assert_foo(generator);
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `&'0 OnlyFooIfStaticRef` must implement `Foo`, for any lifetime `'0`...
+   = note: ...but `Foo` is actually implemented for the type `&'static OnlyFooIfStaticRef`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/generic-associated-types/extended/lending_iterator.stderr
+++ b/tests/ui/generic-associated-types/extended/lending_iterator.stderr
@@ -12,12 +12,6 @@ error: `Self` does not live long enough
    |
 LL |         <B as FromLendingIterator<A>>::from_iter(self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: due to a current limitation of the type system, this implies a `'static` lifetime
-  --> $DIR/lending_iterator.rs:4:21
-   |
-LL |     fn from_iter<T: for<'x> LendingIterator<Item<'x> = A>>(iter: T) -> Self;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/higher-ranked/higher-ranked-lifetime-equality.rs
+++ b/tests/ui/higher-ranked/higher-ranked-lifetime-equality.rs
@@ -33,6 +33,5 @@ fn main() {
     foo.deref();
     let foo: Foo<Two> = foo;
     //~^ ERROR mismatched types [E0308]
-    //~| ERROR mismatched types [E0308]
     foo.deref();
 }

--- a/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
+++ b/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
@@ -7,16 +7,6 @@ LL |     let foo: Foo<Two> = foo;
    = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
               found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
 
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-lifetime-equality.rs:34:25
-   |
-LL |     let foo: Foo<Two> = foo;
-   |                         ^^^ one type is more general than the other
-   |
-   = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
-              found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
@@ -12,21 +12,6 @@ LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
               found enum `Option<for<'a> fn(Inv<'a>, Inv<'a>)>`
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0308]: mismatched types
-  --> $DIR/hr-subtype.rs:54:13
-   |
-LL |               gimme::<$t1>(None::<$t2>);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-...
-LL | / check! { bound_inv_a_b_vs_bound_inv_a: (for<'a,'b> fn(Inv<'a>, Inv<'b>),
-LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
-   | |__________________________________- in this macro invocation
-   |
-   = note: expected enum `Option<for<'a, 'b> fn(Inv<'a>, Inv<'b>)>`
-              found enum `Option<for<'a> fn(Inv<'a>, Inv<'a>)>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/higher-ranked/subtype/hr-subtype.rs
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.rs
@@ -55,9 +55,8 @@ macro_rules! check {
             //[bound_a_vs_free_x]~^ ERROR
             //[free_x_vs_free_y]~^^ ERROR
             //[bound_inv_a_b_vs_bound_inv_a]~^^^ ERROR
-            //[bound_inv_a_b_vs_bound_inv_a]~| ERROR
-            //[bound_a_b_ret_a_vs_bound_a_ret_a]~^^^^^ ERROR
-            //[free_inv_x_vs_free_inv_y]~^^^^^^ ERROR
+            //[bound_a_b_ret_a_vs_bound_a_ret_a]~^^^^ ERROR
+            //[free_inv_x_vs_free_inv_y]~^^^^^ ERROR
         }
     };
 }

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.rs
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.rs
@@ -26,6 +26,5 @@ impl<'a> Foo<(&'a isize, &'a isize)> for SomeStruct
 fn a() { want_foo1::<SomeStruct>(); } // OK -- foo wants just one region
 fn b() { want_foo2::<SomeStruct>(); }
 //~^ ERROR implementation of
-//~| ERROR implementation of
 
 fn main() { }

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-conflate-regions.stderr
@@ -7,15 +7,5 @@ LL | fn b() { want_foo2::<SomeStruct>(); }
    = note: `SomeStruct` must implement `Foo<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `Foo<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
 
-error: implementation of `Foo` is not general enough
-  --> $DIR/hrtb-conflate-regions.rs:27:10
-   |
-LL | fn b() { want_foo2::<SomeStruct>(); }
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
-   |
-   = note: `SomeStruct` must implement `Foo<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
-   = note: ...but it actually implements `Foo<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -48,6 +48,7 @@ fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = im
 // This should resolve.
 fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
 //~^ ERROR implementation of `Bar` is not general enough
+//~^^ ERROR lifetime may not live long enough
 
 // This should resolve.
 fn two_htrb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Qux<'b>> {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:56:77
+  --> $DIR/nested-rpit-hrtb.rs:57:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:64:82
+  --> $DIR/nested-rpit-hrtb.rs:65:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -95,6 +95,12 @@ LL | impl Qux<'_> for () {}
    | ^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
+error: lifetime may not live long enough
+  --> $DIR/nested-rpit-hrtb.rs:49:93
+   |
+LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+   |                                      -- lifetime `'b` defined here                          ^^ opaque type requires that `'b` must outlive `'static`
+
 error: implementation of `Bar` is not general enough
   --> $DIR/nested-rpit-hrtb.rs:49:93
    |
@@ -105,7 +111,7 @@ LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = 
    = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
 error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
-  --> $DIR/nested-rpit-hrtb.rs:60:64
+  --> $DIR/nested-rpit-hrtb.rs:61:64
    |
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
@@ -118,7 +124,7 @@ LL | impl Qux<'_> for () {}
    | ^^^^^^^^^^^^^^^^^^^
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0261, E0277, E0657.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/lub-glb/old-lub-glb-object.rs
+++ b/tests/ui/lub-glb/old-lub-glb-object.rs
@@ -8,7 +8,6 @@ fn foo(x: &dyn for<'a, 'b> Foo<&'a u8, &'b u8>, y: &dyn for<'a> Foo<&'a u8, &'a 
         0 => x,
         _ => y,
         //~^ ERROR mismatched types
-        //~| ERROR mismatched types
     };
 }
 

--- a/tests/ui/lub-glb/old-lub-glb-object.stderr
+++ b/tests/ui/lub-glb/old-lub-glb-object.stderr
@@ -7,16 +7,6 @@ LL |         _ => y,
    = note: expected trait object `dyn for<'a, 'b> Foo<&'a u8, &'b u8>`
               found trait object `dyn for<'a> Foo<&'a u8, &'a u8>`
 
-error[E0308]: mismatched types
-  --> $DIR/old-lub-glb-object.rs:9:14
-   |
-LL |         _ => y,
-   |              ^ one type is more general than the other
-   |
-   = note: expected trait object `dyn for<'a, 'b> Foo<&'a u8, &'b u8>`
-              found trait object `dyn for<'a> Foo<&'a u8, &'a u8>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/nll/relate_tys/hr-fn-aau-eq-abu.rs
+++ b/tests/ui/nll/relate_tys/hr-fn-aau-eq-abu.rs
@@ -17,7 +17,6 @@ fn make_cell_aa() -> Cell<for<'a> fn(&'a u32, &'a u32)> {
 fn aa_eq_ab() {
     let a: Cell<for<'a, 'b> fn(&'a u32, &'b u32)> = make_cell_aa();
     //~^ ERROR mismatched types [E0308]
-    //~| ERROR mismatched types [E0308]
     drop(a);
 }
 

--- a/tests/ui/nll/relate_tys/hr-fn-aau-eq-abu.stderr
+++ b/tests/ui/nll/relate_tys/hr-fn-aau-eq-abu.stderr
@@ -7,16 +7,6 @@ LL |     let a: Cell<for<'a, 'b> fn(&'a u32, &'b u32)> = make_cell_aa();
    = note: expected struct `Cell<for<'a, 'b> fn(&'a _, &'b _)>`
               found struct `Cell<for<'a> fn(&'a _, &'a _)>`
 
-error[E0308]: mismatched types
-  --> $DIR/hr-fn-aau-eq-abu.rs:18:53
-   |
-LL |     let a: Cell<for<'a, 'b> fn(&'a u32, &'b u32)> = make_cell_aa();
-   |                                                     ^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected struct `Cell<for<'a, 'b> fn(&'a _, &'b _)>`
-              found struct `Cell<for<'a> fn(&'a _, &'a _)>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.current.stderr
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.current.stderr
@@ -7,16 +7,6 @@ LL |     x
    = note: expected existential trait ref `for<'a, 'b> Supertrait<'a, 'b>`
               found existential trait ref `for<'a> Supertrait<'a, 'a>`
 
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-upcasting-ub.rs:22:5
-   |
-LL |     x
-   |     ^ one type is more general than the other
-   |
-   = note: expected existential trait ref `for<'a, 'b> Supertrait<'a, 'b>`
-              found existential trait ref `for<'a> Supertrait<'a, 'a>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.rs
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ub.rs
@@ -21,8 +21,7 @@ impl<'a> Subtrait<'a, 'a> for () {}
 fn unsound(x: &dyn for<'a> Subtrait<'a, 'a>) -> &dyn for<'a, 'b> Supertrait<'a, 'b> {
     x
     //[current]~^ ERROR mismatched types
-    //[current]~| ERROR mismatched types
-    //[next]~^^^ ERROR the trait bound `&dyn for<'a> Subtrait<'a, 'a>: CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>` is not satisfied
+    //[next]~^^ ERROR the trait bound `&dyn for<'a> Subtrait<'a, 'a>: CoerceUnsized<&dyn for<'a, 'b> Supertrait<'a, 'b>>` is not satisfied
 }
 
 fn transmute<'a, 'b>(x: &'a str) -> &'b str {


### PR DESCRIPTION
This PR supersedes rust-lang/rust#130227. It removes precise tracking of placeholders in borrowck, moving them to an earlier stage. This leads to better performance, since we track less information. It is also part of the preparations for Polonius by moving specialised logic out of region inference itself and into the region graph or other, common pre-processing steps. Originally, the intention was to do this in multiple steps, but since some of them incur performance penalties won back by later stages, doing them in one go makes the net results clearer.

## Error reporting changes
1. Higher-kinded region errors (placeholder outliving a placeholder, etc) are only reported if there are no other borrowck errors.
2. Due to the less precise nature of the revised tracking, there can be multiple overlapping errors involving the same placeholders/existential regions. In that case, not all errors will be reported. Crucially, only one pair per constraint graph SCC will be reported. A common case is `Trait<r1, r2>`, which frequently gives two error messages, one for each region. Under this logic it only gives one.
3. In some cases, finding named regions to slot into diagnostics is now more difficult, since not all outlived named regions are traced. This degrades some diagnostics by replacing named regions with anonymous ones, or by picking differently named ones.
4. In precisely one test, ` tests/ui/impl-trait/nested-rpit-hrtb.rs`, we now also add `r: 'static`, which causes an extra error. Being more conservative when rewriting the constraint graph and avoiding it when invalid outlives are already detected breaks existing diagnostics for many, many tests that rely on the extra `r: 'static` to find out why they error.

Due to reason 2., several UI tests change, a lot, since they rely on diagnostic duplication being turned off to find several duplicate errors.

## Code structure changes

- Placeholder errors are now detected earlier, if they happen. 
- SCC annotations are dynamically chosen to be less rich for region graphs with no placeholders, opting to skip a lot of the logic. This is crucial for performance; both runtime and memory use, since it allows simple function bodies to skip  some allocations and extra computation during SCC construction.
- SCC annotations are now written in an update-style as opposed to the previous, more functional style. It seems to be more performant and it's certainly more succinct.

r? lcnr