### PR TITLE
Error on invalid signatures for interrupt ABIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,7 @@ dependencies = [
  "rustc_parse",
  "rustc_session",
  "rustc_span",
+ "rustc_target",
  "thin-vec",
 ]
 

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -18,5 +18,6 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+rustc_target = { path = "../rustc_target" }
 thin-vec = "0.2.12"
 # tidy-alphabetical-end

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -1,19 +1,24 @@
-ast_passes_abi_custom_coroutine =
-    functions with the `"custom"` ABI cannot be `{$coroutine_kind_str}`
+ast_passes_abi_cannot_be_coroutine =
+    functions with the {$abi} ABI cannot be `{$coroutine_kind_str}`
     .suggestion = remove the `{$coroutine_kind_str}` keyword from this definiton
 
-ast_passes_abi_custom_invalid_signature =
-    invalid signature for `extern "custom"` function
-    .note = functions with the `"custom"` ABI cannot have any parameters or return type
-    .suggestion = remove the parameters and return type
-
 ast_passes_abi_custom_safe_foreign_function =
-    foreign functions with the `"custom"` ABI cannot be safe
+    foreign functions with the "custom" ABI cannot be safe
     .suggestion = remove the `safe` keyword from this definition
 
 ast_passes_abi_custom_safe_function =
-    functions with the `"custom"` ABI must be unsafe
+    functions with the "custom" ABI must be unsafe
     .suggestion = add the `unsafe` keyword to this definition
+
+ast_passes_abi_must_not_have_parameters_or_return_type=
+    invalid signature for `extern {$abi}` function
+    .note = functions with the {$abi} ABI cannot have any parameters or return type
+    .suggestion = remove the parameters and return type
+
+ast_passes_abi_must_not_have_return_type=
+    invalid signature for `extern {$abi}` function
+    .note = functions with the "custom" ABI cannot have a return type
+    .help = remove the return type
 
 ast_passes_assoc_const_without_body =
     associated constant in `impl` without body

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -1,5 +1,6 @@
 //! Errors emitted by ast_passes.
 
+use rustc_abi::ExternAbi;
 use rustc_ast::ParamKindOrd;
 use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic};
