### PR TITLE
Fix suggestion spans inside macros for the `unused_must_use` lint

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -183,6 +183,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
         let mut op_warned = false;
 
         if let Some(must_use_op) = must_use_op {
+            let span = expr.span.find_oldest_ancestor_in_same_ctxt();
             cx.emit_span_lint(
                 UNUSED_MUST_USE,
                 expr.span,
@@ -191,11 +192,11 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                     label: expr.span,
                     suggestion: if expr_is_from_block {
                         UnusedOpSuggestion::BlockTailExpr {
-                            before_span: expr.span.shrink_to_lo(),
-                            after_span: expr.span.shrink_to_hi(),
+                            before_span: span.shrink_to_lo(),
+                            after_span: span.shrink_to_hi(),
                         }
                     } else {
-                        UnusedOpSuggestion::NormalExpr { span: expr.span.shrink_to_lo() }
+                        UnusedOpSuggestion::NormalExpr { span: span.shrink_to_lo() }
                     },
                 },
             );
@@ -508,9 +509,10 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                     );
                 }
                 MustUsePath::Def(span, def_id, reason) => {
+                    let span = span.find_oldest_ancestor_in_same_ctxt();
                     cx.emit_span_lint(
                         UNUSED_MUST_USE,
-                        *span,
+                        span,
                         UnusedDef {
                             pre: descr_pre,
                             post: descr_post,

--- a/tests/ui/lint/unused/must-use-macros.fixed
+++ b/tests/ui/lint/unused/must-use-macros.fixed
@@ -1,0 +1,60 @@
+// Makes sure the suggestions of the `unused_must_use` lint are not inside
+//
+// See <https://github.com/rust-lang/rust/issues/143025>
+
+//@ check-pass
+//@ run-rustfix
+
+#![expect(unused_macros)]
+#![warn(unused_must_use)]
+
+fn main() {
+    {
+        macro_rules! cmp {
+            ($a:tt, $b:tt) => {
+                $a == $b
+            };
+        }
+
+        // FIXME(Urgau): For some unknown reason the spans we get are not
+        // recorded to be from any expansions, preventing us from either
+        // suggesting in front of the macro or not at all.
+        // cmp!(1, 1);
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:ident, $b:ident) => {
+                $a == $b
+            }; //~^ WARN unused comparison that must be used
+        }
+
+        let a = 1;
+        let b = 1;
+        let _ = cmp!(a, b);
+        //~^ SUGGESTION let _
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:expr, $b:expr) => {
+                $a == $b
+            }; //~^ WARN unused comparison that must be used
+        }
+
+        let _ = cmp!(1, 1);
+        //~^ SUGGESTION let _
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:tt, $b:tt) => {
+                $a.eq(&$b)
+            };
+        }
+
+        let _ = cmp!(1, 1);
+        //~^ WARN unused return value
+        //~| SUGGESTION let _
+    }
+}

--- a/tests/ui/lint/unused/must-use-macros.rs
+++ b/tests/ui/lint/unused/must-use-macros.rs
@@ -1,0 +1,60 @@
+// Makes sure the suggestions of the `unused_must_use` lint are not inside
+//
+// See <https://github.com/rust-lang/rust/issues/143025>
+
+//@ check-pass
+//@ run-rustfix
+
+#![expect(unused_macros)]
+#![warn(unused_must_use)]
+
+fn main() {
+    {
+        macro_rules! cmp {
+            ($a:tt, $b:tt) => {
+                $a == $b
+            };
+        }
+
+        // FIXME(Urgau): For some unknown reason the spans we get are not
+        // recorded to be from any expansions, preventing us from either
+        // suggesting in front of the macro or not at all.
+        // cmp!(1, 1);
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:ident, $b:ident) => {
+                $a == $b
+            }; //~^ WARN unused comparison that must be used
+        }
+
+        let a = 1;
+        let b = 1;
+        cmp!(a, b);
+        //~^ SUGGESTION let _
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:expr, $b:expr) => {
+                $a == $b
+            }; //~^ WARN unused comparison that must be used
+        }
+
+        cmp!(1, 1);
+        //~^ SUGGESTION let _
+    }
+
+    {
+        macro_rules! cmp {
+            ($a:tt, $b:tt) => {
+                $a.eq(&$b)
+            };
+        }
+
+        cmp!(1, 1);
+        //~^ WARN unused return value
+        //~| SUGGESTION let _
+    }
+}

--- a/tests/ui/lint/unused/must-use-macros.stderr
+++ b/tests/ui/lint/unused/must-use-macros.stderr
@@ -1,0 +1,48 @@
+warning: unused comparison that must be used
+  --> $DIR/must-use-macros.rs:28:17
+   |
+LL |                 $a == $b
+   |                 ^^^^^^^^ the comparison produces a value
+...
+LL |         cmp!(a, b);
+   |         ---------- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/must-use-macros.rs:9:9
+   |
+LL | #![warn(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+   = note: this warning originates in the macro `cmp` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = cmp!(a, b);
+   |         +++++++
+
+warning: unused comparison that must be used
+  --> $DIR/must-use-macros.rs:41:17
+   |
+LL |                 $a == $b
+   |                 ^^^^^^^^ the comparison produces a value
+...
+LL |         cmp!(1, 1);
+   |         ---------- in this macro invocation
+   |
+   = note: this warning originates in the macro `cmp` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = cmp!(1, 1);
+   |         +++++++
+
+warning: unused return value of `std::cmp::PartialEq::eq` that must be used
+  --> $DIR/must-use-macros.rs:56:9
+   |
+LL |         cmp!(1, 1);
+   |         ^^^^^^^^^^
+   |
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |         let _ = cmp!(1, 1);
+   |         +++++++
+
+warning: 3 warnings emitted
+

--- a/tests/ui/macros/must-use-in-macro-55516.stderr
+++ b/tests/ui/macros/must-use-in-macro-55516.stderr
@@ -7,7 +7,10 @@ LL |     write!(&mut example, "{}", 42);
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `-W unused-must-use` implied by `-W unused`
    = help: to override `-W unused` add `#[allow(unused_must_use)]`
-   = note: this warning originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = write!(&mut example, "{}", 42);
+   |     +++++++
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
This PR fixes the suggestion spans inside macros for the `unused_must_use` lint by trying to find the oldest ancestor span.

Fixes https://github.com/rust-lang/rust/issues/143025