### PR TITLE
Don't suggest rewriting call if resolution was invalid

### DIFF
--- a/tests/ui/privacy/ctor-private-from-impl.rs
+++ b/tests/ui/privacy/ctor-private-from-impl.rs
@@ -1,0 +1,18 @@
+pub struct MyStruct {}
+
+mod submodule {
+    use super::MyStruct;
+
+    pub struct MyRef<'a>(&'a MyStruct);
+}
+
+use self::submodule::MyRef;
+
+impl MyStruct {
+    pub fn method(&self) -> MyRef {
+        MyRef(self)
+        //~^ ERROR cannot initialize a tuple struct which contains private fields
+    }
+}
+
+fn main() {}

--- a/tests/ui/privacy/ctor-private-from-impl.stderr
+++ b/tests/ui/privacy/ctor-private-from-impl.stderr
@@ -1,0 +1,19 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/ctor-private-from-impl.rs:13:9
+   |
+LL |         MyRef(self)
+   |         ^^^^^
+   |
+note: constructor is not visible here due to private fields
+  --> $DIR/ctor-private-from-impl.rs:6:26
+   |
+LL |     pub struct MyRef<'a>(&'a MyStruct);
+   |                          ^^^^^^^^^^^^ private field
+help: consider making the field publicly accessible
+   |
+LL |     pub struct MyRef<'a>(pub &'a MyStruct);
+   |                          +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/143008.

The suggestion to `"try calling `{ident}` as a method"` was eating the more relevant suggestion to mark the tuple struct's fields as `pub` so its ctor is visible.

See inline comment.