### PR TITLE
Detect unwind-free functions in MIR

### DIFF
--- a/tests/codegen/drop.rs
+++ b/tests/codegen/drop.rs
@@ -11,7 +11,9 @@ impl Drop for SomeUniqueName {
 }
 
 #[inline(never)]
-pub fn possibly_unwinding() {}
+pub fn possibly_unwinding() {
+    panic!();
+}
 
 // CHECK-LABEL: @droppy
 #[no_mangle]

--- a/tests/codegen/mem-replace-big-type.rs
+++ b/tests/codegen/mem-replace-big-type.rs
@@ -25,7 +25,7 @@ pub fn replace_big(dst: &mut Big, src: Big) -> Big {
 // CHECK-NOT: call void @llvm.memcpy
 
 // For a large type, we expect exactly three `memcpy`s
-// CHECK-LABEL: define internal void @{{.+}}mem{{.+}}replace{{.+}}(ptr
+// CHECK-LABEL: define void @{{.+}}mem{{.+}}replace{{.+}}(ptr
 // CHECK-SAME: sret([56 x i8]){{.+}}[[RESULT:%.+]], ptr{{.+}}%dest, ptr{{.+}}%src)
 // CHECK-NOT: call void @llvm.memcpy
 // CHECK: call void @llvm.memcpy.{{.+}}(ptr align 8 [[RESULT]], ptr align 8 %dest, i{{.*}} 56, i1 false)

--- a/tests/codegen/personality_lifetimes.rs
+++ b/tests/codegen/personality_lifetimes.rs
@@ -13,7 +13,9 @@ impl Drop for S {
 }
 
 #[inline(never)]
-fn might_unwind() {}
+fn might_unwind() {
+    panic!();
+}
 
 // CHECK-LABEL: @test
 #[no_mangle]

--- a/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
@@ -10,7 +10,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = bar::<T>() -> [return: bb1, unwind continue];
+-         _1 = bar::<T>() -> [return: bb1, unwind continue];
++         _1 = bar::<T>() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
@@ -56,7 +56,7 @@
 +         StorageLive(_17);
 +         StorageLive(_18);
 +         StorageLive(_19);
-+         _17 = <() as A>::call() -> [return: bb12, unwind continue];
++         _17 = <() as A>::call() -> [return: bb12, unwind unreachable];
       }
   
       bb1: {
@@ -124,11 +124,11 @@
 +     }
 + 
 +     bb12: {
-+         _18 = <() as A>::call() -> [return: bb13, unwind continue];
++         _18 = <() as A>::call() -> [return: bb13, unwind unreachable];
 +     }
 + 
 +     bb13: {
-+         _19 = <() as A>::call() -> [return: bb11, unwind continue];
++         _19 = <() as A>::call() -> [return: bb11, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
@@ -12,7 +12,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);
-        _1 = not_inlined() -> [return: bb1, unwind continue];
+        _1 = not_inlined() -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
@@ -21,7 +21,7 @@ fn main() -> () {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_5);
-        _3 = g() -> [return: bb3, unwind continue];
+        _3 = g() -> [return: bb3, unwind unreachable];
     }
 
     bb2: {
@@ -34,10 +34,10 @@ fn main() -> () {
     }
 
     bb3: {
-        _4 = g() -> [return: bb4, unwind continue];
+        _4 = g() -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _5 = g() -> [return: bb2, unwind continue];
+        _5 = g() -> [return: bb2, unwind unreachable];
     }
 }

--- a/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_106141.outer.Inline.panic-unwind.diff
@@ -20,7 +20,7 @@
 +         StorageLive(_1);
 +         StorageLive(_2);
 +         _1 = const inner::promoted[0];
-+         _0 = index() -> [return: bb1, unwind continue];
++         _0 = index() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
@@ -7,7 +7,8 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = callee() -> [return: bb1, unwind continue];
+-         _1 = callee() -> [return: bb1, unwind continue];
++         _1 = callee() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
@@ -5,7 +5,7 @@ fn caller() -> () {
     let _1: ();
 
     bb0: {
-        _1 = callee() -> [return: bb1, unwind continue];
+        _1 = callee() -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
+++ b/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
@@ -13,11 +13,13 @@
           StorageLive(_3);
           _3 = move _1;
           _4 = copy ((_3.0: std::ptr::Unique<[i32]>).0: std::ptr::NonNull<[i32]>) as *const [i32] (Transmute);
-          _2 = callee(move (*_4)) -> [return: bb1, unwind: bb3];
+-         _2 = callee(move (*_4)) -> [return: bb1, unwind: bb3];
++         _2 = callee(move (*_4)) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
-          drop(_3) -> [return: bb2, unwind: bb4];
+-         drop(_3) -> [return: bb2, unwind: bb4];
++         drop(_3) -> [return: bb2, unwind: bb3];
       }
   
       bb2: {
@@ -28,10 +30,10 @@
       }
   
       bb3 (cleanup): {
-          drop(_3) -> [return: bb4, unwind terminate(cleanup)];
-      }
-  
-      bb4 (cleanup): {
+-         drop(_3) -> [return: bb4, unwind terminate(cleanup)];
+-     }
+- 
+-     bb4 (cleanup): {
           resume;
       }
   }

