### PR TITLE
correct template for `#[align]` attribute

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -273,7 +273,7 @@ pub(crate) struct AlignParser(Option<(Align, Span)>);
 
 impl AlignParser {
     const PATH: &'static [Symbol] = &[sym::align];
-    const TEMPLATE: AttributeTemplate = template!(Word, List: "<alignment in bytes>");
+    const TEMPLATE: AttributeTemplate = template!(List: "<alignment in bytes>");
 
     fn parse<'c, S: Stage>(
         &mut self,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -510,7 +510,7 @@ declare_features! (
     (unstable, ffi_pure, "1.45.0", Some(58329)),
     /// Controlling the behavior of fmt::Debug
     (unstable, fmt_debug, "1.82.0", Some(129709)),
-    /// Allows using `#[repr(align(...))]` on function items
+    /// Allows using `#[align(...)]` on function items
     (unstable, fn_align, "1.53.0", Some(82232)),
     /// Support delegating implementation of functions to other already implemented functions.
     (incomplete, fn_delegation, "1.76.0", Some(118212)),

--- a/src/doc/unstable-book/src/compiler-flags/min-function-alignment.md
+++ b/src/doc/unstable-book/src/compiler-flags/min-function-alignment.md
@@ -15,7 +15,7 @@ This flag is equivalent to:
 - `-fmin-function-alignment` for [GCC](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fmin-function-alignment_003dn)
 - `-falign-functions` for [Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang1-falign-functions)
 
-The specified alignment is a minimum. A higher alignment can be specified for specific functions by using the [`repr(align(...))`](https://github.com/rust-lang/rust/issues/82232) feature and annotating the function with a `#[repr(align(<align>))]` attribute. The attribute's value is ignored when it is lower than the value passed to `min-function-alignment`.
+The specified alignment is a minimum. A higher alignment can be specified for specific functions by using the [`align(...)`](https://github.com/rust-lang/rust/issues/82232) feature and annotating the function with a `#[align(<align>)]` attribute. The attribute's value is ignored when it is lower than the value passed to `min-function-alignment`.
 
 There are two additional edge cases for this flag:
 

--- a/tests/ui/attributes/malformed-fn-align.rs
+++ b/tests/ui/attributes/malformed-fn-align.rs
@@ -3,7 +3,10 @@
 
 trait MyTrait {
     #[align] //~ ERROR malformed `align` attribute input
-    fn myfun();
+    fn myfun1();
+
+    #[align(1, 2)] //~ ERROR malformed `align` attribute input
+    fn myfun2();
 }
 
 #[align = 16] //~ ERROR malformed `align` attribute input

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -2,54 +2,55 @@ error[E0539]: malformed `align` attribute input
   --> $DIR/malformed-fn-align.rs:5:5
    |
 LL |     #[align]
-   |     ^^^^^^^^ expected this to be a list
+   |     ^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[align(<alignment in bytes>)]`
+
+error[E0805]: malformed `align` attribute input
+  --> $DIR/malformed-fn-align.rs:8:5
    |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL |     #[align(<alignment in bytes>)]
-   |            ++++++++++++++++++++++
+LL |     #[align(1, 2)]
+   |     ^^^^^^^------^
+   |     |      |
+   |     |      expected a single argument here
+   |     help: must be of the form: `#[align(<alignment in bytes>)]`
 
 error[E0539]: malformed `align` attribute input
-  --> $DIR/malformed-fn-align.rs:9:1
+  --> $DIR/malformed-fn-align.rs:12:1
    |
 LL | #[align = 16]
-   | ^^^^^^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL - #[align = 16]
-LL + #[align(<alignment in bytes>)]
-   |
-LL - #[align = 16]
-LL + #[align]
-   |
+   | ^^^^^^^^^^^^^
+   | |
+   | expected this to be a list
+   | help: must be of the form: `#[align(<alignment in bytes>)]`
 
 error[E0589]: invalid alignment value: not an unsuffixed integer
-  --> $DIR/malformed-fn-align.rs:12:9
+  --> $DIR/malformed-fn-align.rs:15:9
    |
 LL | #[align("hello")]
    |         ^^^^^^^
 
 error[E0589]: invalid alignment value: not a power of two
-  --> $DIR/malformed-fn-align.rs:15:9
+  --> $DIR/malformed-fn-align.rs:18:9
    |
 LL | #[align(0)]
    |         ^
 
 error: `#[repr(align(...))]` is not supported on function items
-  --> $DIR/malformed-fn-align.rs:18:8
+  --> $DIR/malformed-fn-align.rs:21:8
    |
 LL | #[repr(align(16))]
    |        ^^^^^^^^^
    |
 help: use `#[align(...)]` instead
-  --> $DIR/malformed-fn-align.rs:18:8
+  --> $DIR/malformed-fn-align.rs:21:8
    |
 LL | #[repr(align(16))]
    |        ^^^^^^^^^
 
 error: `#[align(...)]` is not supported on struct items
-  --> $DIR/malformed-fn-align.rs:21:1
+  --> $DIR/malformed-fn-align.rs:24:1
    |
 LL | #[align(16)]
    | ^^^^^^^^^^^^
@@ -60,7 +61,7 @@ LL - #[align(16)]
 LL + #[repr(align(16))]
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0539, E0589.
+Some errors have detailed explanations: E0539, E0589, E0805.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -22,12 +22,10 @@ error[E0539]: malformed `align` attribute input
   --> $DIR/feature-gate-fn_align.rs:8:5
    |
 LL |     #[align]
-   |     ^^^^^^^^ expected this to be a list
-   |
-help: try changing it to one of the following valid forms of the attribute
-   |
-LL |     #[align(<alignment in bytes>)]
-   |            ++++++++++++++++++++++
+   |     ^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[align(<alignment in bytes>)]`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/82232
related: https://github.com/rust-lang/rust/pull/142507

I didn't fully understand what `template!` did, clearly. An empty `#[align]` attribute was still rejected later, but without this change it does get suggested in certain cases.

I've also updated some outdated references to `#[repr(align)]` on functions.

r? @jdonszelmann 