### PR TITLE
[WIP] Normalize rust version string centrally in compiletest

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1639,6 +1639,8 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
 
         let mut cmd = builder.tool_cmd(Tool::Compiletest);
 
+        cmd.arg("--rust-version").arg(builder.rust_version());
+
         if suite == "mir-opt" {
             builder.ensure(compile::Std::new(compiler, target).is_for_mir_opt_tests(true));
         } else {

--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -107,6 +107,8 @@ platforms, mainly about filenames.
 
 Compiletest makes the following replacements on the compiler output:
 
+- The rust version string (e.g. `1.89.0-beta.1 (88b80702e 2025-06-23)`) is
+  replaced with `$RUST_VERSION`.
 - The directory where the test is defined is replaced with `$DIR`. Example:
   `/path/to/rust/tests/ui/error-codes`
 - The directory to the standard library source is replaced with `$SRC_DIR`.

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -181,6 +181,9 @@ pub struct Config {
     /// May run a few more tests before stopping, due to threading.
     pub fail_fast: bool,
 
+    /// E.g. `1.89.0-beta.1 (88b80702e 2025-06-23)`, used for UI normalizations.
+    pub rust_version: String,
+
     /// The library paths required for running the compiler.
     pub compile_lib_path: Utf8PathBuf,
 

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -150,6 +150,7 @@ impl ConfigBuilder {
             "--mode",
             self.mode.as_deref().unwrap_or("ui"),
             "--suite=ui",
+            "--rust-version=DUMMY_VERSION_STRING",
             "--compile-lib-path=",
             "--run-lib-path=",
             "--python=",

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -58,157 +58,144 @@ pub fn parse_config(args: Vec<String>) -> Config {
     }
 
     let mut opts = Options::new();
-    opts.reqopt("", "compile-lib-path", "path to host shared libraries", "PATH")
-        .reqopt("", "run-lib-path", "path to target shared libraries", "PATH")
-        .reqopt("", "rustc-path", "path to rustc to use for compiling", "PATH")
-        .optopt("", "cargo-path", "path to cargo to use for compiling", "PATH")
-        .optopt(
-            "",
-            "stage0-rustc-path",
-            "path to rustc to use for compiling run-make recipes",
-            "PATH",
-        )
-        .optopt("", "rustdoc-path", "path to rustdoc to use for compiling", "PATH")
-        .optopt("", "coverage-dump-path", "path to coverage-dump to use in tests", "PATH")
-        .reqopt("", "python", "path to python to use for doc tests", "PATH")
-        .optopt("", "jsondocck-path", "path to jsondocck to use for doc tests", "PATH")
-        .optopt("", "jsondoclint-path", "path to jsondoclint to use for doc tests", "PATH")
-        .optopt("", "run-clang-based-tests-with", "path to Clang executable", "PATH")
-        .optopt("", "llvm-filecheck", "path to LLVM's FileCheck binary", "DIR")
-        .reqopt("", "src-root", "directory containing sources", "PATH")
-        .reqopt("", "src-test-suite-root", "directory containing test suite sources", "PATH")
-        .reqopt("", "build-root", "path to root build directory", "PATH")
-        .reqopt("", "build-test-suite-root", "path to test suite specific build directory", "PATH")
-        .reqopt("", "sysroot-base", "directory containing the compiler sysroot", "PATH")
-        .reqopt("", "stage", "stage number under test", "N")
-        .reqopt("", "stage-id", "the target-stage identifier", "stageN-TARGET")
-        .reqopt(
-            "",
-            "mode",
-            "which sort of compile tests to run",
-            "pretty | debug-info | codegen | rustdoc \
+    opts.reqopt(
+        "",
+        "rust-version",
+        "rust version info (e.g. `1.89.0-beta.1 (88b80702e 2025-06-23)`)",
+        "VERSION STRING",
+    )
+    .reqopt("", "compile-lib-path", "path to host shared libraries", "PATH")
+    .reqopt("", "run-lib-path", "path to target shared libraries", "PATH")
+    .reqopt("", "rustc-path", "path to rustc to use for compiling", "PATH")
+    .optopt("", "cargo-path", "path to cargo to use for compiling", "PATH")
+    .optopt("", "stage0-rustc-path", "path to rustc to use for compiling run-make recipes", "PATH")
+    .optopt("", "rustdoc-path", "path to rustdoc to use for compiling", "PATH")
+    .optopt("", "coverage-dump-path", "path to coverage-dump to use in tests", "PATH")
+    .reqopt("", "python", "path to python to use for doc tests", "PATH")
+    .optopt("", "jsondocck-path", "path to jsondocck to use for doc tests", "PATH")
+    .optopt("", "jsondoclint-path", "path to jsondoclint to use for doc tests", "PATH")
+    .optopt("", "run-clang-based-tests-with", "path to Clang executable", "PATH")
+    .optopt("", "llvm-filecheck", "path to LLVM's FileCheck binary", "DIR")
+    .reqopt("", "src-root", "directory containing sources", "PATH")
+    .reqopt("", "src-test-suite-root", "directory containing test suite sources", "PATH")
+    .reqopt("", "build-root", "path to root build directory", "PATH")
+    .reqopt("", "build-test-suite-root", "path to test suite specific build directory", "PATH")
+    .reqopt("", "sysroot-base", "directory containing the compiler sysroot", "PATH")
+    .reqopt("", "stage", "stage number under test", "N")
+    .reqopt("", "stage-id", "the target-stage identifier", "stageN-TARGET")
+    .reqopt(
+        "",
+        "mode",
+        "which sort of compile tests to run",
+        "pretty | debug-info | codegen | rustdoc \
             | rustdoc-json | codegen-units | incremental | run-make | ui \
             | rustdoc-js | mir-opt | assembly | crashes",
-        )
-        .reqopt(
-            "",
-            "suite",
-            "which suite of compile tests to run. used for nicer error reporting.",
-            "SUITE",
-        )
-        .optopt(
-            "",
-            "pass",
-            "force {check,build,run}-pass tests to this mode.",
-            "check | build | run",
-        )
-        .optopt("", "run", "whether to execute run-* tests", "auto | always | never")
-        .optflag("", "ignored", "run tests marked as ignored")
-        .optflag("", "has-enzyme", "run tests that require enzyme")
-        .optflag("", "with-rustc-debug-assertions", "whether rustc was built with debug assertions")
-        .optflag("", "with-std-debug-assertions", "whether std was built with debug assertions")
-        .optmulti(
-            "",
-            "skip",
-            "skip tests matching SUBSTRING. Can be passed multiple times",
-            "SUBSTRING",
-        )
-        .optflag("", "exact", "filters match exactly")
-        .optopt(
-            "",
-            "runner",
-            "supervisor program to run tests under \
+    )
+    .reqopt(
+        "",
+        "suite",
+        "which suite of compile tests to run. used for nicer error reporting.",
+        "SUITE",
+    )
+    .optopt("", "pass", "force {check,build,run}-pass tests to this mode.", "check | build | run")
+    .optopt("", "run", "whether to execute run-* tests", "auto | always | never")
+    .optflag("", "ignored", "run tests marked as ignored")
+    .optflag("", "has-enzyme", "run tests that require enzyme")
+    .optflag("", "with-rustc-debug-assertions", "whether rustc was built with debug assertions")
+    .optflag("", "with-std-debug-assertions", "whether std was built with debug assertions")
+    .optmulti(
+        "",
+        "skip",
+        "skip tests matching SUBSTRING. Can be passed multiple times",
+        "SUBSTRING",
+    )
+    .optflag("", "exact", "filters match exactly")
+    .optopt(
+        "",
+        "runner",
+        "supervisor program to run tests under \
              (eg. emulator, valgrind)",
-            "PROGRAM",
-        )
-        .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
-        .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
-        .optflag(
-            "",
-            "rust-randomized-layout",
-            "set this when rustc/stdlib were compiled with randomized layouts",
-        )
-        .optflag("", "optimize-tests", "run tests with optimizations enabled")
-        .optflag("", "verbose", "run tests verbosely, showing all output")
-        .optflag(
-            "",
-            "bless",
-            "overwrite stderr/stdout files instead of complaining about a mismatch",
-        )
-        .optflag("", "fail-fast", "stop as soon as possible after any test fails")
-        .optflag("", "quiet", "print one character per test instead of one line")
-        .optopt("", "color", "coloring: auto, always, never", "WHEN")
-        .optflag("", "json", "emit json output instead of plaintext output")
-        .optopt("", "target", "the target to build for", "TARGET")
-        .optopt("", "host", "the host to build for", "HOST")
-        .optopt("", "cdb", "path to CDB to use for CDB debuginfo tests", "PATH")
-        .optopt("", "gdb", "path to GDB to use for GDB debuginfo tests", "PATH")
-        .optopt("", "lldb-version", "the version of LLDB used", "VERSION STRING")
-        .optopt("", "llvm-version", "the version of LLVM used", "VERSION STRING")
-        .optflag("", "system-llvm", "is LLVM the system LLVM")
-        .optopt("", "android-cross-path", "Android NDK standalone path", "PATH")
-        .optopt("", "adb-path", "path to the android debugger", "PATH")
-        .optopt("", "adb-test-dir", "path to tests for the android debugger", "PATH")
-        .optopt("", "lldb-python-dir", "directory containing LLDB's python module", "PATH")
-        .reqopt("", "cc", "path to a C compiler", "PATH")
-        .reqopt("", "cxx", "path to a C++ compiler", "PATH")
-        .reqopt("", "cflags", "flags for the C compiler", "FLAGS")
-        .reqopt("", "cxxflags", "flags for the CXX compiler", "FLAGS")
-        .optopt("", "ar", "path to an archiver", "PATH")
-        .optopt("", "target-linker", "path to a linker for the target", "PATH")
-        .optopt("", "host-linker", "path to a linker for the host", "PATH")
-        .reqopt("", "llvm-components", "list of LLVM components built in", "LIST")
-        .optopt("", "llvm-bin-dir", "Path to LLVM's `bin` directory", "PATH")
-        .optopt("", "nodejs", "the name of nodejs", "PATH")
-        .optopt("", "npm", "the name of npm", "PATH")
-        .optopt("", "remote-test-client", "path to the remote test client", "PATH")
-        .optopt(
-            "",
-            "compare-mode",
-            "mode describing what file the actual ui output will be compared to",
-            "COMPARE MODE",
-        )
-        .optflag(
-            "",
-            "rustfix-coverage",
-            "enable this to generate a Rustfix coverage file, which is saved in \
+        "PROGRAM",
+    )
+    .optmulti("", "host-rustcflags", "flags to pass to rustc for host", "FLAGS")
+    .optmulti("", "target-rustcflags", "flags to pass to rustc for target", "FLAGS")
+    .optflag(
+        "",
+        "rust-randomized-layout",
+        "set this when rustc/stdlib were compiled with randomized layouts",
+    )
+    .optflag("", "optimize-tests", "run tests with optimizations enabled")
+    .optflag("", "verbose", "run tests verbosely, showing all output")
+    .optflag("", "bless", "overwrite stderr/stdout files instead of complaining about a mismatch")
+    .optflag("", "fail-fast", "stop as soon as possible after any test fails")
+    .optflag("", "quiet", "print one character per test instead of one line")
+    .optopt("", "color", "coloring: auto, always, never", "WHEN")
+    .optflag("", "json", "emit json output instead of plaintext output")
+    .optopt("", "target", "the target to build for", "TARGET")
+    .optopt("", "host", "the host to build for", "HOST")
+    .optopt("", "cdb", "path to CDB to use for CDB debuginfo tests", "PATH")
+    .optopt("", "gdb", "path to GDB to use for GDB debuginfo tests", "PATH")
+    .optopt("", "lldb-version", "the version of LLDB used", "VERSION STRING")
+    .optopt("", "llvm-version", "the version of LLVM used", "VERSION STRING")
+    .optflag("", "system-llvm", "is LLVM the system LLVM")
+    .optopt("", "android-cross-path", "Android NDK standalone path", "PATH")
+    .optopt("", "adb-path", "path to the android debugger", "PATH")
+    .optopt("", "adb-test-dir", "path to tests for the android debugger", "PATH")
+    .optopt("", "lldb-python-dir", "directory containing LLDB's python module", "PATH")
+    .reqopt("", "cc", "path to a C compiler", "PATH")
+    .reqopt("", "cxx", "path to a C++ compiler", "PATH")
+    .reqopt("", "cflags", "flags for the C compiler", "FLAGS")
+    .reqopt("", "cxxflags", "flags for the CXX compiler", "FLAGS")
+    .optopt("", "ar", "path to an archiver", "PATH")
+    .optopt("", "target-linker", "path to a linker for the target", "PATH")
+    .optopt("", "host-linker", "path to a linker for the host", "PATH")
+    .reqopt("", "llvm-components", "list of LLVM components built in", "LIST")
+    .optopt("", "llvm-bin-dir", "Path to LLVM's `bin` directory", "PATH")
+    .optopt("", "nodejs", "the name of nodejs", "PATH")
+    .optopt("", "npm", "the name of npm", "PATH")
+    .optopt("", "remote-test-client", "path to the remote test client", "PATH")
+    .optopt(
+        "",
+        "compare-mode",
+        "mode describing what file the actual ui output will be compared to",
+        "COMPARE MODE",
+    )
+    .optflag(
+        "",
+        "rustfix-coverage",
+        "enable this to generate a Rustfix coverage file, which is saved in \
             `./<build_test_suite_root>/rustfix_missing_coverage.txt`",
-        )
-        .optflag("", "force-rerun", "rerun tests even if the inputs are unchanged")
-        .optflag("", "only-modified", "only run tests that result been modified")
-        // FIXME: Temporarily retained so we can point users to `--no-capture`
-        .optflag("", "nocapture", "")
-        .optflag("", "no-capture", "don't capture stdout/stderr of tests")
-        .optflag("", "profiler-runtime", "is the profiler runtime enabled for this target")
-        .optflag("h", "help", "show this message")
-        .reqopt("", "channel", "current Rust channel", "CHANNEL")
-        .optflag(
-            "",
-            "git-hash",
-            "run tests which rely on commit version being compiled into the binaries",
-        )
-        .optopt("", "edition", "default Rust edition", "EDITION")
-        .reqopt("", "nightly-branch", "name of the git branch for nightly", "BRANCH")
-        .reqopt(
-            "",
-            "git-merge-commit-email",
-            "email address used for finding merge commits",
-            "EMAIL",
-        )
-        .optopt(
-            "",
-            "compiletest-diff-tool",
-            "What custom diff tool to use for displaying compiletest tests.",
-            "COMMAND",
-        )
-        .reqopt("", "minicore-path", "path to minicore aux library", "PATH")
-        .optflag("N", "no-new-executor", "disables the new test executor, and uses libtest instead")
-        .optopt(
-            "",
-            "debugger",
-            "only test a specific debugger in debuginfo tests",
-            "gdb | lldb | cdb",
-        );
+    )
+    .optflag("", "force-rerun", "rerun tests even if the inputs are unchanged")
+    .optflag("", "only-modified", "only run tests that result been modified")
+    // FIXME: Temporarily retained so we can point users to `--no-capture`
+    .optflag("", "nocapture", "")
+    .optflag("", "no-capture", "don't capture stdout/stderr of tests")
+    .optflag("", "profiler-runtime", "is the profiler runtime enabled for this target")
+    .optflag("h", "help", "show this message")
+    .reqopt("", "channel", "current Rust channel", "CHANNEL")
+    .optflag(
+        "",
+        "git-hash",
+        "run tests which rely on commit version being compiled into the binaries",
+    )
+    .optopt("", "edition", "default Rust edition", "EDITION")
+    .reqopt("", "nightly-branch", "name of the git branch for nightly", "BRANCH")
+    .reqopt("", "git-merge-commit-email", "email address used for finding merge commits", "EMAIL")
+    .optopt(
+        "",
+        "compiletest-diff-tool",
+        "What custom diff tool to use for displaying compiletest tests.",
+        "COMMAND",
+    )
+    .reqopt("", "minicore-path", "path to minicore aux library", "PATH")
+    .optflag("N", "no-new-executor", "disables the new test executor, and uses libtest instead")
+    .optopt(
+        "",
+        "debugger",
+        "only test a specific debugger in debuginfo tests",
+        "gdb | lldb | cdb",
+    );
 
     let (argv0, args_) = args.split_first().unwrap();
     if args.len() == 1 || args[1] == "-h" || args[1] == "--help" {
@@ -245,6 +232,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         }
     }
 
+    let rust_version = opt_str2(matches.opt_str("rust-version"));
     let target = opt_str2(matches.opt_str("target"));
     let android_cross_path = opt_path(matches, "android-cross-path");
     let (cdb, cdb_version) = debuggers::analyze_cdb(matches.opt_str("cdb"), &target);
@@ -333,6 +321,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         fail_fast: matches.opt_present("fail-fast")
             || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
 
+        rust_version,
         compile_lib_path: make_absolute(opt_path(matches, "compile-lib-path")),
         run_lib_path: make_absolute(opt_path(matches, "run-lib-path")),
         rustc_path: opt_path(matches, "rustc-path"),
@@ -453,6 +442,8 @@ pub fn parse_config(args: Vec<String>) -> Config {
 pub fn log_config(config: &Config) {
     let c = config;
     logv(c, "configuration:".to_string());
+
+    logv(c, format!("rust_version: {}", config.rust_version));
     logv(c, format!("compile_lib_path: {}", config.compile_lib_path));
     logv(c, format!("run_lib_path: {}", config.run_lib_path));
     logv(c, format!("rustc_path: {}", config.rustc_path));

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2485,6 +2485,10 @@ impl<'test> TestCx<'test> {
                 .into_owned();
         }
 
+        // Normalize out rustc version info strings that may be present in the output (usually for
+        // deprecated since diagnostics).
+        normalized = normalized.replace(&self.config.rust_version, "$RUST_VERSION");
+
         // Custom normalization rules
         for rule in custom_rules {
             let re = Regex::new(&rule.0).expect("bad regex in custom normalization rule");

--- a/tests/ui/deprecation/deprecated_no_stack_check.rs
+++ b/tests/ui/deprecation/deprecated_no_stack_check.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![deny(warnings)]
 #![feature(no_stack_check)]

--- a/tests/ui/deprecation/deprecated_no_stack_check.rs
+++ b/tests/ui/deprecation/deprecated_no_stack_check.rs
@@ -1,5 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
-
 #![deny(warnings)]
 #![feature(no_stack_check)]
 //~^ ERROR: feature has been removed [E0557]

--- a/tests/ui/deprecation/deprecated_no_stack_check.stderr
+++ b/tests/ui/deprecation/deprecated_no_stack_check.stderr
@@ -1,10 +1,10 @@
 error[E0557]: feature has been removed
-  --> $DIR/deprecated_no_stack_check.rs:4:12
+  --> $DIR/deprecated_no_stack_check.rs:2:12
    |
 LL | #![feature(no_stack_check)]
    |            ^^^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.0.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/40110> for more information
+   = note: removed in 1.0.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/40110> for more information
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![crate_type = "lib"]
 #![feature(no_coverage)] //~ ERROR feature has been removed [E0557]

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.rs
@@ -1,5 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
-
 #![crate_type = "lib"]
 #![feature(no_coverage)] //~ ERROR feature has been removed [E0557]
 

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
@@ -1,14 +1,14 @@
 error[E0557]: feature has been removed
-  --> $DIR/feature-gate-coverage-attribute.rs:4:12
+  --> $DIR/feature-gate-coverage-attribute.rs:2:12
    |
 LL | #![feature(no_coverage)]
    |            ^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.74.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/114656> for more information
+   = note: removed in 1.74.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/114656> for more information
    = note: renamed to `coverage_attribute`
 
 error[E0658]: the `#[coverage]` attribute is an experimental feature
-  --> $DIR/feature-gate-coverage-attribute.rs:12:1
+  --> $DIR/feature-gate-coverage-attribute.rs:10:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/gated-bad-feature.rs
+++ b/tests/ui/feature-gates/gated-bad-feature.rs
@@ -1,4 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
 //~^ ERROR malformed `feature`
 //~| ERROR malformed `feature`

--- a/tests/ui/feature-gates/gated-bad-feature.rs
+++ b/tests/ui/feature-gates/gated-bad-feature.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
 //~^ ERROR malformed `feature`
 //~| ERROR malformed `feature`

--- a/tests/ui/feature-gates/gated-bad-feature.stderr
+++ b/tests/ui/feature-gates/gated-bad-feature.stderr
@@ -1,43 +1,43 @@
 error[E0556]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:2:25
+  --> $DIR/gated-bad-feature.rs:1:25
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    |                         ^^^^^^^^ help: expected just one word: `foo`
 
 error[E0556]: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:2:35
+  --> $DIR/gated-bad-feature.rs:1:35
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    |                                   ^^^^^^^^^^^ help: expected just one word: `foo`
 
 error[E0557]: feature has been removed
-  --> $DIR/gated-bad-feature.rs:9:12
+  --> $DIR/gated-bad-feature.rs:8:12
    |
 LL | #![feature(test_removed_feature)]
    |            ^^^^^^^^^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.0.0 (you are using $RUSTC_VERSION)
+   = note: removed in 1.0.0 (you are using $RUST_VERSION)
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:7:1
+  --> $DIR/gated-bad-feature.rs:6:1
    |
 LL | #![feature]
    | ^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name2, ...)]`
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:8:1
+  --> $DIR/gated-bad-feature.rs:7:1
    |
 LL | #![feature = "foo"]
    | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name2, ...)]`
 
 error[E0635]: unknown feature `foo_bar_baz`
-  --> $DIR/gated-bad-feature.rs:2:12
+  --> $DIR/gated-bad-feature.rs:1:12
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    |            ^^^^^^^^^^^
 
 error[E0635]: unknown feature `foo`
-  --> $DIR/gated-bad-feature.rs:2:48
+  --> $DIR/gated-bad-feature.rs:1:48
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
    |                                                ^^^

--- a/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
+++ b/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
@@ -1,5 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
-
 #![feature(external_doc)] //~ ERROR feature has been removed
 #![doc(include("README.md"))] //~ ERROR unknown `doc` attribute `include`
 

--- a/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
+++ b/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(external_doc)] //~ ERROR feature has been removed
 #![doc(include("README.md"))] //~ ERROR unknown `doc` attribute `include`

--- a/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.stderr
+++ b/tests/ui/feature-gates/removed-features-note-version-and-pr-issue-141619.stderr
@@ -1,14 +1,14 @@
 error[E0557]: feature has been removed
-  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:3:12
+  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:1:12
    |
 LL | #![feature(external_doc)]
    |            ^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.54.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/85457> for more information
+   = note: removed in 1.54.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/85457> for more information
    = note: use #[doc = include_str!("filename")] instead, which handles macro invocations
 
 error: unknown `doc` attribute `include`
-  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:4:8
+  --> $DIR/removed-features-note-version-and-pr-issue-141619.rs:2:8
    |
 LL | #![doc(include("README.md"))]
    |        ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/macro-reexport-removed.rs
+++ b/tests/ui/macros/macro-reexport-removed.rs
@@ -1,5 +1,4 @@
 //@ aux-build:two_macros.rs
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(macro_reexport)] //~ ERROR feature has been removed
 

--- a/tests/ui/macros/macro-reexport-removed.rs
+++ b/tests/ui/macros/macro-reexport-removed.rs
@@ -1,5 +1,5 @@
 //@ aux-build:two_macros.rs
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(macro_reexport)] //~ ERROR feature has been removed
 