--- a/tests/mir-opt/pre-codegen/deref_nested_borrows.src.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/deref_nested_borrows.src.GVN.panic-unwind.diff
@@ -20,7 +20,7 @@
 +         nop;
 +         _6 = copy (*_1);
           _2 = copy (*_6);
-          _3 = unknown() -> [return: bb1, unwind continue];
+          _3 = unknown() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/pre-codegen/deref_nested_borrows.src.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/deref_nested_borrows.src.PreCodegen.after.panic-unwind.mir
@@ -15,7 +15,7 @@ fn src(_1: &&u8) -> bool {
     bb0: {
         _2 = copy (*_1);
         _3 = copy (*_2);
-        _4 = unknown() -> [return: bb1, unwind continue];
+        _4 = unknown() -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -76,9 +76,9 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind unreachable];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind unreachable];
       }
   
       bb5: {

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -19,7 +19,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb0: {
         StorageLive(_2);
-        _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> [return: bb1, unwind continue];
+        _2 = <Vec<impl Sized> as IntoIterator>::into_iter(move _1) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
@@ -31,12 +31,12 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
     bb2: {
         StorageLive(_5);
         _4 = &mut _3;
-        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
+        _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind unreachable];
     }
 
     bb3: {
         _6 = discriminant(_5);
-        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
+        switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb10];
     }
 
     bb4: {
@@ -52,7 +52,7 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb6: {
         _7 = move ((_5 as Some).0: impl Sized);
-        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb9];
+        _8 = opaque::<impl Sized>(move _7) -> [return: bb7, unwind: bb8];
     }
 
     bb7: {
@@ -60,15 +60,15 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
         goto -> bb2;
     }
 
-    bb8: {
-        unreachable;
+    bb8 (cleanup): {
+        drop(_3) -> [return: bb9, unwind terminate(cleanup)];
     }
 
     bb9 (cleanup): {
-        drop(_3) -> [return: bb10, unwind terminate(cleanup)];
+        resume;
     }
 
-    bb10 (cleanup): {
-        resume;
+    bb10: {
+        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -112,13 +112,13 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         StorageLive(_15);
         StorageLive(_14);
         _14 = &mut (_13.0: std::slice::Iter<'_, T>);
-        _15 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _14) -> [return: bb5, unwind: bb11];
+        _15 = <std::slice::Iter<'_, T> as DoubleEndedIterator>::next_back(move _14) -> [return: bb5, unwind unreachable];
     }
 
     bb5: {
         StorageDead(_14);
         _16 = discriminant(_15);
-        switchInt(move _16) -> [0: bb6, 1: bb8, otherwise: bb10];
+        switchInt(move _16) -> [0: bb6, 1: bb8, otherwise: bb12];
     }
 
     bb6: {
@@ -137,7 +137,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         _18 = &_2;
         StorageLive(_19);
         _19 = (copy _17,);
-        _20 = <impl Fn(&T) as Fn<(&T,)>>::call(move _18, move _19) -> [return: bb9, unwind: bb11];
+        _20 = <impl Fn(&T) as Fn<(&T,)>>::call(move _18, move _19) -> [return: bb9, unwind: bb10];
     }
 
     bb9: {
@@ -147,15 +147,15 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         goto -> bb4;
     }
 
-    bb10: {
-        unreachable;
+    bb10 (cleanup): {
+        drop(_2) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
+        resume;
     }
 
-    bb12 (cleanup): {
-        resume;
+    bb12: {
+        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_mut_next_back.PreCodegen.after.panic-unwind.mir
@@ -5,7 +5,7 @@ fn slice_iter_mut_next_back(_1: &mut std::slice::IterMut<'_, T>) -> Option<&mut 
     let mut _0: std::option::Option<&mut T>;
 
     bb0: {
-        _0 = <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back(move _1) -> [return: bb1, unwind continue];
+        _0 = <std::slice::IterMut<'_, T> as DoubleEndedIterator>::next_back(move _1) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
@@ -11,7 +11,7 @@
       }
   
       bb1: {
-          _1 = noop() -> [return: bb2, unwind continue];
+          _1 = noop() -> [return: bb2, unwind unreachable];
       }
   
       bb2: {

--- a/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
@@ -23,7 +23,7 @@
       }
   
       bb1: {
-          _0 = noop() -> [return: bb2, unwind continue];
+          _0 = noop() -> [return: bb2, unwind unreachable];
       }
   
       bb2: {


### PR DESCRIPTION
This adds analysis as part of inlining that will mark calls to functions with Unwind::Unreachable even if inlining is not possible, so long as their MIR indicates that they cannot unwind.

This would ideally persist into the codegen fn attrs, but that will take more work.

My guess is this implementation is not going to work in practice (too much overhead, not enough value?) but wanted to see what perf looked like.