### PR TITLE
trait_sel: delay bug for removed pointeesized

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -101,7 +101,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     );
                 }
                 Some(LangItem::PointeeSized) => {
-                    bug!("`PointeeSized` is removed during lowering");
+                    tcx.dcx().delayed_bug("`PointeeSized` is removed during lowering");
                 }
                 Some(LangItem::Unsize) => {
                     self.assemble_candidates_for_unsizing(obligation, &mut candidates);

--- a/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.rs
+++ b/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.rs
@@ -1,0 +1,9 @@
+#![feature(sized_hierarchy)]
+
+use std::marker::PointeeSized;
+
+fn main() {
+      let x = main;
+      let y: Box<dyn PointeeSized> = x;
+//~^ ERROR mismatched types
+}

--- a/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.stderr
+++ b/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/dyn-pointeesized-issue-142652.rs:7:38
+   |
+LL |       let y: Box<dyn PointeeSized> = x;
+   |              ---------------------   ^ expected `Box<dyn PointeeSized>`, found fn item
+   |              |
+   |              expected due to this
+   |
+   = note: expected struct `Box<dyn PointeeSized>`
+             found fn item `fn() {main}`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#142652 

This code path isn't hit during normal compilation, only in error reporting, so delaying the bug is sufficient. It might be possible to trigger this with `dyn PointeeSized` and code that doesn't error but I couldn't work out how to make that happen. This can only happen when you use the feature so it's not an urgent thing and if we find another case then I can fix that then.

r? @oli-obk