### PR TITLE
Fix rustdoc not correctly showing attributes on re-exports

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2746,7 +2746,8 @@ fn add_without_unwanted_attributes<'hir>(
                     attrs.push((Cow::Owned(attr), import_parent));
                 }
             }
-            hir::Attribute::Parsed(..) if is_inline => {
+            // FIXME: make sure to exclude `#[cfg_trace]` here when it is ported to the new parsers
+            hir::Attribute::Parsed(..) => {
                 attrs.push((Cow::Owned(attr), import_parent));
             }
             _ => {}

--- a/tests/rustdoc/attributes-re-export.rs
+++ b/tests/rustdoc/attributes-re-export.rs
@@ -1,0 +1,13 @@
+// Tests that attributes are correctly copied onto a re-exported item.
+//@ edition:2021
+#![crate_name = "re_export"]
+
+//@ has 're_export/fn.thingy2.html' '//pre[@class="rust item-decl"]' '#[no_mangle]'
+pub use thingymod::thingy as thingy2;
+
+mod thingymod {
+    #[no_mangle]
+    pub fn thingy() {
+
+    }
+}


### PR DESCRIPTION
Fixes attributes not being shown correctly in rustdoc on re-exports 

Does this need to be backported to beta?

r? @jdonszelmann 