### PR TITLE
Generate symbols.o for proc-macros too

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1817,8 +1817,13 @@ pub(crate) fn linked_symbols(
     crate_type: CrateType,
 ) -> Vec<(String, SymbolExportKind)> {
     match crate_type {
-        CrateType::Executable | CrateType::Cdylib | CrateType::Dylib | CrateType::Sdylib => (),
-        CrateType::Staticlib | CrateType::ProcMacro | CrateType::Rlib => {
+        CrateType::Executable
+        | CrateType::ProcMacro
+        | CrateType::Cdylib
+        | CrateType::Dylib
+        | CrateType::Sdylib => (),
+        CrateType::Staticlib | CrateType::Rlib => {
+            // These are not linked, so no need to generate symbols.o for them.
             return Vec::new();
         }
     }

--- a/tests/run-make/used-proc-macro/dep.rs
+++ b/tests/run-make/used-proc-macro/dep.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+#[used]
+static VERY_IMPORTANT_SYMBOL: u32 = 12345;

--- a/tests/run-make/used-proc-macro/proc_macro.rs
+++ b/tests/run-make/used-proc-macro/proc_macro.rs
@@ -1,0 +1,3 @@
+#![crate_type = "proc-macro"]
+
+extern crate dep as _;

--- a/tests/run-make/used-proc-macro/rmake.rs
+++ b/tests/run-make/used-proc-macro/rmake.rs
@@ -1,0 +1,18 @@
+// Test that #[used] statics are included in the final dylib for proc-macros too.
+
+//@ ignore-cross-compile
+//@ ignore-windows llvm-readobj --all doesn't show local symbols on Windows
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
+use run_make_support::{dynamic_lib_name, llvm_readobj, rustc};
+
+fn main() {
+    rustc().input("dep.rs").run();
+    rustc().input("proc_macro.rs").run();
+    llvm_readobj()
+        .input(dynamic_lib_name("proc_macro"))
+        .arg("--all")
+        .run()
+        .assert_stdout_contains("VERY_IMPORTANT_SYMBOL");
+}


### PR DESCRIPTION
To ensure used statics are functioning correctly for proc-macros too.