### PR TITLE
Skip unnecessary components in x64 try builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -10,4 +10,7 @@ python3 ../x.py build --set rust.debug=true opt-dist
     build-manifest bootstrap
 
 # Use GCC for building GCC, as it seems to behave badly when built with Clang
-CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc
+# Only build GCC on full builds, not try builds
+if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
+    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist gcc
+fi

--- a/src/tools/opt-dist/src/exec.rs
+++ b/src/tools/opt-dist/src/exec.rs
@@ -113,7 +113,7 @@ impl Bootstrap {
             "library/std",
         ])
         .env("RUST_BACKTRACE", "full");
-        let cmd = add_shared_x_flags(env, cmd);
+        let mut cmd = add_shared_x_flags(env, cmd);
 
         Self { cmd, metrics_path }
     }
@@ -122,7 +122,12 @@ impl Bootstrap {
         let metrics_path = env.build_root().join("build").join("metrics.json");
         let args = dist_args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>();
         let cmd = cmd(&args).env("RUST_BACKTRACE", "full");
-        let cmd = add_shared_x_flags(env, cmd);
+        let mut cmd = add_shared_x_flags(env, cmd);
+        if env.is_fast_try_build() {
+            // We set build.extended=false for fast try builds, but we still need Cargo
+            cmd = cmd.arg("cargo");
+        }
+
         Self { cmd, metrics_path }
     }
 
@@ -188,6 +193,19 @@ impl Bootstrap {
     }
 }
 
-fn add_shared_x_flags(env: &Environment, cmd: CmdBuilder) -> CmdBuilder {
-    if env.is_fast_try_build() { cmd.arg("--set").arg("rust.deny-warnings=false") } else { cmd }
+fn add_shared_x_flags(env: &Environment, mut cmd: CmdBuilder) -> CmdBuilder {
+    if env.is_fast_try_build() {
+        // Skip things that cannot be skipped through `x ... --skip`
+        cmd.arg("--set")
+            .arg("rust.llvm-bitcode-linker=false")
+            // Skip wasm-component-ld. This also skips cargo, which we need to re-enable for dist
+            .arg("--set")
+            .arg("build.extended=false")
+            .arg("--set")
+            .arg("rust.codegen-backends=['llvm']")
+            .arg("--set")
+            .arg("rust.deny-warnings=false")
+    } else {
+        cmd
+    }
 }

--- a/src/tools/opt-dist/src/exec.rs
+++ b/src/tools/opt-dist/src/exec.rs
@@ -113,7 +113,7 @@ impl Bootstrap {
             "library/std",
         ])
         .env("RUST_BACKTRACE", "full");
-        let mut cmd = add_shared_x_flags(env, cmd);
+        let cmd = add_shared_x_flags(env, cmd);
 
         Self { cmd, metrics_path }
     }
@@ -193,7 +193,7 @@ impl Bootstrap {
     }
 }
 
-fn add_shared_x_flags(env: &Environment, mut cmd: CmdBuilder) -> CmdBuilder {
+fn add_shared_x_flags(env: &Environment, cmd: CmdBuilder) -> CmdBuilder {
     if env.is_fast_try_build() {
         // Skip things that cannot be skipped through `x ... --skip`
         cmd.arg("--set")

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -407,13 +407,18 @@ fn main() -> anyhow::Result<()> {
         for target in [
             "rust-docs",
             "rustc-docs",
+            "rustc-dev",
+            "rust-dev",
             "rust-docs-json",
             "rust-analyzer",
             "rustc-src",
+            "extended",
             "clippy",
             "miri",
             "rustfmt",
             "gcc",
+            "generate-copyright",
+            "bootstrap",
         ] {
             build_args.extend(["--skip".to_string(), target.to_string()]);
         }


### PR DESCRIPTION
We unnecessarily rebuild `wasm-component-ld`, `llvm-bitcode-linker` and Cranelift during the intermediate PGO builds several times times, which is unnecessarily and increases the duration of try builds. This PR also disables some unnecessary dist components.

r? @jieyouxu