### PR TITLE
mbe: Rework the `concat` metavariable expression

### DIFF
--- a/compiler/rustc_builtin_macros/src/concat.rs
+++ b/compiler/rustc_builtin_macros/src/concat.rs
@@ -24,6 +24,8 @@ pub(crate) fn expand_concat(
     let mut guar = None;
     for e in es {
         match e.kind {
+            // For consistent user experience, please keep this in sync with the handling of
+            // literals in `rustc_expand::mbe::metavar_expr` `${concat()}`!
             ExprKind::Lit(token_lit) => match LitKind::from_token_lit(token_lit) {
                 Ok(LitKind::Str(s, _) | LitKind::Float(s, _)) => {
                     accumulator.push_str(s.as_str());

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -133,20 +133,23 @@ expand_module_multiple_candidates =
 expand_must_repeat_once =
     this must repeat at least once
 
-expand_mve_concat_invalid =
-    invalid item within a `{"${concat(...)}"}` expression
-    .expr_ident = expanding this `concat(...)` expression
-    .invalid_ident = this literal produced an invalid identifier
+expand_mve_concat_invalid_in =
+    invalid item within a {"`${concat(..)}`"} expression
+    .metavar_label = expanding this metavariable
     .float_lit = float literals cannot be concatenated
     .c_str_lit = C string literals cannot be concatenated
     .b_str_lit = byte literals cannot be concatenated
     .raw_ident = raw identifiers cannot be concatenated
-    .unsupported = unsupported input for `concat(...)`
+    .unsupported = unsupported input for `concat(..)`
     .valid_types = `concat` can join {$valid}
-    .expected_metavar = expected an identifier; got `{$found}`
-    .expected_metavar_dollar = todo
-    .unexpected_group = todo
-    .hi_label = todo
+    .expected_metavar = expected an identifier
+    .expected_metavar_dollar = `$` indicates the start of a metavariable
+    .invalid_metavar = expanding something
+    .valid_metavars = {"`${concat(..)}`"} can join metavariables of type {$valid}
+
+expand_mve_concat_invalid_out =
+    invalid item within a {"`${concat(..)}`"} would produce an invalid identifier
+    .label = todo
 
 expand_mve_expected_ident =
     expected an identifier

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -154,6 +154,11 @@ expand_mve_missing_paren =
     .note = metavariable expressions use function-like parentheses syntax
     .suggestion = try adding parentheses
 
+expand_mve_unrecognized_expr =
+    unrecognized metavariable expression
+    .label = not a valid metavariable expression
+    .note = valid metavariable expressions are {$valid_expr_list}
+
 expand_mve_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
 

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -133,6 +133,27 @@ expand_module_multiple_candidates =
 expand_must_repeat_once =
     this must repeat at least once
 
+expand_mve_extra_tokens =
+    unexpected trailing tokens
+    .label = for this metavariable expression
+    .range = the `{$name}` metavariable expression takes between {$min_or_exact_args} and {$max_args} arguments
+    .exact = the `{$name}` metavariable expression takes {$min_or_exact_args ->
+        [zero] no arguments
+        [one] a single argument
+        *[other] {$min_or_exact_args} arguments
+    }
+    .suggestion = try removing {$extra_count ->
+        [one] this token
+        *[other] these tokens
+    }
+
+expand_mve_missing_paren =
+    expected `(`
+    .label = for this this metavariable expression
+    .unexpected = unexpected token
+    .note = metavariable expressions use function-like parentheses syntax
+    .suggestion = try adding parentheses
+
 expand_mve_unrecognized_var =
     variable `{$key}` is not recognized in meta-variable expression
 

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -133,6 +133,14 @@ expand_module_multiple_candidates =
 expand_must_repeat_once =
     this must repeat at least once
 
+expand_mve_expected_ident =
+    expected an identifier
+    .not_ident = not a valid identifier
+    .expr_name = expected a metavariable expression name: `{"${expr( /* ... */ )}"}`
+    .expr_name_note = valid metavariable expressions are {$valid_expr_list}
+    .ignore_expr_note = `ignore` takes a metavariable argument
+    .count_expr_note = `count` takes a metavariable argument
+
 expand_mve_extra_tokens =
     unexpected trailing tokens
     .label = for this metavariable expression

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -133,6 +133,21 @@ expand_module_multiple_candidates =
 expand_must_repeat_once =
     this must repeat at least once
 
+expand_mve_concat_invalid =
+    invalid item within a `{"${concat(...)}"}` expression
+    .expr_ident = expanding this `concat(...)` expression
+    .invalid_ident = this literal produced an invalid identifier
+    .float_lit = float literals cannot be concatenated
+    .c_str_lit = C string literals cannot be concatenated
+    .b_str_lit = byte literals cannot be concatenated
+    .raw_ident = raw identifiers cannot be concatenated
+    .unsupported = unsupported input for `concat(...)`
+    .valid_types = `concat` can join {$valid}
+    .expected_metavar = expected an identifier; got `{$found}`
+    .expected_metavar_dollar = todo
+    .unexpected_group = todo
+    .hi_label = todo
+
 expand_mve_expected_ident =
     expected an identifier
     .not_ident = not a valid identifier

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -496,6 +496,40 @@ pub(crate) use metavar_exprs::*;
 mod metavar_exprs {
     use super::*;
 
+    #[derive(Diagnostic, Default)]
+    #[diag(expand_mve_extra_tokens)]
+    pub(crate) struct MveExtraTokens {
+        #[primary_span]
+        #[suggestion(code = "", applicability = "machine-applicable")]
+        pub span: Span,
+        #[label]
+        pub ident_span: Span,
+        pub extra_count: usize,
+
+        // The rest is only used for specific diagnostics and can be default if neither
+        // `note` is `Some`.
+        #[note(expand_exact)]
+        pub exact_args_note: Option<()>,
+        #[note(expand_range)]
+        pub range_args_note: Option<()>,
+        pub min_or_exact_args: usize,
+        pub max_args: usize,
+        pub name: &'static str,
+    }
+
+    #[derive(Diagnostic)]
+    #[note]
+    #[diag(expand_mve_missing_paren)]
+    pub(crate) struct MveMissingParen {
+        #[primary_span]
+        #[label]
+        pub ident_span: Span,
+        #[label(expand_unexpected)]
+        pub unexpected_span: Option<Span>,
+        #[suggestion(code = "( /* ... */ )", applicability = "has-placeholders")]
+        pub insert_span: Option<Span>,
+    }
+
     #[derive(Diagnostic)]
     #[diag(expand_mve_unrecognized_var)]
     pub(crate) struct MveUnrecognizedVar {

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -531,6 +531,16 @@ mod metavar_exprs {
     }
 
     #[derive(Diagnostic)]
+    #[note]
+    #[diag(expand_mve_unrecognized_expr)]
+    pub(crate) struct MveUnrecognizedExpr {
+        #[primary_span]
+        #[label]
+        pub span: Span,
+        pub valid_expr_list: &'static str,
+    }
+
+    #[derive(Diagnostic)]
     #[diag(expand_mve_unrecognized_var)]
     pub(crate) struct MveUnrecognizedVar {
         #[primary_span]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -541,6 +541,49 @@ mod metavar_exprs {
     }
 
     #[derive(Diagnostic)]
+    #[diag(expand_mve_concat_invalid)]
+    pub(crate) struct MveConcatInvalid {
+        #[primary_span]
+        pub span: Span,
+        #[subdiagnostic]
+        pub reason: MveConcatInvalidReason,
+        #[help(expand_expr_ident)]
+        pub ident_span: Span,
+        pub valid: &'static str,
+    }
+
+    // TODO: can these be labels rather than notes?
+    #[derive(Subdiagnostic)]
+    pub(crate) enum MveConcatInvalidReason {
+        #[note(expand_invalid_ident)]
+        InvalidIdent,
+        #[note(expand_float_lit)]
+        #[help(expand_valid_types)]
+        FloatLit,
+        #[note(expand_c_str_lit)]
+        #[help(expand_valid_types)]
+        CStrLit,
+        #[note(expand_b_str_lit)]
+        #[help(expand_valid_types)]
+        ByteStrLit,
+        #[note(expand_expected_metavar)]
+        #[label(expand_expected_metavar_dollar)]
+        ExpectedMetavarIdent {
+            found: String,
+            #[primary_span]
+            dollar: Span,
+        },
+        #[note(expand_raw_ident)]
+        RawIdentifier,
+        #[note(expand_unsupported)]
+        #[help(expand_valid_types)]
+        UnsupportedInput,
+        #[note(expand_unexpected_group)]
+        UnexpectedGroup,
+        InvalidLiteral,
+    }
+
+    #[derive(Diagnostic)]
     #[diag(expand_mve_expected_ident)]
     pub(crate) struct MveExpectedIdent {
         #[primary_span]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -541,46 +541,56 @@ mod metavar_exprs {
     }
 
     #[derive(Diagnostic)]
-    #[diag(expand_mve_concat_invalid)]
-    pub(crate) struct MveConcatInvalid {
+    #[diag(expand_mve_concat_invalid_in)]
+    pub(crate) struct MveConcatInvalidTy {
         #[primary_span]
+        // #[label]
         pub span: Span,
+        #[label(expand_metavar_label)]
+        pub metavar_span: Option<Span>,
         #[subdiagnostic]
-        pub reason: MveConcatInvalidReason,
-        #[help(expand_expr_ident)]
-        pub ident_span: Span,
+        pub reason: MveConcatInvalidTyReason,
         pub valid: &'static str,
     }
 
     // TODO: can these be labels rather than notes?
     #[derive(Subdiagnostic)]
-    pub(crate) enum MveConcatInvalidReason {
-        #[note(expand_invalid_ident)]
+    pub(crate) enum MveConcatInvalidTyReason {
         InvalidIdent,
         #[note(expand_float_lit)]
-        #[help(expand_valid_types)]
+        #[note(expand_valid_types)]
         FloatLit,
         #[note(expand_c_str_lit)]
-        #[help(expand_valid_types)]
+        #[note(expand_valid_types)]
         CStrLit,
         #[note(expand_b_str_lit)]
-        #[help(expand_valid_types)]
+        #[note(expand_valid_types)]
         ByteStrLit,
         #[note(expand_expected_metavar)]
         #[label(expand_expected_metavar_dollar)]
         ExpectedMetavarIdent {
-            found: String,
             #[primary_span]
             dollar: Span,
         },
         #[note(expand_raw_ident)]
         RawIdentifier,
         #[note(expand_unsupported)]
-        #[help(expand_valid_types)]
+        #[note(expand_valid_types)]
         UnsupportedInput,
-        #[note(expand_unexpected_group)]
-        UnexpectedGroup,
+        #[note(expand_invalid_metavar)]
+        #[note(expand_valid_metavars)]
+        InvalidMetavarTy,
+        /// Nothing to point out because an error was already emitted.
         InvalidLiteral,
+    }
+
+    #[derive(Diagnostic)]
+    #[note]
+    #[diag(expand_mve_concat_invalid_out)]
+    pub(crate) struct MveConcatInvalidOut {
+        #[primary_span]
+        #[label]
+        pub span: Span,
     }
 
     #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -541,6 +541,30 @@ mod metavar_exprs {
     }
 
     #[derive(Diagnostic)]
+    #[diag(expand_mve_expected_ident)]
+    pub(crate) struct MveExpectedIdent {
+        #[primary_span]
+        pub span: Span,
+        #[label(expand_not_ident)]
+        pub not_ident_label: Option<Span>,
+        /// This error is reused a handful of places, the context here tells us how to customize
+        /// the message.
+        #[subdiagnostic]
+        pub context: MveExpectedIdentContext,
+    }
+
+    #[derive(Subdiagnostic)]
+    pub(crate) enum MveExpectedIdentContext {
+        #[note(expand_expr_name)]
+        #[note(expand_expr_name_note)]
+        ExprName { valid_expr_list: &'static str },
+        #[note(expand_ignore_expr_note)]
+        Ignore,
+        #[note(expand_count_expr_note)]
+        Count,
+    }
+
+    #[derive(Diagnostic)]
     #[diag(expand_mve_unrecognized_var)]
     pub(crate) struct MveUnrecognizedVar {
         #[primary_span]

--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -7,8 +7,30 @@ use rustc_macros::{Decodable, Encodable};
 use rustc_session::parse::ParseSess;
 use rustc_span::{Ident, Span, Symbol};
 
+use crate::errors;
+
 pub(crate) const RAW_IDENT_ERR: &str = "`${concat(..)}` currently does not support raw identifiers";
 pub(crate) const UNSUPPORTED_CONCAT_ELEM_ERR: &str = "expected identifier or string literal";
+
+/// Argument specification for a metavariable expression
+#[derive(Clone, Copy)]
+enum ArgSpec {
+    /// Any number of args
+    Any,
+    /// Between n and m args (inclusive)
+    Between(usize, usize),
+    /// Exactly n args
+    Exact(usize),
+}
+
+/// Map of `(name, max_arg_count, variable_count)`.
+const EXPR_NAME_ARG_MAP: &[(&str, ArgSpec)] = &[
+    ("concat", ArgSpec::Any),
+    ("count", ArgSpec::Between(1, 2)),
+    ("ignore", ArgSpec::Exact(1)),
+    ("index", ArgSpec::Between(0, 1)),
+    ("len", ArgSpec::Between(0, 1)),
+];
 
 /// A meta-variable expression, for expansions based on properties of meta-variables.
 #[derive(Debug, PartialEq, Encodable, Decodable)]
@@ -40,11 +62,32 @@ impl MetaVarExpr {
     ) -> PResult<'psess, MetaVarExpr> {
         let mut iter = input.iter();
         let ident = parse_ident(&mut iter, psess, outer_span)?;
-        let Some(TokenTree::Delimited(.., Delimiter::Parenthesis, args)) = iter.next() else {
-            let msg = "meta-variable expression parameter must be wrapped in parentheses";
-            return Err(psess.dcx().struct_span_err(ident.span, msg));
+        let next = iter.next();
+        let Some(TokenTree::Delimited(.., Delimiter::Parenthesis, args)) = next else {
+            // No `()`; wrong or no delimiters. Point at a problematic span or a place to
+            // add parens if it makes sense.
+            let (unexpected_span, insert_span) = match next {
+                Some(TokenTree::Delimited(..)) => (None, None),
+                Some(tt) => (Some(tt.span()), None),
+                None => (None, Some(ident.span.shrink_to_hi())),
+            };
+            let err =
+                errors::MveMissingParen { ident_span: ident.span, unexpected_span, insert_span };
+            return Err(psess.dcx().create_err(err));
         };
-        check_trailing_token(&mut iter, psess)?;
+
+        // Ensure there are no trailing tokens in the braces, e.g. `${foo() extra}`
+        if iter.peek().is_some() {
+            let span = iter_span(&iter).expect("checked is_some above");
+            let err = errors::MveExtraTokens {
+                span,
+                ident_span: ident.span,
+                extra_count: iter.count(),
+                ..Default::default()
+            };
+            return Err(psess.dcx().create_err(err));
+        }
+
         let mut iter = args.iter();
         let rslt = match ident.as_str() {
             "concat" => parse_concat(&mut iter, psess, outer_span, ident.span)?,
@@ -67,7 +110,7 @@ impl MetaVarExpr {
                 return Err(err);
             }
         };
-        check_trailing_token(&mut iter, psess)?;
+        check_trailing_tokens(&mut iter, psess, ident)?;
         Ok(rslt)
     }
 
@@ -87,20 +130,51 @@ impl MetaVarExpr {
     }
 }
 
-// Checks if there are any remaining tokens. For example, `${ignore(ident ... a b c ...)}`
-fn check_trailing_token<'psess>(
+/// Checks if there are any remaining tokens (for example, `${ignore($valid, extra)}`) and create
+/// a diag with the correct arg count if so.
+fn check_trailing_tokens<'psess>(
     iter: &mut TokenStreamIter<'_>,
     psess: &'psess ParseSess,
+    ident: Ident,
 ) -> PResult<'psess, ()> {
-    if let Some(tt) = iter.next() {
-        let mut diag = psess
-            .dcx()
-            .struct_span_err(tt.span(), format!("unexpected token: {}", pprust::tt_to_string(tt)));
-        diag.span_note(tt.span(), "meta-variable expression must not have trailing tokens");
-        Err(diag)
-    } else {
-        Ok(())
+    if iter.peek().is_none() {
+        // All tokens consumed, as expected
+        return Ok(());
     }
+
+    let (name, spec) = EXPR_NAME_ARG_MAP
+        .iter()
+        .find(|(name, _)| *name == ident.as_str())
+        .expect("called with an invalid name");
+
+    let (min_or_exact_args, max_args) = match *spec {
+        // For expressions like `concat`, all tokens should be consumed already
+        ArgSpec::Any => panic!("{name} takes unlimited tokens but didn't eat them all"),
+        ArgSpec::Between(min, max) => (min, Some(max)),
+        ArgSpec::Exact(n) => (n, None),
+    };
+
+    let err = errors::MveExtraTokens {
+        span: iter_span(iter).expect("checked is_none above"),
+        ident_span: ident.span,
+        extra_count: iter.count(),
+
+        exact_args_note: if max_args.is_some() { None } else { Some(()) },
+        range_args_note: if max_args.is_some() { Some(()) } else { None },
+        min_or_exact_args,
+        max_args: max_args.unwrap_or_default(),
+        name,
+    };
+    Err(psess.dcx().create_err(err))
+}
+
+/// Returns a span encompassing all tokens in the iterator if there is at least one item.
+fn iter_span(iter: &TokenStreamIter<'_>) -> Option<Span> {
+    let mut iter = iter.clone(); // cloning is cheap
+    let first_sp = iter.next()?.span();
+    let last_sp = iter.last().map(TokenTree::span).unwrap_or(first_sp);
+    let span = first_sp.with_hi(last_sp.hi());
+    Some(span)
 }
 
 /// Indicates what is placed in a `concat` parameter. For example, literals

--- a/compiler/rustc_expand/src/mbe/metavar_expr.rs
+++ b/compiler/rustc_expand/src/mbe/metavar_expr.rs
@@ -32,6 +32,9 @@ const EXPR_NAME_ARG_MAP: &[(&str, ArgSpec)] = &[
     ("len", ArgSpec::Between(0, 1)),
 ];
 
+/// List of the above for diagnostics
+const VALID_METAVAR_EXPR_NAMES: &str = "`count`, `ignore`, `index`, `len`, and `concat`";
+
 /// A meta-variable expression, for expansions based on properties of meta-variables.
 #[derive(Debug, PartialEq, Encodable, Decodable)]
 pub(crate) enum MetaVarExpr {
@@ -99,15 +102,11 @@ impl MetaVarExpr {
             "index" => MetaVarExpr::Index(parse_depth(&mut iter, psess, ident.span)?),
             "len" => MetaVarExpr::Len(parse_depth(&mut iter, psess, ident.span)?),
             _ => {
-                let err_msg = "unrecognized meta-variable expression";
-                let mut err = psess.dcx().struct_span_err(ident.span, err_msg);
-                err.span_suggestion(
-                    ident.span,
-                    "supported expressions are count, ignore, index and len",
-                    "",
-                    Applicability::MachineApplicable,
-                );
-                return Err(err);
+                let err = errors::MveUnrecognizedExpr {
+                    span: ident.span,
+                    valid_expr_list: VALID_METAVAR_EXPR_NAMES,
+                };
+                return Err(psess.dcx().create_err(err));
             }
         };
         check_trailing_tokens(&mut iter, psess, ident)?;

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -16,14 +16,17 @@ use rustc_span::{
 };
 use smallvec::{SmallVec, smallvec};
 
+use super::metavar_expr::parse_tok_for_concat;
 use crate::errors::{
-    CountRepetitionMisplaced, MetaVarsDifSeqMatchers, MustRepeatOnce, MveUnrecognizedVar,
+    self, CountRepetitionMisplaced, MetaVarsDifSeqMatchers, MustRepeatOnce, MveUnrecognizedVar,
     NoSyntaxVarsExprRepeat, VarStillRepeating,
 };
 use crate::mbe::macro_parser::NamedMatch;
 use crate::mbe::macro_parser::NamedMatch::*;
-use crate::mbe::metavar_expr::{MetaVarExprConcatElem, RAW_IDENT_ERR};
+use crate::mbe::metavar_expr::{MetaVarExprConcatElem, VALID_EXPR_CONCAT_TYPES};
 use crate::mbe::{self, KleeneOp, MetaVarExpr};
+
+const VALID_METAVAR_CONCAT_TYPES: &str = "`ident`, `literal`, and `tt`";
 
 /// Context needed to perform transcription of metavariable expressions.
 struct TranscrCtx<'psess, 'itp> {
@@ -905,48 +908,37 @@ fn out_of_bounds_err<'a>(dcx: DiagCtxtHandle<'a>, max: usize, span: Span, ty: &s
 }
 
 /// Extracts an metavariable symbol that can be an identifier, a token tree or a literal.
-// TODO: use the same logic as for metavar_expr
 fn extract_symbol_from_pnr<'tx>(
     tscx: &mut TranscrCtx<'tx, '_>,
     pnr: &ParseNtResult,
-    span_err: Span,
-) -> PResult<'tx, Symbol> {
-    let dcx = tscx.psess.dcx();
-    match pnr {
-        ParseNtResult::Ident(nt_ident, is_raw) => {
-            if let IdentIsRaw::Yes = is_raw {
-                Err(dcx.struct_span_err(span_err, RAW_IDENT_ERR))
-            } else {
-                Ok(nt_ident.name)
-            }
+    metavar_span: Span,
+) -> PResult<'tx, String> {
+    // Reconstruct a `Token` so we can share logic with expression parsing.
+    let token = match pnr {
+        ParseNtResult::Tt(TokenTree::Token(tok, _)) => *tok,
+        ParseNtResult::Ident(Ident { name, span }, ident_is_raw) => {
+            Token { kind: TokenKind::Ident(*name, *ident_is_raw), span: *span }
         }
-        ParseNtResult::Tt(TokenTree::Token(
-            Token { kind: TokenKind::Ident(symbol, is_raw), .. },
-            _,
-        )) => {
-            if let IdentIsRaw::Yes = is_raw {
-                Err(dcx.struct_span_err(span_err, RAW_IDENT_ERR))
-            } else {
-                Ok(*symbol)
-            }
+
+        ParseNtResult::Literal(l) if let ExprKind::Lit(lit) = l.kind => {
+            Token { kind: TokenKind::Literal(lit), span: l.span }
         }
-        ParseNtResult::Tt(TokenTree::Token(
-            Token {
-                kind: TokenKind::Literal(Lit { kind: LitKind::Str, symbol, suffix: None }),
-                ..
-            },
-            _,
-        )) => Ok(*symbol),
-        ParseNtResult::Literal(expr)
-            if let ExprKind::Lit(Lit { kind: LitKind::Str, symbol, suffix: None }) = &expr.kind =>
-        {
-            Ok(*symbol)
+        _ => {
+            let err = errors::MveConcatInvalidTy {
+                span: pnr.span(),
+                metavar_span: Some(metavar_span),
+                reason: errors::MveConcatInvalidTyReason::InvalidMetavarTy,
+                valid: VALID_METAVAR_CONCAT_TYPES,
+            };
+            return Err(tscx.psess.dcx().create_err(err));
         }
-        _ => Err(dcx
-            .struct_err(
-                "metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`",
-            )
-            .with_note("currently only string literals are supported")
-            .with_span(span_err)),
-    }
+    };
+
+    parse_tok_for_concat(tscx.psess, token)
+    //     _ => Err(dcx
+    //         .struct_err(
+    //             "metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`",
+    //         )
+    //         .with_note("currently only string literals are supported")
+    //         .with_span(span_err)),
 }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1657,3 +1657,24 @@ pub enum ParseNtResult {
     Path(P<ast::Path>),
     Vis(P<ast::Visibility>),
 }
+
+impl ParseNtResult {
+    #[inline]
+    pub fn span(&self) -> Span {
+        match self {
+            ParseNtResult::Tt(token_tree) => token_tree.span(),
+            ParseNtResult::Ident(ident, ..) => ident.span,
+            ParseNtResult::Lifetime(ident, ..) => ident.span,
+            ParseNtResult::Item(item) => item.span,
+            ParseNtResult::Block(block) => block.span,
+            ParseNtResult::Stmt(stmt) => stmt.span,
+            ParseNtResult::Pat(pat, ..) => pat.span,
+            ParseNtResult::Expr(expr, ..) => expr.span,
+            ParseNtResult::Literal(expr) => expr.span,
+            ParseNtResult::Ty(ty) => ty.span,
+            ParseNtResult::Meta(attr_item) => attr_item.span(),
+            ParseNtResult::Path(path) => path.span,
+            ParseNtResult::Vis(visibility) => visibility.span,
+        }
+    }
+}

--- a/tests/ui/macros/macro-metavar-expr-concat/empty-input.stderr
+++ b/tests/ui/macros/macro-metavar-expr-concat/empty-input.stderr
@@ -1,8 +1,8 @@
-error: expected identifier or string literal
-  --> $DIR/empty-input.rs:6:14
+error: `concat` must have at least two elements
+  --> $DIR/empty-input.rs:6:15
    |
 LL |     () => { ${concat()} }
-   |              ^^^^^^^^^^
+   |               ^^^^^^
 
 error: expected expression, found `$`
   --> $DIR/empty-input.rs:6:13

--- a/tests/ui/macros/metavar-expressions/concat-allowed-operations.rs
+++ b/tests/ui/macros/metavar-expressions/concat-allowed-operations.rs
@@ -38,7 +38,14 @@ macro_rules! without_dollar_sign_is_an_ident {
 }
 
 macro_rules! combinations {
-    ($ident:ident, $literal:literal, $tt_ident:tt, $tt_literal:tt) => {{
+    (
+        $ident:ident,
+        $literal:literal,
+        $char:literal,
+        $tt_ident:tt,
+        $tt_literal:tt,
+        $tt_char:tt
+    ) => {{
         // tt ident
         let ${concat($tt_ident, b)} = ();
         let ${concat($tt_ident, _b)} = ();
@@ -89,17 +96,39 @@ macro_rules! combinations {
         let ${concat($literal, $tt_literal)} = ();
         let ${concat($literal, $ident)} = ();
         let ${concat($literal, $literal)} = ();
+
+        // char literal (adhoc)
+        let ${concat('a', b)} = ();
+        let ${concat('a', _b)} = ();
+        let ${concat('a', 'b')} = ();
+        let ${concat('a', $tt_ident)} = ();
+        let ${concat('a', $tt_literal)} = ();
+        let ${concat('a', $ident)} = ();
+        let ${concat('a', $literal)} = ();
+        // char literal (param)
+        let ${concat($literal, b)} = ();
+        let ${concat($literal, _b)} = ();
+        let ${concat($literal, 'b')} = ();
+        let ${concat($literal, $tt_ident)} = ();
+        let ${concat($literal, $tt_literal)} = ();
+        let ${concat($literal, $ident)} = ();
+        let ${concat($literal, $literal)} = ();
     }};
+}
+
+macro_rules! stripped_suffixes {
+    ($x:literal) => {
+        assert_eq!(stringify!(${concat("a", 40u32)}), "a40");
+        // TODO
+        // assert_eq!(stringify!(${concat("a", $x)}), "a100");
+    };
 }
 
 fn main() {
     create_things!(behold);
     behold_separated_idents_in_a_fn();
     let _ = behold_separated_idents_in_a_module::FOO;
-    let _ = behold_separated_idents_in_a_struct {
-        foo: 1,
-        behold_separated_idents_in_a_field: 2,
-    };
+    let _ = behold_separated_idents_in_a_struct { foo: 1, behold_separated_idents_in_a_field: 2 };
 
     many_idents!(A, C);
     assert_eq!(ABCD, 1);
@@ -111,5 +140,7 @@ fn main() {
     assert_eq!(VARident, 1);
     assert_eq!(VAR_123, 2);
 
-    combinations!(_hello, "a", b, "b");
+    combinations!(_hello, "a", 'a', b, "b", 'b');
+
+    stripped_suffixes!(100u32);
 }

--- a/tests/ui/macros/metavar-expressions/concat-raw-identifiers.rs
+++ b/tests/ui/macros/metavar-expressions/concat-raw-identifiers.rs
@@ -26,14 +26,14 @@ macro_rules! idents_11 {
 macro_rules! no_params {
     () => {
         let ${concat(r#abc, abc)}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         //~| ERROR expected pattern, found `$`
 
         let ${concat(abc, r#abc)}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
 
         let ${concat(r#abc, r#abc)}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
     };
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-raw-identifiers.rs
+++ b/tests/ui/macros/metavar-expressions/concat-raw-identifiers.rs
@@ -3,60 +3,60 @@
 macro_rules! idents_01 {
     ($rhs:ident) => {
         let ${concat(abc, $rhs)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! idents_10 {
     ($lhs:ident) => {
         let ${concat($lhs, abc)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! idents_11 {
     ($lhs:ident, $rhs:ident) => {
         let ${concat($lhs, $rhs)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
-        //~| ERROR `${concat(..)}` currently does not support raw identifiers
-        //~| ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
+        //~| ERROR invalid item within a `${concat(..)}` expression
+        //~| ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! no_params {
     () => {
         let ${concat(r#abc, abc)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         //~| ERROR expected pattern, found `$`
 
         let ${concat(abc, r#abc)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
 
         let ${concat(r#abc, r#abc)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! tts_01 {
     ($rhs:tt) => {
         let ${concat(abc, $rhs)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! tts_10 {
     ($lhs:tt) => {
         let ${concat($lhs, abc)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     };
 }
 
 macro_rules! tts_11 {
     ($lhs:tt, $rhs:tt) => {
         let ${concat($lhs, $rhs)}: () = ();
-        //~^ ERROR `${concat(..)}` currently does not support raw identifiers
-        //~| ERROR `${concat(..)}` currently does not support raw identifiers
-        //~| ERROR `${concat(..)}` currently does not support raw identifiers
+        //~^ ERROR invalid item within a `${concat(..)}` expression
+        //~| ERROR invalid item within a `${concat(..)}` expression
+        //~| ERROR invalid item within a `${concat(..)}` expression
     };
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-raw-identifiers.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-raw-identifiers.stderr
@@ -1,20 +1,41 @@
-error: expected identifier or string literal
+error: invalid item within a `${concat(...)}` expression
   --> $DIR/concat-raw-identifiers.rs:28:22
    |
 LL |         let ${concat(r#abc, abc)}: () = ();
    |                      ^^^^^
+   |
+   = note: raw identifiers cannot be concatenated
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-raw-identifiers.rs:28:15
+   |
+LL |         let ${concat(r#abc, abc)}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
+error: invalid item within a `${concat(...)}` expression
   --> $DIR/concat-raw-identifiers.rs:32:27
    |
 LL |         let ${concat(abc, r#abc)}: () = ();
    |                           ^^^^^
+   |
+   = note: raw identifiers cannot be concatenated
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-raw-identifiers.rs:32:15
+   |
+LL |         let ${concat(abc, r#abc)}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
+error: invalid item within a `${concat(...)}` expression
   --> $DIR/concat-raw-identifiers.rs:35:22
    |
 LL |         let ${concat(r#abc, r#abc)}: () = ();
    |                      ^^^^^
+   |
+   = note: raw identifiers cannot be concatenated
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-raw-identifiers.rs:35:15
+   |
+LL |         let ${concat(r#abc, r#abc)}: () = ();
+   |               ^^^^^^
 
 error: `${concat(..)}` currently does not support raw identifiers
   --> $DIR/concat-raw-identifiers.rs:5:28

--- a/tests/ui/macros/metavar-expressions/concat-raw-identifiers.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-raw-identifiers.stderr
@@ -1,105 +1,106 @@
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-raw-identifiers.rs:28:22
    |
 LL |         let ${concat(r#abc, abc)}: () = ();
    |                      ^^^^^
    |
    = note: raw identifiers cannot be concatenated
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-raw-identifiers.rs:28:15
-   |
-LL |         let ${concat(r#abc, abc)}: () = ();
-   |               ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-raw-identifiers.rs:32:27
    |
 LL |         let ${concat(abc, r#abc)}: () = ();
    |                           ^^^^^
    |
    = note: raw identifiers cannot be concatenated
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-raw-identifiers.rs:32:15
-   |
-LL |         let ${concat(abc, r#abc)}: () = ();
-   |               ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-raw-identifiers.rs:35:22
    |
 LL |         let ${concat(r#abc, r#abc)}: () = ();
    |                      ^^^^^
    |
    = note: raw identifiers cannot be concatenated
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-raw-identifiers.rs:35:15
-   |
-LL |         let ${concat(r#abc, r#abc)}: () = ();
-   |               ^^^^^^
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:5:28
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:64:16
    |
-LL |         let ${concat(abc, $rhs)}: () = ();
-   |                            ^^^
+LL |     idents_01!(r#_c);
+   |                ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:12:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:66:16
    |
-LL |         let ${concat($lhs, abc)}: () = ();
-   |                       ^^^
+LL |     idents_10!(r#_c);
+   |                ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:19:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:68:16
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                       ^^^
+LL |     idents_11!(r#_c, d);
+   |                ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:19:29
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:69:20
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                             ^^^
+LL |     idents_11!(_e, r#f);
+   |                    ^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:19:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:70:16
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                       ^^^
+LL |     idents_11!(r#_g, r#h);
+   |                ^^^^
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:42:28
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:72:13
    |
-LL |         let ${concat(abc, $rhs)}: () = ();
-   |                            ^^^
+LL |     tts_01!(r#_c);
+   |             ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:49:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:74:13
    |
-LL |         let ${concat($lhs, abc)}: () = ();
-   |                       ^^^
+LL |     tts_10!(r#_c);
+   |             ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:56:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:76:13
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                       ^^^
+LL |     tts_11!(r#_c, d);
+   |             ^^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:56:29
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:77:17
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                             ^^^
+LL |     tts_11!(_e, r#f);
+   |                 ^^^
+   |
+   = note: raw identifiers cannot be concatenated
 
-error: `${concat(..)}` currently does not support raw identifiers
-  --> $DIR/concat-raw-identifiers.rs:56:23
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-raw-identifiers.rs:78:13
    |
-LL |         let ${concat($lhs, $rhs)}: () = ();
-   |                       ^^^
+LL |     tts_11!(r#_g, r#h);
+   |             ^^^^
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: raw identifiers cannot be concatenated
 
 error: expected pattern, found `$`
   --> $DIR/concat-raw-identifiers.rs:28:13

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
@@ -7,8 +7,11 @@
 macro_rules! pre_expansion {
     ($a:ident) => {
         ${concat("hi", " bye ")};
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         ${concat("hi", "-", "bye")};
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         ${concat($a, "-")};
+        //~^ ERROR invalid item within a `${concat(...)}` expression
     }
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
@@ -7,11 +7,11 @@
 macro_rules! pre_expansion {
     ($a:ident) => {
         ${concat("hi", " bye ")};
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         ${concat("hi", "-", "bye")};
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         ${concat($a, "-")};
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     }
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
@@ -1,5 +1,44 @@
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-trace-errors.rs:9:24
+   |
+LL |         ${concat("hi", " bye ")};
+   |                        ^^^^^^^
+   |
+   = note: this literal produced an invalid identifier
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-trace-errors.rs:9:11
+   |
+LL |         ${concat("hi", " bye ")};
+   |           ^^^^^^
+
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-trace-errors.rs:11:24
+   |
+LL |         ${concat("hi", "-", "bye")};
+   |                        ^^^
+   |
+   = note: this literal produced an invalid identifier
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-trace-errors.rs:11:11
+   |
+LL |         ${concat("hi", "-", "bye")};
+   |           ^^^^^^
+
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-trace-errors.rs:13:22
+   |
+LL |         ${concat($a, "-")};
+   |                      ^^^
+   |
+   = note: this literal produced an invalid identifier
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-trace-errors.rs:13:11
+   |
+LL |         ${concat($a, "-")};
+   |           ^^^^^^
+
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-trace-errors.rs:17:24
+  --> $DIR/concat-trace-errors.rs:20:24
    |
 LL |         const _: () = ${concat("hi", $a, "bye")};
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +49,7 @@ LL | post_expansion!("!");
    = note: this error originates in the macro `post_expansion` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-trace-errors.rs:26:24
+  --> $DIR/concat-trace-errors.rs:29:24
    |
 LL |         const _: () = ${concat($a, $b, $c, $d, $e)};
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,5 +59,5 @@ LL | post_expansion_many!(a, b, c, ".d", e);
    |
    = note: this error originates in the macro `post_expansion_many` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
@@ -1,63 +1,32 @@
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-trace-errors.rs:9:24
    |
 LL |         ${concat("hi", " bye ")};
    |                        ^^^^^^^
-   |
-   = note: this literal produced an invalid identifier
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-trace-errors.rs:9:11
-   |
-LL |         ${concat("hi", " bye ")};
-   |           ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-trace-errors.rs:11:24
    |
 LL |         ${concat("hi", "-", "bye")};
    |                        ^^^
-   |
-   = note: this literal produced an invalid identifier
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-trace-errors.rs:11:11
-   |
-LL |         ${concat("hi", "-", "bye")};
-   |           ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-trace-errors.rs:13:22
    |
 LL |         ${concat($a, "-")};
    |                      ^^^
-   |
-   = note: this literal produced an invalid identifier
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-trace-errors.rs:13:11
-   |
-LL |         ${concat($a, "-")};
-   |           ^^^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-trace-errors.rs:20:24
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-trace-errors.rs:25:17
    |
-LL |         const _: () = ${concat("hi", $a, "bye")};
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL | post_expansion!("!");
-   | -------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `post_expansion` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                 ^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-trace-errors.rs:29:24
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-trace-errors.rs:34:31
    |
-LL |         const _: () = ${concat($a, $b, $c, $d, $e)};
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL | post_expansion_many!(a, b, c, ".d", e);
-   | -------------------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `post_expansion_many` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                               ^^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
@@ -22,7 +22,7 @@ macro_rules! syntax_errors {
         //~^ ERROR `concat` must have at least two elements
 
         ${concat($ex, aaaa)}
-        //~^ ERROR metavariables of `${concat(..)}` must be of type
+        //~^ ERROR invalid item within a `${concat(..)}` expression
 
         ${concat($ex, aaaa 123)}
         //~^ ERROR expected comma
@@ -54,7 +54,7 @@ macro_rules! starting_valid_unicode {
 macro_rules! starting_invalid_unicode {
     ($ident:ident) => {{
         let ${concat("\u{00BD}", $ident)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         //~| ERROR expected pattern
     }};
 }
@@ -74,7 +74,7 @@ macro_rules! ending_valid_unicode {
 macro_rules! ending_invalid_unicode {
     ($ident:ident) => {{
         let ${concat($ident, "\u{00BD}")}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         //~| ERROR expected pattern
     }};
 }
@@ -89,27 +89,27 @@ macro_rules! empty {
 macro_rules! unsupported_literals {
     ($ident:ident) => {{
         let ${concat(_a, 1.5)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         //~| ERROR expected pattern
         let ${concat(_a, c"hi")}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat(_a, b"hi")}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat(_a, b'b')}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat(_a, b'b')}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
 
         let ${concat($ident, 1.5)}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat($ident, c"hi")}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat($ident, b"hi")}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat($ident, b'b')}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
         let ${concat($ident, b'b')}: () = ();
-        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~^ ERROR invalid item within a `${concat(..)}` expression
     }};
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
@@ -5,13 +5,13 @@
 macro_rules! syntax_errors {
     ($ex:expr) => {
         ${concat()}
-        //~^ ERROR expected identifier
+        //~^ ERROR `concat` must have at least two elements
 
         ${concat(aaaa)}
         //~^ ERROR `concat` must have at least two elements
 
         ${concat(aaaa,)}
-        //~^ ERROR expected identifier
+        //~^ ERROR `concat` must have at least two elements
 
         ${concat(_, aaaa)}
 
@@ -28,7 +28,6 @@ macro_rules! syntax_errors {
         //~^ ERROR expected comma
 
         ${concat($ex, aaaa,)}
-        //~^ ERROR expected identifier
     };
 }
 
@@ -55,7 +54,8 @@ macro_rules! starting_valid_unicode {
 macro_rules! starting_invalid_unicode {
     ($ident:ident) => {{
         let ${concat("\u{00BD}", $ident)}: () = ();
-        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~| ERROR expected pattern
     }};
 }
 
@@ -74,7 +74,8 @@ macro_rules! ending_valid_unicode {
 macro_rules! ending_invalid_unicode {
     ($ident:ident) => {{
         let ${concat($ident, "\u{00BD}")}: () = ();
-        //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~| ERROR expected pattern
     }};
 }
 
@@ -87,36 +88,28 @@ macro_rules! empty {
 
 macro_rules! unsupported_literals {
     ($ident:ident) => {{
-        let ${concat(_a, 'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
-        //~| ERROR expected pattern
-        let ${concat(_a, 1)}: () = ();
-        //~^ ERROR expected identifier or string literal
         let ${concat(_a, 1.5)}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
+        //~| ERROR expected pattern
         let ${concat(_a, c"hi")}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat(_a, b"hi")}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat(_a, b'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat(_a, b'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
 
-        let ${concat($ident, 'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
-        let ${concat($ident, 1)}: () = ();
-        //~^ ERROR expected identifier or string literal
         let ${concat($ident, 1.5)}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat($ident, c"hi")}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat($ident, b"hi")}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat($ident, b'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
         let ${concat($ident, b'b')}: () = ();
-        //~^ ERROR expected identifier or string literal
+        //~^ ERROR invalid item within a `${concat(...)}` expression
     }};
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
@@ -34,179 +34,119 @@ error: expected comma
 LL |         ${concat($ex, aaaa 123)}
    |          ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:56:22
    |
 LL |         let ${concat("\u{00BD}", $ident)}: () = ();
    |                      ^^^^^^^^^^
-   |
-   = note: this literal produced an invalid identifier
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:56:15
-   |
-LL |         let ${concat("\u{00BD}", $ident)}: () = ();
-   |               ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:76:30
    |
 LL |         let ${concat($ident, "\u{00BD}")}: () = ();
    |                              ^^^^^^^^^^
-   |
-   = note: this literal produced an invalid identifier
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:76:15
-   |
-LL |         let ${concat($ident, "\u{00BD}")}: () = ();
-   |               ^^^^^^
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:91:26
    |
 LL |         let ${concat(_a, 1.5)}: () = ();
    |                          ^^^
    |
    = note: float literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:91:15
-   |
-LL |         let ${concat(_a, 1.5)}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:94:26
    |
 LL |         let ${concat(_a, c"hi")}: () = ();
    |                          ^^^^^
    |
    = note: C string literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:94:15
-   |
-LL |         let ${concat(_a, c"hi")}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:96:26
    |
 LL |         let ${concat(_a, b"hi")}: () = ();
    |                          ^^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:96:15
-   |
-LL |         let ${concat(_a, b"hi")}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:98:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:98:15
-   |
-LL |         let ${concat(_a, b'b')}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:100:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:100:15
-   |
-LL |         let ${concat(_a, b'b')}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:103:30
    |
 LL |         let ${concat($ident, 1.5)}: () = ();
    |                              ^^^
    |
    = note: float literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:103:15
-   |
-LL |         let ${concat($ident, 1.5)}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:105:30
    |
 LL |         let ${concat($ident, c"hi")}: () = ();
    |                              ^^^^^
    |
    = note: C string literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:105:15
-   |
-LL |         let ${concat($ident, c"hi")}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:107:30
    |
 LL |         let ${concat($ident, b"hi")}: () = ();
    |                              ^^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:107:15
-   |
-LL |         let ${concat($ident, b"hi")}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:109:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:109:15
-   |
-LL |         let ${concat($ident, b'b')}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: invalid item within a `${concat(...)}` expression
+error: invalid item within a `${concat(..)}` expression
   --> $DIR/concat-usage-errors.rs:111:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
    |
    = note: byte literals cannot be concatenated
-   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
-help: expanding this `concat(...)` expression
-  --> $DIR/concat-usage-errors.rs:111:15
-   |
-LL |         let ${concat($ident, b'b')}: () = ();
-   |               ^^^^^^
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
 
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:24:19
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:150:20
    |
 LL |         ${concat($ex, aaaa)}
-   |                   ^^
+   |                   -- expanding this metavariable
+...
+LL |     syntax_errors!(1);
+   |                    ^
    |
-   = note: currently only string literals are supported
+   = note: expanding something
+   = note: `${concat(..)}` can join metavariables of type `ident`, `literal`, and `tt`
 
 error: variable `foo` is not recognized in meta-variable expression
   --> $DIR/concat-usage-errors.rs:36:30
@@ -269,152 +209,117 @@ LL |     empty!();
    |
    = note: this error originates in the macro `empty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:165:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("\u{00BD}");
-   |     ------------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                         ^^^^^^^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:167:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL |     bad_literal_string!("\x41");
-   |     --------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("🤷");
-   |     ------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                         ^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:168:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("d[-_-]b");
-   |     ------------------------------ in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                         ^^^^^^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:170:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("-1");
-   |     ------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                         ^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:171:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("1.0");
-   |     -------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                         ^^^^^
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:118:16
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:172:25
    |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-...
 LL |     bad_literal_string!("'1'");
+   |                         ^^^^^
+
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:175:29
+   |
+LL |         const ${concat(_foo, $literal)}: () = ();
+   |                               ------- expanding this metavariable
+...
+LL |     bad_literal_non_string!(-1);
+   |                             ^^
+   |
+   = note: expanding something
+   = note: `${concat(..)}` can join metavariables of type `ident`, `literal`, and `tt`
+
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:176:29
+   |
+LL |     bad_literal_non_string!(1.0);
+   |                             ^^^
+   |
+   = note: float literals cannot be concatenated
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
+
+error[E0428]: the name `_foo1` is defined multiple times
+  --> $DIR/concat-usage-errors.rs:131:9
+   |
+LL |         const ${concat(_foo, $literal)}: () = ();
+   |         ^^^^^^^
+   |         |
+   |         `_foo1` redefined here
+   |         previous definition of the value `_foo1` here
+...
+LL |     bad_literal_non_string!(1);
    |     -------------------------- in this macro invocation
    |
-   = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `_foo1` must be defined only once in the value namespace of this block
+   = note: this error originates in the macro `bad_literal_non_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:131:31
+error[E0428]: the name `_foo1` is defined multiple times
+  --> $DIR/concat-usage-errors.rs:142:9
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:131:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:131:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:131:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:131:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:142:31
-   |
+   |         ------- previous definition of the value `_foo1` here
+...
 LL |         const ${concat(_foo, $tt)}: () = ();
-   |                               ^^
+   |         ^^^^^^^ `_foo1` redefined here
+...
+LL |     bad_tt_literal!(1);
+   |     ------------------ in this macro invocation
    |
-   = note: currently only string literals are supported
+   = note: `_foo1` must be defined only once in the value namespace of this block
+   = note: this error originates in the macro `bad_tt_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:142:31
+error: invalid item within a `${concat(..)}` expression
+  --> $DIR/concat-usage-errors.rs:181:21
    |
+LL |     bad_tt_literal!(1.0);
+   |                     ^^^
+   |
+   = note: float literals cannot be concatenated
+   = note: `concat` can join metavariables, identifiers, string literals, and integer literals
+
+error[E0428]: the name `_foo1` is defined multiple times
+  --> $DIR/concat-usage-errors.rs:142:9
+   |
+LL |         const ${concat(_foo, $literal)}: () = ();
+   |         ------- previous definition of the value `_foo1` here
+...
 LL |         const ${concat(_foo, $tt)}: () = ();
-   |                               ^^
+   |         ^^^^^^^ `_foo1` redefined here
+...
+LL |     bad_tt_literal!('1');
+   |     -------------------- in this macro invocation
    |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: `_foo1` must be defined only once in the value namespace of this block
+   = note: this error originates in the macro `bad_tt_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:142:31
-   |
-LL |         const ${concat(_foo, $tt)}: () = ();
-   |                               ^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+error: aborting due to 37 previous errors
 
-error: aborting due to 40 previous errors
-
+For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
@@ -1,8 +1,8 @@
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:7:10
+error: `concat` must have at least two elements
+  --> $DIR/concat-usage-errors.rs:7:11
    |
 LL |         ${concat()}
-   |          ^^^^^^^^^^
+   |           ^^^^^^
 
 error: `concat` must have at least two elements
   --> $DIR/concat-usage-errors.rs:10:11
@@ -10,11 +10,11 @@ error: `concat` must have at least two elements
 LL |         ${concat(aaaa)}
    |           ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:13:10
+error: `concat` must have at least two elements
+  --> $DIR/concat-usage-errors.rs:13:11
    |
 LL |         ${concat(aaaa,)}
-   |          ^^^^^^^^^^^^^^^
+   |           ^^^^^^
 
 error: expected comma
   --> $DIR/concat-usage-errors.rs:18:10
@@ -34,95 +34,171 @@ error: expected comma
 LL |         ${concat($ex, aaaa 123)}
    |          ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:30:10
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:56:22
    |
-LL |         ${concat($ex, aaaa,)}
-   |          ^^^^^^^^^^^^^^^^^^^^
-
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:90:26
+LL |         let ${concat("\u{00BD}", $ident)}: () = ();
+   |                      ^^^^^^^^^^
    |
-LL |         let ${concat(_a, 'b')}: () = ();
-   |                          ^^^
-
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:93:26
+   = note: this literal produced an invalid identifier
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:56:15
    |
-LL |         let ${concat(_a, 1)}: () = ();
-   |                          ^
+LL |         let ${concat("\u{00BD}", $ident)}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:95:26
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:76:30
+   |
+LL |         let ${concat($ident, "\u{00BD}")}: () = ();
+   |                              ^^^^^^^^^^
+   |
+   = note: this literal produced an invalid identifier
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:76:15
+   |
+LL |         let ${concat($ident, "\u{00BD}")}: () = ();
+   |               ^^^^^^
+
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:91:26
    |
 LL |         let ${concat(_a, 1.5)}: () = ();
    |                          ^^^
+   |
+   = note: float literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:91:15
+   |
+LL |         let ${concat(_a, 1.5)}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:97:26
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:94:26
    |
 LL |         let ${concat(_a, c"hi")}: () = ();
    |                          ^^^^^
+   |
+   = note: C string literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:94:15
+   |
+LL |         let ${concat(_a, c"hi")}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:99:26
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:96:26
    |
 LL |         let ${concat(_a, b"hi")}: () = ();
    |                          ^^^^^
+   |
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:96:15
+   |
+LL |         let ${concat(_a, b"hi")}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:101:26
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:98:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
+   |
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:98:15
+   |
+LL |         let ${concat(_a, b'b')}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:103:26
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:100:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
-
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:106:30
    |
-LL |         let ${concat($ident, 'b')}: () = ();
-   |                              ^^^
-
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:108:30
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:100:15
    |
-LL |         let ${concat($ident, 1)}: () = ();
-   |                              ^
+LL |         let ${concat(_a, b'b')}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:110:30
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:103:30
    |
 LL |         let ${concat($ident, 1.5)}: () = ();
    |                              ^^^
+   |
+   = note: float literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:103:15
+   |
+LL |         let ${concat($ident, 1.5)}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:112:30
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:105:30
    |
 LL |         let ${concat($ident, c"hi")}: () = ();
    |                              ^^^^^
+   |
+   = note: C string literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:105:15
+   |
+LL |         let ${concat($ident, c"hi")}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:114:30
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:107:30
    |
 LL |         let ${concat($ident, b"hi")}: () = ();
    |                              ^^^^^
+   |
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:107:15
+   |
+LL |         let ${concat($ident, b"hi")}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:116:30
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:109:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
+   |
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:109:15
+   |
+LL |         let ${concat($ident, b'b')}: () = ();
+   |               ^^^^^^
 
-error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:118:30
+error: invalid item within a `${concat(...)}` expression
+  --> $DIR/concat-usage-errors.rs:111:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
+   |
+   = note: byte literals cannot be concatenated
+   = help: `concat` can join metavariables, identifiers, string literals, and integer literals
+help: expanding this `concat(...)` expression
+  --> $DIR/concat-usage-errors.rs:111:15
+   |
+LL |         let ${concat($ident, b'b')}: () = ();
+   |               ^^^^^^
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
   --> $DIR/concat-usage-errors.rs:24:19
@@ -133,13 +209,13 @@ LL |         ${concat($ex, aaaa)}
    = note: currently only string literals are supported
 
 error: variable `foo` is not recognized in meta-variable expression
-  --> $DIR/concat-usage-errors.rs:37:30
+  --> $DIR/concat-usage-errors.rs:36:30
    |
 LL |         const ${concat(FOO, $foo)}: i32 = 2;
    |                              ^^^
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:44:14
+  --> $DIR/concat-usage-errors.rs:43:14
    |
 LL |         let ${concat("1", $ident)}: () = ();
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -149,22 +225,22 @@ LL |     starting_number!(_abc);
    |
    = note: this error originates in the macro `starting_number` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:57:14
+error: expected pattern, found `$`
+  --> $DIR/concat-usage-errors.rs:56:13
    |
 LL |         let ${concat("\u{00BD}", $ident)}: () = ();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^ expected pattern
 ...
 LL |     starting_invalid_unicode!(_abc);
    |     ------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `starting_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:76:14
+error: expected pattern, found `$`
+  --> $DIR/concat-usage-errors.rs:76:13
    |
 LL |         let ${concat($ident, "\u{00BD}")}: () = ();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^ expected pattern
 ...
 LL |     ending_invalid_unicode!(_abc);
    |     ----------------------------- in this macro invocation
@@ -172,9 +248,9 @@ LL |     ending_invalid_unicode!(_abc);
    = note: this error originates in the macro `ending_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected pattern, found `$`
-  --> $DIR/concat-usage-errors.rs:90:13
+  --> $DIR/concat-usage-errors.rs:91:13
    |
-LL |         let ${concat(_a, 'b')}: () = ();
+LL |         let ${concat(_a, 1.5)}: () = ();
    |             ^ expected pattern
 ...
 LL |     unsupported_literals!(_abc);
@@ -183,7 +259,7 @@ LL |     unsupported_literals!(_abc);
    = note: this error originates in the macro `unsupported_literals` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:83:14
+  --> $DIR/concat-usage-errors.rs:84:14
    |
 LL |         let ${concat("", "")}: () = ();
    |              ^^^^^^^^^^^^^^^^
@@ -194,7 +270,7 @@ LL |     empty!();
    = note: this error originates in the macro `empty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +281,7 @@ LL |     bad_literal_string!("\u{00BD}");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -216,7 +292,7 @@ LL |     bad_literal_string!("\x41");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -227,7 +303,7 @@ LL |     bad_literal_string!("🤷");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,7 +314,7 @@ LL |     bad_literal_string!("d[-_-]b");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -249,7 +325,7 @@ LL |     bad_literal_string!("-1");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +336,7 @@ LL |     bad_literal_string!("1.0");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:118:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,7 +347,7 @@ LL |     bad_literal_string!("'1'");
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:131:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -279,16 +355,7 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: currently only string literals are supported
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:131:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -297,7 +364,7 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:131:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -306,7 +373,7 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:131:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -315,7 +382,16 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:149:31
+  --> $DIR/concat-usage-errors.rs:131:31
+   |
+LL |         const ${concat(_foo, $literal)}: () = ();
+   |                               ^^^^^^^
+   |
+   = note: currently only string literals are supported
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
+  --> $DIR/concat-usage-errors.rs:142:31
    |
 LL |         const ${concat(_foo, $tt)}: () = ();
    |                               ^^
@@ -323,7 +399,7 @@ LL |         const ${concat(_foo, $tt)}: () = ();
    = note: currently only string literals are supported
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:149:31
+  --> $DIR/concat-usage-errors.rs:142:31
    |
 LL |         const ${concat(_foo, $tt)}: () = ();
    |                               ^^
@@ -332,7 +408,7 @@ LL |         const ${concat(_foo, $tt)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:149:31
+  --> $DIR/concat-usage-errors.rs:142:31
    |
 LL |         const ${concat(_foo, $tt)}: () = ();
    |                               ^^
@@ -340,5 +416,5 @@ LL |         const ${concat(_foo, $tt)}: () = ();
    = note: currently only string literals are supported
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 43 previous errors
+error: aborting due to 40 previous errors
 

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -36,13 +36,13 @@ macro_rules! mve_without_parens {
 #[rustfmt::skip]
 macro_rules! empty_expression {
     () => { ${} };
-    //~^ ERROR expected identifier or string literal
+    //~^ ERROR expected an identifier
 }
 
 #[rustfmt::skip]
 macro_rules! open_brackets_with_lit {
      () => { ${ "hi" } };
-     //~^ ERROR expected identifier
+     //~^ ERROR expected an identifier
  }
 
 macro_rules! mvs_missing_paren {
@@ -57,13 +57,13 @@ macro_rules! mve_wrong_delim {
 
 macro_rules! invalid_metavar {
     () => { ${ignore($123)} }
-    //~^ ERROR expected identifier, found `123`
+    //~^ ERROR expected an identifier
 }
 
 #[rustfmt::skip]
 macro_rules! open_brackets_with_group {
     ( $( $i:ident ),* ) => { ${ {} } };
-    //~^ ERROR expected identifier
+    //~^ ERROR expected an identifier
 }
 
 macro_rules! extra_garbage_after_metavar {

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -18,12 +18,7 @@ macro_rules! metavar_in_the_lhs {
     };
 }
 
-macro_rules! metavar_token_without_ident {
-    ( $( $i:ident ),* ) => { ${ ignore() } };
-    //~^ ERROR meta-variable expressions must be referenced using a dollar sign
-}
-
-macro_rules! metavar_with_literal_suffix {
+macro_rules! mve_with_literal_suffix {
     ( $( $i:ident ),* ) => { ${ index(1u32) } };
     //~^ ERROR only unsuffixes integer literals are supported in meta-variable expressions
 }
@@ -48,6 +43,16 @@ macro_rules! open_brackets_with_lit {
 macro_rules! mvs_missing_paren {
     ( $( $i:ident ),* ) => { ${ count $i ($i) } };
     //~^ ERROR expected `(`
+}
+
+macro_rules! mve_wrong_delim {
+    ( $( $i:ident ),* ) => { ${ count{i} } };
+    //~^ ERROR expected `(`
+}
+
+macro_rules! invalid_metavar {
+    () => { ${ignore($123)} }
+    //~^ ERROR expected an identifier
 }
 
 macro_rules! mve_wrong_delim {
@@ -114,6 +119,11 @@ macro_rules! unknown_ignore_ident {
         ${ignore(bar)}
         //~^ ERROR meta-variable expressions must be referenced using a dollar sign
     };
+}
+
+macro_rules! ignore_no_ident {
+    ( $( $i:ident ),* ) => { ${ ignore() } };
+    //~^ ERROR meta-variable expressions must be referenced using a dollar sign
 }
 
 macro_rules! unknown_metavar {

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -118,7 +118,7 @@ macro_rules! unknown_ignore_ident {
 
 macro_rules! unknown_metavar {
     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
-    //~^ ERROR unrecognized meta-variable expression
+    //~^ ERROR unrecognized metavariable expression
 }
 
 fn main() {}

--- a/tests/ui/macros/metavar-expressions/syntax-errors.rs
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.rs
@@ -30,7 +30,7 @@ macro_rules! metavar_with_literal_suffix {
 
 macro_rules! mve_without_parens {
     ( $( $i:ident ),* ) => { ${ count } };
-    //~^ ERROR meta-variable expression parameter must be wrapped in parentheses
+    //~^ ERROR expected `(`
 }
 
 #[rustfmt::skip]
@@ -45,9 +45,14 @@ macro_rules! open_brackets_with_lit {
      //~^ ERROR expected identifier
  }
 
+macro_rules! mvs_missing_paren {
+    ( $( $i:ident ),* ) => { ${ count $i ($i) } };
+    //~^ ERROR expected `(`
+}
+
 macro_rules! mve_wrong_delim {
     ( $( $i:ident ),* ) => { ${ count{i} } };
-    //~^ ERROR meta-variable expression parameter must be wrapped in parentheses
+    //~^ ERROR expected `(`
 }
 
 macro_rules! invalid_metavar {
@@ -64,28 +69,30 @@ macro_rules! open_brackets_with_group {
 macro_rules! extra_garbage_after_metavar {
     ( $( $i:ident ),* ) => {
         ${count() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i, 1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${count($i) a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${ignore($i) a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${ignore($i a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${index() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${index(1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
 
         ${index() a b c}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
         ${index(1 a b c)}
-        //~^ ERROR unexpected token: a
+        //~^ ERROR unexpected trailing tokens
+        ${index(1, a b c)}
+        //~^ ERROR unexpected trailing tokens
     };
 }
 

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -192,11 +192,13 @@ error: meta-variables within meta-variable expressions must be referenced using 
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
-error: unrecognized meta-variable expression
+error: unrecognized metavariable expression
   --> $DIR/syntax-errors.rs:120:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
-   |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
+   |                                 ^^^^^^^^^^^^^^ not a valid metavariable expression
+   |
+   = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: expected identifier or string literal
   --> $DIR/syntax-errors.rs:38:14

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -28,20 +28,14 @@ error: expected one of: `*`, `+`, or `?`
 LL |     ( ${ len() } ) => {
    |        ^^^^^^^^^
 
-error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:22:33
-   |
-LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
-   |                                 ^^^^^^
-
 error: only unsuffixes integer literals are supported in meta-variable expressions
-  --> $DIR/syntax-errors.rs:27:33
+  --> $DIR/syntax-errors.rs:22:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                                 ^^^^^
 
 error: expected `(`
-  --> $DIR/syntax-errors.rs:32:33
+  --> $DIR/syntax-errors.rs:27:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count } };
    |                                 ^^^^^- help: try adding parentheses: `( /* ... */ )`
@@ -51,7 +45,7 @@ LL |     ( $( $i:ident ),* ) => { ${ count } };
    = note: metavariable expressions use function-like parentheses syntax
 
 error: expected `(`
-  --> $DIR/syntax-errors.rs:49:33
+  --> $DIR/syntax-errors.rs:44:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count $i ($i) } };
    |                                 ^^^^^ - unexpected token
@@ -61,7 +55,7 @@ LL |     ( $( $i:ident ),* ) => { ${ count $i ($i) } };
    = note: metavariable expressions use function-like parentheses syntax
 
 error: expected `(`
-  --> $DIR/syntax-errors.rs:54:33
+  --> $DIR/syntax-errors.rs:49:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |                                 ^^^^^ for this this metavariable expression
@@ -69,7 +63,23 @@ LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    = note: metavariable expressions use function-like parentheses syntax
 
 error: expected an identifier
-  --> $DIR/syntax-errors.rs:59:23
+  --> $DIR/syntax-errors.rs:54:23
+   |
+LL |     () => { ${ignore($123)} }
+   |                       ^^^ not a valid identifier
+   |
+   = note: `ignore` takes a metavariable argument
+
+error: expected `(`
+  --> $DIR/syntax-errors.rs:59:33
+   |
+LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
+   |                                 ^^^^^ for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
+
+error: expected an identifier
+  --> $DIR/syntax-errors.rs:64:23
    |
 LL |     () => { ${ignore($123)} }
    |                       ^^^ not a valid identifier
@@ -77,7 +87,7 @@ LL |     () => { ${ignore($123)} }
    = note: `ignore` takes a metavariable argument
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:71:19
+  --> $DIR/syntax-errors.rs:76:19
    |
 LL |         ${count() a b c}
    |           -----   ^^^^^ help: try removing these tokens
@@ -85,7 +95,7 @@ LL |         ${count() a b c}
    |           for this metavariable expression
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:73:20
+  --> $DIR/syntax-errors.rs:78:20
    |
 LL |         ${count($i a b c)}
    |           -----    ^^^^^ help: try removing these tokens
@@ -95,7 +105,7 @@ LL |         ${count($i a b c)}
    = note: the `count` metavariable expression takes between 1 and 2 arguments
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:75:23
+  --> $DIR/syntax-errors.rs:80:23
    |
 LL |         ${count($i, 1 a b c)}
    |           -----       ^^^^^ help: try removing these tokens
@@ -105,7 +115,7 @@ LL |         ${count($i, 1 a b c)}
    = note: the `count` metavariable expression takes between 1 and 2 arguments
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:77:21
+  --> $DIR/syntax-errors.rs:82:21
    |
 LL |         ${count($i) a b c}
    |           -----     ^^^^^ help: try removing these tokens
@@ -113,7 +123,7 @@ LL |         ${count($i) a b c}
    |           for this metavariable expression
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:80:22
+  --> $DIR/syntax-errors.rs:85:22
    |
 LL |         ${ignore($i) a b c}
    |           ------     ^^^^^ help: try removing these tokens
@@ -121,7 +131,7 @@ LL |         ${ignore($i) a b c}
    |           for this metavariable expression
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:82:21
+  --> $DIR/syntax-errors.rs:87:21
    |
 LL |         ${ignore($i a b c)}
    |           ------    ^^^^^ help: try removing these tokens
@@ -129,24 +139,6 @@ LL |         ${ignore($i a b c)}
    |           for this metavariable expression
    |
    = note: the `ignore` metavariable expression takes a single argument
-
-error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:85:19
-   |
-LL |         ${index() a b c}
-   |           -----   ^^^^^ help: try removing these tokens
-   |           |
-   |           for this metavariable expression
-
-error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:87:19
-   |
-LL |         ${index(1 a b c)}
-   |           -----   ^^^^^ help: try removing these tokens
-   |           |
-   |           for this metavariable expression
-   |
-   = note: the `index` metavariable expression takes between 0 and 1 arguments
 
 error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:90:19
@@ -167,7 +159,25 @@ LL |         ${index(1 a b c)}
    = note: the `index` metavariable expression takes between 0 and 1 arguments
 
 error: unexpected trailing tokens
-  --> $DIR/syntax-errors.rs:94:18
+  --> $DIR/syntax-errors.rs:95:19
+   |
+LL |         ${index() a b c}
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:97:19
+   |
+LL |         ${index(1 a b c)}
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+   |
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:99:18
    |
 LL |         ${index(1, a b c)}
    |           -----  ^^^^^^^ help: try removing these tokens
@@ -177,25 +187,31 @@ LL |         ${index(1, a b c)}
    = note: the `index` metavariable expression takes between 0 and 1 arguments
 
 error: meta-variable expression depth must be a literal
-  --> $DIR/syntax-errors.rs:101:33
+  --> $DIR/syntax-errors.rs:106:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                                 ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:107:11
+  --> $DIR/syntax-errors.rs:112:11
    |
 LL |         ${count(foo)}
    |           ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:114:11
+  --> $DIR/syntax-errors.rs:119:11
    |
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
+error: meta-variables within meta-variable expressions must be referenced using a dollar sign
+  --> $DIR/syntax-errors.rs:125:33
+   |
+LL |     ( $( $i:ident ),* ) => { ${ ignore() } };
+   |                                 ^^^^^^
+
 error: unrecognized metavariable expression
-  --> $DIR/syntax-errors.rs:120:33
+  --> $DIR/syntax-errors.rs:130:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                                 ^^^^^^^^^^^^^^ not a valid metavariable expression
@@ -203,7 +219,7 @@ LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: expected an identifier
-  --> $DIR/syntax-errors.rs:38:14
+  --> $DIR/syntax-errors.rs:33:14
    |
 LL |     () => { ${} };
    |              ^^
@@ -212,7 +228,7 @@ LL |     () => { ${} };
    = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: expected an identifier
-  --> $DIR/syntax-errors.rs:44:17
+  --> $DIR/syntax-errors.rs:39:17
    |
 LL |      () => { ${ "hi" } };
    |                 ^^^^ not a valid identifier
@@ -221,7 +237,7 @@ LL |      () => { ${ "hi" } };
    = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: expected an identifier
-  --> $DIR/syntax-errors.rs:65:33
+  --> $DIR/syntax-errors.rs:70:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                                 ^^ not a valid identifier
@@ -229,5 +245,5 @@ LL |     ( $( $i:ident ),* ) => { ${ {} } };
    = note: expected a metavariable expression name: `${expr( /* ... */ )}`
    = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
-error: aborting due to 27 previous errors
+error: aborting due to 29 previous errors
 

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -68,11 +68,13 @@ LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
    |
    = note: metavariable expressions use function-like parentheses syntax
 
-error: expected identifier, found `123`
+error: expected an identifier
   --> $DIR/syntax-errors.rs:59:23
    |
 LL |     () => { ${ignore($123)} }
-   |                       ^^^ help: try removing `123`
+   |                       ^^^ not a valid identifier
+   |
+   = note: `ignore` takes a metavariable argument
 
 error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:71:19
@@ -200,23 +202,32 @@ LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |
    = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
-error: expected identifier or string literal
+error: expected an identifier
   --> $DIR/syntax-errors.rs:38:14
    |
 LL |     () => { ${} };
    |              ^^
+   |
+   = note: expected a metavariable expression name: `${expr( /* ... */ )}`
+   = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
-error: expected identifier, found `"hi"`
+error: expected an identifier
   --> $DIR/syntax-errors.rs:44:17
    |
 LL |      () => { ${ "hi" } };
-   |                 ^^^^ help: try removing `"hi"`
+   |                 ^^^^ not a valid identifier
+   |
+   = note: expected a metavariable expression name: `${expr( /* ... */ )}`
+   = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
-error: expected identifier or string literal
+error: expected an identifier
   --> $DIR/syntax-errors.rs:65:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
-   |                                 ^^
+   |                                 ^^ not a valid identifier
+   |
+   = note: expected a metavariable expression name: `${expr( /* ... */ )}`
+   = note: valid metavariable expressions are `count`, `ignore`, `index`, `len`, and `concat`
 
 error: aborting due to 27 previous errors
 

--- a/tests/ui/macros/metavar-expressions/syntax-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/syntax-errors.stderr
@@ -40,164 +40,160 @@ error: only unsuffixes integer literals are supported in meta-variable expressio
 LL |     ( $( $i:ident ),* ) => { ${ index(1u32) } };
    |                                 ^^^^^
 
-error: meta-variable expression parameter must be wrapped in parentheses
+error: expected `(`
   --> $DIR/syntax-errors.rs:32:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ count } };
-   |                                 ^^^^^
+   |                                 ^^^^^- help: try adding parentheses: `( /* ... */ )`
+   |                                 |
+   |                                 for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
 
-error: meta-variable expression parameter must be wrapped in parentheses
+error: expected `(`
   --> $DIR/syntax-errors.rs:49:33
    |
+LL |     ( $( $i:ident ),* ) => { ${ count $i ($i) } };
+   |                                 ^^^^^ - unexpected token
+   |                                 |
+   |                                 for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
+
+error: expected `(`
+  --> $DIR/syntax-errors.rs:54:33
+   |
 LL |     ( $( $i:ident ),* ) => { ${ count{i} } };
-   |                                 ^^^^^
+   |                                 ^^^^^ for this this metavariable expression
+   |
+   = note: metavariable expressions use function-like parentheses syntax
 
 error: expected identifier, found `123`
-  --> $DIR/syntax-errors.rs:54:23
+  --> $DIR/syntax-errors.rs:59:23
    |
 LL |     () => { ${ignore($123)} }
    |                       ^^^ help: try removing `123`
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:66:19
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:71:19
    |
 LL |         ${count() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:66:19
-   |
-LL |         ${count() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:68:20
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:73:20
    |
 LL |         ${count($i a b c)}
-   |                    ^
+   |           -----    ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:68:20
-   |
-LL |         ${count($i a b c)}
-   |                    ^
+   = note: the `count` metavariable expression takes between 1 and 2 arguments
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:70:23
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:75:23
    |
 LL |         ${count($i, 1 a b c)}
-   |                       ^
+   |           -----       ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:70:23
-   |
-LL |         ${count($i, 1 a b c)}
-   |                       ^
+   = note: the `count` metavariable expression takes between 1 and 2 arguments
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:72:21
-   |
-LL |         ${count($i) a b c}
-   |                     ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:72:21
-   |
-LL |         ${count($i) a b c}
-   |                     ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:75:22
-   |
-LL |         ${ignore($i) a b c}
-   |                      ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:75:22
-   |
-LL |         ${ignore($i) a b c}
-   |                      ^
-
-error: unexpected token: a
+error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:77:21
    |
+LL |         ${count($i) a b c}
+   |           -----     ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:80:22
+   |
+LL |         ${ignore($i) a b c}
+   |           ------     ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:82:21
+   |
 LL |         ${ignore($i a b c)}
-   |                     ^
+   |           ------    ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:77:21
-   |
-LL |         ${ignore($i a b c)}
-   |                     ^
+   = note: the `ignore` metavariable expression takes a single argument
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:80:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:80:19
-   |
-LL |         ${index() a b c}
-   |                   ^
-
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:82:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-   |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:82:19
-   |
-LL |         ${index(1 a b c)}
-   |                   ^
-
-error: unexpected token: a
+error: unexpected trailing tokens
   --> $DIR/syntax-errors.rs:85:19
    |
 LL |         ${index() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:87:19
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:85:19
+LL |         ${index(1 a b c)}
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+   |
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:90:19
    |
 LL |         ${index() a b c}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
 
-error: unexpected token: a
-  --> $DIR/syntax-errors.rs:87:19
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:92:19
    |
 LL |         ${index(1 a b c)}
-   |                   ^
+   |           -----   ^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
    |
-note: meta-variable expression must not have trailing tokens
-  --> $DIR/syntax-errors.rs:87:19
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
+
+error: unexpected trailing tokens
+  --> $DIR/syntax-errors.rs:94:18
    |
-LL |         ${index(1 a b c)}
-   |                   ^
+LL |         ${index(1, a b c)}
+   |           -----  ^^^^^^^ help: try removing these tokens
+   |           |
+   |           for this metavariable expression
+   |
+   = note: the `index` metavariable expression takes between 0 and 1 arguments
 
 error: meta-variable expression depth must be a literal
-  --> $DIR/syntax-errors.rs:94:33
+  --> $DIR/syntax-errors.rs:101:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ index(IDX) } };
    |                                 ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:100:11
+  --> $DIR/syntax-errors.rs:107:11
    |
 LL |         ${count(foo)}
    |           ^^^^^
 
 error: meta-variables within meta-variable expressions must be referenced using a dollar sign
-  --> $DIR/syntax-errors.rs:107:11
+  --> $DIR/syntax-errors.rs:114:11
    |
 LL |         ${ignore(bar)}
    |           ^^^^^^
 
 error: unrecognized meta-variable expression
-  --> $DIR/syntax-errors.rs:113:33
+  --> $DIR/syntax-errors.rs:120:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ aaaaaaaaaaaaaa(i) } };
    |                                 ^^^^^^^^^^^^^^ help: supported expressions are count, ignore, index and len
@@ -215,10 +211,10 @@ LL |      () => { ${ "hi" } };
    |                 ^^^^ help: try removing `"hi"`
 
 error: expected identifier or string literal
-  --> $DIR/syntax-errors.rs:60:33
+  --> $DIR/syntax-errors.rs:65:33
    |
 LL |     ( $( $i:ident ),* ) => { ${ {} } };
    |                                 ^^
 
-error: aborting due to 25 previous errors
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/142950 plus followup

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
