### PR TITLE
Rename run always 

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -272,7 +272,7 @@ fn rustup_installed(builder: &Builder<'_>) -> bool {
     let mut rustup = command("rustup");
     rustup.arg("--version");
 
-    rustup.allow_failure().run_always().run_capture_stdout(builder).is_success()
+    rustup.allow_failure().run_in_dry_run().run_capture_stdout(builder).is_success()
 }
 
 fn stage_dir_exists(stage_path: &str) -> bool {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -809,7 +809,7 @@ impl Config {
         config.initial_sysroot = t!(PathBuf::from_str(
             command(&config.initial_rustc)
                 .args(["--print", "sysroot"])
-                .run_always()
+                .run_in_dry_run()
                 .run_capture_stdout(&config)
                 .stdout()
                 .trim()
@@ -1385,11 +1385,11 @@ impl Config {
         // all the git commands below are actually executed, because some follow-up code
         // in bootstrap might depend on the submodules being checked out. Furthermore, not all
         // the command executions below work with an empty output (produced during dry run).
-        // Therefore, all commands below are marked with `run_always()`, so that they also run in
+        // Therefore, all commands below are marked with `run_in_dry_run()`, so that they also run in
         // dry run mode.
         let submodule_git = || {
             let mut cmd = helpers::git(Some(&absolute_path));
-            cmd.run_always();
+            cmd.run_in_dry_run();
             cmd
         };
 
@@ -1399,7 +1399,7 @@ impl Config {
         let checked_out_hash = checked_out_hash.trim_end();
         // Determine commit that the submodule *should* have.
         let recorded = helpers::git(Some(&self.src))
-            .run_always()
+            .run_in_dry_run()
             .args(["ls-tree", "HEAD"])
             .arg(relative_path)
             .run_capture_stdout(self)
@@ -1419,7 +1419,7 @@ impl Config {
 
         helpers::git(Some(&self.src))
             .allow_failure()
-            .run_always()
+            .run_in_dry_run()
             .args(["submodule", "-q", "sync"])
             .arg(relative_path)
             .run(self);
@@ -1430,12 +1430,12 @@ impl Config {
             // even though that has no relation to the upstream for the submodule.
             let current_branch = helpers::git(Some(&self.src))
                 .allow_failure()
-                .run_always()
+                .run_in_dry_run()
                 .args(["symbolic-ref", "--short", "HEAD"])
                 .run_capture(self);
 
             let mut git = helpers::git(Some(&self.src)).allow_failure();
-            git.run_always();
+            git.run_in_dry_run();
             if current_branch.is_success() {
                 // If there is a tag named after the current branch, git will try to disambiguate by prepending `heads/` to the branch name.
                 // This syntax isn't accepted by `branch.{branch}`. Strip it.

--- a/src/bootstrap/src/core/metadata.rs
+++ b/src/bootstrap/src/core/metadata.rs
@@ -88,7 +88,7 @@ fn workspace_members(build: &Build) -> Vec<Package> {
             .arg("--no-deps")
             .arg("--manifest-path")
             .arg(build.src.join(manifest_path));
-        let metadata_output = cargo.run_always().run_capture_stdout(build).stdout();
+        let metadata_output = cargo.run_in_dry_run().run_capture_stdout(build).stdout();
         let Output { packages, .. } = t!(serde_json::from_str(&metadata_output));
         packages
     };

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -202,7 +202,7 @@ than building it.
 
     let stage0_supported_target_list: HashSet<String> = command(&build.config.initial_rustc)
         .args(["--print", "target-list"])
-        .run_always()
+        .run_in_dry_run()
         .run_capture_stdout(&build)
         .stdout()
         .lines()
@@ -366,7 +366,7 @@ than building it.
             // Cygwin. The Cygwin build does not have generators for Visual
             // Studio, so detect that here and error.
             let out =
-                command("cmake").arg("--help").run_always().run_capture_stdout(&build).stdout();
+                command("cmake").arg("--help").run_in_dry_run().run_capture_stdout(&build).stdout();
             if !out.contains("Visual Studio") {
                 panic!(
                     "

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -383,7 +383,7 @@ impl Build {
         let in_tree_gcc_info = config.in_tree_gcc_info.clone();
 
         let initial_target_libdir = command(&config.initial_rustc)
-            .run_always()
+            .run_in_dry_run()
             .args(["--print", "target-libdir"])
             .run_capture_stdout(&config)
             .stdout()
@@ -490,7 +490,7 @@ impl Build {
         // If local-rust is the same major.minor as the current version, then force a
         // local-rebuild
         let local_version_verbose = command(&build.initial_rustc)
-            .run_always()
+            .run_in_dry_run()
             .args(["--version", "--verbose"])
             .run_capture_stdout(&build)
             .stdout();
@@ -949,7 +949,7 @@ impl Build {
         static SYSROOT_CACHE: OnceLock<PathBuf> = OnceLock::new();
         SYSROOT_CACHE.get_or_init(|| {
             command(&self.initial_rustc)
-                .run_always()
+                .run_in_dry_run()
                 .args(["--print", "sysroot"])
                 .run_capture_stdout(self)
                 .stdout()
@@ -1512,7 +1512,7 @@ impl Build {
                     "refs/remotes/origin/{}..HEAD",
                     self.config.stage0_metadata.config.nightly_branch
                 ))
-                .run_always()
+                .run_in_dry_run()
                 .run_capture(self)
                 .stdout()
         });

--- a/src/bootstrap/src/utils/channel.rs
+++ b/src/bootstrap/src/utils/channel.rs
@@ -66,19 +66,22 @@ impl GitInfo {
             .arg("-1")
             .arg("--date=short")
             .arg("--pretty=format:%cd")
-            .run_always()
+            .run_in_dry_run()
             .start_capture_stdout(&exec_ctx);
 
         let mut git_hash_cmd = helpers::git(Some(dir));
-        let ver_hash =
-            git_hash_cmd.arg("rev-parse").arg("HEAD").run_always().start_capture_stdout(&exec_ctx);
+        let ver_hash = git_hash_cmd
+            .arg("rev-parse")
+            .arg("HEAD")
+            .run_in_dry_run()
+            .start_capture_stdout(&exec_ctx);
 
         let mut git_short_hash_cmd = helpers::git(Some(dir));
         let short_ver_hash = git_short_hash_cmd
             .arg("rev-parse")
             .arg("--short=9")
             .arg("HEAD")
-            .run_always()
+            .run_in_dry_run()
             .start_capture_stdout(&exec_ctx);
 
         GitInfo::Present(Some(Info {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -66,7 +66,7 @@ pub struct BootstrapCommand {
     command: Command,
     pub failure_behavior: BehaviorOnFailure,
     // Run the command even during dry run
-    pub run_always: bool,
+    pub run_in_dry_run: bool,
     // This field makes sure that each command is executed (or disarmed) before it is dropped,
     // to avoid forgetting to execute a command.
     drop_bomb: DropBomb,
@@ -138,8 +138,8 @@ impl<'a> BootstrapCommand {
         Self { failure_behavior: BehaviorOnFailure::Ignore, ..self }
     }
 
-    pub fn run_always(&mut self) -> &mut Self {
-        self.run_always = true;
+    pub fn run_in_dry_run(&mut self) -> &mut Self {
+        self.run_in_dry_run = true;
         self
     }
 
@@ -228,7 +228,7 @@ impl From<Command> for BootstrapCommand {
         Self {
             command,
             failure_behavior: BehaviorOnFailure::Exit,
-            run_always: false,
+            run_in_dry_run: false,
             drop_bomb: DropBomb::arm(program),
         }
     }

--- a/src/bootstrap/src/utils/execution_context.rs
+++ b/src/bootstrap/src/utils/execution_context.rs
@@ -93,7 +93,7 @@ impl ExecutionContext {
         let created_at = command.get_created_location();
         let executed_at = std::panic::Location::caller();
 
-        if self.dry_run() && !command.run_always {
+        if self.dry_run() && !command.run_in_dry_run {
             return DeferredCommand { process: None, stdout, stderr, command, executed_at };
         }
 


### PR DESCRIPTION
This PR renames run_always to run_to_dry_run for better clarity, making the field's purpose more explicit and avoiding confusion with command caching behavior.

r? @Kobzol 