### PR TITLE
Enable textrel-on-minimal-lib for Windows

### DIFF
--- a/tests/run-make/textrel-on-minimal-lib/rmake.rs
+++ b/tests/run-make/textrel-on-minimal-lib/rmake.rs
@@ -6,25 +6,23 @@
 // See https://github.com/rust-lang/rust/issues/68794
 
 //@ ignore-cross-compile
-//@ ignore-windows
-// Reason: There is no `bar.dll` produced by CC to run readobj on
 
 use run_make_support::{
-    cc, dynamic_lib_name, extra_c_flags, extra_cxx_flags, llvm_readobj, rustc, static_lib_name,
+    bin_name, cc, extra_c_flags, extra_cxx_flags, llvm_readobj, rustc, static_lib_name,
 };
 
 fn main() {
     rustc().input("foo.rs").run();
     cc().input("bar.c")
         .input(static_lib_name("foo"))
-        .out_exe(&dynamic_lib_name("bar"))
+        .out_exe(&bin_name("bar"))
         .arg("-fPIC")
         .arg("-shared")
         .args(extra_c_flags())
         .args(extra_cxx_flags())
         .run();
     llvm_readobj()
-        .input(dynamic_lib_name("bar"))
+        .input(bin_name("bar"))
         .arg("--dynamic")
         .run()
         .assert_stdout_not_contains("TEXTREL");


### PR DESCRIPTION
`bin_name` needs to be used when building a runnable executable.

Addresses item in rust-lang/rust#128602

---

try-job: x86_64-mingw-*
try-job: x86_64-msvc-*
try-job: i686-msvc-*