### PR TITLE
core: Add `BorrowedCursor::with_unfilled_buf`

### DIFF
--- a/library/coretests/tests/io/borrowed_buf.rs
+++ b/library/coretests/tests/io/borrowed_buf.rs
@@ -165,3 +165,39 @@ fn cursor_set_init() {
     assert_eq!(rbuf.unfilled().uninit_mut().len(), 4);
     assert_eq!(unsafe { rbuf.unfilled().as_mut().len() }, 12);
 }
+
+#[test]
+fn cursor_with_unfilled_buf() {
+    let buf: &mut [_] = &mut [MaybeUninit::uninit(); 16];
+    let mut rbuf = BorrowedBuf::from(buf);
+    let mut cursor = rbuf.unfilled();
+
+    cursor.with_unfilled_buf(|buf| {
+        buf.unfilled().append(&[1, 2, 3]);
+        assert_eq!(buf.filled(), &[1, 2, 3]);
+    });
+
+    assert_eq!(cursor.init_mut().len(), 0);
+    assert_eq!(cursor.written(), 3);
+
+    cursor.with_unfilled_buf(|buf| {
+        assert_eq!(buf.capacity(), 13);
+        assert_eq!(buf.init_len(), 0);
+
+        buf.unfilled().ensure_init();
+        buf.unfilled().advance(4);
+    });
+
+    assert_eq!(cursor.init_mut().len(), 9);
+    assert_eq!(cursor.written(), 7);
+
+    cursor.with_unfilled_buf(|buf| {
+        assert_eq!(buf.capacity(), 9);
+        assert_eq!(buf.init_len(), 9);
+    });
+
+    assert_eq!(cursor.init_mut().len(), 9);
+    assert_eq!(cursor.written(), 7);
+
+    assert_eq!(rbuf.filled(), &[1, 2, 3, 0, 0, 0, 0]);
+}


### PR DESCRIPTION
Implementation of https://github.com/rust-lang/libs-team/issues/367.

This mainly adds `BorrowedCursor::with_unfilled_buf`, with enables using the unfilled part of a cursor as a `BorrowedBuf`.

Note that unlike the ACP, `BorrowedCursor::unfilled_buf` was moved to a `From` conversion. This is more consistent with other ways of creating a `BorrowedBuf` and hides a bit this conversion that requires unsafe code to be used correctly.

Cc rust-lang/rust#78485 rust-lang/rust#117693
