### PR TITLE
Compute hard errors without diagnostics in impl_intersection_has_impossible_obligation

### DIFF
--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -19,7 +19,8 @@ pub enum ScrubbedTraitError<'tcx> {
     TrueError,
     /// An ambiguity. This goal may hold if further inference is done.
     Ambiguity,
-    /// An old-solver-style cycle error, which will fatal.
+    /// An old-solver-style cycle error, which will fatal. This is not
+    /// returned by the new solver.
     Cycle(PredicateObligations<'tcx>),
 }
 

--- a/tests/crashes/139905.rs
+++ b/tests/crashes/139905.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #139905
-trait a<const b: bool> {}
-impl a<{}> for () {}
-trait c {}
-impl<const d: u8> c for () where (): a<d> {}
-impl c for () {}


### PR DESCRIPTION
First compute hard errors without diagnostics, then ambiguities with diagnostics since we need to know if any of them overflowed.