### PR TITLE
add doc(alias("AsciiChar")) to core::ascii::Char

### DIFF
--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -15,6 +15,7 @@ use crate::iter::FusedIterator;
 use crate::num::NonZero;
 
 mod ascii_char;
+#[doc(alias("AsciiChar"))]
 #[unstable(feature = "ascii_char", issue = "110998")]
 pub use ascii_char::AsciiChar as Char;
 

--- a/tests/rustdoc-js-std/doc-alias-use.js
+++ b/tests/rustdoc-js-std/doc-alias-use.js
@@ -1,0 +1,12 @@
+// AsciiChar has a doc alias on its reexport and we
+// want to make sure that actually works correctly,
+// since apperently there are no other tests for this.
+
+const EXPECTED = [
+    {
+        'query': 'AsciiChar',
+        'others': [
+            { 'path': 'core::ascii', 'name': 'Char' },
+        ],
+    },
+];


### PR DESCRIPTION
Added it to the reexported, which is intended rustdoc behavior, but is apparently untested, so I also added a test for it.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
