### PR TITLE
fix `-Zmin-function-alignment` on functions without attributes

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -145,12 +145,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             }
         }
 
-        // Apply the minimum function alignment here, so that individual backends don't have to.
-        codegen_fn_attrs.alignment = Ord::max(
-            codegen_fn_attrs.alignment,
-            tcx.sess.opts.unstable_opts.min_function_alignment,
-        );
-
         let Some(Ident { name, .. }) = attr.ident() else {
             continue;
         };
@@ -453,6 +447,10 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
     }
 
     mixed_export_name_no_mangle_lint_state.lint_if_mixed(tcx);
+
+    // Apply the minimum function alignment here, so that individual backends don't have to.
+    codegen_fn_attrs.alignment =
+        Ord::max(codegen_fn_attrs.alignment, tcx.sess.opts.unstable_opts.min_function_alignment);
 
     let inline_span;
     (codegen_fn_attrs.inline, inline_span) = if let Some((inline_attr, span)) =

--- a/tests/codegen/min-function-alignment.rs
+++ b/tests/codegen/min-function-alignment.rs
@@ -1,17 +1,19 @@
 //@ revisions: align16 align1024
-//@ compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0
+//@ compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0 -Clink-dead-code
 //@ [align16] compile-flags: -Zmin-function-alignment=16
 //@ [align1024] compile-flags: -Zmin-function-alignment=1024
 
 #![crate_type = "lib"]
 #![feature(fn_align)]
 
-// functions without explicit alignment use the global minimum
+// Functions without explicit alignment use the global minimum.
 //
-// CHECK-LABEL: @no_explicit_align
+// NOTE: this function deliberately has zero (0) attributes! That is to make sure that
+// `-Zmin-function-alignment` is applied regardless of whether attributes are used.
+//
+// CHECK-LABEL: no_explicit_align
 // align16: align 16
 // align1024: align 1024
-#[no_mangle]
 pub fn no_explicit_align() {}
 
 // CHECK-LABEL: @lower_align


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/82232
related: https://github.com/rust-lang/rust/pull/142854

The minimum function alignment was skipped on functions without attributes (because the logic was in a loop that only runs if there is at least one attribute). The underlying reason we didn't catch this before is that in our testing we generally apply `#[no_mangle]` to functions that are tested. I've added a test now that deliberately has no attributes.

r? @workingjubilee 
