### PR TITLE
Dont suggest remove semi inside macro expansion for redundant semi lint

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -738,7 +738,8 @@ lint_redundant_semicolons =
         [true] semicolons
         *[false] semicolon
     }
-    .suggestion = remove {$multiple ->
+
+lint_redundant_semicolons_suggestion = remove {$multiple_semicolons ->
         [true] these semicolons
         *[false] this semicolon
     }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1538,8 +1538,16 @@ pub(crate) struct PassByValueDiag {
 #[diag(lint_redundant_semicolons)]
 pub(crate) struct RedundantSemicolonsDiag {
     pub multiple: bool,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
-    pub suggestion: Span,
+    #[subdiagnostic]
+    pub suggestion: Option<RedundantSemicolonsSuggestion>,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(lint_redundant_semicolons_suggestion, code = "", applicability = "maybe-incorrect")]
+pub(crate) struct RedundantSemicolonsSuggestion {
+    pub multiple_semicolons: bool,
+    #[primary_span]
+    pub span: Span,
 }
 
 // traits.rs

--- a/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.rs
+++ b/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.rs
@@ -1,0 +1,11 @@
+// Make sure we don't suggest remove redundant semicolon inside macro expansion.(issue #142143)
+
+#![deny(redundant_semicolons)]
+
+macro_rules! m {
+    ($stmt:stmt) => { #[allow(bad_style)] $stmt } //~ ERROR unnecessary trailing semicolon [redundant_semicolons]
+}
+
+fn main() {
+    m!(;);
+}

--- a/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
+++ b/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
@@ -1,0 +1,18 @@
+error: unnecessary trailing semicolon
+  --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:6:43
+   |
+LL |     ($stmt:stmt) => { #[allow(bad_style)] $stmt }
+   |                                           ^^^^^ help: remove this semicolon
+...
+LL |     m!(;);
+   |     ----- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:3:9
+   |
+LL | #![deny(redundant_semicolons)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
+++ b/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
@@ -2,7 +2,7 @@ error: unnecessary trailing semicolon
   --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:6:43
    |
 LL |     ($stmt:stmt) => { #[allow(bad_style)] $stmt }
-   |                                           ^^^^^ help: remove this semicolon
+   |                                           ^^^^^
 ...
 LL |     m!(;);
    |     ----- in this macro invocation


### PR DESCRIPTION
Fixes rust-lang/rust#142143

r? compiler