### PR TITLE
Add `StepMetadata` to describe steps

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -24,7 +24,8 @@ use crate::core::build_steps::tool::SourceType;
 use crate::core::build_steps::{dist, llvm};
 use crate::core::builder;
 use crate::core::builder::{
-    Builder, Cargo, Kind, PathSet, RunConfig, ShouldRun, Step, TaskPath, crate_description,
+    Builder, Cargo, Kind, PathSet, RunConfig, ShouldRun, Step, StepMetadata, TaskPath,
+    crate_description,
 };
 use crate::core::config::{DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection};
 use crate::utils::build_stamp;
@@ -304,6 +305,14 @@ impl Step for Std {
             self,
             builder.compiler(compiler.stage, builder.config.host_target),
         ));
+    }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(
+            StepMetadata::build("std", self.target)
+                .built_by(self.compiler)
+                .stage(self.compiler.stage),
+        )
     }
 }
 
@@ -1170,6 +1179,14 @@ impl Step for Rustc {
         ));
 
         build_compiler.stage
+    }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(
+            StepMetadata::build("rustc", self.target)
+                .built_by(self.build_compiler)
+                .stage(self.build_compiler.stage + 1),
+        )
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -18,7 +18,7 @@ use build_helper::git::PathFreshness;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
+use crate::core::builder::{Builder, RunConfig, ShouldRun, Step, StepMetadata};
 use crate::core::config::{Config, TargetSelection};
 use crate::utils::build_stamp::{BuildStamp, generate_smart_stamp_hash};
 use crate::utils::exec::command;
@@ -581,6 +581,10 @@ impl Step for Llvm {
         t!(stamp.write());
 
         res
+    }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(StepMetadata::build("llvm", self.target))
     }
 }
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -130,6 +130,38 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
         // as such calling them from ./x.py isn't logical.
         unimplemented!()
     }
+
+    /// Returns metadata of the step, for tests
+    fn metadata(&self) -> Option<StepMetadata> {
+        None
+    }
+}
+
+/// Metadata that describes an executed step, mostly for testing and tracing.
+#[allow(unused)]
+#[derive(Debug)]
+pub struct StepMetadata {
+    name: &'static str,
+    kind: Kind,
+    target: TargetSelection,
+    built_by: Option<Compiler>,
+    stage: Option<u32>,
+}
+
+impl StepMetadata {
+    pub fn build(name: &'static str, target: TargetSelection) -> Self {
+        Self { name, kind: Kind::Build, target, built_by: None, stage: None }
+    }
+
+    pub fn built_by(mut self, compiler: Compiler) -> Self {
+        self.built_by = Some(compiler);
+        self
+    }
+
+    pub fn stage(mut self, stage: u32) -> Self {
+        self.stage = Some(stage);
+        self
+    }
 }
 
 pub struct RunConfig<'a> {

--- a/src/bootstrap/src/utils/cache.rs
+++ b/src/bootstrap/src/utils/cache.rs
@@ -218,10 +218,15 @@ pub struct Cache {
         >,
     >,
     #[cfg(test)]
-    /// Contains steps in the same order in which they were executed
-    /// Useful for tests
-    /// Tuples (step, step output)
-    executed_steps: RefCell<Vec<(Box<dyn Any>, Box<dyn Any>)>>,
+    /// Contains step metadata of executed steps (in the same order in which they were executed).
+    /// Useful for tests.
+    executed_steps: RefCell<Vec<ExecutedStep>>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub struct ExecutedStep {
+    pub metadata: Option<crate::core::builder::StepMetadata>,
 }
 
 impl Cache {
@@ -243,9 +248,8 @@ impl Cache {
 
         #[cfg(test)]
         {
-            let step: Box<dyn Any> = Box::new(step.clone());
-            let output: Box<dyn Any> = Box::new(value.clone());
-            self.executed_steps.borrow_mut().push((step, output));
+            let metadata = step.metadata();
+            self.executed_steps.borrow_mut().push(ExecutedStep { metadata });
         }
 
         stepcache.insert(step, value);
@@ -283,7 +287,7 @@ impl Cache {
     }
 
     #[cfg(test)]
-    pub fn into_executed_steps(mut self) -> Vec<(Box<dyn Any>, Box<dyn Any>)> {
+    pub fn into_executed_steps(mut self) -> Vec<ExecutedStep> {
         mem::take(&mut self.executed_steps.borrow_mut())
     }
 }


### PR DESCRIPTION
This is used to replace the previous downcasting of executed steps, which wasn't very scalable. In addition to tests, we could also use the metadata e.g. for tracing.

r? @jieyouxu