### PR TITLE
[crater] Add `impl From<f16> for f32`

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -184,8 +184,7 @@ impl_from!(u32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0
 // impl_from!(u64 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 
 // float -> float
-// FIXME(f16_f128): adding additional `From<{float}>` impls to `f32` breaks inference. See
-// <https://github.com/rust-lang/rust/issues/123831>
+impl_from!(f16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(f32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);

--- a/tests/ui/inference/untyped-primitives.rs
+++ b/tests/ui/inference/untyped-primitives.rs
@@ -1,9 +1,0 @@
-//@ check-pass
-// issue: rust-lang/rust#123824
-// This test is a sanity check and does not enforce any stable API, so may be
-// removed at a future point.
-
-fn main() {
-    let x = f32::from(3.14);
-    let y = f64::from(3.14);
-}


### PR DESCRIPTION
Crater run to see what the effects of adding `impl From<f16> for f32` without changing the fallback (a.k.a. things that would be caught by the FCW in rust-lang/rust#139087). This needs a `@craterbot check`.