### PR TITLE
MIR inliner maintains unused var_debug_info

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -982,14 +982,16 @@ fn inline_call<'tcx, I: Inliner<'tcx>>(
     // Insert all of the (mapped) parts of the callee body into the caller.
     caller_body.local_decls.extend(callee_body.drain_vars_and_temps());
     caller_body.source_scopes.append(&mut callee_body.source_scopes);
+
+    // only "full" debug promises any variable-level information
     if tcx
         .sess
         .opts
         .unstable_opts
         .inline_mir_preserve_debug
-        .unwrap_or(tcx.sess.opts.debuginfo != DebugInfo::None)
+        .unwrap_or(tcx.sess.opts.debuginfo == DebugInfo::Full)
     {
-        // Note that we need to preserve these in the standard library so that
+        // -Zinline-mir-preserve-debug is enabled when building the standard library, so that
         // people working on rust can build with or without debuginfo while
         // still getting consistent results from the mir-opt tests.
         caller_body.var_debug_info.append(&mut callee_body.var_debug_info);

--- a/tests/mir-opt/inline_var_debug_info_kept.rs
+++ b/tests/mir-opt/inline_var_debug_info_kept.rs
@@ -1,0 +1,50 @@
+//@ test-mir-pass: Inline
+//@ revisions: PRESERVE FULL NONE LIMITED
+//@ [PRESERVE]compile-flags: -O -C debuginfo=0 -Zinline-mir-preserve-debug
+//@ [FULL]compile-flags: -O -C debuginfo=2
+//@ [NONE]compile-flags: -O -C debuginfo=0
+//@ [LIMITED]compile-flags: -O -C debuginfo=1
+
+#[inline(always)]
+fn inline_fn1(arg1: i32) -> i32 {
+    let local1 = arg1 + 1;
+    let _local2 = 10;
+    arg1 + local1
+}
+
+#[inline(always)]
+fn inline_fn2(binding: i32) -> i32 {
+    {
+        let binding = inline_fn1(binding);
+        binding
+    }
+}
+
+#[inline(never)]
+fn test() -> i32 {
+    // CHECK-LABEL: fn test
+    inline_fn2(1)
+    // CHECK-LABEL: (inlined inline_fn2)
+
+    // PRESERVE: debug binding =>
+    // FULL: debug binding =>
+    // NONE-NOT: debug binding =>
+    // LIMITED-NOT: debug binding =>
+
+    // CHECK-LABEL: (inlined inline_fn1)
+
+    // PRESERVE: debug arg1 =>
+    // FULL: debug arg1 =>
+    // NONE-NOT: debug arg1 =>
+    // LIMITED-NOT: debug arg1 =>
+
+    // PRESERVE: debug local1 =>
+    // FULL: debug local1 =>
+    // NONE-NOT: debug local1 =>
+    // LIMITED-NOT: debug local1 =>
+
+    // PRESERVE: debug _local2 =>
+    // FULL: debug _local2 =>
+    // NONE-NOT: debug _local2 =>
+    // LIMITED-NOT: debug _local2 =>
+}


### PR DESCRIPTION
Only `full` debuginfo level promises variable-level debug information, but the MIR inline pass needlessly preserved the local variable debug info for the `limited` level too.
