### PR TITLE
`librustdoc` house-keeping 🧹

### DIFF
--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -8,23 +8,25 @@ build = "build.rs"
 path = "lib.rs"
 
 [dependencies]
+# tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.14", default-features = false, features = ["alloc", "config", "derive"] }
 base64 = "0.21.7"
-itertools = "0.12"
 indexmap = "2"
+itertools = "0.12"
 minifier = { version = "0.3.5", default-features = false }
 pulldown-cmark-escape = { version = "0.11.0", features = ["simd"] }
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }
-serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 smallvec = "1.8.1"
 tempfile = "3"
+threadpool = "1.8.1"
 tracing = "0.1"
 tracing-tree = "0.3.0"
-threadpool = "1.8.1"
 unicode-segmentation = "1.9"
+# tidy-alphabetical-end
 
 [dependencies.tracing-subscriber]
 version = "0.3.3"

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -1,8 +1,8 @@
+// tidy-alphabetical-start
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/",
     html_playground_url = "https://play.rust-lang.org/"
 )]
-#![feature(rustc_private)]
 #![feature(ascii_char)]
 #![feature(ascii_char_variants)]
 #![feature(assert_matches)]
@@ -13,8 +13,10 @@
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(round_char_boundary)]
+#![feature(rustc_private)]
 #![feature(test)]
 #![warn(rustc::internal)]
+// tidy-alphabetical-end
 
 extern crate thin_vec;
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -20,9 +20,6 @@
 #![feature(type_ascription)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
-#![allow(clippy::collapsible_if, clippy::collapsible_else_if)]
-#![allow(rustc::diagnostic_outside_of_impl)]
-#![allow(rustc::untranslatable_diagnostic)]
 
 extern crate thin_vec;
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -11,13 +11,9 @@
 #![feature(file_buffered)]
 #![feature(format_args_nl)]
 #![feature(if_let_guard)]
-#![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
-#![feature(never_type)]
 #![feature(round_char_boundary)]
 #![feature(test)]
-#![feature(type_alias_impl_trait)]
-#![feature(type_ascription)]
 #![warn(rustc::internal)]
 
 extern crate thin_vec;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -18,7 +18,6 @@
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
 #![feature(type_ascription)]
-#![recursion_limit = "256"]
 #![warn(rustc::internal)]
 
 extern crate thin_vec;


### PR DESCRIPTION
This PR mostly removes a bunch of crate-level attributes that were added at some point, but then later on became unnecessary:
- some `#[feature]` gates
- some `#[allow]`s
- a `#[recursion_limit]`

Then I went ahead and sprinkled some tidy sorting on the remaining attrs, and `Cargo.toml`.

Trying to give my anal retentiveness some peace of mind 😅