### PR TITLE
Assign an AttrStyle to all HIR attributes

### DIFF
--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -113,6 +113,7 @@ pub trait HirTyCtxt<'hir> {
     /// Retrieves the `Node` corresponding to `id`.
     fn hir_node(&self, hir_id: HirId) -> Node<'hir>;
     fn hir_body(&self, id: BodyId) -> &'hir Body<'hir>;
+    fn hir_body_owner(&self, id: BodyId) -> HirId;
     fn hir_item(&self, id: ItemId) -> &'hir Item<'hir>;
     fn hir_trait_item(&self, id: TraitItemId) -> &'hir TraitItem<'hir>;
     fn hir_impl_item(&self, id: ImplItemId) -> &'hir ImplItem<'hir>;
@@ -125,6 +126,9 @@ impl<'hir> HirTyCtxt<'hir> for ! {
         unreachable!();
     }
     fn hir_body(&self, _: BodyId) -> &'hir Body<'hir> {
+        unreachable!();
+    }
+    fn hir_body_owner(&self, _: BodyId) -> HirId {
         unreachable!();
     }
     fn hir_item(&self, _: ItemId) -> &'hir Item<'hir> {

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1095,6 +1095,10 @@ impl<'tcx> intravisit::HirTyCtxt<'tcx> for TyCtxt<'tcx> {
         (*self).hir_body(id)
     }
 
+    fn hir_body_owner(&self, id: BodyId) -> HirId {
+        (*self).hir_body_owner(id)
+    }
+
     fn hir_item(&self, id: ItemId) -> &'tcx Item<'tcx> {
         (*self).hir_item(id)
     }

--- a/tests/ui/deprecation/deprecated-expr-precedence.rs
+++ b/tests/ui/deprecation/deprecated-expr-precedence.rs
@@ -1,0 +1,8 @@
+//@ check-fail
+//@ compile-flags: --crate-type=lib
+
+// Regression test for issue 142649
+pub fn public() {
+    #[deprecated] 0
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/deprecation/deprecated-expr-precedence.stderr
+++ b/tests/ui/deprecation/deprecated-expr-precedence.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/deprecated-expr-precedence.rs:6:19
+   |
+LL | pub fn public() {
+   |                - help: try adding a return type: `-> i32`
+LL |     #[deprecated] 0
+   |                   ^ expected `()`, found integer
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/unpretty/deprecated-attr.rs
+++ b/tests/ui/unpretty/deprecated-attr.rs
@@ -16,3 +16,8 @@ pub struct SinceAndNote;
 
 #[deprecated(note = "here's why this is deprecated", since = "1.2.3")]
 pub struct FlippedOrder;
+
+pub fn f() {
+    // Attribute is ignored here (with a warning), but still preserved in HIR
+    #[deprecated] 0
+}

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -24,3 +24,12 @@ struct SinceAndNote;
 #[attr = Deprecation {deprecation: Deprecation {since: NonStandard("1.2.3"),
 note: "here's why this is deprecated"}}]
 struct FlippedOrder;
+
+fn f() {
+
+    // Attribute is ignored here (with a warning), but still preserved in HIR
+    #[attr = Deprecation {deprecation:
+    Deprecation {since:
+    Unspecified}}]
+    0
+}

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -12,6 +12,4 @@ extern crate std;
 trait ImportantTrait<A> { }
 
 #[diagnostic::do_not_recommend]
