### PR TITLE
Fix stack overflow when macro_rules! macros shadow builtin attributes or types

### DIFF
--- a/tests/ui/resolve/macro-builtin-attr-no-crash.rs
+++ b/tests/ui/resolve/macro-builtin-attr-no-crash.rs
@@ -1,0 +1,38 @@
+// Regression test for stack overflow when a `macro_rules!` macro shadows
+// a builtin attribute and is used recursively within its own expansion.
+
+//@ check-pass
+
+#![allow(unused)]
+
+#[macro_export]
+macro_rules! test {
+    () => {
+        #[test]
+        fn generated_test() {
+            assert!(true);
+        }
+    };
+}
+
+// Additional case with derive
+#[macro_export]
+macro_rules! derive {
+    () => {
+        #[derive(Debug)]
+        struct Foo;
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    test!();
+}
+
+mod another_test {
+    use super::*;
+    derive!();
+}
+
+fn main() {}


### PR DESCRIPTION
Compiler crashes with SIGSEGV when `macro_rules!` shadows a builtin attribute like `#[test]` and uses that attribute within its expansion.

### Repro

```rust
#[macro_export]
macro_rules! test {
    () => {
        #[test]  // tries to resolve to macro, causing infinite recursion
        fn my_test() {
            test!();
        }
    };
}

#[cfg(test)]
mod tests {
    use super::*;  // Wildcard import brings macro into scope
    test!();
}
```

```bash
RUST_MIN_STACK=1048576 rustc --test crash_test.rs
# Segmentation fault (core dumped)
```

Can crash in regular situations without limiting stack as well, like gpui tests in Zed.

Fix adds a check in `early_resolve_ident_in_lexical_scope` to prevent infinite recursion by always preferring the builtin attribute when there's an ambiguity between a `macro_rules!` macro and a builtin attribute. This only applies to `macro_rules!` macros to preserve existing proc-macro ambiguity detection.

### Questions
Should there be a warning when a `macro_rules!` macro shadows a builtin attribute? What's the precedence order?
With a very small stack, a crash can still happen before execution gets here. Move fix?

r? @WaffleLapkin bug originally found in gpui :smile_cat: 