--- a/tests/ui/macros/macro-reexport-removed.stderr
+++ b/tests/ui/macros/macro-reexport-removed.stderr
@@ -1,14 +1,14 @@
 error[E0557]: feature has been removed
-  --> $DIR/macro-reexport-removed.rs:4:12
+  --> $DIR/macro-reexport-removed.rs:3:12
    |
 LL | #![feature(macro_reexport)]
    |            ^^^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.0.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/49982> for more information
+   = note: removed in 1.0.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/49982> for more information
    = note: subsumed by `pub use`
 
 error: cannot find attribute `macro_reexport` in this scope
-  --> $DIR/macro-reexport-removed.rs:6:3
+  --> $DIR/macro-reexport-removed.rs:5:3
    |
 LL | #[macro_reexport(macro_one)]
    |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`

--- a/tests/ui/rustdoc/renamed-features-rustdoc_internals.rs
+++ b/tests/ui/rustdoc/renamed-features-rustdoc_internals.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(doc_keyword)] //~ ERROR
 #![feature(doc_primitive)] //~ ERROR

--- a/tests/ui/rustdoc/renamed-features-rustdoc_internals.rs
+++ b/tests/ui/rustdoc/renamed-features-rustdoc_internals.rs
@@ -1,5 +1,3 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
-
 #![feature(doc_keyword)] //~ ERROR
 #![feature(doc_primitive)] //~ ERROR
 #![crate_type = "lib"]

--- a/tests/ui/rustdoc/renamed-features-rustdoc_internals.stderr
+++ b/tests/ui/rustdoc/renamed-features-rustdoc_internals.stderr
@@ -1,19 +1,19 @@
 error[E0557]: feature has been removed
-  --> $DIR/renamed-features-rustdoc_internals.rs:3:12
+  --> $DIR/renamed-features-rustdoc_internals.rs:1:12
    |
 LL | #![feature(doc_keyword)]
    |            ^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.58.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/90420> for more information
+   = note: removed in 1.58.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/90420> for more information
    = note: merged into `#![feature(rustdoc_internals)]`
 
 error[E0557]: feature has been removed
