### PR TITLE
`proven_via` into query response

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -8,14 +8,13 @@ use std::ops::ControlFlow;
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::lang_items::TraitSolverLangItem;
-use rustc_type_ir::solve::SizedTraitKind;
+use rustc_type_ir::solve::{SizedTraitKind, TraitGoalProvenVia};
 use rustc_type_ir::{
     self as ty, Interner, TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt as _,
     TypeVisitor, TypingMode, Upcast as _, elaborate,
 };
 use tracing::{debug, instrument};
 
-use super::trait_goals::TraitGoalProvenVia;
 use super::{has_only_region_constraints, inspect};
 use crate::delegate::SolverDelegate;
 use crate::solve::inspect::ProbeKind;

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -394,11 +394,8 @@ where
         &mut self,
         goal: Goal<I, ty::HostEffectPredicate<I>>,
     ) -> QueryResult<I> {
-        let (_, proven_via) = self.probe(|_| ProbeKind::ShadowedEnvProbing).enter(|ecx| {
-            let trait_goal: Goal<I, ty::TraitPredicate<I>> =
-                goal.with(ecx.cx(), goal.predicate.trait_ref);
-            ecx.compute_trait_goal(trait_goal)
-        })?;
+        let trait_goal = goal.with(self.cx(), goal.predicate.trait_ref);
+        let proven_via = self.trait_goal_proven_via(trait_goal)?;
         self.assemble_and_merge_candidates(proven_via, goal, |_ecx| Err(NoSolution))
     }
 }

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -5,7 +5,6 @@ use rustc_type_ir::fast_reject::DeepRejectCtxt;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::lang_items::TraitSolverLangItem;
 use rustc_type_ir::solve::SizedTraitKind;
-use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{self as ty, Interner, elaborate};
 use tracing::instrument;
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -472,7 +472,7 @@ where
         &mut self,
         goal: Goal<I, I::Predicate>,
     ) -> Result<Option<TraitGoalProvenVia>, NoSolution> {
-        let (orig_values, canonical_goal) = self.canonicalize_goal(goal);
+        let (_, canonical_goal) = self.canonicalize_goal(goal);
         let canonical_response = EvalCtxt::evaluate_canonical_goal(
             self.cx(),
             self.search_graph,

--- a/compiler/rustc_next_trait_solver/src/solve/inspect/build.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/inspect/build.rs
@@ -246,7 +246,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> ProofTreeBuilder<D> {
         ProofTreeBuilder::new(DebugSolver::Root)
     }
 
-    fn new_noop() -> ProofTreeBuilder<D> {
+    pub(crate) fn new_noop() -> ProofTreeBuilder<D> {
         ProofTreeBuilder { state: None, _infcx: PhantomData }
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -365,6 +365,7 @@ fn response_no_constraints_raw<I: Interner>(
             var_values: ty::CanonicalVarValues::make_identity(cx, variables),
             // FIXME: maybe we should store the "no response" version in cx, like
             // we do for cx.types and stuff.
+            trait_goal_proven_via: None,
             external_constraints: cx.mk_external_constraints(ExternalConstraintsData::default()),
             certainty,
         },

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -363,9 +363,10 @@ fn response_no_constraints_raw<I: Interner>(
         variables,
         value: Response {
             var_values: ty::CanonicalVarValues::make_identity(cx, variables),
+            // Cycles start out without knowing how the trait goal was proven.
+            trait_goal_proven_via: None,
             // FIXME: maybe we should store the "no response" version in cx, like
             // we do for cx.types and stuff.
-            trait_goal_proven_via: None,
             external_constraints: cx.mk_external_constraints(ExternalConstraintsData::default()),
             certainty,
         },

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -34,11 +34,8 @@ where
         match goal.predicate.alias.kind(cx) {
             ty::AliasTermKind::ProjectionTy | ty::AliasTermKind::ProjectionConst => {
                 let trait_ref = goal.predicate.alias.trait_ref(cx);
-                let (_, proven_via) =
-                    self.probe(|_| ProbeKind::ShadowedEnvProbing).enter(|ecx| {
-                        let trait_goal: Goal<I, ty::TraitPredicate<I>> = goal.with(cx, trait_ref);
-                        ecx.compute_trait_goal(trait_goal)
-                    })?;
+                let trait_goal = goal.with(cx, trait_ref);
+                let proven_via = self.trait_goal_proven_via(trait_goal)?;
                 self.assemble_and_merge_candidates(proven_via, goal, |ecx| {
                     ecx.probe(|&result| ProbeKind::RigidAlias { result }).enter(|this| {
                         this.structurally_instantiate_normalizes_to_term(

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -225,6 +225,32 @@ pub struct Response<I: Interner> {
     pub var_values: CanonicalVarValues<I>,
     /// Additional constraints returned by this query.
     pub external_constraints: I::ExternalConstraints,
+    #[type_foldable(identity)]
+    #[type_visitable(ignore)]
+    pub trait_goal_proven_via: Option<TraitGoalProvenVia>,
+}
+
+/// How we've proven this trait goal.
+///
+/// This is used by `NormalizesTo` goals to only normalize
+/// by using the same 'kind of candidate' we've used to prove
+/// its corresponding trait goal. Most notably, we do not
+/// normalize by using an impl if the trait goal has been
+/// proven via a `ParamEnv` candidate.
+///
+/// This is necessary to avoid unnecessary region constraints,
+/// see trait-system-refactor-initiative#125 for more details.
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+pub enum TraitGoalProvenVia {
+    /// We've proven the trait goal by something which is
+    /// is not a non-global where-bound or an alias-bound.
+    ///
+    /// This means we don't disable any candidates during
+    /// normalization.
+    Misc,
+    ParamEnv,
+    AliasBound,
 }
 
 /// Additional constraints returned on success.


### PR DESCRIPTION
quite sus. doesn't handle proof trees, seems to incorrectly handle `trait_goal_proven_via` if the `Trait` goal is cyclic :thinking: 

r? compiler-errors