### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -893,7 +893,7 @@ impl Token {
             || self.is_qpath_start()
             || matches!(self.is_metavar_seq(), Some(MetaVarKind::Path))
             || self.is_path_segment_keyword()
-            || self.is_ident() && !self.is_reserved_ident()
+            || self.is_non_reserved_ident()
     }
 
     /// Returns `true` if the token is a given keyword, `kw`.
@@ -935,6 +935,10 @@ impl Token {
     /// Returns `true` if the token is either a special identifier or a keyword.
     pub fn is_reserved_ident(&self) -> bool {
         self.is_non_raw_ident_where(Ident::is_reserved)
+    }
+
+    pub fn is_non_reserved_ident(&self) -> bool {
+        self.ident().is_some_and(|(id, raw)| raw == IdentIsRaw::Yes || !Ident::is_reserved(id))
     }
 
     /// Returns `true` if the token is the identifier `true` or `false`.

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -634,10 +634,8 @@ impl TokenStream {
                     (
                         TokenTree::Token(token_left, Spacing::Alone),
                         TokenTree::Token(token_right, _),
-                    ) if ((token_left.is_ident() && !token_left.is_reserved_ident())
-                        || token_left.is_lit())
-                        && ((token_right.is_ident() && !token_right.is_reserved_ident())
-                            || token_right.is_lit()) =>
+                    ) if (token_left.is_non_reserved_ident() || token_left.is_lit())
+                        && (token_right.is_non_reserved_ident() || token_right.is_lit()) =>
                     {
                         token_left.span
                     }

--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -131,6 +131,17 @@ impl Deprecation {
     }
 }
 
+/// There are three valid forms of the attribute:
+/// `#[used]`, which is semantically equivalent to `#[used(linker)]` except that the latter is currently unstable.
+/// `#[used(compiler)]`
+/// `#[used(linker)]`
+#[derive(Encodable, Decodable, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(HashStable_Generic, PrintAttribute)]
+pub enum UsedBy {
+    Compiler,
+    Linker,
+}
+
 /// Represents parsed *built-in* inert attributes.
 ///
 /// ## Overview
@@ -285,5 +296,8 @@ pub enum AttributeKind {
 
     /// Represents `#[track_caller]`
     TrackCaller(Span),
+
+    /// Represents `#[used]`
+    Used { used_by: UsedBy, span: Span },
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -38,6 +38,7 @@ impl AttributeKind {
             PubTransparent(..) => Yes,
             SkipDuringMethodDispatch { .. } => No,
             TrackCaller(..) => Yes,
+            Used { .. } => No,
         }
     }
 }

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -17,6 +17,7 @@ use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
 use crate::attributes::allow_unstable::{AllowConstFnUnstableParser, AllowInternalUnstableParser};
 use crate::attributes::codegen_attrs::{
     ColdParser, ExportNameParser, NakedParser, NoMangleParser, OptimizeParser, TrackCallerParser,
+    UsedParser,
 };
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
@@ -103,6 +104,7 @@ attribute_parsers!(
         ConstStabilityParser,
         NakedParser,
         StabilityParser,
+        UsedParser,
         // tidy-alphabetical-end
 
         // tidy-alphabetical-start

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -48,8 +48,6 @@ codegen_ssa_error_writing_def_file =
 
 codegen_ssa_expected_name_value_pair = expected name value pair
 
-codegen_ssa_expected_used_symbol = expected `used`, `used(compiler)` or `used(linker)`
-
 codegen_ssa_extern_funcs_not_found = some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
 
 codegen_ssa_extract_bundled_libs_archive_member = failed to get data from archive member '{$rlib}': {$error}

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -4,7 +4,7 @@ use rustc_abi::ExternAbi;
 use rustc_ast::expand::autodiff_attrs::{AutoDiffAttrs, DiffActivity, DiffMode};
 use rustc_ast::{LitKind, MetaItem, MetaItemInner, attr};
 use rustc_attr_data_structures::{
-    AttributeKind, InlineAttr, InstructionSetAttr, OptimizeAttr, ReprAttr, find_attr,
+    AttributeKind, InlineAttr, InstructionSetAttr, OptimizeAttr, ReprAttr, UsedBy, find_attr,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
@@ -160,6 +160,10 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     }
                     codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER
                 }
+                AttributeKind::Used { used_by, .. } => match used_by {
+                    UsedBy::Compiler => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_COMPILER,
+                    UsedBy::Linker => codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_LINKER,
+                },
                 _ => {}
             }
         }
@@ -180,44 +184,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             }
             sym::rustc_std_internal_symbol => {
                 codegen_fn_attrs.flags |= CodegenFnAttrFlags::RUSTC_STD_INTERNAL_SYMBOL
-            }
-            sym::used => {
-                let inner = attr.meta_item_list();
-                match inner.as_deref() {
-                    Some([item]) if item.has_name(sym::linker) => {
-                        if !tcx.features().used_with_arg() {
-                            feature_err(
-                                &tcx.sess,
-                                sym::used_with_arg,
-                                attr.span(),
-                                "`#[used(linker)]` is currently unstable",
-                            )
-                            .emit();
-                        }
-                        codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_LINKER;
-                    }
-                    Some([item]) if item.has_name(sym::compiler) => {
-                        if !tcx.features().used_with_arg() {
-                            feature_err(
-                                &tcx.sess,
-                                sym::used_with_arg,
-                                attr.span(),
-                                "`#[used(compiler)]` is currently unstable",
-                            )
-                            .emit();
-                        }
-                        codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_COMPILER;
-                    }
-                    Some(_) => {
-                        tcx.dcx().emit_err(errors::ExpectedUsedSymbol { span: attr.span() });
-                    }
-                    None => {
-                        // Unconditionally using `llvm.used` causes issues in handling
-                        // `.init_array` with the gold linker. Luckily gold has been
-                        // deprecated with GCC 15 and rustc now warns about using gold.
-                        codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED_LINKER
-                    }
-                }
             }
             sym::thread_local => codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL,
             sym::target_feature => {

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -430,7 +430,9 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
         }
     }
 
-    // Apply the minimum function alignment here, so that individual backends don't have to.
+    // Apply the minimum function alignment here. This ensures that a function's alignment is
+    // determined by the `-C` flags of the crate it is defined in, not the `-C` flags of the crate
+    // it happens to be codegen'd (or const-eval'd) in.
     codegen_fn_attrs.alignment =
         Ord::max(codegen_fn_attrs.alignment, tcx.sess.opts.unstable_opts.min_function_alignment);
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -727,13 +727,6 @@ pub struct UnknownArchiveKind<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa_expected_used_symbol)]
-pub(crate) struct ExpectedUsedSymbol {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(codegen_ssa_multiple_main_functions)]
 #[help]
 pub(crate) struct MultipleMainFunctions {

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -352,7 +352,7 @@ const_eval_realloc_or_alloc_with_offset =
         *[other] {""}
     } {$ptr} which does not point to the beginning of an object
 
-const_eval_recursive_static = encountered static that tried to initialize itself with itself
+const_eval_recursive_static = encountered static that tried to access itself during initialization
 
 const_eval_remainder_by_zero =
     calculating the remainder with a divisor of zero

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -7,7 +7,7 @@ use rustc_hir::def::DefKind;
 use rustc_middle::mir::interpret::{AllocId, ErrorHandled, InterpErrorInfo, ReportedErrorInfo};
 use rustc_middle::mir::{self, ConstAlloc, ConstValue};
 use rustc_middle::query::TyCtxtAt;
-use rustc_middle::ty::layout::{HasTypingEnv, LayoutOf};
+use rustc_middle::ty::layout::HasTypingEnv;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, throw_inval};

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -2,7 +2,6 @@
 
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_middle::query::Key;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, mir};
 use tracing::instrument;

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -1,7 +1,7 @@
 use rustc_abi::{BackendRepr, FieldIdx, VariantIdx};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId, ValTreeCreationError};
-use rustc_middle::ty::layout::{LayoutCx, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{LayoutCx, TyAndLayout};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, mir};
 use rustc_span::DUMMY_SP;

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use either::{Left, Right};
 use rustc_abi::{self as abi, ExternAbi, FieldIdx, Integer, VariantIdx};
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::layout::{FnAbiOf, IntegerExt, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{FnAbiOf, IntegerExt, TyAndLayout};
 use rustc_middle::ty::{self, AdtDef, Instance, Ty, VariantDef};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_span::sym;

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -6,7 +6,7 @@ use rustc_apfloat::{Float, FloatConvert};
 use rustc_middle::mir::CastKind;
 use rustc_middle::mir::interpret::{InterpResult, PointerArithmetic, Scalar};
 use rustc_middle::ty::adjustment::PointerCoercion;
-use rustc_middle::ty::layout::{IntegerExt, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{IntegerExt, TyAndLayout};
 use rustc_middle::ty::{self, FloatTy, Ty};
 use rustc_middle::{bug, span_bug};
 use tracing::trace;

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -1,7 +1,7 @@
 //! Functions for reading and writing discriminants of multi-variant layouts (enums and coroutines).
 
 use rustc_abi::{self as abi, FieldIdx, TagEncoding, VariantIdx, Variants};
-use rustc_middle::ty::layout::{LayoutOf, PrimitiveExt, TyAndLayout};
+use rustc_middle::ty::layout::{PrimitiveExt, TyAndLayout};
 use rustc_middle::ty::{self, CoroutineArgsExt, ScalarInt, Ty};
 use rustc_middle::{mir, span_bug};
 use tracing::{instrument, trace};

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -7,7 +7,8 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir::interpret::{ErrorHandled, InvalidMetaKind, ReportedErrorInfo};
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::{
-    self, FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOfHelpers, TyAndLayout,
+    self, FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOf, LayoutOfHelpers,
+    TyAndLayout,
 };
 use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeFoldable, TypingEnv, Variance};
 use rustc_middle::{mir, span_bug};
@@ -88,6 +89,20 @@ impl<'tcx, M: Machine<'tcx>> LayoutOfHelpers<'tcx> for InterpCx<'tcx, M> {
         _: Ty<'tcx>,
     ) -> InterpErrorKind<'tcx> {
         err_inval!(Layout(err))
+    }
+}
+
+impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
+    /// This inherent method takes priority over the trait method with the same name in LayoutOf,
+    /// and allows wrapping the actual [LayoutOf::layout_of] with a tracing span.
+    /// See [LayoutOf::layout_of] for the original documentation.
+    #[inline]
+    pub fn layout_of(
+        &self,
+        ty: Ty<'tcx>,
+    ) -> <InterpCx<'tcx, M> as LayoutOfHelpers<'tcx>>::LayoutOfResult {
+        let _span = enter_trace_span!(M, "InterpCx::layout_of", "ty = {:?}", ty.kind());
+        LayoutOf::layout_of(self, ty)
     }
 }
 

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -21,7 +21,7 @@ use super::{
     MemPlaceMeta, Memory, OpTy, Place, PlaceTy, PointerArithmetic, Projectable, Provenance,
     err_inval, interp_ok, throw_inval, throw_ub, throw_ub_custom,
 };
