### PR TITLE
Add windows-gnullvm hosts to the manifest

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -14,6 +14,7 @@ use crate::versions::{PkgType, Versions};
 
 static HOSTS: &[&str] = &[
     "aarch64-apple-darwin",
+    "aarch64-pc-windows-gnullvm",
     "aarch64-pc-windows-msvc",
     "aarch64-unknown-linux-gnu",
     "aarch64-unknown-linux-musl",
@@ -44,6 +45,7 @@ static HOSTS: &[&str] = &[
     "x86_64-apple-darwin",
     "x86_64-pc-solaris",
     "x86_64-pc-windows-gnu",
+    "x86_64-pc-windows-gnullvm",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-freebsd",
     "x86_64-unknown-illumos",
@@ -470,7 +472,7 @@ impl Builder {
                 }
                 // so is rust-mingw if it's available for the target
                 PkgType::RustMingw => {
-                    if host.contains("pc-windows-gnu") {
+                    if host.ends_with("pc-windows-gnu") {
                         components.push(host_component(pkg));
                     }
                 }


### PR DESCRIPTION
I made a mistake testing https://github.com/rust-lang/rust/pull/140772 only with `rustup-toolchain-install-master` which doesn't care about the manifests.

This means windows-gnullvm self-hosting will have to wait one more release, unless this change is backported to beta and a new beta release is made, which doesn't seem worth the trouble.