### PR TITLE
ci: aarch64-gnu: Stop skipping `panic_abort_doc_tests`

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -26,6 +26,5 @@ ENV RUST_CONFIGURE_ARGS \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs
-# FIXME: Skipping cargo panic_abort_doc_tests due to https://github.com/rust-lang/rust/issues/123733
 ENV SCRIPT python3 ../x.py --stage 2 test && \
-  python3 ../x.py --stage 2 test src/tools/cargo --test-args \"--skip panic_abort_doc_tests\"
+  python3 ../x.py --stage 2 test src/tools/cargo


### PR DESCRIPTION
The skipped test passes since `nightly-2024-11-29`. See https://github.com/rust-lang/rust/issues/123733#issuecomment-2928770365 and https://github.com/rust-lang/rust/issues/123733#issuecomment-2929091266 for more info.

Let's stop skipping it to increase the chance of detecting a regression.

r? @cuviper who added the skip in https://github.com/rust-lang/rust/pull/123828

Also see https://github.com/rust-lang/rust/pull/142304 for an alternative regression test that I am hoping to also land in the near future to complement the test we now stop skipping, but I need to investigate that setup more.


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
