### PR TITLE
emit `StorageLive` and schedule `StorageDead` for `let`-`else`'s bindings after matching

### DIFF
--- a/compiler/rustc_mir_build/src/builder/block.rs
+++ b/compiler/rustc_mir_build/src/builder/block.rs
@@ -6,7 +6,7 @@ use rustc_span::Span;
 use tracing::debug;
 
 use crate::builder::ForGuard::OutsideGuard;
-use crate::builder::matches::{DeclareLetBindings, EmitStorageLive, ScheduleDrops};
+use crate::builder::matches::{DeclareLetBindings, ScheduleDrops};
 use crate::builder::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -199,15 +199,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             None,
                             Some((Some(&destination), initializer_span)),
                         );
-                        this.visit_primary_bindings(pattern, &mut |this, node, span| {
-                            this.storage_live_binding(
-                                block,
-                                node,
-                                span,
-                                OutsideGuard,
-                                ScheduleDrops::Yes,
-                            );
-                        });
                         let else_block_span = this.thir[*else_block].span;
                         let (matching, failure) =
                             this.in_if_then_scope(last_remainder_scope, else_block_span, |this| {
@@ -218,7 +209,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                     None,
                                     initializer_span,
                                     DeclareLetBindings::No,
-                                    EmitStorageLive::No,
                                 )
                             });
                         matching.and(failure)

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -24,7 +24,6 @@ fn main() -> () {
         _1 = Option::<u8>::Some(const 1_u8);
         FakeRead(ForLet(None), _1);
         AscribeUserType(_1, o, UserTypeProjection { base: UserType(1), projs: [] });
-        StorageLive(_5);
         PlaceMention(_1);
         _6 = discriminant(_1);
         switchInt(move _6) -> [1: bb4, otherwise: bb3];
@@ -55,6 +54,7 @@ fn main() -> () {
     }
 
     bb6: {
+        StorageLive(_5);
         _5 = copy ((_1 as Some).0: u8);
         _0 = const ();
         StorageDead(_5);
@@ -63,7 +63,6 @@ fn main() -> () {
     }
 
     bb7: {
-        StorageDead(_5);
         goto -> bb1;
     }
 

--- a/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
+++ b/tests/mir-opt/building/user_type_annotations.let_else.built.after.mir
@@ -21,9 +21,6 @@ fn let_else() -> () {
     }
 
     bb0: {
-        StorageLive(_2);
-        StorageLive(_3);
-        StorageLive(_4);
         StorageLive(_5);
         StorageLive(_6);
         StorageLive(_7);
@@ -51,16 +48,19 @@ fn let_else() -> () {
 
     bb4: {
         AscribeUserType(_5, +, UserTypeProjection { base: UserType(1), projs: [] });
+        StorageLive(_2);
         _2 = copy (_5.0: u32);
+        StorageLive(_3);
         _3 = copy (_5.1: u64);
+        StorageLive(_4);
         _4 = copy (_5.2: &char);
         StorageDead(_7);
         StorageDead(_5);
         _0 = const ();
-        StorageDead(_8);
         StorageDead(_4);
         StorageDead(_3);
         StorageDead(_2);
+        StorageDead(_8);
         return;
     }
 
@@ -68,9 +68,6 @@ fn let_else() -> () {
         StorageDead(_7);
         StorageDead(_5);
         StorageDead(_8);
-        StorageDead(_4);
-        StorageDead(_3);
-        StorageDead(_2);
         goto -> bb1;
     }
 

--- a/tests/ui/dropck/let-else-more-permissive.rs
+++ b/tests/ui/dropck/let-else-more-permissive.rs
@@ -1,5 +1,5 @@
-//! The drop check is currently more permissive when `let` statements have an `else` block, due to
-//! scheduling drops for bindings' storage before pattern-matching (#142056).
+//! Regression test for #142056. The drop check used to be more permissive for `let` statements with
+//! `else` blocks, due to scheduling drops for bindings' storage before pattern-matching.
 
 struct Struct<T>(T);
 impl<T> Drop for Struct<T> {
@@ -14,10 +14,11 @@ fn main() {
         //~^ ERROR `short1` does not live long enough
     }
     {
-        // This is OK: `short2`'s storage is live until after `long2`'s drop runs.
+        // This was OK: `short2`'s storage was live until after `long2`'s drop ran.
         #[expect(irrefutable_let_patterns)]
         let (mut long2, short2) = (Struct(&0), 1) else { unreachable!() };
         long2.0 = &short2;
+        //~^ ERROR `short2` does not live long enough
     }
     {
         // Sanity check: `short3`'s drop is significant; it's dropped before `long3`:

--- a/tests/ui/dropck/let-else-more-permissive.stderr
+++ b/tests/ui/dropck/let-else-more-permissive.stderr
@@ -14,8 +14,24 @@ LL |     }
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
+error[E0597]: `short2` does not live long enough
+  --> $DIR/let-else-more-permissive.rs:20:19
+   |
+LL |         let (mut long2, short2) = (Struct(&0), 1) else { unreachable!() };
+   |                         ------ binding `short2` declared here
+LL |         long2.0 = &short2;
+   |                   ^^^^^^^ borrowed value does not live long enough
+LL |
+LL |     }
+   |     -
+   |     |
+   |     `short2` dropped here while still borrowed
+   |     borrow might be used here, when `long2` is dropped and runs the `Drop` code for type `Struct`
+   |
+   = note: values in a scope are dropped in the opposite order they are defined
+
 error[E0597]: `short3` does not live long enough
-  --> $DIR/let-else-more-permissive.rs:27:19
+  --> $DIR/let-else-more-permissive.rs:28:19
    |
 LL |         let (mut long3, short3) = (Struct(&tmp), Box::new(1)) else { unreachable!() };
    |                         ------ binding `short3` declared here
@@ -30,6 +46,6 @@ LL |     }
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
This PR removes special handling of `let`-`else`, so that `StorageLive`s are emitted and `StorageDead`s are scheduled only after pattern-matching has succeeded. This means `StorageDead`s will no longer appear for all of its bindings on the `else` branch (because they're not live yet) and its drops&`StorageDead`s will happen together like they do elsewhere, rather than having all drops first, then all `StorageDead`s.

This fixes rust-lang/rust#142056, and is therefore a breaking change. I believe it'll need a crater run and a T-lang nomination/fcp thereafter. Specifically, this makes drop-checking slightly more restrictive for `let`-`else` to match the behavior of other variable binding forms. An alternative approach could be to change the relative order of drops and `StorageDead`s for other binding forms to make drop-checking more permissive, but making that consistent would be a significantly more involved change.

r? mir
cc @dingxiangfei2009 

@rustbot label +T-lang +needs-crater