-  --> $DIR/renamed-features-rustdoc_internals.rs:4:12
+  --> $DIR/renamed-features-rustdoc_internals.rs:2:12
    |
 LL | #![feature(doc_primitive)]
    |            ^^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in 1.58.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/90420> for more information
+   = note: removed in 1.58.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/90420> for more information
    = note: merged into `#![feature(rustdoc_internals)]`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
+++ b/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
@@ -6,7 +6,6 @@
 // Regression test for issue #125877.
 
 //@ compile-flags: -Znext-solver
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(const_trait_impl, effects)]
 //~^ ERROR feature has been removed

--- a/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
+++ b/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.rs
@@ -6,7 +6,7 @@
 // Regression test for issue #125877.
 
 //@ compile-flags: -Znext-solver
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(const_trait_impl, effects)]
 //~^ ERROR feature has been removed

--- a/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.stderr
+++ b/tests/ui/traits/const-traits/const-trait-impl-parameter-mismatch.stderr
@@ -1,14 +1,14 @@
 error[E0557]: feature has been removed
-  --> $DIR/const-trait-impl-parameter-mismatch.rs:11:30
+  --> $DIR/const-trait-impl-parameter-mismatch.rs:10:30
    |
 LL | #![feature(const_trait_impl, effects)]
    |                              ^^^^^^^ feature has been removed
    |
