### PR TITLE
Update LLVM submodule

### DIFF
--- a/tests/ui/darwin-ld64.rs
+++ b/tests/ui/darwin-ld64.rs
@@ -1,0 +1,24 @@
+//@ compile-flags: -Copt-level=3 -Ccodegen-units=256 -Clink-arg=-ld_classic
+//@ run-pass
+//@ only-x86_64-apple-darwin
+
+// This is a regression test for https://github.com/rust-lang/rust/issues/140686.
+// Although this is a ld64(ld-classic) bug, we still need to support it
+// due to cross-compilation and support for older Xcode.
+
+fn main() {
+    let dst: Vec<u8> = Vec::new();
+    let len = broken_func(std::hint::black_box(2), dst);
+    assert_eq!(len, 8);
+}
+
+#[inline(never)]
+pub fn broken_func(version: usize, mut dst: Vec<u8>) -> usize {
+    match version {
+        1 => dst.extend_from_slice(b"aaaaaaaa"),
+        2 => dst.extend_from_slice(b"bbbbbbbb"),
+        3 => dst.extend_from_slice(b"bbbbbbbb"),
+        _ => panic!(),
+    }
+    dst.len()
+}


### PR DESCRIPTION
Fixes rust-lang/rust#140686, fixes rust-lang/rust#141913, fixes rust-lang/rust#142752, fixes rust-lang/rust#143399.