### PR TITLE
Reduce mismatched-lifetime-syntaxes suggestions to MaybeIncorrect

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3261,7 +3261,7 @@ impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
                 diag.multipart_suggestion_with_style(
                     fluent::lint_mismatched_lifetime_syntaxes_suggestion_implicit,
                     suggestions,
-                    Applicability::MachineApplicable,
+                    Applicability::MaybeIncorrect,
                     style(tool_only),
                 );
             }
@@ -3276,7 +3276,7 @@ impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
                 diag.multipart_suggestion_with_style(
                     fluent::lint_mismatched_lifetime_syntaxes_suggestion_mixed,
                     suggestions,
-                    Applicability::MachineApplicable,
+                    Applicability::MaybeIncorrect,
                     style(tool_only),
                 );
             }
@@ -3291,7 +3291,7 @@ impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
                 diag.multipart_suggestion_with_style(
                     msg,
                     suggestions,
-                    Applicability::MachineApplicable,
+                    Applicability::MaybeIncorrect,
                     style(tool_only),
                 );
             }


### PR DESCRIPTION
`cargo fix` does not have a way of distinguishing a suggestion with
multiple spans which should all be applied from multiple suggestions
where only one should be applied (see rust-lang/rust#53934). `cargo fix` only works
with `MachineApplicable` suggestions, so downgrading the applicability
will stop `cargo` from suggesting the user run `cargo
fix`. rust-analyzer does work with `MaybeIncorrect`, so interactive
fixes are still available.

r? @ehuss 