### PR TITLE
Encode hir attributes cross-crate properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,6 +3724,7 @@ dependencies = [
 name = "rustc_feature"
 version = "0.0.0"
 dependencies = [
+ "rustc_attr_data_structures",
  "rustc_data_structures",
  "rustc_span",
  "serde",

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -1,0 +1,42 @@
+use crate::AttributeKind;
+
+#[derive(PartialEq)]
+pub enum EncodeCrossCrate {
+    Yes,
+    No,
+}
+
+impl AttributeKind {
+    pub fn encode_cross_crate(&self) -> EncodeCrossCrate {
+        use AttributeKind::*;
+        use EncodeCrossCrate::*;
+
+        match self {
+            Align { .. } => No,
+            AllowConstFnUnstable(..) => No,
+            AllowInternalUnstable(..) => Yes,
+            AsPtr(..) => Yes,
+            BodyStability { .. } => No,
+            Confusables { .. } => Yes,
+            ConstStability { .. } => Yes,
+            ConstStabilityIndirect => No,
+            Deprecation { .. } => Yes,
+            DocComment { .. } => Yes,
+            Inline(..) => No,
+            MacroTransparency(..) => Yes,
+            Repr(..) => No,
+            Stability { .. } => Yes,
+            Cold(..) => No,
+            ConstContinue(..) => No,
+            LoopMatch(..) => No,
+            MayDangle(..) => No,
+            MustUse { .. } => Yes,
+            Naked(..) => No,
+            NoMangle(..) => No,
+            Optimize(..) => No,
+            PubTransparent(..) => Yes,
+            SkipDuringMethodDispatch { .. } => No,
+            TrackCaller(..) => Yes,
+        }
+    }
+}

--- a/compiler/rustc_attr_data_structures/src/lib.rs
+++ b/compiler/rustc_attr_data_structures/src/lib.rs
@@ -9,6 +9,7 @@
 // tidy-alphabetical-end
 
 mod attributes;
+mod encode_cross_crate;
 mod stability;
 mod version;
 
@@ -17,6 +18,7 @@ pub mod lints;
 use std::num::NonZero;
 
 pub use attributes::*;
+pub use encode_cross_crate::EncodeCrossCrate;
 use rustc_abi::Align;
 use rustc_ast::token::CommentKind;
 use rustc_ast::{AttrStyle, IntTy, UintTy};

--- a/compiler/rustc_feature/Cargo.toml
+++ b/compiler/rustc_feature/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
+rustc_attr_data_structures = { path = "../rustc_attr_data_structures" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_span = { path = "../rustc_span" }
-serde = { version = "1.0.125", features = [ "derive" ] }
+serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
 # tidy-alphabetical-end

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -5,6 +5,7 @@ use std::sync::LazyLock;
 use AttributeDuplicates::*;
 use AttributeGate::*;
 use AttributeType::*;
+use rustc_attr_data_structures::EncodeCrossCrate;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::edition::Edition;
 use rustc_span::{Symbol, sym};
@@ -366,12 +367,6 @@ macro_rules! experimental {
     ($attr:ident) => {
         concat!("the `#[", stringify!($attr), "]` attribute is an experimental feature")
     };
-}
-
-#[derive(PartialEq)]
-pub enum EncodeCrossCrate {
-    Yes,
-    No,
 }
 
 pub struct BuiltinAttribute {


### PR DESCRIPTION
r? @oli-obk 

This should return the lost perf in rust-lang/rust#138165 

cc: @therealprof 