### PR TITLE
Make missing lifetime suggestion verbose

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3122,15 +3122,10 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 &mut err,
                 Some(lifetime_ref.ident.name.as_str()),
                 |err, _, span, message, suggestion, span_suggs| {
-                    err.multipart_suggestion_with_style(
+                    err.multipart_suggestion_verbose(
                         message,
                         std::iter::once((span, suggestion)).chain(span_suggs.clone()).collect(),
                         Applicability::MaybeIncorrect,
-                        if span_suggs.is_empty() {
-                            SuggestionStyle::ShowCode
-                        } else {
-                            SuggestionStyle::ShowAlways
-                        },
                     );
                     true
                 },

--- a/tests/ui/associated-inherent-types/issue-109299.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'d`
   --> $DIR/issue-109299.rs:6:12
    |
 LL | impl Lexer<'d> {
-   |     -      ^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'d` here: `<'d>`
+   |            ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'d` here
+   |
+LL | impl<'d> Lexer<'d> {
+   |     ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/generic_const_early_param.stderr
+++ b/tests/ui/borrowck/generic_const_early_param.stderr
@@ -7,19 +7,24 @@ LL | struct DataWrapper<'static> {
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/generic_const_early_param.rs:6:12
    |
-LL | struct DataWrapper<'static> {
-   |                    - help: consider introducing lifetime `'a` here: `'a,`
-LL |
 LL |     data: &'a [u8; Self::SIZE],
    |            ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | struct DataWrapper<'a, 'static> {
+   |                    +++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/generic_const_early_param.rs:10:18
    |
 LL | impl DataWrapper<'a> {
-   |     -            ^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'a` here: `<'a>`
+   |                  ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | impl<'a> DataWrapper<'a> {
+   |     ++++
 
 warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/generic_const_early_param.rs:1:12

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -2,27 +2,34 @@ error[E0261]: use of undeclared lifetime name `'unpinned`
   --> $DIR/ice-cast-type-with-error-124848.rs:7:32
    |
 LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
-   |               -                ^^^^^^^^^ undeclared lifetime
-   |               |
-   |               help: consider introducing lifetime `'unpinned` here: `'unpinned,`
+   |                                ^^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'unpinned` here
+   |
+LL | struct MyType<'unpinned, 'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
+   |               ++++++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/ice-cast-type-with-error-124848.rs:14:53
    |
-LL | fn main() {
-   |        - help: consider introducing lifetime `'a` here: `<'a>`
-...
 LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
    |                                                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn main<'a>() {
+   |        ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/ice-cast-type-with-error-124848.rs:14:67
    |
-LL | fn main() {
-   |        - help: consider introducing lifetime `'a` here: `<'a>`
-...
 LL |     let bad_addr = &unpinned as *const Cell<Option<&'a mut MyType<'a>>> as usize;
    |                                                                   ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn main<'a>() {
+   |        ++++
 
 error[E0412]: cannot find type `Pin` in this scope
   --> $DIR/ice-cast-type-with-error-124848.rs:7:60

--- a/tests/ui/const-generics/generic_const_exprs/unresolved_lifetimes_error.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unresolved_lifetimes_error.stderr
@@ -1,10 +1,13 @@
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/unresolved_lifetimes_error.rs:5:13
    |
-LL | fn foo() -> [(); {
-   |       - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     let a: &'a ();
    |             ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn foo<'a>() -> [(); {
+   |       ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
+++ b/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
@@ -17,9 +17,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/ice-unexpected-inference-var-122549.rs:11:34
    |
 LL | struct ConstChunksExact<'rem, T: 'a, const N: usize> {}
-   |                         -        ^^ undeclared lifetime
-   |                         |
-   |                         help: consider introducing lifetime `'a` here: `'a,`
+   |                                  ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | struct ConstChunksExact<'a, 'rem, T: 'a, const N: usize> {}
+   |                         +++
 
 error[E0046]: not all trait items implemented, missing: `const_chunks_exact`
   --> $DIR/ice-unexpected-inference-var-122549.rs:9:1

--- a/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
+++ b/tests/ui/const_prop/ice-type-mismatch-when-copying-112824.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/ice-type-mismatch-when-copying-112824.rs:5:21
    |
 LL | pub struct Opcode2(&'a S);
-   |                   - ^^ undeclared lifetime
-   |                   |
-   |                   help: consider introducing lifetime `'a` here: `<'a>`
+   |                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | pub struct Opcode2<'a>(&'a S);
+   |                   ++++
 
 error[E0412]: cannot find type `S` in this scope
   --> $DIR/ice-type-mismatch-when-copying-112824.rs:5:24

--- a/tests/ui/dyn-compatibility/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.stderr
+++ b/tests/ui/dyn-compatibility/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.stderr
@@ -139,9 +139,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.rs:96:12
    |
 LL | fn bar(_: &'a Trait) {}
-   |       -    ^^ undeclared lifetime
-   |       |
-   |       help: consider introducing lifetime `'a` here: `<'a>`
+   |            ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn bar<'a>(_: &'a Trait) {}
+   |       ++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.rs:110:13
@@ -171,9 +174,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.rs:122:17
    |
 LL | fn kitten() -> &'a Trait {
-   |          -      ^^ undeclared lifetime
-   |          |
-   |          help: consider introducing lifetime `'a` here: `<'a>`
+   |                 ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn kitten<'a>() -> &'a Trait {
+   |          ++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/reference-to-bare-trait-in-fn-inputs-and-outputs-issue-125139.rs:133:16

--- a/tests/ui/error-codes/E0261.stderr
+++ b/tests/ui/error-codes/E0261.stderr
@@ -2,17 +2,23 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/E0261.rs:1:12
    |
 LL | fn foo(x: &'a str) { }
-   |       -    ^^ undeclared lifetime
-   |       |
-   |       help: consider introducing lifetime `'a` here: `<'a>`
+   |            ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn foo<'a>(x: &'a str) { }
+   |       ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/E0261.rs:5:9
    |
-LL | struct Foo {
-   |           - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     x: &'a str,
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | struct Foo<'a> {
+   |           ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/generic-extern-lifetime.stderr
+++ b/tests/ui/generics/generic-extern-lifetime.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/generic-extern-lifetime.rs:6:26
    |
 LL |     pub fn life2<'b>(x: &'a i32, y: &'b i32);
-   |                  -       ^^ undeclared lifetime
-   |                  |
-   |                  help: consider introducing lifetime `'a` here: `'a,`
+   |                          ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     pub fn life2<'a, 'b>(x: &'a i32, y: &'b i32);
+   |                  +++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/generic-extern-lifetime.rs:8:37

--- a/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
+++ b/tests/ui/generics/impl-block-params-declared-in-wrong-spot-issue-113073.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:7:13
    |
 LL | impl Foo<T: 'a + Default> for u8 {}
-   |     -       ^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'a` here: `<'a>`
+   |             ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | impl<'a> Foo<T: 'a + Default> for u8 {}
+   |     ++++
 
 error[E0229]: associated item constraints are not allowed here
   --> $DIR/impl-block-params-declared-in-wrong-spot-issue-113073.rs:3:10

--- a/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
@@ -15,9 +15,12 @@ error[E0261]: use of undeclared lifetime name `'missing`
   --> $DIR/bad-lifetimes.rs:7:37
    |
 LL | fn missing_lt() -> impl Sized + use<'missing> {}
-   |              -                      ^^^^^^^^ undeclared lifetime
-   |              |
-   |              help: consider introducing lifetime `'missing` here: `<'missing>`
+   |                                     ^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'missing` here
+   |
+LL | fn missing_lt<'missing>() -> impl Sized + use<'missing> {}
+   |              ++++++++++
 
 error: expected lifetime parameter in `use<...>` precise captures list, found `'static`
   --> $DIR/bad-lifetimes.rs:4:36

--- a/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
+++ b/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
@@ -23,9 +23,12 @@ error[E0261]: use of undeclared lifetime name `'q`
   --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:14:21
    |
 LL | impl<'static> Query<'q> {
-   |      -              ^^ undeclared lifetime
-   |      |
-   |      help: consider introducing lifetime `'q` here: `'q,`
+   |                     ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'q` here
+   |
+LL | impl<'q, 'static> Query<'q> {
+   |      +++
 
 error[E0392]: lifetime parameter `'q` is never used
   --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:11:14

--- a/tests/ui/inference/issue-107090.stderr
+++ b/tests/ui/inference/issue-107090.stderr
@@ -33,15 +33,23 @@ error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/issue-107090.rs:11:47
    |
 LL | impl<'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
-   |      -                                        ^^ undeclared lifetime
-   |      |
-   |      help: consider introducing lifetime `'b` here: `'b,`
+   |                                               ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'b` here
+   |
+LL | impl<'b, 'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
+   |      +++
 
 error[E0261]: use of undeclared lifetime name `'out`
   --> $DIR/issue-107090.rs:11:67
    |
 LL | impl<'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
-   |      - help: consider introducing lifetime `'out` here: `'out,`   ^^^^ undeclared lifetime
+   |                                                                   ^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'out` here
+   |
+LL | impl<'out, 'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
+   |      +++++
 
 error[E0261]: use of undeclared lifetime name `'out`
   --> $DIR/issue-107090.rs:14:49
@@ -62,9 +70,12 @@ error[E0261]: use of undeclared lifetime name `'short`
   --> $DIR/issue-107090.rs:20:68
    |
 LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
-   |           -                                                        ^^^^^^ undeclared lifetime
-   |           |
-   |           help: consider introducing lifetime `'short` here: `'short,`
+   |                                                                    ^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'short` here
+   |
+LL | fn badboi<'short, 'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
+   |           +++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/lifetimes/issue-107988.stderr
+++ b/tests/ui/lifetimes/issue-107988.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'tcx`
   --> $DIR/issue-107988.rs:7:52
    |
 LL | impl<T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
-   |      -                                             ^^^^ undeclared lifetime
-   |      |
-   |      help: consider introducing lifetime `'tcx` here: `'tcx,`
+   |                                                    ^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'tcx` here
+   |
+LL | impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+   |      +++++
 
 error[E0261]: use of undeclared lifetime name `'tcx`
   --> $DIR/issue-107988.rs:7:30

--- a/tests/ui/lifetimes/undeclared-lifetime-used-in-debug-macro-issue-70152.stderr
+++ b/tests/ui/lifetimes/undeclared-lifetime-used-in-debug-macro-issue-70152.stderr
@@ -1,10 +1,13 @@
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/undeclared-lifetime-used-in-debug-macro-issue-70152.rs:3:9
    |
-LL | struct Test {
-   |            - help: consider introducing lifetime `'b` here: `<'b>`
 LL |     a: &'b str,
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'b` here
+   |
+LL | struct Test<'b> {
+   |            ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/undeclared-lifetime-used-in-debug-macro-issue-70152.rs:3:9
@@ -12,9 +15,13 @@ error[E0261]: use of undeclared lifetime name `'b`
 LL | #[derive(Eq, PartialEq)]
    |          -- lifetime `'b` is missing in item created through this procedural macro
 LL | struct Test {
-   |            - help: consider introducing lifetime `'b` here: `<'b>`
 LL |     a: &'b str,
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'b` here
+   |
+LL | struct Test<'b> {
+   |            ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/undeclared-lifetime-used-in-debug-macro-issue-70152.rs:13:13

--- a/tests/ui/methods/dont-ice-on-object-lookup-w-error-region.stderr
+++ b/tests/ui/methods/dont-ice-on-object-lookup-w-error-region.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'missing`
   --> $DIR/dont-ice-on-object-lookup-w-error-region.rs:6:20
    |
 LL | fn project(x: Pin<&'missing mut dyn Future<Output = ()>>) {
-   |           -        ^^^^^^^^ undeclared lifetime
-   |           |
-   |           help: consider introducing lifetime `'missing` here: `<'missing>`
+   |                    ^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'missing` here
+   |
+LL | fn project<'missing>(x: Pin<&'missing mut dyn Future<Output = ()>>) {
+   |           ++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-unresolved.stderr
@@ -1,10 +1,13 @@
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/method-call-lifetime-args-unresolved.rs:2:15
    |
-LL | fn main() {
-   |        - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     0.clone::<'a>();
    |               ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn main<'a>() {
+   |        ++++
 
 warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-unresolved.rs:2:15

--- a/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
+++ b/tests/ui/nll/user-annotations/region-error-ice-109072.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'missing`
   --> $DIR/region-error-ice-109072.rs:8:9
    |
 LL | impl Lt<'missing> for () {
-   |     -   ^^^^^^^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'missing` here: `<'missing>`
+   |         ^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'missing` here
+   |
+LL | impl<'missing> Lt<'missing> for () {
+   |     ++++++++++
 
 error[E0261]: use of undeclared lifetime name `'missing`
   --> $DIR/region-error-ice-109072.rs:9:15

--- a/tests/ui/regions/regions-in-enums.stderr
+++ b/tests/ui/regions/regions-in-enums.stderr
@@ -1,18 +1,24 @@
 error[E0261]: use of undeclared lifetime name `'foo`
   --> $DIR/regions-in-enums.rs:13:9
    |
-LL | enum No0 {
-   |         - help: consider introducing lifetime `'foo` here: `<'foo>`
 LL |     X5(&'foo usize)
    |         ^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'foo` here
+   |
+LL | enum No0<'foo> {
+   |         ++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-in-enums.rs:17:9
    |
-LL | enum No1 {
-   |         - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     X6(&'a usize)
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | enum No1<'a> {
+   |         ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/regions/regions-in-structs.stderr
+++ b/tests/ui/regions/regions-in-structs.stderr
@@ -1,19 +1,24 @@
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-in-structs.rs:10:9
    |
-LL | struct StructDecl {
-   |                  - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     a: &'a isize,
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | struct StructDecl<'a> {
+   |                  ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-in-structs.rs:11:9
    |
-LL | struct StructDecl {
-   |                  - help: consider introducing lifetime `'a` here: `<'a>`
-LL |     a: &'a isize,
 LL |     b: &'a isize,
    |         ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | struct StructDecl<'a> {
+   |                  ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/regions/regions-name-undeclared.stderr
+++ b/tests/ui/regions/regions-name-undeclared.stderr
@@ -50,9 +50,12 @@ LL | fn bar<'a>(x: &'a isize) {
    |        -- lifetime parameter from outer item
 ...
 LL |     type X = Option<&'a isize>;
-   |           -          ^^ use of generic parameter from outer item
-   |           |
-   |           help: consider introducing lifetime `'a` here: `<'a>`
+   |                      ^^ use of generic parameter from outer item
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     type X<'a> = Option<&'a isize>;
+   |           ++++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/regions-name-undeclared.rs:28:13
@@ -60,10 +63,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn bar<'a>(x: &'a isize) {
    |        -- lifetime parameter from outer item
 ...
-LL |     enum E {
-   |           - help: consider introducing lifetime `'a` here: `<'a>`
 LL |         E1(&'a isize)
    |             ^^ use of generic parameter from outer item
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     enum E<'a> {
+   |           ++++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/regions-name-undeclared.rs:31:13
@@ -71,10 +77,13 @@ error[E0401]: can't use generic parameters from outer item
 LL | fn bar<'a>(x: &'a isize) {
    |        -- lifetime parameter from outer item
 ...
-LL |     struct S {
-   |             - help: consider introducing lifetime `'a` here: `<'a>`
 LL |         f: &'a isize
    |             ^^ use of generic parameter from outer item
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     struct S<'a> {
+   |             ++++
 
 error[E0401]: can't use generic parameters from outer item
   --> $DIR/regions-name-undeclared.rs:33:14
@@ -83,17 +92,23 @@ LL | fn bar<'a>(x: &'a isize) {
    |        -- lifetime parameter from outer item
 ...
 LL |     fn f(a: &'a isize) { }
-   |         -    ^^ use of generic parameter from outer item
-   |         |
-   |         help: consider introducing lifetime `'a` here: `<'a>`
+   |              ^^ use of generic parameter from outer item
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn f<'a>(a: &'a isize) { }
+   |         ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-name-undeclared.rs:41:17
    |
 LL | fn fn_types(a: &'a isize,
-   |            -    ^^ undeclared lifetime
-   |            |
-   |            help: consider introducing lifetime `'a` here: `<'a>`
+   |                 ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn fn_types<'a>(a: &'a isize,
+   |            ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/regions-name-undeclared.rs:43:36
@@ -129,11 +144,13 @@ LL | fn fn_types<'b>(a: &'a isize,
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-name-undeclared.rs:47:17
    |
-LL | fn fn_types(a: &'a isize,
-   |            - help: consider introducing lifetime `'a` here: `<'a>`
-...
 LL |             c: &'a isize)
    |                 ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn fn_types<'a>(a: &'a isize,
+   |            ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-name-undeclared.rs:53:31

--- a/tests/ui/regions/regions-undeclared.stderr
+++ b/tests/ui/regions/regions-undeclared.stderr
@@ -7,35 +7,46 @@ LL | static c_x: &'blk isize = &22;
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-undeclared.rs:4:10
    |
-LL | enum EnumDecl {
-   |              - help: consider introducing lifetime `'a` here: `<'a>`
 LL |     Foo(&'a isize),
    |          ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | enum EnumDecl<'a> {
+   |              ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-undeclared.rs:5:10
    |
-LL | enum EnumDecl {
-   |              - help: consider introducing lifetime `'a` here: `<'a>`
-LL |     Foo(&'a isize),
 LL |     Bar(&'a isize),
    |          ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | enum EnumDecl<'a> {
+   |              ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-undeclared.rs:8:15
    |
 LL | fn fnDecl(x: &'a isize,
-   |          -    ^^ undeclared lifetime
-   |          |
-   |          help: consider introducing lifetime `'a` here: `<'a>`
+   |               ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn fnDecl<'a>(x: &'a isize,
+   |          ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/regions-undeclared.rs:9:15
    |
-LL | fn fnDecl(x: &'a isize,
-   |          - help: consider introducing lifetime `'a` here: `<'a>`
 LL |           y: &'a isize)
    |               ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn fnDecl<'a>(x: &'a isize,
+   |          ++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/statics/missing_lifetime.stderr
+++ b/tests/ui/statics/missing_lifetime.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'reborrow`
   --> $DIR/missing_lifetime.rs:4:15
    |
 LL | struct Slice(&'reborrow [&'static [u8]]);
-   |             - ^^^^^^^^^ undeclared lifetime
-   |             |
-   |             help: consider introducing lifetime `'reborrow` here: `<'reborrow>`
+   |               ^^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'reborrow` here
+   |
+LL | struct Slice<'reborrow>(&'reborrow [&'static [u8]]);
+   |             +++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'a`
   --> $DIR/missing-lifetimes-in-signature.rs:37:11
    |
 LL | fn baz<G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-   |        -  ^^ undeclared lifetime
-   |        |
-   |        help: consider introducing lifetime `'a` here: `'a,`
+   |           ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | fn baz<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |        +++
 
 error[E0700]: hidden type for `impl FnOnce()` captures lifetime that does not appear in bounds
   --> $DIR/missing-lifetimes-in-signature.rs:19:5

--- a/tests/ui/traits/next-solver/dont-canonicalize-re-error.stderr
+++ b/tests/ui/traits/next-solver/dont-canonicalize-re-error.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'missing`
   --> $DIR/dont-canonicalize-re-error.rs:25:26
    |
 LL | impl<A: Sized> Constrain<'missing> for W<A> {}
-   |      -                   ^^^^^^^^ undeclared lifetime
-   |      |
-   |      help: consider introducing lifetime `'missing` here: `'missing,`
+   |                          ^^^^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'missing` here
+   |
+LL | impl<'missing, A: Sized> Constrain<'missing> for W<A> {}
+   |      +++++++++
 
 error[E0119]: conflicting implementations of trait `Tr<'_>` for type `W<_>`
   --> $DIR/dont-canonicalize-re-error.rs:21:1

--- a/tests/ui/traits/span-bug-issue-121414.stderr
+++ b/tests/ui/traits/span-bug-issue-121414.stderr
@@ -2,9 +2,12 @@ error[E0261]: use of undeclared lifetime name `'f`
   --> $DIR/span-bug-issue-121414.rs:5:22
    |
 LL | impl<'a> Bar for Foo<'f> {
-   |      -               ^^ undeclared lifetime
-   |      |
-   |      help: consider introducing lifetime `'f` here: `'f,`
+   |                      ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'f` here
+   |
+LL | impl<'f, 'a> Bar for Foo<'f> {
+   |      +++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
I keep seeing this suggestion when working on rustc, and it's annoying that it's inline. Part of https://github.com/rust-lang/rust/issues/141973. Feel free to close this if there's another PR already doing this.

r? @estebank 