### PR TITLE
Remove FromBytesWithNulErrorKind and make FromVecWithNulErrorKind more actionable

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -1,7 +1,7 @@
 //! [`CString`] and its related types.
 
 use core::borrow::Borrow;
-use core::ffi::{CStr, c_char, FromBytesWithNulError};
+use core::ffi::{CStr, FromBytesWithNulError, c_char};
 use core::num::NonZero;
 use core::slice::memchr;
 use core::str::{self, FromStr, Utf8Error};


### PR DESCRIPTION
rust-lang/rust#134143 converted `FromBytesWithNulError` into an enum to address https://github.com/rust-lang/libs-team/issues/493 (`CStr::from_bytes_with_nul` returns non-actionable error result)

However, the `FromVecWithNulError` returned from `CString::from_vec_with_nul` has a similar issue of returning non-actionable error result because you can't get the `FromBytesWithNulErrorKind` out of `FromVecWithNulError`.

Additionally, rust-lang/rust#134143 creates `FromBytesWithNulError` alongside the existing `FromBytesWithNulErrorKind` which is exactly the same.

This PR removes `FromBytesWithNulErrorKind` so that `FromVecWithNulError` uses `FromBytesWithNulError` directly. It also adds a new method `kind` to `FromVecWithNulError` so that the user can access the underlying error.

This is not a breaking change because `FromBytesWithNulErrorKind` is private, and we're only adding a method to `FromVecWithNulError`.

cc @nyurik 