### PR TITLE
mbe: Inline functions in `transcribe` that are only called once

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -833,6 +833,7 @@ impl DiagCtxt {
         *fulfilled_expectations = Default::default();
     }
 
+    #[inline]
     pub fn handle<'a>(&'a self) -> DiagCtxtHandle<'a> {
         DiagCtxtHandle { dcx: self, tainted_with_errors: None }
     }

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -289,7 +289,7 @@ pub(super) fn transcribe<'a>(
 }
 
 /// Turn `$(...)*` sequences into tokens.
-#[inline] // called once
+#[inline(always)] // called once
 fn transcribe_sequence<'tx, 'itp>(
     tscx: &mut TranscrCtx<'tx, 'itp>,
     seq: &mbe::TokenTree,
@@ -358,7 +358,7 @@ fn transcribe_sequence<'tx, 'itp>(
 /// producing "xyz", which is bad because it effectively merges tokens.
 /// `Spacing::Alone` is the safer option. Fortunately, `space_between` will avoid
 /// some of the unnecessary whitespace.
-#[inline] // called once
+#[inline(always)] // called once
 fn transcribe_metavar<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     mut sp: Span,
@@ -494,7 +494,7 @@ fn transcribe_metavar<'tx>(
 }
 
 /// Turn `${expr(...)}` metavariable expressionss into tokens.
-#[inline] // called once
+#[inline(always)] // called once
 fn transcribe_metavar_expr<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     dspan: DelimSpan,
@@ -540,7 +540,7 @@ fn transcribe_metavar_expr<'tx>(
 }
 
 /// Handle the `${concat(...)}` metavariable expression.
-#[inline] // called once
+#[inline(always)] // called once
 fn metavar_expr_concat<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     dspan: DelimSpan,
@@ -621,7 +621,7 @@ fn metavar_expr_concat<'tx>(
 ///   These are typically used for passing larger amounts of code, and tokens in that code usually
 ///   combine with each other and not with tokens outside of the sequence.
 /// - The metavariable span comes from a different crate, then we prefer the more local span.