@@ -845,6 +846,7 @@ pub(crate) struct AbiCustomSafeForeignFunction {
 pub(crate) struct AbiCustomSafeFunction {
     #[primary_span]
     pub span: Span,
+    pub abi: ExternAbi,
 
     #[suggestion(
         ast_passes_suggestion,
@@ -856,10 +858,11 @@ pub(crate) struct AbiCustomSafeFunction {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_abi_custom_coroutine)]
-pub(crate) struct AbiCustomCoroutine {
+#[diag(ast_passes_abi_cannot_be_coroutine)]
+pub(crate) struct AbiCannotBeCoroutine {
     #[primary_span]
     pub span: Span,
+    pub abi: ExternAbi,
 
     #[suggestion(
         ast_passes_suggestion,
@@ -872,11 +875,12 @@ pub(crate) struct AbiCustomCoroutine {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_abi_custom_invalid_signature)]
+#[diag(ast_passes_abi_must_not_have_parameters_or_return_type)]
 #[note]
-pub(crate) struct AbiCustomInvalidSignature {
+pub(crate) struct AbiMustNotHaveParametersOrReturnType {
     #[primary_span]
     pub spans: Vec<Span>,
+    pub abi: ExternAbi,
 
     #[suggestion(
         ast_passes_suggestion,
@@ -887,4 +891,14 @@ pub(crate) struct AbiCustomInvalidSignature {
     pub suggestion_span: Span,
     pub symbol: Symbol,
     pub padding: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_abi_must_not_have_return_type)]
+#[note]
+pub(crate) struct AbiMustNotHaveReturnType {
+    #[primary_span]
+    #[help]
+    pub span: Span,
+    pub abi: ExternAbi,
 }

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -1,5 +1,5 @@
 hir_analysis_abi_custom_clothed_function =
-    items with the `"custom"` ABI can only be declared externally or defined via naked functions
+    items with the "custom" ABI can only be declared externally or defined via naked functions
     .suggestion = convert this to an `#[unsafe(naked)]` function
 
 hir_analysis_ambiguous_assoc_item = ambiguous associated {$assoc_kind} `{$assoc_ident}` in bounds of `{$qself}`

--- a/tests/codegen/abi-x86-interrupt.rs
+++ b/tests/codegen/abi-x86-interrupt.rs
@@ -13,8 +13,6 @@
 extern crate minicore;
 use minicore::*;
 
-// CHECK: define x86_intrcc i64 @has_x86_interrupt_abi
+// CHECK: define x86_intrcc void @has_x86_interrupt_abi
 #[no_mangle]
-pub extern "x86-interrupt" fn has_x86_interrupt_abi(a: i64) -> i64 {
-    a
-}
+pub extern "x86-interrupt" fn has_x86_interrupt_abi() {}

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -5,7 +5,7 @@
 
 #[unsafe(naked)]
 extern "custom" fn must_be_unsafe(a: i64) -> i64 {
-    //~^ ERROR functions with the `"custom"` ABI must be unsafe
+    //~^ ERROR functions with the "custom" ABI must be unsafe
     //~| ERROR invalid signature for `extern "custom"` function
     std::arch::naked_asm!("")
 }
@@ -23,7 +23,7 @@ unsafe extern "custom" fn no_return_type() -> i64 {
 }
 
 unsafe extern "custom" fn double(a: i64) -> i64 {
-    //~^ ERROR items with the `"custom"` ABI can only be declared externally or defined via naked functions
+    //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
     //~| ERROR invalid signature for `extern "custom"` function
     unimplemented!()
 }
@@ -32,7 +32,7 @@ struct Thing(i64);
 
 impl Thing {
     unsafe extern "custom" fn is_even(self) -> bool {
-        //~^ ERROR items with the `"custom"` ABI can only be declared externally or defined via naked functions
+        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
         unimplemented!()
     }
@@ -40,7 +40,7 @@ impl Thing {
 
 trait BitwiseNot {
     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
-        //~^ ERROR items with the `"custom"` ABI can only be declared externally or defined via naked functions
+        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
         unimplemented!()
     }
@@ -50,14 +50,14 @@ impl BitwiseNot for Thing {}
 
 trait Negate {
     extern "custom" fn negate(a: i64) -> i64;
-    //~^ ERROR functions with the `"custom"` ABI must be unsafe
+    //~^ ERROR functions with the "custom" ABI must be unsafe
     //~| ERROR invalid signature for `extern "custom"` function
 }
 
 impl Negate for Thing {
     extern "custom" fn negate(a: i64) -> i64 {
-        //~^ ERROR items with the `"custom"` ABI can only be declared externally or defined via naked functions
-        //~| ERROR functions with the `"custom"` ABI must be unsafe
+        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+        //~| ERROR functions with the "custom" ABI must be unsafe
         //~| ERROR invalid signature for `extern "custom"` function
         -a
     }
@@ -68,7 +68,7 @@ unsafe extern "custom" {
     //~^ ERROR invalid signature for `extern "custom"` function
 
     safe fn extern_cannot_be_safe();
-    //~^ ERROR foreign functions with the `"custom"` ABI cannot be safe
+    //~^ ERROR foreign functions with the "custom" ABI cannot be safe
 }
 
 fn caller(f: unsafe extern "custom" fn(i64) -> i64, mut x: i64) -> i64 {
@@ -95,8 +95,8 @@ const unsafe extern "custom" fn no_const_fn() {
 }
 
 async unsafe extern "custom" fn no_async_fn() {
-    //~^ ERROR items with the `"custom"` ABI can only be declared externally or defined via naked functions
-    //~| ERROR functions with the `"custom"` ABI cannot be `async`
+    //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+    //~| ERROR functions with the "custom" ABI cannot be `async`
 }
 
 fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn()  {

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -1,4 +1,4 @@
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/bad-custom.rs:7:1
    |
 LL | extern "custom" fn must_be_unsafe(a: i64) -> i64 {
@@ -15,7 +15,7 @@ error: invalid signature for `extern "custom"` function
 LL | extern "custom" fn must_be_unsafe(a: i64) -> i64 {
    |                                   ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL - extern "custom" fn must_be_unsafe(a: i64) -> i64 {
@@ -28,7 +28,7 @@ error: invalid signature for `extern "custom"` function
 LL | unsafe extern "custom" fn no_parameters(a: i64) {
    |                                         ^^^^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL - unsafe extern "custom" fn no_parameters(a: i64) {
@@ -41,7 +41,7 @@ error: invalid signature for `extern "custom"` function
 LL | unsafe extern "custom" fn no_return_type() -> i64 {
    |                                               ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL - unsafe extern "custom" fn no_return_type() -> i64 {
@@ -54,7 +54,7 @@ error: invalid signature for `extern "custom"` function
 LL | unsafe extern "custom" fn double(a: i64) -> i64 {
    |                                  ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL - unsafe extern "custom" fn double(a: i64) -> i64 {
@@ -67,7 +67,7 @@ error: invalid signature for `extern "custom"` function
 LL |     unsafe extern "custom" fn is_even(self) -> bool {
    |                                       ^^^^     ^^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL -     unsafe extern "custom" fn is_even(self) -> bool {
@@ -80,14 +80,14 @@ error: invalid signature for `extern "custom"` function
 LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
    |                                           ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL -     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
 LL +     unsafe extern "custom" fn bitwise_not() {
    |
 
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/bad-custom.rs:52:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64;
@@ -104,14 +104,14 @@ error: invalid signature for `extern "custom"` function
 LL |     extern "custom" fn negate(a: i64) -> i64;
    |                               ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL -     extern "custom" fn negate(a: i64) -> i64;
 LL +     extern "custom" fn negate();
    |
 
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/bad-custom.rs:58:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {
@@ -128,7 +128,7 @@ error: invalid signature for `extern "custom"` function
 LL |     extern "custom" fn negate(a: i64) -> i64 {
    |                               ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL -     extern "custom" fn negate(a: i64) -> i64 {
@@ -141,14 +141,14 @@ error: invalid signature for `extern "custom"` function
 LL |     fn increment(a: i64) -> i64;
    |                  ^^^^^^     ^^^
    |
-   = note: functions with the `"custom"` ABI cannot have any parameters or return type
+   = note: functions with the "custom" ABI cannot have any parameters or return type
 help: remove the parameters and return type
    |
 LL -     fn increment(a: i64) -> i64;
 LL +     fn increment();
    |
 
-error: foreign functions with the `"custom"` ABI cannot be safe
+error: foreign functions with the "custom" ABI cannot be safe
   --> $DIR/bad-custom.rs:70:5
    |
 LL |     safe fn extern_cannot_be_safe();
@@ -160,7 +160,7 @@ LL -     safe fn extern_cannot_be_safe();
 LL +     fn extern_cannot_be_safe();
    |
 
-error: functions with the `"custom"` ABI cannot be `async`
+error: functions with the "custom" ABI cannot be `async`
   --> $DIR/bad-custom.rs:97:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
@@ -172,7 +172,7 @@ LL - async unsafe extern "custom" fn no_async_fn() {
 LL + unsafe extern "custom" fn no_async_fn() {
    |
 
-error: items with the `"custom"` ABI can only be declared externally or defined via naked functions
+error: items with the "custom" ABI can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:97:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
@@ -197,7 +197,7 @@ LL |     f
    = note: unsafe function cannot be called generically without an unsafe block
    = note: wrap the `unsafe extern "custom" fn()` in a closure with no arguments: `|| { /* code */ }`
 
-error: items with the `"custom"` ABI can only be declared externally or defined via naked functions
+error: items with the "custom" ABI can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:25:1
    |
 LL | unsafe extern "custom" fn double(a: i64) -> i64 {
@@ -209,7 +209,7 @@ LL + #[unsafe(naked)]
 LL | unsafe extern "custom" fn double(a: i64) -> i64 {
    |
 
-error: items with the `"custom"` ABI can only be declared externally or defined via naked functions
+error: items with the "custom" ABI can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:34:5
    |
 LL |     unsafe extern "custom" fn is_even(self) -> bool {
@@ -221,7 +221,7 @@ LL +     #[unsafe(naked)]
 LL |     unsafe extern "custom" fn is_even(self) -> bool {
    |
 
-error: items with the `"custom"` ABI can only be declared externally or defined via naked functions
+error: items with the "custom" ABI can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:42:5
    |
 LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
@@ -233,7 +233,7 @@ LL +     #[unsafe(naked)]
 LL |     unsafe extern "custom" fn bitwise_not(a: i64) -> i64 {
    |
 
-error: items with the `"custom"` ABI can only be declared externally or defined via naked functions
+error: items with the "custom" ABI can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:58:5
    |
 LL |     extern "custom" fn negate(a: i64) -> i64 {

--- a/tests/ui/abi/cannot-be-called.avr.stderr
+++ b/tests/ui/abi/cannot-be-called.avr.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:41:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "x86-interrupt" fn x86() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
+  --> $DIR/cannot-be-called.rs:70:25
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                         ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:77:26
+  --> $DIR/cannot-be-called.rs:76:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:83:26
+  --> $DIR/cannot-be-called.rs:82:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:89:22
+  --> $DIR/cannot-be-called.rs:88:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "avr-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:53:5
+  --> $DIR/cannot-be-called.rs:50:5
    |
 LL |     avr();
    |     ^^^^^
    |
 note: an `extern "avr-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:53:5
+  --> $DIR/cannot-be-called.rs:50:5
    |
 LL |     avr();
    |     ^^^^^
 
 error: functions with the "avr-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:73:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "avr-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:73:5
+  --> $DIR/cannot-be-called.rs:66:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.i686.stderr
+++ b/tests/ui/abi/cannot-be-called.i686.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:41:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
-error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
-   |
-LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-   |                         ^^^^^^^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:70:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:77:26
+  --> $DIR/cannot-be-called.rs:76:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:83:26
+  --> $DIR/cannot-be-called.rs:82:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.msp430.stderr
+++ b/tests/ui/abi/cannot-be-called.msp430.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:41:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "x86-interrupt" fn x86() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:77:26
+  --> $DIR/cannot-be-called.rs:76:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:83:26
+  --> $DIR/cannot-be-called.rs:82:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:89:22
+  --> $DIR/cannot-be-called.rs:88:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:51:5
+  --> $DIR/cannot-be-called.rs:52:5
    |
 LL |     msp430();
    |     ^^^^^^^^
    |
 note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:51:5
+  --> $DIR/cannot-be-called.rs:52:5
    |
 LL |     msp430();
    |     ^^^^^^^^
 
 error: functions with the "msp430-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:67:5
+  --> $DIR/cannot-be-called.rs:72:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "msp430-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:67:5
+  --> $DIR/cannot-be-called.rs:72:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv32.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "x86-interrupt" fn x86() {}
    |        ^^^^^^^^^^^^^^^
 
-error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
-   |
-LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-   |                         ^^^^^^^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:70:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:89:22
+  --> $DIR/cannot-be-called.rs:88:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:55:5
+  --> $DIR/cannot-be-called.rs:54:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:55:5
+  --> $DIR/cannot-be-called.rs:54:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:56:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:56:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:79:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:79:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:85:5
+  --> $DIR/cannot-be-called.rs:84:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:85:5
+  --> $DIR/cannot-be-called.rs:84:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv64.stderr
@@ -1,83 +1,83 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:46:8
+  --> $DIR/cannot-be-called.rs:45:8
    |
 LL | extern "x86-interrupt" fn x86() {}
    |        ^^^^^^^^^^^^^^^
 
-error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
-   |
-LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-   |                         ^^^^^^^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:70:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:89:22
+  --> $DIR/cannot-be-called.rs:88:22
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:55:5
+  --> $DIR/cannot-be-called.rs:54:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:55:5
+  --> $DIR/cannot-be-called.rs:54:5
    |
 LL |     riscv_m();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:56:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:57:5
+  --> $DIR/cannot-be-called.rs:56:5
    |
 LL |     riscv_s();
    |     ^^^^^^^^^
 
 error: functions with the "riscv-interrupt-m" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:79:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-m"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:79:5
+  --> $DIR/cannot-be-called.rs:78:5
    |
 LL |     f()
    |     ^^^
 
 error: functions with the "riscv-interrupt-s" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:85:5
+  --> $DIR/cannot-be-called.rs:84:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "riscv-interrupt-s"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:85:5
+  --> $DIR/cannot-be-called.rs:84:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.rs
+++ b/tests/ui/abi/cannot-be-called.rs
@@ -25,9 +25,8 @@ So we test that they error in essentially all of the same places.
     no_core,
     abi_msp430_interrupt,
     abi_avr_interrupt,
-    abi_gpu_kernel,
     abi_x86_interrupt,
-    abi_riscv_interrupt,
+    abi_riscv_interrupt
 )]
 
 extern crate minicore;
@@ -48,10 +47,10 @@ extern "x86-interrupt" fn x86() {}
 
 /* extern "interrupt" calls  */
 fn call_the_interrupts() {
-    msp430();
-    //[msp430]~^ ERROR functions with the "msp430-interrupt" ABI cannot be called
     avr();
     //[avr]~^ ERROR functions with the "avr-interrupt" ABI cannot be called
+    msp430();
+    //[msp430]~^ ERROR functions with the "msp430-interrupt" ABI cannot be called
     riscv_m();
     //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-m" ABI cannot be called
     riscv_s();
@@ -62,16 +61,16 @@ fn call_the_interrupts() {
 
 /* extern "interrupt" fnptr calls */
 
-fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-    //[x64,x64_win,i686,riscv32,riscv64,avr]~^ ERROR is not a supported ABI
-    f()
-    //[msp430]~^ ERROR functions with the "msp430-interrupt" ABI cannot be called
-}
-
 fn avr_ptr(f: extern "avr-interrupt" fn()) {
     //[x64,x64_win,i686,riscv32,riscv64,msp430]~^ ERROR is not a supported ABI
     f()
     //[avr]~^ ERROR functions with the "avr-interrupt" ABI cannot be called
+}
+
+fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+    //[x64,x64_win,i686,riscv32,riscv64,avr]~^ ERROR is not a supported ABI
+    f()
+    //[msp430]~^ ERROR functions with the "msp430-interrupt" ABI cannot be called
 }
 
 fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {

--- a/tests/ui/abi/cannot-be-called.x64.stderr
+++ b/tests/ui/abi/cannot-be-called.x64.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:41:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
-error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
-   |
-LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-   |                         ^^^^^^^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:70:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:77:26
+  --> $DIR/cannot-be-called.rs:76:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:83:26
+  --> $DIR/cannot-be-called.rs:82:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-called.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-called.x64_win.stderr
@@ -1,71 +1,71 @@
 error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:38:8
+  --> $DIR/cannot-be-called.rs:37:8
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:40:8
+  --> $DIR/cannot-be-called.rs:39:8
    |
 LL | extern "avr-interrupt" fn avr() {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:42:8
+  --> $DIR/cannot-be-called.rs:41:8
    |
 LL | extern "riscv-interrupt-m" fn riscv_m() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:44:8
+  --> $DIR/cannot-be-called.rs:43:8
    |
 LL | extern "riscv-interrupt-s" fn riscv_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
 
-error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:65:25
-   |
-LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
-   |                         ^^^^^^^^^^^^^^^^^^
-
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:71:22
+  --> $DIR/cannot-be-called.rs:64:22
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |                      ^^^^^^^^^^^^^^^
 
+error[E0570]: "msp430-interrupt" is not a supported ABI for the current target
+  --> $DIR/cannot-be-called.rs:70:25
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                         ^^^^^^^^^^^^^^^^^^
+
 error[E0570]: "riscv-interrupt-m" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:77:26
+  --> $DIR/cannot-be-called.rs:76:26
    |
 LL | fn riscv_m_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: "riscv-interrupt-s" is not a supported ABI for the current target
-  --> $DIR/cannot-be-called.rs:83:26
+  --> $DIR/cannot-be-called.rs:82:26
    |
 LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:59:5
+  --> $DIR/cannot-be-called.rs:58:5
    |
 LL |     x86();
    |     ^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
-  --> $DIR/cannot-be-called.rs:91:5
+  --> $DIR/cannot-be-called.rs:90:5
    |
 LL |     f()
    |     ^^^

--- a/tests/ui/abi/cannot-be-coroutine.avr.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.avr.stderr
@@ -1,0 +1,23 @@
+error: functions with the "avr-interrupt" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:36:1
+   |
+LL | async extern "avr-interrupt" fn avr() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "avr-interrupt" fn avr() {
+LL + extern "avr-interrupt" fn avr() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.i686.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.i686.stderr
@@ -1,0 +1,23 @@
+error: functions with the "x86-interrupt" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:52:1
+   |
+LL | async extern "x86-interrupt" fn x86() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "x86-interrupt" fn x86() {
+LL + extern "x86-interrupt" fn x86() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.msp430.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.msp430.stderr
@@ -1,0 +1,23 @@
+error: functions with the "msp430-interrupt" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:40:1
+   |
+LL | async extern "msp430-interrupt" fn msp430() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "msp430-interrupt" fn msp430() {
+LL + extern "msp430-interrupt" fn msp430() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.riscv32.stderr
@@ -1,0 +1,35 @@
+error: functions with the "riscv-interrupt-m" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:44:1
+   |
+LL | async extern "riscv-interrupt-m" fn riscv_m() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "riscv-interrupt-m" fn riscv_m() {
+LL + extern "riscv-interrupt-m" fn riscv_m() {
+   |
+
+error: functions with the "riscv-interrupt-s" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:48:1
+   |
+LL | async extern "riscv-interrupt-s" fn riscv_s() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "riscv-interrupt-s" fn riscv_s() {
+LL + extern "riscv-interrupt-s" fn riscv_s() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.riscv64.stderr
@@ -1,0 +1,35 @@
+error: functions with the "riscv-interrupt-m" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:44:1
+   |
+LL | async extern "riscv-interrupt-m" fn riscv_m() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "riscv-interrupt-m" fn riscv_m() {
+LL + extern "riscv-interrupt-m" fn riscv_m() {
+   |
+
+error: functions with the "riscv-interrupt-s" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:48:1
+   |
+LL | async extern "riscv-interrupt-s" fn riscv_s() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "riscv-interrupt-s" fn riscv_s() {
+LL + extern "riscv-interrupt-s" fn riscv_s() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.rs
+++ b/tests/ui/abi/cannot-be-coroutine.rs
@@ -1,0 +1,54 @@
+//@ add-core-stubs
+//@ edition: 2021
+//@ revisions: x64 x64_win i686 riscv32 riscv64 avr msp430
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [x64_win] needs-llvm-components: x86
+//@ [x64_win] compile-flags: --target=x86_64-pc-windows-msvc --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ [riscv32] needs-llvm-components: riscv
+//@ [riscv32] compile-flags: --target=riscv32i-unknown-none-elf --crate-type=rlib
+//@ [riscv64] needs-llvm-components: riscv
+//@ [riscv64] compile-flags: --target=riscv64gc-unknown-none-elf --crate-type=rlib
+//@ [avr] needs-llvm-components: avr
+//@ [avr] compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
+//@ [msp430] needs-llvm-components: msp430
+//@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
+#![no_core]
+#![feature(
+    no_core,
+    abi_msp430_interrupt,
+    abi_avr_interrupt,
+    abi_x86_interrupt,
+    abi_riscv_interrupt
+)]
+
+extern crate minicore;
+use minicore::*;
+
+// We ignore this error; implementing all of the async-related lang items is not worth it.
+async fn vanilla(){
+    //~^ ERROR requires `ResumeTy` lang_item
+}
+
+async extern "avr-interrupt" fn avr() {
+    //[avr]~^ ERROR functions with the "avr-interrupt" ABI cannot be `async`
+}
+
+async extern "msp430-interrupt" fn msp430() {
+    //[msp430]~^ ERROR functions with the "msp430-interrupt" ABI cannot be `async`
+}
+
+async extern "riscv-interrupt-m" fn riscv_m() {
+    //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-m" ABI cannot be `async`
+}
+
+async extern "riscv-interrupt-s" fn riscv_s() {
+    //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-s" ABI cannot be `async`
+}
+
+async extern "x86-interrupt" fn x86() {
+    //[x64,x64_win,i686]~^ ERROR functions with the "x86-interrupt" ABI cannot be `async`
+}

--- a/tests/ui/abi/cannot-be-coroutine.x64.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.x64.stderr
@@ -1,0 +1,23 @@
+error: functions with the "x86-interrupt" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:52:1
+   |
+LL | async extern "x86-interrupt" fn x86() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "x86-interrupt" fn x86() {
+LL + extern "x86-interrupt" fn x86() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/cannot-be-coroutine.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-coroutine.x64_win.stderr
@@ -1,0 +1,23 @@
+error: functions with the "x86-interrupt" ABI cannot be `async`
+  --> $DIR/cannot-be-coroutine.rs:52:1
+   |
+LL | async extern "x86-interrupt" fn x86() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `async` keyword from this definiton
+   |
+LL - async extern "x86-interrupt" fn x86() {
+LL + extern "x86-interrupt" fn x86() {
+   |
+
+error: requires `ResumeTy` lang_item
+  --> $DIR/cannot-be-coroutine.rs:32:19
+   |
+LL |   async fn vanilla(){
+   |  ___________________^
+LL | |
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/feature-gates/feature-gate-abi-custom.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-custom.rs
@@ -15,11 +15,11 @@ unsafe extern "custom" fn f7() {
 trait Tr {
     extern "custom" fn m7();
     //~^ ERROR "custom" ABI is experimental
-    //~| ERROR functions with the `"custom"` ABI must be unsafe
+    //~| ERROR functions with the "custom" ABI must be unsafe
     #[unsafe(naked)]
     extern "custom" fn dm7() {
         //~^ ERROR "custom" ABI is experimental
-        //~| ERROR functions with the `"custom"` ABI must be unsafe
+        //~| ERROR functions with the "custom" ABI must be unsafe
         naked_asm!("")
     }
 }
@@ -31,7 +31,7 @@ impl Tr for S {
     #[unsafe(naked)]
     extern "custom" fn m7() {
         //~^ ERROR "custom" ABI is experimental
-        //~| ERROR functions with the `"custom"` ABI must be unsafe
+        //~| ERROR functions with the "custom" ABI must be unsafe
         naked_asm!("")
     }
 }
@@ -41,7 +41,7 @@ impl S {
     #[unsafe(naked)]
     extern "custom" fn im7() {
         //~^ ERROR "custom" ABI is experimental
-        //~| ERROR functions with the `"custom"` ABI must be unsafe
+        //~| ERROR functions with the "custom" ABI must be unsafe
         naked_asm!("")
     }
 }

--- a/tests/ui/feature-gates/feature-gate-abi-custom.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-custom.stderr
@@ -1,4 +1,4 @@
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/feature-gate-abi-custom.rs:16:5
    |
 LL |     extern "custom" fn m7();
@@ -9,7 +9,7 @@ help: add the `unsafe` keyword to this definition
 LL |     unsafe extern "custom" fn m7();
    |     ++++++
 
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/feature-gate-abi-custom.rs:20:5
    |
 LL |     extern "custom" fn dm7() {
@@ -20,7 +20,7 @@ help: add the `unsafe` keyword to this definition
 LL |     unsafe extern "custom" fn dm7() {
    |     ++++++
 
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/feature-gate-abi-custom.rs:32:5
    |
 LL |     extern "custom" fn m7() {
@@ -31,7 +31,7 @@ help: add the `unsafe` keyword to this definition
 LL |     unsafe extern "custom" fn m7() {
    |     ++++++
 
-error: functions with the `"custom"` ABI must be unsafe
+error: functions with the "custom" ABI must be unsafe
   --> $DIR/feature-gate-abi-custom.rs:42:5
    |
 LL |     extern "custom" fn im7() {


### PR DESCRIPTION
We recently added `extern "custom"`, which must have type `fn()`. The various `extern "interrupt"` ABIs impose similar constraints on the signature of functions with that ABI: `x86-interrupt` should not have a return type (linting on the exact argument types is left as future work), and the other interrupt ABIs cannot have any parameters or a return type.

r? @workingjubilee

<!-- homu-ignore:start -->
Closes https://github.com/rust-lang/rust/issues/132841
<!-- homu-ignore:end -->