### PR TITLE
Enable short-ice for Windows

### DIFF
--- a/tests/run-make/short-ice/rmake.rs
+++ b/tests/run-make/short-ice/rmake.rs
@@ -5,8 +5,9 @@
 // See https://github.com/rust-lang/rust/issues/107910
 
 //@ needs-target-std
-//@ ignore-windows
-// Reason: the assert_eq! on line 32 fails, as error output on Windows is different.
+//@ ignore-i686-pc-windows-msvc
+// Reason: the assert_eq! on line 37 fails, almost seems like it missing debug info?
+// Haven't been able to reproduce locally, but it happens on CI.
 
 use run_make_support::rustc;
 
@@ -29,10 +30,16 @@ fn main() {
 
     let rustc_query_count_full = count_lines_with(rust_test_log_2, "rustc_query_");
 
-    assert!(rust_test_log_1.lines().count() < rust_test_log_2.lines().count());
+    assert!(
+        rust_test_log_1.lines().count() < rust_test_log_2.lines().count(),
+        "Short backtrace should be shorter than full backtrace.\nShort backtrace:\n\
+        {rust_test_log_1}\nFull backtrace:\n{rust_test_log_2}"
+    );
     assert_eq!(
         count_lines_with(rust_test_log_2, "__rust_begin_short_backtrace"),
-        count_lines_with(rust_test_log_2, "__rust_end_short_backtrace")
+        count_lines_with(rust_test_log_2, "__rust_end_short_backtrace"),
+        "Full backtrace should contain the short backtrace markers.\nFull backtrace:\n\
+        {rust_test_log_2}"
     );
     assert!(count_lines_with(rust_test_log_1, "rustc_query_") + 5 < rustc_query_count_full);
     assert!(rustc_query_count_full > 5);


### PR DESCRIPTION
Works fine for x64 without modifications.

x86 MSVC is still failing.

Addresses item in rust-lang/rust#128602

---

try-job: x86_64-mingw-*
try-job: x86_64-msvc-*
try-job: i686-msvc-*