-use crate::{ReportErrorExt, fluent_generated as fluent, util};
+use crate::{ReportErrorExt, enter_trace_span, fluent_generated as fluent, util};
 
 pub struct InterpCx<'tcx, M: Machine<'tcx>> {
     /// Stores the `Machine` instance.
@@ -284,6 +284,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
         value: T,
     ) -> Result<T, ErrorHandled> {
+        let _span = enter_trace_span!(
+            M,
+            "instantiate_from_frame_and_normalize_erasing_regions",
+            "{}",
+            frame.instance
+        );
         frame
             .instance
             .try_instantiate_mir_and_normalize_erasing_regions(

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -8,7 +8,7 @@ use rustc_abi::Size;
 use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{self, BinOp, ConstValue, NonDivergingIntrinsic};
-use rustc_middle::ty::layout::{LayoutOf as _, TyAndLayout, ValidityRequirement};
+use rustc_middle::ty::layout::{TyAndLayout, ValidityRequirement};
 use rustc_middle::ty::{GenericArgsRef, Ty, TyCtxt};
 use rustc_middle::{bug, ty};
 use rustc_span::{Symbol, sym};

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -443,7 +443,11 @@ pub trait Machine<'tcx>: Sized {
     ///
     /// Used to prevent statics from self-initializing by reading from their own memory
     /// as it is being initialized.
-    fn before_alloc_read(_ecx: &InterpCx<'tcx, Self>, _alloc_id: AllocId) -> InterpResult<'tcx> {
+    fn before_alloc_access(
+        _tcx: TyCtxtAt<'tcx>,
+        _machine: &Self,
+        _alloc_id: AllocId,
+    ) -> InterpResult<'tcx> {
         interp_ok(())
     }
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -720,7 +720,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // do this after `check_and_deref_ptr` to ensure some basic sanity has already been checked.
         if !self.memory.validation_in_progress.get() {
             if let Ok((alloc_id, ..)) = self.ptr_try_get_alloc_id(ptr, size_i64) {
-                M::before_alloc_read(self, alloc_id)?;
+                M::before_alloc_access(self.tcx, &self.machine, alloc_id)?;
             }
         }
 
@@ -821,6 +821,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         if let Some((alloc_id, offset, prov, alloc, machine)) = ptr_and_alloc {
             let range = alloc_range(offset, size);
             if !validation_in_progress {
+                // For writes, it's okay to only call those when there actually is a non-zero
+                // amount of bytes to be written: a zero-sized write doesn't manifest anything.
+                M::before_alloc_access(tcx, machine, alloc_id)?;
                 M::before_memory_write(
                     tcx,
                     machine,
@@ -1396,6 +1399,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let src_parts = self.get_ptr_access(src, size)?;
         let dest_parts = self.get_ptr_access(dest, size * num_copies)?; // `Size` multiplication
 
+        // Similar to `get_ptr_alloc`, we need to call `before_alloc_access` even for zero-sized
+        // reads. However, just like in `get_ptr_alloc_mut`, the write part is okay to skip for
+        // zero-sized writes.
+        if let Ok((alloc_id, ..)) = self.ptr_try_get_alloc_id(src, size.bytes().try_into().unwrap())
+        {
+            M::before_alloc_access(tcx, &self.machine, alloc_id)?;
+        }
+
         // FIXME: we look up both allocations twice here, once before for the `check_ptr_access`
         // and once below to get the underlying `&[mut] Allocation`.
 
@@ -1408,12 +1419,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let src_range = alloc_range(src_offset, size);
         assert!(!self.memory.validation_in_progress.get(), "we can't be copying during validation");
 
-        // Trigger read hooks.
-        // For the overlapping case, it is crucial that we trigger the read hooks
+        // Trigger read hook.
+        // For the overlapping case, it is crucial that we trigger the read hook
         // before the write hook -- the aliasing model cares about the order.
-        if let Ok((alloc_id, ..)) = self.ptr_try_get_alloc_id(src, size.bytes() as i64) {
-            M::before_alloc_read(self, alloc_id)?;
-        }
         M::before_memory_read(
             tcx,
             &self.machine,
@@ -1438,16 +1446,18 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let provenance = src_alloc
             .provenance()
             .prepare_copy(src_range, dest_offset, num_copies, self)
-            .map_err(|e| e.to_interp_error(dest_alloc_id))?;
+            .map_err(|e| e.to_interp_error(src_alloc_id))?;
         // Prepare a copy of the initialization mask.
         let init = src_alloc.init_mask().prepare_copy(src_range);
 
-        // Destination alloc preparations and access hooks.
-        let (dest_alloc, extra) = self.get_alloc_raw_mut(dest_alloc_id)?;
+        // Destination alloc preparations...
+        let (dest_alloc, machine) = self.get_alloc_raw_mut(dest_alloc_id)?;
         let dest_range = alloc_range(dest_offset, size * num_copies);
+        // ...and access hooks.
+        M::before_alloc_access(tcx, machine, dest_alloc_id)?;
         M::before_memory_write(
             tcx,
-            extra,
+            machine,
             &mut dest_alloc.extra,
             dest,
             (dest_alloc_id, dest_prov),

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -8,7 +8,7 @@ use rustc_abi as abi;
 use rustc_abi::{BackendRepr, HasDataLayout, Size};
 use rustc_hir::def::Namespace;
 use rustc_middle::mir::interpret::ScalarSizeMismatch;
-use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, TyAndLayout};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter};
 use rustc_middle::ty::{ConstInt, ScalarInt, Ty, TyCtxt};
 use rustc_middle::{bug, mir, span_bug, ty};

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -3,7 +3,7 @@ use rustc_abi::Size;
 use rustc_apfloat::{Float, FloatConvert};
 use rustc_middle::mir::NullOp;
 use rustc_middle::mir::interpret::{InterpResult, PointerArithmetic, Scalar};
-use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{self, FloatTy, ScalarInt, Ty};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_span::sym;

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -7,7 +7,7 @@ use std::assert_matches::assert_matches;
 use either::{Either, Left, Right};
 use rustc_abi::{BackendRepr, HasDataLayout, Size};
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::{bug, mir, span_bug};
 use tracing::{instrument, trace};
 

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -12,7 +12,7 @@ use std::ops::Range;
 
 use rustc_abi::{self as abi, FieldIdx, Size, VariantIdx};
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::{bug, mir, span_bug, ty};
 use tracing::{debug, instrument};
 

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -7,7 +7,7 @@ use either::{Either, Left, Right};
 use rustc_hir as hir;
 use rustc_hir::definitions::DefPathData;
 use rustc_index::IndexVec;
-use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, mir};
 use rustc_mir_dataflow::impls::always_storage_live_locals;

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -1,6 +1,5 @@
 use rustc_abi::{Align, FieldIdx, Size};
 use rustc_middle::mir::interpret::{InterpResult, Pointer};
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, ExistentialPredicateStableCmpExt, Ty, TyCtxt, VtblEntry};
 use tracing::trace;
 

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -24,7 +24,7 @@ use rustc_middle::mir::interpret::{
     ExpectedKind, InterpErrorKind, InvalidMetaKind, Misalignment, PointerKind, Provenance,
     UnsupportedOpInfo, ValidationErrorInfo, alloc_range, interp_ok,
 };
-use rustc_middle::ty::layout::{LayoutCx, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{LayoutCx, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::{Symbol, sym};
 use tracing::trace;

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -35,6 +35,7 @@ use super::{
     Machine, MemPlaceMeta, PlaceTy, Pointer, Projectable, Scalar, ValueVisitor, err_ub,
     format_interp_error,
 };
+use crate::enter_trace_span;
 
 // for the validation errors
 #[rustfmt::skip]
@@ -1401,6 +1402,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         recursive: bool,
         reset_provenance_and_padding: bool,
     ) -> InterpResult<'tcx> {
+        let _span = enter_trace_span!(
+            M,
+            "validate_operand",
+            "recursive={recursive}, reset_provenance_and_padding={reset_provenance_and_padding}, val={val:?}"
+        );
+
         // Note that we *could* actually be in CTFE here with `-Zextra-const-ub-checks`, but it's
         // still correct to not use `ctfe_mode`: that mode is for validation of the final constant
         // value, it rules out things like `UnsafeCell` in awkward places.

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1364,8 +1364,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         })
     }
 
-    /// This function checks the data at `op` to be const-valid.
-    /// `op` is assumed to cover valid memory if it is an indirect operand.
+    /// This function checks the data at `val` to be const-valid.
+    /// `val` is assumed to cover valid memory if it is an indirect operand.
     /// It will error if the bits at the destination do not match the ones described by the layout.
     ///
     /// `ref_tracking` is used to record references that we encounter so that they
@@ -1391,8 +1391,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         )
     }
 
-    /// This function checks the data at `op` to be runtime-valid.
-    /// `op` is assumed to cover valid memory if it is an indirect operand.
+    /// This function checks the data at `val` to be runtime-valid.
+    /// `val` is assumed to cover valid memory if it is an indirect operand.
     /// It will error if the bits at the destination do not match the ones described by the layout.
     #[inline(always)]
     pub fn validate_operand(

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -6,7 +6,6 @@ use std::num::NonZero;
 use rustc_abi::{FieldIdx, FieldsShape, VariantIdx, Variants};
 use rustc_index::IndexVec;
 use rustc_middle::mir::interpret::InterpResult;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Ty};
 use tracing::trace;
 

--- a/compiler/rustc_const_eval/src/util/caller_location.rs
+++ b/compiler/rustc_const_eval/src/util/caller_location.rs
@@ -1,6 +1,5 @@
 use rustc_abi::FieldIdx;
 use rustc_hir::LangItem;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::{bug, mir};
 use rustc_span::Symbol;

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1109,6 +1109,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     rustc_attr!(
+        TEST, rustc_no_implicit_bounds, CrateLevel, template!(Word),
+        WarnFollowing, EncodeCrossCrate::No
+    ),
+    rustc_attr!(
         TEST, rustc_strict_coherence, Normal, template!(Word),
         WarnFollowing, EncodeCrossCrate::Yes
     ),

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3141,6 +3141,15 @@ pub enum TraitItemKind<'hir> {
     /// type.
     Type(GenericBounds<'hir>, Option<&'hir Ty<'hir>>),
 }
+impl TraitItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            TraitItemKind::Const(..) => "associated constant",
+            TraitItemKind::Fn(..) => "function",
+            TraitItemKind::Type(..) => "associated type",
+        }
+    }
+}
 
 // The bodies for items are stored "out of line", in a separate
 // hashmap in the `Crate`. Here we just record the hir-id of the item
@@ -3201,6 +3210,15 @@ pub enum ImplItemKind<'hir> {
     Fn(FnSig<'hir>, BodyId),
     /// An associated type.
     Type(&'hir Ty<'hir>),
+}
+impl ImplItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            ImplItemKind::Const(..) => "associated constant",
+            ImplItemKind::Fn(..) => "function",
+            ImplItemKind::Type(..) => "associated type",
+        }
+    }
 }
 
 /// A constraint on an associated item.
@@ -4525,6 +4543,16 @@ pub enum ForeignItemKind<'hir> {
     Static(&'hir Ty<'hir>, Mutability, Safety),
     /// A foreign type.
     Type,
+}
+
+impl ForeignItemKind<'_> {
+    pub fn descr(&self) -> &'static str {
+        match self {
+            ForeignItemKind::Fn(..) => "function",
+            ForeignItemKind::Static(..) => "static variable",
+            ForeignItemKind::Type => "type",
+        }
+    }
 }
 
 /// A variable captured by a closure.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -231,7 +231,6 @@ fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) -> Result<()
         item.name = ? tcx.def_path_str(def_id)
     );
     crate::collect::lower_item(tcx, item.item_id());
-    crate::collect::reject_placeholder_type_signatures_in_item(tcx, item);
 
     let res = match item.kind {
         // Right now we check that every default trait implementation

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -29,7 +29,7 @@ use rustc_errors::{
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt, walk_generics};
+use rustc_hir::intravisit::{InferKind, Visitor, VisitorExt};
 use rustc_hir::{self as hir, GenericParamKind, HirId, Node, PreciseCapturingArgKind};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
@@ -154,26 +154,7 @@ impl<'v> Visitor<'v> for HirPlaceholderCollector {
     }
 }
 
-/// If there are any placeholder types (`_`), emit an error explaining that this is not allowed
-/// and suggest adding type parameters in the appropriate place, taking into consideration any and
-/// all already existing generic type parameters to avoid suggesting a name that is already in use.
-pub(crate) fn placeholder_type_error<'tcx>(
-    cx: &dyn HirTyLowerer<'tcx>,
-    generics: Option<&hir::Generics<'_>>,
-    placeholder_types: Vec<Span>,
-    suggest: bool,
-    hir_ty: Option<&hir::Ty<'_>>,
-    kind: &'static str,
-) {
-    if placeholder_types.is_empty() {
-        return;
-    }
-
-    placeholder_type_error_diag(cx, generics, placeholder_types, vec![], suggest, hir_ty, kind)
-        .emit();
-}
-
-pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
+fn placeholder_type_error_diag<'cx, 'tcx>(
     cx: &'cx dyn HirTyLowerer<'tcx>,
     generics: Option<&hir::Generics<'_>>,
     placeholder_types: Vec<Span>,
@@ -245,37 +226,6 @@ pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
     err
 }
 
-pub(super) fn reject_placeholder_type_signatures_in_item<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item: &'tcx hir::Item<'tcx>,
-) {
-    let (generics, suggest) = match &item.kind {
-        hir::ItemKind::Union(_, generics, _)
-        | hir::ItemKind::Enum(_, generics, _)
-        | hir::ItemKind::TraitAlias(_, generics, _)
-        | hir::ItemKind::Trait(_, _, _, generics, ..)
-        | hir::ItemKind::Impl(hir::Impl { generics, .. })
-        | hir::ItemKind::Struct(_, generics, _) => (generics, true),
-        hir::ItemKind::TyAlias(_, generics, _) => (generics, false),
-        // `static`, `fn` and `const` are handled elsewhere to suggest appropriate type.
-        _ => return,
-    };
-
-    let mut visitor = HirPlaceholderCollector::default();
-    visitor.visit_item(item);
-
-    let icx = ItemCtxt::new(tcx, item.owner_id.def_id);
-
-    placeholder_type_error(
-        icx.lowerer(),
-        Some(generics),
-        visitor.spans,
-        suggest && !visitor.may_contain_const_infer,
-        None,
-        item.kind.descr(),
-    );
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // Utility types and common code for the above passes.
 
@@ -313,6 +263,54 @@ impl<'tcx> ItemCtxt<'tcx> {
             None => Ok(()),
         }
     }
+
+    fn report_placeholder_type_error(
+        &self,
+        placeholder_types: Vec<Span>,
+        infer_replacements: Vec<(Span, String)>,
+    ) -> ErrorGuaranteed {
+        let node = self.tcx.hir_node_by_def_id(self.item_def_id);
+        let generics = node.generics();
+        let kind_id = match node {
+            Node::GenericParam(_) | Node::WherePredicate(_) | Node::Field(_) => {
+                self.tcx.local_parent(self.item_def_id)
+            }
+            _ => self.item_def_id,
+        };
+        // FIXME: just invoke `tcx.def_descr` instead of going through the HIR
+        // Can also remove most `descr` methods then.
+        let kind = match self.tcx.hir_node_by_def_id(kind_id) {
+            Node::Item(it) => it.kind.descr(),
+            Node::ImplItem(it) => it.kind.descr(),
+            Node::TraitItem(it) => it.kind.descr(),
+            Node::ForeignItem(it) => it.kind.descr(),
+            Node::OpaqueTy(_) => "opaque type",
+            Node::Synthetic => self.tcx.def_descr(kind_id.into()),
+            node => todo!("{node:#?}"),
+        };
+        let mut diag = placeholder_type_error_diag(
+            self,
+            generics,
+            placeholder_types,
+            infer_replacements.iter().map(|&(span, _)| span).collect(),
+            false,
+            None,
+            kind,
+        );
+        if !infer_replacements.is_empty() {
+            diag.multipart_suggestion(
+                format!(
+                    "try replacing `_` with the type{} in the corresponding trait method \
+                        signature",
+                    rustc_errors::pluralize!(infer_replacements.len()),
+                ),
+                infer_replacements,
+                Applicability::MachineApplicable,
+            );
+        }
+
+        diag.emit()
+    }
 }
 
 impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
@@ -346,10 +344,14 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     }
 
     fn ty_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Ty<'tcx> {
+        if !self.tcx.dcx().has_stashed_diagnostic(span, StashKey::ItemNoType) {
+            self.report_placeholder_type_error(vec![span], vec![]);
+        }
         Ty::new_error_with_message(self.tcx(), span, "bad placeholder type")
     }
 
     fn ct_infer(&self, _: Option<&ty::GenericParamDef>, span: Span) -> Const<'tcx> {
+        self.report_placeholder_type_error(vec![span], vec![]);
         ty::Const::new_error_with_message(self.tcx(), span, "bad placeholder constant")
     }
 
@@ -524,18 +526,13 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
     fn lower_fn_sig(
         &self,
         decl: &hir::FnDecl<'tcx>,
-        generics: Option<&hir::Generics<'_>>,
+        _generics: Option<&hir::Generics<'_>>,
         hir_id: rustc_hir::HirId,
-        hir_ty: Option<&hir::Ty<'_>>,
+        _hir_ty: Option<&hir::Ty<'_>>,
     ) -> (Vec<Ty<'tcx>>, Ty<'tcx>) {
         let tcx = self.tcx();
-        // We proactively collect all the inferred type params to emit a single error per fn def.
-        let mut visitor = HirPlaceholderCollector::default();
-        let mut infer_replacements = vec![];
 
-        if let Some(generics) = generics {
-            walk_generics(&mut visitor, generics);
-        }
+        let mut infer_replacements = vec![];
 
         let input_tys = decl
             .inputs
@@ -551,8 +548,6 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                     }
                 }
 
-                // Only visit the type looking for `_` if we didn't fix the type above
-                visitor.visit_ty_unambig(a);
                 self.lowerer().lower_ty(a)
             })
             .collect();
@@ -566,42 +561,15 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                     infer_replacements.push((output.span, suggested_ty.to_string()));
                     Ty::new_error_with_message(tcx, output.span, suggested_ty.to_string())
                 } else {
-                    visitor.visit_ty_unambig(output);
                     self.lower_ty(output)
                 }
             }
             hir::FnRetTy::DefaultReturn(..) => tcx.types.unit,
         };
 
