### PR TITLE
Add OperandValue::Uninit to improve lowering of MaybeUninit::uninit

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -298,7 +298,7 @@ pub(crate) fn coerce_unsized_into<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let (base, info) = match bx.load_operand(src).val {
                 OperandValue::Pair(base, info) => unsize_ptr(bx, base, src_ty, dst_ty, Some(info)),
                 OperandValue::Immediate(base) => unsize_ptr(bx, base, src_ty, dst_ty, None),
-                OperandValue::Ref(..) | OperandValue::ZeroSized => bug!(),
+                OperandValue::Ref(..) | OperandValue::ZeroSized | OperandValue::Uninit => bug!(),
             };
             OperandValue::Pair(base, info).store(bx, dst);
         }

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -341,6 +341,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     OperandValue::ZeroSized => {
                         // These never have a value to talk about
                     }
+                    OperandValue::Uninit => {
+                        // Better not have a useful name
+                    }
                 },
                 LocalRef::PendingOperand => {}
             }

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -328,6 +328,9 @@ impl<T> MaybeUninit<T> {
     #[inline(always)]
     #[rustc_diagnostic_item = "maybe_uninit_uninit"]
     pub const fn uninit() -> MaybeUninit<T> {
+        // It is very helpful for codegen to know when are writing uninit bytes. MIR optimizations
+        // currently do not const-propagate unions, but if we create the const manually that can be
+        // trivially propagated. See #142837.
         const { MaybeUninit { uninit: () } }
     }
 

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -328,7 +328,7 @@ impl<T> MaybeUninit<T> {
     #[inline(always)]
     #[rustc_diagnostic_item = "maybe_uninit_uninit"]
     pub const fn uninit() -> MaybeUninit<T> {
-        MaybeUninit { uninit: () }
+        const { MaybeUninit { uninit: () } }
     }
 
     /// Creates a new `MaybeUninit<T>` in an uninitialized state, with the memory being

--- a/tests/codegen/maybeuninit.rs
+++ b/tests/codegen/maybeuninit.rs
@@ -1,0 +1,32 @@
+//@ compile-flags: -Copt-level=3 -Cdebuginfo=0
+
+// This is a regression test for https://github.com/rust-lang/rust/issues/139355 as well as
+// regressions I introduced while implementing a solution.
+
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+
+// CHECK-LABEL: @create_small_uninit_array
+#[no_mangle]
+fn create_small_uninit_array() -> [MaybeUninit<u8>; 4] {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret i32 undef
+    [MaybeUninit::<u8>::uninit(); 4]
+}
+
+// CHECK-LABEL: @create_nested_uninit_array
+#[no_mangle]
+fn create_nested_uninit_array() -> [[MaybeUninit<u8>; 4]; 100] {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret void
+    [[MaybeUninit::<u8>::uninit(); 4]; 100]
+}
+
+// CHECK-LABEL: @create_ptr
+#[no_mangle]
+fn create_ptr() -> MaybeUninit<&'static str> {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret { ptr, i64 } undef
+    MaybeUninit::uninit()
+}

--- a/tests/codegen/uninit-consts.rs
+++ b/tests/codegen/uninit-consts.rs
@@ -11,21 +11,18 @@ pub struct PartiallyUninit {
     y: MaybeUninit<[u8; 10]>,
 }
 
-// CHECK: [[FULLY_UNINIT:@.*]] = private unnamed_addr constant [10 x i8] undef
-
 // CHECK: [[PARTIALLY_UNINIT:@.*]] = private unnamed_addr constant <{ [4 x i8], [12 x i8] }> <{ [4 x i8] c"{{\\EF\\BE\\AD\\DE|\\DE\\AD\\BE\\EF}}", [12 x i8] undef }>, align 4
 
 // This shouldn't contain undef, since it contains more chunks
 // than the default value of uninit_const_chunk_threshold.
 // CHECK: [[UNINIT_PADDING_HUGE:@.*]] = private unnamed_addr constant [32768 x i8] c"{{.+}}", align 4
 
-// CHECK: [[FULLY_UNINIT_HUGE:@.*]] = private unnamed_addr constant [16384 x i8] undef
-
 // CHECK-LABEL: @fully_uninit
 #[no_mangle]
 pub const fn fully_uninit() -> MaybeUninit<[u8; 10]> {
     const M: MaybeUninit<[u8; 10]> = MaybeUninit::uninit();
-    // CHECK: call void @llvm.memcpy.{{.+}}(ptr align 1 %_0, ptr align 1 {{.*}}[[FULLY_UNINIT]]{{.*}}, i{{(32|64)}} 10, i1 false)
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret void
     M
 }
 
@@ -49,6 +46,7 @@ pub const fn uninit_padding_huge() -> [(u32, u8); 4096] {
 #[no_mangle]
 pub const fn fully_uninit_huge() -> MaybeUninit<[u32; 4096]> {
     const F: MaybeUninit<[u32; 4096]> = MaybeUninit::uninit();
-    // CHECK: call void @llvm.memcpy.{{.+}}(ptr align 4 %_0, ptr align 4 {{.*}}[[FULLY_UNINIT_HUGE]]{{.*}}, i{{(32|64)}} 16384, i1 false)
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: ret void
     F
 }


### PR DESCRIPTION
This is a fix for https://github.com/rust-lang/rust/issues/139355 and it refines what I introduced in https://github.com/rust-lang/rust/pull/138634 (which was itself a fix for https://github.com/rust-lang/rust/issues/138625).

In my assessment, the reason we keep running into these weird optimization problems is that there is no holistic effort in LLVM to make uninit bytes stay uninit across optimizations. In the `[MaybeUninit<u8>; N]` case, SROA wants to run really early and turn as many aggregates into scalars as possible. To do this, tries to replace our memset with undef of a `[i8 x N]` with a write of an integer where possible. This is an easy optimization to fix up (just write an undef integer) but the i8 value comes out of memory so we'd need to run mem2reg before SROA, but currently mem2reg runs immediately after SROA because SROA enables mem2reg.

So my solution in this PR is to generate cleaner IR in the first place so that LLVM doesn't have to work so hard to fix our mess. There are two parts to my solution.

The library diff is tiny but very important. GVN does not const-propagate union aggregate rvalues, so we need to create the const manually. Perhaps we should also improve MIR optimizations to do this without library assistance, but that seems hard.

Then in `codegen_operand` we now generate `OperandValue::Uninit` if we codegen a `mir::Operand::Constant` where all bytes of the constant are uninit. And this propagates the efficient lowering across the backend, usually doing nothing or lowering to a const undef.

cc @scottmcm because you asked about this approach before: https://github.com/rust-lang/rust/pull/138634#discussion_r2000156259

In the previous PR (https://github.com/rust-lang/rust/pull/138634) I said:
> It is technically correct to just do nothing. But if we actually do nothing, we may miss that this is de-initializing something

And now that I've learned more I think my reasoning was wrong. In every case I've looked at where `OperandValue::Uninit` kicks in, we are "initializing" a fresh allocation. So while this codegen could theoretically be worse, I think the approach in this PR has been proven out to be more robust.

cc @nikic in case I'm mischaracterizing LLVM