### PR TITLE
mbe: Rework diagnostics for metavariable expressions

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -154,6 +154,11 @@ expand_mve_missing_paren =
     .note = metavariable expressions use function-like parentheses syntax
     .suggestion = try adding parentheses
 
+expand_mve_unrecognized_expr =
+    unrecognized metavariable expression
+    .label = not a valid metavariable expression
+    .note = valid metavariable expressions are {$valid_expr_list}
+
 expand_mve_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
 

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -133,6 +133,27 @@ expand_module_multiple_candidates =
 expand_must_repeat_once =
     this must repeat at least once
 
+expand_mve_extra_tokens =
+    unexpected trailing tokens
+    .label = for this metavariable expression
+    .range = the `{$name}` metavariable expression takes between {$min_or_exact_args} and {$max_args} arguments
+    .exact = the `{$name}` metavariable expression takes {$min_or_exact_args ->
+        [zero] no arguments
+        [one] a single argument
+        *[other] {$min_or_exact_args} arguments
+    }
+    .suggestion = try removing {$extra_count ->
+        [one] this token
+        *[other] these tokens
+    }
+
+expand_mve_missing_paren =
+    expected `(`
+    .label = for this this metavariable expression
+    .unexpected = unexpected token
+    .note = metavariable expressions use function-like parentheses syntax
+    .suggestion = try adding parentheses
+
 expand_mve_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
 

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -531,6 +531,16 @@ mod metavar_exprs {
     }
 
     #[derive(Diagnostic)]
