### PR TITLE
Apply effects to `otherwise` edge in dataflow analysis

### DIFF
--- a/compiler/rustc_mir_dataflow/src/framework/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/mod.rs
@@ -224,6 +224,7 @@ pub trait Analysis<'tcx> {
         _data: &mut Self::SwitchIntData,
         _state: &mut Self::Domain,
         _value: SwitchTargetValue,
+        _targets: &mir::SwitchTargets,
     ) {
         unreachable!();
     }

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -62,12 +62,14 @@ impl<'tcx> crate::MirPass<'tcx> for ElaborateDrops {
             let env = MoveDataTypingEnv { move_data, typing_env };
 
             let mut inits = MaybeInitializedPlaces::new(tcx, body, &env.move_data)
+                .exclude_inactive_in_otherwise()
                 .skipping_unreachable_unwind()
                 .iterate_to_fixpoint(tcx, body, Some("elaborate_drops"))
                 .into_results_cursor(body);
             let dead_unwinds = compute_dead_unwinds(body, &mut inits);
 
             let uninits = MaybeUninitializedPlaces::new(tcx, body, &env.move_data)
+                .include_inactive_in_otherwise()
                 .mark_inactive_variants_as_uninit()
                 .skipping_unreachable_unwind(dead_unwinds)
                 .iterate_to_fixpoint(tcx, body, Some("elaborate_drops"))

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -22,6 +22,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveUninitDrops {
         let move_data = MoveData::gather_moves(body, tcx, |ty| ty.needs_drop(tcx, typing_env));
 
         let mut maybe_inits = MaybeInitializedPlaces::new(tcx, body, &move_data)
+            .exclude_inactive_in_otherwise()
             .iterate_to_fixpoint(tcx, body, Some("remove_uninit_drops"))
             .into_results_cursor(body);
 

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -1,0 +1,108 @@
+- // MIR for `result_ok` before ElaborateDrops
++ // MIR for `result_ok` after ElaborateDrops
+  
+  fn result_ok(_1: Result<String, ()>) -> Option<String> {
+      debug result => _1;
+      let mut _0: std::option::Option<std::string::String>;
+      let mut _2: isize;
+      let _3: std::string::String;
+      let mut _4: std::string::String;
++     let mut _5: bool;
++     let mut _6: isize;
++     let mut _7: isize;
+      scope 1 {
+          debug s => _3;
+      }
+  
+      bb0: {
++         _5 = const false;
++         _5 = const true;
+          PlaceMention(_1);
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [0: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          _0 = Option::<String>::None;
+          goto -> bb5;
+      }
+  
+      bb2: {
+          StorageLive(_3);
+          _3 = move ((_1 as Ok).0: std::string::String);
+          StorageLive(_4);
+          _4 = move _3;
+          _0 = Option::<String>::Some(move _4);
+-         drop(_4) -> [return: bb3, unwind: bb7];
++         goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_4);
+-         drop(_3) -> [return: bb4, unwind: bb8];
++         goto -> bb4;
+      }
+  
+      bb4: {
+          StorageDead(_3);
+          goto -> bb5;
+      }
+  
+      bb5: {
+-         drop(_1) -> [return: bb6, unwind: bb9];
++         goto -> bb16;
+      }
+  
+      bb6: {
+          return;
+      }
+  
+      bb7 (cleanup): {
+-         drop(_3) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb8 (cleanup): {
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
+      }
+  
+      bb9 (cleanup): {
+          resume;
++     }
++ 
++     bb10: {
++         goto -> bb6;
++     }
++ 
++     bb11 (cleanup): {
++         goto -> bb9;
++     }
++ 
++     bb12 (cleanup): {
++         goto -> bb9;
++     }
++ 
++     bb13: {
++         goto -> bb10;
++     }
++ 
++     bb14: {
++         goto -> bb10;
++     }
++ 
++     bb15 (cleanup): {
++         goto -> bb9;
++     }
++ 
++     bb16: {
++         _6 = discriminant(_1);
++         switchInt(move _6) -> [0: bb13, otherwise: bb14];
++     }
++ 
++     bb17 (cleanup): {
++         _7 = discriminant(_1);
++         switchInt(move _7) -> [0: bb11, otherwise: bb15];
+      }
+  }
+  

--- a/tests/mir-opt/otherwise_drops.rs
+++ b/tests/mir-opt/otherwise_drops.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -C panic=abort
+//@ test-mir-pass: ElaborateDrops
+
+// Ensures there are no drops for the wildcard match arm.
+
+// EMIT_MIR otherwise_drops.result_ok.ElaborateDrops.diff
+fn result_ok(result: Result<String, ()>) -> Option<String> {
+    // CHECK-NOT: drop
+    match result {
+        Ok(s) => Some(s),
+        _ => None,
+    }
+}

--- a/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/lifetimes.foo.ScalarReplacementOfAggregates.diff
@@ -96,7 +96,6 @@
   
       bb2: {
           StorageLive(_8);
-          _28 = const false;
           _8 = move ((_5 as Ok).0: std::boxed::Box<dyn std::fmt::Display>);
           StorageLive(_9);
           StorageLive(_10);
@@ -186,7 +185,7 @@
       bb9: {
           StorageDead(_6);
           _29 = discriminant(_5);
-          switchInt(move _29) -> [0: bb11, otherwise: bb13];
+          switchInt(move _29) -> [0: bb10, otherwise: bb11];
       }
   
       bb10: {
@@ -200,14 +199,6 @@
       }
   
       bb11: {
-          switchInt(copy _28) -> [0: bb10, otherwise: bb12];
-      }
-  
-      bb12: {
-          drop(((_5 as Ok).0: std::boxed::Box<dyn std::fmt::Display>)) -> [return: bb10, unwind unreachable];
-      }
-  
-      bb13: {
           drop(_5) -> [return: bb10, unwind unreachable];
       }
   }


### PR DESCRIPTION
This allows `ElaborateDrops` to remove drops when a `match` wildcard arm covers multiple no-Drop enum variants. It modifies dataflow analysis to update the `MaybeUninitializedPlaces` and `MaybeInitializedPlaces` data for a block reached through an `otherwise` edge.

Fixes rust-lang/rust#142705.