### PR TITLE
rustdoc: Remove `FormatRenderer::cache`

### DIFF
--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -68,8 +68,6 @@ pub(crate) trait FormatRenderer<'tcx>: Sized {
 
     /// Post processing hook for cleanup and dumping output to files.
     fn after_krate(self) -> Result<(), Error>;
-
-    fn cache(&self) -> &Cache;
 }
 
 fn run_format_inner<'tcx, T: FormatRenderer<'tcx>>(

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -875,8 +875,4 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
 
         Ok(())
     }
-
-    fn cache(&self) -> &Cache {
-        &self.shared.cache
-    }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -16,7 +16,6 @@ use rustdoc_json_types::*;
 use thin_vec::ThinVec;
 
 use crate::clean::{self, ItemId};
-use crate::formats::FormatRenderer;
 use crate::formats::item_type::ItemType;
 use crate::json::JsonRenderer;
 use crate::passes::collect_intra_doc_links::UrlFragment;
@@ -41,7 +40,7 @@ impl JsonRenderer<'_> {
             })
             .collect();
         let docs = item.opt_doc_value();
-        let attrs = item.attributes_and_repr(self.tcx, self.cache(), true);
+        let attrs = item.attributes_and_repr(self.tcx, &self.cache, true);
         let span = item.span(self.tcx);
         let visibility = item.visibility(self.tcx);
         let clean::ItemInner { name, item_id, .. } = *item.inner;

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -377,8 +377,4 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
             self.serialize_and_write(output_crate, BufWriter::new(stdout().lock()), "<stdout>")
         }
     }
-
-    fn cache(&self) -> &Cache {
-        &self.cache
-    }
 }


### PR DESCRIPTION
We only called it it one place, which isn't generic and can be replaced with a field access.
