### PR TITLE
Treat `include_str!` like it produces a raw string.

### DIFF
--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -207,7 +207,7 @@ pub(crate) fn expand_include_str(
         Ok((bytes, bsp)) => match std::str::from_utf8(&bytes) {
             Ok(src) => {
                 let interned_src = Symbol::intern(src);
-                MacEager::expr(cx.expr_str(cx.with_def_site_ctxt(bsp), interned_src))
+                MacEager::expr(cx.expr_str_raw(cx.with_def_site_ctxt(bsp), interned_src))
             }
             Err(utf8err) => {
                 let mut err = cx.dcx().struct_span_err(sp, format!("`{path}` wasn't a utf-8 file"));

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -445,6 +445,11 @@ impl<'a> ExtCtxt<'a> {
         self.expr(span, ast::ExprKind::Lit(lit))
     }
 
+    pub fn expr_str_raw(&self, span: Span, s: Symbol) -> P<ast::Expr> {
+        let lit = token::Lit::new(token::StrRaw(0), s, None);
+        self.expr(span, ast::ExprKind::Lit(lit))
+    }
+
     pub fn expr_byte_str(&self, span: Span, bytes: Vec<u8>) -> P<ast::Expr> {
         let lit = token::Lit::new(token::ByteStr, literal::escape_byte_str_symbol(&bytes), None);
         self.expr(span, ast::ExprKind::Lit(lit))

--- a/tests/ui/proc-macro/expand-expr.rs
+++ b/tests/ui/proc-macro/expand-expr.rs
@@ -17,7 +17,8 @@ expand_expr_is!("Hello, World!", concat!("Hello, ", "World", "!"));
 expand_expr_is!("int10floats5.3booltrue", concat!("int", 10, "floats", 5.3, "bool", true));
 expand_expr_is!("Hello", concat!(r##"Hello"##));
 
-expand_expr_is!("Included file contents\n", include_str!("auxiliary/included-file.txt"));
+expand_expr_is!(r"Included file contents
+", include_str!("auxiliary/included-file.txt"));
 expand_expr_is!(b"Included file contents\n", include_bytes!("auxiliary/included-file.txt"));
 
 expand_expr_is!(

--- a/tests/ui/proc-macro/expand-expr.stderr
+++ b/tests/ui/proc-macro/expand-expr.stderr
@@ -1,29 +1,29 @@
 error: expected one of `.`, `?`, or an operator, found `;`
-  --> $DIR/expand-expr.rs:108:27
+  --> $DIR/expand-expr.rs:109:27
    |
 LL | expand_expr_fail!("string"; hello);
    |                           ^ expected one of `.`, `?`, or an operator
 
 error: expected expression, found `$`
-  --> $DIR/expand-expr.rs:111:19
+  --> $DIR/expand-expr.rs:112:19
    |
 LL | expand_expr_fail!($);
    |                   ^ expected expression
 
 error: expected expression, found `$`
-  --> $DIR/expand-expr.rs:112:29
+  --> $DIR/expand-expr.rs:113:29
    |
 LL | expand_expr_fail!(echo_tts!($));
    |                             ^ expected expression
 
 error: expected expression, found `$`
-  --> $DIR/expand-expr.rs:113:28
+  --> $DIR/expand-expr.rs:114:28
    |
 LL | expand_expr_fail!(echo_pm!($));
    |                            ^ expected expression
 
 error: macro expansion ignores `hello` and any tokens following
-  --> $DIR/expand-expr.rs:117:47
+  --> $DIR/expand-expr.rs:118:47
    |
 LL | expand_expr_is!("string", echo_tts!("string"; hello));
    |                           --------------------^^^^^- caused by the macro expansion here
@@ -35,7 +35,7 @@ LL | expand_expr_is!("string", echo_tts!("string"; hello););
    |                                                     +
 
 error: macro expansion ignores `;` and any tokens following
-  --> $DIR/expand-expr.rs:118:44
+  --> $DIR/expand-expr.rs:119:44
    |
 LL | expand_expr_is!("string", echo_pm!("string"; hello));
    |                           -----------------^------- caused by the macro expansion here
@@ -47,7 +47,7 @@ LL | expand_expr_is!("string", echo_pm!("string"; hello););
    |                                                    +
 
 error: recursion limit reached while expanding `recursive_expand!`
-  --> $DIR/expand-expr.rs:126:16
+  --> $DIR/expand-expr.rs:127:16
    |
 LL | const _: u32 = recursive_expand!();
    |                ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There are two reasons to do this:

- It just makes sense. The contents of an included file is just like the contents of a raw string literal, because string escapes like `\"` and `\x61` don't get special treatment.

- We can avoid escaping it when putting it into `token::Lit::StrRaw`, unlike `token::Lit::Str`. On a tiny test program that included an 80 MiB file, this reduced compile time from 2.2s to 1.0s.

The change is detectable from proc macros that use `to_string` on tokens, as the change to the `expand-expr.rs` test indicates. But this kind of change is allowable, and it seems very unlikely to cause problems in practice.

r? @petrochenkov 