### PR TITLE
fix(linkcheck): Build using the lockfile

### DIFF
--- a/src/tools/linkchecker/linkcheck.sh
+++ b/src/tools/linkchecker/linkcheck.sh
@@ -98,6 +98,7 @@ then
     nightly_hash=$(rustc +nightly -Vv | grep commit-hash | cut -f2 -d" ")
     url="https://raw.githubusercontent.com/rust-lang/rust"
     mkdir linkchecker
+    curl -o linkchecker/Cargo.lock ${url}/${nightly_hash}/Cargo.lock
     curl -o linkchecker/Cargo.toml ${url}/${nightly_hash}/src/tools/linkchecker/Cargo.toml
     curl -o linkchecker/main.rs ${url}/${nightly_hash}/src/tools/linkchecker/main.rs
 fi


### PR DESCRIPTION
This is to unblock cargo from servo/html5ever#623

I ran `linkcheck.sh` locally and it now works

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
