### PR TITLE
Fix Windows bootstrap panic on invalid symlink removal (issue #143045)

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -542,19 +542,8 @@ impl Build {
         if host.is_symlink() {
             // Left over from a previous build; overwrite it.
             // This matters if `build.build` has changed between invocations.
-            #[cfg(windows)]
-            {
-                // On Windows, symlinks (including junctions) can fail to be removed with
-                // `fs::remove_dir` if the target is invalid, causing error 267
-                // "The directory name is invalid". This can happen when the symlink
-                // points to a non-existent or corrupted target.
-                // We try removing as a file first (works for invalid symlinks),
-                // then fall back to removing as a directory if needed.
-                if let Err(_) = fs::remove_file(&host) {
-                    t!(fs::remove_dir(&host));
-                }
-            }
-            #[cfg(not(windows))]
+            // On Windows, `fs::remove_file` can remove both file and directory symlinks/junctions,
+            // even when the target is invalid (which causes error 267 with `fs::remove_dir`).
             t!(fs::remove_file(&host));
         }
         t!(

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -549,7 +549,7 @@ impl Build {
                 if e.kind() == io::ErrorKind::NotADirectory {
                     t!(fs::remove_file(&host));
                 } else {
-                    panic!("failed to remove symlink: {}", e);
+                    panic!("failed to remove symlink: {e}");
                 }
             }
         }


### PR DESCRIPTION
Fix Windows bootstrap panic on invalid symlink removal (issue rust-lang/rust#143045)

On Windows, use `fs::remove_file` for symlinks instead of `fs::remove_dir` to avoid error 267 when the symlink target is invalid. `fs::remove_file` can handle both file and directory symlinks/junctions, even when their targets don't exist.

r? @ghost