### PR TITLE
Replace JSONPath with `jq` in `jsondocck`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1314,15 @@ name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
 dependencies = [
  "autocfg",
 ]
@@ -1999,6 +2020,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jaq-core"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77526a72eb79412c29fd141767a6549bbfcb1cb40e00556fe16532d5e878e098"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-json"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01dbdbd07b076e8403abac68ce7744d93e2ecd953bbc44bf77bf00e1e81172bc"
+dependencies = [
+ "foldhash",
+ "indexmap",
+ "jaq-core",
+ "jaq-std",
+ "serde_json",
+]
+
+[[package]]
+name = "jaq-std"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c264fe397c981705976c71f1bfe020382b9eda52ae950e57fe885e147bdd67d"
+dependencies = [
+ "aho-corasick",
+ "base64 0.22.1",
+ "chrono",
+ "jaq-core",
+ "libm",
+ "log",
+ "regex-lite",
+ "urlencoding",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,12 +2107,15 @@ dependencies = [
 name = "jsondocck"
 version = "0.0.0"
 dependencies = [
- "fs-err",
+ "foldhash",
+ "fs-err 3.1.1",
  "getopts",
- "jsonpath-rust",
+ "indexmap",
+ "jaq-core",
+ "jaq-json",
+ "jaq-std",
  "regex",
  "serde_json",
- "shlex",
 ]
 
 [[package]]
@@ -2060,24 +2124,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "fs-err",
+ "fs-err 2.11.0",
  "rustc-hash 2.1.1",
  "rustdoc-json-types",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "jsonpath-rust"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d057f8fd19e20c3f14d3663983397155739b6bc1148dc5cd4c4a1a5b3130eb0"
-dependencies = [
- "pest",
- "pest_derive",
- "regex",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2778,50 +2829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b29be2ba35c12c6939f6bc73187f728bba82c3c062ecdc5fa90ea739282a1f58"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "pest"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
-dependencies = [
- "memchr",
- "thiserror 2.0.12",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
-dependencies = [
- "pest",
- "sha2",
 ]
 
 [[package]]
@@ -4753,7 +4760,7 @@ version = "0.0.0"
 dependencies = [
  "arrayvec",
  "askama",
- "base64",
+ "base64 0.21.7",
  "expect-test",
  "indexmap",
  "itertools",
@@ -5683,6 +5690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,12 +5709,6 @@ checksum = "c06ff81122fcbf4df4c1660b15f7e3336058e7aec14437c9f85c6b31a0f279b9"
 dependencies = [
  "regex-lite",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ui_test"
@@ -5873,6 +5880,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "jsondocck"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "fs-err",
  "getopts",

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -790,8 +790,7 @@ const KNOWN_HTMLDOCCK_DIRECTIVE_NAMES: &[&str] = &[
     "!snapshot",
 ];
 
-const KNOWN_JSONDOCCK_DIRECTIVE_NAMES: &[&str] =
-    &["count", "!count", "has", "!has", "is", "!is", "ismany", "!ismany", "set", "!set"];
+const KNOWN_JSONDOCCK_DIRECTIVE_NAMES: &[&str] = &["jq", "arg", "eq", "ne"];
 
 /// The (partly) broken-down contents of a line containing a test directive,
 /// which [`iter_directives`] passes to its callback function.

--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -18,8 +18,6 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }
 
-        let mut json_out = out_dir.join(self.testpaths.file.file_stem().unwrap());
-        json_out.set_extension("json");
         let res = self.run_command_to_procres(
             Command::new(self.config.jsondocck_path.as_ref().unwrap())
                 .arg("--doc-dir")

--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -13,7 +13,7 @@ impl TestCx<'_> {
             panic!("failed to remove and recreate output directory `{out_dir}`: {e}")
         });
 
-        let proc_res = self.document(&out_dir, &self.testpaths);
+        let proc_res = self.document(&out_dir, self.testpaths);
         if !proc_res.status.success() {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }

--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jsondocck"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 jsonpath-rust = "1.0.0"

--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -3,9 +3,16 @@ name = "jsondocck"
 edition = "2024"
 
 [dependencies]
-jsonpath-rust = "1.0.0"
 getopts = "0.2"
-regex = "1.4"
-shlex = "1.0"
-serde_json = "1.0"
-fs-err = "2.5.0"
+regex = "1"
+serde_json = "1"
+fs-err = "3"
+jaq-core = "2"
+# FIXME: Depends on `jaq-std` with default features (a ton of unused by `jsondocck` stuff). Consider
+# disabling them when it'll be possible.
+jaq-json = { version = "1", default-features = false, features = [
+    "serde_json",
+] }
+jaq-std = { version = "2", default-features = false }
+indexmap = "2"
+foldhash = "0.1"

--- a/src/tools/jsondocck/Cargo.toml
+++ b/src/tools/jsondocck/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jsondocck"
-version = "0.1.0"
 edition = "2024"
 
 [dependencies]

--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -1,35 +1,115 @@
-use std::collections::HashMap;
-use std::path::Path;
+use std::borrow::Cow;
+use std::iter::{self, Empty};
+use std::path::{Path, PathBuf};
 
+use foldhash::fast::RandomState;
 use fs_err as fs;
+use indexmap::IndexMap as InnerIndexMap;
+use jaq_core::load::{Arena, File, Loader};
+use jaq_core::{Compiler, Ctx, Filter as InnerFilter, Native, RcIter};
+use jaq_json::Val;
 use serde_json::Value;
 
 use crate::config::Config;
 
+type IndexMap<K, V> = InnerIndexMap<K, V, RandomState>;
+
 #[derive(Debug)]
 pub struct Cache {
-    value: Value,
-    pub variables: HashMap<String, Value>,
+    value: Val,
+    global_vars: IndexMap<String, Val>,
 }
 
 impl Cache {
-    /// Create a new cache, used to read files only once and otherwise store their contents.
-    pub fn new(config: &Config) -> Cache {
-        let root = Path::new(&config.doc_dir);
+    /// Create a new cache, used to read a documentation JSON file only once and otherwise store its
+    /// content.
+    pub fn new(Config { doc_dir, template }: &Config) -> Self {
+        let root = Path::new(doc_dir);
         // `filename` needs to replace `-` with `_` to be sure the JSON path will always be valid.
-        let filename =
-            Path::new(&config.template).file_stem().unwrap().to_str().unwrap().replace('-', "_");
-        let file_path = root.join(&Path::with_extension(Path::new(&filename), "json"));
-        let content = fs::read_to_string(&file_path).expect("failed to read JSON file");
+        let mut filename: PathBuf =
+            Path::new(template).file_stem().unwrap().to_str().unwrap().replace('-', "_").into();
+
+        filename.set_extension("json");
+
+        let content = fs::read(root.join(filename)).expect("failed to read a JSON file");
 
         Cache {
-            value: serde_json::from_str::<Value>(&content).expect("failed to convert from JSON"),
-            variables: HashMap::from([("FILE".to_owned(), config.template.clone().into())]),
+            value: serde_json::from_slice::<Value>(&content)
+                .expect("failed to convert from JSON")
+                .into(),
+            // FIXME: Replace this with empty `HashMap` and use `input_filename` instead of `$FILE`
+            // in tests once https://github.com/01mf02/jaq/issues/144 is fixed.
+            global_vars: [("$FILE".into(), template.to_owned().into())].into_iter().collect(),
         }
     }
 
-    // FIXME: Make this failible, so jsonpath syntax error has line number.
-    pub fn select(&self, path: &str) -> Vec<&Value> {
-        jsonpath_rust::query::js_path_vals(path, &self.value).unwrap()
+    pub fn arg(&mut self, name: &str, value: Val) {
+        self.global_vars.insert(format!("${name}"), value);
+    }
+
+    pub fn filter(&self, code: &str) -> Result<Filter, Cow<'static, str>> {
+        let arena = Arena::default();
+        let modules = Loader::new(
+            // `tonumber` depends on `fromjson` that requires adding the extra "hifijson"
+            // dependency.
+            jaq_std::defs().chain(jaq_json::defs().filter(|def| !matches!(def.name, "tonumber"))),
+        )
+        .load(&arena, File { code, path: () })
+        .map_err(|e| format!("failed to parse the given filter: {e:?}"))?;
+
+        Ok(Filter {
+            inner: Compiler::default()
+                .with_funs(jaq_std::funs().chain(jaq_json::base_funs()))
+                .with_global_vars(self.global_vars.keys().map(String::as_ref))
+                .compile(modules)
+                .map_err(|e| format!("failed to compile the given filter: {e:?}"))?,
+            inputs: RcIter::new(iter::empty()),
+        })
+    }
+}
+
+pub struct Filter {
+    inner: InnerFilter<Native<Val>>,
+    inputs: RcIter<Empty<Result<Val, String>>>,
+}
+
+impl Filter {
+    pub fn run(&self, cache: &Cache) -> Values<impl Iterator<Item = Result<Val, String>> + '_> {
+        Values {
+            inner: self
+                .inner
+                .run((
+                    Ctx::new(cache.global_vars.values().cloned(), &self.inputs),
+                    cache.value.clone(),
+                ))
+                .map(|r| r.map_err(|e| format!("failed to execute the given filter: {e}"))),
+            counter: 0,
+        }
+    }
+}
+
+pub struct Values<I> {
+    inner: I,
+    counter: usize,
+}
+
+impl<I: Iterator<Item = Result<Val, String>>> Values<I> {
+    pub fn is_empty(&mut self) -> Result<(), String> {
+        if self.inner.next().is_none() {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected {expected} value(s), received more than {expected}",
+                expected = self.counter
+            ))
+        }
+    }
+
+    pub fn next(&mut self) -> Result<Val, String> {
+        self.counter += 1;
+
+        self.inner
+            .next()
+            .ok_or_else(|| format!("{} value was expected, received nothing", self.counter))?
     }
 }

--- a/src/tools/jsondocck/src/config.rs
+++ b/src/tools/jsondocck/src/config.rs
@@ -4,11 +4,11 @@ use getopts::Options;
 pub struct Config {
     /// The directory documentation output was generated in.
     pub doc_dir: String,
-    /// The file documentation was generated for, with docck directives to check.
+    /// The file documentation was generated for, with `jsondocck` directives to check.
     pub template: String,
 }
 
-/// Create a Config from a vector of command-line arguments.
+/// Create [`Config`] from a vector of command-line arguments.
 pub fn parse_config(args: Vec<String>) -> Config {
     let mut opts = Options::new();
     opts.reqopt("", "doc-dir", "Path to the documentation output directory.", "PATH")

--- a/src/tools/jsondocck/src/config.rs
+++ b/src/tools/jsondocck/src/config.rs
@@ -11,32 +11,34 @@ pub struct Config {
     pub template: String,
 }
 
-/// Create [`Config`] from an iterator of command-line arguments.
-pub fn parse_config(mut args: Args) -> Option<Config> {
-    let mut opts = Options::new();
-    opts.reqopt("", "doc-dir", "Path to the documentation output directory.", "PATH")
-        .reqopt("", "template", "Path to the input template file.", "PATH")
-        .optflag("h", "help", "Show this message.");
+impl Config {
+    /// Create [`Config`] from an iterator of command-line arguments.
+    pub fn parse(mut args: Args) -> Option<Config> {
+        let mut opts = Options::new();
+        opts.reqopt("", "doc-dir", "Path to the documentation output directory.", "PATH")
+            .reqopt("", "template", "Path to the input template file.", "PATH")
+            .optflag("h", "help", "Show this message.");
 
-    let argv0 = args.next().unwrap();
-    let usage = &*LazyCell::new(|| opts.usage(&format!("Usage: {argv0} <doc-dir> <template>")));
+        let argv0 = args.next().unwrap();
+        let usage = &*LazyCell::new(|| opts.usage(&format!("Usage: {argv0} <doc-dir> <template>")));
 
-    if args.len() == 0 {
-        print!("{usage}");
+        if args.len() == 0 {
+            print!("{usage}");
 
-        return None;
+            return None;
+        }
+
+        let matches = opts.parse(args).unwrap();
+
+        if matches.opt_present("h") || matches.opt_present("help") {
+            print!("{usage}");
+
+            return None;
+        }
+
+        Some(Config {
+            doc_dir: matches.opt_str("doc-dir").unwrap(),
+            template: matches.opt_str("template").unwrap(),
+        })
     }
-
-    let matches = opts.parse(args).unwrap();
-
-    if matches.opt_present("h") || matches.opt_present("help") {
-        print!("{usage}");
-
-        return None;
-    }
-
-    Some(Config {
-        doc_dir: matches.opt_str("doc-dir").unwrap(),
-        template: matches.opt_str("template").unwrap(),
-    })
 }

--- a/src/tools/jsondocck/src/config.rs
+++ b/src/tools/jsondocck/src/config.rs
@@ -2,18 +2,18 @@ use getopts::Options;
 
 #[derive(Debug)]
 pub struct Config {
-    /// The directory documentation output was generated in
+    /// The directory documentation output was generated in.
     pub doc_dir: String,
-    /// The file documentation was generated for, with docck directives to check
+    /// The file documentation was generated for, with docck directives to check.
     pub template: String,
 }
 
-/// Create a Config from a vector of command-line arguments
+/// Create a Config from a vector of command-line arguments.
 pub fn parse_config(args: Vec<String>) -> Config {
     let mut opts = Options::new();
-    opts.reqopt("", "doc-dir", "Path to the documentation directory", "PATH")
-        .reqopt("", "template", "Path to the template file", "PATH")
-        .optflag("h", "help", "show this message");
+    opts.reqopt("", "doc-dir", "Path to the documentation directory.", "PATH")
+        .reqopt("", "template", "Path to the template file.", "PATH")
+        .optflag("h", "help", "Show this message.");
 
     let (argv0, args_) = args.split_first().unwrap();
     if args.len() == 1 {

--- a/src/tools/jsondocck/src/config.rs
+++ b/src/tools/jsondocck/src/config.rs
@@ -11,8 +11,8 @@ pub struct Config {
 /// Create a Config from a vector of command-line arguments.
 pub fn parse_config(args: Vec<String>) -> Config {
     let mut opts = Options::new();
-    opts.reqopt("", "doc-dir", "Path to the documentation directory.", "PATH")
-        .reqopt("", "template", "Path to the template file.", "PATH")
+    opts.reqopt("", "doc-dir", "Path to the documentation output directory.", "PATH")
+        .reqopt("", "template", "Path to the input template file.", "PATH")
         .optflag("h", "help", "Show this message.");
 
     let (argv0, args_) = args.split_first().unwrap();

--- a/src/tools/jsondocck/src/error.rs
+++ b/src/tools/jsondocck/src/error.rs
@@ -1,7 +1,0 @@
-use crate::Directive;
-
-#[derive(Debug)]
-pub struct CkError {
-    pub message: String,
-    pub directive: Directive,
-}

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -76,8 +76,8 @@ fn get_directives(template: &str) -> Result<Vec<Directive>, ()> {
     let mut errors = false;
     let file = fs::read_to_string(template).unwrap();
 
-    for (lineno, line) in file.split('\n').enumerate() {
-        let lineno = lineno + 1;
+    for (mut lineno, line) in file.split('\n').enumerate() {
+        lineno += 1;
 
         if DEPRECATED_LINE_PATTERN.is_match(line) {
             print_err("Deprecated directive syntax, replace `// @` with `//@ `", lineno);

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -15,13 +15,13 @@ use directive::{Directive, DirectiveKind};
 
 static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(
-        r#"
+        r"
         ^\s*
         //@\s+
         (?P<negated>!?)
         (?P<directive>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)
         (?P<args>.*)$
-    "#,
+    ",
     )
     .ignore_whitespace(true)
     .build()
@@ -29,7 +29,7 @@ static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static DEPRECATED_LINE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| RegexBuilder::new(r#"//\s+@"#).build().unwrap());
+    LazyLock::new(|| RegexBuilder::new(r"//\s+@").build().unwrap());
 
 /// ```
 /// // Directive on its own line
@@ -39,7 +39,7 @@ static DEPRECATED_LINE_PATTERN: LazyLock<Regex> =
 /// struct S; //@ ignored-directive
 /// ```
 static MIXED_LINE: LazyLock<Regex> =
-    LazyLock::new(|| RegexBuilder::new(r#".*\S.*//@"#).build().unwrap());
+    LazyLock::new(|| RegexBuilder::new(r".*\S.*//@").build().unwrap());
 
 struct ErrorReporter<'a> {
     /// See [`Config::template`].

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -60,11 +60,8 @@ static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 
 static DEPRECATED_LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(
-        r#"
-        //\s+@
-    "#,
+        r#"//\s+@"#,
     )
-    .ignore_whitespace(true)
     .build()
     .unwrap()
 });

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> ExitCode {
         lineno += 1;
 
         if DEPRECATED_LINE_PATTERN.is_match(line) {
-            error_reporter.print("Deprecated directive syntax, replace `// @` with `//@ `", lineno);
+            error_reporter.print("deprecated directive syntax, replace `// @` with `//@ `", lineno);
 
             continue;
         }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -15,7 +15,9 @@ use directive::{Directive, DirectiveKind};
 use error::CkError;
 
 fn main() -> ExitCode {
-    let config = parse_config(env::args().collect());
+    let Some(config) = parse_config(env::args()) else {
+        return ExitCode::FAILURE;
+    };
 
     let mut failed = Vec::new();
     let mut cache = Cache::new(&config);

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -54,7 +54,6 @@ static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     "#,
     )
     .ignore_whitespace(true)
-    .unicode(true)
     .build()
     .unwrap()
 });
@@ -66,7 +65,6 @@ static DEPRECATED_LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     "#,
     )
     .ignore_whitespace(true)
-    .unicode(true)
     .build()
     .unwrap()
 });

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -16,12 +16,15 @@ use directive::{Directive, DirectiveKind};
 static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(
         r"
-        ^\s*
-        //@\s+
-        (?P<negated>!?)
-        (?P<directive>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)
-        (?P<args>.*)$
-    ",
+            # Any number of whitespaces.
+            \s*
+            # The directive prefix (`//@`) and 1 or more whitespaces after.
+            //@\s+
+            # The directive itself (1 or more word or `-` characters).
+            (?P<directive>[\w-]+)
+            # The optional remainder (1 non-word character and 0 or more of any characters after).
+            (?P<args>\W.*)?
+        ",
     )
     .ignore_whitespace(true)
     .build()

--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -9,5 +9,6 @@ impl Default for Manual {
     }
 }
 
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'
+//@ arg default [.index[] | select(.inner.impl.trait?.path == "Default")]
+//@ eq $default[] | select(.inner.impl.for?.resolved_path?.path == "Derive").attrs | ., ["#[automatically_derived]"]
+//@ eq $default[] | select(.inner.impl.for?.resolved_path?.path == "Manual").attrs | ., []

--- a/tests/rustdoc-json/attrs/cold.rs
+++ b/tests/rustdoc-json/attrs/cold.rs
@@ -1,3 +1,3 @@
-//@ is "$.index[?(@.name=='cold_fn')].attrs" '["#[attr = Cold]"]'
+//@ eq .index[] | select(.name == "cold_fn").attrs | ., ["#[attr = Cold]"]
 #[cold]
 pub fn cold_fn() {}

--- a/tests/rustdoc-json/attrs/deprecated.rs
+++ b/tests/rustdoc-json/attrs/deprecated.rs
@@ -1,38 +1,30 @@
-//@ is "$.index[?(@.name=='not')].attrs" []
-//@ is "$.index[?(@.name=='not')].deprecation" null
+//@ eq .index[] | select(.name == "not") | [.attrs, .deprecation], [[], null]
 pub fn not() {}
 
-//@ is "$.index[?(@.name=='raw')].attrs" []
-//@ is "$.index[?(@.name=='raw')].deprecation" '{"since": null, "note": null}'
+//@ eq .index[] | select(.name == "raw") | [.attrs, .deprecation], [[], {"since": null, "note": null}]
 #[deprecated]
 pub fn raw() {}
 
-//@ is "$.index[?(@.name=='equals_string')].attrs" []
-//@ is "$.index[?(@.name=='equals_string')].deprecation" '{"since": null, "note": "here is a reason"}'
+//@ eq .index[] | select(.name == "equals_string") | [.attrs, .deprecation], [[], {"since": null, "note": "here is a reason"}]
 #[deprecated = "here is a reason"]
 pub fn equals_string() {}
 
-//@ is "$.index[?(@.name=='since')].attrs" []
-//@ is "$.index[?(@.name=='since')].deprecation" '{"since": "yoinks ago", "note": null}'
+//@ eq .index[] | select(.name == "since") | [.attrs, .deprecation], [[], {"since": "yoinks ago", "note": null}]
 #[deprecated(since = "yoinks ago")]
 pub fn since() {}
 
-//@ is "$.index[?(@.name=='note')].attrs" []
-//@ is "$.index[?(@.name=='note')].deprecation" '{"since": null, "note": "7"}'
+//@ eq .index[] | select(.name == "note") | [.attrs, .deprecation], [[], {"since": null, "note": "7"}]
 #[deprecated(note = "7")]
 pub fn note() {}
 
-//@ is "$.index[?(@.name=='since_and_note')].attrs" []
-//@ is "$.index[?(@.name=='since_and_note')].deprecation" '{"since": "tomorrow", "note": "sorry"}'
+//@ eq .index[] | select(.name == "since_and_note") | [.attrs, .deprecation], [[], {"since": "tomorrow", "note": "sorry"}]
 #[deprecated(since = "tomorrow", note = "sorry")]
 pub fn since_and_note() {}
 
-//@ is "$.index[?(@.name=='note_and_since')].attrs" []
-//@ is "$.index[?(@.name=='note_and_since')].deprecation" '{"since": "a year from tomorrow", "note": "your welcome"}'
+//@ eq .index[] | select(.name == "note_and_since") | [.attrs, .deprecation], [[], {"since": "a year from tomorrow", "note": "your welcome"}]
 #[deprecated(note = "your welcome", since = "a year from tomorrow")]
 pub fn note_and_since() {}
 
-//@ is "$.index[?(@.name=='neither_but_parens')].attrs" []
-//@ is "$.index[?(@.name=='neither_but_parens')].deprecation" '{"since": null, "note": null}'
+//@ eq .index[] | select(.name == "neither_but_parens") | [.attrs, .deprecation], [[], {"since": null, "note": null}]
 #[deprecated()]
 pub fn neither_but_parens() {}

--- a/tests/rustdoc-json/attrs/export_name_2021.rs
+++ b/tests/rustdoc-json/attrs/export_name_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[export_name = \"altered\"]"]
 #[export_name = "altered"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/export_name_2024.rs
+++ b/tests/rustdoc-json/attrs/export_name_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(export_name = ..)]` in rustdoc in edition 2024
 // is still `#[export_name = ..]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[export_name = \"altered\"]"]
 #[unsafe(export_name = "altered")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/inline.rs
+++ b/tests/rustdoc-json/attrs/inline.rs
@@ -1,11 +1,11 @@
-//@ is "$.index[?(@.name=='just_inline')].attrs" '["#[attr = Inline(Hint)]"]'
+//@ eq .index[] | select(.name == "just_inline").attrs | ., ["#[attr = Inline(Hint)]"]
 #[inline]
 pub fn just_inline() {}
 
-//@ is "$.index[?(@.name=='inline_always')].attrs" '["#[attr = Inline(Always)]"]'
+//@ eq .index[] | select(.name == "inline_always").attrs | ., ["#[attr = Inline(Always)]"]
 #[inline(always)]
 pub fn inline_always() {}
 
-//@ is "$.index[?(@.name=='inline_never')].attrs" '["#[attr = Inline(Never)]"]'
+//@ eq .index[] | select(.name == "inline_never").attrs | ., ["#[attr = Inline(Never)]"]
 #[inline(never)]
 pub fn inline_never() {}

--- a/tests/rustdoc-json/attrs/link_section_2021.rs
+++ b/tests/rustdoc-json/attrs/link_section_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[link_section = \".text\"]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[link_section = \".text\"]"]
 #[link_section = ".text"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/link_section_2024.rs
+++ b/tests/rustdoc-json/attrs/link_section_2024.rs
@@ -4,6 +4,6 @@
 // Since the 2024 edition the link_section attribute must use the unsafe qualification.
 // However, the unsafe qualification is not shown by rustdoc.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[link_section = \".text\"]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[link_section = \".text\"]"]
 #[unsafe(link_section = ".text")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/must_use.rs
+++ b/tests/rustdoc-json/attrs/must_use.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[attr = MustUse]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[attr = MustUse]"]
 #[must_use]
 pub fn example() -> impl Iterator<Item = i64> {}
 
-//@ is "$.index[?(@.name=='explicit_message')].attrs" '["#[attr = MustUse {reason: \"does nothing if you do not use it\"}]"]'
+//@ eq .index[] | select(.name == "explicit_message").attrs | ., ["#[attr = MustUse {reason: \"does nothing if you do not use it\"}]"]
 #[must_use = "does nothing if you do not use it"]
 pub fn explicit_message() -> impl Iterator<Item = i64> {}

--- a/tests/rustdoc-json/attrs/no_mangle_2021.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[no_mangle]"]
 #[no_mangle]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/no_mangle_2024.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(no_mangle)]` in rustdoc in edition 2024
 // is still `#[no_mangle]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ eq .index[] | select(.name == "example").attrs | ., ["#[no_mangle]"]
 #[unsafe(no_mangle)]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/non_exhaustive.rs
+++ b/tests/rustdoc-json/attrs/non_exhaustive.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]"]'
+//@ eq .index[] | select(.name == "MyEnum").attrs | ., ["#[non_exhaustive]"]
 #[non_exhaustive]
 pub enum MyEnum {
     First,
 }
 
 pub enum NonExhaustiveVariant {
-    //@ is "$.index[?(@.name=='Variant')].attrs" '["#[non_exhaustive]"]'
+    //@ eq .index[] | select(.name == "Variant").attrs | ., ["#[non_exhaustive]"]
     #[non_exhaustive]
     Variant(i64),
 }
 
-//@ is "$.index[?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]"]'
+//@ eq .index[] | select(.name == "MyStruct").attrs | ., ["#[non_exhaustive]"]
 #[non_exhaustive]
 pub struct MyStruct {
     pub x: i64,

--- a/tests/rustdoc-json/attrs/optimize.rs
+++ b/tests/rustdoc-json/attrs/optimize.rs
@@ -1,13 +1,13 @@
 #![feature(optimize_attribute)]
 
-//@ is "$.index[?(@.name=='speed')].attrs" '["#[attr = Optimize(Speed)]"]'
+//@ eq .index[] | select(.name == "speed").attrs | ., ["#[attr = Optimize(Speed)]"]
 #[optimize(speed)]
 pub fn speed() {}
 
-//@ is "$.index[?(@.name=='size')].attrs" '["#[attr = Optimize(Size)]"]'
+//@ eq .index[] | select(.name == "size").attrs | ., ["#[attr = Optimize(Size)]"]
 #[optimize(size)]
 pub fn size() {}
 
-//@ is "$.index[?(@.name=='none')].attrs" '["#[attr = Optimize(DoNotOptimize)]"]'
+//@ eq .index[] | select(.name == "none").attrs | ., ["#[attr = Optimize(DoNotOptimize)]"]
 #[optimize(none)]
 pub fn none() {}

--- a/tests/rustdoc-json/attrs/repr_align.rs
+++ b/tests/rustdoc-json/attrs/repr_align.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='Aligned')].attrs" '["#[repr(align(4))]"]'
+//@ eq .index[] | select(.name == "Aligned").attrs | ., ["#[repr(align(4))]"]
 #[repr(align(4))]
 pub struct Aligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/repr_c.rs
+++ b/tests/rustdoc-json/attrs/repr_c.rs
@@ -1,16 +1,16 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='ReprCStruct')].attrs" '["#[repr(C)]"]'
+//@ eq .index[] | select(.name == "ReprCStruct").attrs | ., ["#[repr(C)]"]
 #[repr(C)]
 pub struct ReprCStruct(pub i64);
 
-//@ is "$.index[?(@.name=='ReprCEnum')].attrs" '["#[repr(C)]"]'
+//@ eq .index[] | select(.name == "ReprCEnum").attrs | ., ["#[repr(C)]"]
 #[repr(C)]
 pub enum ReprCEnum {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCUnion')].attrs" '["#[repr(C)]"]'
+//@ eq .index[] | select(.name == "ReprCUnion").attrs | ., ["#[repr(C)]"]
 #[repr(C)]
 pub union ReprCUnion {
     pub left: i64,

--- a/tests/rustdoc-json/attrs/repr_combination.rs
+++ b/tests/rustdoc-json/attrs/repr_combination.rs
@@ -3,33 +3,33 @@
 // Combinations of `#[repr(..)]` attributes.
 // Rustdoc JSON emits normalized output, regardless of the original source.
 
-//@ is "$.index[?(@.name=='ReprCI8')].attrs" '["#[repr(C, i8)]"]'
+//@ eq .index[] | select(.name == "ReprCI8").attrs | ., ["#[repr(C, i8)]"]
 #[repr(C, i8)]
 pub enum ReprCI8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCI16')].attrs" '["#[repr(C, i16)]"]'
+//@ eq .index[] | select(.name == "SeparateReprCI16").attrs | ., ["#[repr(C, i16)]"]
 #[repr(C)]
 #[repr(i16)]
 pub enum SeparateReprCI16 {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCUsize')].attrs" '["#[repr(C, usize)]"]'
+//@ eq .index[] | select(.name == "ReversedReprCUsize").attrs | ., ["#[repr(C, usize)]"]
 #[repr(usize, C)]
 pub enum ReversedReprCUsize {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCPacked')].attrs" '["#[repr(C, packed(1))]"]'
+//@ eq .index[] | select(.name == "ReprCPacked").attrs | ., ["#[repr(C, packed(1))]"]
 #[repr(C, packed)]
 pub struct ReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ eq .index[] | select(.name == "SeparateReprCPacked").attrs | ., ["#[repr(C, packed(2))]"]
 #[repr(C)]
 #[repr(packed(2))]
 pub struct SeparateReprCPacked {
@@ -37,21 +37,21 @@ pub struct SeparateReprCPacked {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ eq .index[] | select(.name == "ReversedReprCPacked").attrs | ., ["#[repr(C, packed(2))]"]
 #[repr(packed(2), C)]
 pub struct ReversedReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReprCAlign')].attrs" '["#[repr(C, align(16))]"]'
+//@ eq .index[] | select(.name == "ReprCAlign").attrs | ., ["#[repr(C, align(16))]"]
 #[repr(C, align(16))]
 pub struct ReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ eq .index[] | select(.name == "SeparateReprCAlign").attrs | ., ["#[repr(C, align(2))]"]
 #[repr(C)]
 #[repr(align(2))]
 pub struct SeparateReprCAlign {
@@ -59,25 +59,25 @@ pub struct SeparateReprCAlign {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ eq .index[] | select(.name == "ReversedReprCAlign").attrs | ., ["#[repr(C, align(2))]"]
 #[repr(align(2), C)]
 pub struct ReversedReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='AlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ eq .index[] | select(.name == "AlignedExplicitRepr").attrs | ., ["#[repr(C, align(16), isize)]"]
 #[repr(C, align(16), isize)]
 pub enum AlignedExplicitRepr {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ eq .index[] | select(.name == "ReorderedAlignedExplicitRepr").attrs | ., ["#[repr(C, align(16), isize)]"]
 #[repr(isize, C, align(16))]
 pub enum ReorderedAlignedExplicitRepr {
     First,
 }
 
-//@ is "$.index[?(@.name=='Transparent')].attrs" '["#[repr(transparent)]"]'
+//@ eq .index[] | select(.name == "Transparent").attrs | ., ["#[repr(transparent)]"]
 #[repr(transparent)]
 pub struct Transparent(i64);

--- a/tests/rustdoc-json/attrs/repr_int_enum.rs
+++ b/tests/rustdoc-json/attrs/repr_int_enum.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='I8')].attrs" '["#[repr(i8)]"]'
+//@ eq .index[] | select(.name == "I8").attrs | ., ["#[repr(i8)]"]
 #[repr(i8)]
 pub enum I8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='I32')].attrs" '["#[repr(i32)]"]'
+//@ eq .index[] | select(.name == "I32").attrs | ., ["#[repr(i32)]"]
 #[repr(i32)]
 pub enum I32 {
     First,
 }
 
-//@ is "$.index[?(@.name=='Usize')].attrs" '["#[repr(usize)]"]'
+//@ eq .index[] | select(.name == "Usize").attrs | ., ["#[repr(usize)]"]
 #[repr(usize)]
 pub enum Usize {
     First,

--- a/tests/rustdoc-json/attrs/repr_packed.rs
+++ b/tests/rustdoc-json/attrs/repr_packed.rs
@@ -3,14 +3,14 @@
 // Note the normalization:
 // `#[repr(packed)]` in source becomes `#[repr(packed(1))]` in rustdoc JSON.
 //
-//@ is "$.index[?(@.name=='Packed')].attrs" '["#[repr(packed(1))]"]'
+//@ eq .index[] | select(.name == "Packed").attrs | ., ["#[repr(packed(1))]"]
 #[repr(packed)]
 pub struct Packed {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='PackedAligned')].attrs" '["#[repr(packed(4))]"]'
+//@ eq .index[] | select(.name == "PackedAligned").attrs | ., ["#[repr(packed(4))]"]
 #[repr(packed(4))]
 pub struct PackedAligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/target_feature.rs
+++ b/tests/rustdoc-json/attrs/target_feature.rs
@@ -1,40 +1,33 @@
 //@ only-x86_64
 
-//@ is "$.index[?(@.name=='test1')].attrs" '["#[target_feature(enable=\"avx\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ eq .index[] | select(.name == "test1") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\")]"], false]
 #[target_feature(enable = "avx")]
 pub fn test1() {}
 
-//@ is "$.index[?(@.name=='test2')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ eq .index[] | select(.name == "test2") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\", enable=\"avx2\")]"], false]
 #[target_feature(enable = "avx,avx2")]
 pub fn test2() {}
 
-//@ is "$.index[?(@.name=='test3')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ eq .index[] | select(.name == "test3") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\", enable=\"avx2\")]"], false]
 #[target_feature(enable = "avx", enable = "avx2")]
 pub fn test3() {}
 
-//@ is "$.index[?(@.name=='test4')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\", enable=\"avx512f\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ eq .index[] | select(.name == "test4") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\", enable=\"avx2\", enable=\"avx512f\")]"], false]
 #[target_feature(enable = "avx", enable = "avx2,avx512f")]
 pub fn test4() {}
 
-//@ is "$.index[?(@.name=='test_unsafe_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
-//@ is "$.index[?(@.name=='test_unsafe_fn')].inner.function.header.is_unsafe" true
+//@ eq .index[] | select(.name == "test_unsafe_fn") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\")]"], true]
 #[target_feature(enable = "avx")]
 pub unsafe fn test_unsafe_fn() {}
 
 pub struct Example;
 
 impl Example {
-    //@ is "$.index[?(@.name=='safe_assoc_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
-    //@ is "$.index[?(@.name=='safe_assoc_fn')].inner.function.header.is_unsafe" false
+    //@ eq .index[] | select(.name == "safe_assoc_fn") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\")]"], false]
     #[target_feature(enable = "avx")]
     pub fn safe_assoc_fn() {}
 
-    //@ is "$.index[?(@.name=='unsafe_assoc_fn')].attrs" '["#[target_feature(enable=\"avx\")]"]'
-    //@ is "$.index[?(@.name=='unsafe_assoc_fn')].inner.function.header.is_unsafe" true
+    //@ eq .index[] | select(.name == "unsafe_assoc_fn") | [.attrs, .inner.function.header?.is_unsafe], [["#[target_feature(enable=\"avx\")]"], true]
     #[target_feature(enable = "avx")]
     pub unsafe fn unsafe_assoc_fn() {}
 }

--- a/tests/rustdoc-json/enums/discriminant/basic.rs
+++ b/tests/rustdoc-json/enums/discriminant/basic.rs
@@ -1,12 +1,15 @@
 #[repr(i8)]
 pub enum Ordering {
-    //@ is "$.index[?(@.name=='Less')].inner.variant.discriminant.expr" '"-1"'
-    //@ is "$.index[?(@.name=='Less')].inner.variant.discriminant.value" '"-1"'
+    //@ arg less .index[] | select(.name == "Less").inner.variant.discriminant?
+    //@ jq $less.expr? == "-1"
+    //@ jq $less.value? == "-1"
     Less = -1,
-    //@ is "$.index[?(@.name=='Equal')].inner.variant.discriminant.expr" '"0"'
-    //@ is "$.index[?(@.name=='Equal')].inner.variant.discriminant.value" '"0"'
+    //@ arg equal .index[] | select(.name == "Equal").inner.variant.discriminant?
+    //@ jq $equal.expr? == "0"
+    //@ jq $equal.value? == "0"
     Equal = 0,
-    //@ is "$.index[?(@.name=='Greater')].inner.variant.discriminant.expr" '"1"'
-    //@ is "$.index[?(@.name=='Greater')].inner.variant.discriminant.value" '"1"'
+    //@ arg greater .index[] | select(.name == "Greater").inner.variant.discriminant?
+    //@ jq $greater.expr? == "1"
+    //@ jq $greater.value? == "1"
     Greater = 1,
 }

--- a/tests/rustdoc-json/enums/discriminant/expr.rs
+++ b/tests/rustdoc-json/enums/discriminant/expr.rs
@@ -1,30 +1,39 @@
 pub enum Foo {
-    //@ is "$.index[?(@.name=='Addition')].inner.variant.discriminant.value" '"0"'
-    //@ is "$.index[?(@.name=='Addition')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ arg addition .index[] | select(.name == "Addition").inner.variant.discriminant?
+    //@ jq $addition.value? == "0"
+    //@ jq $addition.expr? == "{ _ }"
     Addition = 0 + 0,
-    //@ is "$.index[?(@.name=='Bin')].inner.variant.discriminant.value" '"1"'
-    //@ is "$.index[?(@.name=='Bin')].inner.variant.discriminant.expr" '"0b1"'
+    //@ arg bin .index[] | select(.name == "Bin").inner.variant.discriminant?
+    //@ jq $bin.value? == "1"
+    //@ jq $bin.expr? == "0b1"
     Bin = 0b1,
-    //@ is "$.index[?(@.name=='Oct')].inner.variant.discriminant.value" '"2"'
-    //@ is "$.index[?(@.name=='Oct')].inner.variant.discriminant.expr" '"0o2"'
+    //@ arg oct .index[] | select(.name == "Oct").inner.variant.discriminant?
+    //@ jq $oct.value? == "2"
+    //@ jq $oct.expr? == "0o2"
     Oct = 0o2,
-    //@ is "$.index[?(@.name=='PubConst')].inner.variant.discriminant.value" '"3"'
-    //@ is "$.index[?(@.name=='PubConst')].inner.variant.discriminant.expr" '"THREE"'
+    //@ arg pub_const .index[] | select(.name == "PubConst").inner.variant.discriminant?
+    //@ jq $pub_const.value? == "3"
+    //@ jq $pub_const.expr? == "THREE"
     PubConst = THREE,
-    //@ is "$.index[?(@.name=='Hex')].inner.variant.discriminant.value" '"4"'
-    //@ is "$.index[?(@.name=='Hex')].inner.variant.discriminant.expr" '"0x4"'
+    //@ arg hex .index[] | select(.name == "Hex").inner.variant.discriminant?
+    //@ jq $hex.value? == "4"
+    //@ jq $hex.expr? == "0x4"
     Hex = 0x4,
-    //@ is "$.index[?(@.name=='Cast')].inner.variant.discriminant.value" '"5"'
-    //@ is "$.index[?(@.name=='Cast')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ arg cast .index[] | select(.name == "Cast").inner.variant.discriminant?
+    //@ jq $cast.value? == "5"
+    //@ jq $cast.expr? == "{ _ }"
     Cast = 5 as isize,
-    //@ is "$.index[?(@.name=='PubCall')].inner.variant.discriminant.value" '"6"'
-    //@ is "$.index[?(@.name=='PubCall')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ arg pub_call .index[] | select(.name == "PubCall").inner.variant.discriminant?
+    //@ jq $pub_call.value? == "6"
+    //@ jq $pub_call.expr? == "{ _ }"
     PubCall = six(),
-    //@ is "$.index[?(@.name=='PrivCall')].inner.variant.discriminant.value" '"7"'
-    //@ is "$.index[?(@.name=='PrivCall')].inner.variant.discriminant.expr" '"{ _ }"'
+    //@ arg priv_call .index[] | select(.name == "PrivCall").inner.variant.discriminant?
+    //@ jq $priv_call.value? == "7"
+    //@ jq $priv_call.expr? == "{ _ }"
     PrivCall = seven(),
-    //@ is "$.index[?(@.name=='PrivConst')].inner.variant.discriminant.value" '"8"'
-    //@ is "$.index[?(@.name=='PrivConst')].inner.variant.discriminant.expr" '"EIGHT"'
+    //@ arg priv_const .index[] | select(.name == "PrivConst").inner.variant.discriminant?
+    //@ jq $priv_const.value? == "8"
+    //@ jq $priv_const.expr? == "EIGHT"
     PrivConst = EIGHT,
 }
 

--- a/tests/rustdoc-json/enums/discriminant/limits.rs
+++ b/tests/rustdoc-json/enums/discriminant/limits.rs
@@ -1,39 +1,47 @@
 #[repr(u64)]
 pub enum U64 {
-    //@ is "$.index[?(@.name=='U64Min')].inner.variant.discriminant.value" '"0"'
-    //@ is "$.index[?(@.name=='U64Min')].inner.variant.discriminant.expr" '"u64::MIN"'
+    //@ arg u64min .index[] | select(.name == "U64Min").inner.variant.discriminant?
+    //@ jq $u64min.value? == "0"
+    //@ jq $u64min.expr? == "u64::MIN"
     U64Min = u64::MIN,
-    //@ is "$.index[?(@.name=='U64Max')].inner.variant.discriminant.value" '"18446744073709551615"'
-    //@ is "$.index[?(@.name=='U64Max')].inner.variant.discriminant.expr" '"u64::MAX"'
+    //@ arg u64max .index[] | select(.name == "U64Max").inner.variant.discriminant?
+    //@ jq $u64max.value? == "18446744073709551615"
+    //@ jq $u64max.expr? == "u64::MAX"
     U64Max = u64::MAX,
 }
 
 #[repr(i64)]
 pub enum I64 {
-    //@ is "$.index[?(@.name=='I64Min')].inner.variant.discriminant.value" '"-9223372036854775808"'
-    //@ is "$.index[?(@.name=='I64Min')].inner.variant.discriminant.expr" '"i64::MIN"'
+    //@ arg i64min .index[] | select(.name == "I64Min").inner.variant.discriminant?
+    //@ jq $i64min.value? == "-9223372036854775808"
+    //@ jq $i64min.expr? == "i64::MIN"
     I64Min = i64::MIN,
-    //@ is "$.index[?(@.name=='I64Max')].inner.variant.discriminant.value" '"9223372036854775807"'
-    //@ is "$.index[?(@.name=='I64Max')].inner.variant.discriminant.expr" '"i64::MAX"'
+    //@ arg i64max .index[] | select(.name == "I64Max").inner.variant.discriminant?
+    //@ jq $i64max.value? == "9223372036854775807"
+    //@ jq $i64max.expr? == "i64::MAX"
     I64Max = i64::MAX,
 }
 
 #[repr(u128)]
 pub enum U128 {
-    //@ is "$.index[?(@.name=='U128Min')].inner.variant.discriminant.value" '"0"'
-    //@ is "$.index[?(@.name=='U128Min')].inner.variant.discriminant.expr" '"u128::MIN"'
+    //@ arg u128min .index[] | select(.name == "U128Min").inner.variant.discriminant?
+    //@ jq $u128min.value? == "0"
+    //@ jq $u128min.expr? == "u128::MIN"
     U128Min = u128::MIN,
-    //@ is "$.index[?(@.name=='U128Max')].inner.variant.discriminant.value" '"340282366920938463463374607431768211455"'
-    //@ is "$.index[?(@.name=='U128Max')].inner.variant.discriminant.expr" '"u128::MAX"'
+    //@ arg u128max .index[] | select(.name == "U128Max").inner.variant.discriminant?
+    //@ jq $u128max.value? == "340282366920938463463374607431768211455"
+    //@ jq $u128max.expr? == "u128::MAX"
     U128Max = u128::MAX,
 }
 
 #[repr(i128)]
 pub enum I128 {
-    //@ is "$.index[?(@.name=='I128Min')].inner.variant.discriminant.value" '"-170141183460469231731687303715884105728"'
-    //@ is "$.index[?(@.name=='I128Min')].inner.variant.discriminant.expr" '"i128::MIN"'
+    //@ arg i128min .index[] | select(.name == "I128Min").inner.variant.discriminant?
+    //@ jq $i128min.value? == "-170141183460469231731687303715884105728"
+    //@ jq $i128min.expr? == "i128::MIN"
     I128Min = i128::MIN,
-    //@ is "$.index[?(@.name=='I128Max')].inner.variant.discriminant.value" '"170141183460469231731687303715884105727"'
-    //@ is "$.index[?(@.name=='I128Max')].inner.variant.discriminant.expr" '"i128::MAX"'
+    //@ arg i128max .index[] | select(.name == "I128Max").inner.variant.discriminant?
+    //@ jq $i128max.value? == "170141183460469231731687303715884105727"
+    //@ jq $i128max.expr? == "i128::MAX"
     I128Max = i128::MAX,
 }

--- a/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
+++ b/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
@@ -1,15 +1,19 @@
 #[repr(u32)]
 pub enum Foo {
-    //@ is "$.index[?(@.name=='Basic')].inner.variant.discriminant.value" '"0"'
-    //@ is "$.index[?(@.name=='Basic')].inner.variant.discriminant.expr" '"0"'
+    //@ arg basic .index[] | select(.name == "Basic").inner.variant.discriminant?
+    //@ jq $basic.value? == "0"
+    //@ jq $basic.expr? == "0"
     Basic = 0,
-    //@ is "$.index[?(@.name=='Suffix')].inner.variant.discriminant.value" '"10"'
-    //@ is "$.index[?(@.name=='Suffix')].inner.variant.discriminant.expr" '"10u32"'
+    //@ arg suffix .index[] | select(.name == "Suffix").inner.variant.discriminant?
+    //@ jq $suffix.value? == "10"
+    //@ jq $suffix.expr? == "10u32"
     Suffix = 10u32,
-    //@ is "$.index[?(@.name=='Underscore')].inner.variant.discriminant.value" '"100"'
-    //@ is "$.index[?(@.name=='Underscore')].inner.variant.discriminant.expr" '"1_0_0"'
+    //@ arg underscore .index[] | select(.name == "Underscore").inner.variant.discriminant?
+    //@ jq $underscore.value? == "100"
+    //@ jq $underscore.expr? == "1_0_0"
     Underscore = 1_0_0,
-    //@ is "$.index[?(@.name=='SuffixUnderscore')].inner.variant.discriminant.value" '"1000"'
-    //@ is "$.index[?(@.name=='SuffixUnderscore')].inner.variant.discriminant.expr" '"1_0_0_0u32"'
+    //@ arg suffix_underscore .index[] | select(.name == "SuffixUnderscore").inner.variant.discriminant?
+    //@ jq $suffix_underscore.value? == "1000"
+    //@ jq $suffix_underscore.expr? == "1_0_0_0u32"
     SuffixUnderscore = 1_0_0_0u32,
 }

--- a/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
+++ b/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
@@ -1,10 +1,10 @@
 pub enum Foo {
-    //@ is "$.index[?(@.name=='Has')].inner.variant.discriminant" '{"expr":"0", "value":"0"}'
+    //@ jq .index[] | select(.name == "Has").inner.variant.discriminant? == {"expr":"0", "value":"0"}
     Has = 0,
-    //@ is "$.index[?(@.name=='Doesnt')].inner.variant.discriminant" null
+    //@ jq .index[] | select(.name == "Doesnt").inner.variant.discriminant? == null
     Doesnt,
-    //@ is "$.index[?(@.name=='AlsoDoesnt')].inner.variant.discriminant" null
+    //@ jq .index[] | select(.name == "AlsoDoesnt").inner.variant.discriminant? == null
     AlsoDoesnt,
-    //@ is "$.index[?(@.name=='AlsoHas')].inner.variant.discriminant" '{"expr":"44", "value":"44"}'
+    //@ jq .index[] | select(.name == "AlsoHas").inner.variant.discriminant? == {"expr":"44", "value":"44"}
     AlsoHas = 44,
 }

--- a/tests/rustdoc-json/enums/discriminant/struct.rs
+++ b/tests/rustdoc-json/enums/discriminant/struct.rs
@@ -1,13 +1,16 @@
 #[repr(i32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(i32)]"]'
+//@ jq .index[] | select(.name == "Foo").attrs == ["#[repr(i32)]"]
 pub enum Foo {
-    //@ is    "$.index[?(@.name=='Struct')].inner.variant.discriminant" null
-    //@ count "$.index[?(@.name=='Struct')].inner.variant.kind.struct.fields[*]" 0
+    //@ arg struct .index[] | select(.name == "Struct").inner.variant
+    //@ jq $struct.discriminant? == null
+    //@ jq $struct.kind?.struct.fields? | length == 0
     Struct {},
-    //@ is    "$.index[?(@.name=='StructWithDiscr')].inner.variant.discriminant" '{"expr": "42", "value": "42"}'
-    //@ count "$.index[?(@.name=='StructWithDiscr')].inner.variant.kind.struct.fields[*]" 1
+    //@ arg struct_with_discr .index[] | select(.name == "StructWithDiscr").inner.variant
+    //@ jq $struct_with_discr.discriminant? == {"expr": "42", "value": "42"}
+    //@ jq $struct_with_discr.kind?.struct.fields? | length == 1
     StructWithDiscr { x: i32 } = 42,
-    //@ is    "$.index[?(@.name=='StructWithHexDiscr')].inner.variant.discriminant"  '{"expr": "0x42", "value": "66"}'
-    //@ count "$.index[?(@.name=='StructWithHexDiscr')].inner.variant.kind.struct.fields[*]" 2
+    //@ arg struct_with_hex_discr .index[] | select(.name == "StructWithHexDiscr").inner.variant
+    //@ jq $struct_with_hex_discr.discriminant? == {"expr": "0x42", "value": "66"}
+    //@ jq $struct_with_hex_discr.kind?.struct.fields? | length == 2
     StructWithHexDiscr { x: i32, y: bool } = 0x42,
 }

--- a/tests/rustdoc-json/enums/discriminant/tuple.rs
+++ b/tests/rustdoc-json/enums/discriminant/tuple.rs
@@ -1,13 +1,16 @@
 #[repr(u32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(u32)]"]'
+//@ jq .index[] | select(.name == "Foo").attrs == ["#[repr(u32)]"]
 pub enum Foo {
-    //@ is    "$.index[?(@.name=='Tuple')].inner.variant.discriminant" null
-    //@ count "$.index[?(@.name=='Tuple')].inner.variant.kind.tuple[*]" 0
+    //@ arg tuple .index[] | select(.name == "Tuple").inner.variant
+    //@ jq $tuple.discriminant? == null
+    //@ jq $tuple.kind?.tuple | length == 0
     Tuple(),
-    //@ is    "$.index[?(@.name=='TupleWithDiscr')].inner.variant.discriminant" '{"expr": "1", "value": "1"}'
-    //@ count "$.index[?(@.name=='TupleWithDiscr')].inner.variant.kind.tuple[*]" 1
+    //@ arg tuple_with_discr .index[] | select(.name == "TupleWithDiscr").inner.variant
+    //@ jq $tuple_with_discr.discriminant? == {"expr": "1", "value": "1"}
+    //@ jq $tuple_with_discr.kind?.tuple | length == 1
     TupleWithDiscr(i32) = 1,
-    //@ is    "$.index[?(@.name=='TupleWithBinDiscr')].inner.variant.discriminant" '{"expr": "0b10", "value": "2"}'
-    //@ count "$.index[?(@.name=='TupleWithBinDiscr')].inner.variant.kind.tuple[*]" 2
+    //@ arg tuple_with_bin_discr .index[] | select(.name == "TupleWithBinDiscr").inner.variant
+    //@ jq $tuple_with_bin_discr.discriminant? == {"expr": "0b10", "value": "2"}
+    //@ jq $tuple_with_bin_discr.kind?.tuple | length == 2
     TupleWithBinDiscr(i32, i32) = 0b10,
 }

--- a/tests/rustdoc-json/enums/doc_link_to_foreign_variant.rs
+++ b/tests/rustdoc-json/enums/doc_link_to_foreign_variant.rs
@@ -5,7 +5,5 @@
 extern crate color;
 use color::Color::Red;
 
-//@ set red = "$.index[?(@.inner.module.is_crate)].links.Red"
-
-//@ !has "$.index[?(@.name == 'Red')]"
-//@ !has "$.index[?(@.name == 'Color')]"
+//@ jq .index["\(.root)"].links.Red
+//@ jq [.index[] | select(.name == "Red" or .name == "Color")] == []

--- a/tests/rustdoc-json/enums/field_hidden.rs
+++ b/tests/rustdoc-json/enums/field_hidden.rs
@@ -1,9 +1,10 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/100529>.
 
-//@ has "$.index[?(@.name=='ParseError')]"
-//@ has "$.index[?(@.name=='UnexpectedEndTag')]"
-//@ is "$.index[?(@.name=='UnexpectedEndTag')].inner.variant.kind.tuple" [null]
-//@ is "$.index[?(@.name=='UnexpectedEndTag')].inner.variant.discriminant" null
+//@ jq .index[] | select(.name == "ParseError")
+//@ arg unexpected_end_tag .index[] | select(.name == "UnexpectedEndTag")
+//@ jq $unexpected_end_tag
+//@ jq $unexpected_end_tag.inner.variant.kind?.tuple == [null]
+//@ jq $unexpected_end_tag.inner.variant.discriminant? == null
 
 pub enum ParseError {
     UnexpectedEndTag(#[doc(hidden)] u32),

--- a/tests/rustdoc-json/enums/field_order.rs
+++ b/tests/rustdoc-json/enums/field_order.rs
@@ -17,24 +17,14 @@ pub enum Whatever {
     },
 }
 
-//@ set 0 = '$.index[?(@.name == "ews_0")].id'
-//@ set 1 = '$.index[?(@.name == "dik_1")].id'
-//@ set 2 = '$.index[?(@.name == "hsk_2")].id'
-//@ set 3 = '$.index[?(@.name == "djt_3")].id'
-//@ set 4 = '$.index[?(@.name == "jnr_4")].id'
-//@ set 5 = '$.index[?(@.name == "dfs_5")].id'
-//@ set 6 = '$.index[?(@.name == "bja_6")].id'
-//@ set 7 = '$.index[?(@.name == "lyc_7")].id'
-//@ set 8 = '$.index[?(@.name == "yqd_8")].id'
-//@ set 9 = '$.index[?(@.name == "vll_9")].id'
-
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[0]' $0
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[1]' $1
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[2]' $2
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[3]' $3
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[4]' $4
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[5]' $5
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[6]' $6
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[7]' $7
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[8]' $8
-//@ is '$.index[?(@.name == "Foo")].inner.variant.kind.struct.fields[9]' $9
+//@ arg foo .index[] | select(.name == "Foo").inner.variant.kind?.struct.fields?
+//@ jq .index[] | select(.name == "ews_0").id == $foo[0]
+//@ jq .index[] | select(.name == "dik_1").id == $foo[1]
+//@ jq .index[] | select(.name == "hsk_2").id == $foo[2]
+//@ jq .index[] | select(.name == "djt_3").id == $foo[3]
+//@ jq .index[] | select(.name == "jnr_4").id == $foo[4]
+//@ jq .index[] | select(.name == "dfs_5").id == $foo[5]
+//@ jq .index[] | select(.name == "bja_6").id == $foo[6]
+//@ jq .index[] | select(.name == "lyc_7").id == $foo[7]
+//@ jq .index[] | select(.name == "yqd_8").id == $foo[8]
+//@ jq .index[] | select(.name == "vll_9").id == $foo[9]

--- a/tests/rustdoc-json/enums/kind.rs
+++ b/tests/rustdoc-json/enums/kind.rs
@@ -1,27 +1,26 @@
+//@ arg foo .index[] | select(.name == "Foo").inner.enum.variants?
+//@ jq $foo | length == 5
+
 pub enum Foo {
-    //@ set Unit = "$.index[?(@.name=='Unit')].id"
-    //@ is "$.index[?(@.name=='Unit')].inner.variant.kind" '"plain"'
+    //@ arg unit .index[] | select(.name == "Unit")
+    //@ jq $unit.id == $foo[0]
+    //@ jq $unit.inner.variant.kind? == "plain"
     Unit,
-    //@ set Named = "$.index[?(@.name=='Named')].id"
-    //@ is "$.index[?(@.name=='Named')].inner.variant.kind.struct" '{"fields": [], "has_stripped_fields": false}'
+    //@ arg named .index[] | select(.name == "Named")
+    //@ jq $named.id == $foo[1]
+    //@ jq $named.inner.variant.kind?.struct == {"fields": [], "has_stripped_fields": false}
     Named {},
-    //@ set Tuple = "$.index[?(@.name=='Tuple')].id"
-    //@ is "$.index[?(@.name=='Tuple')].inner.variant.kind.tuple" []
+    //@ arg tuple .index[] | select(.name == "Tuple")
+    //@ jq $tuple.id == $foo[2]
+    //@ jq $tuple.inner.variant.kind?.tuple == []
     Tuple(),
-    //@ set NamedField = "$.index[?(@.name=='NamedField')].id"
-    //@ set x = "$.index[?(@.name=='x' && @.inner.struct_field)].id"
-    //@ is "$.index[?(@.name=='NamedField')].inner.variant.kind.struct.fields[*]" $x
-    //@ is "$.index[?(@.name=='NamedField')].inner.variant.kind.struct.has_stripped_fields" false
+    //@ arg named_field .index[] | select(.name == "NamedField")
+    //@ jq $named_field.id == $foo[3]
+    //@ jq $named_field.inner.variant.kind?.struct.fields[]? == (.index[] | select(.name == "x" and .inner.struct_field).id)
+    //@ jq $named_field.inner.variant.kind?.struct.has_stripped_fields? == false
     NamedField { x: i32 },
-    //@ set TupleField = "$.index[?(@.name=='TupleField')].id"
-    //@ set tup_field = "$.index[?(@.name=='0' && @.inner.struct_field)].id"
-    //@ is "$.index[?(@.name=='TupleField')].inner.variant.kind.tuple[*]" $tup_field
+    //@ arg tuple_field .index[] | select(.name == "TupleField")
+    //@ jq $tuple_field.id == $foo[4]
+    //@ jq $tuple_field.inner.variant.kind?.tuple[]? == (.index[] | select(.name == "0" and .inner.struct_field).id)
     TupleField(i32),
 }
-
-//@ is    "$.index[?(@.name=='Foo')].inner.enum.variants[0]" $Unit
-//@ is    "$.index[?(@.name=='Foo')].inner.enum.variants[1]" $Named
-//@ is    "$.index[?(@.name=='Foo')].inner.enum.variants[2]" $Tuple
-//@ is    "$.index[?(@.name=='Foo')].inner.enum.variants[3]" $NamedField
-//@ is    "$.index[?(@.name=='Foo')].inner.enum.variants[4]" $TupleField
-//@ count "$.index[?(@.name=='Foo')].inner.enum.variants[*]" 5

--- a/tests/rustdoc-json/enums/struct_field_hidden.rs
+++ b/tests/rustdoc-json/enums/struct_field_hidden.rs
@@ -2,15 +2,12 @@ pub enum Foo {
     Variant {
         #[doc(hidden)]
         a: i32,
-        //@ set b = "$.index[?(@.name=='b')].id"
         b: i32,
         #[doc(hidden)]
         x: i32,
-        //@ set y = "$.index[?(@.name=='y')].id"
         y: i32,
     },
-    //@ is "$.index[?(@.name=='Variant')].inner.variant.kind.struct.has_stripped_fields" true
-    //@ is "$.index[?(@.name=='Variant')].inner.variant.kind.struct.fields[0]" $b
-    //@ is "$.index[?(@.name=='Variant')].inner.variant.kind.struct.fields[1]" $y
-    //@ count "$.index[?(@.name=='Variant')].inner.variant.kind.struct.fields[*]" 2
+    //@ arg variant .index[] | select(.name == "Variant").inner.variant.kind?.struct
+    //@ jq $variant.has_stripped_fields? == true
+    //@ jq [$variant.fields[]?] == [.index[] | select(.name == "b" or .name == "y").id]
 }

--- a/tests/rustdoc-json/enums/tuple_fields_hidden.rs
+++ b/tests/rustdoc-json/enums/tuple_fields_hidden.rs
@@ -1,80 +1,51 @@
-//@ set 1.1.0 = "$.index[?(@.docs=='1.1.0')].id"
-//@ set 2.1.0 = "$.index[?(@.docs=='2.1.0')].id"
-//@ set 2.1.1 = "$.index[?(@.docs=='2.1.1')].id"
-//@ set 2.2.1 = "$.index[?(@.docs=='2.2.1')].id"
-//@ set 2.3.0 = "$.index[?(@.docs=='2.3.0')].id"
-//@ set 3.1.1 = "$.index[?(@.docs=='3.1.1')].id"
-//@ set 3.1.2 = "$.index[?(@.docs=='3.1.2')].id"
-//@ set 3.2.0 = "$.index[?(@.docs=='3.2.0')].id"
-//@ set 3.2.2 = "$.index[?(@.docs=='3.2.2')].id"
-//@ set 3.3.0 = "$.index[?(@.docs=='3.3.0')].id"
-//@ set 3.3.1 = "$.index[?(@.docs=='3.3.1')].id"
+//@ arg _1_1_0 .index[] | select(.docs == "1.1.0")
+//@ arg _2_1_0 .index[] | select(.docs == "2.1.0")
+//@ arg _2_1_1 .index[] | select(.docs == "2.1.1")
+//@ arg _2_2_1 .index[] | select(.docs == "2.2.1")
+//@ arg _2_3_0 .index[] | select(.docs == "2.3.0")
+//@ arg _3_1_1 .index[] | select(.docs == "3.1.1")
+//@ arg _3_1_2 .index[] | select(.docs == "3.1.2")
+//@ arg _3_2_0 .index[] | select(.docs == "3.2.0")
+//@ arg _3_2_2 .index[] | select(.docs == "3.2.2")
+//@ arg _3_3_0 .index[] | select(.docs == "3.3.0")
+//@ arg _3_3_1 .index[] | select(.docs == "3.3.1")
 
 pub enum EnumWithStrippedTupleVariants {
-    //@ count "$.index[?(@.name=='None')].inner.variant.kind.tuple[*]" 0
+    //@ jq .index[] | select(.name == "None").inner.variant.kind?.tuple | length == 0
     None(),
 
-    //@ count "$.index[?(@.name=='One')].inner.variant.kind.tuple[*]" 1
-    //@ is    "$.index[?(@.name=='One')].inner.variant.kind.tuple[0]" $1.1.0
+    //@ jq .index[] | select(.name == "One").inner.variant.kind?.tuple == [$_1_1_0.id]
     One(/** 1.1.0*/ bool),
-    //@ count "$.index[?(@.name=='OneHidden')].inner.variant.kind.tuple[*]" 1
-    //@ is    "$.index[?(@.name=='OneHidden')].inner.variant.kind.tuple[0]" null
+    //@ jq .index[] | select(.name == "OneHidden").inner.variant.kind?.tuple == [null]
     OneHidden(#[doc(hidden)] bool),
 
-    //@ count "$.index[?(@.name=='Two')].inner.variant.kind.tuple[*]" 2
-    //@ is    "$.index[?(@.name=='Two')].inner.variant.kind.tuple[0]" $2.1.0
-    //@ is    "$.index[?(@.name=='Two')].inner.variant.kind.tuple[1]" $2.1.1
+    //@ jq .index[] | select(.name == "Two").inner.variant.kind?.tuple == [$_2_1_0.id, $_2_1_1.id]
     Two(/** 2.1.0*/ bool, /** 2.1.1*/ bool),
-    //@ count "$.index[?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[*]" 2
-    //@ is    "$.index[?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[0]" null
-    //@ is    "$.index[?(@.name=='TwoLeftHidden')].inner.variant.kind.tuple[1]" $2.2.1
+    //@ jq .index[] | select(.name == "TwoLeftHidden").inner.variant.kind?.tuple == [null, $_2_2_1.id]
     TwoLeftHidden(#[doc(hidden)] bool, /** 2.2.1*/ bool),
-    //@ count "$.index[?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[*]" 2
-    //@ is    "$.index[?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[0]" $2.3.0
-    //@ is    "$.index[?(@.name=='TwoRightHidden')].inner.variant.kind.tuple[1]" null
+    //@ jq .index[] | select(.name == "TwoRightHidden").inner.variant.kind?.tuple == [$_2_3_0.id, null]
     TwoRightHidden(/** 2.3.0*/ bool, #[doc(hidden)] bool),
-    //@ count "$.index[?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[*]" 2
-    //@ is    "$.index[?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[0]" null
-    //@ is    "$.index[?(@.name=='TwoBothHidden')].inner.variant.kind.tuple[1]" null
+    //@ jq .index[] | select(.name == "TwoBothHidden").inner.variant.kind?.tuple == [null, null]
     TwoBothHidden(#[doc(hidden)] bool, #[doc(hidden)] bool),
 
-    //@ count "$.index[?(@.name=='Three1')].inner.variant.kind.tuple[*]" 3
-    //@ is    "$.index[?(@.name=='Three1')].inner.variant.kind.tuple[0]" null
-    //@ is    "$.index[?(@.name=='Three1')].inner.variant.kind.tuple[1]" $3.1.1
-    //@ is    "$.index[?(@.name=='Three1')].inner.variant.kind.tuple[2]" $3.1.2
+    //@ jq .index[] | select(.name == "Three1").inner.variant.kind?.tuple == [null, $_3_1_1.id, $_3_1_2.id]
     Three1(#[doc(hidden)] bool, /** 3.1.1*/ bool, /** 3.1.2*/ bool),
-    //@ count "$.index[?(@.name=='Three2')].inner.variant.kind.tuple[*]" 3
-    //@ is    "$.index[?(@.name=='Three2')].inner.variant.kind.tuple[0]" $3.2.0
-    //@ is    "$.index[?(@.name=='Three2')].inner.variant.kind.tuple[1]" null
-    //@ is    "$.index[?(@.name=='Three2')].inner.variant.kind.tuple[2]" $3.2.2
+    //@ jq .index[] | select(.name == "Three2").inner.variant.kind?.tuple == [$_3_2_0.id, null, $_3_2_2.id]
     Three2(/** 3.2.0*/ bool, #[doc(hidden)] bool, /** 3.2.2*/ bool),
-    //@ count "$.index[?(@.name=='Three3')].inner.variant.kind.tuple[*]" 3
-    //@ is    "$.index[?(@.name=='Three3')].inner.variant.kind.tuple[0]" $3.3.0
-    //@ is    "$.index[?(@.name=='Three3')].inner.variant.kind.tuple[1]" $3.3.1
-    //@ is    "$.index[?(@.name=='Three3')].inner.variant.kind.tuple[2]" null
+    //@ jq .index[] | select(.name == "Three3").inner.variant.kind?.tuple == [$_3_3_0.id, $_3_3_1.id, null]
     Three3(/** 3.3.0*/ bool, /** 3.3.1*/ bool, #[doc(hidden)] bool),
 }
 
-//@ is "$.index[?(@.docs=='1.1.0')].name" '"0"'
-//@ is "$.index[?(@.docs=='2.1.0')].name" '"0"'
-//@ is "$.index[?(@.docs=='2.1.1')].name" '"1"'
-//@ is "$.index[?(@.docs=='2.2.1')].name" '"1"'
-//@ is "$.index[?(@.docs=='2.3.0')].name" '"0"'
-//@ is "$.index[?(@.docs=='3.1.1')].name" '"1"'
-//@ is "$.index[?(@.docs=='3.1.2')].name" '"2"'
-//@ is "$.index[?(@.docs=='3.2.0')].name" '"0"'
-//@ is "$.index[?(@.docs=='3.2.2')].name" '"2"'
-//@ is "$.index[?(@.docs=='3.3.0')].name" '"0"'
-//@ is "$.index[?(@.docs=='3.3.1')].name" '"1"'
+//@ jq $_1_1_0.name == "0"
+//@ jq $_2_1_0.name == "0"
+//@ jq $_2_1_1.name == "1"
+//@ jq $_2_2_1.name == "1"
+//@ jq $_2_3_0.name == "0"
+//@ jq $_3_1_1.name == "1"
+//@ jq $_3_1_2.name == "2"
+//@ jq $_3_2_0.name == "0"
+//@ jq $_3_2_2.name == "2"
+//@ jq $_3_3_0.name == "0"
+//@ jq $_3_3_1.name == "1"
 
-//@ is "$.index[?(@.docs=='1.1.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.1.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.1.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.2.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='2.3.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.1.1')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.1.2')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.2.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.2.2')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.3.0')].inner.struct_field" '{"primitive": "bool"}'
-//@ is "$.index[?(@.docs=='3.3.1')].inner.struct_field" '{"primitive": "bool"}'
+//@ jq [[$_1_1_0, $_2_1_0, $_2_1_1, $_2_2_1, $_2_3_0, $_3_1_1, $_3_1_2, $_3_2_0, $_3_2_2, $_3_3_0, $_3_3_1][].inner.struct_field.primitive? == "bool"] | all

--- a/tests/rustdoc-json/enums/use_glob.rs
+++ b/tests/rustdoc-json/enums/use_glob.rs
@@ -1,15 +1,15 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104942>
 
-//@ set Color = "$.index[?(@.name == 'Color')].id"
+//@ arg color .index[] | select(.name == "Color").id
 pub enum Color {
     Red,
     Green,
     Blue,
 }
 
-//@ set use_Color = "$.index[?(@.inner.use)].id"
-//@ is "$.index[?(@.inner.use)].inner.use.id" $Color
-//@ is "$.index[?(@.inner.use)].inner.use.is_glob" true
+//@ arg use_color .index[] | select(.inner.use)
+//@ jq $use_color.inner.use.id? == $color
+//@ jq $use_color.inner.use.is_glob? == true
 pub use Color::*;
 
-//@ ismany "$.index[?(@.name == 'use_glob')].inner.module.items[*]" $Color $use_Color
+//@ jq .index["\(.root)"].inner.module.items? == [$color, $use_color.id]

--- a/tests/rustdoc-json/enums/use_variant.rs
+++ b/tests/rustdoc-json/enums/use_variant.rs
@@ -1,12 +1,12 @@
-//@ set AlwaysNone = "$.index[?(@.name == 'AlwaysNone')].id"
+//@ arg always_none .index[] | select(.name == "AlwaysNone")
 pub enum AlwaysNone {
-    //@ set None = "$.index[?(@.name == 'None')].id"
+    //@ arg none .index[] | select(.name == "None").id
     None,
 }
-//@ is "$.index[?(@.name == 'AlwaysNone')].inner.enum.variants[*]" $None
+//@ jq $always_none.inner.enum.variants? == [$none]
 
-//@ set use_None = "$.index[?(@.inner.use)].id"
-//@ is "$.index[?(@.inner.use)].inner.use.id" $None
+//@ arg use_none .index[] | select(.inner.use)
+//@ jq $use_none.inner.use.id? == $none
 pub use AlwaysNone::None;
 
-//@ ismany "$.index[?(@.name == 'use_variant')].inner.module.items[*]" $AlwaysNone $use_None
+//@ jq .index["\(.root)"].inner.module.items? == [$always_none.id, $use_none.id]

--- a/tests/rustdoc-json/enums/use_variant_foreign.rs
+++ b/tests/rustdoc-json/enums/use_variant_foreign.rs
@@ -2,8 +2,7 @@
 
 extern crate color;
 
-//@ has "$.index[?(@.inner.use.name == 'Red')]"
+//@ jq .index[] | select(.inner.use.name? == "Red")
 pub use color::Color::Red;
 
-//@ !has "$.index[?(@.name == 'Red')]"
-//@ !has "$.index[?(@.name == 'Color')]"
+//@ jq [.index[] | select(.name == "Red" or .name == "Color")] == []

--- a/tests/rustdoc-json/enums/variant_order.rs
+++ b/tests/rustdoc-json/enums/variant_order.rs
@@ -15,24 +15,14 @@ pub enum Foo {
     Vll9,
 }
 
-//@ set 0 = '$.index[?(@.name == "Ews0")].id'
-//@ set 1 = '$.index[?(@.name == "Dik1")].id'
-//@ set 2 = '$.index[?(@.name == "Hsk2")].id'
-//@ set 3 = '$.index[?(@.name == "Djt3")].id'
-//@ set 4 = '$.index[?(@.name == "Jnr4")].id'
-//@ set 5 = '$.index[?(@.name == "Dfs5")].id'
-//@ set 6 = '$.index[?(@.name == "Bja6")].id'
-//@ set 7 = '$.index[?(@.name == "Lyc7")].id'
-//@ set 8 = '$.index[?(@.name == "Yqd8")].id'
-//@ set 9 = '$.index[?(@.name == "Vll9")].id'
-
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[0]' $0
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[1]' $1
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[2]' $2
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[3]' $3
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[4]' $4
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[5]' $5
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[6]' $6
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[7]' $7
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[8]' $8
-//@ is '$.index[?(@.name == "Foo")].inner.enum.variants[9]' $9
+//@ arg foo .index[] | select(.name == "Foo").inner.enum.variants?
+//@ jq .index[] | select(.name == "Ews0").id == $foo[0]
+//@ jq .index[] | select(.name == "Dik1").id == $foo[1]
+//@ jq .index[] | select(.name == "Hsk2").id == $foo[2]
+//@ jq .index[] | select(.name == "Djt3").id == $foo[3]
+//@ jq .index[] | select(.name == "Jnr4").id == $foo[4]
+//@ jq .index[] | select(.name == "Dfs5").id == $foo[5]
+//@ jq .index[] | select(.name == "Bja6").id == $foo[6]
+//@ jq .index[] | select(.name == "Lyc7").id == $foo[7]
+//@ jq .index[] | select(.name == "Yqd8").id == $foo[8]
+//@ jq .index[] | select(.name == "Vll9").id == $foo[9]

--- a/tests/rustdoc-json/enums/variant_struct.rs
+++ b/tests/rustdoc-json/enums/variant_struct.rs
@@ -1,10 +1,10 @@
-//@ is "$.index[?(@.name=='EnumStruct')].visibility" \"public\"
-//@ has "$.index[?(@.name=='EnumStruct')].inner.enum"
+//@ arg enum_struct .index[] | select(.name == "EnumStruct")
+//@ jq $enum_struct.visibility == "public"
+//@ jq $enum_struct.inner.enum
 pub enum EnumStruct {
-    //@ has "$.index[?(@.name=='x')].inner.struct_field"
-    //@ set x = "$.index[?(@.name=='x')].id"
-    //@ has "$.index[?(@.name=='y')].inner.struct_field"
-    //@ set y = "$.index[?(@.name=='y')].id"
-    //@ ismany "$.index[?(@.name=='VariantS')].inner.variant.kind.struct.fields[*]" $x $y
+    //@ arg x .index[] | select(.name == "x")
+    //@ arg y .index[] | select(.name == "y")
+    //@ jq [[$x, $y][].inner.struct_field] | all
+    //@ jq .index[] | select(.name == "VariantS").inner.variant.kind?.struct.fields? == [$x.id, $y.id]
     VariantS { x: u32, y: String },
 }

--- a/tests/rustdoc-json/enums/variant_tuple_struct.rs
+++ b/tests/rustdoc-json/enums/variant_tuple_struct.rs
@@ -1,10 +1,10 @@
-//@ is "$.index[?(@.name=='EnumTupleStruct')].visibility" \"public\"
-//@ has "$.index[?(@.name=='EnumTupleStruct')].inner.enum"
+//@ arg enum_tuple_struct .index[] | select(.name == "EnumTupleStruct")
+//@ jq $enum_tuple_struct.visibility == "public"
+//@ jq $enum_tuple_struct.inner.enum
 pub enum EnumTupleStruct {
-    //@ has "$.index[?(@.name=='0')].inner.struct_field"
-    //@ set f0 = "$.index[?(@.name=='0')].id"
-    //@ has "$.index[?(@.name=='1')].inner.struct_field"
-    //@ set f1 = "$.index[?(@.name=='1')].id"
-    //@ ismany "$.index[?(@.name=='VariantA')].inner.variant.kind.tuple[*]" $f0 $f1
+    //@ arg f0 .index[] | select(.name == "0")
+    //@ arg f1 .index[] | select(.name == "1")
+    //@ jq [[$f0, $f1][].inner.struct_field] | all
+    //@ jq .index[] | select(.name == "VariantA").inner.variant.kind?.tuple == [$f0.id, $f1.id]
     VariantA(u32, String),
 }

--- a/tests/rustdoc-json/fn_pointer/abi.rs
+++ b/tests/rustdoc-json/fn_pointer/abi.rs
@@ -1,19 +1,19 @@
 #![feature(rust_cold_cc)]
 
-//@ is "$.index[?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"
+//@ jq .index[] | select(.name == "AbiRust").inner.type_alias.type?.function_pointer.header?.abi == "Rust"
 pub type AbiRust = fn();
 
-//@ is "$.index[?(@.name=='AbiC')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": false}}'
+//@ jq .index[] | select(.name == "AbiC").inner.type_alias.type?.function_pointer.header?.abi == {"C": {"unwind": false}}
 pub type AbiC = extern "C" fn();
 
-//@ is "$.index[?(@.name=='AbiSystem')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": false}}'
+//@ jq .index[] | select(.name == "AbiSystem").inner.type_alias.type?.function_pointer.header?.abi == {"System": {"unwind": false}}
 pub type AbiSystem = extern "system" fn();
 
-//@ is "$.index[?(@.name=='AbiCUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"C": {"unwind": true}}'
+//@ jq .index[] | select(.name == "AbiCUnwind").inner.type_alias.type?.function_pointer.header?.abi == {"C": {"unwind": true}}
 pub type AbiCUnwind = extern "C-unwind" fn();
 
-//@ is "$.index[?(@.name=='AbiSystemUnwind')].inner.type_alias.type.function_pointer.header.abi" '{"System": {"unwind": true}}'
+//@ jq .index[] | select(.name == "AbiSystemUnwind").inner.type_alias.type?.function_pointer.header?.abi == {"System": {"unwind": true}}
 pub type AbiSystemUnwind = extern "system-unwind" fn();
 
-//@ is "$.index[?(@.name=='AbiRustCold')].inner.type_alias.type.function_pointer.header.abi.Other" '"\"rust-cold\""'
+//@ jq .index[] | select(.name == "AbiRustCold").inner.type_alias.type?.function_pointer.header?.abi.Other == "\"rust-cold\""
 pub type AbiRustCold = extern "rust-cold" fn();

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,8 +1,5 @@
-//@ count "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][0]" '"val"'
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.output.primitive" \"i32\"
-//@ count "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[*]" 1
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].name" \"\'c\"
-//@ is "$.index[?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+//@ arg with_higher_rank_trait_bounds .index[] | select(.name == "WithHigherRankTraitBounds").inner.type_alias.type?.function_pointer
+//@ jq $with_higher_rank_trait_bounds.sig?.inputs[] | .[0] == "val" and .[1].borrowed_ref.lifetime? == "'c"
+//@ jq $with_higher_rank_trait_bounds.sig?.output.primitive == "i32"
+//@ jq $with_higher_rank_trait_bounds.generic_params[]? | .name == "'c" and .kind == {"lifetime": {"outlives": []}}
 pub type WithHigherRankTraitBounds = for<'c> fn(val: &'c i32) -> i32;

--- a/tests/rustdoc-json/fn_pointer/qualifiers.rs
+++ b/tests/rustdoc-json/fn_pointer/qualifiers.rs
@@ -1,9 +1,5 @@
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_unsafe" false
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_const" false
-//@ is "$.index[?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_async" false
+//@ jq .index[] | select(.name == "FnPointer").inner.type_alias.type?.function_pointer.header? | [.is_unsafe, .is_const, .is_async] == [false, false, false]
 pub type FnPointer = fn();
 
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_unsafe" true
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_const" false
-//@ is "$.index[?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_async" false
+//@ jq .index[] | select(.name == "UnsafePointer").inner.type_alias.type?.function_pointer.header? | [.is_unsafe, .is_const, .is_async] == [true, false, false]
 pub type UnsafePointer = unsafe fn();

--- a/tests/rustdoc-json/fns/abi.rs
+++ b/tests/rustdoc-json/fns/abi.rs
@@ -1,19 +1,19 @@
 #![feature(rust_cold_cc)]
 
-//@ is "$.index[?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"
+//@ jq .index[] | select(.name == "abi_rust").inner.function.header?.abi == "Rust"
 pub fn abi_rust() {}
 
-//@ is "$.index[?(@.name=='abi_c')].inner.function.header.abi" '{"C": {"unwind": false}}'
+//@ jq .index[] | select(.name == "abi_c").inner.function.header?.abi == {"C": {"unwind": false}}
 pub extern "C" fn abi_c() {}
 
-//@ is "$.index[?(@.name=='abi_system')].inner.function.header.abi" '{"System": {"unwind": false}}'
+//@ jq .index[] | select(.name == "abi_system").inner.function.header?.abi == {"System": {"unwind": false}}
 pub extern "system" fn abi_system() {}
 
-//@ is "$.index[?(@.name=='abi_c_unwind')].inner.function.header.abi" '{"C": {"unwind": true}}'
+//@ jq .index[] | select(.name == "abi_c_unwind").inner.function.header?.abi == {"C": {"unwind": true}}
 pub extern "C-unwind" fn abi_c_unwind() {}
 
-//@ is "$.index[?(@.name=='abi_system_unwind')].inner.function.header.abi" '{"System": {"unwind": true}}'
+//@ jq .index[] | select(.name == "abi_system_unwind").inner.function.header?.abi == {"System": {"unwind": true}}
 pub extern "system-unwind" fn abi_system_unwind() {}
 
-//@ is "$.index[?(@.name=='abi_rust_cold')].inner.function.header.abi.Other" '"\"rust-cold\""'
+//@ jq .index[] | select(.name == "abi_rust_cold").inner.function.header?.abi.Other == "\"rust-cold\""
 pub extern "rust-cold" fn abi_rust_cold() {}

--- a/tests/rustdoc-json/fns/async_return.rs
+++ b/tests/rustdoc-json/fns/async_return.rs
@@ -4,30 +4,30 @@
 
 use std::future::Future;
 
-//@ is "$.index[?(@.name=='get_int')].inner.function.sig.output.primitive" \"i32\"
-//@ is "$.index[?(@.name=='get_int')].inner.function.header.is_async" false
+//@ jq .index[] | select(.name == "get_int").inner.function | .sig?.output.primitive == "i32" and .header?.is_async == false
 pub fn get_int() -> i32 {
     42
 }
 
-//@ is "$.index[?(@.name=='get_int_async')].inner.function.sig.output.primitive" \"i32\"
-//@ is "$.index[?(@.name=='get_int_async')].inner.function.header.is_async" true
+//@ jq .index[] | select(.name == "get_int_async").inner.function | .sig?.output.primitive == "i32" and .header?.is_async == true
 pub async fn get_int_async() -> i32 {
     42
 }
 
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.path" '"Future"'
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive"  \"i32\"
-//@ is "$.index[?(@.name=='get_int_future')].inner.function.header.is_async" false
+//@ arg get_int_future .index[] | select(.name == "get_int_future").inner.function
+//@ jq $get_int_future.sig?.output.impl_trait[]?.trait_bound.trait?.path == "Future"
+//@ jq $get_int_future.sig?.output.impl_trait[]?.trait_bound.trait?.args.angle_bracketed?.constraints?[].name == "Output"
+//@ jq $get_int_future.sig?.output.impl_trait[]?.trait_bound.trait?.args.angle_bracketed?.constraints?[].binding.equality.type?.primitive == "i32"
+//@ jq $get_int_future.header?.is_async == false
 pub fn get_int_future() -> impl Future<Output = i32> {
     async { 42 }
 }
 
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.path" '"Future"'
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive" \"i32\"
-//@ is "$.index[?(@.name=='get_int_future_async')].inner.function.header.is_async" true
+//@ arg get_int_future_async .index[] | select(.name == "get_int_future_async").inner.function
+//@ jq $get_int_future_async.sig?.output.impl_trait[]?.trait_bound.trait?.path == "Future"
+//@ jq $get_int_future_async.sig?.output.impl_trait[]?.trait_bound.trait?.args.angle_bracketed?.constraints?[].name == "Output"
+//@ jq $get_int_future_async.sig?.output.impl_trait[]?.trait_bound.trait?.args.angle_bracketed?.constraints?[].binding.equality.type?.primitive == "i32"
+//@ jq $get_int_future_async.header?.is_async == true
 pub async fn get_int_future_async() -> impl Future<Output = i32> {
     async { 42 }
 }

--- a/tests/rustdoc-json/fns/extern_c_variadic.rs
+++ b/tests/rustdoc-json/fns/extern_c_variadic.rs
@@ -1,6 +1,6 @@
 extern "C" {
-    //@ is "$.index[?(@.name == 'not_variadic')].inner.function.sig.is_c_variadic" false
+    //@ jq .index[] | select(.name == "not_variadic").inner.function.sig?.is_c_variadic == false
     pub fn not_variadic(_: i32);
-    //@ is "$.index[?(@.name == 'variadic')].inner.function.sig.is_c_variadic" true
+    //@ jq .index[] | select(.name == "variadic").inner.function.sig?.is_c_variadic == true
     pub fn variadic(_: i32, ...);
 }

--- a/tests/rustdoc-json/fns/extern_safe.rs
+++ b/tests/rustdoc-json/fns/extern_safe.rs
@@ -1,17 +1,17 @@
 extern "C" {
-    //@ is "$.index[?(@.name=='f1')].inner.function.header.is_unsafe" true
+    //@ jq .index[] | select(.name == "f1").inner.function.header?.is_unsafe == true
     pub fn f1();
 
     // items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
 }
 
 unsafe extern "C" {
-    //@ is "$.index[?(@.name=='f4')].inner.function.header.is_unsafe" true
+    //@ jq .index[] | select(.name == "f4").inner.function.header?.is_unsafe == true
     pub fn f4();
 
-    //@ is "$.index[?(@.name=='f5')].inner.function.header.is_unsafe" true
+    //@ jq .index[] | select(.name == "f5").inner.function.header?.is_unsafe == true
     pub unsafe fn f5();
 
-    //@ is "$.index[?(@.name=='f6')].inner.function.header.is_unsafe" false
+    //@ jq .index[] | select(.name == "f6").inner.function.header?.is_unsafe == false
     pub safe fn f6();
 }

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -1,58 +1,37 @@
-//@ set foo = "$.index[?(@.name=='Foo')].id"
+//@ arg foo .index[] | select(.name == "Foo").id
 pub trait Foo {}
 
-//@ set generic_foo = "$.index[?(@.name=='GenericFoo')].id"
+//@ arg generic_foo .index[] | select(.name == "GenericFoo").id
 pub trait GenericFoo<'a> {}
 
-//@ is "$.index[?(@.name=='generics')].inner.function.generics.where_predicates" "[]"
-//@ count "$.index[?(@.name=='generics')].inner.function.generics.params[*]" 1
-//@ is "$.index[?(@.name=='generics')].inner.function.generics.params[0].name" '"F"'
-//@ is "$.index[?(@.name=='generics')].inner.function.generics.params[0].kind.type.default" 'null'
-//@ count "$.index[?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[*]" 1
-//@ is "$.index[?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
-//@ count "$.index[?(@.name=='generics')].inner.function.sig.inputs[*]" 1
-//@ is "$.index[?(@.name=='generics')].inner.function.sig.inputs[0][0]" '"f"'
-//@ is "$.index[?(@.name=='generics')].inner.function.sig.inputs[0][1].generic" '"F"'
+//@ arg generics .index[] | select(.name == "generics").inner.function
+//@ jq $generics.generics?.where_predicates == []
+//@ jq $generics.generics?.params[] | .name == "F" and .kind.type.default? == null and .kind.type.bounds?[].trait_bound.trait?.id == $foo
+//@ jq $generics.sig?.inputs[] | .[0] == "f" and .[1].generic == "F"
 pub fn generics<F: Foo>(f: F) {}
 
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.generics.where_predicates" "[]"
-//@ count "$.index[?(@.name=='impl_trait')].inner.function.generics.params[*]" 1
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.generics.params[0].name" '"impl Foo"'
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
-//@ count "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[*]" 1
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][0]" '"f"'
-//@ count "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[*]" 1
-//@ is "$.index[?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
+//@ arg impl_trait .index[] | select(.name == "impl_trait").inner.function
+//@ jq $impl_trait.generics?.where_predicates == []
+//@ jq $impl_trait.generics?.params[] | .name == "impl Foo" and .kind.type.bounds?[].trait_bound.trait?.id == $foo
+//@ jq $impl_trait.sig?.inputs[] | .[0] == "f" and .[1].impl_trait[]?.trait_bound.trait?.id == $foo
 pub fn impl_trait(f: impl Foo) {}
 
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.params[*]" 3
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.params[0].name" '"F"'
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "is_synthetic": false}}'
-//@ count "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[*]" 3
-//@ is "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[0][0]" '"f"'
-//@ is "$.index[?(@.name=='where_clase')].inner.function.sig.inputs[0][1].generic" '"F"'
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[*]" 3
+//@ arg where_clase .index[] | select(.name == "where_clase").inner.function
+//@ jq $where_clase.generics?.params | length == 3
+//@ jq $where_clase.generics?.params[0] | .name == "F" and .kind == {"type": {"bounds": [], "default": null, "is_synthetic": false}}
+//@ jq $where_clase.sig?.inputs | length == 3
+//@ jq $where_clase.sig?.inputs[0] | .[0] == "f" and .[1].generic == "F"
+//@ jq $where_clase.generics?.where_predicates | length == 3
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type.generic" \"F\"
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[*]" 1
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.id" $foo
+//@ jq $where_clase.generics?.where_predicates[0].bound_predicate | .type?.generic == "F" and .bounds?[].trait_bound.trait?.id == $foo
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.type.generic" \"G\"
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[*]" 1
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.id" $generic_foo
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].name" \"\'a\"
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind.lifetime.outlives" "[]"
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[1].bound_predicate.generic_params" "[]"
+//@ jq $where_clase.generics?.where_predicates[1].bound_predicate | .type?.generic == "G" and .generic_params? == []
+//@ jq $where_clase.generics?.where_predicates[1].bound_predicate.bounds?[].trait_bound.trait?.id == $generic_foo
+//@ jq $where_clase.generics?.where_predicates[1].bound_predicate.bounds?[].trait_bound.generic_params?[] | .name == "'a" and .kind.lifetime.outlives? == []
 
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.lifetime" \"\'b\"
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.type.borrowed_ref.type.generic" \"H\"
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[*]" 1
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.trait.id" $foo
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"
-//@ count "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[*]" 1
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].name" \"\'b\"
-//@ is "$.index[?(@.name=='where_clase')].inner.function.generics.where_predicates[2].bound_predicate.generic_params[0].kind.lifetime.outlives" "[]"
+//@ jq $where_clase.generics?.where_predicates[2].bound_predicate.type?.borrowed_ref | .lifetime? == "'b" and .type?.generic == "H"
+//@ jq $where_clase.generics?.where_predicates[2].bound_predicate.bounds?[].trait_bound | .trait?.id == $foo and .generic_params? == []
+//@ jq $where_clase.generics?.where_predicates[2].bound_predicate.generic_params?[] | .name == "'b" and .kind.lifetime.outlives? == []
 pub fn where_clase<F, G, H>(f: F, g: G, h: H)
 where
     F: Foo,

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -1,11 +1,11 @@
-//@ count "$.index[?(@.name=='generic_returns')].inner.module.items[*]" 2
+//@ jq .index["\(.root)"].inner.module.items? | length == 2
 
-//@ set foo = "$.index[?(@.name=='Foo')].id"
+//@ arg foo .index[] | select(.name == "Foo").id
 pub trait Foo {}
 
-//@ is "$.index[?(@.name=='get_foo')].inner.function.sig.inputs" []
-//@ count "$.index[?(@.name=='get_foo')].inner.function.sig.output.impl_trait[*]" 1
-//@ is "$.index[?(@.name=='get_foo')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $foo
+//@ arg get_foo .index[] | select(.name == "get_foo").inner.function.sig
+//@ jq $get_foo.inputs? == []
+//@ jq $get_foo.output?.impl_trait[]?.trait_bound.trait?.id == $foo
 pub fn get_foo() -> impl Foo {
     Fooer {}
 }

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -1,20 +1,14 @@
-//@ set wham_id = "$.index[?(@.name=='Wham')].id"
+//@ arg wham_id .index[] | select(.name == "Wham").id
 pub trait Wham {}
 
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.where_predicates" []
-//@ count "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[*]" 1
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].name" '"T"'
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.is_synthetic" false
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-//@ is    "$.index[?(@.name=='one_generic_param_fn')].inner.function.sig.inputs" '[["w", {"generic": "T"}]]'
+//@ arg one_generic_param_fn .index[] | select(.name == "one_generic_param_fn").inner.function
+//@ jq $one_generic_param_fn.generics? | .where_predicates == [] and .params[].name == "T"
+//@ jq $one_generic_param_fn.generics?.params[].kind.type | .is_synthetic? == false and .bounds?[].trait_bound.trait?.id == $wham_id
+//@ jq $one_generic_param_fn.sig?.inputs == [["w", {"generic": "T"}]]
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.where_predicates" []
-//@ count "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[*]" 1
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].name" '"impl Wham"'
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.is_synthetic" true
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-//@ count "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[*]" 1
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][0]" '"w"'
-//@ is    "$.index[?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
+//@ arg one_synthetic_generic_param_fn .index[] | select(.name == "one_synthetic_generic_param_fn").inner.function
+//@ jq $one_synthetic_generic_param_fn.generics? | .where_predicates == [] and .params[].name == "impl Wham"
+//@ jq $one_synthetic_generic_param_fn.generics?.params[].kind.type | .is_synthetic? == true and .bounds?[].trait_bound.trait?.id == $wham_id
+//@ jq $one_synthetic_generic_param_fn.sig?.inputs[] | .[0] == "w" and .[1].impl_trait[]?.trait_bound.trait?.id == $wham_id
 pub fn one_synthetic_generic_param_fn(w: impl Wham) {}

--- a/tests/rustdoc-json/fns/pattern_arg.rs
+++ b/tests/rustdoc-json/fns/pattern_arg.rs
@@ -1,7 +1,7 @@
-//@ is "$.index[?(@.name=='fst')].inner.function.sig.inputs[0][0]" '"(x, _)"'
+//@ jq .index[] | select(.name == "fst").inner.function.sig?.inputs[][0] == "(x, _)"
 pub fn fst<X, Y>((x, _): (X, Y)) -> X {
     x
 }
 
-//@ is "$.index[?(@.name=='drop_int')].inner.function.sig.inputs[0][0]" '"_"'
+//@ jq .index[] | select(.name == "drop_int").inner.function.sig?.inputs[][0] == "_"
 pub fn drop_int(_: i32) {}

--- a/tests/rustdoc-json/fns/qualifiers.rs
+++ b/tests/rustdoc-json/fns/qualifiers.rs
@@ -1,33 +1,21 @@
 //@ edition:2018
 
-//@ is "$.index[?(@.name=='nothing_fn')].inner.function.header.is_async" false
-//@ is "$.index[?(@.name=='nothing_fn')].inner.function.header.is_const"  false
-//@ is "$.index[?(@.name=='nothing_fn')].inner.function.header.is_unsafe" false
+//@ jq .index[] | select(.name == "nothing_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [false, false, false]
 pub fn nothing_fn() {}
 
-//@ is "$.index[?(@.name=='unsafe_fn')].inner.function.header.is_async"  false
-//@ is "$.index[?(@.name=='unsafe_fn')].inner.function.header.is_const"  false
-//@ is "$.index[?(@.name=='unsafe_fn')].inner.function.header.is_unsafe" true
+//@ jq .index[] | select(.name == "unsafe_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [false, false, true]
 pub unsafe fn unsafe_fn() {}
 
-//@ is "$.index[?(@.name=='const_fn')].inner.function.header.is_async"  false
-//@ is "$.index[?(@.name=='const_fn')].inner.function.header.is_const"  true
-//@ is "$.index[?(@.name=='const_fn')].inner.function.header.is_unsafe" false
+//@ jq .index[] | select(.name == "const_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [false, true, false]
 pub const fn const_fn() {}
 
-//@ is "$.index[?(@.name=='async_fn')].inner.function.header.is_async"  true
-//@ is "$.index[?(@.name=='async_fn')].inner.function.header.is_const"  false
-//@ is "$.index[?(@.name=='async_fn')].inner.function.header.is_unsafe" false
+//@ jq .index[] | select(.name == "async_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [true, false, false]
 pub async fn async_fn() {}
 
-//@ is "$.index[?(@.name=='async_unsafe_fn')].inner.function.header.is_async"  true
-//@ is "$.index[?(@.name=='async_unsafe_fn')].inner.function.header.is_const"  false
-//@ is "$.index[?(@.name=='async_unsafe_fn')].inner.function.header.is_unsafe" true
+//@ jq .index[] | select(.name == "async_unsafe_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [true, false, true]
 pub async unsafe fn async_unsafe_fn() {}
 
-//@ is "$.index[?(@.name=='const_unsafe_fn')].inner.function.header.is_async"  false
-//@ is "$.index[?(@.name=='const_unsafe_fn')].inner.function.header.is_const"  true
-//@ is "$.index[?(@.name=='const_unsafe_fn')].inner.function.header.is_unsafe" true
+//@ jq .index[] | select(.name == "const_unsafe_fn").inner.function.header? | [.is_async, .is_const, .is_unsafe] == [false, true, true]
 pub const unsafe fn const_unsafe_fn() {}
 
 // It's impossible for a function to be both const and async, so no test for that

--- a/tests/rustdoc-json/fns/return_type_alias.rs
+++ b/tests/rustdoc-json/fns/return_type_alias.rs
@@ -1,9 +1,9 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104851>
 
-//@ set foo = "$.index[?(@.name=='Foo')].id"
+//@ arg foo .index[] | select(.name == "Foo").id
 pub type Foo = i32;
 
-//@ is "$.index[?(@.name=='demo')].inner.function.sig.output.resolved_path.id" $foo
+//@ jq .index[] | select(.name == "demo").inner.function.sig?.output.resolved_path?.id == $foo
 pub fn demo() -> Foo {
     42
 }


### PR DESCRIPTION
This is an ongoing effort to close https://github.com/rust-lang/rust/issues/142479. I've decided to take a hard path and rewrite `rustdoc-types`'s entire testsuite. I don't think it'll be a good idea to construct a JSONPath-`jq` transpiler because it'll look really awkward for new contributors, JSONPath's limitations + [`jaq`'s own quirks](https://github.com/01mf02/jaq/blob/8c5131b4060d95856cc347e98baaf270b5bd43a8/README.md#miscellaneous) may create a lot of questions that even current maintainers would've no answers for without digging into `jsondocck`'s internals.

I expect `jsondocck` to have just 2 directives: `jq` and `arg`. Thanks to `jq`'s flexibility, these 2 can do everything that the current directive set can and much more (actually, too much, I left some comments to opt out some dependencies when it'll be possible on `jaq`'s side). I'm trying to actively utilize `jq`'s features instead of just blindly rewriting existing assertions, so there should be more deletions than additions.

When I'll be done, I'll try to rebase and split my work to make it more easier to review. So far `jsondocck` is already functional, so you can check out how it may look like and give some feedback if you want. I'll commit updated tests folder by folder.