### PR TITLE
trait_sel: add builtin impl for `PointeeSized`

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1779,7 +1779,7 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
-    /// Fast path helper for testing if a type is `Sized` or `MetaSized`.
+    /// Fast path helper for testing if a type is `Sized`, `MetaSized` or `PointeeSized`.
     ///
     /// Returning true means the type is known to implement the sizedness trait. Returning `false`
     /// means nothing -- could be sized, might not be.
@@ -1814,11 +1814,12 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Str | ty::Slice(_) | ty::Dynamic(_, _, ty::Dyn) => match sizedness {
                 SizedTraitKind::Sized => false,
-                SizedTraitKind::MetaSized => true,
+                SizedTraitKind::MetaSized | SizedTraitKind::PointeeSized => true,
             },
 
             ty::Foreign(..) => match sizedness {
                 SizedTraitKind::Sized | SizedTraitKind::MetaSized => false,
+                SizedTraitKind::PointeeSized => true,
             },
 
             ty::Tuple(tys) => tys.last().is_none_or(|ty| ty.has_trivial_sizedness(tcx, sizedness)),

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -476,7 +476,11 @@ where
                     G::consider_builtin_sizedness_candidates(self, goal, SizedTraitKind::MetaSized)
                 }
                 Some(TraitSolverLangItem::PointeeSized) => {
-                    unreachable!("`PointeeSized` is removed during lowering");
+                    G::consider_builtin_sizedness_candidates(
+                        self,
+                        goal,
+                        SizedTraitKind::PointeeSized,
+                    )
                 }
                 Some(TraitSolverLangItem::Copy | TraitSolverLangItem::Clone) => {
                     G::consider_builtin_copy_clone_candidate(self, goal)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -201,7 +201,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // begin with in those cases.
                 if matches!(
                     self.tcx.as_lang_item(trait_pred.def_id()),
-                    Some(LangItem::Sized | LangItem::MetaSized)
+                    Some(LangItem::Sized | LangItem::MetaSized | LangItem::PointeeSized)
                 ) {
                     match self.tainted_by_errors() {
                         None => {

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -90,6 +90,13 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                     {
                         return Some(Certainty::Yes);
                     }
+                    Some(LangItem::PointeeSized)
+                        if self
+                            .resolve_vars_if_possible(trait_pred.self_ty().skip_binder())
+                            .has_trivial_sizedness(self.0.tcx, SizedTraitKind::PointeeSized) =>
+                    {
+                        return Some(Certainty::Yes);
+                    }
                     Some(LangItem::Copy | LangItem::Clone) => {
                         let self_ty =
                             self.resolve_vars_if_possible(trait_pred.self_ty().skip_binder());

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -101,7 +101,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     );
                 }
                 Some(LangItem::PointeeSized) => {
-                    bug!("`PointeeSized` is removed during lowering");
+                    self.assemble_builtin_sized_candidate(
+                        obligation,
+                        &mut candidates,
+                        SizedTraitKind::PointeeSized,
+                    );
                 }
                 Some(LangItem::Unsize) => {
                     self.assemble_candidates_for_unsizing(obligation, &mut candidates);
@@ -1113,7 +1117,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
     }
 
-    /// Assembles the `Sized` and `MetaSized` traits which are built-in to the language itself.
+    /// Assembles the `Sized`, `MetaSized` and `PointeeSized` traits which are built-in to the
+    /// language itself.
     #[instrument(level = "debug", skip(self, candidates))]
     fn assemble_builtin_sized_candidate(
         &mut self,

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -270,7 +270,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     self.sizedness_conditions(obligation, SizedTraitKind::MetaSized)
                 }
                 Some(LangItem::PointeeSized) => {
-                    bug!("`PointeeSized` is removing during lowering");
+                    self.sizedness_conditions(obligation, SizedTraitKind::PointeeSized)
                 }
                 Some(LangItem::Copy | LangItem::Clone) => self.copy_clone_conditions(obligation),
                 Some(LangItem::FusedIterator) => self.fused_iterator_conditions(obligation),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2129,10 +2129,15 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
             ty::Str | ty::Slice(_) | ty::Dynamic(..) => match sizedness {
                 SizedTraitKind::Sized => None,
-                SizedTraitKind::MetaSized => Where(ty::Binder::dummy(Vec::new())),
+                SizedTraitKind::MetaSized | SizedTraitKind::PointeeSized => {
+                    Where(ty::Binder::dummy(Vec::new()))
+                }
             },
 
-            ty::Foreign(..) => None,
+            ty::Foreign(..) => match sizedness {
+                SizedTraitKind::Sized | SizedTraitKind::MetaSized => None,
+                SizedTraitKind::PointeeSized => Where(ty::Binder::dummy(Vec::new())),
+            },
 
             ty::Tuple(tys) => Where(
                 obligation.predicate.rebind(tys.last().map_or_else(Vec::new, |&last| vec![last])),

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -374,6 +374,7 @@ pub fn sizedness_fast_path<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tc
         let sizedness = match tcx.as_lang_item(trait_ref.def_id()) {
             Some(LangItem::Sized) => SizedTraitKind::Sized,
             Some(LangItem::MetaSized) => SizedTraitKind::MetaSized,
+            Some(LangItem::PointeeSized) => SizedTraitKind::PointeeSized,
             _ => return false,
         };
 

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -377,6 +377,8 @@ pub enum SizedTraitKind {
     Sized,
     /// `MetaSized` trait
     MetaSized,
+    /// `PointeeSized` trait
+    PointeeSized,
 }
 
 impl SizedTraitKind {
@@ -385,6 +387,7 @@ impl SizedTraitKind {
         cx.require_lang_item(match self {
             SizedTraitKind::Sized => TraitSolverLangItem::Sized,
             SizedTraitKind::MetaSized => TraitSolverLangItem::MetaSized,
+            SizedTraitKind::PointeeSized => TraitSolverLangItem::PointeeSized,
         })
     }
 }

--- a/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652-1.rs
+++ b/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652-1.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+#![feature(sized_hierarchy)]
+
+use std::marker::PointeeSized;
+
+type Foo = dyn PointeeSized;
+
+fn foo(f: &Foo) {}
+
+fn main() {
+    foo(&());
+}

--- a/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.rs
+++ b/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.rs
@@ -1,0 +1,9 @@
+#![feature(sized_hierarchy)]
+
+use std::marker::PointeeSized;
+
+fn main() {
+      let x = main;
+      let y: Box<dyn PointeeSized> = x;
+//~^ ERROR mismatched types
+}

--- a/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.stderr
+++ b/tests/ui/sized-hierarchy/dyn-pointeesized-issue-142652.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/dyn-pointeesized-issue-142652.rs:7:38
+   |
+LL |       let y: Box<dyn PointeeSized> = x;
+   |              ---------------------   ^ expected `Box<dyn PointeeSized>`, found fn item
+   |              |
+   |              expected due to this
+   |
+   = note: expected struct `Box<dyn PointeeSized>`
+             found fn item `fn() {main}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |       let y: Box<dyn PointeeSized> = Box::new(x);
+   |                                      +++++++++ +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#142652
Supersedes rust-lang/rust#142661

During review of rust-lang/rust#137944, we thought we could remove the builtin impl of `PointeeSized` as it was removed during lowering, but users can still write `dyn PointeeSized` and so we need the builtin impl.

r? @oli-obk
