### PR TITLE
Make lint `ambiguous_glob_imports` deny-by-default and report-in-deps

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4343,11 +4343,12 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub AMBIGUOUS_GLOB_IMPORTS,
-    Warn,
+    Deny,
     "detects certain glob imports that require reporting an ambiguity error",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #114095 <https://github.com/rust-lang/rust/issues/114095>",
+        report_in_deps: true,
     };
 }
 

--- a/tests/ui/imports/ambiguous-1.rs
+++ b/tests/ui/imports/ambiguous-1.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/112743#issuecomment-1601986883
 
 macro_rules! m {
@@ -25,6 +24,6 @@ pub use openssl::*;
 
 fn main() {
     id();
-    //~^ WARNING `id` is ambiguous
+    //~^ ERROR `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-1.rs
+++ b/tests/ui/imports/ambiguous-1.rs
@@ -1,4 +1,7 @@
+//@ check-pass
 // https://github.com/rust-lang/rust/pull/112743#issuecomment-1601986883
+
+#![warn(ambiguous_glob_imports)]
 
 macro_rules! m {
     () => {
@@ -24,6 +27,6 @@ pub use openssl::*;
 
 fn main() {
     id();
-    //~^ ERROR `id` is ambiguous
+    //~^ WARNING `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-1.stderr
+++ b/tests/ui/imports/ambiguous-1.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-1.rs:11:13
+  --> $DIR/ambiguous-1.rs:10:13
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^^^^ the name `id` in the value namespace is first re-exported here
@@ -9,8 +9,8 @@ LL |     pub use self::handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `id` is ambiguous
-  --> $DIR/ambiguous-1.rs:27:5
+error: `id` is ambiguous
+  --> $DIR/ambiguous-1.rs:26:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -19,18 +19,42 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-1.rs:11:13
+  --> $DIR/ambiguous-1.rs:10:13
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-1.rs:13:13
+  --> $DIR/ambiguous-1.rs:12:13
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+error: `id` is ambiguous
+  --> $DIR/ambiguous-1.rs:26:5
+   |
+LL |     id();
+   |     ^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `id` could refer to the function imported here
+  --> $DIR/ambiguous-1.rs:10:13
+   |
+LL |     pub use self::evp::*;
+   |             ^^^^^^^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+note: `id` could also refer to the function imported here
+  --> $DIR/ambiguous-1.rs:12:13
+   |
+LL |     pub use self::handwritten::*;
+   |             ^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-1.stderr
+++ b/tests/ui/imports/ambiguous-1.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-1.rs:10:13
+  --> $DIR/ambiguous-1.rs:13:13
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^^^^ the name `id` in the value namespace is first re-exported here
@@ -9,8 +9,8 @@ LL |     pub use self::handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-error: `id` is ambiguous
-  --> $DIR/ambiguous-1.rs:26:5
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-1.rs:29:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -19,24 +19,28 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-1.rs:10:13
+  --> $DIR/ambiguous-1.rs:13:13
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-1.rs:12:13
+  --> $DIR/ambiguous-1.rs:15:13
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+note: the lint level is defined here
+  --> $DIR/ambiguous-1.rs:4:9
+   |
+LL | #![warn(ambiguous_glob_imports)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+warning: 2 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
-error: `id` is ambiguous
-  --> $DIR/ambiguous-1.rs:26:5
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-1.rs:29:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -45,16 +49,20 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-1.rs:10:13
+  --> $DIR/ambiguous-1.rs:13:13
    |
 LL |     pub use self::evp::*;
    |             ^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-1.rs:12:13
+  --> $DIR/ambiguous-1.rs:15:13
    |
 LL |     pub use self::handwritten::*;
    |             ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+note: the lint level is defined here
+  --> $DIR/ambiguous-1.rs:4:9
+   |
+LL | #![warn(ambiguous_glob_imports)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/imports/ambiguous-10.rs
+++ b/tests/ui/imports/ambiguous-10.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
 
 mod a {
@@ -14,6 +13,6 @@ mod b {
 use crate::a::*;
 use crate::b::*;
 fn c(_: Token) {}
-//~^ WARNING `Token` is ambiguous
+//~^ ERROR `Token` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-10.stderr
+++ b/tests/ui/imports/ambiguous-10.stderr
@@ -1,5 +1,5 @@
-warning: `Token` is ambiguous
-  --> $DIR/ambiguous-10.rs:16:9
+error: `Token` is ambiguous
+  --> $DIR/ambiguous-10.rs:15:9
    |
 LL | fn c(_: Token) {}
    |         ^^^^^ ambiguous name
@@ -8,18 +8,42 @@ LL | fn c(_: Token) {}
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Token` could refer to the enum imported here
-  --> $DIR/ambiguous-10.rs:14:5
+  --> $DIR/ambiguous-10.rs:13:5
    |
 LL | use crate::a::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
 note: `Token` could also refer to the enum imported here
-  --> $DIR/ambiguous-10.rs:15:5
+  --> $DIR/ambiguous-10.rs:14:5
    |
 LL | use crate::b::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Token` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `Token` is ambiguous
+  --> $DIR/ambiguous-10.rs:15:9
+   |
+LL | fn c(_: Token) {}
+   |         ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Token` could refer to the enum imported here
+  --> $DIR/ambiguous-10.rs:13:5
+   |
+LL | use crate::a::*;
+   |     ^^^^^^^^^^^
+   = help: consider adding an explicit import of `Token` to disambiguate
+note: `Token` could also refer to the enum imported here
+  --> $DIR/ambiguous-10.rs:14:5
+   |
+LL | use crate::b::*;
+   |     ^^^^^^^^^^^
+   = help: consider adding an explicit import of `Token` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-12.rs
+++ b/tests/ui/imports/ambiguous-12.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
 
 macro_rules! m {
@@ -20,6 +19,6 @@ use crate::public::*;
 
 fn main() {
     b();
-    //~^ WARNING `b` is ambiguous
+    //~^ ERROR `b` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-12.stderr
+++ b/tests/ui/imports/ambiguous-12.stderr
@@ -1,5 +1,5 @@
-warning: `b` is ambiguous
-  --> $DIR/ambiguous-12.rs:22:5
+error: `b` is ambiguous
+  --> $DIR/ambiguous-12.rs:21:5
    |
 LL |     b();
    |     ^ ambiguous name
@@ -8,18 +8,42 @@ LL |     b();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `b` could refer to the function imported here
-  --> $DIR/ambiguous-12.rs:18:5
+  --> $DIR/ambiguous-12.rs:17:5
    |
 LL | use crate::ciphertext::*;
    |     ^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
 note: `b` could also refer to the function imported here
-  --> $DIR/ambiguous-12.rs:19:5
+  --> $DIR/ambiguous-12.rs:18:5
    |
 LL | use crate::public::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `b` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `b` is ambiguous
+  --> $DIR/ambiguous-12.rs:21:5
+   |
+LL |     b();
+   |     ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `b` could refer to the function imported here
+  --> $DIR/ambiguous-12.rs:17:5
+   |
+LL | use crate::ciphertext::*;
+   |     ^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `b` to disambiguate
+note: `b` could also refer to the function imported here
+  --> $DIR/ambiguous-12.rs:18:5
+   |
+LL | use crate::public::*;
+   |     ^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `b` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-13.rs
+++ b/tests/ui/imports/ambiguous-13.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
 
 pub mod object {
@@ -17,6 +16,6 @@ use crate::object::*;
 use crate::content::*;
 
 fn a(_: Rect) {}
-//~^ WARNING `Rect` is ambiguous
+//~^ ERROR `Rect` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 fn main() { }

--- a/tests/ui/imports/ambiguous-13.stderr
+++ b/tests/ui/imports/ambiguous-13.stderr
@@ -1,5 +1,5 @@
-warning: `Rect` is ambiguous
-  --> $DIR/ambiguous-13.rs:19:9
+error: `Rect` is ambiguous
+  --> $DIR/ambiguous-13.rs:18:9
    |
 LL | fn a(_: Rect) {}
    |         ^^^^ ambiguous name
@@ -8,18 +8,42 @@ LL | fn a(_: Rect) {}
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Rect` could refer to the struct imported here
-  --> $DIR/ambiguous-13.rs:16:5
+  --> $DIR/ambiguous-13.rs:15:5
    |
 LL | use crate::object::*;
    |     ^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
 note: `Rect` could also refer to the struct imported here
-  --> $DIR/ambiguous-13.rs:17:5
+  --> $DIR/ambiguous-13.rs:16:5
    |
 LL | use crate::content::*;
    |     ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Rect` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `Rect` is ambiguous
+  --> $DIR/ambiguous-13.rs:18:9
+   |
+LL | fn a(_: Rect) {}
+   |         ^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Rect` could refer to the struct imported here
+  --> $DIR/ambiguous-13.rs:15:5
+   |
+LL | use crate::object::*;
+   |     ^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `Rect` to disambiguate
+note: `Rect` could also refer to the struct imported here
+  --> $DIR/ambiguous-13.rs:16:5
+   |
+LL | use crate::content::*;
+   |     ^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `Rect` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-14.rs
+++ b/tests/ui/imports/ambiguous-14.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/issues/98467
 
 mod a {
@@ -21,6 +20,6 @@ mod g {
 
 fn main() {
     g::foo();
-    //~^ WARNING `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-14.stderr
+++ b/tests/ui/imports/ambiguous-14.stderr
@@ -1,5 +1,5 @@
-warning: `foo` is ambiguous
-  --> $DIR/ambiguous-14.rs:23:8
+error: `foo` is ambiguous
+  --> $DIR/ambiguous-14.rs:22:8
    |
 LL |     g::foo();
    |        ^^^ ambiguous name
@@ -8,18 +8,42 @@ LL |     g::foo();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `foo` could refer to the function imported here
-  --> $DIR/ambiguous-14.rs:13:13
+  --> $DIR/ambiguous-14.rs:12:13
    |
 LL |     pub use a::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 note: `foo` could also refer to the function imported here
-  --> $DIR/ambiguous-14.rs:14:13
+  --> $DIR/ambiguous-14.rs:13:13
    |
 LL |     pub use b::*;
    |             ^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `foo` is ambiguous
+  --> $DIR/ambiguous-14.rs:22:8
+   |
+LL |     g::foo();
+   |        ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `foo` could refer to the function imported here
+  --> $DIR/ambiguous-14.rs:12:13
+   |
+LL |     pub use a::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+note: `foo` could also refer to the function imported here
+  --> $DIR/ambiguous-14.rs:13:13
+   |
+LL |     pub use b::*;
+   |             ^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-15.rs
+++ b/tests/ui/imports/ambiguous-15.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
 
 mod t2 {
@@ -21,7 +20,7 @@ mod t3 {
 
 use self::t3::*;
 fn a<E: Error>(_: E) {}
-//~^ WARNING `Error` is ambiguous
+//~^ ERROR `Error` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/ambiguous-15.stderr
+++ b/tests/ui/imports/ambiguous-15.stderr
@@ -1,5 +1,5 @@
-warning: `Error` is ambiguous
-  --> $DIR/ambiguous-15.rs:23:9
+error: `Error` is ambiguous
+  --> $DIR/ambiguous-15.rs:22:9
    |
 LL | fn a<E: Error>(_: E) {}
    |         ^^^^^ ambiguous name
@@ -8,18 +8,42 @@ LL | fn a<E: Error>(_: E) {}
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Error` could refer to the trait imported here
-  --> $DIR/ambiguous-15.rs:22:5
+  --> $DIR/ambiguous-15.rs:21:5
    |
 LL | use self::t3::*;
    |     ^^^^^^^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
 note: `Error` could also refer to the enum imported here
-  --> $DIR/ambiguous-15.rs:16:9
+  --> $DIR/ambiguous-15.rs:15:9
    |
 LL | pub use t2::*;
    |         ^^^^^
    = help: consider adding an explicit import of `Error` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `Error` is ambiguous
+  --> $DIR/ambiguous-15.rs:22:9
+   |
+LL | fn a<E: Error>(_: E) {}
+   |         ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Error` could refer to the trait imported here
+  --> $DIR/ambiguous-15.rs:21:5
+   |
+LL | use self::t3::*;
+   |     ^^^^^^^^^^^
+   = help: consider adding an explicit import of `Error` to disambiguate
+note: `Error` could also refer to the enum imported here
+  --> $DIR/ambiguous-15.rs:15:9
+   |
+LL | pub use t2::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `Error` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-16.rs
+++ b/tests/ui/imports/ambiguous-16.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099
 
 mod framing {
@@ -21,7 +20,7 @@ mod framing {
 }
 
 use crate::framing::ConfirmedTranscriptHashInput;
-//~^ WARNING `ConfirmedTranscriptHashInput` is ambiguous
+//~^ ERROR `ConfirmedTranscriptHashInput` is ambiguous
 //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() { }

--- a/tests/ui/imports/ambiguous-16.stderr
+++ b/tests/ui/imports/ambiguous-16.stderr
@@ -1,5 +1,5 @@
-warning: `ConfirmedTranscriptHashInput` is ambiguous
-  --> $DIR/ambiguous-16.rs:23:21
+error: `ConfirmedTranscriptHashInput` is ambiguous
+  --> $DIR/ambiguous-16.rs:22:21
    |
 LL | use crate::framing::ConfirmedTranscriptHashInput;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
@@ -8,18 +8,42 @@ LL | use crate::framing::ConfirmedTranscriptHashInput;
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `ConfirmedTranscriptHashInput` could refer to the struct imported here
-  --> $DIR/ambiguous-16.rs:19:13
+  --> $DIR/ambiguous-16.rs:18:13
    |
 LL |     pub use self::public_message::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
 note: `ConfirmedTranscriptHashInput` could also refer to the struct imported here
-  --> $DIR/ambiguous-16.rs:20:13
+  --> $DIR/ambiguous-16.rs:19:13
    |
 LL |     pub use self::public_message_in::*;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `ConfirmedTranscriptHashInput` is ambiguous
+  --> $DIR/ambiguous-16.rs:22:21
+   |
+LL | use crate::framing::ConfirmedTranscriptHashInput;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `ConfirmedTranscriptHashInput` could refer to the struct imported here
+  --> $DIR/ambiguous-16.rs:18:13
+   |
+LL |     pub use self::public_message::*;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
+note: `ConfirmedTranscriptHashInput` could also refer to the struct imported here
+  --> $DIR/ambiguous-16.rs:19:13
+   |
+LL |     pub use self::public_message_in::*;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `ConfirmedTranscriptHashInput` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-17.rs
+++ b/tests/ui/imports/ambiguous-17.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
 
 pub use evp::*; //~ WARNING ambiguous glob re-exports
@@ -24,6 +23,6 @@ mod handwritten {
 
 fn main() {
     id();
-    //~^ WARNING `id` is ambiguous
+    //~^ ERROR `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-17.stderr
+++ b/tests/ui/imports/ambiguous-17.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-17.rs:4:9
+  --> $DIR/ambiguous-17.rs:3:9
    |
 LL | pub use evp::*;
    |         ^^^^^^ the name `id` in the value namespace is first re-exported here
@@ -8,8 +8,8 @@ LL | pub use handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `id` is ambiguous
-  --> $DIR/ambiguous-17.rs:26:5
+error: `id` is ambiguous
+  --> $DIR/ambiguous-17.rs:25:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -18,18 +18,42 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-17.rs:4:9
+  --> $DIR/ambiguous-17.rs:3:9
    |
 LL | pub use evp::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-17.rs:5:9
+  --> $DIR/ambiguous-17.rs:4:9
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+error: `id` is ambiguous
+  --> $DIR/ambiguous-17.rs:25:5
+   |
+LL |     id();
+   |     ^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `id` could refer to the function imported here
+  --> $DIR/ambiguous-17.rs:3:9
+   |
+LL | pub use evp::*;
+   |         ^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+note: `id` could also refer to the function imported here
+  --> $DIR/ambiguous-17.rs:4:9
+   |
+LL | pub use handwritten::*;
+   |         ^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,5 +1,4 @@
-//@ ignore-test
-// ^^ don't know how to change this test
+//@ check-pass
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
 

--- a/tests/ui/imports/ambiguous-2.rs
+++ b/tests/ui/imports/ambiguous-2.rs
@@ -1,4 +1,5 @@
-//@ check-pass
+//@ ignore-test
+// ^^ don't know how to change this test
 //@ aux-build: ../ambiguous-1.rs
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
 

--- a/tests/ui/imports/ambiguous-3.rs
+++ b/tests/ui/imports/ambiguous-3.rs
@@ -1,10 +1,9 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/issues/47525
 
 fn main() {
     use a::*;
     x();
-    //~^ WARNING `x` is ambiguous
+    //~^ ERROR `x` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-3.stderr
+++ b/tests/ui/imports/ambiguous-3.stderr
@@ -1,5 +1,5 @@
-warning: `x` is ambiguous
-  --> $DIR/ambiguous-3.rs:6:5
+error: `x` is ambiguous
+  --> $DIR/ambiguous-3.rs:5:5
    |
 LL |     x();
    |     ^ ambiguous name
@@ -8,18 +8,42 @@ LL |     x();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `x` could refer to the function imported here
-  --> $DIR/ambiguous-3.rs:19:13
+  --> $DIR/ambiguous-3.rs:18:13
    |
 LL |     pub use self::b::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
 note: `x` could also refer to the function imported here
-  --> $DIR/ambiguous-3.rs:20:13
+  --> $DIR/ambiguous-3.rs:19:13
    |
 LL |     pub use self::c::*;
    |             ^^^^^^^^^^
    = help: consider adding an explicit import of `x` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `x` is ambiguous
+  --> $DIR/ambiguous-3.rs:5:5
+   |
+LL |     x();
+   |     ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `x` could refer to the function imported here
+  --> $DIR/ambiguous-3.rs:18:13
+   |
+LL |     pub use self::b::*;
+   |             ^^^^^^^^^^
+   = help: consider adding an explicit import of `x` to disambiguate
+note: `x` could also refer to the function imported here
+  --> $DIR/ambiguous-3.rs:19:13
+   |
+LL |     pub use self::c::*;
+   |             ^^^^^^^^^^
+   = help: consider adding an explicit import of `x` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-4-extern.rs
+++ b/tests/ui/imports/ambiguous-4-extern.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/112743#issuecomment-1601986883
 
 macro_rules! m {
@@ -21,6 +20,6 @@ mod handwritten {
 
 fn main() {
     id();
-    //~^ WARNING `id` is ambiguous
+    //~^ ERROR `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-4-extern.rs
+++ b/tests/ui/imports/ambiguous-4-extern.rs
@@ -1,4 +1,7 @@
+//@ check-pass
 // https://github.com/rust-lang/rust/pull/112743#issuecomment-1601986883
+
+#![warn(ambiguous_glob_imports)]
 
 macro_rules! m {
     () => {
@@ -20,6 +23,6 @@ mod handwritten {
 
 fn main() {
     id();
-    //~^ ERROR `id` is ambiguous
+    //~^ WARNING `id` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-4-extern.stderr
+++ b/tests/ui/imports/ambiguous-4-extern.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-4-extern.rs:10:9
+  --> $DIR/ambiguous-4-extern.rs:9:9
    |
 LL | pub use evp::*;
    |         ^^^^^^ the name `id` in the value namespace is first re-exported here
@@ -8,8 +8,8 @@ LL | pub use handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `id` is ambiguous
-  --> $DIR/ambiguous-4-extern.rs:23:5
+error: `id` is ambiguous
+  --> $DIR/ambiguous-4-extern.rs:22:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -18,18 +18,42 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:10:9
+  --> $DIR/ambiguous-4-extern.rs:9:9
    |
 LL | pub use evp::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:11:9
+  --> $DIR/ambiguous-4-extern.rs:10:9
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+error: `id` is ambiguous
+  --> $DIR/ambiguous-4-extern.rs:22:5
+   |
+LL |     id();
+   |     ^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `id` could refer to the function imported here
+  --> $DIR/ambiguous-4-extern.rs:9:9
+   |
+LL | pub use evp::*;
+   |         ^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+note: `id` could also refer to the function imported here
+  --> $DIR/ambiguous-4-extern.rs:10:9
+   |
+LL | pub use handwritten::*;
+   |         ^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `id` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-4-extern.stderr
+++ b/tests/ui/imports/ambiguous-4-extern.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-4-extern.rs:9:9
+  --> $DIR/ambiguous-4-extern.rs:12:9
    |
 LL | pub use evp::*;
    |         ^^^^^^ the name `id` in the value namespace is first re-exported here
@@ -8,8 +8,8 @@ LL | pub use handwritten::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-error: `id` is ambiguous
-  --> $DIR/ambiguous-4-extern.rs:22:5
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-4-extern.rs:25:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -18,24 +18,28 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:9:9
+  --> $DIR/ambiguous-4-extern.rs:12:9
    |
 LL | pub use evp::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:10:9
+  --> $DIR/ambiguous-4-extern.rs:13:9
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+note: the lint level is defined here
+  --> $DIR/ambiguous-4-extern.rs:4:9
+   |
+LL | #![warn(ambiguous_glob_imports)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+warning: 2 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
-error: `id` is ambiguous
-  --> $DIR/ambiguous-4-extern.rs:22:5
+warning: `id` is ambiguous
+  --> $DIR/ambiguous-4-extern.rs:25:5
    |
 LL |     id();
    |     ^^ ambiguous name
@@ -44,16 +48,20 @@ LL |     id();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `id` could refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:9:9
+  --> $DIR/ambiguous-4-extern.rs:12:9
    |
 LL | pub use evp::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
 note: `id` could also refer to the function imported here
-  --> $DIR/ambiguous-4-extern.rs:10:9
+  --> $DIR/ambiguous-4-extern.rs:13:9
    |
 LL | pub use handwritten::*;
    |         ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `id` to disambiguate
-   = note: `#[deny(ambiguous_glob_imports)]` on by default
+note: the lint level is defined here
+  --> $DIR/ambiguous-4-extern.rs:4:9
+   |
+LL | #![warn(ambiguous_glob_imports)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,4 +1,5 @@
-//@ build-pass
+//@ ignore-test
+// ^^ don't know how to change this test
 //@ aux-build: ../ambiguous-4-extern.rs
 
 extern crate ambiguous_4_extern;

--- a/tests/ui/imports/ambiguous-4.rs
+++ b/tests/ui/imports/ambiguous-4.rs
@@ -1,5 +1,4 @@
-//@ ignore-test
-// ^^ don't know how to change this test
+//@ check-pass
 //@ aux-build: ../ambiguous-4-extern.rs
 
 extern crate ambiguous_4_extern;

--- a/tests/ui/imports/ambiguous-5.rs
+++ b/tests/ui/imports/ambiguous-5.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1637022296
 
 mod a {
@@ -11,7 +10,7 @@ mod gpos {
     use super::gsubgpos::*;
     use super::*;
     struct MarkRecord(Class);
-    //~^ WARNING `Class` is ambiguous
+    //~^ ERROR`Class` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-5.stderr
+++ b/tests/ui/imports/ambiguous-5.stderr
@@ -1,5 +1,5 @@
-warning: `Class` is ambiguous
-  --> $DIR/ambiguous-5.rs:13:23
+error: `Class` is ambiguous
+  --> $DIR/ambiguous-5.rs:12:23
    |
 LL |     struct MarkRecord(Class);
    |                       ^^^^^ ambiguous name
@@ -8,18 +8,42 @@ LL |     struct MarkRecord(Class);
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `Class` could refer to the struct imported here
-  --> $DIR/ambiguous-5.rs:12:9
+  --> $DIR/ambiguous-5.rs:11:9
    |
 LL |     use super::*;
    |         ^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
 note: `Class` could also refer to the struct imported here
-  --> $DIR/ambiguous-5.rs:11:9
+  --> $DIR/ambiguous-5.rs:10:9
    |
 LL |     use super::gsubgpos::*;
    |         ^^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `Class` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `Class` is ambiguous
+  --> $DIR/ambiguous-5.rs:12:23
+   |
+LL |     struct MarkRecord(Class);
+   |                       ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `Class` could refer to the struct imported here
+  --> $DIR/ambiguous-5.rs:11:9
+   |
+LL |     use super::*;
+   |         ^^^^^^^^
+   = help: consider adding an explicit import of `Class` to disambiguate
+note: `Class` could also refer to the struct imported here
+  --> $DIR/ambiguous-5.rs:10:9
+   |
+LL |     use super::gsubgpos::*;
+   |         ^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `Class` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-6.rs
+++ b/tests/ui/imports/ambiguous-6.rs
@@ -1,11 +1,10 @@
-//@ check-pass
 //@ edition: 2021
 // https://github.com/rust-lang/rust/issues/112713
 
 pub fn foo() -> u32 {
     use sub::*;
     C
-    //~^ WARNING `C` is ambiguous
+    //~^ ERROR `C` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/ambiguous-6.stderr
+++ b/tests/ui/imports/ambiguous-6.stderr
@@ -1,5 +1,5 @@
-warning: `C` is ambiguous
-  --> $DIR/ambiguous-6.rs:7:5
+error: `C` is ambiguous
+  --> $DIR/ambiguous-6.rs:6:5
    |
 LL |     C
    |     ^ ambiguous name
@@ -8,18 +8,42 @@ LL |     C
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `C` could refer to the constant imported here
-  --> $DIR/ambiguous-6.rs:16:13
+  --> $DIR/ambiguous-6.rs:15:13
    |
 LL |     pub use mod1::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
 note: `C` could also refer to the constant imported here
-  --> $DIR/ambiguous-6.rs:17:13
+  --> $DIR/ambiguous-6.rs:16:13
    |
 LL |     pub use mod2::*;
    |             ^^^^^^^
    = help: consider adding an explicit import of `C` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: `C` is ambiguous
+  --> $DIR/ambiguous-6.rs:6:5
+   |
+LL |     C
+   |     ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `C` could refer to the constant imported here
+  --> $DIR/ambiguous-6.rs:15:13
+   |
+LL |     pub use mod1::*;
+   |             ^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+note: `C` could also refer to the constant imported here
+  --> $DIR/ambiguous-6.rs:16:13
+   |
+LL |     pub use mod2::*;
+   |             ^^^^^^^
+   = help: consider adding an explicit import of `C` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/ambiguous-9.rs
+++ b/tests/ui/imports/ambiguous-9.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1638206152
 
 pub mod dsl {
@@ -22,8 +21,8 @@ use prelude::*;
 
 fn main() {
     date_range();
-    //~^ WARNING `date_range` is ambiguous
+    //~^ ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //~| WARNING `date_range` is ambiguous
+    //~| ERROR `date_range` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-9.stderr
+++ b/tests/ui/imports/ambiguous-9.stderr
@@ -1,5 +1,5 @@
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-9.rs:8:13
+  --> $DIR/ambiguous-9.rs:7:13
    |
 LL |     pub use self::range::*;
    |             ^^^^^^^^^^^^^^ the name `date_range` in the value namespace is first re-exported here
@@ -8,8 +8,8 @@ LL |     use super::prelude::*;
    |
    = note: `#[warn(ambiguous_glob_reexports)]` on by default
 
-warning: `date_range` is ambiguous
-  --> $DIR/ambiguous-9.rs:24:5
+error: `date_range` is ambiguous
+  --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
@@ -18,29 +18,29 @@ LL |     date_range();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
-  --> $DIR/ambiguous-9.rs:8:13
+  --> $DIR/ambiguous-9.rs:7:13
    |
 LL |     pub use self::range::*;
    |             ^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
 note: `date_range` could also refer to the function imported here
-  --> $DIR/ambiguous-9.rs:9:9
+  --> $DIR/ambiguous-9.rs:8:9
    |
 LL |     use super::prelude::*;
    |         ^^^^^^^^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
 warning: ambiguous glob re-exports
-  --> $DIR/ambiguous-9.rs:16:13
+  --> $DIR/ambiguous-9.rs:15:13
    |
 LL |     pub use self::t::*;
    |             ^^^^^^^^^^ the name `date_range` in the value namespace is first re-exported here
 LL |     pub use super::dsl::*;
    |             ------------- but the name `date_range` in the value namespace is also re-exported here
 
-warning: `date_range` is ambiguous
-  --> $DIR/ambiguous-9.rs:24:5
+error: `date_range` is ambiguous
+  --> $DIR/ambiguous-9.rs:23:5
    |
 LL |     date_range();
    |     ^^^^^^^^^^ ambiguous name
@@ -49,17 +49,65 @@ LL |     date_range();
    = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
    = note: ambiguous because of multiple glob imports of a name in the same module
 note: `date_range` could refer to the function imported here
-  --> $DIR/ambiguous-9.rs:20:5
+  --> $DIR/ambiguous-9.rs:19:5
    |
 LL | use dsl::*;
    |     ^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
 note: `date_range` could also refer to the function imported here
-  --> $DIR/ambiguous-9.rs:21:5
+  --> $DIR/ambiguous-9.rs:20:5
    |
 LL | use prelude::*;
    |     ^^^^^^^^^^
    = help: consider adding an explicit import of `date_range` to disambiguate
 
-warning: 4 warnings emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
+
+Future incompatibility report: Future breakage diagnostic:
+error: `date_range` is ambiguous
+  --> $DIR/ambiguous-9.rs:23:5
+   |
+LL |     date_range();
+   |     ^^^^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `date_range` could refer to the function imported here
+  --> $DIR/ambiguous-9.rs:7:13
+   |
+LL |     pub use self::range::*;
+   |             ^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `date_range` to disambiguate
+note: `date_range` could also refer to the function imported here
+  --> $DIR/ambiguous-9.rs:8:9
+   |
+LL |     use super::prelude::*;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `date_range` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
+
+Future breakage diagnostic:
+error: `date_range` is ambiguous
+  --> $DIR/ambiguous-9.rs:23:5
+   |
+LL |     date_range();
+   |     ^^^^^^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `date_range` could refer to the function imported here
+  --> $DIR/ambiguous-9.rs:19:5
+   |
+LL | use dsl::*;
+   |     ^^^^^^
+   = help: consider adding an explicit import of `date_range` to disambiguate
+note: `date_range` could also refer to the function imported here
+  --> $DIR/ambiguous-9.rs:20:5
+   |
+LL | use prelude::*;
+   |     ^^^^^^^^^^
+   = help: consider adding an explicit import of `date_range` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 

--- a/tests/ui/imports/duplicate.rs
+++ b/tests/ui/imports/duplicate.rs
@@ -34,7 +34,7 @@ fn main() {
     e::foo();
     f::foo(); //~ ERROR `foo` is ambiguous
     g::foo();
-    //~^ WARNING `foo` is ambiguous
+    //~^ ERROR `foo` is ambiguous
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 

--- a/tests/ui/imports/duplicate.stderr
+++ b/tests/ui/imports/duplicate.stderr
@@ -68,7 +68,7 @@ LL |     use self::m2::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
 
-warning: `foo` is ambiguous
+error: `foo` is ambiguous
   --> $DIR/duplicate.rs:36:8
    |
 LL |     g::foo();
@@ -89,9 +89,33 @@ note: `foo` could also refer to the function imported here
 LL |     pub use crate::b::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `foo` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0252, E0659.
 For more information about an error, try `rustc --explain E0252`.
+Future incompatibility report: Future breakage diagnostic:
+error: `foo` is ambiguous
+  --> $DIR/duplicate.rs:36:8
+   |
+LL |     g::foo();
+   |        ^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `foo` could refer to the function imported here
+  --> $DIR/duplicate.rs:24:13
+   |
+LL |     pub use crate::a::*;
+   |             ^^^^^^^^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+note: `foo` could also refer to the function imported here
+  --> $DIR/duplicate.rs:25:13
+   |
+LL |     pub use crate::b::*;
+   |             ^^^^^^^^^^^
+   = help: consider adding an explicit import of `foo` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
+

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.rs
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.rs
@@ -18,7 +18,7 @@ mod a {
 
 use self::a::E::in_exist;
 //~^ ERROR: unresolved import `self::a::E`
-//~| WARNING: `E` is ambiguous
+//~| ERROR: `E` is ambiguous
 //~| WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 fn main() {}

--- a/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
+++ b/tests/ui/imports/unresolved-seg-after-ambiguous.stderr
@@ -4,7 +4,7 @@ error[E0432]: unresolved import `self::a::E`
 LL | use self::a::E::in_exist;
    |              ^ `E` is a struct, not a module
 
-warning: `E` is ambiguous
+error: `E` is ambiguous
   --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
    |
 LL | use self::a::E::in_exist;
@@ -25,8 +25,32 @@ note: `E` could also refer to the struct imported here
 LL |         pub use self::d::*;
    |                 ^^^^^^^^^^
    = help: consider adding an explicit import of `E` to disambiguate
-   = note: `#[warn(ambiguous_glob_imports)]` on by default
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.
+Future incompatibility report: Future breakage diagnostic:
+error: `E` is ambiguous
+  --> $DIR/unresolved-seg-after-ambiguous.rs:19:14
+   |
+LL | use self::a::E::in_exist;
+   |              ^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `E` could refer to the struct imported here
+  --> $DIR/unresolved-seg-after-ambiguous.rs:13:17
+   |
+LL |         pub use self::c::*;
+   |                 ^^^^^^^^^^
+   = help: consider adding an explicit import of `E` to disambiguate
+note: `E` could also refer to the struct imported here
+  --> $DIR/unresolved-seg-after-ambiguous.rs:12:17
+   |
+LL |         pub use self::d::*;
+   |                 ^^^^^^^^^^
+   = help: consider adding an explicit import of `E` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` on by default
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This pr aims to finish the second part of rust-lang/rust#114095. It converts the `ambiguous_glob_imports` lint from a warning to an error.

Currently, only the lint definition and the related tests are changed, a crater run should provide us with information on whether we should go for this.
