### PR TITLE
Make sure to rebuild rustdoc if `src/rustdoc-json-types` is changed

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -716,7 +716,7 @@ impl Step for Rustdoc {
             && target_compiler.stage > 0
             && builder.rust_info().is_managed_git_subrepository()
         {
-            let files_to_track = &["src/librustdoc", "src/tools/rustdoc"];
+            let files_to_track = &["src/librustdoc", "src/tools/rustdoc", "src/rustdoc-json-types"];
 
             // Check if unchanged
             if !builder.config.has_changes_from_upstream(files_to_track) {


### PR DESCRIPTION
I think `rustdoc-json-types` was more recently split out, so this download-rustc logic became outdated as it wasn't tracked. This PR adds `src/rustdoc-json-types` to be tracked for difference versus upstream, so that we properly rebuild rustdoc if it has changes versus upstream.

Fixes rust-lang/rust#142738.

### Local testing

This is not so easy to test locally because it requires download-rustc. To test this, you need to:

1. Disable `download-rustc` inhibition from bootstrap changes versus upstream, by including `:!src/bootstrap` in https://github.com/rust-lang/rust/blob/255aa220821c05c3eac7605fce4ea1c9ab2cbdb4/src/bootstrap/src/core/config/config.rs#L67-L74.
2. Then, use a config like `profile = "tools"` which by default uses `download-rustc = "if-unchanged"`.
3. Run `./x test tests/rustdoc-json` one time, to "prime" initial build caches.
4. Change the `FORMAT_VERSION` in `src/rustdoc-json-types`, i.e.
	```diff
	diff --git a/src/rustdoc-json-types/lib.rs b/src/rustdoc-json-types/lib.rs
	index 1f93895ae07..72a3720c7b4 100644
	--- a/src/rustdoc-json-types/lib.rs
	+++ b/src/rustdoc-json-types/lib.rs
	@@ -38,7 +38,7 @@
	 // are deliberately not in a doc comment, because they need not be in public docs.)
	 //
	 // Latest feature: Pretty printing of inline attributes changed
	-pub const FORMAT_VERSION: u32 = 48;
	+pub const FORMAT_VERSION: u32 = 666;
	```
5. Observe that without this patch, `rustdoc-json` tests fail because `FORMAT_VERSION` mismatch. Observe that with this patch, rustdoc gets properly rebuilt and `rustdoc-json` tests pass.

cc @aDotInTheVoid

r? Kobzol