### PR TITLE
Skip debug dep node code in non-incremental mode

### DIFF
--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -808,7 +808,10 @@ impl<D: Deps> DepGraph<D> {
     where
         F: FnOnce() -> String,
     {
-        let dep_node_debug = &self.data.as_ref().unwrap().dep_node_debug;
+        let Some(data) = &self.data.as_ref() else {
+            return;
+        };
+        let dep_node_debug = &data.dep_node_debug;
 
         if dep_node_debug.borrow().contains_key(&dep_node) {
             return;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -336,6 +336,7 @@ impl Session {
     pub fn record_trimmed_def_paths(&self) {
         if self.opts.unstable_opts.print_type_sizes
             || self.opts.unstable_opts.query_dep_graph
+            || self.opts.unstable_opts.incremental_info
             || self.opts.unstable_opts.dump_mir.is_some()
             || self.opts.unstable_opts.unpretty.is_some()
             || self.prof.is_args_recording_enabled()


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Issues happen when trying to use incremental_info with compiler's debug_assertions enabled to access more info, like the "Total Duplicate Edge Reads" counter.