-#[inline] // called once
+#[inline(always)] // called once
 fn maybe_use_metavar_location(
     psess: &ParseSess,
     stack: &[Frame<'_>],
@@ -813,13 +813,13 @@ fn lockstep_iter_size(
 /// * `[ $( ${count(foo, 0)} ),* ]` will be the same as `[ $( ${count(foo)} ),* ]`
 /// * `[ $( ${count(foo, 1)} ),* ]` will return an error because `${count(foo, 1)}` is
 ///   declared inside a single repetition and the index `1` implies two nested repetitions.
-#[inline] // called once
+#[inline(always)] // called once
 fn count_repetitions<'dx>(
     dcx: DiagCtxtHandle<'dx>,
     depth_user: usize,
     mut matched: &NamedMatch,
     repeats: &[(usize, usize)],
-    sp: &DelimSpan,
+    sp: DelimSpan,
 ) -> PResult<'dx, usize> {
     // Recursively count the number of matches in `matched` at given depth
     // (or at the top-level of `matched` if no depth is given).

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -27,14 +27,6 @@ use crate::mbe::{self, KleeneOp, MetaVarExpr};
 
 /// Context needed to perform transcription of metavariable expressions.
 struct TranscrCtx<'psess, 'itp> {
-    psess: &'psess ParseSess,
-
-    /// Map from metavars to matched tokens
-    interp: &'itp FxHashMap<MacroRulesNormalizedIdent, NamedMatch>,
-
-    /// Allow marking spans.
-    marker: Marker,
-
     /// The stack of things yet to be completely expanded.
     ///
     /// We descend into the RHS (`src`), expanding things as we go. This stack contains the things
@@ -66,6 +58,14 @@ struct TranscrCtx<'psess, 'itp> {
     /// The in-progress `result` lives at the top of this stack. Each entered `TokenTree` adds a
     /// new entry.
     result_stack: Vec<Vec<TokenTree>>,
+
+    /// Allow marking spans.
+    marker: Marker,
+
+    psess: &'psess ParseSess,
+
+    /// Map from metavars to matched tokens
+    interp: &'itp FxHashMap<MacroRulesNormalizedIdent, NamedMatch>,
 }
 
 impl<'psess> TranscrCtx<'psess, '_> {
@@ -174,17 +174,17 @@ pub(super) fn transcribe<'a>(
     }
 
     let mut tscx = TranscrCtx {
-        psess,
-        interp,
-        marker: Marker { expand_id, transparency, cache: Default::default() },
-        repeats: Vec::new(),
         stack: smallvec![Frame::new_delimited(
             src,
             src_span,
             DelimSpacing::new(Spacing::Alone, Spacing::Alone)
         )],
+        repeats: Vec::new(),
         result: Vec::new(),
         result_stack: Vec::new(),
+        marker: Marker { expand_id, transparency, cache: Default::default() },
+        psess,
+        interp,
     };
 
     loop {

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -505,7 +505,7 @@ fn transcribe_metavar_expr<'tx>(
         MetaVarExpr::Concat(ref elements) => metavar_expr_concat(tscx, dspan, elements)?,
         MetaVarExpr::Count(original_ident, depth) => {
             let matched = matched_from_ident(dcx, original_ident, tscx.interp)?;
-            let count = count_repetitions(dcx, depth, matched, &tscx.repeats, &dspan)?;
+            let count = count_repetitions(dcx, depth, matched, &tscx.repeats, dspan)?;
             TokenTree::token_alone(
                 TokenKind::lit(token::Integer, sym::integer(count), None),
                 tscx.visited_dspan(dspan),

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -289,6 +289,7 @@ pub(super) fn transcribe<'a>(
 }
 
 /// Turn `$(...)*` sequences into tokens.
+#[inline] // called once
 fn transcribe_sequence<'tx, 'itp>(
     tscx: &mut TranscrCtx<'tx, 'itp>,
     seq: &mbe::TokenTree,
@@ -357,6 +358,7 @@ fn transcribe_sequence<'tx, 'itp>(
 /// producing "xyz", which is bad because it effectively merges tokens.
 /// `Spacing::Alone` is the safer option. Fortunately, `space_between` will avoid
 /// some of the unnecessary whitespace.
+#[inline] // called once
 fn transcribe_metavar<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     mut sp: Span,
@@ -492,6 +494,7 @@ fn transcribe_metavar<'tx>(
 }
 
 /// Turn `${expr(...)}` metavariable expressionss into tokens.
+#[inline] // called once
 fn transcribe_metavar_expr<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     dspan: DelimSpan,
@@ -537,6 +540,7 @@ fn transcribe_metavar_expr<'tx>(
 }
 
 /// Handle the `${concat(...)}` metavariable expression.
+#[inline] // called once
 fn metavar_expr_concat<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     dspan: DelimSpan,
@@ -617,6 +621,7 @@ fn metavar_expr_concat<'tx>(
 ///   These are typically used for passing larger amounts of code, and tokens in that code usually
 ///   combine with each other and not with tokens outside of the sequence.
 /// - The metavariable span comes from a different crate, then we prefer the more local span.
+#[inline] // called once
 fn maybe_use_metavar_location(
     psess: &ParseSess,
     stack: &[Frame<'_>],
@@ -808,6 +813,7 @@ fn lockstep_iter_size(
 /// * `[ $( ${count(foo, 0)} ),* ]` will be the same as `[ $( ${count(foo)} ),* ]`
 /// * `[ $( ${count(foo, 1)} ),* ]` will return an error because `${count(foo, 1)}` is
 ///   declared inside a single repetition and the index `1` implies two nested repetitions.
+#[inline] // called once
 fn count_repetitions<'dx>(
     dcx: DiagCtxtHandle<'dx>,
     depth_user: usize,

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -70,6 +70,7 @@ struct TranscrCtx<'psess, 'itp> {
 
 impl<'psess> TranscrCtx<'psess, '_> {
     /// Span marked with the correct expansion and transparency.
+    #[inline(always)]
     fn visited_dspan(&mut self, dspan: DelimSpan) -> Span {
         let mut span = dspan.entire();
         self.marker.mark_span(&mut span);
@@ -86,6 +87,7 @@ struct Marker {
 
 impl Marker {
     /// Mark a span with the stored expansion ID and transparency.
+    #[inline(always)]
     fn mark_span(&mut self, span: &mut Span) {
         // `apply_mark` is a relatively expensive operation, both due to taking hygiene lock, and
         // by itself. All tokens in a macro body typically have the same syntactic context, unless
@@ -113,6 +115,7 @@ enum FrameKind {
 }
 
 impl<'a> Frame<'a> {
+    #[inline(always)]
     fn new_delimited(src: &'a mbe::Delimited, span: DelimSpan, spacing: DelimSpacing) -> Frame<'a> {
         Frame {
             tts: &src.tts,
@@ -121,6 +124,7 @@ impl<'a> Frame<'a> {
         }
     }
 
+    #[inline(always)]
     fn new_sequence(
         src: &'a mbe::SequenceRepetition,
         sep: Option<Token>,
@@ -133,6 +137,7 @@ impl<'a> Frame<'a> {
 impl<'a> Iterator for Frame<'a> {
     type Item = &'a mbe::TokenTree;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<&'a mbe::TokenTree> {
         let res = self.tts.get(self.idx);
         self.idx += 1;
@@ -687,6 +692,7 @@ fn maybe_use_metavar_location(
 /// See the definition of `repeats` in the `transcribe` function. `repeats` is used to descend
 /// into the right place in nested matchers. If we attempt to descend too far, the macro writer has
 /// made a mistake, and we return `None`.
+#[inline(always)]
 fn lookup_cur_matched<'a>(
     ident: MacroRulesNormalizedIdent,
     interpolations: &'a FxHashMap<MacroRulesNormalizedIdent, NamedMatch>,
@@ -727,6 +733,7 @@ impl LockstepIterSize {
     /// - `Unconstrained` is compatible with everything.
     /// - `Contradiction` is incompatible with everything.
     /// - `Constraint(len)` is only compatible with other constraints of the same length.
+    #[inline(always)]
     fn with(self, other: LockstepIterSize) -> LockstepIterSize {
         match self {
             LockstepIterSize::Unconstrained => other,
@@ -764,6 +771,7 @@ impl LockstepIterSize {
 /// declared at depths which weren't equal or there was a compiler bug. For example, if we have 3 repetitions of
 /// the outer sequence and 4 repetitions of the inner sequence for `x`, we should have the same for
 /// `y`; otherwise, we can't transcribe them both at the given depth.
+#[inline(always)]
 fn lockstep_iter_size(
     tree: &mbe::TokenTree,
     interpolations: &FxHashMap<MacroRulesNormalizedIdent, NamedMatch>,
@@ -875,6 +883,7 @@ fn count_repetitions<'dx>(
 }
 
 /// Returns a `NamedMatch` item declared on the LHS given an arbitrary [Ident]
+#[inline(always)]
 fn matched_from_ident<'ctx, 'interp, 'rslt>(
     dcx: DiagCtxtHandle<'ctx>,
     ident: Ident,
@@ -906,6 +915,7 @@ fn out_of_bounds_err<'a>(dcx: DiagCtxtHandle<'a>, max: usize, span: Span, ty: &s
 }
 
 /// Extracts an metavariable symbol that can be an identifier, a token tree or a literal.
+#[inline(always)]
 fn extract_symbol_from_pnr<'a>(
     dcx: DiagCtxtHandle<'a>,
     pnr: &ParseNtResult,

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -334,6 +334,7 @@ impl ParseSess {
         self.proc_macro_quoted_spans.iter_enumerated()
     }
 
+    #[inline]
     pub fn dcx(&self) -> DiagCtxtHandle<'_> {
         self.dcx.handle()
     }


### PR DESCRIPTION
[rust-lang/rust#142713] did some refactoring of macro expansion, which seems to have had an effect on performance. The only change was to split large functions into smaller ones, so mark some functions that are only called once `#[inline]` to make codegen more similar.

[rust-lang/rust#142713]: https://www.github.com/rust-lang/rust/pull/142713