### PR TITLE
compiler-builtins: Clean up features

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins", features = ["rustc-dep-of-std"] }
+compiler_builtins = { path = "../compiler-builtins/compiler-builtins", features = ["compiler-builtins"] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/compiler-builtins/builtins-shim/Cargo.toml
+++ b/library/compiler-builtins/builtins-shim/Cargo.toml
@@ -39,7 +39,7 @@ test = false
 cc = { version = "1.2", optional = true }
 
 [features]
-default = ["compiler-builtins"]
+default = []
 
 # Enable compilation of C code in compiler-rt, filling in some more optimized
 # implementations and also filling in unimplemented intrinsics
@@ -50,7 +50,8 @@ c = ["dep:cc"]
 # the generic versions on all platforms.
 no-asm = []
 
-# Flag this library as the unstable compiler-builtins lib
+# Flag this library as the unstable compiler-builtins lib. This must be enabled
+# when using as `std`'s dependency.'
 compiler-builtins = []
 
 # Generate memory-related intrinsics like memcpy
@@ -59,9 +60,6 @@ mem = []
 # Mangle all names so this can be linked in with other versions or other
 # compiler-rt implementations. Also used for testing
 mangled-names = []
-
-# Only used in the compiler's build system
-rustc-dep-of-std = ["compiler-builtins"]
 
 # This makes certain traits and function specializations public that
 # are not normally public but are required by the `builtins-test`

--- a/library/compiler-builtins/compiler-builtins/Cargo.toml
+++ b/library/compiler-builtins/compiler-builtins/Cargo.toml
@@ -34,7 +34,7 @@ core = { path = "../../core", optional = true }
 cc = { version = "1.2", optional = true }
 
 [features]
-default = ["compiler-builtins"]
+default = []
 
 # Enable compilation of C code in compiler-rt, filling in some more optimized
 # implementations and also filling in unimplemented intrinsics
@@ -45,8 +45,9 @@ c = ["dep:cc"]
 # the generic versions on all platforms.
 no-asm = []
 
-# Flag this library as the unstable compiler-builtins lib
-compiler-builtins = []
+# Flag this library as the unstable compiler-builtins lib. This must be enabled
+# when using as `std`'s dependency.'
+compiler-builtins = ["dep:core"]
 
 # Generate memory-related intrinsics like memcpy
 mem = []
@@ -54,9 +55,6 @@ mem = []
 # Mangle all names so this can be linked in with other versions or other
 # compiler-rt implementations. Also used for testing
 mangled-names = []
-
-# Only used in the compiler's build system
-rustc-dep-of-std = ["compiler-builtins", "dep:core"]
 
 # This makes certain traits and function specializations public that
 # are not normally public but are required by the `builtins-test`


### PR DESCRIPTION
Remove the `compiler-builtins` feature from default because it prevents
testing via the default `cargo test` command. It made more sense as a
default when `compiler-builtins` was a dependency that some crates added
via crates.io, but is no longer needed.

The `rustc-dep-of-std` feature is also removed since it doesn't do
anything beyond what the `compiler-builtins` feature already does.

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
