### PR TITLE
Couple of test suite fixes for cg_clif

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
@@ -151,20 +151,6 @@ rm tests/ui/process/process-panic-after-fork.rs # same
 cp ../dist/bin/rustdoc-clif ../dist/bin/rustdoc # some tests expect bin/rustdoc to exist
 
 cat <<EOF | git apply -
-diff --git a/tests/run-make/linker-warning/rmake.rs b/tests/run-make/linker-warning/rmake.rs
-index 30387af428c..f7895b12961 100644
---- a/tests/run-make/linker-warning/rmake.rs
-+++ b/tests/run-make/linker-warning/rmake.rs
-@@ -57,7 +57,8 @@ fn main() {
-             .actual_text("(linker error)", out.stderr())
--            .normalize(r#"/rustc[^/]*/"#, "/rustc/")
-+            .normalize(r#"/tmp/rustc[^/]*/"#, "/tmp/rustc/")
-+            .normalize("libpanic_abort", "libpanic_unwind")
-             .normalize(
-                 regex::escape(run_make_support::build_root().to_str().unwrap()),
-                 "/build-root",
-             )
-             .normalize(r#""[^"]*\/symbols.o""#, "\\"/symbols.o\\"")
 diff --git a/src/tools/compiletest/src/runtest/run_make.rs b/src/tools/compiletest/src/runtest/run_make.rs
 index 073116933bd..c3e4578204d 100644
 --- a/src/tools/compiletest/src/runtest/run_make.rs

--- a/tests/run-make/bin-emit-no-symbols/app.rs
+++ b/tests/run-make/bin-emit-no-symbols/app.rs
@@ -12,7 +12,15 @@ fn panic(_: &PanicInfo) -> ! {
 }
 
 #[lang = "eh_personality"]
-fn eh() {}
+fn eh(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}
 
 #[alloc_error_handler]
 fn oom(_: Layout) -> ! {

--- a/tests/run-make/crate-circular-deps-link/a.rs
+++ b/tests/run-make/crate-circular-deps-link/a.rs
@@ -21,6 +21,12 @@ extern "C" fn __rust_foreign_exception() -> ! {
 }
 
 #[lang = "eh_personality"]
-fn eh_personality() {
+fn eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
     loop {}
 }

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -57,7 +57,8 @@ fn main() {
         diff()
             .expected_file("short-error.txt")
             .actual_text("(linker error)", out.stderr())
-            .normalize(r#"/rustc[^/]*/"#, "/rustc/")
+            .normalize(r#"/rustc[^/_-]*/"#, "/rustc/")
+            .normalize("libpanic_abort", "libpanic_unwind")
             .normalize(
                 regex::escape(run_make_support::build_root().to_str().unwrap()),
                 "/build-root",

--- a/tests/run-make/no-alloc-shim/foo.rs
+++ b/tests/run-make/no-alloc-shim/foo.rs
@@ -12,7 +12,13 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
-extern "C" fn rust_eh_personality() {
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
     loop {}
 }
 

--- a/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
@@ -6,13 +6,14 @@
 //@ compile-flags:-C panic=abort
 //@ aux-build:helper.rs
 
-#![feature(rustc_private, lang_items)]
+#![feature(rustc_private, lang_items, panic_unwind)]
 #![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 
 extern crate alloc;
 extern crate libc;
+extern crate unwind; // For _Unwind_Resume
 
 // ARM targets need these symbols
 #[no_mangle]

--- a/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
@@ -70,7 +70,15 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
 // in these libraries will refer to `rust_eh_personality` if LLVM can not *prove* the contents won't
 // unwind. So, for this test case we will define the symbol.
 #[lang = "eh_personality"]
-extern "C" fn rust_eh_personality() {}
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}
 
 #[derive(Default, Debug)]
 struct Page(#[allow(dead_code)] [[u64; 32]; 16]);

--- a/tests/ui/allocator/no_std-alloc-error-handler-default.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-default.rs
@@ -6,12 +6,13 @@
 //@ compile-flags:-C panic=abort
 //@ aux-build:helper.rs
 
-#![feature(rustc_private, lang_items)]
+#![feature(rustc_private, lang_items, panic_unwind)]
 #![no_std]
 #![no_main]
 
 extern crate alloc;
 extern crate libc;
+extern crate unwind; // For _Unwind_Resume
 
 // ARM targets need these symbols
 #[no_mangle]

--- a/tests/ui/allocator/no_std-alloc-error-handler-default.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-default.rs
@@ -57,7 +57,15 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
 // in these libraries will refer to `rust_eh_personality` if LLVM can not *prove* the contents won't
 // unwind. So, for this test case we will define the symbol.
 #[lang = "eh_personality"]
-extern "C" fn rust_eh_personality() {}
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}
 
 #[derive(Default, Debug)]
 struct Page(#[allow(dead_code)] [[u64; 32]; 16]);

--- a/tests/ui/extern-flag/auxiliary/panic_handler.rs
+++ b/tests/ui/extern-flag/auxiliary/panic_handler.rs
@@ -12,4 +12,12 @@ pub fn begin_panic_handler(_info: &core::panic::PanicInfo<'_>) -> ! {
 }
 
 #[lang = "eh_personality"]
-extern "C" fn eh_personality() {}
+extern "C" fn eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}

--- a/tests/ui/no_std/simple-runs.rs
+++ b/tests/ui/no_std/simple-runs.rs
@@ -4,6 +4,7 @@
 //@ compile-flags: -Cpanic=abort
 //@ ignore-wasm different `main` convention
 
+#![feature(lang_items)]
 #![no_std]
 #![no_main]
 
@@ -32,6 +33,17 @@ extern "C" {}
 
 #[panic_handler]
 fn panic_handler(_info: &PanicInfo<'_>) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
     loop {}
 }
 

--- a/tests/ui/panic-runtime/incompatible-type.rs
+++ b/tests/ui/panic-runtime/incompatible-type.rs
@@ -21,4 +21,12 @@ pub fn test(_: DropMe) {
 }
 
 #[rustc_std_internal_symbol]
-pub unsafe extern "C" fn rust_eh_personality() {}
+pub unsafe extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    loop {}
+}


### PR DESCRIPTION
Most of these are required for getting the test suite running with panic=unwind for cg_clif.