### PR TITLE
Add impl_trait_in_bindings tests from #61773

### DIFF
--- a/tests/ui/impl-trait/in-bindings/lifetime-equality.rs
+++ b/tests/ui/impl-trait/in-bindings/lifetime-equality.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![feature(impl_trait_in_bindings)]
+
+// A test for #61773 which would have been difficult to support if we
+// were to represent `impl_trait_in_bindings` using opaque types.
+
+trait Trait<'a, 'b> { }
+impl<T> Trait<'_, '_> for T { }
+
+
+fn bar<'a, 'b>(data0: &'a u32, data1: &'b u32) {
+  let x: impl Trait<'_, '_> = (data0, data1);
+  force_equal(x);
+}
+
+fn force_equal<'a>(t: impl Trait<'a, 'a>) { }
+
+fn main() { }

--- a/tests/ui/impl-trait/in-bindings/region-lifetimes.rs
+++ b/tests/ui/impl-trait/in-bindings/region-lifetimes.rs
@@ -1,0 +1,17 @@
+//@ check-pass
+
+#![feature(impl_trait_in_bindings)]
+
+// A test for #61773 which would have been difficult to support if we
+// were to represent `impl_trait_in_bindings` using opaque types.
+
+trait Foo<'a> { }
+impl Foo<'_> for &u32 { }
+
+fn bar<'a>(data: &'a u32) {
+  let x: impl Foo<'_> = data;
+}
+
+fn main() {
+  let _: impl Foo<'_> = &44;
+}


### PR DESCRIPTION
This adds the [three test cases](https://github.com/rust-lang/rust/issues/61773#issuecomment-2952638727) from the rust-lang/rust#61773 as was suggested by @lcnr. 

I have merged the first two cases into one, named as `region-lifetimes.rs`

r? @lcnr 

Closes rust-lang/rust#61773