### PR TITLE
Remove unused feature gates

### DIFF
--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -16,10 +16,7 @@
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(macro_metavar_expr)]
-#![feature(negative_impls)]
-#![feature(never_type)]
 #![feature(rustdoc_internals)]
-#![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -3,7 +3,6 @@
 #![doc(rust_logo)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
-#![feature(type_alias_impl_trait)]
 // tidy-alphabetical-end
 
 use std::borrow::Cow;

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -65,7 +65,6 @@ This API is completely unstable and subject to change.
 #![feature(debug_closure_helpers)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
-#![feature(iter_from_coroutine)]
 #![feature(iter_intersperse)]
 #![feature(never_type)]
 #![feature(rustdoc_internals)]

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -7,7 +7,6 @@
 #![feature(file_buffered)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
-#![feature(iter_from_coroutine)]
 #![feature(macro_metavar_expr)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -48,7 +48,6 @@
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]
-#![feature(iter_from_coroutine)]
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]


### PR DESCRIPTION
After finding some unused feature gates in rust-lang/rust#143155 , I wrote a small script to see if I can find any others.
And I did. Not a lot, but still a small win 😁
Contains a few instances of `iter_from_coroutine` that can be removed due to rust-lang/rust#142801 (I guess).