### PR TITLE
Add a few inline directives in rustc_serialize.

### DIFF
--- a/compiler/rustc_serialize/src/int_overflow.rs
+++ b/compiler/rustc_serialize/src/int_overflow.rs
@@ -20,6 +20,7 @@ macro_rules! impl_debug_strict_add {
     ($( $ty:ty )*) => {
         $(
             impl DebugStrictAdd for $ty {
+                #[inline]
                 fn debug_strict_add(self, other: Self) -> Self {
                     if cfg!(debug_assertions) {
                         self + other
@@ -42,6 +43,7 @@ macro_rules! impl_debug_strict_sub {
     ($( $ty:ty )*) => {
         $(
             impl DebugStrictSub for $ty {
+                #[inline]
                 fn debug_strict_sub(self, other: Self) -> Self {
                     if cfg!(debug_assertions) {
                         self - other

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -89,10 +89,12 @@ impl FileEncoder {
         self.buffered = 0;
     }
 
+    #[inline]
     pub fn file(&self) -> &File {
         &self.file
     }
 
+    #[inline]
     pub fn path(&self) -> &Path {
         &self.path
     }


### PR DESCRIPTION
I see `debug_strict_add` and `debug_strict_sub` appearing in callgrind output. This bothers me. This PR should make them disappear.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
