### PR TITLE
Assorted bootstrap cleanups (step 3)

### DIFF
--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -289,7 +289,7 @@ macro_rules! lint_any {
                 let target = self.target;
 
                 if !builder.download_rustc() {
-                    builder.ensure(check::Rustc::new(target, builder).build_kind(Some(Kind::Check)));
+                    builder.ensure(check::Rustc::new(target, builder));
                 };
 
                 let cargo = prepare_tool_cargo(

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -217,7 +217,7 @@ impl Step for Rustc {
                 builder.ensure(compile::Std::new(compiler, compiler.host));
                 builder.ensure(compile::Std::new(compiler, target));
             } else {
-                builder.ensure(check::Std::new(target).build_kind(Some(Kind::Check)));
+                builder.ensure(check::Std::new(target));
             }
         }
 


### PR DESCRIPTION
I keep failing to unwrap the gordic knot of the logic of checking tools in bootstrap :confounded: So in the meantime I at least want to upstream some cleanups I did along the way.

Since some time ago, we have separate steps for Clippy, so it shouldn't ever happen again that the check steps would be invoked with `builder.kind == Clippy`.

r? @jieyouxu