### PR TITLE
rustdoc: show attributes on enum variants

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1702,6 +1702,7 @@ fn render_enum_fields(
                 if v.is_stripped() {
                     continue;
                 }
+                write!(w, "{}", render_attributes_in_pre(v, TAB, cx))?;
                 w.write_str(TAB)?;
                 match v.kind {
                     clean::VariantItem(ref var) => match var.kind {

--- a/tests/rustdoc/enum/enum-variant-non_exhaustive.rs
+++ b/tests/rustdoc/enum/enum-variant-non_exhaustive.rs
@@ -1,0 +1,17 @@
+// regression test for https://github.com/rust-lang/rust/issues/142599
+
+#![crate_name = "foo"]
+
+//@ snapshot type-code 'foo/enum.Type.html' '//pre[@class="rust item-decl"]/code'
+pub enum Type {
+    #[non_exhaustive]
+    // attribute that should not be shown
+    #[warn(unsafe_code)]
+    Variant,
+}
+
+// we would love to use the `following-sibling::` axis
+// (along with an `h2[@id="aliased-type"]` query),
+// but unfortunately python doesn't implement that.
+//@ snapshot type-alias-code 'foo/type.TypeAlias.html' '//pre[@class="rust item-decl"][2]/code'
+pub type TypeAlias = Type;

--- a/tests/rustdoc/enum/enum-variant-non_exhaustive.type-alias-code.html
+++ b/tests/rustdoc/enum/enum-variant-non_exhaustive.type-alias-code.html
@@ -1,0 +1,4 @@
+<code>pub enum TypeAlias {
+    #[non_exhaustive]
+    Variant,
+}</code>

--- a/tests/rustdoc/enum/enum-variant-non_exhaustive.type-code.html
+++ b/tests/rustdoc/enum/enum-variant-non_exhaustive.type-code.html
@@ -1,0 +1,4 @@
+<code>pub enum Type {
+    #[non_exhaustive]
+    Variant,
+}</code>


### PR DESCRIPTION
mostly for #[non_exhaustive]

unsure if there's any attributes we should take care to *not* include, it could use `render_code_attribute` and `is_non_exhaustive` instead, if that is a concern. 

fixes rust-lang/rust#142599
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
