### PR TITLE
Add a missing mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -162,8 +162,10 @@ David Carlier <devnexen@gmail.com>
 David Klein <david.klein@baesystemsdetica.com>
 David Manescu <david.manescu@gmail.com> <dman2626@uni.sydney.edu.au>
 David Ross <daboross@daboross.net>
-David Wood <david@davidtw.co> <david.wood@huawei.com>
+David Wood <david@davidtw.co> <Q0KPU0H1YOEPHRY1R2SN5B5RL@david.davidtw.co>
+David Wood <david@davidtw.co> <agile.lion3441@fuligin.ink>
 David Wood <david@davidtw.co> <david.wood2@arm.com>
+David Wood <david@davidtw.co> <david.wood@huawei.com>
 Deadbeef <ent3rm4n@gmail.com>
 Deadbeef <ent3rm4n@gmail.com> <fee1-dead-beef@protonmail.com>
 dependabot[bot] <dependabot[bot]@users.noreply.github.com> <27856297+dependabot-preview[bot]@users.noreply.github.com>


### PR DESCRIPTION
There aren't too many commits with the new emails, but per https://github.com/rust-lang/rust/pull/142470#issuecomment-3000079137 they belong to the same person so we may as well map them.

<!-- homu-ignore:start -->
r? @davidtwco
<!-- homu-ignore:end -->