-        if !(visitor.spans.is_empty() && infer_replacements.is_empty()) {
-            // We check for the presence of
-            // `ident_span` to not emit an error twice when we have `fn foo(_: fn() -> _)`.
-
-            let mut diag = crate::collect::placeholder_type_error_diag(
-                self,
-                generics,
-                visitor.spans,
-                infer_replacements.iter().map(|(s, _)| *s).collect(),
-                !visitor.may_contain_const_infer,
-                hir_ty,
-                "function",
-            );
-
-            if !infer_replacements.is_empty() {
-                diag.multipart_suggestion(
-                    format!(
-                        "try replacing `_` with the type{} in the corresponding trait method \
-                         signature",
-                        rustc_errors::pluralize!(infer_replacements.len()),
-                    ),
-                    infer_replacements,
-                    Applicability::MachineApplicable,
-                );
-            }
-
-            diag.emit();
+        if !infer_replacements.is_empty() {
+            self.report_placeholder_type_error(vec![], infer_replacements);
         }
-
         (input_tys, output_ty)
     }
 
@@ -652,7 +620,6 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
     let it = tcx.hir_item(item_id);
     debug!(item = ?it.kind.ident(), id = %it.hir_id());
     let def_id = item_id.owner_id.def_id;
-    let icx = ItemCtxt::new(tcx, def_id);
 
     match &it.kind {
         // These don't define types.
@@ -678,16 +645,6 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                     }
                     hir::ForeignItemKind::Static(..) => {
                         tcx.ensure_ok().codegen_fn_attrs(item.owner_id);
-                        let mut visitor = HirPlaceholderCollector::default();
-                        visitor.visit_foreign_item(item);
-                        placeholder_type_error(
-                            icx.lowerer(),
-                            None,
-                            visitor.spans,
-                            false,
-                            None,
-                            "static variable",
-                        );
                     }
                     _ => (),
                 }
@@ -741,22 +698,10 @@ pub(super) fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
             tcx.ensure_ok().predicates_of(def_id);
         }
 
-        hir::ItemKind::Static(_, _, ty, _) | hir::ItemKind::Const(_, _, ty, _) => {
+        hir::ItemKind::Static(..) | hir::ItemKind::Const(..) => {
             tcx.ensure_ok().generics_of(def_id);
             tcx.ensure_ok().type_of(def_id);
             tcx.ensure_ok().predicates_of(def_id);
-            if !ty.is_suggestable_infer_ty() {
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_item(it);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    it.kind.descr(),
-                );
-            }
         }
 
         hir::ItemKind::Fn { .. } => {
@@ -773,7 +718,6 @@ pub(crate) fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId)
     let trait_item = tcx.hir_trait_item(trait_item_id);
     let def_id = trait_item_id.owner_id;
     tcx.ensure_ok().generics_of(def_id);
-    let icx = ItemCtxt::new(tcx, def_id.def_id);
 
     match trait_item.kind {
         hir::TraitItemKind::Fn(..) => {
@@ -782,58 +726,19 @@ pub(crate) fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId)
             tcx.ensure_ok().fn_sig(def_id);
         }
 
-        hir::TraitItemKind::Const(ty, body_id) => {
+        hir::TraitItemKind::Const(..) => {
             tcx.ensure_ok().type_of(def_id);
-            if !tcx.dcx().has_stashed_diagnostic(ty.span, StashKey::ItemNoType)
-                && !(ty.is_suggestable_infer_ty() && body_id.is_some())
-            {
-                // Account for `const C: _;`.
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_trait_item(trait_item);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    "associated constant",
-                );
-            }
         }
 
         hir::TraitItemKind::Type(_, Some(_)) => {
             tcx.ensure_ok().item_bounds(def_id);
             tcx.ensure_ok().item_self_bounds(def_id);
             tcx.ensure_ok().type_of(def_id);
-            // Account for `type T = _;`.
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_trait_item(trait_item);
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
         }
 
         hir::TraitItemKind::Type(_, None) => {
             tcx.ensure_ok().item_bounds(def_id);
             tcx.ensure_ok().item_self_bounds(def_id);
-            // #74612: Visit and try to find bad placeholders
-            // even if there is no concrete type.
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_trait_item(trait_item);
-
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
         }
     };
 
@@ -846,41 +751,13 @@ pub(super) fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
     tcx.ensure_ok().type_of(def_id);
     tcx.ensure_ok().predicates_of(def_id);
     let impl_item = tcx.hir_impl_item(impl_item_id);
