### PR TITLE
Change search "not found" links

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4922,7 +4922,7 @@ ${item.displayPath}<span class="${type}">${name}</span>\
         const docsrsURL = `https://docs.rs/releases/search?query=${encodeURIComponent(query.userQuery)}`;
         const duckduckgoURL = `https://duckduckgo.com/?q=${encodeURIComponent("rust " + query.userQuery)}`;
         output.className = "search-failed" + extraClass;
-        output.innerHTML = `No results in <code>${getVar("crate")}</code> :(<br/>` +
+        output.innerHTML = `No results in <code>${getVar("current-crate")}</code> :(<br/>` +
             `Search for <a href="${docsrsURL}">other crates</a>?<br/>` +
             `Or try on <a href="${duckduckgoURL}">DuckDuckGo</a>?<br/><br/>` +
             "Or try looking in one of these:<ul><li>The <a " +

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4919,11 +4919,12 @@ ${item.displayPath}<span class="${type}">${name}</span>\
         });
     } else if (query.error === null) {
         const dlroChannel = `https://doc.rust-lang.org/${getVar("channel")}`;
+        const docsrsURL = `https://docs.rs/releases/search?query=${encodeURIComponent(query.userQuery)}`;
+        const duckduckgoURL = `https://duckduckgo.com/?q=${encodeURIComponent("rust " + query.userQuery)}`;
         output.className = "search-failed" + extraClass;
-        output.innerHTML = "No results :(<br/>" +
-            "Try on <a href=\"https://duckduckgo.com/?q=" +
-            encodeURIComponent("rust " + query.userQuery) +
-            "\">DuckDuckGo</a>?<br/><br/>" +
+        output.innerHTML = `No results in <code>${getVar("crate")}</code> :(<br/>` +
+            `Search for <a href="${docsrsURL}">other crates</a>?<br/>` +
+            `Or try on <a href="${duckduckgoURL}">DuckDuckGo</a>?<br/><br/>` +
             "Or try looking in one of these:<ul><li>The <a " +
             `href="${dlroChannel}/reference/index.html">Rust Reference</a> ` +
             " for technical details about the language.</li><li><a " +


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds an additional link to the not found section on the search page in the rustdoc output. This new link points to `https://docs.rs/releases/search?q=*input*`.

The use case is that I keep going to find an external item when unintentionally on <https://doc.rust-lang.org/stable/std/>. This provides a quicker way to where I actually want to search `docs.rs`.

This also shows the current crate name in the section to remind the user what crate is being searched.

---

A concern is that the `docs.rs` search is by crate name, not by actual items. Maybe the message should be `Search crates matching *query*`
