### PR TITLE
libtest: expose --fail-fast as an unstable command-line option

### DIFF
--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -57,6 +57,7 @@ fn optgroups() -> getopts::Options {
         .optflag("", "test", "Run tests and not benchmarks")
         .optflag("", "bench", "Run benchmarks instead of tests")
         .optflag("", "list", "List all tests and benchmarks")
+        .optflag("", "fail-fast", "Don't start new tests after the first failure")
         .optflag("h", "help", "Display this message")
         .optopt("", "logfile", "Write logs to the specified file (deprecated)", "PATH")
         .optflag(
@@ -270,6 +271,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let exact = matches.opt_present("exact");
     let list = matches.opt_present("list");
     let skip = matches.opt_strs("skip");
+    let fail_fast = matches.opt_present("fail-fast");
 
     let bench_benchmarks = matches.opt_present("bench");
     let run_tests = !bench_benchmarks || matches.opt_present("test");
@@ -307,7 +309,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
         skip,
         time_options,
         options,
-        fail_fast: false,
+        fail_fast,
     };
 
     Ok(test_opts)

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -262,6 +262,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     // Unstable flags
     let force_run_in_process = unstable_optflag!(matches, allow_unstable, "force-run-in-process");
     let exclude_should_panic = unstable_optflag!(matches, allow_unstable, "exclude-should-panic");
+    let fail_fast = unstable_optflag!(matches, allow_unstable, "fail-fast");
     let time_options = get_time_options(&matches, allow_unstable)?;
     let shuffle = get_shuffle(&matches, allow_unstable)?;
     let shuffle_seed = get_shuffle_seed(&matches, allow_unstable)?;
@@ -271,7 +272,6 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let exact = matches.opt_present("exact");
     let list = matches.opt_present("list");
     let skip = matches.opt_strs("skip");
-    let fail_fast = matches.opt_present("fail-fast");
 
     let bench_benchmarks = matches.opt_present("bench");
     let run_tests = !bench_benchmarks || matches.opt_present("test");

--- a/src/doc/rustc/src/tests/index.md
+++ b/src/doc/rustc/src/tests/index.md
@@ -158,6 +158,16 @@ unstable-options` flag. See [tracking issue
 
 The following options affect how tests are executed.
 
+#### `--fail-fast`
+
+Stops tests after the first failure.
+
+If running tests in parallel (which is the default), then tests that have already been started on
+other threads will be allowed to run to completion before the process exits.
+
+Note that when running tests in parallel, the test execution order is non-deterministic:
+if multiple tests would fail, the first failure encountered will be reported.
+
 #### `--test-threads` _NUM_THREADS_
 
 Sets the number of threads to use for running tests in parallel. By default,

--- a/src/doc/rustc/src/tests/index.md
+++ b/src/doc/rustc/src/tests/index.md
@@ -168,6 +168,8 @@ other threads will be allowed to run to completion before the process exits.
 Note that when running tests in parallel, the test execution order is non-deterministic:
 if multiple tests would fail, the first failure encountered will be reported.
 
+⚠️ 🚧 This requires the `-Z unstable-options` flag.
+
 #### `--test-threads` _NUM_THREADS_
 
 Sets the number of threads to use for running tests in parallel. By default,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This exposes the `fail_fast` option added in rust-lang/rust#105153 on the test harness command line, so that workflows that only want to know if any test fails can find out without waiting for everything to run. For example, cargo-mutants just needs to know if any tests fails. It only works with `-Zunstable-options`. 

Tracking issue: rust-lang/rust#142859