-    let icx = ItemCtxt::new(tcx, def_id.def_id);
     match impl_item.kind {
         hir::ImplItemKind::Fn(..) => {
             tcx.ensure_ok().codegen_fn_attrs(def_id);
             tcx.ensure_ok().fn_sig(def_id);
         }
-        hir::ImplItemKind::Type(_) => {
-            // Account for `type T = _;`
-            let mut visitor = HirPlaceholderCollector::default();
-            visitor.visit_impl_item(impl_item);
-
-            placeholder_type_error(
-                icx.lowerer(),
-                None,
-                visitor.spans,
-                false,
-                None,
-                "associated type",
-            );
-        }
-        hir::ImplItemKind::Const(ty, _) => {
-            // Account for `const T: _ = ..;`
-            if !ty.is_suggestable_infer_ty() {
-                let mut visitor = HirPlaceholderCollector::default();
-                visitor.visit_impl_item(impl_item);
-                placeholder_type_error(
-                    icx.lowerer(),
-                    None,
-                    visitor.spans,
-                    false,
-                    None,
-                    "associated constant",
-                );
-            }
-        }
+        hir::ImplItemKind::Type(_) => {}
+        hir::ImplItemKind::Const(..) => {}
     }
 }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -768,6 +768,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn def_kind_descr(self, def_kind: DefKind, def_id: DefId) -> &'static str {
         match def_kind {
             DefKind::AssocFn if self.associated_item(def_id).is_method() => "method",
+            DefKind::AssocTy if self.opt_rpitit_info(def_id).is_some() => "opaque type",
             DefKind::Closure if let Some(coroutine_kind) = self.coroutine_kind(def_id) => {
                 match coroutine_kind {
                     hir::CoroutineKind::Desugared(

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -16,7 +16,6 @@ use rustc_middle::bug;
 use rustc_middle::mir::interpret::{InterpResult, Scalar};
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::*;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_mir_dataflow::fmt::DebugWithContext;
 use rustc_mir_dataflow::lattice::{FlatSet, HasBottom};

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -102,7 +102,7 @@ use rustc_middle::bug;
 use rustc_middle::mir::interpret::GlobalAlloc;
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
-use rustc_middle::ty::layout::{HasTypingEnv, LayoutOf};
+use rustc_middle::ty::layout::HasTypingEnv;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::DUMMY_SP;
 use rustc_span::def_id::DefId;

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -45,7 +45,6 @@ use rustc_middle::bug;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, ScalarInt, TyCtxt};
 use rustc_mir_dataflow::lattice::HasBottom;
 use rustc_mir_dataflow::value_analysis::{Map, PlaceIndex, State, TrackElem};

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2731,7 +2731,7 @@ impl<'a> Parser<'a> {
             return first_pat;
         }
         if !matches!(first_pat.kind, PatKind::Ident(_, _, None) | PatKind::Path(..))
-            || !self.look_ahead(1, |token| token.is_ident() && !token.is_reserved_ident())
+            || !self.look_ahead(1, |token| token.is_non_reserved_ident())
         {
             let mut snapshot_type = self.create_snapshot_for_diagnostic();
             snapshot_type.bump(); // `:`

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3875,8 +3875,7 @@ impl<'a> Parser<'a> {
             // Check if a colon exists one ahead. This means we're parsing a fieldname.
             let is_shorthand = !this.look_ahead(1, |t| t == &token::Colon || t == &token::Eq);
             // Proactively check whether parsing the field will be incorrect.
-            let is_wrong = this.token.is_ident()
-                && !this.token.is_reserved_ident()
+            let is_wrong = this.token.is_non_reserved_ident()
                 && !this.look_ahead(1, |t| {
                     t == &token::Colon
                         || t == &token::Eq

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -353,6 +353,20 @@ impl<'a> Parser<'a> {
         if !self.eat_keyword(exp!(Where)) {
             return Ok((where_clause, None));
         }
+
+        if self.eat_noexpect(&token::Colon) {
+            let colon_span = self.prev_token.span;
+            self.dcx()
+                .struct_span_err(colon_span, "unexpected colon after `where`")
+                .with_span_suggestion_short(
+                    colon_span,
+                    "remove the colon",
+                    "",
+                    Applicability::MachineApplicable,
+                )
+                .emit();
+        }
+
         where_clause.has_where_token = true;
         let where_lo = self.prev_token.span;
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1552,7 +1552,8 @@ impl<'a> Parser<'a> {
             })
             .map_err(|mut err| {
                 err.span_label(ident.span, "while parsing this enum");
-                if self.token == token::Colon {
+                // Try to recover `enum Foo { ident : Ty }`.
+                if self.prev_token.is_non_reserved_ident() && self.token == token::Colon {
                     let snapshot = self.create_snapshot_for_diagnostic();
                     self.bump();
                     match self.parse_ty() {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -685,7 +685,7 @@ impl<'a> Parser<'a> {
 
     /// Is the given keyword `kw` followed by a non-reserved identifier?
     fn is_kw_followed_by_ident(&self, kw: Symbol) -> bool {
-        self.token.is_keyword(kw) && self.look_ahead(1, |t| t.is_ident() && !t.is_reserved_ident())
+        self.token.is_keyword(kw) && self.look_ahead(1, |t| t.is_non_reserved_ident())
     }
 
     #[inline]

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -126,7 +126,7 @@ impl<'a> Parser<'a> {
     /// ```
     fn recover_colon_before_qpath_proj(&mut self) -> bool {
         if !self.check_noexpect(&TokenKind::Colon)
-            || self.look_ahead(1, |t| !t.is_ident() || t.is_reserved_ident())
+            || self.look_ahead(1, |t| !t.is_non_reserved_ident())
         {
             return false;
         }
@@ -260,7 +260,7 @@ impl<'a> Parser<'a> {
                 if self.may_recover()
                     && style == PathStyle::Expr // (!)
                     && self.token == token::Colon
-                    && self.look_ahead(1, |token| token.is_ident() && !token.is_reserved_ident())
+                    && self.look_ahead(1, |token| token.is_non_reserved_ident())
                 {
                     // Emit a special error message for `a::b:c` to help users
                     // otherwise, `a: c` might have meant to introduce a new binding
@@ -334,9 +334,7 @@ impl<'a> Parser<'a> {
                     self.expect_gt().map_err(|mut err| {
                         // Try to recover a `:` into a `::`
                         if self.token == token::Colon
-                            && self.look_ahead(1, |token| {
-                                token.is_ident() && !token.is_reserved_ident()
-                            })
+                            && self.look_ahead(1, |token| token.is_non_reserved_ident())
                         {
                             err.cancel();
                             err = self.dcx().create_err(PathSingleColon {

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -798,7 +798,7 @@ impl<'a> Parser<'a> {
         }
         if self.prev_token.is_reserved_ident() && self.prev_token.is_ident_named(kw::Await) {
             // Likely `foo.await bar`
-        } else if !self.prev_token.is_reserved_ident() && self.prev_token.is_ident() {
+        } else if self.prev_token.is_non_reserved_ident() {
             // Likely `foo bar`
         } else if self.prev_token.kind == token::Question {
             // `foo? bar`

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -816,9 +816,6 @@ passes_unused_variable_try_prefix = unused variable: `{$name}`
     .suggestion = if this is intentional, prefix it with an underscore
 
 
-passes_used_compiler_linker =
-    `used(compiler)` and `used(linker)` can't be used together
-
 passes_used_static =
     attribute must be applied to a `static` variable
     .label = but this is a {$target}

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -642,13 +642,6 @@ pub(crate) struct UsedStatic {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_used_compiler_linker)]
-pub(crate) struct UsedCompilerLinker {
-    #[primary_span]
-    pub spans: Vec<Span>,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_allow_internal_unstable)]
 pub(crate) struct AllowInternalUnstable {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1866,6 +1866,7 @@ symbols! {
         rustc_never_returns_null_ptr,
         rustc_never_type_options,
         rustc_no_implicit_autorefs,
+        rustc_no_implicit_bounds,
         rustc_no_mir_inline,
         rustc_nonnull_optimization_guaranteed,
         rustc_nounwind,

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -4,6 +4,8 @@
 
 /* eslint-disable */
 declare global {
+    /** Search engine data used by main.js and search.js */
+    declare var searchState: rustdoc.SearchState;
     /** Defined and documented in `storage.js` */
     declare function nonnull(x: T|null, msg: string|undefined);
     /** Defined and documented in `storage.js` */
@@ -17,8 +19,6 @@ declare global {
         RUSTDOC_TOOLTIP_HOVER_MS: number;
         /** Used by the popover tooltip code. */
         RUSTDOC_TOOLTIP_HOVER_EXIT_MS: number;
-        /** Search engine data used by main.js and search.js */
-        searchState: rustdoc.SearchState;
         /** Global option, with a long list of "../"'s */
         rootPath: string|null;
         /**
@@ -102,20 +102,22 @@ declare namespace rustdoc {
         currentTab: number;
         focusedByTab: [number|null, number|null, number|null];
         clearInputTimeout: function;
-        outputElement: function(): HTMLElement|null;
-        focus: function();
-        defocus: function();
-        showResults: function(HTMLElement|null|undefined);
-        removeQueryParameters: function();
-        hideResults: function();
-        getQueryStringParams: function(): Object.<any, string>;
+        outputElement(): HTMLElement|null;
+        focus();
+        defocus();
+        // note: an optional param is not the same as
+        // a nullable/undef-able param.
+        showResults(elem?: HTMLElement|null);
+        removeQueryParameters();
+        hideResults();
+        getQueryStringParams(): Object.<any, string>;
         origPlaceholder: string;
         setup: function();
-        setLoadingSearch: function();
+        setLoadingSearch();
         descShards: Map<string, SearchDescShard[]>;
         loadDesc: function({descShard: SearchDescShard, descIndex: number}): Promise<string|null>;
-        loadedDescShard: function(string, number, string);
-        isDisplayed: function(): boolean,
+        loadedDescShard(string, number, string);
+        isDisplayed(): boolean,
     }
 
     interface SearchDescShard {
@@ -237,7 +239,7 @@ declare namespace rustdoc {
         query: ParsedQuery,
     }
 
-    type Results = Map<String, ResultObject>;
+    type Results = { max_dist?: number } & Map<number, ResultObject>
 
     /**
      * An annotated `Row`, used in the viewmodel.

--- a/src/tools/miri/src/eval.rs
+++ b/src/tools/miri/src/eval.rs
@@ -11,7 +11,7 @@ use rustc_abi::ExternAbi;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::layout::{LayoutCx, LayoutOf};
+use rustc_middle::ty::layout::LayoutCx;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_session::config::EntryFnType;
 

--- a/src/tools/miri/src/intrinsics/simd.rs
+++ b/src/tools/miri/src/intrinsics/simd.rs
@@ -3,7 +3,6 @@ use rand::Rng;
 use rustc_abi::{Endian, HasDataLayout};
 use rustc_apfloat::{Float, Round};
 use rustc_middle::ty::FloatTy;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::{mir, ty};
 use rustc_span::{Symbol, sym};
 

--- a/src/tools/miri/src/shims/backtrace.rs
+++ b/src/tools/miri/src/shims/backtrace.rs
@@ -1,5 +1,4 @@
 use rustc_abi::{CanonAbi, FieldIdx, Size};
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_middle::ty::{self, Instance, Ty};
 use rustc_span::{BytePos, Loc, Symbol, hygiene};
 use rustc_target::callconv::FnAbi;

--- a/src/tools/miri/src/shims/os_str.rs
+++ b/src/tools/miri/src/shims/os_str.rs
@@ -7,7 +7,6 @@ use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf;
 
 use crate::*;
 

--- a/src/tools/miri/src/shims/unix/env.rs
+++ b/src/tools/miri/src/shims/unix/env.rs
@@ -6,7 +6,6 @@ use rustc_abi::{FieldIdx, Size};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::IndexVec;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf;
 
 use crate::*;
 

--- a/src/tools/miri/src/shims/unix/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/foreign_items.rs
@@ -3,7 +3,6 @@ use std::str;
 
 use rustc_abi::{CanonAbi, ExternAbi, Size};
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 

--- a/src/tools/miri/src/shims/windows/thread.rs
+++ b/src/tools/miri/src/shims/windows/thread.rs
@@ -1,5 +1,4 @@
 use rustc_abi::ExternAbi;
-use rustc_middle::ty::layout::LayoutOf;
 
 use self::shims::windows::handle::{EvalContextExt as _, Handle, PseudoHandle};
 use crate::*;

--- a/src/tools/miri/src/shims/x86/aesni.rs
+++ b/src/tools/miri/src/shims/x86/aesni.rs
@@ -1,6 +1,5 @@
 use rustc_abi::CanonAbi;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 

--- a/src/tools/miri/src/shims/x86/avx.rs
+++ b/src/tools/miri/src/shims/x86/avx.rs
@@ -2,7 +2,6 @@ use rustc_abi::CanonAbi;
 use rustc_apfloat::ieee::{Double, Single};
 use rustc_middle::mir;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 

--- a/src/tools/miri/src/shims/x86/avx2.rs
+++ b/src/tools/miri/src/shims/x86/avx2.rs
@@ -1,7 +1,6 @@
 use rustc_abi::CanonAbi;
 use rustc_middle::mir;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 

--- a/src/tools/miri/src/shims/x86/mod.rs
+++ b/src/tools/miri/src/shims/x86/mod.rs
@@ -2,7 +2,6 @@ use rustc_abi::{CanonAbi, FieldIdx, Size};
 use rustc_apfloat::Float;
 use rustc_apfloat::ieee::Single;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_middle::{mir, ty};
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;

--- a/src/tools/miri/src/shims/x86/sse42.rs
+++ b/src/tools/miri/src/shims/x86/sse42.rs
@@ -1,7 +1,6 @@
 use rustc_abi::{CanonAbi, Size};
 use rustc_middle::mir;
 use rustc_middle::ty::Ty;
-use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 

--- a/tests/ui/async-await/issues/issue-95307.rs
+++ b/tests/ui/async-await/issues/issue-95307.rs
@@ -5,7 +5,10 @@
 
 pub trait C {
     async fn new() -> [u8; _];
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
+    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for opaque types
 }
 
 fn main() {}

--- a/tests/ui/async-await/issues/issue-95307.stderr
+++ b/tests/ui/async-await/issues/issue-95307.stderr
@@ -1,9 +1,33 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
   --> $DIR/issue-95307.rs:7:28
    |
 LL |     async fn new() -> [u8; _];
    |                            ^ not allowed in type signatures
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/issue-95307.rs:7:28
+   |
+LL |     async fn new() -> [u8; _];
+   |                            ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/attributes/used_with_arg.rs
+++ b/tests/ui/attributes/used_with_arg.rs
@@ -1,3 +1,4 @@
+#![deny(unused_attributes)]
 #![feature(used_with_arg)]
 
 #[used(linker)]
@@ -6,14 +7,22 @@ static mut USED_LINKER: [usize; 1] = [0];
 #[used(compiler)]
 static mut USED_COMPILER: [usize; 1] = [0];
 
-#[used(compiler)] //~ ERROR `used(compiler)` and `used(linker)` can't be used together
+#[used(compiler)]
 #[used(linker)]
 static mut USED_COMPILER_LINKER2: [usize; 1] = [0];
 
-#[used(compiler)] //~ ERROR `used(compiler)` and `used(linker)` can't be used together
-#[used(linker)]
 #[used(compiler)]
 #[used(linker)]
+#[used(compiler)] //~ ERROR unused attribute
+#[used(linker)] //~ ERROR unused attribute
 static mut USED_COMPILER_LINKER3: [usize; 1] = [0];
+
+#[used(compiler)]
+#[used]
+static mut USED_WITHOUT_ATTR1: [usize; 1] = [0];
+
+#[used(linker)]
+#[used] //~ ERROR unused attribute
+static mut USED_WITHOUT_ATTR2: [usize; 1] = [0];
 
 fn main() {}

--- a/tests/ui/attributes/used_with_arg.stderr
+++ b/tests/ui/attributes/used_with_arg.stderr
@@ -1,18 +1,43 @@
-error: `used(compiler)` and `used(linker)` can't be used together
-  --> $DIR/used_with_arg.rs:9:1
+error: unused attribute
+  --> $DIR/used_with_arg.rs:16:1
+   |
+LL | #[used(compiler)]
+   | ^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/used_with_arg.rs:14:1
    |
 LL | #[used(compiler)]
    | ^^^^^^^^^^^^^^^^^
-LL | #[used(linker)]
-   | ^^^^^^^^^^^^^^^
-
-error: `used(compiler)` and `used(linker)` can't be used together
-  --> $DIR/used_with_arg.rs:13:1
+note: the lint level is defined here
+  --> $DIR/used_with_arg.rs:1:9
    |
-LL | #[used(compiler)]
-   | ^^^^^^^^^^^^^^^^^
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/used_with_arg.rs:17:1
+   |
+LL | #[used(linker)]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/used_with_arg.rs:15:1
+   |
 LL | #[used(linker)]
    | ^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unused attribute
+  --> $DIR/used_with_arg.rs:25:1
+   |
+LL | #[used]
+   | ^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/used_with_arg.rs:24:1
+   |
+LL | #[used(linker)]
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/used_with_multi_args.rs
+++ b/tests/ui/attributes/used_with_multi_args.rs
@@ -1,6 +1,6 @@
 #![feature(used_with_arg)]
 
-#[used(compiler, linker)] //~ ERROR expected `used`, `used(compiler)` or `used(linker)`
+#[used(compiler, linker)] //~ ERROR malformed `used` attribute input
 static mut USED_COMPILER_LINKER: [usize; 1] = [0];
 
 fn main() {}

--- a/tests/ui/attributes/used_with_multi_args.stderr
+++ b/tests/ui/attributes/used_with_multi_args.stderr
@@ -1,8 +1,20 @@
-error: expected `used`, `used(compiler)` or `used(linker)`
+error[E0805]: malformed `used` attribute input
   --> $DIR/used_with_multi_args.rs:3:1
    |
 LL | #[used(compiler, linker)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^------------------^
+   |       |
+   |       expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[used(compiler, linker)]
+LL + #[used(compiler|linker)]
+   |
+LL - #[used(compiler, linker)]
+LL + #[used]
+   |
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0805`.

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.rs
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.rs
@@ -41,6 +41,7 @@ trait TyAssocConst {
 trait TyAssocConstMixed {
     const ARR: Bar<_, _>;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated constants
 }
 
 trait AssocTy {
@@ -57,4 +58,5 @@ impl AssocTy for i16 {
 impl AssocTy for i32 {
     type Assoc = Bar<_, _>;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -103,24 +103,28 @@ LL + static TY_STATIC_MIXED: Bar<i32, 3> = Bar::<i32, 3>(0);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:50:23
+  --> $DIR/in-signature.rs:51:23
    |
 LL |     type Assoc = [u8; _];
    |                       ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:54:27
+  --> $DIR/in-signature.rs:55:27
    |
 LL |     type Assoc = Bar<i32, _>;
    |                           ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/in-signature.rs:58:22
+  --> $DIR/in-signature.rs:59:22
    |
 LL |     type Assoc = Bar<_, _>;
-   |                      ^  ^ not allowed in type signatures
-   |                      |
-   |                      not allowed in type signatures
+   |                      ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/in-signature.rs:59:25
+   |
+LL |     type Assoc = Bar<_, _>;
+   |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/in-signature.rs:34:21
@@ -138,10 +142,14 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/in-signature.rs:42:20
    |
 LL |     const ARR: Bar<_, _>;
-   |                    ^  ^ not allowed in type signatures
-   |                    |
-   |                    not allowed in type signatures
+   |                    ^ not allowed in type signatures
 
-error: aborting due to 15 previous errors
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/in-signature.rs:42:23
+   |
+LL |     const ARR: Bar<_, _>;
+   |                       ^ not allowed in type signatures
+
+error: aborting due to 17 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/consts/recursive-static-write.rs
+++ b/tests/ui/consts/recursive-static-write.rs
@@ -1,0 +1,24 @@
+//! Ensure that writing to `S` while initializing `S` errors.
+//! Regression test for <https://github.com/rust-lang/rust/issues/142404>.
+#![allow(dead_code)]
+
+struct Foo {
+    x: i32,
+    y: (),
+}
+
+static S: Foo = Foo {
+    x: 0,
+    y: unsafe {
+        (&raw const S.x).cast_mut().write(1); //~ERROR access itself during initialization
+    },
+};
+
+static mut S2: Foo = Foo {
+    x: 0,
+    y: unsafe {
+        S2.x = 1; //~ERROR access itself during initialization
+    },
+};
+
+fn main() {}

--- a/tests/ui/consts/recursive-static-write.stderr
+++ b/tests/ui/consts/recursive-static-write.stderr
@@ -1,0 +1,15 @@
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/recursive-static-write.rs:13:9
+   |
+LL |         (&raw const S.x).cast_mut().write(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S` failed here
+
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/recursive-static-write.rs:20:9
+   |
+LL |         S2.x = 1;
+   |         ^^^^^^^^ evaluation of `S2` failed here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/recursive-zst-static.default.stderr
+++ b/tests/ui/consts/recursive-zst-static.default.stderr
@@ -1,20 +1,20 @@
-error[E0080]: encountered static that tried to initialize itself with itself
+error[E0080]: encountered static that tried to access itself during initialization
   --> $DIR/recursive-zst-static.rs:10:18
    |
 LL | static FOO: () = FOO;
    |                  ^^^ evaluation of `FOO` failed here
 
 error[E0391]: cycle detected when evaluating initializer of static `A`
-  --> $DIR/recursive-zst-static.rs:13:16
+  --> $DIR/recursive-zst-static.rs:13:1
    |
 LL | static A: () = B;
-   |                ^
+   | ^^^^^^^^^^^^
    |
 note: ...which requires evaluating initializer of static `B`...
-  --> $DIR/recursive-zst-static.rs:14:16
+  --> $DIR/recursive-zst-static.rs:14:1
    |
 LL | static B: () = A;
-   |                ^
+   | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information

--- a/tests/ui/consts/recursive-zst-static.rs
+++ b/tests/ui/consts/recursive-zst-static.rs
@@ -8,7 +8,7 @@
 // See https://github.com/rust-lang/rust/issues/71078 for more details.
 
 static FOO: () = FOO;
-//~^ ERROR encountered static that tried to initialize itself with itself
+//~^ ERROR encountered static that tried to access itself during initialization
 
 static A: () = B; //~ ERROR cycle detected when evaluating initializer of static `A`
 static B: () = A;

--- a/tests/ui/consts/recursive-zst-static.unleash.stderr
+++ b/tests/ui/consts/recursive-zst-static.unleash.stderr
@@ -1,20 +1,20 @@
-error[E0080]: encountered static that tried to initialize itself with itself
+error[E0080]: encountered static that tried to access itself during initialization
   --> $DIR/recursive-zst-static.rs:10:18
    |
 LL | static FOO: () = FOO;
    |                  ^^^ evaluation of `FOO` failed here
 
 error[E0391]: cycle detected when evaluating initializer of static `A`
-  --> $DIR/recursive-zst-static.rs:13:16
+  --> $DIR/recursive-zst-static.rs:13:1
    |
 LL | static A: () = B;
-   |                ^
+   | ^^^^^^^^^^^^
    |
 note: ...which requires evaluating initializer of static `B`...
-  --> $DIR/recursive-zst-static.rs:14:16
+  --> $DIR/recursive-zst-static.rs:14:1
    |
 LL | static B: () = A;
-   |                ^
+   | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information

--- a/tests/ui/consts/write-to-static-mut-in-static.rs
+++ b/tests/ui/consts/write-to-static-mut-in-static.rs
@@ -3,8 +3,9 @@ pub static mut B: () = unsafe { A = 1; };
 //~^ ERROR modifying a static's initial value
 
 pub static mut C: u32 = unsafe { C = 1; 0 };
+//~^ ERROR static that tried to access itself during initialization
 
 pub static D: u32 = D;
-//~^ ERROR static that tried to initialize itself with itself
+//~^ ERROR static that tried to access itself during initialization
 
 fn main() {}

--- a/tests/ui/consts/write-to-static-mut-in-static.stderr
+++ b/tests/ui/consts/write-to-static-mut-in-static.stderr
@@ -4,12 +4,18 @@ error[E0080]: modifying a static's initial value from another static's initializ
 LL | pub static mut B: () = unsafe { A = 1; };
    |                                 ^^^^^ evaluation of `B` failed here
 
-error[E0080]: encountered static that tried to initialize itself with itself
-  --> $DIR/write-to-static-mut-in-static.rs:7:21
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/write-to-static-mut-in-static.rs:5:34
+   |
+LL | pub static mut C: u32 = unsafe { C = 1; 0 };
+   |                                  ^^^^^ evaluation of `C` failed here
+
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/write-to-static-mut-in-static.rs:8:21
    |
 LL | pub static D: u32 = D;
    |                     ^ evaluation of `D` failed here
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -240,96 +240,52 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/bad-assoc-ty.rs:56:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:59:34
+  --> $DIR/bad-assoc-ty.rs:56:16
+   |
+LL | fn foo<X: K<_, _>>(x: X) {}
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:60:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn bar<F>(_: F) where F: Fn() -> _ {}
-LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:62:19
+  --> $DIR/bad-assoc-ty.rs:63:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn baz<F: Fn() -> _>(_: F) {}
-LL + fn baz<F: Fn() -> T, T>(_: F) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:65:33
+  --> $DIR/bad-assoc-ty.rs:66:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct L<F>(F) where F: Fn() -> _;
-LL + struct L<F, T>(F) where F: Fn() -> T;
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:87:38
-   |
-LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
-   |                                      ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn foo<F>(_: F) where F: Fn() -> _ {}
-LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:67:30
+  --> $DIR/bad-assoc-ty.rs:68:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct M<F> where F: Fn() -> _ {
-LL + struct M<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:71:28
+  --> $DIR/bad-assoc-ty.rs:72:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - enum N<F> where F: Fn() -> _ {
-LL + enum N<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - union O<F> where F: Fn() -> _ {
-LL + union O<F, T> where F: Fn() -> T {
-   |
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/bad-assoc-ty.rs:78:5
+  --> $DIR/bad-assoc-ty.rs:79:5
    |
 LL |     foo: F,
    |     ^^^^^^
@@ -341,18 +297,18 @@ LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:82:29
+  --> $DIR/bad-assoc-ty.rs:83:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - trait P<F> where F: Fn() -> _ {
-LL + trait P<F, T> where F: Fn() -> T {
-   |
 
-error: aborting due to 29 previous errors; 1 warning emitted
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:88:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+
+error: aborting due to 30 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0121, E0223, E0740.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
@@ -222,96 +222,52 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/bad-assoc-ty.rs:56:13
    |
 LL | fn foo<X: K<_, _>>(x: X) {}
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:59:34
+  --> $DIR/bad-assoc-ty.rs:56:16
+   |
+LL | fn foo<X: K<_, _>>(x: X) {}
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:60:34
    |
 LL | fn bar<F>(_: F) where F: Fn() -> _ {}
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn bar<F>(_: F) where F: Fn() -> _ {}
-LL + fn bar<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:62:19
+  --> $DIR/bad-assoc-ty.rs:63:19
    |
 LL | fn baz<F: Fn() -> _>(_: F) {}
    |                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn baz<F: Fn() -> _>(_: F) {}
-LL + fn baz<F: Fn() -> T, T>(_: F) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:65:33
+  --> $DIR/bad-assoc-ty.rs:66:33
    |
 LL | struct L<F>(F) where F: Fn() -> _;
    |                                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct L<F>(F) where F: Fn() -> _;
-LL + struct L<F, T>(F) where F: Fn() -> T;
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:87:38
-   |
-LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
-   |                                      ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn foo<F>(_: F) where F: Fn() -> _ {}
-LL +     fn foo<F, T>(_: F) where F: Fn() -> T {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/bad-assoc-ty.rs:67:30
+  --> $DIR/bad-assoc-ty.rs:68:30
    |
 LL | struct M<F> where F: Fn() -> _ {
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct M<F> where F: Fn() -> _ {
-LL + struct M<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for enums
-  --> $DIR/bad-assoc-ty.rs:71:28
+  --> $DIR/bad-assoc-ty.rs:72:28
    |
 LL | enum N<F> where F: Fn() -> _ {
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - enum N<F> where F: Fn() -> _ {
-LL + enum N<F, T> where F: Fn() -> T {
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for unions
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | union O<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - union O<F> where F: Fn() -> _ {
-LL + union O<F, T> where F: Fn() -> T {
-   |
 
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
-  --> $DIR/bad-assoc-ty.rs:78:5
+  --> $DIR/bad-assoc-ty.rs:79:5
    |
 LL |     foo: F,
    |     ^^^^^^
@@ -323,18 +279,18 @@ LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:82:29
+  --> $DIR/bad-assoc-ty.rs:83:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - trait P<F> where F: Fn() -> _ {
-LL + trait P<F, T> where F: Fn() -> T {
-   |
 
-error: aborting due to 29 previous errors
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:88:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+
+error: aborting due to 30 previous errors
 
 Some errors have detailed explanations: E0121, E0223, E0740, E0782.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -55,6 +55,7 @@ type I = ty!()::AssocTy;
 trait K<A, B> {}
 fn foo<X: K<_, _>>(x: X) {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 fn bar<F>(_: F) where F: Fn() -> _ {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions

--- a/tests/ui/fn/error-recovery-mismatch.stderr
+++ b/tests/ui/fn/error-recovery-mismatch.stderr
@@ -34,12 +34,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn fold<T>(&self, _: T, &self._) {}
    |                                   ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fold<T>(&self, _: T, &self._) {}
-LL +     fn fold<T, U>(&self, _: T, &self.U) {}
-   |
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
+++ b/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
@@ -30,12 +30,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn mainIterator<_ = _> {}
    |                     ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn mainIterator<_ = _> {}
-LL + fn mainIterator<T = T> {}
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
+++ b/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
@@ -5,7 +5,7 @@ LL |     ().publish_typed();
    |        ^^^^^^^^^^^^^ cannot infer type of the type parameter `F` declared on the method `publish_typed`
    |
    = note: cannot satisfy `_: Clone`
-   = note: associated types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
+   = note: opaque types cannot be accessed directly on a `trait`, they can only be accessed through a specific `impl`
 note: required by a bound in `TypedClient::publish_typed::{anon_assoc#0}`
   --> $DIR/not-inferred-generic.rs:4:12
    |

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -90,18 +90,6 @@ LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:102:1
-   |
-LL | #[used]
-   | ^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:101:1
-   |
-LL | #[used]
-   | ^^^^^^^
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:86:5
    |
 LL |     #[link_name = "this_does_not_exist"]
@@ -288,6 +276,18 @@ note: attribute also specified here
    |
 LL | #[no_mangle]
    | ^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:102:1
+   |
+LL | #[used]
+   | ^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:101:1
+   |
+LL | #[used]
+   | ^^^^^^^
 
 error: aborting due to 23 previous errors
 

--- a/tests/ui/macros/issue-118048.rs
+++ b/tests/ui/macros/issue-118048.rs
@@ -6,5 +6,6 @@ macro_rules! foo {
 
 foo!(_);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 fn main() {}

--- a/tests/ui/macros/issue-118048.stderr
+++ b/tests/ui/macros/issue-118048.stderr
@@ -2,20 +2,16 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-118048.rs:7:6
    |
 LL | foo!(_);
-   |      ^
-   |      |
-   |      not allowed in type signatures
-   |      not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~         fn foo<T>(_: $ty, _: $ty) {}
-LL |     }
-LL | }
-LL |
-LL ~ foo!(T);
-   |
+   |      ^ not allowed in type signatures
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/issue-118048.rs:7:6
+   |
+LL | foo!(_);
+   |      ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/macros/macro-span-issue-116502.rs
+++ b/tests/ui/macros/macro-span-issue-116502.rs
@@ -5,6 +5,8 @@ fn bug() {
     macro_rules! m {
         () => {
             _ //~ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+            //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+            //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
         };
     }
     struct S<T = m!()>(m!(), T)

--- a/tests/ui/macros/macro-span-issue-116502.stderr
+++ b/tests/ui/macros/macro-span-issue-116502.stderr
@@ -2,22 +2,35 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/macro-span-issue-116502.rs:7:13
    |
 LL |             _
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             not allowed in type signatures
-   |             not allowed in type signatures
+   |             ^ not allowed in type signatures
 ...
-LL |     struct S<T = m!()>(m!(), T)
-   |                  ----  ---- in this macro invocation
-   |                  |
-   |                  in this macro invocation
-LL |     where
 LL |         T: Trait<m!()>;
    |                  ---- in this macro invocation
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
+   |                        ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/macro-span-issue-116502.rs:7:13
+   |
+LL |             _
+   |             ^ not allowed in type signatures
+...
+LL |     struct S<T = m!()>(m!(), T)
+   |                  ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/recursion/recursive-static-definition.rs
+++ b/tests/ui/recursion/recursive-static-definition.rs
@@ -1,5 +1,5 @@
 pub static FOO: u32 = FOO;
-//~^ ERROR encountered static that tried to initialize itself with itself
+//~^ ERROR encountered static that tried to access itself during initialization
 
 #[derive(Copy, Clone)]
 pub union Foo {
@@ -7,6 +7,6 @@ pub union Foo {
 }
 
 pub static BAR: Foo = BAR;
-//~^ ERROR encountered static that tried to initialize itself with itself
+//~^ ERROR encountered static that tried to access itself during initialization
 
 fn main() {}

--- a/tests/ui/recursion/recursive-static-definition.stderr
+++ b/tests/ui/recursion/recursive-static-definition.stderr
@@ -1,10 +1,10 @@
-error[E0080]: encountered static that tried to initialize itself with itself
+error[E0080]: encountered static that tried to access itself during initialization
   --> $DIR/recursive-static-definition.rs:1:23
    |
 LL | pub static FOO: u32 = FOO;
    |                       ^^^ evaluation of `FOO` failed here
 
-error[E0080]: encountered static that tried to initialize itself with itself
+error[E0080]: encountered static that tried to access itself during initialization
   --> $DIR/recursive-static-definition.rs:9:23
    |
 LL | pub static BAR: Foo = BAR;

--- a/tests/ui/self/self-infer.stderr
+++ b/tests/ui/self/self-infer.stderr
@@ -3,24 +3,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn f(self: _) {}
    |                ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn f(self: _) {}
-LL +     fn f<T>(self: T) {}
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/self-infer.rs:5:17
    |
 LL |     fn g(self: &_) {}
    |                 ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn g(self: &_) {}
-LL +     fn g<T>(self: &T) {}
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/statics/read_before_init.rs
+++ b/tests/ui/statics/read_before_init.rs
@@ -8,13 +8,15 @@
 
 use std::mem::MaybeUninit;
 
-pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0));
-//~^ ERROR: encountered static that tried to initialize itself with itself
+pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0, 1));
+//~^ ERROR: encountered static that tried to access itself during initialization
+pub static Y: (i32, MaybeUninit<i32>) = (1, foo(&Y.0, 0));
+//~^ ERROR: encountered static that tried to access itself during initialization
 
-const fn foo(x: &i32) -> MaybeUninit<i32> {
+const fn foo(x: &i32, num: usize) -> MaybeUninit<i32> {
     let mut temp = MaybeUninit::<i32>::uninit();
     unsafe {
-        std::ptr::copy(x, temp.as_mut_ptr(), 1);
+        std::ptr::copy(x, temp.as_mut_ptr(), num);
     }
     temp
 }

--- a/tests/ui/statics/read_before_init.stderr
+++ b/tests/ui/statics/read_before_init.stderr
@@ -1,17 +1,31 @@
-error[E0080]: encountered static that tried to initialize itself with itself
+error[E0080]: encountered static that tried to access itself during initialization
   --> $DIR/read_before_init.rs:11:45
    |
-LL | pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0));
-   |                                             ^^^^^^^^^ evaluation of `X` failed inside this call
+LL | pub static X: (i32, MaybeUninit<i32>) = (1, foo(&X.0, 1));
+   |                                             ^^^^^^^^^^^^ evaluation of `X` failed inside this call
    |
 note: inside `foo`
-  --> $DIR/read_before_init.rs:17:9
+  --> $DIR/read_before_init.rs:19:9
    |
-LL |         std::ptr::copy(x, temp.as_mut_ptr(), 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         std::ptr::copy(x, temp.as_mut_ptr(), num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: inside `std::ptr::copy::<i32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
-error: aborting due to 1 previous error
+error[E0080]: encountered static that tried to access itself during initialization
+  --> $DIR/read_before_init.rs:13:45
+   |
+LL | pub static Y: (i32, MaybeUninit<i32>) = (1, foo(&Y.0, 0));
+   |                                             ^^^^^^^^^^^^ evaluation of `Y` failed inside this call
+   |
+note: inside `foo`
+  --> $DIR/read_before_init.rs:19:9
+   |
+LL |         std::ptr::copy(x, temp.as_mut_ptr(), num);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: inside `std::ptr::copy::<i32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/structs-enums/recover-enum-with-bad-where.rs
+++ b/tests/ui/structs-enums/recover-enum-with-bad-where.rs
@@ -1,6 +1,8 @@
 pub enum Foo<T>
 where:
-//~^ ERROR expected one of `#`, `{`, lifetime, or type, found `:`
+//~^ ERROR unexpected colon after `where`
     T: Missing, {}
+//~^ ERROR cannot find trait `Missing` in this scope
+// (evidence that we continue parsing after the erroneous colon)
 
 fn main() {}

--- a/tests/ui/structs-enums/recover-enum-with-bad-where.rs
+++ b/tests/ui/structs-enums/recover-enum-with-bad-where.rs
@@ -1,0 +1,6 @@
+pub enum Foo<T>
+where:
+//~^ ERROR expected one of `#`, `{`, lifetime, or type, found `:`
+    T: Missing, {}
+
+fn main() {}

--- a/tests/ui/structs-enums/recover-enum-with-bad-where.stderr
+++ b/tests/ui/structs-enums/recover-enum-with-bad-where.stderr
@@ -1,0 +1,10 @@
+error: expected one of `#`, `{`, lifetime, or type, found `:`
+  --> $DIR/recover-enum-with-bad-where.rs:2:6
+   |
+LL | pub enum Foo<T>
+   |          --- while parsing this enum
+LL | where:
+   |      ^ expected one of `#`, `{`, lifetime, or type
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/structs-enums/recover-enum-with-bad-where.stderr
+++ b/tests/ui/structs-enums/recover-enum-with-bad-where.stderr
@@ -1,10 +1,15 @@
-error: expected one of `#`, `{`, lifetime, or type, found `:`
+error: unexpected colon after `where`
   --> $DIR/recover-enum-with-bad-where.rs:2:6
    |
-LL | pub enum Foo<T>
-   |          --- while parsing this enum
 LL | where:
-   |      ^ expected one of `#`, `{`, lifetime, or type
+   |      ^ help: remove the colon
 
-error: aborting due to 1 previous error
+error[E0405]: cannot find trait `Missing` in this scope
+  --> $DIR/recover-enum-with-bad-where.rs:4:8
+   |
+LL |     T: Missing, {}
+   |        ^^^^^^^ not found in this scope
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0405`.

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -3,12 +3,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     fn bar(s: _) {}
    |               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn bar(s: _) {}
-LL +     fn bar<T>(s: T) {}
-   |
 
 error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 0
   --> $DIR/bad-infer-in-trait-impl.rs:6:15

--- a/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.rs
+++ b/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.rs
@@ -1,15 +1,17 @@
 //@ compile-flags: -Znext-solver=coherence
 
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 #![recursion_limit = "10"]
 
 trait Trait {}
 
-struct W<T: ?Sized>(*const T);
+struct W<T>(*const T);
 trait TwoW {}
-impl<T: ?Sized + TwoW> TwoW for W<W<T>> {}
+impl<T: TwoW> TwoW for W<W<T>> {}
 
-impl<T: ?Sized + TwoW> Trait for W<T> {}
-impl<T: ?Sized + TwoW> Trait for T {}
+impl<T: TwoW> Trait for W<T> {}
+impl<T: TwoW> Trait for T {}
 //~^ ERROR conflicting implementations of trait `Trait` for type `W
 
 fn main() {}

--- a/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence/coherence-fulfill-overflow.stderr
@@ -1,10 +1,10 @@
 error[E0119]: conflicting implementations of trait `Trait` for type `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>>`
-  --> $DIR/coherence-fulfill-overflow.rs:12:1
+  --> $DIR/coherence-fulfill-overflow.rs:14:1
    |
-LL | impl<T: ?Sized + TwoW> Trait for W<T> {}
-   | ------------------------------------- first implementation here
-LL | impl<T: ?Sized + TwoW> Trait for T {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>>`
+LL | impl<T: TwoW> Trait for W<T> {}
+   | ---------------------------- first implementation here
+LL | impl<T: TwoW> Trait for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.rs
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.rs
@@ -1,6 +1,7 @@
 //@ revisions: with without
 //@ compile-flags: -Znext-solver
 #![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // This test is incredibly subtle. At its core the goal is to get a coinductive cycle,
 // which, depending on its root goal, either holds or errors. We achieve this by getting
@@ -17,20 +18,20 @@
 // test for that.
 
 #[rustc_coinductive]
-trait Trait<T: ?Sized, V: ?Sized, D: ?Sized> {}
-struct A<T: ?Sized>(*const T);
-struct B<T: ?Sized>(*const T);
+trait Trait<T, V, D> {}
+struct A<T>(*const T);
+struct B<T>(*const T);
 
-trait IncompleteGuidance<T: ?Sized, V: ?Sized> {}
-impl<T: ?Sized, U: ?Sized + 'static> IncompleteGuidance<U, u8> for T {}
-impl<T: ?Sized, U: ?Sized + 'static> IncompleteGuidance<U, i8> for T {}
-impl<T: ?Sized, U: ?Sized + 'static> IncompleteGuidance<U, i16> for T {}
+trait IncompleteGuidance<T, V> {}
+impl<T, U: 'static> IncompleteGuidance<U, u8> for T {}
+impl<T, U: 'static> IncompleteGuidance<U, i8> for T {}
+impl<T, U: 'static> IncompleteGuidance<U, i16> for T {}
 
-trait ImplGuidance<T: ?Sized, V: ?Sized> {}
-impl<T: ?Sized> ImplGuidance<u32, u8> for T {}
-impl<T: ?Sized> ImplGuidance<i32, i8> for T {}
+trait ImplGuidance<T, V> {}
+impl<T> ImplGuidance<u32, u8> for T {}
+impl<T> ImplGuidance<i32, i8> for T {}
 
-impl<T: ?Sized, U: ?Sized, V: ?Sized, D: ?Sized> Trait<U, V, D> for A<T>
+impl<T, U, V, D> Trait<U, V, D> for A<T>
 where
     T: IncompleteGuidance<U, V>,
     A<T>: Trait<U, D, V>,
@@ -39,17 +40,17 @@ where
 {
 }
 
-trait ToU8<T: ?Sized> {}
+trait ToU8<T> {}
 impl ToU8<u8> for () {}
 
-impl<T: ?Sized, U: ?Sized, V: ?Sized, D: ?Sized> Trait<U, V, D> for B<T>
+impl<T, U, V, D> Trait<U, V, D> for B<T>
 where
     T: ImplGuidance<U, V>,
     A<T>: Trait<U, V, D>,
 {
 }
 
-fn impls_trait<T: ?Sized + Trait<U, V, D>, U: ?Sized, V: ?Sized, D: ?Sized>() {}
+fn impls_trait<T: Trait<U, V, D>, U, V, D>() {}
 
 fn with_bound<X>()
 where

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.with.stderr
@@ -1,25 +1,25 @@
 error[E0277]: the trait bound `A<X>: Trait<_, _, _>` is not satisfied
-  --> $DIR/incompleteness-unstable-result.rs:65:19
+  --> $DIR/incompleteness-unstable-result.rs:66:19
    |
 LL |     impls_trait::<A<X>, _, _, _>();
    |                   ^^^^ the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
    = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
 note: required for `A<X>` to implement `Trait<_, _, _>`
-  --> $DIR/incompleteness-unstable-result.rs:33:50
+  --> $DIR/incompleteness-unstable-result.rs:34:18
    |
-LL | impl<T: ?Sized, U: ?Sized, V: ?Sized, D: ?Sized> Trait<U, V, D> for A<T>
-   |                                                  ^^^^^^^^^^^^^^     ^^^^
+LL | impl<T, U, V, D> Trait<U, V, D> for A<T>
+   |                  ^^^^^^^^^^^^^^     ^^^^
 ...
 LL |     A<T>: Trait<U, D, V>,
    |           -------------- unsatisfied trait bound introduced here
    = note: 8 redundant requirements hidden
    = note: required for `A<X>` to implement `Trait<_, _, _>`
 note: required by a bound in `impls_trait`
-  --> $DIR/incompleteness-unstable-result.rs:52:28
+  --> $DIR/incompleteness-unstable-result.rs:53:19
    |
-LL | fn impls_trait<T: ?Sized + Trait<U, V, D>, U: ?Sized, V: ?Sized, D: ?Sized>() {}
-   |                            ^^^^^^^^^^^^^^ required by this bound in `impls_trait`
+LL | fn impls_trait<T: Trait<U, V, D>, U, V, D>() {}
+   |                   ^^^^^^^^^^^^^^ required by this bound in `impls_trait`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
+++ b/tests/ui/traits/next-solver/cycles/coinduction/incompleteness-unstable-result.without.stderr
@@ -1,25 +1,25 @@
 error[E0277]: the trait bound `A<X>: Trait<_, _, _>` is not satisfied
-  --> $DIR/incompleteness-unstable-result.rs:65:19
+  --> $DIR/incompleteness-unstable-result.rs:66:19
    |
 LL |     impls_trait::<A<X>, _, _, _>();
    |                   ^^^^ the trait `Trait<_, _, _>` is not implemented for `A<X>`
    |
    = help: the trait `Trait<U, V, D>` is implemented for `A<T>`
 note: required for `A<X>` to implement `Trait<_, _, _>`
-  --> $DIR/incompleteness-unstable-result.rs:33:50
+  --> $DIR/incompleteness-unstable-result.rs:34:18
    |
-LL | impl<T: ?Sized, U: ?Sized, V: ?Sized, D: ?Sized> Trait<U, V, D> for A<T>
-   |                                                  ^^^^^^^^^^^^^^     ^^^^
+LL | impl<T, U, V, D> Trait<U, V, D> for A<T>
+   |                  ^^^^^^^^^^^^^^     ^^^^
 ...
 LL |     A<T>: Trait<U, D, V>,
    |           -------------- unsatisfied trait bound introduced here
    = note: 8 redundant requirements hidden
    = note: required for `A<X>` to implement `Trait<_, _, _>`
 note: required by a bound in `impls_trait`
-  --> $DIR/incompleteness-unstable-result.rs:52:28
+  --> $DIR/incompleteness-unstable-result.rs:53:19
    |
-LL | fn impls_trait<T: ?Sized + Trait<U, V, D>, U: ?Sized, V: ?Sized, D: ?Sized>() {}
-   |                            ^^^^^^^^^^^^^^ required by this bound in `impls_trait`
+LL | fn impls_trait<T: Trait<U, V, D>, U, V, D>() {}
+   |                   ^^^^^^^^^^^^^^ required by this bound in `impls_trait`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/cycles/fixpoint-rerun-all-cycle-heads.rs
+++ b/tests/ui/traits/next-solver/cycles/fixpoint-rerun-all-cycle-heads.rs
@@ -1,23 +1,24 @@
 //@ compile-flags: -Znext-solver
 #![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // Check that we correctly rerun the trait solver for heads of cycles,
 // even if they are not the root.
 
-struct A<T: ?Sized>(*const T);
-struct B<T: ?Sized>(*const T);
-struct C<T: ?Sized>(*const T);
+struct A<T>(*const T);
+struct B<T>(*const T);
+struct C<T>(*const T);
 
 #[rustc_coinductive]
 trait Trait<'a, 'b> {}
 trait NotImplemented {}
 
-impl<'a, 'b, T: ?Sized> Trait<'a, 'b> for A<T> where B<T>: Trait<'a, 'b> {}
+impl<'a, 'b, T> Trait<'a, 'b> for A<T> where B<T>: Trait<'a, 'b> {}
 
 // With this the root of `B<T>` is `A<T>`, even if the other impl does
 // not have a cycle with `A<T>`. This candidate never applies because of
 // the `A<T>: NotImplemented` bound.
-impl<'a, 'b, T: ?Sized> Trait<'a, 'b> for B<T>
+impl<'a, 'b, T> Trait<'a, 'b> for B<T>
 where
     A<T>: Trait<'a, 'b>,
     A<T>: NotImplemented,
@@ -31,7 +32,7 @@ where
 // use the impl itself to prove that adds region constraints as we uniquified the
 // regions in the `A<T>: Trait<'a, 'b>` where-bound. As both the impl above
 // and the impl below now apply with some constraints, we failed with ambiguity.
-impl<'a, 'b, T: ?Sized> Trait<'a, 'b> for B<T>
+impl<'a, 'b, T> Trait<'a, 'b> for B<T>
 where
     A<T>: NotImplemented,
 {}
@@ -40,7 +41,7 @@ where
 //
 // Because of the coinductive cycle through `C<T>` it also requires
 // 'a to be 'static.
-impl<'a, T: ?Sized> Trait<'a, 'static> for B<T>
+impl<'a, T> Trait<'a, 'static> for B<T>
 where
     C<T>: Trait<'a, 'a>,
 {}
@@ -48,14 +49,14 @@ where
 // In the first iteration of `B<T>: Trait<'a, 'b>` we don't add any
 // constraints here, only after setting the provisional result to require
 // `'b == 'static` do we also add that constraint for `'a`.
-impl<'a, 'b, T: ?Sized> Trait<'a, 'b> for C<T>
+impl<'a, 'b, T> Trait<'a, 'b> for C<T>
 where
     B<T>: Trait<'a, 'b>,
 {}
 
-fn impls_trait<'a, 'b, T: Trait<'a, 'b> + ?Sized>() {}
+fn impls_trait<'a, 'b, T: Trait<'a, 'b>>() {}
 
-fn check<'a, T: ?Sized>() {
+fn check<'a, T>() {
     impls_trait::<'a, 'static, A<T>>();
     //~^ ERROR lifetime may not live long enough
 }

--- a/tests/ui/traits/next-solver/cycles/fixpoint-rerun-all-cycle-heads.stderr
+++ b/tests/ui/traits/next-solver/cycles/fixpoint-rerun-all-cycle-heads.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-  --> $DIR/fixpoint-rerun-all-cycle-heads.rs:59:5
+  --> $DIR/fixpoint-rerun-all-cycle-heads.rs:60:5
    |
-LL | fn check<'a, T: ?Sized>() {
+LL | fn check<'a, T>() {
    |          -- lifetime `'a` defined here
 LL |     impls_trait::<'a, 'static, A<T>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`

--- a/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.rs
+++ b/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.rs
@@ -1,4 +1,6 @@
 //@ compile-flags: -Znext-solver
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // This currently hangs if we do not erase constraints from
 // overflow.
@@ -17,9 +19,9 @@
 // the solver to hang without hitting the recursion limit.
 trait Trait {}
 
-struct W<T: ?Sized>(*const T);
+struct W<T>(*const T);
 
-impl<T: ?Sized> Trait for W<W<T>>
+impl<T> Trait for W<W<T>>
 where
     W<T>: Trait,
     W<T>: Trait,

--- a/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
+++ b/tests/ui/traits/next-solver/cycles/inductive-fixpoint-hang.stderr
@@ -1,11 +1,11 @@
 error[E0275]: overflow evaluating the requirement `W<_>: Trait`
-  --> $DIR/inductive-fixpoint-hang.rs:31:19
+  --> $DIR/inductive-fixpoint-hang.rs:33:19
    |
 LL |     impls_trait::<W<_>>();
    |                   ^^^^
    |
 note: required by a bound in `impls_trait`
-  --> $DIR/inductive-fixpoint-hang.rs:28:19
+  --> $DIR/inductive-fixpoint-hang.rs:30:19
    |
 LL | fn impls_trait<T: Trait>() {}
    |                   ^^^^^ required by this bound in `impls_trait`

--- a/tests/ui/traits/next-solver/cycles/provisional-cache-impacts-behavior.rs
+++ b/tests/ui/traits/next-solver/cycles/provisional-cache-impacts-behavior.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 #![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // A test showcasing that using a provisional cache can differ
 // from only tracking stack entries.
@@ -59,9 +60,9 @@ trait B {}
 #[rustc_coinductive]
 trait C {}
 
-impl<T: ?Sized + B + C> A for T {}
-impl<T: ?Sized + A + C> B for T {}
-impl<T: ?Sized + B> C for T {}
+impl<T: B + C> A for T {}
+impl<T: A + C> B for T {}
+impl<T: B> C for T {}
 
 fn impls_a<T: A>() {}
 

--- a/tests/ui/traits/next-solver/dont-canonicalize-re-error.rs
+++ b/tests/ui/traits/next-solver/dont-canonicalize-re-error.rs
@@ -1,4 +1,6 @@
 //@ compile-flags: -Znext-solver
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 trait Tr<'a> {}
 
@@ -16,9 +18,9 @@ trait Tr<'a> {}
 // Then, when we recompute the goal `W<?0>: Constrain<'error>`, when
 // collecting ambiguities and overflows, we end up assembling a default
 // error candidate w/o ambiguity, which causes the goal to pass, and ICE.
-impl<'a, A: ?Sized> Tr<'a> for W<A> {}
-struct W<A: ?Sized>(A);
-impl<'a, A: ?Sized> Tr<'a> for A where A: Constrain<'a> {}
+impl<'a, A> Tr<'a> for W<A> {}
+struct W<A>(A);
+impl<'a, A> Tr<'a> for A where A: Constrain<'a> {}
 //~^ ERROR conflicting implementations of trait `Tr<'_>` for type `W<_>`
 
 trait Constrain<'a> {}

--- a/tests/ui/traits/next-solver/dont-canonicalize-re-error.stderr
+++ b/tests/ui/traits/next-solver/dont-canonicalize-re-error.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'missing`
-  --> $DIR/dont-canonicalize-re-error.rs:25:26
+  --> $DIR/dont-canonicalize-re-error.rs:27:26
    |
 LL | impl<A: Sized> Constrain<'missing> for W<A> {}
    |      -                   ^^^^^^^^ undeclared lifetime
@@ -7,13 +7,13 @@ LL | impl<A: Sized> Constrain<'missing> for W<A> {}
    |      help: consider introducing lifetime `'missing` here: `'missing,`
 
 error[E0119]: conflicting implementations of trait `Tr<'_>` for type `W<_>`
-  --> $DIR/dont-canonicalize-re-error.rs:21:1
+  --> $DIR/dont-canonicalize-re-error.rs:23:1
    |
-LL | impl<'a, A: ?Sized> Tr<'a> for W<A> {}
-   | ----------------------------------- first implementation here
-LL | struct W<A: ?Sized>(A);
-LL | impl<'a, A: ?Sized> Tr<'a> for A where A: Constrain<'a> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<_>`
+LL | impl<'a, A> Tr<'a> for W<A> {}
+   | --------------------------- first implementation here
+LL | struct W<A>(A);
+LL | impl<'a, A> Tr<'a> for A where A: Constrain<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<_>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/next-solver/normalize/normalize-region-obligations.rs
+++ b/tests/ui/traits/next-solver/normalize/normalize-region-obligations.rs
@@ -1,6 +1,8 @@
 //@ revisions: normalize_param_env normalize_obligation hrtb
 //@ check-pass
 //@ compile-flags: -Znext-solver
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 trait Foo {
     #[cfg(normalize_param_env)]
@@ -11,11 +13,11 @@ trait Foo {
     type Gat<'b> where for<'a> <Self as MirrorRegion<'a>>::Assoc: 'b;
 }
 
-trait Mirror { type Assoc: ?Sized; }
-impl<T: ?Sized> Mirror for T { type Assoc = T; }
+trait Mirror { type Assoc; }
+impl<T> Mirror for T { type Assoc = T; }
 
-trait MirrorRegion<'a> { type Assoc: ?Sized; }
-impl<'a, T: ?Sized> MirrorRegion<'a> for T { type Assoc = T; }
+trait MirrorRegion<'a> { type Assoc; }
+impl<'a, T> MirrorRegion<'a> for T { type Assoc = T; }
 
 impl<T> Foo for T {
     #[cfg(normalize_param_env)]

--- a/tests/ui/traits/next-solver/overflow/coherence-alias-hang.rs
+++ b/tests/ui/traits/next-solver/overflow/coherence-alias-hang.rs
@@ -4,16 +4,18 @@
 // Regression test for nalgebra hang <https://github.com/rust-lang/rust/issues/130056>.
 
 #![feature(lazy_type_alias)]
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 #![allow(incomplete_features)]
 
-type Id<T: ?Sized> = T;
+type Id<T> = T;
 trait NotImplemented {}
 
-struct W<T: ?Sized, U: ?Sized>(*const T, *const U);
+struct W<T, U>(*const T, *const U);
 trait Trait {
-    type Assoc: ?Sized;
+    type Assoc;
 }
-impl<T: ?Sized + Trait> Trait for W<T, T> {
+impl<T: Trait> Trait for W<T, T> {
     #[cfg(ai)]
     type Assoc = W<T::Assoc, Id<T::Assoc>>;
     #[cfg(ia)]
@@ -22,8 +24,8 @@ impl<T: ?Sized + Trait> Trait for W<T, T> {
     type Assoc = W<Id<T::Assoc>, Id<T::Assoc>>;
 }
 
-trait Overlap<T: ?Sized> {}
-impl<T: ?Sized> Overlap<T> for W<T, T> {}
-impl<T: ?Sized + Trait + NotImplemented> Overlap<T::Assoc> for T {}
+trait Overlap<T> {}
+impl<T> Overlap<T> for W<T, T> {}
+impl<T: Trait + NotImplemented> Overlap<T::Assoc> for T {}
 
 fn main() {}

--- a/tests/ui/traits/next-solver/overflow/recursion-limit-normalizes-to-constraints.rs
+++ b/tests/ui/traits/next-solver/overflow/recursion-limit-normalizes-to-constraints.rs
@@ -1,5 +1,7 @@
 //@ compile-flags: -Znext-solver=coherence
 //@ check-pass
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // A regression test for trait-system-refactor-initiative#70.
 
@@ -7,8 +9,8 @@ trait Trait {
     type Assoc;
 }
 
-struct W<T: ?Sized>(*mut T);
-impl<T: ?Sized> Trait for W<W<T>>
+struct W<T>(*mut T);
+impl<T> Trait for W<W<T>>
 where
     W<T>: Trait,
 {
@@ -20,6 +22,6 @@ impl<T: Trait<Assoc = u32>> NoOverlap for T {}
 // `Projection(<W<_> as Trait>::Assoc, u32)` should result in error even
 // though applying the impl results in overflow. This is necessary to match
 // the behavior of the old solver.
-impl<T: ?Sized> NoOverlap for W<T> {}
+impl<T> NoOverlap for W<T> {}
 
 fn main() {}

--- a/tests/ui/traits/next-solver/supertrait-alias-1.rs
+++ b/tests/ui/traits/next-solver/supertrait-alias-1.rs
@@ -1,5 +1,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
 
 // Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/171>.
 // Tests that we don't try to replace `<V as Super>::Output` when replacing projections in the
@@ -13,9 +15,9 @@ pub trait Super {
     type Output;
 }
 
-fn bound<T: Trait + ?Sized>() {}
+fn bound<T: Trait>() {}
 
-fn visit_simd_operator<V: Super + ?Sized>() {
+fn visit_simd_operator<V: Super>() {
     bound::<dyn Trait<Output = <V as Super>::Output>>();
 }
 

--- a/tests/ui/traits/overflow-computing-ambiguity.rs
+++ b/tests/ui/traits/overflow-computing-ambiguity.rs
@@ -1,12 +1,15 @@
+#![feature(rustc_attrs)]
+#![rustc_no_implicit_bounds]
+
 trait Hello {}
 
-struct Foo<'a, T: ?Sized>(&'a T);
+struct Foo<'a, T>(&'a T);
 
-impl<'a, T: ?Sized> Hello for Foo<'a, &'a T> where Foo<'a, T>: Hello {}
+impl<'a, T> Hello for Foo<'a, &'a T> where Foo<'a, T>: Hello {}
 
 impl Hello for Foo<'static, i32> {}
 
-fn hello<T: ?Sized + Hello>() {}
+fn hello<T: Hello>() {}
 
 fn main() {
     hello();

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -1,5 +1,5 @@
 error[E0283]: type annotations needed
-  --> $DIR/overflow-computing-ambiguity.rs:12:5
+  --> $DIR/overflow-computing-ambiguity.rs:15:5
    |
 LL |     hello();
    |     ^^^^^ cannot infer type of the type parameter `T` declared on the function `hello`
@@ -9,10 +9,10 @@ LL |     hello();
              Foo<'a, &'a T>
              Foo<'static, i32>
 note: required by a bound in `hello`
-  --> $DIR/overflow-computing-ambiguity.rs:9:22
+  --> $DIR/overflow-computing-ambiguity.rs:12:13
    |
-LL | fn hello<T: ?Sized + Hello>() {}
-   |                      ^^^^^ required by this bound in `hello`
+LL | fn hello<T: Hello>() {}
+   |             ^^^^^ required by this bound in `hello`
 help: consider specifying the generic argument
    |
 LL |     hello::<T>();

--- a/tests/ui/typeck/issue-74086.rs
+++ b/tests/ui/typeck/issue-74086.rs
@@ -1,5 +1,4 @@
 fn main() {
     static BUG: fn(_) -> u8 = |_| 8;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR the placeholder `_` is not allowed within types on item signatures for static items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static items
 }

--- a/tests/ui/typeck/issue-74086.stderr
+++ b/tests/ui/typeck/issue-74086.stderr
@@ -1,15 +1,9 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-74086.rs:2:20
-   |
-LL |     static BUG: fn(_) -> u8 = |_| 8;
-   |                    ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
   --> $DIR/issue-74086.rs:2:20
    |
 LL |     static BUG: fn(_) -> u8 = |_| 8;
    |                    ^ not allowed in type signatures
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/issue-81885.rs
+++ b/tests/ui/typeck/issue-81885.rs
@@ -1,9 +1,7 @@
 const TEST4: fn() -> _ = 42;
-                  //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-                  //~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 
 fn main() {
     const TEST5: fn() -> _ = 42;
-                      //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-                      //~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 }

--- a/tests/ui/typeck/issue-81885.stderr
+++ b/tests/ui/typeck/issue-81885.stderr
@@ -1,27 +1,15 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-81885.rs:1:22
-   |
-LL | const TEST4: fn() -> _ = 42;
-   |                      ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
   --> $DIR/issue-81885.rs:1:22
    |
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-81885.rs:6:26
-   |
-LL |     const TEST5: fn() -> _ = 42;
-   |                          ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
-  --> $DIR/issue-81885.rs:6:26
+  --> $DIR/issue-81885.rs:5:26
    |
 LL |     const TEST5: fn() -> _ = 42;
    |                          ^ not allowed in type signatures
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/type-placeholder-fn-in-const.rs
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.rs
@@ -2,14 +2,12 @@ struct MyStruct;
 
 trait Test {
     const TEST: fn() -> _;
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 impl Test for MyStruct {
     const TEST: fn() -> _ = 42;
-    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions [E0121]
-    //~| ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for associated constants [E0121]
 }
 
 fn main() {}

--- a/tests/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -1,17 +1,5 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
-   |
-LL |     const TEST: fn() -> _ = 42;
-   |                         ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:4:25
-   |
-LL |     const TEST: fn() -> _;
-   |                         ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+  --> $DIR/type-placeholder-fn-in-const.rs:9:25
    |
 LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
@@ -22,6 +10,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -33,7 +33,6 @@ fn test7(x: _) { let _x: usize = x; }
 
 fn test8(_f: fn() -> _) { }
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-//~^^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 struct Test9;
 
@@ -67,6 +66,8 @@ struct Test10 {
     a: _,
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
     b: (_, _),
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
 }
 
 pub fn main() {
@@ -99,7 +100,6 @@ pub fn main() {
 
     fn fn_test8(_f: fn() -> _) { }
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-    //~^^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
     struct FnTest9;
 
@@ -123,6 +123,8 @@ pub fn main() {
         a: _,
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
         b: (_, _),
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for structs
+        //~| ERROR the placeholder `_` is not allowed within types on item signatures for structs
     }
 
     fn fn_test11(_: _) -> (_, _) { panic!() }
@@ -141,12 +143,14 @@ trait T {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn method_test2(&self, x: _) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn method_test3(&self) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test1(x: _);
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test2(x: _) -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
     fn assoc_fn_test3() -> _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 }
@@ -158,9 +162,11 @@ trait BadTrait<_> {}
 //~^ ERROR expected identifier, found reserved identifier `_`
 impl BadTrait<_> for BadStruct<_> {}
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for implementations
 
 fn impl_trait() -> impl BadTrait<_> {
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
     unimplemented!()
 }
 
@@ -180,7 +186,8 @@ struct Struct;
 trait Trait<T> {}
 impl Trait<usize> for Struct {}
 type Y = impl Trait<_>;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for type aliases
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for opaque types
 #[define_opaque(Y)]
 fn foo() -> Y {
     Struct
@@ -197,6 +204,7 @@ trait Qux {
     // type E: _; // FIXME: make the parser propagate the existence of `B`
     type F: std::ops::Fn(_);
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
     //~^ ERROR not all trait items implemented, missing: `F`

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -1,35 +1,35 @@
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:154:18
+  --> $DIR/typeck_type_placeholder_item.rs:158:18
    |
 LL | struct BadStruct<_>(_);
    |                  ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:157:16
+  --> $DIR/typeck_type_placeholder_item.rs:161:16
    |
 LL | trait BadTrait<_> {}
    |                ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:167:19
+  --> $DIR/typeck_type_placeholder_item.rs:173:19
    |
 LL | struct BadStruct1<_, _>(_);
    |                   ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:167:22
+  --> $DIR/typeck_type_placeholder_item.rs:173:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                      ^ expected identifier, found reserved identifier
 
 error: expected identifier, found reserved identifier `_`
-  --> $DIR/typeck_type_placeholder_item.rs:172:19
+  --> $DIR/typeck_type_placeholder_item.rs:178:19
    |
 LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:207:5
+  --> $DIR/typeck_type_placeholder_item.rs:215:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -37,7 +37,7 @@ LL |     const C: _;
    |               help: provide a definition for the constant: `= <expr>;`
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/typeck_type_placeholder_item.rs:167:22
+  --> $DIR/typeck_type_placeholder_item.rs:173:22
    |
 LL | struct BadStruct1<_, _>(_);
    |                   -  ^ already used
@@ -106,72 +106,87 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL | fn test6(_: _) { }
    |             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6(_: _) { }
-LL + fn test6<T>(_: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:25:18
    |
 LL | fn test6_b<T>(_: _, _: T) { }
    |                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6_b<T>(_: _, _: T) { }
-LL + fn test6_b<T, U>(_: U, _: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:28:30
    |
 LL | fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
    |                              ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test6_c<T, K, L, A, B>(_: _, _: (T, K, L, A, B)) { }
-LL + fn test6_c<T, K, L, A, B, U>(_: U, _: (T, K, L, A, B)) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:31:13
    |
 LL | fn test7(x: _) { let _x: usize = x; }
    |             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - fn test7(x: _) { let _x: usize = x; }
-LL + fn test7<T>(x: T) { let _x: usize = x; }
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:34:22
-   |
-LL | fn test8(_f: fn() -> _) { }
-   |                      ^
-   |                      |
-   |                      not allowed in type signatures
-   |                      help: use type parameters instead: `T`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:34:22
    |
 LL | fn test8(_f: fn() -> _) { }
    |                      ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:66:8
    |
-help: use type parameters instead
+LL |     a: _,
+   |        ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:9
    |
-LL - fn test8(_f: fn() -> _) { }
-LL + fn test8<T>(_f: fn() -> T) { }
+LL |     b: (_, _),
+   |         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:68:12
    |
+LL |     b: (_, _),
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:123:12
+   |
+LL |         a: _,
+   |            ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:13
+   |
+LL |         b: (_, _),
+   |             ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:125:16
+   |
+LL |         b: (_, _),
+   |                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:158:21
+   |
+LL | struct BadStruct<_>(_);
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:173:25
+   |
+LL | struct BadStruct1<_, _>(_);
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:178:25
+   |
+LL | struct BadStruct2<_, T>(_, T);
+   |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:48:26
+  --> $DIR/typeck_type_placeholder_item.rs:47:26
    |
 LL | fn test11(x: &usize) -> &_ {
    |                         -^
@@ -180,7 +195,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         help: replace with the correct return type: `&&usize`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:53:52
+  --> $DIR/typeck_type_placeholder_item.rs:52:52
    |
 LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      --------------^
@@ -189,7 +204,7 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      help: replace with the correct return type: `*const *const usize`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:59:24
+  --> $DIR/typeck_type_placeholder_item.rs:58:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
    |                        ^ not allowed in type signatures
@@ -201,7 +216,7 @@ LL +     fn clone(&self) -> Test9 { Test9 }
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:62:37
+  --> $DIR/typeck_type_placeholder_item.rs:61:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
    |                                     ^ not allowed in type signatures
@@ -212,33 +227,14 @@ LL -     fn clone_from(&mut self, other: _) { *self = Test9; }
 LL +     fn clone_from(&mut self, other: &Test9) { *self = Test9; }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:67:8
-   |
-LL |     a: _,
-   |        ^ not allowed in type signatures
-LL |
-LL |     b: (_, _),
-   |         ^  ^ not allowed in type signatures
-   |         |
-   |         not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~ struct Test10<T> {
-LL ~     a: T,
-LL |
-LL ~     b: (T, T),
-   |
-
 error: missing type for `static` item
-  --> $DIR/typeck_type_placeholder_item.rs:73:13
+  --> $DIR/typeck_type_placeholder_item.rs:74:13
    |
 LL |     static A = 42;
    |             ^ help: provide a type for the static variable: `: i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:75:15
+  --> $DIR/typeck_type_placeholder_item.rs:76:15
    |
 LL |     static B: _ = 42;
    |               ^ not allowed in type signatures
@@ -250,7 +246,7 @@ LL +     static B: i32 = 42;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:77:22
+  --> $DIR/typeck_type_placeholder_item.rs:78:22
    |
 LL |     static C: Option<_> = Some(42);
    |                      ^ not allowed in type signatures
@@ -262,7 +258,7 @@ LL +     static C: Option<i32> = Some(42);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:79:21
+  --> $DIR/typeck_type_placeholder_item.rs:80:21
    |
 LL |     fn fn_test() -> _ { 5 }
    |                     ^
@@ -271,7 +267,7 @@ LL |     fn fn_test() -> _ { 5 }
    |                     help: replace with the correct return type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:82:23
+  --> $DIR/typeck_type_placeholder_item.rs:83:23
    |
 LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      -^--^-
@@ -281,7 +277,7 @@ LL |     fn fn_test2() -> (_, _) { (5, 5) }
    |                      help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:85:22
+  --> $DIR/typeck_type_placeholder_item.rs:86:22
    |
 LL |     static FN_TEST3: _ = "test";
    |                      ^ not allowed in type signatures
@@ -293,7 +289,7 @@ LL +     static FN_TEST3: &str = "test";
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:88:22
+  --> $DIR/typeck_type_placeholder_item.rs:89:22
    |
 LL |     static FN_TEST4: _ = 145;
    |                      ^ not allowed in type signatures
@@ -305,7 +301,7 @@ LL +     static FN_TEST4: i32 = 145;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:91:23
+  --> $DIR/typeck_type_placeholder_item.rs:92:23
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
    |                       ^  ^ not allowed in type signatures
@@ -319,49 +315,22 @@ LL +     static FN_TEST5: (i32, i32) = (1, 2);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:94:20
+  --> $DIR/typeck_type_placeholder_item.rs:95:20
    |
 LL |     fn fn_test6(_: _) { }
    |                    ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test6(_: _) { }
-LL +     fn fn_test6<T>(_: T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:97:20
+  --> $DIR/typeck_type_placeholder_item.rs:98:20
    |
 LL |     fn fn_test7(x: _) { let _x: usize = x; }
    |                    ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test7(x: _) { let _x: usize = x; }
-LL +     fn fn_test7<T>(x: T) { let _x: usize = x; }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:100:29
-   |
-LL |     fn fn_test8(_f: fn() -> _) { }
-   |                             ^
-   |                             |
-   |                             not allowed in type signatures
-   |                             help: use type parameters instead: `T`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:100:29
+  --> $DIR/typeck_type_placeholder_item.rs:101:29
    |
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn fn_test8(_f: fn() -> _) { }
-LL +     fn fn_test8<T>(_f: fn() -> T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:115:28
@@ -387,33 +356,14 @@ LL -         fn clone_from(&mut self, other: _) { *self = FnTest9; }
 LL +         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:123:12
-   |
-LL |         a: _,
-   |            ^ not allowed in type signatures
-LL |
-LL |         b: (_, _),
-   |             ^  ^ not allowed in type signatures
-   |             |
-   |             not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL ~     struct FnTest10<T> {
-LL ~         a: T,
-LL |
-LL ~         b: (T, T),
-   |
-
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:128:21
+  --> $DIR/typeck_type_placeholder_item.rs:130:21
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                     ^ cannot infer type
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:128:28
+  --> $DIR/typeck_type_placeholder_item.rs:130:28
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            ^  ^ not allowed in type signatures
@@ -421,7 +371,7 @@ LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
    |                            not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:132:30
+  --> $DIR/typeck_type_placeholder_item.rs:134:30
    |
 LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             -^--^-
@@ -431,7 +381,7 @@ LL |     fn fn_test12(x: i32) -> (_, _) { (x, x) }
    |                             help: replace with the correct return type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:135:33
+  --> $DIR/typeck_type_placeholder_item.rs:137:33
    |
 LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           ------^-
@@ -439,152 +389,116 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:154:21
-   |
-LL | struct BadStruct<_>(_);
-   |                     ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct<_>(_);
-LL + struct BadStruct<T>(T);
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:140:31
-   |
-LL |     fn method_test1(&self, x: _);
-   |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test1(&self, x: _);
-LL +     fn method_test1<T>(&self, x: T);
-   |
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:142:31
    |
-LL |     fn method_test2(&self, x: _) -> _;
-   |                               ^     ^ not allowed in type signatures
-   |                               |
-   |                               not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test2(&self, x: _) -> _;
-LL +     fn method_test2<T>(&self, x: T) -> T;
-   |
+LL |     fn method_test1(&self, x: _);
+   |                               ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:144:31
    |
-LL |     fn method_test3(&self) -> _;
+LL |     fn method_test2(&self, x: _) -> _;
    |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn method_test3(&self) -> _;
-LL +     fn method_test3<T>(&self) -> T;
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:146:26
+  --> $DIR/typeck_type_placeholder_item.rs:144:37
+   |
+LL |     fn method_test2(&self, x: _) -> _;
+   |                                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:147:31
+   |
+LL |     fn method_test3(&self) -> _;
+   |                               ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:149:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test1(x: _);
-LL +     fn assoc_fn_test1<T>(x: T);
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:148:26
+  --> $DIR/typeck_type_placeholder_item.rs:151:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
-   |                          ^     ^ not allowed in type signatures
-   |                          |
-   |                          not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test2(x: _) -> _;
-LL +     fn assoc_fn_test2<T>(x: T) -> T;
-   |
+   |                          ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:150:28
+  --> $DIR/typeck_type_placeholder_item.rs:151:32
+   |
+LL |     fn assoc_fn_test2(x: _) -> _;
+   |                                ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:154:28
    |
 LL |     fn assoc_fn_test3() -> _;
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn assoc_fn_test3() -> _;
-LL +     fn assoc_fn_test3<T>() -> T;
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
-  --> $DIR/typeck_type_placeholder_item.rs:159:15
+  --> $DIR/typeck_type_placeholder_item.rs:163:32
    |
 LL | impl BadTrait<_> for BadStruct<_> {}
-   |               ^                ^ not allowed in type signatures
-   |               |
-   |               not allowed in type signatures
+   |                                ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:162:34
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/typeck_type_placeholder_item.rs:163:15
+   |
+LL | impl BadTrait<_> for BadStruct<_> {}
+   |               ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:167:34
    |
 LL | fn impl_trait() -> impl BadTrait<_> {
    |                                  ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:167:25
-   |
-LL | struct BadStruct1<_, _>(_);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct1<_, _>(_);
-LL + struct BadStruct1<T, _>(T);
-   |
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:172:25
-   |
-LL | struct BadStruct2<_, T>(_, T);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL - struct BadStruct2<_, T>(_, T);
-LL + struct BadStruct2<U, T>(U, T);
-   |
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/typeck_type_placeholder_item.rs:176:14
+  --> $DIR/typeck_type_placeholder_item.rs:182:14
    |
 LL | type X = Box<_>;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/typeck_type_placeholder_item.rs:182:21
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:188:21
    |
 LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:198:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:211:14
+   |
+LL |     type A = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:213:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:207:14
+  --> $DIR/typeck_type_placeholder_item.rs:200:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:195:14
+  --> $DIR/typeck_type_placeholder_item.rs:215:14
+   |
+LL |     const C: _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     const D: _ = 42;
    |              ^ not allowed in type signatures
@@ -596,13 +510,13 @@ LL +     const D: i32 = 42;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:210:14
+  --> $DIR/typeck_type_placeholder_item.rs:218:14
    |
 LL |     const D: _ = 42;
    |              ^ not allowed in type signatures
 
 error[E0046]: not all trait items implemented, missing: `F`
-  --> $DIR/typeck_type_placeholder_item.rs:201:1
+  --> $DIR/typeck_type_placeholder_item.rs:209:1
    |
 LL |     type F: std::ops::Fn(_);
    |     ----------------------- `F` from trait
@@ -611,7 +525,7 @@ LL | impl Qux for Struct {
    | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:218:31
+  --> $DIR/typeck_type_placeholder_item.rs:226:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -620,7 +534,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:223:17
+  --> $DIR/typeck_type_placeholder_item.rs:231:17
    |
 LL | const _: Option<_> = map(value);
    |                 ^ not allowed in type signatures
@@ -632,7 +546,7 @@ LL + const _: Option<u8> = map(value);
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:227:31
+  --> $DIR/typeck_type_placeholder_item.rs:235:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -641,19 +555,19 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:10
+  --> $DIR/typeck_type_placeholder_item.rs:240:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:232:29}>, {closure@typeck_type_placeholder_item.rs:232:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:232:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:240:29}>, {closure@typeck_type_placeholder_item.rs:240:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:240:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:41:24
+  --> $DIR/typeck_type_placeholder_item.rs:40:24
    |
 LL |     fn test9(&self) -> _ { () }
    |                        ^
@@ -662,16 +576,10 @@ LL |     fn test9(&self) -> _ { () }
    |                        help: replace with the correct return type: `()`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:44:27
+  --> $DIR/typeck_type_placeholder_item.rs:43:27
    |
 LL |     fn test10(&self, _x : _) { }
    |                           ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -     fn test10(&self, _x : _) { }
-LL +     fn test10<T>(&self, _x : T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:107:31
@@ -687,68 +595,62 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |         fn fn_test10(&self, _x : _) { }
    |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL -         fn fn_test10(&self, _x : _) { }
-LL +         fn fn_test10<T>(&self, _x : T) { }
-   |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
-   |
-LL |     type A = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:191:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:193:14
-   |
-LL |     const C: _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:198:26
+  --> $DIR/typeck_type_placeholder_item.rs:205:26
    |
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:205:26
+   |
+LL |     type F: std::ops::Fn(_);
+   |                          ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:167:34
+   |
+LL | fn impl_trait() -> impl BadTrait<_> {
+   |                                  ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:188:21
+   |
+LL | type Y = impl Trait<_>;
+   |                     ^ not allowed in type signatures
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0015]: cannot call non-const function `map::<u8>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:223:22
+  --> $DIR/typeck_type_placeholder_item.rs:231:22
    |
 LL | const _: Option<_> = map(value);
    |                      ^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:232:29: 232:32}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:22
+error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:240:22
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:232:29: 232:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:232:49: 232:52}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:232:45
+error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:240:49: 240:52}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:240:45
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                                             ^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to 75 previous errors
+error: aborting due to 83 previous errors
 
 Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -11,8 +11,7 @@ const TEST3: _ = Some(42);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 
 const TEST4: fn() -> _ = 42;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-//~| ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
 
 trait Test5 {
     const TEST5: _ = 42;

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -31,12 +31,6 @@ LL - const TEST3: _ = Some(42);
 LL + const TEST3: Option<i32> = Some(42);
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item_help.rs:13:22
-   |
-LL | const TEST4: fn() -> _ = 42;
-   |                      ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
    |
@@ -44,7 +38,7 @@ LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:25:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:24:18
    |
 LL |     const TEST6: _ = 13;
    |                  ^ not allowed in type signatures
@@ -56,7 +50,7 @@ LL +     const TEST6: i32 = 13;
    |
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:18:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:17:18
    |
 LL |     const TEST5: _ = 42;
    |                  ^ not allowed in type signatures
@@ -68,7 +62,7 @@ LL +     const TEST5: i32 = 42;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_item_help.rs:30:28
+  --> $DIR/typeck_type_placeholder_item_help.rs:29:28
    |
 LL |     let _: Option<usize> = test1();
    |            -------------   ^^^^^^^ expected `Option<usize>`, found `Option<i32>`
@@ -79,7 +73,7 @@ LL |     let _: Option<usize> = test1();
               found enum `Option<i32>`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_item_help.rs:31:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:30:18
    |
 LL |     let _: f64 = test1();
    |            ---   ^^^^^^^ expected `f64`, found `Option<i32>`
@@ -89,7 +83,7 @@ LL |     let _: f64 = test1();
    = note: expected type `f64`
               found enum `Option<i32>`
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0121, E0308.
 For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#142270 (Rustdoc js: even more typechecking improvements)
 - rust-lang/rust#142420 (Report infer ty errors during hir ty lowering)
 - rust-lang/rust#142671 (add #![rustc_no_implicit_bounds])
 - rust-lang/rust#142721 (Add tracing to `InterpCx::layout_of()` )
 - rust-lang/rust#142818 (Port `#[used]` to new attribute parsing infrastructure)
 - rust-lang/rust#143020 (codegen_fn_attrs: make comment more precise)
 - rust-lang/rust#143051 (Add tracing to `validate_operand`)
 - rust-lang/rust#143060 (Only args in main diag are saved and restored without removing the newly added ones)
 - rust-lang/rust#143065 (Improve recovery when users write `where:`)
 - rust-lang/rust#143084 (const-eval: error when initializing a static writes to that static)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=142270,142420,142671,142721,142818,143020,143051,143060,143065,143084)
<!-- homu-ignore:end -->