### PR TITLE
Do not ICE on generic const expr referencing missing ty param

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1557,7 +1557,9 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                     ty::ConstKind::Unevaluated(uv) => {
                         infcx.tcx.type_of(uv.def).instantiate(infcx.tcx, uv.args)
                     }
-                    ty::ConstKind::Param(param_ct) => param_ct.find_ty_from_env(wfcx.param_env),
+                    ty::ConstKind::Param(param_ct) => {
+                        param_ct.find_ty_from_env(wfcx.param_env).unwrap()
+                    }
                 };
 
                 let param_ty = tcx.type_of(param.def_id).instantiate_identity();

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -346,7 +346,7 @@ impl ParamConst {
     }
 
     #[instrument(level = "debug")]
-    pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
+    pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Option<Ty<'tcx>> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {
@@ -362,9 +362,9 @@ impl ParamConst {
             }
         });
 
-        let ty = candidates.next().unwrap();
+        let ty = candidates.next()?;
         assert!(candidates.next().is_none());
-        ty
+        Some(ty)
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -39,7 +39,9 @@ pub(super) fn fulfillment_error_for_no_solution<'tcx>(
                 ty::ConstKind::Unevaluated(uv) => {
                     infcx.tcx.type_of(uv.def).instantiate(infcx.tcx, uv.args)
                 }
-                ty::ConstKind::Param(param_ct) => param_ct.find_ty_from_env(obligation.param_env),
+                ty::ConstKind::Param(param_ct) => {
+                    param_ct.find_ty_from_env(obligation.param_env).unwrap()
+                }
                 ty::ConstKind::Value(cv) => cv.ty,
                 kind => span_bug!(
                     obligation.cause.span,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -979,7 +979,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                         ty::ConstKind::Bound(_, _) => bug!("escaping bound vars in {:?}", ct),
                         ty::ConstKind::Param(param_ct) => {
-                            param_ct.find_ty_from_env(obligation.param_env)
+                            let Some(ty) = param_ct.find_ty_from_env(obligation.param_env) else {
+                                return Ok(EvaluatedToErr);
+                            };
+                            ty
                         }
                     };
 

--- a/tests/ui/const-generics/generic_const_exprs/missing_param_ty_while_evaluating_const_param.rs
+++ b/tests/ui/const-generics/generic_const_exprs/missing_param_ty_while_evaluating_const_param.rs
@@ -1,0 +1,11 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs, adt_const_params)]
+struct X<
+    const FN: () = {
+        || {
+            let _: [(); B]; //~ ERROR cannot find value `B` in this scope
+            //~^ ERROR the constant `FN` is not of type `()`
+        };
+    },
+>;
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/missing_param_ty_while_evaluating_const_param.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/missing_param_ty_while_evaluating_const_param.stderr
@@ -1,0 +1,27 @@
+error[E0425]: cannot find value `B` in this scope
+  --> $DIR/missing_param_ty_while_evaluating_const_param.rs:6:25
+   |
+LL |             let _: [(); B];
+   |                         ^ not found in this scope
+
+error: the constant `FN` is not of type `()`
+  --> $DIR/missing_param_ty_while_evaluating_const_param.rs:6:20
+   |
+LL |             let _: [(); B];
+   |                    ^^^^^^^ expected `()`, found type error
+   |
+note: required by a const generic parameter in `X`
+  --> $DIR/missing_param_ty_while_evaluating_const_param.rs:4:5
+   |
+LL |   struct X<
+   |          - required by a bound in this struct
+LL | /     const FN: () = {
+LL | |         || {
+LL | |             let _: [(); B];
+...  |
+LL | |     },
+   | |_____^ required by this const generic parameter in `X`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Make `ParamEnv::find_ty_from_env` return an `Option<Ty>>` so if a const has a type corresponding to an unknown type parameter, we don't ICE when using `generic_const_exprs`:

```rust
#![allow(incomplete_features)]
#![feature(generic_const_exprs, adt_const_params)]
struct X<
    const FN: () = {
        || {
            let _: [(); B]; //~ ERROR cannot find value `B` in this scope
            //~^ ERROR the constant `FN` is not of type `()`
        };
    },
>;
fn main() {}
```

Fix rust-lang/rust#142709.