### PR TITLE
hir_analysis: prohibit `dyn PointeeSized`

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -447,6 +447,9 @@ hir_analysis_parenthesized_fn_trait_expansion =
 
 hir_analysis_placeholder_not_allowed_item_signatures = the placeholder `_` is not allowed within types on item signatures for {$kind}
     .label = not allowed in type signatures
+
+hir_analysis_pointee_sized_trait_object = `PointeeSized` cannot be used with trait objects
+
 hir_analysis_precise_capture_self_alias = `Self` can't be captured in `use<...>` precise captures list, since it is an alias
     .label = `Self` is not a generic argument, but an alias to the type of the {$what}
 

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -319,6 +319,13 @@ pub(crate) struct TraitObjectDeclaredWithNoTraits {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_pointee_sized_trait_object)]
+pub(crate) struct PointeeSizedTraitObject {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_ambiguous_lifetime_bound, code = E0227)]
 pub(crate) struct AmbiguousLifetimeBound {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -2,6 +2,7 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::struct_span_code_err;
 use rustc_hir as hir;
+use rustc_hir::LangItem;
 use rustc_hir::def::{DefKind, Res};
 use rustc_lint_defs::builtin::UNUSED_ASSOCIATED_TYPE_BOUNDS;
 use rustc_middle::ty::elaborate::ClauseWithSupertraitSpan;
@@ -69,7 +70,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .into_iter()
             .partition(|(trait_ref, _)| !tcx.trait_is_auto(trait_ref.def_id()));
 
-        // We  don't support empty trait objects.
+        // We don't support empty trait objects.
         if regular_traits.is_empty() && auto_traits.is_empty() {
             let guar =
                 self.report_trait_object_with_no_traits(span, user_written_bounds.iter().copied());
@@ -80,6 +81,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             let guar = self.report_trait_object_addition_traits(&regular_traits);
             return Ty::new_error(tcx, guar);
         }
+        // We don't support `PointeeSized` principals
+        let pointee_sized_did = tcx.require_lang_item(LangItem::PointeeSized, span);
+        if regular_traits.iter().any(|(pred, _)| pred.def_id() == pointee_sized_did) {
+            let guar = self.report_pointee_sized_trait_object(span);
+            return Ty::new_error(tcx, guar);
+        }
+
         // Don't create a dyn trait if we have errors in the principal.
         if let Err(guar) = regular_traits.error_reported() {
             return Ty::new_error(tcx, guar);

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -29,7 +29,7 @@ use tracing::debug;
 use super::InherentAssocCandidate;
 use crate::errors::{
     self, AssocItemConstraintsNotAllowedHere, ManualImplementation, MissingTypeParams,
-    ParenthesizedFnTraitExpansion, TraitObjectDeclaredWithNoTraits,
+    ParenthesizedFnTraitExpansion, PointeeSizedTraitObject, TraitObjectDeclaredWithNoTraits,
 };
 use crate::fluent_generated as fluent;
 use crate::hir_ty_lowering::{AssocItemQSelf, HirTyLowerer};
@@ -1409,6 +1409,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .map(|trait_ref| tcx.def_span(trait_ref.def_id()));
 
         self.dcx().emit_err(TraitObjectDeclaredWithNoTraits { span, trait_alias_span })
+    }
+
+    pub(super) fn report_pointee_sized_trait_object(&self, span: Span) -> ErrorGuaranteed {
+        self.dcx().emit_err(PointeeSizedTraitObject { span })
     }
 }
 

--- a/tests/ui/sized-hierarchy/reject-dyn-pointeesized.rs
+++ b/tests/ui/sized-hierarchy/reject-dyn-pointeesized.rs
@@ -1,0 +1,16 @@
+#![feature(sized_hierarchy)]
+
+use std::marker::PointeeSized;
+
+type Foo = dyn PointeeSized;
+//~^ ERROR `PointeeSized` cannot be used with trait objects
+
+fn foo(f: &Foo) {}
+
+fn main() {
+    foo(&());
+
+    let x = main;
+    let y: Box<dyn PointeeSized> = x;
+//~^ ERROR `PointeeSized` cannot be used with trait objects
+}

--- a/tests/ui/sized-hierarchy/reject-dyn-pointeesized.stderr
+++ b/tests/ui/sized-hierarchy/reject-dyn-pointeesized.stderr
@@ -1,0 +1,14 @@
+error: `PointeeSized` cannot be used with trait objects
+  --> $DIR/reject-dyn-pointeesized.rs:5:12
+   |
+LL | type Foo = dyn PointeeSized;
+   |            ^^^^^^^^^^^^^^^^
+
+error: `PointeeSized` cannot be used with trait objects
+  --> $DIR/reject-dyn-pointeesized.rs:14:16
+   |
+LL |     let y: Box<dyn PointeeSized> = x;
+   |                ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#142652
Supersedes rust-lang/rust#142663

`dyn PointeeSized` is nonsensical as a `dyn PointeeSized` needs to be `MetaSized`, so lets reject it to avoid hitting code paths that expect a builtin impl for `PointeeSized`

r? @compiler-errors