### PR TITLE
feat(build): centralize LLVM_VERSION

### DIFF
--- a/src/ci/docker/scripts/build-clang.sh
+++ b/src/ci/docker/scripts/build-clang.sh
@@ -2,10 +2,11 @@
 
 set -ex
 
+source versions.sh
 source shared.sh
 
-# Try to keep the LLVM version here in sync with src/ci/scripts/install-clang.sh
-LLVM=llvmorg-21.1.0-rc2
+# Should be in sync with src/ci/scripts/install-clang.sh
+LLVM=llvmorg-$LLVM_VERSION
 
 mkdir llvm-project
 cd llvm-project

--- a/src/ci/docker/scripts/versions.sh
+++ b/src/ci/docker/scripts/versions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# ignore-tidy-linelength
+
+# To keep docker / non-docker builds in sync
+
+# renovate: datasource=github-releases depName=llvm/llvm-project versioning=semver-coerced extractVersion=^llvmorg-(?<version>\d+\.\d+\.\d+(?:.*))
+export LLVM_VERSION=20.1.3

--- a/src/ci/docker/scripts/versions.sh
+++ b/src/ci/docker/scripts/versions.sh
@@ -4,4 +4,4 @@
 # To keep docker / non-docker builds in sync
 
 # renovate: datasource=github-releases depName=llvm/llvm-project versioning=semver-coerced extractVersion=^llvmorg-(?<version>\d+\.\d+\.\d+(?:.*))
-export LLVM_VERSION=20.1.3
+export LLVM_VERSION=21.1.0-rc2

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -7,12 +7,11 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# LLVM_VERSION should be in sync with src/ci/docker/scripts/build-clang.sh
+source "$(cd "$(dirname "$0")" && pwd)/../docker/scripts/versions.sh"
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Update both macOS's and Windows's tarballs when bumping the version here.
-# Try to keep this in sync with src/ci/docker/scripts/build-clang.sh
-LLVM_VERSION="20.1.3"
-
 if isMacOS; then
     # FIXME: This is the latest pre-built version of LLVM that's available for
     # x86_64 MacOS. We may want to consider building our own LLVM binaries


### PR DESCRIPTION
### Features
- Centralized the diverged `LLVM_VERSION` in docker / non-docker builds
- Folded the higher number from non-docker 20.1.3 (latest is 20.1.7)
- Prepared the renovate comment if updates would be allowed in `.github/renovate.json5`

### Working example
https://docs.renovatebot.com/modules/manager/regex/#regular-expression-capture-groups
```json5
{
  "customManagers": [
    {
      "description": "Update _VERSION in ci scripts",
      "customType": "regex",
      "managerFilePatterns": ["src/ci/**/*.sh"],
      "matchStrings": [
        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?( extractVersion=(?<extractVersion>\\S+))?[^\\n]*\\nexport .+_VERSION=(?<currentValue>\\S+)",
      ],
      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
    },
  ],
}
```