### PR TITLE
Misc. cleanups to `librustdoc`s "clean" fns

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2384,7 +2384,7 @@ pub const STDLIB_STABLE_CRATES: &[Symbol] = &[sym::std, sym::core, sym::alloc, s
 #[derive(Copy, Clone, Eq, HashStable_Generic, Encodable, Decodable)]
 pub struct Ident {
     // `name` should never be the empty symbol. If you are considering that,
-    // you are probably conflating "empty identifer with "no identifier" and
+    // you are probably conflating "empty identifer" with "no identifier" and
     // you should use `Option<Ident>` instead.
     pub name: Symbol,
     pub span: Span,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -178,7 +178,7 @@ fn is_glob_import(tcx: TyCtxt<'_>, import_id: LocalDefId) -> bool {
 }
 
 fn generate_item_with_correct_attrs(
-    cx: &mut DocContext<'_>,
+    cx: &DocContext<'_>,
     kind: ItemKind,
     def_id: DefId,
     name: Symbol,
@@ -2622,7 +2622,7 @@ pub(crate) fn reexport_chain(
 
 /// Collect attributes from the whole import chain.
 fn get_all_import_attributes<'hir>(
-    cx: &mut DocContext<'hir>,
+    cx: &DocContext<'hir>,
     import_def_id: LocalDefId,
     target_def_id: DefId,
     is_inline: bool,


### PR DESCRIPTION
Small cleanups while working on bigger stuff.

Might have very slight performance improvement (408dc5084a9604cccaa9193f54d39fe4d2114f37 avoids a few unneeded `Clone`s), but I doubt they'll register on a perf run. So this is mostly just making the code (hopefully) a bit nicer.