### PR TITLE
remove joboet from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1235,7 +1235,6 @@ compiler = [
 libs = [
     "@Mark-Simulacrum",
     "@workingjubilee",
-    "@joboet",
     "@jhpratt",
     "@tgross35",
     "@thomcc",


### PR DESCRIPTION
I've been very busy recently and this has led to reviews feeling less like fun and more like an additional chore – in short: I need a break. I'm still around though and am happy to review PRs explicitly assigned to me.