### PR TITLE
Stop collecting unmentioned constants

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1481,12 +1481,14 @@ impl<'v> RootCollector<'_, 'v> {
                 // Const items only generate mono items if they are actually used somewhere.
                 // Just declaring them is insufficient.
 
-                // But even just declaring them must collect the items they refer to
-                // unless their generics require monomorphization.
-                if !self.tcx.generics_of(id.owner_id).own_requires_monomorphization()
-                    && let Ok(val) = self.tcx.const_eval_poly(id.owner_id.to_def_id())
-                {
-                    collect_const_value(self.tcx, val, self.output);
+                // If we're collecting items eagerly, then recurse into all constants.
+                // Otherwise the value is only collected when explicitly mentioned in other items.
+                if self.strategy == MonoItemCollectionStrategy::Eager {
+                    if !self.tcx.generics_of(id.owner_id).own_requires_monomorphization()
+                        && let Ok(val) = self.tcx.const_eval_poly(id.owner_id.to_def_id())
+                    {
+                        collect_const_value(self.tcx, val, self.output);
+                    }
                 }
             }
             DefKind::Impl { .. } => {

--- a/tests/codegen-units/partitioning/vtable-through-const.rs
+++ b/tests/codegen-units/partitioning/vtable-through-const.rs
@@ -35,7 +35,6 @@ mod mod1 {
         }
     }
 
-    //~ MONO_ITEM fn mod1::id::<i64> @@ vtable_through_const-mod1.volatile[Internal]
     fn id<T>(x: T) -> T {
         x
     }
@@ -50,8 +49,6 @@ mod mod1 {
         fn do_something_else(&self) {}
     }
 
-    //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait2>::do_something @@ vtable_through_const-mod1.volatile[External]
-    //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait2>::do_something_else @@ vtable_through_const-mod1.volatile[External]
     impl Trait2 for NeedsDrop {}
 
     pub trait Trait2Gen<T> {
@@ -93,8 +90,6 @@ pub fn main() {
     // Same as above
     //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait1Gen<u8>>::do_something @@ vtable_through_const-mod1.volatile[External]
     //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait1Gen<u8>>::do_something_else @@ vtable_through_const-mod1.volatile[External]
-    //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait2Gen<u8>>::do_something @@ vtable_through_const-mod1.volatile[External]
-    //~ MONO_ITEM fn <mod1::NeedsDrop as mod1::Trait2Gen<u8>>::do_something_else @@ vtable_through_const-mod1.volatile[External]
     mod1::TRAIT1_GEN_REF.do_something(0u8);
 
     //~ MONO_ITEM fn mod1::id::<char> @@ vtable_through_const-mod1.volatile[External]


### PR DESCRIPTION
This avoids generating useless dead LLVM IR. This appears to have regressed and/or been introduced in rust-lang/rust#53821 (unfortunately a very large PR - I don't see any direct discussion there of this particular change), but as far as I can tell is at least no longer necessary -- or we lack test coverage -- because none of our UI tests indicate diagnostics regressions. The adjusted codegen-units test has comments explicitly noting that these items should *not* be collected ("These are not referenced, so they do not produce mono-items").

I noticed this while looking at libcore LLVM IR we generate, which contained dead code references to the NOOP Waker item, which is never used inside libcore. Producing LLVM IR for it during libcore's compilation, only for that IR to get deleted by LLVM as unused, isn't useful. Note that the IR is generally all marked internal, too.


