### PR TITLE
compiler: Allow `extern "interrupt" fn() -> !`

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -17,7 +17,7 @@ ast_passes_abi_must_not_have_parameters_or_return_type=
 
 ast_passes_abi_must_not_have_return_type=
     invalid signature for `extern {$abi}` function
-    .note = functions with the "custom" ABI cannot have a return type
+    .note = functions with the {$abi} ABI cannot have a return type
     .help = remove the return type
 
 ast_passes_assoc_const_without_body =

--- a/tests/ui/abi/interrupt-invalid-signature.avr.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.avr.stderr
@@ -1,0 +1,28 @@
+error: invalid signature for `extern "avr-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:44:35
+   |
+LL | extern "avr-interrupt" fn avr_arg(_byte: u8) {}
+   |                                   ^^^^^^^^^
+   |
+   = note: functions with the "avr-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "avr-interrupt" fn avr_arg(_byte: u8) {}
+LL + extern "avr-interrupt" fn avr_arg() {}
+   |
+
+error: invalid signature for `extern "avr-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:59:40
+   |
+LL | extern "avr-interrupt" fn avr_ret() -> u8 {
+   |                                        ^^
+   |
+   = note: functions with the "avr-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "avr-interrupt" fn avr_ret() -> u8 {
+LL + extern "avr-interrupt" fn avr_ret() {
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/interrupt-invalid-signature.i686.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.i686.stderr
@@ -4,7 +4,7 @@ error: invalid signature for `extern "x86-interrupt"` function
 LL | extern "x86-interrupt" fn x86_ret() -> u8 {
    |                                        ^^
    |
-   = note: functions with the "custom" ABI cannot have a return type
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
   --> $DIR/interrupt-invalid-signature.rs:83:40
    |

--- a/tests/ui/abi/interrupt-invalid-signature.i686.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.i686.stderr
@@ -1,0 +1,15 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:83:40
+   |
+LL | extern "x86-interrupt" fn x86_ret() -> u8 {
+   |                                        ^^
+   |
+   = note: functions with the "custom" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:83:40
+   |
+LL | extern "x86-interrupt" fn x86_ret() -> u8 {
+   |                                        ^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/abi/interrupt-invalid-signature.msp430.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.msp430.stderr
@@ -1,0 +1,28 @@
+error: invalid signature for `extern "msp430-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:40:41
+   |
+LL | extern "msp430-interrupt" fn msp430_arg(_byte: u8) {}
+   |                                         ^^^^^^^^^
+   |
+   = note: functions with the "msp430-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "msp430-interrupt" fn msp430_arg(_byte: u8) {}
+LL + extern "msp430-interrupt" fn msp430_arg() {}
+   |
+
+error: invalid signature for `extern "msp430-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:65:46
+   |
+LL | extern "msp430-interrupt" fn msp430_ret() -> u8 {
+   |                                              ^^
+   |
+   = note: functions with the "msp430-interrupt" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "msp430-interrupt" fn msp430_ret() -> u8 {
+LL + extern "msp430-interrupt" fn msp430_ret() {
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/abi/interrupt-invalid-signature.riscv32.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.riscv32.stderr
@@ -1,0 +1,54 @@
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:48:43
+   |
+LL | extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
+   |                                           ^^^^^^^^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
+LL + extern "riscv-interrupt-m" fn riscv_m_arg() {}
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:52:43
+   |
+LL | extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
+   |                                           ^^^^^^^^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
+LL + extern "riscv-interrupt-s" fn riscv_s_arg() {}
+   |
+
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:71:48
+   |
+LL | extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
+   |                                                ^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
+LL + extern "riscv-interrupt-m" fn riscv_m_ret() {
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:77:48
+   |
+LL | extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
+   |                                                ^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
+LL + extern "riscv-interrupt-s" fn riscv_s_ret() {
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/abi/interrupt-invalid-signature.riscv64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.riscv64.stderr
@@ -1,0 +1,54 @@
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:48:43
+   |
+LL | extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
+   |                                           ^^^^^^^^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
+LL + extern "riscv-interrupt-m" fn riscv_m_arg() {}
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:52:43
+   |
+LL | extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
+   |                                           ^^^^^^^^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
+LL + extern "riscv-interrupt-s" fn riscv_s_arg() {}
+   |
+
+error: invalid signature for `extern "riscv-interrupt-m"` function
+  --> $DIR/interrupt-invalid-signature.rs:71:48
+   |
+LL | extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
+   |                                                ^^
+   |
+   = note: functions with the "riscv-interrupt-m" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
+LL + extern "riscv-interrupt-m" fn riscv_m_ret() {
+   |
+
+error: invalid signature for `extern "riscv-interrupt-s"` function
+  --> $DIR/interrupt-invalid-signature.rs:77:48
+   |
+LL | extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
+   |                                                ^^
+   |
+   = note: functions with the "riscv-interrupt-s" ABI cannot have any parameters or return type
+help: remove the parameters and return type
+   |
+LL - extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
+LL + extern "riscv-interrupt-s" fn riscv_s_ret() {
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/abi/interrupt-invalid-signature.rs
+++ b/tests/ui/abi/interrupt-invalid-signature.rs
@@ -1,0 +1,110 @@
+/*! Tests interrupt ABIs have a constricted signature
+
+Most interrupt ABIs share a similar restriction in terms of not allowing most signatures.
+Specifically, they generally cannot have arguments or return types.
+So we test that they error in essentially all of the same places.
+A notable and interesting exception is x86.
+
+This test uses `cfg` because it is not testing whether these ABIs work on the platform.
+*/
+//@ add-core-stubs
+//@ revisions: x64 i686 riscv32 riscv64 avr msp430
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ [riscv32] needs-llvm-components: riscv
+//@ [riscv32] compile-flags: --target=riscv32i-unknown-none-elf --crate-type=rlib
+//@ [riscv64] needs-llvm-components: riscv
+//@ [riscv64] compile-flags: --target=riscv64gc-unknown-none-elf --crate-type=rlib
+//@ [avr] needs-llvm-components: avr
+//@ [avr] compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
+//@ [msp430] needs-llvm-components: msp430
+//@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
+#![no_core]
+#![feature(
+    no_core,
+    abi_msp430_interrupt,
+    abi_avr_interrupt,
+    abi_x86_interrupt,
+    abi_riscv_interrupt
+)]
+
+extern crate minicore;
+use minicore::*;
+
+/* most extern "interrupt" definitions should not accept args */
+
+#[cfg(msp430)]
+extern "msp430-interrupt" fn msp430_arg(_byte: u8) {}
+//[msp430]~^ ERROR invalid signature
+
+#[cfg(avr)]
+extern "avr-interrupt" fn avr_arg(_byte: u8) {}
+//[avr]~^ ERROR invalid signature
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-m" fn riscv_m_arg(_byte: u8) {}
+//[riscv32,riscv64]~^ ERROR invalid signature
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-s" fn riscv_s_arg(_byte: u8) {}
+//[riscv32,riscv64]~^ ERROR invalid signature
+
+
+/* all extern "interrupt" definitions should not return non-1ZST values */
+
+#[cfg(avr)]
+extern "avr-interrupt" fn avr_ret() -> u8 {
+    //[avr]~^ ERROR invalid signature
+    1
+}
+
+#[cfg(msp430)]
+extern "msp430-interrupt" fn msp430_ret() -> u8 {
+    //[msp430]~^ ERROR invalid signature
+    1
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-m" fn riscv_m_ret() -> u8 {
+    //[riscv32,riscv64]~^ ERROR invalid signature
+    1
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
+    //[riscv32,riscv64]~^ ERROR invalid signature
+    1
+}
+
+#[cfg(any(x64,i686))]
+extern "x86-interrupt" fn x86_ret() -> u8 {
+    //[x64,i686]~^ ERROR invalid signature
+    1
+}
+
+
+
+/* extern "interrupt" fnptrs with invalid signatures */
+
+#[cfg(avr)]
+fn avr_ptr(_f: extern "avr-interrupt" fn(u8) -> u8) {
+}
+
+#[cfg(msp430)]
+fn msp430_ptr(_f: extern "msp430-interrupt" fn(u8) -> u8) {
+}
+
+#[cfg(any(riscv32,riscv64))]
+fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn(u8) -> u8) {
+}
+
+#[cfg(any(riscv32,riscv64))]
+fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn(u8) -> u8) {
+}
+
+#[cfg(any(x64,i686))]
+fn x86_ptr(_f: extern "x86-interrupt" fn() -> u8) {
+}

--- a/tests/ui/abi/interrupt-invalid-signature.x64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.x64.stderr
@@ -4,7 +4,7 @@ error: invalid signature for `extern "x86-interrupt"` function
 LL | extern "x86-interrupt" fn x86_ret() -> u8 {
    |                                        ^^
    |
-   = note: functions with the "custom" ABI cannot have a return type
+   = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
   --> $DIR/interrupt-invalid-signature.rs:83:40
    |

--- a/tests/ui/abi/interrupt-invalid-signature.x64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.x64.stderr
@@ -1,0 +1,15 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/interrupt-invalid-signature.rs:83:40
+   |
+LL | extern "x86-interrupt" fn x86_ret() -> u8 {
+   |                                        ^^
+   |
+   = note: functions with the "custom" ABI cannot have a return type
+help: remove the return type
+  --> $DIR/interrupt-invalid-signature.rs:83:40
+   |
+LL | extern "x86-interrupt" fn x86_ret() -> u8 {
+   |                                        ^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/abi/interrupt-returns-never-or-unit.rs
+++ b/tests/ui/abi/interrupt-returns-never-or-unit.rs
@@ -37,54 +37,54 @@ use minicore::*;
 
 #[cfg(avr)]
 extern "avr-interrupt" fn avr_ret_never() -> ! {
-    unsafe { hint::unreachable_unchecked() }
+    loop {}
 }
 
 #[cfg(msp430)]
 extern "msp430-interrupt" fn msp430_ret_never() -> ! {
-    unsafe { hint::unreachable_unchecked() }
+    loop {}
 }
 
 #[cfg(any(riscv32,riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_ret_never() -> ! {
-    unsafe { hint::unreachable_unchecked() }
+    loop {}
 }
 
 #[cfg(any(riscv32,riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_ret_never() -> ! {
-    unsafe { hint::unreachable_unchecked() }
+    loop {}
 }
 
 #[cfg(any(x64,i686))]
 extern "x86-interrupt" fn x86_ret_never() -> ! {
-    unsafe { hint::unreachable_unchecked() }
+    loop {}
 }
 
 /* interrupts can return explicit () */
 
 #[cfg(avr)]
 extern "avr-interrupt" fn avr_ret_unit() -> () {
-    unsafe { hint::unreachable_unchecked() }
+    ()
 }
 
 #[cfg(msp430)]
 extern "msp430-interrupt" fn msp430_ret_unit() -> () {
-    unsafe { hint::unreachable_unchecked() }
+    ()
 }
 
 #[cfg(any(riscv32,riscv64))]
 extern "riscv-interrupt-m" fn riscv_m_ret_unit() -> () {
-    unsafe { hint::unreachable_unchecked() }
+    ()
 }
 
 #[cfg(any(riscv32,riscv64))]
 extern "riscv-interrupt-s" fn riscv_s_ret_unit() -> () {
-    unsafe { hint::unreachable_unchecked() }
+    ()
 }
 
 #[cfg(any(x64,i686))]
 extern "x86-interrupt" fn x86_ret_unit() -> () {
-    unsafe { hint::unreachable_unchecked() }
+    ()
 }
 
 /* extern "interrupt" fnptrs can return ! too */

--- a/tests/ui/abi/interrupt-returns-never-or-unit.rs
+++ b/tests/ui/abi/interrupt-returns-never-or-unit.rs
@@ -1,0 +1,110 @@
+/*! Tests interrupt ABIs can return !
+
+Most interrupt ABIs share a similar restriction in terms of not allowing most signatures,
+but it makes sense to allow them to return ! because they could indeed be divergent.
+
+This test uses `cfg` because it is not testing whether these ABIs work on the platform.
+*/
+//@ add-core-stubs
+//@ revisions: x64 i686 riscv32 riscv64 avr msp430
+//@ build-pass
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ [riscv32] needs-llvm-components: riscv
+//@ [riscv32] compile-flags: --target=riscv32i-unknown-none-elf --crate-type=rlib
+//@ [riscv64] needs-llvm-components: riscv
+//@ [riscv64] compile-flags: --target=riscv64gc-unknown-none-elf --crate-type=rlib
+//@ [avr] needs-llvm-components: avr
+//@ [avr] compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
+//@ [msp430] needs-llvm-components: msp430
+//@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
+#![no_core]
+#![feature(
+    no_core,
+    abi_msp430_interrupt,
+    abi_avr_interrupt,
+    abi_x86_interrupt,
+    abi_riscv_interrupt
+)]
+
+extern crate minicore;
+use minicore::*;
+
+/* interrupts can return never */
+
+#[cfg(avr)]
+extern "avr-interrupt" fn avr_ret_never() -> ! {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(msp430)]
+extern "msp430-interrupt" fn msp430_ret_never() -> ! {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-m" fn riscv_m_ret_never() -> ! {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-s" fn riscv_s_ret_never() -> ! {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(x64,i686))]
+extern "x86-interrupt" fn x86_ret_never() -> ! {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+/* interrupts can return explicit () */
+
+#[cfg(avr)]
+extern "avr-interrupt" fn avr_ret_unit() -> () {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(msp430)]
+extern "msp430-interrupt" fn msp430_ret_unit() -> () {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-m" fn riscv_m_ret_unit() -> () {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(riscv32,riscv64))]
+extern "riscv-interrupt-s" fn riscv_s_ret_unit() -> () {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+#[cfg(any(x64,i686))]
+extern "x86-interrupt" fn x86_ret_unit() -> () {
+    unsafe { hint::unreachable_unchecked() }
+}
+
+/* extern "interrupt" fnptrs can return ! too */
+
+#[cfg(avr)]
+fn avr_ptr(_f: extern "avr-interrupt" fn() -> !) {
+}
+
+#[cfg(msp430)]
+fn msp430_ptr(_f: extern "msp430-interrupt" fn() -> !) {
+}
+
+#[cfg(any(riscv32,riscv64))]
+fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn() -> !) {
+}
+
+#[cfg(any(riscv32,riscv64))]
+fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn() -> !) {
+}
+
+#[cfg(any(x64,i686))]
+fn x86_ptr(_f: extern "x86-interrupt" fn() -> !) {
+}


### PR DESCRIPTION
While reviewing rust-lang/rust#142633 I overlooked a few details because I was kind of excited.

- Fixes rust-lang/rust#143072

