### PR TITLE
rustdoc-json: Structured attributes

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1191,7 +1191,7 @@ fn render_assoc_item(
 // a whitespace prefix and newline.
 fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) -> impl fmt::Display {
     fmt::from_fn(move |f| {
-        for a in it.attributes(cx.tcx(), cx.cache(), false) {
+        for a in it.attributes(cx.tcx(), cx.cache()) {
             writeln!(f, "{prefix}{a}")?;
         }
         Ok(())
@@ -1207,7 +1207,7 @@ fn render_code_attribute(code_attr: CodeAttribute, w: &mut impl fmt::Write) {
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
-    for attr in it.attributes(cx.tcx(), cx.cache(), false) {
+    for attr in it.attributes(cx.tcx(), cx.cache()) {
         render_code_attribute(CodeAttribute(attr), w);
     }
 }
@@ -1219,7 +1219,7 @@ fn render_repr_attributes_in_code(
     def_id: DefId,
     item_type: ItemType,
 ) {
-    if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type, false) {
+    if let Some(repr) = clean::repr_attributes(cx.tcx(), cx.cache(), def_id, item_type) {
         render_code_attribute(CodeAttribute(repr), w);
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1487,12 +1487,11 @@ impl<'a, 'cx: 'a> ItemUnion<'a, 'cx> {
                     self.cx.cache(),
                     self.def_id,
                     ItemType::Union,
-                    false,
                 ) {
                     writeln!(f, "{repr}")?;
                 };
             } else {
-                for a in self.it.attributes(self.cx.tcx(), self.cx.cache(), false) {
+                for a in self.it.attributes(self.cx.tcx(), self.cx.cache()) {
                     writeln!(f, "{a}")?;
                 }
             }

--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -9,5 +9,5 @@ impl Default for Manual {
     }
 }
 
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
+//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["automatically_derived"]'
 //@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'

--- a/tests/rustdoc-json/attrs/cold.rs
+++ b/tests/rustdoc-json/attrs/cold.rs
@@ -1,3 +1,3 @@
-//@ is "$.index[?(@.name=='cold_fn')].attrs" '["#[attr = Cold]"]'
+//@ is "$.index[?(@.name=='cold_fn')].attrs" '[{"other": "#[attr = Cold]"}]'
 #[cold]
 pub fn cold_fn() {}

--- a/tests/rustdoc-json/attrs/export_name_2021.rs
+++ b/tests/rustdoc-json/attrs/export_name_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"export_name": "altered"}]'
 #[export_name = "altered"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/export_name_2024.rs
+++ b/tests/rustdoc-json/attrs/export_name_2024.rs
@@ -2,8 +2,8 @@
 #![no_std]
 
 // The representation of `#[unsafe(export_name = ..)]` in rustdoc in edition 2024
-// is still `#[export_name = ..]` without the `unsafe` attribute wrapper.
+// doesn't mention the `unsafe`.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"export_name": "altered"}]'
 #[unsafe(export_name = "altered")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/inline.rs
+++ b/tests/rustdoc-json/attrs/inline.rs
@@ -1,11 +1,11 @@
-//@ is "$.index[?(@.name=='just_inline')].attrs" '["#[attr = Inline(Hint)]"]'
+//@ is "$.index[?(@.name=='just_inline')].attrs" '[{"other": "#[attr = Inline(Hint)]"}]'
 #[inline]
 pub fn just_inline() {}
 
-//@ is "$.index[?(@.name=='inline_always')].attrs" '["#[attr = Inline(Always)]"]'
+//@ is "$.index[?(@.name=='inline_always')].attrs" '[{"other": "#[attr = Inline(Always)]"}]'
 #[inline(always)]
 pub fn inline_always() {}
 
-//@ is "$.index[?(@.name=='inline_never')].attrs" '["#[attr = Inline(Never)]"]'
+//@ is "$.index[?(@.name=='inline_never')].attrs" '[{"other": "#[attr = Inline(Never)]"}]'
 #[inline(never)]
 pub fn inline_never() {}

--- a/tests/rustdoc-json/attrs/link_section_2021.rs
+++ b/tests/rustdoc-json/attrs/link_section_2021.rs
@@ -1,6 +1,7 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[link_section = \".text\"]"]'
+//@ count "$.index[?(@.name=='example')].attrs[*]" 1
+//@ is "$.index[?(@.name=='example')].attrs[*].link_section" '".text"'
 #[link_section = ".text"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/link_section_2024.rs
+++ b/tests/rustdoc-json/attrs/link_section_2024.rs
@@ -4,6 +4,7 @@
 // Since the 2024 edition the link_section attribute must use the unsafe qualification.
 // However, the unsafe qualification is not shown by rustdoc.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[link_section = \".text\"]"]'
+//@ count "$.index[?(@.name=='example')].attrs[*]" 1
+//@ is "$.index[?(@.name=='example')].attrs[*].link_section" '".text"'
 #[unsafe(link_section = ".text")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/must_use.rs
+++ b/tests/rustdoc-json/attrs/must_use.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[attr = MustUse]"]'
+//@ is "$.index[?(@.name=='example')].attrs[*].must_use.reason" null
 #[must_use]
 pub fn example() -> impl Iterator<Item = i64> {}
 
-//@ is "$.index[?(@.name=='explicit_message')].attrs" '["#[attr = MustUse {reason: \"does nothing if you do not use it\"}]"]'
+//@ is "$.index[?(@.name=='explicit_message')].attrs[*].must_use.reason" '"does nothing if you do not use it"'
 #[must_use = "does nothing if you do not use it"]
 pub fn explicit_message() -> impl Iterator<Item = i64> {}

--- a/tests/rustdoc-json/attrs/no_mangle_2021.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["no_mangle"]'
 #[no_mangle]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/no_mangle_2024.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(no_mangle)]` in rustdoc in edition 2024
 // is still `#[no_mangle]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["no_mangle"]'
 #[unsafe(no_mangle)]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/non_exhaustive.rs
+++ b/tests/rustdoc-json/attrs/non_exhaustive.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]"]'
+//@ is "$.index[?(@.name=='MyEnum')].attrs" '["non_exhaustive"]'
 #[non_exhaustive]
 pub enum MyEnum {
     First,
 }
 
 pub enum NonExhaustiveVariant {
-    //@ is "$.index[?(@.name=='Variant')].attrs" '["#[non_exhaustive]"]'
+    //@ is "$.index[?(@.name=='Variant')].attrs" '["non_exhaustive"]'
     #[non_exhaustive]
     Variant(i64),
 }
 
-//@ is "$.index[?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]"]'
+//@ is "$.index[?(@.name=='MyStruct')].attrs" '["non_exhaustive"]'
 #[non_exhaustive]
 pub struct MyStruct {
     pub x: i64,

--- a/tests/rustdoc-json/attrs/optimize.rs
+++ b/tests/rustdoc-json/attrs/optimize.rs
@@ -1,13 +1,13 @@
 #![feature(optimize_attribute)]
 
-//@ is "$.index[?(@.name=='speed')].attrs" '["#[attr = Optimize(Speed)]"]'
+//@ is "$.index[?(@.name=='speed')].attrs" '[{"other": "#[attr = Optimize(Speed)]"}]'
 #[optimize(speed)]
 pub fn speed() {}
 
-//@ is "$.index[?(@.name=='size')].attrs" '["#[attr = Optimize(Size)]"]'
+//@ is "$.index[?(@.name=='size')].attrs" '[{"other": "#[attr = Optimize(Size)]"}]'
 #[optimize(size)]
 pub fn size() {}
 
-//@ is "$.index[?(@.name=='none')].attrs" '["#[attr = Optimize(DoNotOptimize)]"]'
+//@ is "$.index[?(@.name=='none')].attrs" '[{"other": "#[attr = Optimize(DoNotOptimize)]"}]'
 #[optimize(none)]
 pub fn none() {}

--- a/tests/rustdoc-json/attrs/repr_align.rs
+++ b/tests/rustdoc-json/attrs/repr_align.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='Aligned')].attrs" '["#[repr(align(4))]"]'
+//@ count "$.index[?(@.name=='Aligned')].attrs[*]" 1
+//@ is "$.index[?(@.name=='Aligned')].attrs[*].repr.align" 4
 #[repr(align(4))]
 pub struct Aligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/repr_c.rs
+++ b/tests/rustdoc-json/attrs/repr_c.rs
@@ -1,16 +1,28 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='ReprCStruct')].attrs" '["#[repr(C)]"]'
+//@ count "$.index[?(@.name=='ReprCStruct')].attrs" 1
+//@ is "$.index[?(@.name=='ReprCStruct')].attrs[*].repr.kind" '"c"'
+//@ is "$.index[?(@.name=='ReprCStruct')].attrs[*].repr.int" null
+//@ is "$.index[?(@.name=='ReprCStruct')].attrs[*].repr.packed" null
+//@ is "$.index[?(@.name=='ReprCStruct')].attrs[*].repr.align" null
 #[repr(C)]
 pub struct ReprCStruct(pub i64);
 
