### PR TITLE
Emit a single error when importing a path with `_`

### DIFF
--- a/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2015.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2015.stderr
@@ -4,12 +4,5 @@ error: expected identifier, found reserved identifier `_`
 LL |     use ::_;
    |           ^ expected identifier, found reserved identifier
 
-error[E0432]: unresolved import `_`
-  --> $DIR/multiple-extern-by-macro-for-underscore.rs:18:9
-   |
-LL |     use ::_;
-   |         ^^^ no `_` in the root
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2015.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2015.stderr
@@ -1,0 +1,15 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-extern-by-macro-for-underscore.rs:18:11
+   |
+LL |     use ::_;
+   |           ^ expected identifier, found reserved identifier
+
+error[E0432]: unresolved import `_`
+  --> $DIR/multiple-extern-by-macro-for-underscore.rs:18:9
+   |
+LL |     use ::_;
+   |         ^^^ no `_` in the root
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2021.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-underscore.ed2021.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/multiple-extern-by-macro-for-underscore.rs:16:11
+  --> $DIR/multiple-extern-by-macro-for-underscore.rs:18:11
    |
 LL |     use ::_;
    |           ^ expected identifier, found reserved identifier

--- a/tests/ui/imports/multiple-extern-by-macro-for-underscore.rs
+++ b/tests/ui/imports/multiple-extern-by-macro-for-underscore.rs
@@ -15,6 +15,6 @@ macro_rules! m {
 m!();
 
 fn main() {
-    use ::_; //[ed2015]~ ERROR: unresolved import `_`
+    use ::_;
     //~^ ERROR: expected identifier, found reserved identifier `_`
 }

--- a/tests/ui/imports/multiple-extern-by-macro-for-underscore.rs
+++ b/tests/ui/imports/multiple-extern-by-macro-for-underscore.rs
@@ -1,4 +1,6 @@
-//@ edition: 2021
+//@ revisions: ed2015 ed2021
+//@[ed2015] edition: 2015
+//@[ed2021] edition: 2021
 
 // issue#128813
 
@@ -13,6 +15,6 @@ macro_rules! m {
 m!();
 
 fn main() {
-    use ::_;
+    use ::_; //[ed2015]~ ERROR: unresolved import `_`
     //~^ ERROR: expected identifier, found reserved identifier `_`
 }

--- a/tests/ui/underscore-imports/issue-110164.ed2015.stderr
+++ b/tests/ui/underscore-imports/issue-110164.ed2015.stderr
@@ -1,0 +1,63 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/issue-110164.rs:8:5
+   |
+LL | use _::a;
+   |     ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/issue-110164.rs:11:5
+   |
+LL | use _::*;
+   |     ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/issue-110164.rs:16:9
+   |
+LL |     use _::a;
+   |         ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/issue-110164.rs:19:9
+   |
+LL |     use _::*;
+   |         ^ expected identifier, found reserved identifier
+
+error[E0432]: unresolved import `self::*`
+  --> $DIR/issue-110164.rs:4:5
+   |
+LL | use self::*;
+   |     ^^^^^^^ cannot glob-import a module into itself
+
+error[E0432]: unresolved import `crate::*`
+  --> $DIR/issue-110164.rs:6:5
+   |
+LL | use crate::*;
+   |     ^^^^^^^^ cannot glob-import a module into itself
+
+error[E0432]: unresolved import `_`
+  --> $DIR/issue-110164.rs:11:5
+   |
+LL | use _::*;
+   |     ^ `_` is not a valid crate or module name
+
+error[E0432]: unresolved import `_`
+  --> $DIR/issue-110164.rs:8:5
+   |
+LL | use _::a;
+   |     ^ `_` is not a valid crate or module name
+
+error[E0432]: unresolved import `_`
+  --> $DIR/issue-110164.rs:16:9
+   |
+LL |     use _::a;
+   |         ^ `_` is not a valid crate or module name
+
+error[E0432]: unresolved import `_`
+  --> $DIR/issue-110164.rs:19:9
+   |
+LL |     use _::*;
+   |         ^ `_` is not a valid crate or module name
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/underscore-imports/issue-110164.ed2015.stderr
+++ b/tests/ui/underscore-imports/issue-110164.ed2015.stderr
@@ -5,19 +5,19 @@ LL | use _::a;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:11:5
+  --> $DIR/issue-110164.rs:10:5
    |
 LL | use _::*;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:16:9
+  --> $DIR/issue-110164.rs:14:9
    |
 LL |     use _::a;
    |         ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:19:9
+  --> $DIR/issue-110164.rs:16:9
    |
 LL |     use _::*;
    |         ^ expected identifier, found reserved identifier
@@ -34,30 +34,6 @@ error[E0432]: unresolved import `crate::*`
 LL | use crate::*;
    |     ^^^^^^^^ cannot glob-import a module into itself
 
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:11:5
-   |
-LL | use _::*;
-   |     ^ `_` is not a valid crate or module name
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:8:5
-   |
-LL | use _::a;
-   |     ^ `_` is not a valid crate or module name
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:16:9
-   |
-LL |     use _::a;
-   |         ^ `_` is not a valid crate or module name
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:19:9
-   |
-LL |     use _::*;
-   |         ^ `_` is not a valid crate or module name
-
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/underscore-imports/issue-110164.ed2021.stderr
+++ b/tests/ui/underscore-imports/issue-110164.ed2021.stderr
@@ -5,19 +5,19 @@ LL | use _::a;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:11:5
+  --> $DIR/issue-110164.rs:10:5
    |
 LL | use _::*;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:16:9
+  --> $DIR/issue-110164.rs:14:9
    |
 LL |     use _::a;
    |         ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:19:9
+  --> $DIR/issue-110164.rs:16:9
    |
 LL |     use _::*;
    |         ^ expected identifier, found reserved identifier
@@ -34,38 +34,6 @@ error[E0432]: unresolved import `crate::*`
 LL | use crate::*;
    |     ^^^^^^^^ cannot glob-import a module into itself
 
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:11:5
-   |
-LL | use _::*;
-   |     ^ use of unresolved module or unlinked crate `_`
-   |
-   = help: you might be missing a crate named `_`
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:8:5
-   |
-LL | use _::a;
-   |     ^ use of unresolved module or unlinked crate `_`
-   |
-   = help: you might be missing a crate named `_`
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:16:9
-   |
-LL |     use _::a;
-   |         ^ use of unresolved module or unlinked crate `_`
-   |
-   = help: you might be missing a crate named `_`
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:19:9
-   |
-LL |     use _::*;
-   |         ^ use of unresolved module or unlinked crate `_`
-   |
-   = help: you might be missing a crate named `_`
-
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/underscore-imports/issue-110164.ed2021.stderr
+++ b/tests/ui/underscore-imports/issue-110164.ed2021.stderr
@@ -1,62 +1,70 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:5:5
+  --> $DIR/issue-110164.rs:8:5
    |
 LL | use _::a;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:8:5
+  --> $DIR/issue-110164.rs:11:5
    |
 LL | use _::*;
    |     ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:13:9
+  --> $DIR/issue-110164.rs:16:9
    |
 LL |     use _::a;
    |         ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/issue-110164.rs:16:9
+  --> $DIR/issue-110164.rs:19:9
    |
 LL |     use _::*;
    |         ^ expected identifier, found reserved identifier
 
 error[E0432]: unresolved import `self::*`
-  --> $DIR/issue-110164.rs:1:5
+  --> $DIR/issue-110164.rs:4:5
    |
 LL | use self::*;
    |     ^^^^^^^ cannot glob-import a module into itself
 
 error[E0432]: unresolved import `crate::*`
-  --> $DIR/issue-110164.rs:3:5
+  --> $DIR/issue-110164.rs:6:5
    |
 LL | use crate::*;
    |     ^^^^^^^^ cannot glob-import a module into itself
 
 error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:8:5
+  --> $DIR/issue-110164.rs:11:5
    |
 LL | use _::*;
-   |     ^ `_` is not a valid crate or module name
+   |     ^ use of unresolved module or unlinked crate `_`
+   |
+   = help: you might be missing a crate named `_`
 
 error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:5:5
+  --> $DIR/issue-110164.rs:8:5
    |
 LL | use _::a;
-   |     ^ `_` is not a valid crate or module name
-
-error[E0432]: unresolved import `_`
-  --> $DIR/issue-110164.rs:13:9
+   |     ^ use of unresolved module or unlinked crate `_`
    |
-LL |     use _::a;
-   |         ^ `_` is not a valid crate or module name
+   = help: you might be missing a crate named `_`
 
 error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:16:9
    |
+LL |     use _::a;
+   |         ^ use of unresolved module or unlinked crate `_`
+   |
+   = help: you might be missing a crate named `_`
+
+error[E0432]: unresolved import `_`
+  --> $DIR/issue-110164.rs:19:9
+   |
 LL |     use _::*;
-   |         ^ `_` is not a valid crate or module name
+   |         ^ use of unresolved module or unlinked crate `_`
+   |
+   = help: you might be missing a crate named `_`
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/underscore-imports/issue-110164.rs
+++ b/tests/ui/underscore-imports/issue-110164.rs
@@ -1,3 +1,6 @@
+//@ revisions: ed2015 ed2021
+//@[ed2015] edition: 2015
+//@[ed2021] edition: 2021
 use self::*;
 //~^ ERROR unresolved import `self::*`
 use crate::*;

--- a/tests/ui/underscore-imports/issue-110164.rs
+++ b/tests/ui/underscore-imports/issue-110164.rs
@@ -7,16 +7,12 @@ use crate::*;
 //~^ ERROR unresolved import `crate::*`
 use _::a;
 //~^ ERROR expected identifier, found reserved identifier `_`
-//~| ERROR unresolved import `_`
 use _::*;
 //~^ ERROR expected identifier, found reserved identifier `_`
-//~| ERROR unresolved import `_`
 
 fn main() {
     use _::a;
     //~^ ERROR expected identifier, found reserved identifier `_`
-    //~| ERROR unresolved import `_`
     use _::*;
     //~^ ERROR expected identifier, found reserved identifier `_`
-    //~| ERROR unresolved import `_`
 }

--- a/tests/ui/underscore-imports/multiple-uses.ed2015.stderr
+++ b/tests/ui/underscore-imports/multiple-uses.ed2015.stderr
@@ -1,0 +1,49 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:4:9
+   |
+LL | pub use _::{a, b};
+   |         ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:6:18
+   |
+LL | pub use std::{a, _};
+   |                  ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:9:18
+   |
+LL | pub use std::{b, _, c};
+   |                  ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:12:15
+   |
+LL | pub use std::{_, d};
+   |               ^ expected identifier, found reserved identifier
+
+error[E0432]: unresolved import `std::a`
+  --> $DIR/multiple-uses.rs:6:15
+   |
+LL | pub use std::{a, _};
+   |               ^ no `a` in the root
+
+error[E0432]: unresolved imports `std::b`, `std::c`
+  --> $DIR/multiple-uses.rs:9:15
+   |
+LL | pub use std::{b, _, c};
+   |               ^     ^
+   |               |     |
+   |               |     no `c` in the root
+   |               |     help: a similar name exists in the module: `rc`
+   |               no `b` in the root
+
+error[E0432]: unresolved import `std::d`
+  --> $DIR/multiple-uses.rs:12:18
+   |
+LL | pub use std::{_, d};
+   |                  ^ no `d` in the root
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/underscore-imports/multiple-uses.ed2021.stderr
+++ b/tests/ui/underscore-imports/multiple-uses.ed2021.stderr
@@ -1,0 +1,49 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:4:9
+   |
+LL | pub use _::{a, b};
+   |         ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:6:18
+   |
+LL | pub use std::{a, _};
+   |                  ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:9:18
+   |
+LL | pub use std::{b, _, c};
+   |                  ^ expected identifier, found reserved identifier
+
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/multiple-uses.rs:12:15
+   |
+LL | pub use std::{_, d};
+   |               ^ expected identifier, found reserved identifier
+
+error[E0432]: unresolved import `std::a`
+  --> $DIR/multiple-uses.rs:6:15
+   |
+LL | pub use std::{a, _};
+   |               ^ no `a` in the root
+
+error[E0432]: unresolved imports `std::b`, `std::c`
+  --> $DIR/multiple-uses.rs:9:15
+   |
+LL | pub use std::{b, _, c};
+   |               ^     ^
+   |               |     |
+   |               |     no `c` in the root
+   |               |     help: a similar name exists in the module: `rc`
+   |               no `b` in the root
+
+error[E0432]: unresolved import `std::d`
+  --> $DIR/multiple-uses.rs:12:18
+   |
+LL | pub use std::{_, d};
+   |                  ^ no `d` in the root
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/underscore-imports/multiple-uses.rs
+++ b/tests/ui/underscore-imports/multiple-uses.rs
@@ -1,0 +1,16 @@
+//@ revisions: ed2015 ed2021
+//@[ed2015] edition: 2015
+//@[ed2021] edition: 2021
+pub use _::{a, b};
+//~^ ERROR expected identifier, found reserved identifier `_`
+pub use std::{a, _};
+//~^ ERROR expected identifier, found reserved identifier `_`
+//~| ERROR unresolved import `std::a`
+pub use std::{b, _, c};
+//~^ ERROR expected identifier, found reserved identifier `_`
+//~| ERROR unresolved imports `std::b`, `std::c`
+pub use std::{_, d};
+//~^ ERROR expected identifier, found reserved identifier `_`
+//~| ERROR unresolved import `std::d`
+
+fn main() {}


### PR DESCRIPTION
When encountering `use _;`, `use _::*'` or similar, do not emit two errors for that single mistake. This also side-steps the issue of resolve errors suggesting adding a crate named `_` to `Cargo.toml`.

Fix rust-lang/rust#142662.