### PR TITLE
Convert `ilog(10)` to `ilog10()`

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2841,7 +2841,7 @@ macro_rules! impl_to_string {
         impl SpecToString for $signed {
             #[inline]
             fn spec_to_string(&self) -> String {
-                const SIZE: usize = $signed::MAX.ilog(10) as usize + 1;
+                const SIZE: usize = $signed::MAX.ilog10() as usize + 1;
                 let mut buf = [core::mem::MaybeUninit::<u8>::uninit(); SIZE];
                 // Only difference between signed and unsigned are these 8 lines.
                 let mut out;
@@ -2861,7 +2861,7 @@ macro_rules! impl_to_string {
         impl SpecToString for $unsigned {
             #[inline]
             fn spec_to_string(&self) -> String {
-                const SIZE: usize = $unsigned::MAX.ilog(10) as usize + 1;
+                const SIZE: usize = $unsigned::MAX.ilog10() as usize + 1;
                 let mut buf = [core::mem::MaybeUninit::<u8>::uninit(); SIZE];
 
                 self._fmt(&mut buf).to_string()

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -208,7 +208,7 @@ macro_rules! impl_Display {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 #[cfg(not(feature = "optimize_for_size"))]
                 {
-                    const MAX_DEC_N: usize = $unsigned::MAX.ilog(10) as usize + 1;
+                    const MAX_DEC_N: usize = $unsigned::MAX.ilog10() as usize + 1;
                     // Buffer decimals for $unsigned with right alignment.
                     let mut buf = [MaybeUninit::<u8>::uninit(); MAX_DEC_N];
 
@@ -226,7 +226,7 @@ macro_rules! impl_Display {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 #[cfg(not(feature = "optimize_for_size"))]
                 {
-                    const MAX_DEC_N: usize = $unsigned::MAX.ilog(10) as usize + 1;
+                    const MAX_DEC_N: usize = $unsigned::MAX.ilog10() as usize + 1;
                     // Buffer decimals for $unsigned with right alignment.
                     let mut buf = [MaybeUninit::<u8>::uninit(); MAX_DEC_N];
 
@@ -323,7 +323,7 @@ macro_rules! impl_Display {
 
         #[cfg(feature = "optimize_for_size")]
         fn $gen_name(mut n: $u, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            const MAX_DEC_N: usize = $u::MAX.ilog(10) as usize + 1;
+            const MAX_DEC_N: usize = $u::MAX.ilog10() as usize + 1;
             let mut buf = [MaybeUninit::<u8>::uninit(); MAX_DEC_N];
             let mut curr = MAX_DEC_N;
             let buf_ptr = MaybeUninit::slice_as_mut_ptr(&mut buf);
@@ -565,7 +565,7 @@ mod imp {
 }
 impl_Exp!(i128, u128 as u128 via to_u128 named exp_u128);
 
-const U128_MAX_DEC_N: usize = u128::MAX.ilog(10) as usize + 1;
+const U128_MAX_DEC_N: usize = u128::MAX.ilog10() as usize + 1;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for u128 {

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -353,7 +353,7 @@ pub(crate) fn print_src(
         );
         Ok(())
     });
-    let max_nb_digits = if lines > 0 { lines.ilog(10) + 1 } else { 1 };
+    let max_nb_digits = if lines > 0 { lines.ilog10() + 1 } else { 1 };
     match source_context {
         SourceContext::Standalone { file_path } => Source {
             code_html: code,


### PR DESCRIPTION
Except in tests, convert `integer.ilog(10)` to `integer.ilog10()` for better speed and to provide better examples of code that efficiently counts decimal digits. I couldn't find any instances of `integer.ilog(2)`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
