### PR TITLE
nicer autodiff error handling

### DIFF
--- a/compiler/rustc_ast/src/expand/autodiff_attrs.rs
+++ b/compiler/rustc_ast/src/expand/autodiff_attrs.rs
@@ -6,6 +6,8 @@
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
+use rustc_span::Span;
+
 use crate::expand::{Decodable, Encodable, HashStable_Generic};
 use crate::ptr::P;
 use crate::{Ty, TyKind};
@@ -85,6 +87,7 @@ pub struct AutoDiffItem {
     /// The name of the function being generated
     pub target: String,
     pub attrs: AutoDiffAttrs,
+    pub span: Span,
 }
 
 #[derive(Clone, Eq, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
@@ -276,8 +279,8 @@ impl AutoDiffAttrs {
         !matches!(self.mode, DiffMode::Error | DiffMode::Source)
     }
 
-    pub fn into_item(self, source: String, target: String) -> AutoDiffItem {
-        AutoDiffItem { source, target, attrs: self }
+    pub fn into_item(self, source: String, target: String, span: Span) -> AutoDiffItem {
+        AutoDiffItem { source, target, attrs: self, span }
     }
 }
 

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -8,7 +8,9 @@ codegen_ssa_aix_strip_not_used = using host's `strip` binary to cross-compile to
 
 codegen_ssa_archive_build_failure = failed to build archive at `{$path}`: {$error}
 
-codegen_ssa_autodiff_without_lto = using the autodiff feature requires using fat-lto
+codegen_ssa_autodiff_lib_unsupported = using the autodiff feature with library builds is not yet supported
+
+codegen_ssa_autodiff_without_lto = using the autodiff feature requires using fat-lto.
 
 codegen_ssa_bare_instruction_set = `#[instruction_set]` requires an argument
 

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -419,11 +419,12 @@ fn generate_lto_work<B: ExtraBackendMethods>(
     } else {
         if !autodiff.is_empty() {
             let dcx = cgcx.create_dcx();
+            let span = autodiff[0].span;
             if cgcx.crate_types.contains(&CrateType::Rlib) {
-                dcx.handle().emit_fatal(AutodiffLibraryBuild {});
+                dcx.handle().span_fatal(AutodiffLibraryBuild { span });
             }
             if cgcx.lto != Lto::Fat {
-                dcx.handle().emit_fatal(AutodiffWithoutLto {});
+                dcx.handle().emit_fatal(AutodiffWithoutLto { span });
             }
         }
         assert!(needs_fat_lto.is_empty());

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -42,6 +42,10 @@ pub(crate) struct CguNotRecorded<'a> {
 pub struct AutodiffWithoutLto;
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_autodiff_lib_unsupported)]
+pub struct AutodiffLibraryBuild;
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_reuse_kind)]
 pub(crate) struct UnknownReuseKind {
     #[primary_span]

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -39,11 +39,17 @@ pub(crate) struct CguNotRecorded<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_autodiff_without_lto)]
-pub struct AutodiffWithoutLto;
+pub struct AutodiffWithoutLto {
+    #[primary_span]
+    pub span: Span,
+}
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_autodiff_lib_unsupported)]
-pub struct AutodiffLibraryBuild;
+pub struct AutodiffLibraryBuild {
+    #[primary_span]
+    pub span: Span,
+}
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_reuse_kind)]

--- a/compiler/rustc_monomorphize/src/partitioning/autodiff.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/autodiff.rs
@@ -120,7 +120,8 @@ pub(crate) fn find_autodiff_source_functions<'tcx>(
             None => continue,
         };
 
-        debug!("source_id: {:?}", inst.def_id());
+        let source_def_id = inst.def_id();
+        debug!("source_id: {:?}", source_def_id);
         let fn_ty = inst.ty(tcx, ty::TypingEnv::fully_monomorphized());
         assert!(fn_ty.is_fn());
         adjust_activity_to_abi(tcx, fn_ty, &mut input_activities);
@@ -128,7 +129,7 @@ pub(crate) fn find_autodiff_source_functions<'tcx>(
 
         let mut new_target_attrs = target_attrs.clone();
         new_target_attrs.input_activity = input_activities;
-        let itm = new_target_attrs.into_item(symb, target_symbol);
+        let itm = new_target_attrs.into_item(symb, target_symbol, tcx.def_span(source_def_id));
         autodiff_items.push(itm);
     }
 

--- a/tests/ui/autodiff/autodiff_in_rlib.rs
+++ b/tests/ui/autodiff/autodiff_in_rlib.rs
@@ -1,0 +1,17 @@
+#![feature(autodiff)]
+#![crate_type = "rlib"]
+//@ needs-enzyme
+//@ compile-flags: -Zautodiff=Enable -C opt-level=3  -Clto=fat
+//@ build-fail
+
+// We test that we fail to compile if a user applied an autodiff_ macro in src/lib.rs,
+// since autodiff doesn't work in libraries yet. In the past we used to just return zeros in the
+// autodiffed functions, which is obviously confusing and wrong, so erroring is an improvement.
+
+use std::autodiff::autodiff_reverse;
+//~? ERROR: using the autodiff feature with library builds is not yet supported
+
+#[autodiff_reverse(d_square, Duplicated, Active)]
+pub fn square(x: &f64) -> f64 {
+    *x * *x
+}

--- a/tests/ui/autodiff/autodiff_in_rlib.stderr
+++ b/tests/ui/autodiff/autodiff_in_rlib.stderr
@@ -1,0 +1,4 @@
+error: using the autodiff feature with library builds is not yet supported
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/autodiff/no_lto_flag.no_lto.stderr
+++ b/tests/ui/autodiff/no_lto_flag.no_lto.stderr
@@ -1,0 +1,4 @@
+error: using the autodiff feature requires using fat-lto.
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/autodiff/no_lto_flag.rs
+++ b/tests/ui/autodiff/no_lto_flag.rs
@@ -1,0 +1,31 @@
+//@ needs-enzyme
+//@ no-prefer-dynamic
+//@ revisions: with_lto no_lto
+//@[with_lto] compile-flags: -Zautodiff=Enable -C opt-level=3  -Clto=fat
+//@[no_lto] compile-flags: -Zautodiff=Enable -C opt-level=3 -Clto=thin
+
+#![feature(autodiff)]
+//@[no_lto] build-fail
+//@[with_lto] build-pass
+
+// Autodiff requires users to enable lto=fat (for now).
+// In the past, autodiff did not run if users forget to enable fat-lto, which caused functions to
+// returning zero-derivatives. That's obviously wrong and confusing to users. We now added a check
+// which will abort compilation instead.
+
+use std::autodiff::autodiff_reverse;
+//[no_lto]~? ERROR using the autodiff feature requires using fat-lto.
+
+#[autodiff_reverse(d_square, Duplicated, Active)]
+fn square(x: &f64) -> f64 {
+    *x * *x
+}
+
+fn main() {
+    let xf64: f64 = std::hint::black_box(3.0);
+
+    let mut df_dxf64: f64 = std::hint::black_box(0.0);
+
+    let _output_f64 = d_square(&xf64, &mut df_dxf64, 1.0);
+    assert_eq!(6.0, df_dxf64);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I still intend to finish https://github.com/rust-lang/rust/pull/137570 by adding proper handling for library builds.
I was hoping to directly get the proper fix in, but I haven't had the time in a while, and other contributors and early testers run into this issue often enough.