### PR TITLE
Fix hang in --print=file-names in bootstrap

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -683,6 +683,7 @@ impl Builder<'_> {
                         .arg("--print=file-names")
                         .arg("--crate-type=proc-macro")
                         .arg("-")
+                        .stdin(std::process::Stdio::null())
                         .run_capture(self)
                         .stderr();
 

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -120,6 +120,11 @@ impl BootstrapCommand {
         self
     }
 
+    pub fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
+        self.command.stdin(stdin);
+        self
+    }
+
     #[must_use]
     pub fn delay_failure(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::DelayFail, ..self }


### PR DESCRIPTION
In an interactive context, the subprocess inherited a real tty stdin, which lead it it waiting for something to happen, even though nothing happened. By explicitly passing null as stdin we make sure an empty file is passed, which achieves the desired behavior.

Fixes rust-lang/rust#142926 (verified locally by cherry-picking the patch onto beta where I was building).