### PR TITLE
[RTE-497] Ignore `c-link-to-rust-va-list-fn` test on SGX platform

### DIFF
--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -5,6 +5,7 @@
 
 //@ needs-target-std
 //@ ignore-android: FIXME(#142855)
+//@ ignore-sgx: (x86 machine code cannot be directly executed)
 
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib_name};
 


### PR DESCRIPTION
rust-lang/rust#141856 enables using the runner defined in bootstrap.toml to execute run-make tests. A test was added for this feature that compiles a Rust library and C code, links them together and passes the result to the runner. Unfortunately, that's not sufficient for the SGX platform; x86 machine code cannot be directly executed. This PR fixes the issue by disabling this test for SGX.