### PR TITLE
Ensure -V --verbose processes both codegen_backend and codegen-backend

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1112,7 +1112,9 @@ fn get_backend_from_raw_matches(
     matches: &Matches,
 ) -> Box<dyn CodegenBackend> {
     let debug_flags = matches.opt_strs("Z");
-    let backend_name = debug_flags.iter().find_map(|x| x.strip_prefix("codegen-backend="));
+    let backend_name = debug_flags
+        .iter()
+        .find_map(|x| x.strip_prefix("codegen-backend=").or(x.strip_prefix("codegen_backend=")));
     let target = parse_target_triple(early_dcx, matches);
     let sysroot = filesearch::materialize_sysroot(matches.opt_str("sysroot").map(PathBuf::from));
     let target = config::build_target_config(early_dcx, &target, &sysroot);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