+    #[note]
+    #[diag(expand_mve_unrecognized_expr)]
+    pub(crate) struct MveUnrecognizedExpr {
+        #[primary_span]
+        #[label]
+        pub span: Span,
+        pub valid_expr_list: &'static str,
+    }
+
+    #[derive(Diagnostic)]
     #[diag(expand_mve_unrecognized_var)]
     pub(crate) struct MveUnrecognizedVar {
         #[primary_span]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -496,6 +496,40 @@ pub(crate) use metavar_exprs::*;
 mod metavar_exprs {
     use super::*;
 
+    #[derive(Diagnostic, Default)]
+    #[diag(expand_mve_extra_tokens)]
+    pub(crate) struct MveExtraTokens {
+        #[primary_span]
+        #[suggestion(code = "", applicability = "machine-applicable")]
+        pub span: Span,
+        #[label]
+        pub ident_span: Span,
+        pub extra_count: usize,
+
+        // The rest is only used for specific diagnostics and can be default if neither
+        // `note` is `Some`.
+        #[note(expand_exact)]
+        pub exact_args_note: Option<()>,
+        #[note(expand_range)]
+        pub range_args_note: Option<()>,
+        pub min_or_exact_args: usize,
+        pub max_args: usize,
+        pub name: String,
+    }
+
+    #[derive(Diagnostic)]
+    #[note]
+    #[diag(expand_mve_missing_paren)]
+    pub(crate) struct MveMissingParen {
+        #[primary_span]
+        #[label]
+        pub ident_span: Span,
+        #[label(expand_unexpected)]
+        pub unexpected_span: Option<Span>,
+        #[suggestion(code = "( /* ... */ )", applicability = "has-placeholders")]
+        pub insert_span: Option<Span>,
+    }
+
     #[derive(Diagnostic)]
     #[diag(expand_mve_unrecognized_var)]
     pub(crate) struct MveUnrecognizedVar {

--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -79,15 +79,11 @@ impl MetaVarExpr {
             "index" => MetaVarExpr::Index(parse_depth(&mut iter, psess, ident.span)?),
             "len" => MetaVarExpr::Len(parse_depth(&mut iter, psess, ident.span)?),
             _ => {
-                let err_msg = "unrecognized meta-variable expression";
-                let mut err = psess.dcx().struct_span_err(ident.span, err_msg);
-                err.span_suggestion(
-                    ident.span,
-                    "supported expressions are count, ignore, index and len",
-                    "",
-                    Applicability::MachineApplicable,
-                );
-                return Err(err);
+                let err = errors::MveUnrecognizedExpr {
+                    span: ident.span,
+                    valid_expr_list: "`count`, `ignore`, `index`, `len`, and `concat`",
+                };
+                return Err(psess.dcx().create_err(err));
             }
         };
         check_trailing_tokens(&mut iter, psess, ident)?;

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -118,7 +118,7 @@ macro_rules! unknown_ignore_ident {
 
 macro_rules! unknown_metavar {
     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
-    //~^ ERROR unrecognized meta-variable expression
+    //~^ ERROR unrecognized metavariable expression
 }
 
 fn main() {}

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -30,7 +30,7 @@ macro_rules! metavar_with_literal_suffix {
 
 macro_rules! mve_without_parens {
     ( $( $i:ident ),* ) => { ${ count } };
-    //~^ ERROR meta-variable expression parameter must be wrapped in parentheses
+    //~^ ERROR expected `(`
 }
 
 #[rustfmt::skip]
@@ -45,9 +45,14 @@ macro_rules! open_brackets_with_lit {
      //~^ ERROR expected identifier
  }
 
+macro_rules! mvs_missing_paren {
+    ( $( $i:ident ),* ) => { ${ count $i ($i) } };
+    //~^ ERROR expected `(`
+}
+
 macro_rules! mve_wrong_delim {
     ( $( $i:ident ),* ) => { ${ count{i} } };
-    //~^ ERROR meta-variable expression parameter must be wrapped in parentheses
+    //~^ ERROR expected `(`
 }
 
 macro_rules! invalid_metavar {
@@ -64,28 +69,30 @@ macro_rules! open_brackets_with_group {
 macro_rules! extra_garbage_after_metavar {
     ( $( $i:ident ),* ) => {
         ${count() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i, 1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i) a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${ignore($i) a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${ignore($i a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${index() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${index(1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${index() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${index(1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
+        ${index(1, a b c)}
+        //~^ ERROR unexpected trailing tokens
     };
 }
 

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -192,11 +192,13 @@ error: meta-variables within meta-variable expressions must be referenced using 
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
-error: unrecognized meta-variable expression
+error: unrecognized metavariable expression
   --> $DIR/syntax-errors.rs:120:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
-   |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
+   |                                 ^^^^^^^^^^^^^^ not a valid metavariable expression
+   |
+   = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: expected identifier or string literal
   --> $DIR/syntax-errors.rs:38:14

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -40,164 +40,160 @@ error: only unsuffixes integer literals are supported in meta-variable expressio
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                                 ^^^^^
 
-error: meta-variable expression parameter must be wrapped in parentheses
+error: expected `(`
   --> $DIR/syntax-errors.rs:32:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count } };
-   |                                 ^^^^^
+   |                                 ^^^^^- help: try adding parentheses: `( /* ... */ )`
+   |                                 |
+   |                                 for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
 
-error: meta-variable expression parameter must be wrapped in parentheses
+error: expected `(`
   --> $DIR/syntax-errors.rs:49:33
    |
+LL |     ( $( $i:ident ),* ) => { ${ count $i ($i) } };
+   |                                 ^^^^^ - unexpected token
+   |                                 |
+   |                                 for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
+
+error: expected `(`
+  --> $DIR/syntax-errors.rs:54:33
+   |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
-   |                                 ^^^^^
+   |                                 ^^^^^ for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
 
 error: expected identifier, found `123`
-  --> $DIR/syntax-errors.rs:54:23
+  --> $DIR/syntax-errors.rs:59:23
    |
 LL |     () => { ${ignore($123)} }
    |                       ^^^ help: try removing `123`
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:66:19
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:71:19
    |
 LL |         ${count() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:66:19
-   |
-LL |         ${count() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:68:20
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:73:20
    |
 LL |         ${count($i a b c)}
-   |                    ^
+   |           -----    ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:68:20
-   |
-LL |         ${count($i a b c)}
-   |                    ^
+   = note: the `count` metavariable expression takes between 1 and 2 arguments
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:70:23
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:75:23
    |
 LL |         ${count($i, 1 a b c)}
-   |                       ^
+   |           -----       ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:70:23
-   |
-LL |         ${count($i, 1 a b c)}
-   |                       ^
+   = note: the `count` metavariable expression takes between 1 and 2 arguments
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:72:21
-   |
-LL |         ${count($i) a b c}
-   |                     ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:72:21
-   |
-LL |         ${count($i) a b c}
-   |                     ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:75:22
-   |
-LL |         ${ignore($i) a b c}
-   |                      ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:75:22
-   |
-LL |         ${ignore($i) a b c}
-   |                      ^
-
-error: unexpected token: a
+error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:77:21
    |
+LL |         ${count($i) a b c}
+   |           -----     ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:80:22
+   |
+LL |         ${ignore($i) a b c}
+   |           ------     ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:82:21
+   |
 LL |         ${ignore($i a b c)}
-   |                     ^
+   |           ------    ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:77:21
-   |
-LL |         ${ignore($i a b c)}
-   |                     ^
+   = note: the `ignore` metavariable expression takes a single argument
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:80:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:80:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:82:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:82:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-
-error: unexpected token: a
+error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:85:19
    |
 LL |         ${index() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:87:19
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:85:19
+LL |         ${index(1 a b c)}
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+   |
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:90:19
    |
 LL |         ${index() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:87:19
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:92:19
    |
 LL |         ${index(1 a b c)}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:87:19
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:94:18
    |
-LL |         ${index(1 a b c)}
-   |                   ^
+LL |         ${index(1, a b c)}
+   |           -----  ^^^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+   |
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
 
 error: meta-variable expression depth must be a literal
-  --> $DIR/syntax-errors.rs:94:33
+  --> $DIR/syntax-errors.rs:101:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                                 ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:100:11
+  --> $DIR/syntax-errors.rs:107:11
    |
 LL |         ${count(foo)}
    |           ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:107:11
+  --> $DIR/syntax-errors.rs:114:11
    |
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
 error: unrecognized meta-variable expression
-  --> $DIR/syntax-errors.rs:113:33
+  --> $DIR/syntax-errors.rs:120:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
@@ -215,10 +211,10 @@ LL |      () => { ${ "hi" } };
    |                 ^^^^ help: try removing `"hi"`
 
 error: expected identifier or string literal
-  --> $DIR/syntax-errors.rs:60:33
+  --> $DIR/syntax-errors.rs:65:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                                 ^^
 
-error: aborting due to 25 previous errors
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
Make the diagnostics for metavariable expressions more user-friendly. This mostly addresses syntactic errors; I will be following up with improvements to `concat(..)`.

<!-- homu-ignore:start -->
r? @petrochenkov
<!-- homu-ignore:end -->
