### PR TITLE
Don't fail to parse a struct if a semicolon is used to separate fields

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1916,11 +1916,7 @@ impl<'a> Parser<'a> {
         safety: Safety,
         attrs: AttrVec,
     ) -> PResult<'a, FieldDef> {
-        let mut seen_comma: bool = false;
         let a_var = self.parse_name_and_ty(adt_ty, lo, vis, safety, attrs)?;
-        if self.token == token::Comma {
-            seen_comma = true;
-        }
         if self.eat(exp!(Semi)) {
             let sp = self.prev_token.span;
             let mut err =
@@ -1945,19 +1941,11 @@ impl<'a> Parser<'a> {
                     missing_comma: None,
                 };
                 self.bump(); // consume the doc comment
-                let comma_after_doc_seen = self.eat(exp!(Comma));
-                // `seen_comma` is always false, because we are inside doc block
-                // condition is here to make code more readable
-                if !seen_comma && comma_after_doc_seen {
-                    seen_comma = true;
-                }
-                if comma_after_doc_seen || self.token == token::CloseBrace {
+                if self.eat(exp!(Comma)) || self.token == token::CloseBrace {
                     self.dcx().emit_err(err);
                 } else {
-                    if !seen_comma {
-                        let sp = previous_span.shrink_to_hi();
-                        err.missing_comma = Some(sp);
-                    }
+                    let sp = previous_span.shrink_to_hi();
+                    err.missing_comma = Some(sp);
                     return Err(self.dcx().create_err(err));
                 }
             }

--- a/tests/ui/parser/recover/recover-field-semi.rs
+++ b/tests/ui/parser/recover/recover-field-semi.rs
@@ -3,7 +3,7 @@ struct Foo {
     //~^ ERROR struct fields are separated by `,`
 }
 
-union Bar { //~ ERROR
+union Bar {
     foo: i32;
     //~^ ERROR union fields are separated by `,`
 }
@@ -13,4 +13,6 @@ enum Baz {
     //~^ ERROR struct fields are separated by `,`
 }
 
-fn main() {}
+fn main() {
+    let _ = Foo { foo: "" }; //~ ERROR mismatched types
+}

--- a/tests/ui/parser/recover/recover-field-semi.stderr
+++ b/tests/ui/parser/recover/recover-field-semi.stderr
@@ -22,14 +22,12 @@ LL |     Qux { foo: i32; }
    |     |
    |     while parsing this struct
 
-error: unions cannot have zero fields
-  --> $DIR/recover-field-semi.rs:6:1
+error[E0308]: mismatched types
+  --> $DIR/recover-field-semi.rs:17:24
    |
-LL | / union Bar {
-LL | |     foo: i32;
-LL | |
-LL | | }
-   | |_^
+LL |     let _ = Foo { foo: "" };
+   |                        ^^ expected `i32`, found `&str`
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The first commit is a small refactor.