-   = note: removed in 1.84.0 (you are using $RUSTC_VERSION); see <https://github.com/rust-lang/rust/pull/132479> for more information
+   = note: removed in 1.84.0 (you are using $RUST_VERSION); see <https://github.com/rust-lang/rust/pull/132479> for more information
    = note: removed, redundant with `#![feature(const_trait_impl)]`
 
 error[E0049]: associated function `compute` has 0 type parameters but its trait declaration has 1 type parameter
-  --> $DIR/const-trait-impl-parameter-mismatch.rs:20:16
+  --> $DIR/const-trait-impl-parameter-mismatch.rs:19:16
    |
 LL |     fn compute<T: ~const Aux>() -> u32;
    |                - expected 1 type parameter

--- a/tests/ui/unsized-locals/yote.rs
+++ b/tests/ui/unsized-locals/yote.rs
@@ -1,4 +1,2 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
-
 #![feature(unsized_locals)] //~ERROR feature has been removed
 #![crate_type = "lib"]

--- a/tests/ui/unsized-locals/yote.rs
+++ b/tests/ui/unsized-locals/yote.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
+//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
 
 #![feature(unsized_locals)] //~ERROR feature has been removed
 #![crate_type = "lib"]

--- a/tests/ui/unsized-locals/yote.stderr
+++ b/tests/ui/unsized-locals/yote.stderr
@@ -1,10 +1,10 @@
 error[E0557]: feature has been removed
-  --> $DIR/yote.rs:3:12
+  --> $DIR/yote.rs:1:12
    |
 LL | #![feature(unsized_locals)]
    |            ^^^^^^^^^^^^^^ feature has been removed
    |
-   = note: removed in CURRENT_RUSTC_VERSION (you are using $RUSTC_VERSION)
+   = note: removed in CURRENT_RUSTC_VERSION (you are using $RUST_VERSION)
    = note: removed due to implementation concerns; see https://github.com/rust-lang/rust/issues/111942
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
> [!CAUTION]
>
> Stacked on top of #142930, that needs to merge first then this PR needs to be rebased.

Instead of maintaining `n` copies of

```
//@ normalize-stderr: "you are using [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?( \([^)]*\))?" -> "you are using $$RUSTC_VERSION"
```

Normalize this consistently and centrally in compiletest instead.

cc @cuviper 
r? @Kobzol