### PR TITLE
Clarify bootstrap tools description

### DIFF
--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -105,6 +105,10 @@ build/
       debuginfo/
       ...
 
+    # Bootstrap host tools (which are always compiled with the stage0 compiler)
+    # are stored here.
+    bootstrap-tools/
+
     # Location where the stage0 Cargo and Rust compiler are unpacked. This
     # directory is purely an extracted and overlaid tarball of these two (done
     # by the bootstrap Python script). In theory, the build system does not

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -246,12 +246,17 @@ pub enum Mode {
     /// Build a codegen backend for rustc, placing the output in the "stageN-codegen" directory.
     Codegen,
 
-    /// Build a tool, placing output in the "stage0-bootstrap-tools"
-    /// directory. This is for miscellaneous sets of tools that are built
-    /// using the bootstrap stage0 compiler in its entirety (target libraries
-    /// and all). Typically these tools compile with stable Rust.
+    /// Build a tool, placing output in the "bootstrap-tools"
+    /// directory. This is for miscellaneous sets of tools that extend
+    /// bootstrap.
     ///
-    /// Only works for stage 0.
+    /// These tools are intended to be only executed on the host system that
+    /// invokes bootstrap, and they thus cannot be cross-compiled.
+    ///
+    /// They are always built using the stage0 compiler, and typically they
+    /// can be compiled with stable Rust.
+    ///
+    /// These tools also essentially do not participate in staging.
     ToolBootstrap,
 
     /// Build a tool which uses the locally built std, placing output in the
@@ -804,7 +809,9 @@ impl Build {
             Mode::Std => "-std",
             Mode::Rustc => "-rustc",
             Mode::Codegen => "-codegen",
-            Mode::ToolBootstrap => "-bootstrap-tools",
+            Mode::ToolBootstrap => {
+                return self.out.join(compiler.host).join("bootstrap-tools");
+            }
             Mode::ToolStd | Mode::ToolRustc => "-tools",
         };
         self.out.join(compiler.host).join(format!("stage{}{}", compiler.stage, suffix))

--- a/src/doc/rustc-dev-guide/src/building/bootstrapping/writing-tools-in-bootstrap.md
+++ b/src/doc/rustc-dev-guide/src/building/bootstrapping/writing-tools-in-bootstrap.md
@@ -4,7 +4,7 @@ There are three types of tools you can write in bootstrap:
 
 - **`Mode::ToolBootstrap`**
   Use this for tools that don’t need anything from the in-tree compiler and can run with the stage0 `rustc`.
-  The output is placed in the "stage0-bootstrap-tools" directory. This mode is for general-purpose tools built
+  The output is placed in the "bootstrap-tools" directory. This mode is for general-purpose tools built
   entirely with the stage0 compiler, including target libraries and only works for stage 0.
 
 - **`Mode::ToolStd`**

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -12,7 +12,7 @@ impl TestCx<'_> {
         // For `run-make` V2, we need to perform 2 steps to build and run a `run-make` V2 recipe
         // (`rmake.rs`) to run the actual tests. The support library is already built as a tool rust
         // library and is available under
-        // `build/$HOST/stage0-bootstrap-tools/$TARGET/release/librun_make_support.rlib`.
+        // `build/$HOST/bootstrap-tools/$TARGET/release/librun_make_support.rlib`.
         //
         // 1. We need to build the recipe `rmake.rs` as a binary and link in the `run_make_support`
         //    library.
@@ -63,7 +63,7 @@ impl TestCx<'_> {
         //
         // ```
         // build/<target_triple>/
-        // ├── stage0-bootstrap-tools/
+        // ├── bootstrap-tools/
         // │   ├── <host_triple>/release/librun_make_support.rlib   // <- support rlib itself
         // │   ├── <host_triple>/release/deps/                      // <- deps
         // │   └── release/deps/                                    // <- deps of deps
@@ -72,7 +72,7 @@ impl TestCx<'_> {
         // FIXME(jieyouxu): there almost certainly is a better way to do this (specifically how the
         // support lib and its deps are organized), but this seems to work for now.
 
-        let tools_bin = host_build_root.join("stage0-bootstrap-tools");
+        let tools_bin = host_build_root.join("bootstrap-tools");
         let support_host_path = tools_bin.join(&self.config.host).join("release");
         let support_lib_path = support_host_path.join("librun_make_support.rlib");
 


### PR DESCRIPTION
The existence of `stage0-bootstrap-tools` suggests the possiblity of `stage1/N-bootstrap-tools`, but that's not really a thing. Also it doesn't fit the new bootstrap model, where `stageN` essentially means that it was built with a `stageN-1` compiler (except for std).

r? @jieyouxu