### PR TITLE
Expand const-stabilized API links in relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -69,8 +69,12 @@ These previously stable APIs are now stable in const contexts:
 
 - [`NonNull<T>::replace`](https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html#method.replace)
 - [`<*mut T>::replace`](https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.replace)
-- [`std::ptr::swap_nonoverlapping`](https://github.com/rust-lang/rust/pull/137280)
-- [`Cell::{replace, get, get_mut, from_mut, as_slice_of_cells}`](https://github.com/rust-lang/rust/pull/137928)
+- [`std::ptr::swap_nonoverlapping`](https://doc.rust-lang.org/stable/std/ptr/fn.swap_nonoverlapping.html)
+- [`Cell::replace`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html#method.replace)
+- [`Cell::get`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html#method.get)
+- [`Cell::get_mut`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html#method.get_mut)
+- [`Cell::from_mut`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html#method.from_mut)
+- [`Cell::as_slice_of_cells`](https://doc.rust-lang.org/stable/std/cell/struct.Cell.html#method.as_slice_of_cells)
 
 
 <a id="1.88.0-Cargo"></a>


### PR DESCRIPTION
Noticed while looking at the relnotes blog post https://github.com/rust-lang/blog.rust-lang.org/pull/1651#discussion_r2165569631.

r? @cuviper 