### PR TITLE
Add CI check to ensure that rustdoc JSON `FORMAT_VERSION` is correctly updated

### DIFF
--- a/src/build_helper/src/ci.rs
+++ b/src/build_helper/src/ci.rs
@@ -17,7 +17,11 @@ impl CiEnv {
     }
 
     pub fn is_ci() -> bool {
-        Self::current() != CiEnv::None
+        Self::current().is_running_in_ci()
+    }
+
+    pub fn is_running_in_ci(self) -> bool {
+        self != CiEnv::None
     }
 
     /// Checks if running in rust-lang/rust managed CI job.

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -198,7 +198,7 @@ fn get_latest_upstream_commit_that_modified_files(
 /// author.
 ///
 /// If we are in CI, we simply return our first parent.
-fn get_closest_upstream_commit(
+pub fn get_closest_upstream_commit(
     git_dir: Option<&Path>,
     config: &GitConfig<'_>,
     env: CiEnv,

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -83,6 +83,7 @@ pub mod pal;
 pub mod rustdoc_css_themes;
 pub mod rustdoc_gui_tests;
 pub mod rustdoc_js;
+pub mod rustdoc_json;
 pub mod rustdoc_templates;
 pub mod style;
 pub mod target_policy;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
         check!(rustdoc_css_themes, &librustdoc_path);
         check!(rustdoc_templates, &librustdoc_path);
         check!(rustdoc_js, &librustdoc_path, &tools_path, &src_path);
+        check!(rustdoc_json);
         check!(known_bug, &crashes_path);
         check!(unknown_revision, &tests_path);
 

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
         check!(rustdoc_css_themes, &librustdoc_path);
         check!(rustdoc_templates, &librustdoc_path);
         check!(rustdoc_js, &librustdoc_path, &tools_path, &src_path);
-        check!(rustdoc_json);
+        check!(rustdoc_json, &src_path);
         check!(known_bug, &crashes_path);
         check!(unknown_revision, &tests_path);
 

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -9,33 +9,41 @@ use build_helper::ci::CiEnv;
 use build_helper::git::{GitConfig, get_closest_upstream_commit};
 use build_helper::stage0_parser::parse_stage0_file;
 
+const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
+
 fn git_diff<S: AsRef<OsStr>>(base_commit: &str, extra_arg: S) -> Option<String> {
     let output = Command::new("git").arg("diff").arg(base_commit).arg(extra_arg).output().ok()?;
     Some(String::from_utf8_lossy(&output.stdout).into())
 }
 
+fn error_if_in_ci(ci_env: CiEnv, msg: &str, bad: &mut bool) {
+    if ci_env.is_running_in_ci() {
+        *bad = true;
+        eprintln!("error in `rustdoc_json` tidy check: {msg}");
+    } else {
+        eprintln!("{msg}. Skipping `rustdoc_json` tidy check");
+    }
+}
+
 pub fn check(src_path: &Path, bad: &mut bool) {
     println!("Checking tidy rustdoc_json...");
     let stage0 = parse_stage0_file();
+    let ci_env = CiEnv::current();
     let base_commit = match get_closest_upstream_commit(
         None,
         &GitConfig {
             nightly_branch: &stage0.config.nightly_branch,
             git_merge_commit_email: &stage0.config.git_merge_commit_email,
         },
-        CiEnv::current(),
+        ci_env,
     ) {
         Ok(Some(commit)) => commit,
         Ok(None) => {
-            *bad = true;
-            eprintln!("error: no base commit found for rustdoc_json check");
+            error_if_in_ci(ci_env, "no base commit found", bad);
             return;
         }
         Err(error) => {
-            *bad = true;
-            eprintln!(
-                "error: failed to retrieve base commit for rustdoc_json check because of `{error}`"
-            );
+            error_if_in_ci(ci_env, &format!("failed to retrieve base commit: {error}"), bad);
             return;
         }
     };
@@ -45,7 +53,7 @@ pub fn check(src_path: &Path, bad: &mut bool) {
         Some(output) => {
             if !output
                 .lines()
-                .any(|line| line.starts_with("M") && line.contains("src/rustdoc-json-types"))
+                .any(|line| line.starts_with("M") && line.contains(RUSTDOC_JSON_TYPES))
             {
                 // `rustdoc-json-types` was not modified so nothing more to check here.
                 println!("`rustdoc-json-types` was not modified.");
@@ -74,11 +82,13 @@ pub fn check(src_path: &Path, bad: &mut bool) {
                 *bad = true;
                 if latest_feature_comment_updated {
                     eprintln!(
-                        "error: `Latest feature` comment was updated whereas `FORMAT_VERSION` wasn't"
+                        "error in `rustdoc_json` tidy check: `Latest feature` comment was updated \
+                         whereas `FORMAT_VERSION` wasn't in `{RUSTDOC_JSON_TYPES}/lib.rs`"
                     );
                 } else {
                     eprintln!(
-                        "error: `Latest feature` comment was not updated whereas `FORMAT_VERSION` was"
+                        "error in `rustdoc_json` tidy check: `Latest feature` comment was not \
+                         updated whereas `FORMAT_VERSION` was in `{RUSTDOC_JSON_TYPES}/lib.rs`"
                     );
                 }
             }

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -1,0 +1,66 @@
+//! Tidy check to ensure that `FORMAT_VERSION` was correctly updated if `rustdoc-json-types` was
+//! updated as well.
+
+use std::process::Command;
+
+fn git_diff(base_commit: &str, extra_arg: &str) -> Option<String> {
+    let output = Command::new("git").arg("diff").arg(base_commit).arg(extra_arg).output().ok()?;
+    Some(String::from_utf8_lossy(&output.stdout).into())
+}
+
+pub fn check(bad: &mut bool) {
+    let Ok(base_commit) = std::env::var("BASE_COMMIT") else {
+        // Not in CI so nothing we can check here.
+        println!("not checking rustdoc JSON `FORMAT_VERSION` update");
+        return;
+    };
+
+    // First we check that `src/rustdoc-json-types` was modified.
+    match git_diff(&base_commit, "--name-status") {
+        Some(output) => {
+            if !output
+                .lines()
+                .any(|line| line.starts_with("M") && line.contains("src/rustdoc-json-types"))
+            {
+                // `rustdoc-json-types` was not modified so nothing more to check here.
+                return;
+            }
+        }
+        None => {
+            *bad = true;
+            eprintln!("Failed to run `git diff`");
+            return;
+        }
+    }
+    // Then we check that if `FORMAT_VERSION` was updated, the `Latest feature:` was also updated.
+    match git_diff(&base_commit, "src/rustdoc-json-types") {
+        Some(output) => {
+            let mut format_version_updated = false;
+            let mut latest_feature_comment_updated = false;
+            for line in output.lines() {
+                if line.starts_with("+pub const FORMAT_VERSION: u32 =") {
+                    format_version_updated = true;
+                } else if line.starts_with("+// Latest feature:") {
+                    latest_feature_comment_updated = true;
+                }
+            }
+            if format_version_updated != latest_feature_comment_updated {
+                *bad = true;
+                if latest_feature_comment_updated {
+                    eprintln!(
+                        "`Latest feature` comment was updated whereas `FORMAT_VERSION` wasn't"
+                    );
+                } else {
+                    eprintln!(
+                        "`Latest feature` comment was not updated whereas `FORMAT_VERSION` was"
+                    );
+                }
+            }
+        }
+        None => {
+            *bad = true;
+            eprintln!("Failed to run `git diff`");
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/142601.

Tested it locally with: `BASE_COMMIT=1bb335244c311a07cee165c28c553c869e6f64a9 src/ci/docker/host-x86_64/mingw-check-1/validate-rustdoc-json-format-version-update.sh` (where `BASE_COMMIT` value was the commit before I made a wrong change with the `FORMAT_VERSION` update).

This is a first version. I plan to send a follow-up to also ensure that `FORMAT_VERSION` is updated if any code change is done in `rustdoc-json-types`. For that I just need to check that a line not starting with `/` and not an empty line was updated. Fun times with `grep` ahead. :')

cc @aDotInTheVoid 
r? @nnethercote 