### PR TITLE
Improve diagnostic for link.exe special case exit code 0xc0000409 (STATUS_STACK_BUFFER_OVERRUN)

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -176,6 +176,10 @@ codegen_ssa_ld64_unimplemented_modifier = `as-needed` modifier not implemented y
 
 codegen_ssa_lib_def_write_failure = failed to write lib.def file: {$error}
 
+codegen_ssa_link_exe_fastfail_abort_note = This may occur when using the MSVC toolchain on Windows and can be caused by `__fastfail` termination, rather than necessarily indicating a stack buffer overrun.
+
+codegen_ssa_link_exe_fastfail_status = 0xc0000409 is `STATUS_STACK_BUFFER_OVERRUN`
+
 codegen_ssa_link_exe_unexpected_error = `link.exe` returned an unexpected error
 
 codegen_ssa_link_script_unavailable = can only use link script when linking with GNU-like linker

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -872,6 +872,13 @@ fn link_natively(
                 // is not a Microsoft LNK error then suggest a way to fix or
                 // install the Visual Studio build tools.
                 if let Some(code) = prog.status.code() {
+                    // 0xc0000409 (`STATUS_STACK_BUFFER_OVERRUN`) is also used by `abort()` via `__fastfail` on Windows. Not necessarily a buffer overrun.
+                    // See <https://devblogs.microsoft.com/oldnewthing/20190108-00/?p=100655>
+                    const STATUS_STACK_BUFFER_OVERRUN: i32 = 0xC0000409u32 as i32; // = -1073740791
+                    if code == STATUS_STACK_BUFFER_OVERRUN {
+                        sess.dcx().emit_note(errors::LinkExeFastFailAbort);
+                    }
+
                     // All Microsoft `link.exe` linking ror codes are
                     // four digit numbers in the range 1000 to 9999 inclusive
                     if is_msvc_link_exe && (code < 1000 || code > 9999) {
@@ -880,6 +887,7 @@ fn link_natively(
                             windows_registry::find_tool(&sess.target.arch, "link.exe").is_some();
 
                         sess.dcx().emit_note(errors::LinkExeUnexpectedError);
+
                         if is_vs_installed && has_linker {
                             // the linker is broken
                             sess.dcx().emit_note(errors::RepairVSBuildTools);

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -544,6 +544,11 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for LinkingFailed<'_> {
 pub(crate) struct LinkExeUnexpectedError;
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_link_exe_fastfail_status)]
+#[note(codegen_ssa_link_exe_fastfail_abort_note)]
+pub(crate) struct LinkExeFastFailAbort;
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_repair_vs_build_tools)]
 pub(crate) struct RepairVSBuildTools;
 

--- a/tests/ui/linking/auxiliary/link.rs
+++ b/tests/ui/linking/auxiliary/link.rs
@@ -1,0 +1,6 @@
+// Dummy linker implementation simulating __fastfail termination
+// See <https://devblogs.microsoft.com/oldnewthing/20190108-00/?p=100655>
+fn main() {
+    const STATUS_STACK_BUFFER_OVERRUN: i32 = 0xC0000409u32 as i32;
+    std::process::exit(STATUS_STACK_BUFFER_OVERRUN);
+}

--- a/tests/ui/linking/linker-fastfail-abort.rs
+++ b/tests/ui/linking/linker-fastfail-abort.rs
@@ -1,0 +1,19 @@
+//@ build-fail
+//@ only-windows The abnormal behaviour may be observed only on Windows using the MSVC linker
+//@ only-msvc
+
+//@ ignore-cross-compile because aux-bin does not yet support it
+//@ aux-bin: link.rs
+// Dummy linker that will always exit as if like with __fastfail abort()
+
+//@ compile-flags: -Clinker={{build-base}}\linking\linker-fastfail-abort\auxiliary\bin\link.exe -Ctarget-feature=+crt-static
+
+// Since the error notes are too verbose
+//@ dont-check-compiler-stderr
+//@ dont-require-annotations: NOTE
+
+//~? ERROR linking with `$TEST_BUILD_DIR/auxiliary/bin/link.exe` failed: exit code: 0xc0000409
+//~? NOTE 0xc0000409 is `STATUS_STACK_BUFFER_OVERRUN`
+//~? NOTE This may occur when using the MSVC toolchain on Windows and can be caused by `__fastfail` termination, rather than necessarily indicating a stack buffer overrun.
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#141757.

Adds note for when link.exe exits with code 0xc0000409