-//@ is "$.index[?(@.name=='ReprCEnum')].attrs" '["#[repr(C)]"]'
+//@ count "$.index[?(@.name=='ReprCEnum')].attrs" 1
+//@ is "$.index[?(@.name=='ReprCEnum')].attrs[*].repr.kind" '"c"'
+//@ is "$.index[?(@.name=='ReprCEnum')].attrs[*].repr.int" null
+//@ is "$.index[?(@.name=='ReprCEnum')].attrs[*].repr.packed" null
+//@ is "$.index[?(@.name=='ReprCEnum')].attrs[*].repr.align" null
 #[repr(C)]
 pub enum ReprCEnum {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCUnion')].attrs" '["#[repr(C)]"]'
+//@ count "$.index[?(@.name=='ReprCUnion')].attrs" 1
+//@ is "$.index[?(@.name=='ReprCUnion')].attrs[*].repr.kind" '"c"'
+//@ is "$.index[?(@.name=='ReprCUnion')].attrs[*].repr.int" null
+//@ is "$.index[?(@.name=='ReprCUnion')].attrs[*].repr.packed" null
+//@ is "$.index[?(@.name=='ReprCUnion')].attrs[*].repr.align" null
 #[repr(C)]
 pub union ReprCUnion {
     pub left: i64,

--- a/tests/rustdoc-json/attrs/repr_c_int_enum.rs
+++ b/tests/rustdoc-json/attrs/repr_c_int_enum.rs
@@ -1,0 +1,11 @@
+//@ count "$.index[?(@.name=='Foo')].attrs" 1
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.kind" '"c"'
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.int" '"u8"'
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.packed" null
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.align" 16
+#[repr(C, u8)]
+#[repr(align(16))]
+pub enum Foo {
+    A(bool) = b'A',
+    B(char) = b'C',
+}

--- a/tests/rustdoc-json/attrs/repr_combination.rs
+++ b/tests/rustdoc-json/attrs/repr_combination.rs
@@ -1,35 +1,34 @@
 #![no_std]
 
 // Combinations of `#[repr(..)]` attributes.
-// Rustdoc JSON emits normalized output, regardless of the original source.
 
-//@ is "$.index[?(@.name=='ReprCI8')].attrs" '["#[repr(C, i8)]"]'
+//@ is "$.index[?(@.name=='ReprCI8')].attrs" '[{"repr":{"align":null,"int":"i8","kind":"c","packed":null}}]'
 #[repr(C, i8)]
 pub enum ReprCI8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCI16')].attrs" '["#[repr(C, i16)]"]'
+//@ is "$.index[?(@.name=='SeparateReprCI16')].attrs" '[{"repr":{"align":null,"int":"i16","kind":"c","packed":null}}]'
 #[repr(C)]
 #[repr(i16)]
 pub enum SeparateReprCI16 {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCUsize')].attrs" '["#[repr(C, usize)]"]'
+//@ is "$.index[?(@.name=='ReversedReprCUsize')].attrs" '[{"repr":{"align":null,"int":"usize","kind":"c","packed":null}}]'
 #[repr(usize, C)]
 pub enum ReversedReprCUsize {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCPacked')].attrs" '["#[repr(C, packed(1))]"]'
+//@ is "$.index[?(@.name=='ReprCPacked')].attrs" '[{"repr":{"align":null,"int":null,"kind":"c","packed":1}}]'
 #[repr(C, packed)]
 pub struct ReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ is "$.index[?(@.name=='SeparateReprCPacked')].attrs" '[{"repr":{"align":null,"int":null,"kind":"c","packed":2}}]'
 #[repr(C)]
 #[repr(packed(2))]
 pub struct SeparateReprCPacked {
@@ -37,21 +36,21 @@ pub struct SeparateReprCPacked {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ is "$.index[?(@.name=='ReversedReprCPacked')].attrs" '[{"repr":{"align":null,"int":null,"kind":"c","packed":2}}]'
 #[repr(packed(2), C)]
 pub struct ReversedReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReprCAlign')].attrs" '["#[repr(C, align(16))]"]'
+//@ is "$.index[?(@.name=='ReprCAlign')].attrs" '[{"repr":{"align":16,"int":null,"kind":"c","packed":null}}]'
 #[repr(C, align(16))]
 pub struct ReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ is "$.index[?(@.name=='SeparateReprCAlign')].attrs" '[{"repr":{"align":2,"int":null,"kind":"c","packed":null}}]'
 #[repr(C)]
 #[repr(align(2))]
 pub struct SeparateReprCAlign {
@@ -59,25 +58,25 @@ pub struct SeparateReprCAlign {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ is "$.index[?(@.name=='ReversedReprCAlign')].attrs" '[{"repr":{"align":2,"int":null,"kind":"c","packed":null}}]'
 #[repr(align(2), C)]
 pub struct ReversedReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='AlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ is "$.index[?(@.name=='AlignedExplicitRepr')].attrs" '[{"repr":{"align":16,"int":"isize","kind":"c","packed":null}}]'
 #[repr(C, align(16), isize)]
 pub enum AlignedExplicitRepr {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ is "$.index[?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '[{"repr":{"align":16,"int":"isize","kind":"c","packed":null}}]'
 #[repr(isize, C, align(16))]
 pub enum ReorderedAlignedExplicitRepr {
     First,
 }
 
-//@ is "$.index[?(@.name=='Transparent')].attrs" '["#[repr(transparent)]"]'
+//@ is "$.index[?(@.name=='Transparent')].attrs" '[{"repr":{"align":null,"int":null,"kind":"transparent","packed":null}}]'
 #[repr(transparent)]
 pub struct Transparent(i64);

--- a/tests/rustdoc-json/attrs/repr_int_enum.rs
+++ b/tests/rustdoc-json/attrs/repr_int_enum.rs
@@ -1,18 +1,27 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='I8')].attrs" '["#[repr(i8)]"]'
+//@ is "$.index[?(@.name=='I8')].attrs[*].repr.int" '"i8"'
+//@ is "$.index[?(@.name=='I8')].attrs[*].repr.kind" '"rust"'
+//@ is "$.index[?(@.name=='I8')].attrs[*].repr.align" null
+//@ is "$.index[?(@.name=='I8')].attrs[*].repr.packed" null
 #[repr(i8)]
 pub enum I8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='I32')].attrs" '["#[repr(i32)]"]'
+//@ is "$.index[?(@.name=='I32')].attrs[*].repr.int" '"i32"'
+//@ is "$.index[?(@.name=='I32')].attrs[*].repr.kind" '"rust"'
+//@ is "$.index[?(@.name=='I32')].attrs[*].repr.align" null
+//@ is "$.index[?(@.name=='I32')].attrs[*].repr.packed" null
 #[repr(i32)]
 pub enum I32 {
     First,
 }
 
-//@ is "$.index[?(@.name=='Usize')].attrs" '["#[repr(usize)]"]'
+//@ is "$.index[?(@.name=='Usize')].attrs[*].repr.int" '"usize"'
+//@ is "$.index[?(@.name=='Usize')].attrs[*].repr.kind" '"rust"'
+//@ is "$.index[?(@.name=='Usize')].attrs[*].repr.align" null
+//@ is "$.index[?(@.name=='Usize')].attrs[*].repr.packed" null
 #[repr(usize)]
 pub enum Usize {
     First,

--- a/tests/rustdoc-json/attrs/repr_packed.rs
+++ b/tests/rustdoc-json/attrs/repr_packed.rs
@@ -1,16 +1,18 @@
 #![no_std]
 
 // Note the normalization:
-// `#[repr(packed)]` in source becomes `#[repr(packed(1))]` in rustdoc JSON.
+// `#[repr(packed)]` in source becomes `{"repr": {"packed": 1, ...}}` in rustdoc JSON.
 //
-//@ is "$.index[?(@.name=='Packed')].attrs" '["#[repr(packed(1))]"]'
+//@ is "$.index[?(@.name=='Packed')].attrs[*].repr.packed" 1
+//@ is "$.index[?(@.name=='Packed')].attrs[*].repr.kind" '"rust"'
 #[repr(packed)]
 pub struct Packed {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='PackedAligned')].attrs" '["#[repr(packed(4))]"]'
+//@ is "$.index[?(@.name=='PackedAligned')].attrs[*].repr.packed" 4
+//@ is "$.index[?(@.name=='PackedAligned')].attrs[*].repr.kind" '"rust"'
 #[repr(packed(4))]
 pub struct PackedAligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/target_feature.rs
+++ b/tests/rustdoc-json/attrs/target_feature.rs
@@ -1,38 +1,49 @@
-//@ is "$.index[?(@.name=='test1')].attrs" '["#[target_feature(enable=\"avx\")]"]'
 //@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ count "$.index[?(@.name=='test1')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test1')].attrs[*].target_feature.enable" '["avx"]'
 #[target_feature(enable = "avx")]
 pub fn test1() {}
 
-//@ is "$.index[?(@.name=='test2')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
 //@ is "$.index[?(@.name=='test2')].inner.function.header.is_unsafe" false
+//@ count "$.index[?(@.name=='test2')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test2')].attrs[*].target_feature.enable" '["avx", "avx2"]'
 #[target_feature(enable = "avx,avx2")]
 pub fn test2() {}
 
-//@ is "$.index[?(@.name=='test3')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
 //@ is "$.index[?(@.name=='test3')].inner.function.header.is_unsafe" false
+//@ count "$.index[?(@.name=='test3')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test3')].attrs[*].target_feature.enable" '["avx", "avx2"]'
 #[target_feature(enable = "avx", enable = "avx2")]
 pub fn test3() {}
 
-//@ is "$.index[?(@.name=='test4')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\", enable=\"avx512f\")]"]'
 //@ is "$.index[?(@.name=='test4')].inner.function.header.is_unsafe" false
+//@ count "$.index[?(@.name=='test4')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test4')].attrs[*].target_feature.enable" '["avx", "avx2", "avx512f"]'
 #[target_feature(enable = "avx", enable = "avx2,avx512f")]
 pub fn test4() {}
 
-//@ is "$.index[?(@.name=='test_unsafe_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
+//@ count "$.index[?(@.name=='test5')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test5')].attrs[*].target_feature.enable" '["avx", "avx2"]'
+#[target_feature(enable = "avx")]
+#[target_feature(enable = "avx2")]
+pub fn test5() {}
+
 //@ is "$.index[?(@.name=='test_unsafe_fn')].inner.function.header.is_unsafe" true
+//@ count "$.index[?(@.name=='test_unsafe_fn')].attrs[*]" 1
+//@ is    "$.index[?(@.name=='test_unsafe_fn')].attrs[*].target_feature.enable" '["avx"]'
 #[target_feature(enable = "avx")]
 pub unsafe fn test_unsafe_fn() {}
 
 pub struct Example;
 
 impl Example {
-    //@ is "$.index[?(@.name=='safe_assoc_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
     //@ is "$.index[?(@.name=='safe_assoc_fn')].inner.function.header.is_unsafe" false
+    //@ is "$.index[?(@.name=='safe_assoc_fn')].attrs[*].target_feature.enable" '["avx"]'
     #[target_feature(enable = "avx")]
     pub fn safe_assoc_fn() {}
 
-    //@ is "$.index[?(@.name=='unsafe_assoc_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
     //@ is "$.index[?(@.name=='unsafe_assoc_fn')].inner.function.header.is_unsafe" true
+    //@ is "$.index[?(@.name=='unsafe_assoc_fn')].attrs[*].target_feature.enable" '["avx"]'
     #[target_feature(enable = "avx")]
     pub unsafe fn unsafe_assoc_fn() {}
 }

--- a/tests/rustdoc-json/enums/discriminant/struct.rs
+++ b/tests/rustdoc-json/enums/discriminant/struct.rs
@@ -1,5 +1,5 @@
 #[repr(i32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(i32)]"]'
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.int" '"i32"'
 pub enum Foo {
     //@ is    "$.index[?(@.name=='Struct')].inner.variant.discriminant" null
     //@ count "$.index[?(@.name=='Struct')].inner.variant.kind.struct.fields[*]" 0

--- a/tests/rustdoc-json/enums/discriminant/tuple.rs
+++ b/tests/rustdoc-json/enums/discriminant/tuple.rs
@@ -1,5 +1,5 @@
 #[repr(u32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(u32)]"]'
+//@ is "$.index[?(@.name=='Foo')].attrs[*].repr.int" '"u32"'
 pub enum Foo {
     //@ is    "$.index[?(@.name=='Tuple')].inner.variant.discriminant" null
     //@ count "$.index[?(@.name=='Tuple')].inner.variant.kind.tuple[*]" 0

--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -5,7 +5,7 @@
 
 //@ !has "$.index[?(@.name=='match')]"
 //@ has  "$.index[?(@.name=='foo')]"
-//@ is   "$.index[?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
+//@ is   "$.index[?(@.name=='foo')].attrs[*].other" '"#[doc(keyword = \"match\")]"'
 //@ is   "$.index[?(@.name=='foo')].docs" '"this is a test!"'
 #[doc(keyword = "match")]
 /// this is a test!
@@ -13,7 +13,7 @@ pub mod foo {}
 
 //@ !has "$.index[?(@.name=='break')]"
 //@ has "$.index[?(@.name=='bar')]"
-//@ is   "$.index[?(@.name=='bar')].attrs" '["#[doc(keyword = \"break\")]"]'
+//@ is   "$.index[?(@.name=='bar')].attrs[*].other" '"#[doc(keyword = \"break\")]"'
 //@ is   "$.index[?(@.name=='bar')].docs" '"hello"'
 #[doc(keyword = "break")]
 /// hello

--- a/tests/rustdoc-json/visibility/doc_hidden_documented.rs
+++ b/tests/rustdoc-json/visibility/doc_hidden_documented.rs
@@ -1,15 +1,15 @@
 //@ compile-flags: --document-hidden-items
 #![no_std]
 
-//@ is "$.index[?(@.name=='func')].attrs" '["#[doc(hidden)]"]'
+//@ is "$.index[?(@.name=='func')].attrs" '[{"other": "#[doc(hidden)]"}]'
 #[doc(hidden)]
 pub fn func() {}
 
-//@ is "$.index[?(@.name=='Unit')].attrs" '["#[doc(hidden)]"]'
+//@ is "$.index[?(@.name=='Unit')].attrs" '[{"other": "#[doc(hidden)]"}]'
 #[doc(hidden)]
 pub struct Unit;
 
-//@ is "$.index[?(@.name=='hidden')].attrs" '["#[doc(hidden)]"]'
+//@ is "$.index[?(@.name=='hidden')].attrs" '[{"other": "#[doc(hidden)]"}]'
 #[doc(hidden)]
 pub mod hidden {
     //@ is "$.index[?(@.name=='Inner')].attrs" '[]'


### PR DESCRIPTION
Implements and closes rust-lang/rust#141358.

This has 2 primary benefits.

1. For rustdoc-json consumers, they no longer need to parse strings of attributes, but it's there in a structured and normalized way. CC @obi1kenobi 
2. For rustc conributors, the output of HIR pretty printing is no longer a versioned thing in the output. People can work on rust-lang/rust#131229 without needing to bump `FORMAT_VERSION`. CC @jdonszelmann @JonathanBrouwer.

(Over time, as the attribute refractor continues, I expect we'll add new things to `rustdoc_json_types::Attribute`. But this can be done separately to the rustc changes).

Todo before being mergable:
- [x] Update test assertions.
- [x] Fix modeling of `#[repr]`.
- [ ] ~~Add tests of `#[doc(hidden)]` in `Item::attrs` (probably in a seperate PR).~~ I'm gonna punt this to a future PR
- [x] Documentation.