### PR TITLE
Fix RwLock::try_write documentation for WouldBlock condition

### DIFF
--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -481,7 +481,7 @@ impl<T: ?Sized> RwLock<T> {
     /// in the returned error.
     ///
     /// This function will return the [`WouldBlock`] error if the `RwLock` could
-    /// not be acquired because it was already locked exclusively.
+    /// not be acquired because it was already locked.
     ///
     /// [`Poisoned`]: TryLockError::Poisoned
     /// [`WouldBlock`]: TryLockError::WouldBlock


### PR DESCRIPTION
Fix RwLock::try_write documentation for WouldBlock condition

The documentation incorrectly stated that try_write only fails when 
'already locked exclusively', but it actually fails when there are 
either shared (read) or exclusive (write) locks.

Fixes rust-lang/rust#142852