### PR TITLE
Make named asm_labels lint not trigger on hexagon register spans

### DIFF
--- a/compiler/rustc_lint/src/tests.rs
+++ b/compiler/rustc_lint/src/tests.rs
@@ -2,6 +2,7 @@
 
 use rustc_span::{Symbol, create_default_session_globals_then};
 
+use crate::builtin::is_hexagon_register_span;
 use crate::levels::parse_lint_and_tool_name;
 
 #[test]
@@ -26,4 +27,30 @@ fn parse_lint_multiple_path() {
             (Some(Symbol::intern("clippy")), "foo::bar")
         )
     });
+}
+
+#[test]
+fn test_hexagon_register_span_patterns() {
+    // Valid Hexagon register span patterns
+    assert!(is_hexagon_register_span("r1:0"));
+    assert!(is_hexagon_register_span("r15:14"));
+    assert!(is_hexagon_register_span("V5:4"));
+    assert!(is_hexagon_register_span("V3:2"));
+    assert!(is_hexagon_register_span("V5:4.w"));
+    assert!(is_hexagon_register_span("V3:2.h"));
+    assert!(is_hexagon_register_span("r99:98"));
+    assert!(is_hexagon_register_span("V123:122.whatever"));
+
+    // Invalid patterns - these should be treated as potential labels
+    assert!(!is_hexagon_register_span("label1"));
+    assert!(!is_hexagon_register_span("foo:"));
+    assert!(!is_hexagon_register_span(":0"));
+    assert!(!is_hexagon_register_span("r:0")); // missing digits before colon
+    assert!(!is_hexagon_register_span("r1:")); // missing digits after colon
+    assert!(!is_hexagon_register_span("r1:a")); // non-digit after colon
+    assert!(!is_hexagon_register_span("1:0")); // starts with digit, not letter
+    assert!(!is_hexagon_register_span("r1")); // no colon
+    assert!(!is_hexagon_register_span("r")); // too short
+    assert!(!is_hexagon_register_span("")); // empty
+    assert!(!is_hexagon_register_span("ra:0")); // letter in first digit group
 }

--- a/tests/ui/asm/hexagon-register-pairs.rs
+++ b/tests/ui/asm/hexagon-register-pairs.rs
@@ -1,0 +1,35 @@
+//@ add-core-stubs
+//@ compile-flags: --target hexagon-unknown-linux-musl -C target-feature=+hvx-length128b
+//@ needs-llvm-components: hexagon
+//@ ignore-backends: gcc
+
+#![feature(no_core, asm_experimental_arch)]
+#![crate_type = "lib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+fn test_register_spans() {
+    unsafe {
+        // These are valid Hexagon register span notations, not labels
+        // Should NOT trigger the named labels lint
+
+        // General register pairs
+        asm!("r1:0 = memd(r29+#0)", lateout("r0") _, lateout("r1") _);
+        asm!("r3:2 = combine(#1, #0)", lateout("r2") _, lateout("r3") _);
+        asm!("r15:14 = memd(r30+#8)", lateout("r14") _, lateout("r15") _);
+        asm!("memd(r29+#0) = r5:4", in("r4") 0u32, in("r5") 0u32);
+
+        // These patterns look like register spans but test different edge cases
+        // All should NOT trigger the lint as they match valid hexagon register syntax patterns
+        asm!("V5:4 = vaddw(v1:0, v1:0)", options(nostack));  // Uppercase V register pair
+        asm!("v1:0.w = vsub(v1:0.w,v1:0.w):sat", options(nostack));  // Lowercase v with suffix
+
+        // Mixed with actual labels should still trigger for the labels
+        asm!("label1: r7:6 = combine(#2, #3)"); //~ ERROR avoid using named labels
+
+        // Regular labels should still trigger
+        asm!("hexagon_label: nop"); //~ ERROR avoid using named labels
+    }
+}

--- a/tests/ui/asm/hexagon-register-pairs.rs
+++ b/tests/ui/asm/hexagon-register-pairs.rs
@@ -1,4 +1,4 @@
-//@ add-core-stubs
+//@ add-minicore
 //@ compile-flags: --target hexagon-unknown-linux-musl -C target-feature=+hvx-length128b
 //@ needs-llvm-components: hexagon
 //@ ignore-backends: gcc
@@ -6,6 +6,8 @@
 #![feature(no_core, asm_experimental_arch)]
 #![crate_type = "lib"]
 #![no_core]
+
+//~? WARN unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
 
 extern crate minicore;
 use minicore::*;

--- a/tests/ui/asm/hexagon-register-pairs.stderr
+++ b/tests/ui/asm/hexagon-register-pairs.stderr
@@ -1,5 +1,9 @@
+warning: unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
+   |
+   = note: this feature is not stably supported; its behavior can change in the future
+
 error: avoid using named labels in inline assembly
-  --> $DIR/hexagon-register-pairs.rs:30:15
+  --> $DIR/hexagon-register-pairs.rs:32:15
    |
 LL |         asm!("label1: r7:6 = combine(#2, #3)");
    |               ^^^^^^
@@ -9,7 +13,7 @@ LL |         asm!("label1: r7:6 = combine(#2, #3)");
    = note: `#[deny(named_asm_labels)]` on by default
 
 error: avoid using named labels in inline assembly
-  --> $DIR/hexagon-register-pairs.rs:33:15
+  --> $DIR/hexagon-register-pairs.rs:35:15
    |
 LL |         asm!("hexagon_label: nop");
    |               ^^^^^^^^^^^^^
@@ -17,5 +21,5 @@ LL |         asm!("hexagon_label: nop");
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
-error: aborting due to 2 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/asm/hexagon-register-pairs.stderr
+++ b/tests/ui/asm/hexagon-register-pairs.stderr
@@ -1,0 +1,21 @@
+error: avoid using named labels in inline assembly
+  --> $DIR/hexagon-register-pairs.rs:30:15
+   |
+LL |         asm!("label1: r7:6 = combine(#2, #3)");
+   |               ^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+   = note: `#[deny(named_asm_labels)]` on by default
+
+error: avoid using named labels in inline assembly
+  --> $DIR/hexagon-register-pairs.rs:33:15
+   |
+LL |         asm!("hexagon_label: nop");
+   |               ^^^^^^^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/143021

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
