### PR TITLE
Add a missing colon at the end of the panic location details in location-detail-unwrap-multiline.rs

### DIFF
--- a/tests/ui/panics/location-detail-unwrap-multiline.rs
+++ b/tests/ui/panics/location-detail-unwrap-multiline.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only -Copt-level=0
 //@ exec-env:RUST_BACKTRACE=1
-//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:11(:10)?\n
+//@ regex-error-pattern: location-detail-unwrap-multiline\.rs:11(:10)?:\n
 //@ needs-unwind
 //@ ignore-android FIXME #17520
 


### PR DESCRIPTION
The `location-detail-unwrap-multiline` test was failing when trying to enable `aarch64-pc-windows-msvc` CI Runners: https://github.com/rust-lang/rust/pull/140136#issuecomment-2978175728

When debugging, the normalized stderr was:

```
thread 'main' panicked at $DIR/location-detail-unwrap-multiline.rs:11:10:
called `Option::unwrap()` on a `None` value
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Note the trailing colon at the end of the location details in the panic message. This was missing in the error pattern regex. No idea why it has been passing for all other targets and failed for `aarch64-pc-windows-msvc`, but with the trailing colon it is now passing for all.