### PR TITLE
add issue template for rustdoc

### DIFF
--- a/.github/ISSUE_TEMPLATE/rustdoc.md
+++ b/.github/ISSUE_TEMPLATE/rustdoc.md
@@ -1,0 +1,54 @@
+---
+name: Problem with rustdoc
+about: Report an issue with how docs get generated.
+labels: C-bug, T-rustdoc
+---
+<!--
+Thank you for filing a rustdoc issue! Rustdoc is the tool that handles the generation of docs.  It is usually invoked via `cargo doc`, but can also be used directly.
+
+If you have an issue with the actual content of the docs, use the "Documentation problem" template instead.
+-->
+
+# Code
+<!-- problematic snippet and/or link to repo and/or full path of standard library function -->
+
+```rust
+<code>
+```
+
+# Reproduction Steps
+<!--
+* command(s) to run, if any
+* permalink to hosted documentation, if any
+* search query, if any
+-->
+
+# Expected Outcome
+<!--
+What did you want to happen?
+
+For GUI issues, feel free to provide a mockup image of what you want it to look like.
+
+For diagnostics, please provide a mockup of the desired output in a code block.
+-->
+
+# Actual Output
+<!--
+* rustdoc console output
+* browser screenshot of generated html
+* rustdoc json (prettify by running through `jq` or running thorugh an online formatter)
+-->
+```console
+<code>
+```
+
+
+# Version
+<!--
+Available via `rustdoc --version` or under the "Help" menu.
+
+If the issue involves opening the documentation in a browser, please also provide the name and version of the browser used.
+-->
+
+# Additional Details
+<!-- Anything else you think is relevant -->


### PR DESCRIPTION
~~This also expands the scope of the "diagnostic
issue" template to include rustdoc lints,
meaning diagnostic issues will need triaging again. I think this is preferable to the alternative of
cramming even more cases under a single issue template.~~

r? t-rustdoc

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