-impl <T> ImportantTrait<T> for T where T: Clone
-    {#![diagnostic::do_not_recommend]
-}
+impl <T> ImportantTrait<T> for T where T: Clone { }

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -26,7 +26,7 @@ mod expressions {
 
 mod items {
     /// ItemKind::GlobalAsm
-    mod item_global_asm {/// ItemKind::GlobalAsm
+    mod item_global_asm {
         global_asm! (".globl my_asm_func");
     }
 }

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -50,13 +50,6 @@ mod prelude {
     }
 }
 
-//! inner single-line doc comment
-/*!
-     * inner multi-line doc comment
-     */
-#[doc = "inner doc attribute"]
-#[allow(dead_code, unused_variables)]
-#[no_std]
 mod attributes {//! inner single-line doc comment
     /*!
      * inner multi-line doc comment
@@ -236,8 +229,8 @@ mod expressions {
         'a: { }
         #[allow()]
         { }
-        #[allow()]
-        { }
+        {#![allow()]
+        }
     }
 
     /// ExprKind::Gen
@@ -411,25 +404,25 @@ mod expressions {
 }
 mod items {
     /// ItemKind::ExternCrate
-    mod item_extern_crate {/// ItemKind::ExternCrate
+    mod item_extern_crate {
         extern crate core;
         extern crate self as unpretty;
         extern crate core as _;
     }
     /// ItemKind::Use
-    mod item_use {/// ItemKind::Use
+    mod item_use {
         use ::{};
         use crate::expressions;
         use crate::items::item_use;
         use core::*;
     }
     /// ItemKind::Static
-    mod item_static {/// ItemKind::Static
+    mod item_static {
         static A: () = { };
         static mut B: () = { };
     }
     /// ItemKind::Const
-    mod item_const {/// ItemKind::Const
+    mod item_const {
         const A: () = { };
         trait TraitItems {
             const
@@ -443,7 +436,7 @@ mod items {
         }
     }
     /// ItemKind::Fn
-    mod item_fn {/// ItemKind::Fn
+    mod item_fn {
         const unsafe extern "C" fn f() { }
         async unsafe extern "C" fn g()
             ->
@@ -458,21 +451,19 @@ mod items {
         }
     }
     /// ItemKind::Mod
-    mod item_mod {/// ItemKind::Mod
-    }
+    mod item_mod { }
     /// ItemKind::ForeignMod
-    mod item_foreign_mod {/// ItemKind::ForeignMod
+    mod item_foreign_mod {
         extern "Rust" { }
         extern "C" { }
     }
     /// ItemKind::GlobalAsm: see exhaustive-asm.rs
     /// ItemKind::TyAlias
-    mod item_ty_alias {/// ItemKind::GlobalAsm: see exhaustive-asm.rs
-        /// ItemKind::TyAlias
+    mod item_ty_alias {
         type Type<'a> where T: 'a = T;
     }
     /// ItemKind::Enum
-    mod item_enum {/// ItemKind::Enum
+    mod item_enum {
         enum Void { }
         enum Empty {
             Unit,
@@ -488,7 +479,7 @@ mod items {
         }
     }
     /// ItemKind::Struct
-    mod item_struct {/// ItemKind::Struct
+    mod item_struct {
         struct Unit;
         struct Tuple();
         struct Newtype(Unit);
@@ -499,44 +490,39 @@ mod items {
         }
     }
     /// ItemKind::Union
-    mod item_union {/// ItemKind::Union
+    mod item_union {
         union Generic<'a, T> where T: 'a {
             t: T,
         }
     }
     /// ItemKind::Trait
-    mod item_trait {/// ItemKind::Trait
+    mod item_trait {
         auto unsafe trait Send { }
         trait Trait<'a>: Sized where Self: 'a { }
     }
     /// ItemKind::TraitAlias
-    mod item_trait_alias {/// ItemKind::TraitAlias
+    mod item_trait_alias {
         trait Trait<T> = Sized where for<'a> T: 'a;
     }
     /// ItemKind::Impl
-    mod item_impl {/// ItemKind::Impl
+    mod item_impl {
         impl () { }
         impl <T> () { }
         impl Default for () { }
         impl const <T> Default for () { }
     }
     /// ItemKind::MacCall
-    mod item_mac_call {/// ItemKind::MacCall
-    }
+    mod item_mac_call { }
     /// ItemKind::MacroDef
-    mod item_macro_def {/// ItemKind::MacroDef
+    mod item_macro_def {
         macro_rules! mac { () => {...}; }
         macro stringify { () => {} }
     }
     /// ItemKind::Delegation
-    /*! FIXME: todo */
-    mod item_delegation {/// ItemKind::Delegation
-        /*! FIXME: todo */
+    mod item_delegation {/*! FIXME: todo */
     }
     /// ItemKind::DelegationMac
-    /*! FIXME: todo */
-    mod item_delegation_mac {/// ItemKind::DelegationMac
-        /*! FIXME: todo */
+    mod item_delegation_mac {/*! FIXME: todo */
     }
 }
 mod patterns {
@@ -688,29 +674,29 @@ mod types {
     /// TyKind::Paren
     fn ty_paren() { let _: T; }
     /// TyKind::Typeof
-    /*! unused for now */
-    fn ty_typeof() { }
+    fn ty_typeof() {/*! unused for now */
+    }
     /// TyKind::Infer
     fn ty_infer() { let _: _; }
     /// TyKind::ImplicitSelf
-    /*! there is no syntax for this */
-    fn ty_implicit_self() { }
+    fn ty_implicit_self() {/*! there is no syntax for this */
+    }
     /// TyKind::MacCall
     #[expect(deprecated)]
     fn ty_mac_call() { let _: T; let _: T; let _: T; }
     /// TyKind::CVarArgs
-    /*! FIXME: todo */
-    fn ty_c_var_args() { }
+    fn ty_c_var_args() {/*! FIXME: todo */
+    }
     /// TyKind::Pat
     fn ty_pat() { let _: u32 is 1..=RangeMax; }
 }
 mod visibilities {
     /// VisibilityKind::Public
-    mod visibility_public {/// VisibilityKind::Public
+    mod visibility_public {
         struct Pub;
     }
     /// VisibilityKind::Restricted
-    mod visibility_restricted {/// VisibilityKind::Restricted
+    mod visibility_restricted {
         struct PubCrate;
         struct PubSelf;
         struct PubSuper;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/142649.

Prior to https://github.com/rust-lang/rust/pull/135726, all `hir::Attribute` used to have a "style" (either `AttrStyle::Outer` or `AttrStyle::Inner`, for #\[…\] and #!\[…\] respectively). After that refactor, `hir::Attribute`'s `fn style(&self) -> AttrStyle` began to panic if called on certain builtin attributes like `#[deprecated]`.

I looked into changing this method to `fn style(&self) -> Option<AttrStyle>` where builtin attributes would not have a style. But ultimately the HIR pretty-printer needs to print all these attributes, and needs to print them in either outer or inner position, so at least every attribute included in `-Zunpretty=hir` definitely needs a style, including builtin attributes.

I looked into storing every attribute's original `AttrStyle` in either `rustc_attr_data_structures::AttributeKind` or `hir::Attribute`. This does not make sense because there is a many-to-one correspondence between AST attributes and HIR attributes. Two different AST attributes with different style can get parsed into the same single HIR attribute. I have added an example of this in a comment.

Since the HIR pretty-printer chooses to print all of these builtin attributes as outer attributes, and we need to be able to know the style of every expression-level attribute in order to correctly handle expression precedence during pretty-printing and diagnostics, in this PR I have made `hir::Attribute::style` return `AttrStyle::Outer` instead of panicking for builtin attributes.

This solution fixes several `rustc_hir_pretty` bugs associated with not being able to know the style of HIR attributes. For example, some attributes used to get duplicated as both outer _and_ inner when printed, as you can see in the tests.

@jdonszelmann @fmease