### PR TITLE
library: Increase timeout on mpmc test to reduce flakes

### DIFF
--- a/library/std/tests/sync/mpmc.rs
+++ b/library/std/tests/sync/mpmc.rs
@@ -463,12 +463,12 @@ fn oneshot_single_thread_recv_timeout() {
 fn stress_recv_timeout_two_threads() {
     let (tx, rx) = channel();
     let stress = stress_factor() + 50;
-    let timeout = Duration::from_millis(5);
+    let timeout = Duration::from_millis(10);
 
     thread::spawn(move || {
         for i in 0..stress {
             if i % 2 == 0 {
-                thread::sleep(timeout * 2);
+                thread::sleep(timeout * 4);
             }
             tx.send(1usize).unwrap();
         }


### PR DESCRIPTION
This recently spuriously failed in a rollup, so I think we can afford to increase the base timeout and the amount of time slept for to provide a much wider margin for the timeout to be reached.

<!-- homu-ignore:start -->
Rollup was https://github.com/rust-lang/rust/pull/142616#issuecomment-2980359872

r? @joshtriplett
<!-- homu-ignore:end -->
