### PR TITLE
Extend dead code analysis of impls and impl items to non-ADTs

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -58,6 +58,8 @@ fn local_adt_def_of_ty<'tcx>(ty: &hir::Ty<'tcx>) -> Option<LocalDefId> {
                 None
             }
         }
+        TyKind::Slice(ty) | TyKind::Array(ty, _) => local_adt_def_of_ty(ty),
+        TyKind::Ptr(ty) | TyKind::Ref(_, ty) => local_adt_def_of_ty(ty.ty),
         _ => None,
     }
 }

--- a/tests/ui/lint/dead-code/unused-impl-for-non-adts.rs
+++ b/tests/ui/lint/dead-code/unused-impl-for-non-adts.rs
@@ -1,0 +1,89 @@
+#![deny(dead_code)]
+
+struct Foo; //~ ERROR struct `Foo` is never constructed
+
+trait Trait { //~ ERROR trait `Trait` is never used
+    fn foo(&self);
+}
+
+impl Trait for Foo {
+    fn foo(&self) {}
+}
+
+impl Trait for [Foo] {
+    fn foo(&self) {}
+}
+impl<const N: usize> Trait for [Foo; N] {
+    fn foo(&self) {}
+}
+
+impl Trait for *const Foo {
+    fn foo(&self) {}
+}
+impl Trait for *mut Foo {
+    fn foo(&self) {}
+}
+
+impl Trait for &Foo {
+    fn foo(&self) {}
+}
+impl Trait for &&Foo {
+    fn foo(&self) {}
+}
+impl Trait for &mut Foo {
+    fn foo(&self) {}
+}
+
+impl Trait for [&Foo] {
+    fn foo(&self) {}
+}
+impl Trait for &[Foo] {
+    fn foo(&self) {}
+}
+impl Trait for &*const Foo {
+    fn foo(&self) {}
+}
+
+pub trait Trait2 {
+    fn foo(&self);
+}
+
+impl Trait2 for Foo {
+    fn foo(&self) {}
+}
+
+impl Trait2 for [Foo] {
+    fn foo(&self) {}
+}
+impl<const N: usize> Trait2 for [Foo; N] {
+    fn foo(&self) {}
+}
+
+impl Trait2 for *const Foo {
+    fn foo(&self) {}
+}
+impl Trait2 for *mut Foo {
+    fn foo(&self) {}
+}
+
+impl Trait2 for &Foo {
+    fn foo(&self) {}
+}
+impl Trait2 for &&Foo {
+    fn foo(&self) {}
+}
+impl Trait2 for &mut Foo {
+    fn foo(&self) {}
+}
+
+impl Trait2 for [&Foo] {
+    fn foo(&self) {}
+}
+impl Trait2 for &[Foo] {
+    fn foo(&self) {}
+}
+impl Trait2 for &*const Foo {
+    fn foo(&self) {}
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/unused-impl-for-non-adts.stderr
+++ b/tests/ui/lint/dead-code/unused-impl-for-non-adts.stderr
@@ -1,0 +1,20 @@
+error: struct `Foo` is never constructed
+  --> $DIR/unused-impl-for-non-adts.rs:3:8
+   |
+LL | struct Foo;
+   |        ^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-impl-for-non-adts.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: trait `Trait` is never used
+  --> $DIR/unused-impl-for-non-adts.rs:5:7
+   |
+LL | trait Trait {
+   |       ^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Then we can lint more unused structs and traits like the following:
```
struct Foo; //~ ERROR struct `Foo` is never constructed

trait Trait { //~ ERROR trait `Trait` is never used
    fn foo(&self) {}
}

impl Trait for &Foo {}
```

Extracted from https://github.com/rust-lang/rust/pull/128637.
r? @petrochenkov