### PR TITLE
Update poison.rs to fix the typo (sys->sync)

### DIFF
--- a/library/std/src/sync/poison.rs
+++ b/library/std/src/sync/poison.rs
@@ -13,7 +13,7 @@
 //! depend on the primitive. See [#Overview] bellow.
 //!
 //! For the alternative implementations that do not employ poisoning,
-//! see `std::sys::nonpoisoning`.
+//! see `std::sync::nonpoisoning`.
 //!
 //! # Overview
 //!


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Fixes rust-lang/rust#143049 
<!-- homu-ignore:end -->
