### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1592,24 +1592,33 @@ pub enum TagEncoding<VariantIdx: Idx> {
     /// (so converting the tag to the discriminant can require sign extension).
     Direct,
 
-    /// Niche (values invalid for a type) encoding the discriminant:
-    /// Discriminant and variant index coincide.
+    /// Niche (values invalid for a type) encoding the discriminant.
+    /// Note that for this encoding, the discriminant and variant index of each variant coincide!
+    /// (This gets checked, for example, in [codegen_ssa](https://github.com/rust-lang/rust/blob/df32e15c56f582eb2bdde07711af6271f2ae660b/compiler/rustc_codegen_ssa/src/mir/operand.rs#L485).)
+    /// 
     /// The variant `untagged_variant` contains a niche at an arbitrary
-    /// offset (field `tag_field` of the enum), which for a variant with
-    /// discriminant `d` is set to
-    /// `(d - niche_variants.start).wrapping_add(niche_start)`
-    /// (this is wrapping arithmetic using the type of the niche field).
-    ///
-    /// For example, `Option<(usize, &T)>`  is represented such that
-    /// `None` has a null pointer for the second tuple field, and
-    /// `Some` is the identity function (with a non-null reference).
+    /// offset (field [`Variants::Multiple::tag_field`] of the enum).
+    /// For a variant with variant index `i`, such that `i!=untagged_variant`,
+    /// the tag is set to `(i - niche_variants.start).wrapping_add(niche_start)`
+    /// (this is wrapping arithmetic using the type of the niche field, cf. the 
+    /// [`tag_for_variant`](../rustc_const_eval/interpret/struct.InterpCx.html#method.tag_for_variant)
+    /// query implementation).
+    /// To recover the variant index `i` from a `tag`, the above formula has to be reversed,
+    /// i.e. `i = (tag.wrapping_sub(niche_start))+niche_variants.start`. If `i` ends up outside
+    /// `niche_variants`, the tag must have encoded the `untagged_variant`.
+    /// 
+    /// For example, `Option<(usize, &T)>`  is represented such that the tag for
+    /// `None` is the null pointer in the second tuple field, and
+    /// `Some` is the identity function (with a non-null reference) 
+    /// and has no additional tag, i.e. the reference being non-null uniquely identifies this variant.
     ///
     /// Other variants that are not `untagged_variant` and that are outside the `niche_variants`
     /// range cannot be represented; they must be uninhabited.
+    /// Nonetheless, uninhabited variants can also fall into the range of `niche_variants`.
     Niche {
         untagged_variant: VariantIdx,
-        /// This range *may* contain `untagged_variant`; that is then just a "dead value" and
-        /// not used to encode anything.
+        /// This range *may* contain `untagged_variant` or uninhabited variants; 
+        /// these are then just "dead values" and not used to encode anything.
         niche_variants: RangeInclusive<VariantIdx>,
         /// This is inbounds of the type of the niche field
         /// (not sign-extended, i.e., all bits beyond the niche field size are 0).

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1595,21 +1595,21 @@ pub enum TagEncoding<VariantIdx: Idx> {
     /// Niche (values invalid for a type) encoding the discriminant.
     /// Note that for this encoding, the discriminant and variant index of each variant coincide!
     /// (This gets checked, for example, in [codegen_ssa](https://github.com/rust-lang/rust/blob/df32e15c56f582eb2bdde07711af6271f2ae660b/compiler/rustc_codegen_ssa/src/mir/operand.rs#L485).)
-    /// 
+    ///
     /// The variant `untagged_variant` contains a niche at an arbitrary
     /// offset (field [`Variants::Multiple::tag_field`] of the enum).
     /// For a variant with variant index `i`, such that `i!=untagged_variant`,
     /// the tag is set to `(i - niche_variants.start).wrapping_add(niche_start)`
-    /// (this is wrapping arithmetic using the type of the niche field, cf. the 
+    /// (this is wrapping arithmetic using the type of the niche field, cf. the
     /// [`tag_for_variant`](../rustc_const_eval/interpret/struct.InterpCx.html#method.tag_for_variant)
     /// query implementation).
     /// To recover the variant index `i` from a `tag`, the above formula has to be reversed,
     /// i.e. `i = (tag.wrapping_sub(niche_start))+niche_variants.start`. If `i` ends up outside
     /// `niche_variants`, the tag must have encoded the `untagged_variant`.
-    /// 
+    ///
     /// For example, `Option<(usize, &T)>`  is represented such that the tag for
     /// `None` is the null pointer in the second tuple field, and
-    /// `Some` is the identity function (with a non-null reference) 
+    /// `Some` is the identity function (with a non-null reference)
     /// and has no additional tag, i.e. the reference being non-null uniquely identifies this variant.
     ///
     /// Other variants that are not `untagged_variant` and that are outside the `niche_variants`
@@ -1617,7 +1617,7 @@ pub enum TagEncoding<VariantIdx: Idx> {
     /// Nonetheless, uninhabited variants can also fall into the range of `niche_variants`.
     Niche {
         untagged_variant: VariantIdx,
-        /// This range *may* contain `untagged_variant` or uninhabited variants; 
+        /// This range *may* contain `untagged_variant` or uninhabited variants;
         /// these are then just "dead values" and not used to encode anything.
         niche_variants: RangeInclusive<VariantIdx>,
         /// This is inbounds of the type of the niche field

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1594,17 +1594,17 @@ pub enum TagEncoding<VariantIdx: Idx> {
 
     /// Niche (values invalid for a type) encoding the discriminant.
     /// Note that for this encoding, the discriminant and variant index of each variant coincide!
-    /// (This gets checked, for example, in [codegen_ssa](https://github.com/rust-lang/rust/blob/df32e15c56f582eb2bdde07711af6271f2ae660b/compiler/rustc_codegen_ssa/src/mir/operand.rs#L485).)
+    /// This invariant is codified as part of [`layout_sanity_check`](../rustc_ty_utils/layout/invariant/fn.layout_sanity_check.html).
     ///
     /// The variant `untagged_variant` contains a niche at an arbitrary
     /// offset (field [`Variants::Multiple::tag_field`] of the enum).
-    /// For a variant with variant index `i`, such that `i!=untagged_variant`,
+    /// For a variant with variant index `i`, such that `i != untagged_variant`,
     /// the tag is set to `(i - niche_variants.start).wrapping_add(niche_start)`
     /// (this is wrapping arithmetic using the type of the niche field, cf. the
     /// [`tag_for_variant`](../rustc_const_eval/interpret/struct.InterpCx.html#method.tag_for_variant)
     /// query implementation).
     /// To recover the variant index `i` from a `tag`, the above formula has to be reversed,
-    /// i.e. `i = (tag.wrapping_sub(niche_start))+niche_variants.start`. If `i` ends up outside
+    /// i.e. `i = tag.wrapping_sub(niche_start) + niche_variants.start`. If `i` ends up outside
     /// `niche_variants`, the tag must have encoded the `untagged_variant`.
     ///
     /// For example, `Option<(usize, &T)>`  is represented such that the tag for

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -16,10 +16,7 @@
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(macro_metavar_expr)]
-#![feature(negative_impls)]
-#![feature(never_type)]
 #![feature(rustdoc_internals)]
-#![feature(stmt_expr_attributes)]
 #![recursion_limit = "256"]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -253,6 +253,9 @@ pub enum AttributeKind {
     /// Represents `#[inline]` and `#[rustc_force_inline]`.
     Inline(InlineAttr, Span),
 
+    /// Represents `#[link_name]`.
+    LinkName { name: Symbol, span: Span },
+
     /// Represents `#[loop_match]`.
     LoopMatch(Span),
 

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -29,6 +29,7 @@ impl AttributeKind {
             Stability { .. } => Yes,
             Cold(..) => No,
             ConstContinue(..) => No,
+            LinkName { .. } => Yes,
             LoopMatch(..) => No,
             MayDangle(..) => No,
             MustUse { .. } => Yes,

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -1,0 +1,30 @@
+use rustc_attr_data_structures::AttributeKind;
+use rustc_attr_data_structures::AttributeKind::LinkName;
+use rustc_feature::{AttributeTemplate, template};
+use rustc_span::{Symbol, sym};
+
+use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::context::{AcceptContext, Stage};
+use crate::parser::ArgParser;
+
+pub(crate) struct LinkNameParser;
+
+impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
+    const PATH: &[Symbol] = &[sym::link_name];
+    const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepFirst;
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
+
+    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
+        let Some(nv) = args.name_value() else {
+            cx.expected_name_value(cx.attr_span, None);
+            return None;
+        };
+        let Some(name) = nv.value_as_str() else {
+            cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+            return None;
+        };
+
+        Some(LinkName { name, span: cx.attr_span })
+    }
+}

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod codegen_attrs;
 pub(crate) mod confusables;
 pub(crate) mod deprecation;
 pub(crate) mod inline;
+pub(crate) mod link_attrs;
 pub(crate) mod lint_helpers;
 pub(crate) mod loop_match;
 pub(crate) mod must_use;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -22,6 +22,7 @@ use crate::attributes::codegen_attrs::{
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
 use crate::attributes::inline::{InlineParser, RustcForceInlineParser};
+use crate::attributes::link_attrs::LinkNameParser;
 use crate::attributes::lint_helpers::{AsPtrParser, PubTransparentParser};
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
 use crate::attributes::must_use::MustUseParser;
@@ -121,6 +122,7 @@ attribute_parsers!(
         Single<DeprecationParser>,
         Single<ExportNameParser>,
         Single<InlineParser>,
+        Single<LinkNameParser>,
         Single<LoopMatchParser>,
         Single<MayDangleParser>,
         Single<MustUseParser>,

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1817,8 +1817,13 @@ pub(crate) fn linked_symbols(
     crate_type: CrateType,
 ) -> Vec<(String, SymbolExportKind)> {
     match crate_type {
-        CrateType::Executable | CrateType::Cdylib | CrateType::Dylib | CrateType::Sdylib => (),
-        CrateType::Staticlib | CrateType::ProcMacro | CrateType::Rlib => {
+        CrateType::Executable
+        | CrateType::ProcMacro
+        | CrateType::Cdylib
+        | CrateType::Dylib
+        | CrateType::Sdylib => (),
+        CrateType::Staticlib | CrateType::Rlib => {
+            // These are not linked, so no need to generate symbols.o for them.
             return Vec::new();
         }
     }

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -123,6 +123,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                 }
                 AttributeKind::Naked(_) => codegen_fn_attrs.flags |= CodegenFnAttrFlags::NAKED,
                 AttributeKind::Align { align, .. } => codegen_fn_attrs.alignment = Some(*align),
+                AttributeKind::LinkName { name, .. } => codegen_fn_attrs.link_name = Some(*name),
                 AttributeKind::NoMangle(attr_span) => {
                     if tcx.opt_item_name(did.to_def_id()).is_some() {
                         codegen_fn_attrs.flags |= CodegenFnAttrFlags::NO_MANGLE;
@@ -262,7 +263,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     }
                 }
             }
-            sym::link_name => codegen_fn_attrs.link_name = attr.value_str(),
             sym::link_ordinal => {
                 link_ordinal_span = Some(attr.span());
                 if let ordinal @ Some(_) = check_link_ordinal(tcx, attr) {

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -479,17 +479,8 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                     _ => (tag_imm, bx.cx().immediate_backend_type(tag_op.layout)),
                 };
 
-                // Layout ensures that we only get here for cases where the discriminant
+                // `layout_sanity_check` ensures that we only get here for cases where the discriminant
                 // value and the variant index match, since that's all `Niche` can encode.
-                // But for emphasis and debugging, let's double-check one anyway.
-                debug_assert_eq!(
-                    self.layout
-                        .ty
-                        .discriminant_for_variant(bx.tcx(), untagged_variant)
-                        .unwrap()
-                        .val,
-                    u128::from(untagged_variant.as_u32()),
-                );
 
                 let relative_max = niche_variants.end().as_u32() - niche_variants.start().as_u32();
 

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -3,7 +3,6 @@
 #![doc(rust_logo)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
-#![feature(type_alias_impl_trait)]
 // tidy-alphabetical-end
 
 use std::borrow::Cow;

--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -341,7 +341,7 @@ declare_features! (
     (accepted, pattern_parentheses, "1.31.0", Some(51087)),
     /// Allows `use<'a, 'b, A, B>` in `impl Trait + use<...>` for precise capture of generic args.
     (accepted, precise_capturing, "1.82.0", Some(123432)),
-    /// Allows `use<..>` precise capturign on impl Trait in traits.
+    /// Allows `use<..>` precise capturing on impl Trait in traits.
     (accepted, precise_capturing_in_traits, "1.87.0", Some(130044)),
     /// Allows procedural macros in `proc-macro` crates.
     (accepted, proc_macro, "1.29.0", Some(38356)),
@@ -388,7 +388,7 @@ declare_features! (
     (accepted, self_struct_ctor, "1.32.0", Some(51994)),
     /// Allows use of x86 SHA512, SM3 and SM4 target-features and intrinsics
     (accepted, sha512_sm_x86, "CURRENT_RUSTC_VERSION", Some(126624)),
-    /// Shortern the tail expression lifetime
+    /// Shorten the tail expression lifetime
     (accepted, shorter_tail_lifetimes, "1.84.0", Some(123739)),
     /// Allows using subslice patterns, `[a, .., b]` and `[a, xs @ .., b]`.
     (accepted, slice_patterns, "1.42.0", Some(62254)),

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -65,7 +65,6 @@ This API is completely unstable and subject to change.
 #![feature(debug_closure_helpers)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
-#![feature(iter_from_coroutine)]
 #![feature(iter_intersperse)]
 #![feature(never_type)]
 #![feature(rustdoc_internals)]

--- a/compiler/rustc_lint/src/foreign_modules.rs
+++ b/compiler/rustc_lint/src/foreign_modules.rs
@@ -1,4 +1,5 @@
 use rustc_abi::FIRST_VARIANT;
+use rustc_attr_data_structures::{AttributeKind, find_attr};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir as hir;
@@ -6,7 +7,7 @@ use rustc_hir::def::DefKind;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{self, AdtDef, Instance, Ty, TyCtxt};
 use rustc_session::declare_lint;
-use rustc_span::{Span, Symbol, sym};
+use rustc_span::{Span, Symbol};
 use tracing::{debug, instrument};
 
 use crate::lints::{BuiltinClashingExtern, BuiltinClashingExternSub};
@@ -182,7 +183,11 @@ fn name_of_extern_decl(tcx: TyCtxt<'_>, fi: hir::OwnerId) -> SymbolName {
             // information, we could have codegen_fn_attrs also give span information back for
             // where the attribute was defined. However, until this is found to be a
             // bottleneck, this does just fine.
-            (overridden_link_name, tcx.get_attr(fi, sym::link_name).unwrap().span())
+            (
+                overridden_link_name,
+                find_attr!(tcx.get_all_attrs(fi), AttributeKind::LinkName {span, ..} => *span)
+                    .unwrap(),
+            )
         })
     {
         SymbolName::Link(overridden_link_name, overridden_link_name_span)

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -7,7 +7,6 @@
 #![feature(file_buffered)]
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
-#![feature(iter_from_coroutine)]
 #![feature(macro_metavar_expr)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -48,7 +48,6 @@
 #![feature(gen_blocks)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]
-#![feature(iter_from_coroutine)]
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -284,15 +284,15 @@ pub enum FakeBorrowKind {
     ///
     /// This is used when lowering deref patterns, where shallow borrows wouldn't prevent something
     /// like:
-    // ```compile_fail
-    // let mut b = Box::new(false);
-    // match b {
-    //     deref!(true) => {} // not reached because `*b == false`
-    //     _ if { *b = true; false } => {} // not reached because the guard is `false`
-    //     deref!(false) => {} // not reached because the guard changed it
-    //     // UB because we reached the unreachable.
-    // }
-    // ```
+    /// ```compile_fail
+    /// let mut b = Box::new(false);
+    /// match b {
+    ///     deref!(true) => {} // not reached because `*b == false`
+    ///     _ if { *b = true; false } => {} // not reached because the guard is `false`
+    ///     deref!(false) => {} // not reached because the guard changed it
+    ///     // UB because we reached the unreachable.
+    /// }
+    /// ```
     Deep,
 }
 

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -1071,7 +1071,7 @@ impl<'a> Parser<'a> {
             && self.look_ahead(1, |t| t.is_keyword(kw::Const))
             && self.look_ahead(2, |t| *t == token::CloseBracket)
         {
-            let start = self.prev_token.span;
+            let start = self.token.span;
             self.bump();
             self.expect_keyword(exp!(Const)).unwrap();
             self.bump();

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -302,6 +302,7 @@ fn emit_malformed_attribute(
             | sym::no_mangle
             | sym::must_use
             | sym::track_caller
+            | sym::link_name
     ) {
         return;
     }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -502,7 +502,7 @@ pub(crate) struct Link {
 #[warning]
 pub(crate) struct LinkName<'a> {
     #[help]
-    pub attr_span: Option<Span>,
+    pub help_span: Option<Span>,
     #[label]
     pub span: Span,
     pub value: &'a str,

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -174,7 +174,14 @@ pub(crate) struct ImportData<'ra> {
 
     pub parent_scope: ParentScope<'ra>,
     pub module_path: Vec<Segment>,
-    /// The resolution of `module_path`.
+    /// The resolution of `module_path`:
+    ///
+    /// | `module_path` | `imported_module` | remark |
+    /// |-|-|-|
+    /// |`use prefix::foo`| `ModuleOrUniformRoot::Module(prefix)`               | - |
+    /// |`use ::foo`      | `ModuleOrUniformRoot::ExternPrelude`                | 2018+ editions |
+    /// |`use ::foo`      | `ModuleOrUniformRoot::CrateRootAndExternPrelude`    | a special case in 2015 edition |
+    /// |`use foo`        | `ModuleOrUniformRoot::CurrentScope`                 | - |
     pub imported_module: Cell<Option<ModuleOrUniformRoot<'ra>>>,
     pub vis: ty::Visibility,
 }

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -277,6 +277,12 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                     if !variant.is_uninhabited() {
                         assert!(idx == *untagged_variant || niche_variants.contains(&idx));
                     }
+
+                    // Ensure that for niche encoded tags the discriminant coincides with the variant index.
+                    assert_eq!(
+                        layout.ty.discriminant_for_variant(tcx, idx).unwrap().val,
+                        u128::from(idx.as_u32()),
+                    );
                 }
             }
             for variant in variants.iter() {

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -408,24 +408,22 @@ pub trait OpenOptionsExt {
     /// Pass custom flags to the `flags` argument of `open`.
     ///
     /// The bits that define the access mode are masked out with `O_ACCMODE`, to
-    /// ensure they do not interfere with the access mode set by Rusts options.
+    /// ensure they do not interfere with the access mode set by Rust's options.
     ///
-    /// Custom flags can only set flags, not remove flags set by Rusts options.
-    /// This options overwrites any previously set custom flags.
+    /// Custom flags can only set flags, not remove flags set by Rust's options.
+    /// This function overwrites any previously-set custom flags.
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(rustc_private)]
+    /// # mod libc { pub const O_NOFOLLOW: i32 = 0; }
     /// use std::fs::OpenOptions;
     /// use std::os::unix::fs::OpenOptionsExt;
     ///
     /// # fn main() {
     /// let mut options = OpenOptions::new();
     /// options.write(true);
-    /// if cfg!(unix) {
-    ///     options.custom_flags(libc::O_NOFOLLOW);
-    /// }
+    /// options.custom_flags(libc::O_NOFOLLOW);
     /// let file = options.open("foo.txt");
     /// # }
     /// ```

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -8,23 +8,25 @@ build = "build.rs"
 path = "lib.rs"
 
 [dependencies]
+# tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.14", default-features = false, features = ["alloc", "config", "derive"] }
 base64 = "0.21.7"
-itertools = "0.12"
 indexmap = "2"
+itertools = "0.12"
 minifier = { version = "0.3.5", default-features = false }
 pulldown-cmark-escape = { version = "0.11.0", features = ["simd"] }
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }
-serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 smallvec = "1.8.1"
 tempfile = "3"
+threadpool = "1.8.1"
 tracing = "0.1"
 tracing-tree = "0.3.0"
-threadpool = "1.8.1"
 unicode-segmentation = "1.9"
+# tidy-alphabetical-end
 
 [dependencies.tracing-subscriber]
 version = "0.3.3"

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -1,8 +1,8 @@
+// tidy-alphabetical-start
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/",
     html_playground_url = "https://play.rust-lang.org/"
 )]
-#![feature(rustc_private)]
 #![feature(ascii_char)]
 #![feature(ascii_char_variants)]
 #![feature(assert_matches)]
@@ -13,8 +13,10 @@
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(round_char_boundary)]
+#![feature(rustc_private)]
 #![feature(test)]
 #![warn(rustc::internal)]
+// tidy-alphabetical-end
 
 extern crate thin_vec;
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -20,9 +20,6 @@
 #![feature(type_ascription)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
-#![allow(clippy::collapsible_if, clippy::collapsible_else_if)]
-#![allow(rustc::diagnostic_outside_of_impl)]
-#![allow(rustc::untranslatable_diagnostic)]
 
 extern crate thin_vec;
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -11,13 +11,9 @@
 #![feature(file_buffered)]
 #![feature(format_args_nl)]
 #![feature(if_let_guard)]
-#![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]
-#![feature(never_type)]
 #![feature(round_char_boundary)]
 #![feature(test)]
-#![feature(type_alias_impl_trait)]
-#![feature(type_ascription)]
 #![warn(rustc::internal)]
 
 extern crate thin_vec;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -18,7 +18,6 @@
 #![feature(test)]
 #![feature(type_alias_impl_trait)]
 #![feature(type_ascription)]
-#![recursion_limit = "256"]
 #![warn(rustc::internal)]
 
 extern crate thin_vec;

--- a/tests/run-make/used-proc-macro/dep.rs
+++ b/tests/run-make/used-proc-macro/dep.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+#[used]
+static VERY_IMPORTANT_SYMBOL: u32 = 12345;

--- a/tests/run-make/used-proc-macro/proc_macro.rs
+++ b/tests/run-make/used-proc-macro/proc_macro.rs
@@ -1,0 +1,3 @@
+#![crate_type = "proc-macro"]
+
+extern crate dep as _;

--- a/tests/run-make/used-proc-macro/rmake.rs
+++ b/tests/run-make/used-proc-macro/rmake.rs
@@ -1,0 +1,18 @@
+// Test that #[used] statics are included in the final dylib for proc-macros too.
+
+//@ ignore-cross-compile
+//@ ignore-windows llvm-readobj --all doesn't show local symbols on Windows
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
+use run_make_support::{dynamic_lib_name, llvm_readobj, rustc};
+
+fn main() {
+    rustc().input("dep.rs").run();
+    rustc().input("proc_macro.rs").run();
+    llvm_readobj()
+        .input(dynamic_lib_name("proc_macro"))
+        .arg("--all")
+        .run()
+        .assert_stdout_contains("VERY_IMPORTANT_SYMBOL");
+}

--- a/tests/rustdoc/intra-doc/deps.rs
+++ b/tests/rustdoc/intra-doc/deps.rs
@@ -1,0 +1,23 @@
+// Checks that links to crates are correctly generated and only existing crates
+// have a link generated.
+// Regression test for <https://github.com/rust-lang/rust/issues/137857>.
+
+//@ compile-flags: --document-private-items -Z unstable-options
+//@ compile-flags: --extern-html-root-url=empty=https://empty.example/
+// This one is to ensure that we don't link to any item we see which has
+// an external html root URL unless it actually exists.
+//@ compile-flags: --extern-html-root-url=non_existant=https://non-existant.example/
+//@ aux-build: empty.rs
+
+#![crate_name = "foo"]
+#![expect(rustdoc::broken_intra_doc_links)]
+
+//@ has 'foo/index.html'
+//@ has - '//a[@href="https://empty.example/empty/index.html"]' 'empty'
+// There should only be one intra doc links, we should not link `non_existant`.
+//@ count - '//*[@class="docblock"]//a' 1
+//! [`empty`]
+//!
+//! [`non_existant`]
+
+extern crate empty;

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -5,145 +5,145 @@ LL | #![feature(const_fn_trait_ref_impls)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:14:6
+  --> $DIR/fn_trait_refs.rs:14:8
    |
 LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
+   |        ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:14:6
+  --> $DIR/fn_trait_refs.rs:14:8
    |
 LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
-   |
-note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:14:6
-   |
-LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
+   |        ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:21:6
+  --> $DIR/fn_trait_refs.rs:14:8
+   |
+LL |     T: [const] Fn<()> + [const] Destruct,
+   |        ^^^^^^^ can't be applied to `Fn`
+   |
+note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `[const]` can only be applied to `#[const_trait]` traits
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:21:6
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:21:6
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:28:6
+  --> $DIR/fn_trait_refs.rs:28:8
    |
 LL |     T: [const] FnOnce<()>,
-   |      ^^^^^^^^^ can't be applied to `FnOnce`
+   |        ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:28:6
+  --> $DIR/fn_trait_refs.rs:28:8
    |
 LL |     T: [const] FnOnce<()>,
-   |      ^^^^^^^^^ can't be applied to `FnOnce`
-   |
-note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
-  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:28:6
-   |
-LL |     T: [const] FnOnce<()>,
-   |      ^^^^^^^^^ can't be applied to `FnOnce`
+   |        ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:35:6
+  --> $DIR/fn_trait_refs.rs:28:8
+   |
+LL |     T: [const] FnOnce<()>,
+   |        ^^^^^^^ can't be applied to `FnOnce`
+   |
+note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `[const]` can only be applied to `#[const_trait]` traits
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
+   |        ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:35:6
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
+   |        ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:35:6
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: [const] Fn<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `Fn`
+   |        ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:49:6
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:49:6
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:49:6
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: [const] FnMut<()> + [const] Destruct,
-   |      ^^^^^^^^^ can't be applied to `FnMut`
+   |        ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:30
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:32
    |
 LL |     const fn unwrap_or_else<F: [const] FnOnce() -> T>(self, f: F) -> T {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:30
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:32
    |
 LL |     const fn unwrap_or_else<F: [const] FnOnce() -> T>(self, f: F) -> T {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/extern/issue-47725.rs
+++ b/tests/ui/extern/issue-47725.rs
@@ -17,12 +17,9 @@ extern "C" {
 #[link_name]
 //~^ ERROR malformed `link_name` attribute input
 //~| HELP must be of the form
-//~| WARN attribute should be applied to a foreign function or static [unused_attributes]
-//~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-//~| HELP try `#[link(name = "...")]` instead
+//~| NOTE expected this to be of the form `link_name = "..."
 extern "C" {
     fn bar() -> u32;
 }
-//~^^^ NOTE not a foreign function or static
 
 fn main() {}

--- a/tests/ui/extern/issue-47725.stderr
+++ b/tests/ui/extern/issue-47725.stderr
@@ -1,8 +1,11 @@
-error: malformed `link_name` attribute input
+error[E0539]: malformed `link_name` attribute input
   --> $DIR/issue-47725.rs:17:1
    |
 LL | #[link_name]
-   | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
+   | ^^^^^^^^^^^^
+   | |
+   | expected this to be of the form `link_name = "..."`
+   | help: must be of the form: `#[link_name = "name"]`
 
 warning: attribute should be applied to a foreign function or static
   --> $DIR/issue-47725.rs:3:1
@@ -38,23 +41,6 @@ help: try `#[link(name = "foobar")]` instead
 LL | #[link_name = "foobar"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: attribute should be applied to a foreign function or static
-  --> $DIR/issue-47725.rs:17:1
-   |
-LL |   #[link_name]
-   |   ^^^^^^^^^^^^
-...
-LL | / extern "C" {
-LL | |     fn bar() -> u32;
-LL | | }
-   | |_- not a foreign function or static
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-help: try `#[link(name = "...")]` instead
-  --> $DIR/issue-47725.rs:17:1
-   |
-LL | #[link_name]
-   | ^^^^^^^^^^^^
+error: aborting due to 1 previous error; 2 warnings emitted
 
-error: aborting due to 1 previous error; 3 warnings emitted
-
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -387,14 +387,6 @@ LL | #![link()]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: attribute should be applied to a foreign function or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:66:1
-   |
-LL | #![link_name = "1900"]
-   | ^^^^^^^^^^^^^^^^^^^^^^ not a foreign function or static
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
 warning: attribute should be applied to a function or static
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:69:1
    |
@@ -408,6 +400,14 @@ warning: attribute should be applied to a function definition
    |
 LL | #![cold]
    | ^^^^^^^^ cannot be applied to crates
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+warning: attribute should be applied to a foreign function or static
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:66:1
+   |
+LL | #![link_name = "1900"]
+   | ^^^^^^^^^^^^^^^^^^^^^^ not a foreign function or static
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:27:33
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> [const] Fn(&'a Alias<'a>) + [const] Destruct>(fun: F) {
-   |                                 ^^^^^^^^^ can't be applied to `Fn`
+   |                                   ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:27:33
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> [const] Fn(&'a Alias<'a>) + [const] Destruct>(fun: F) {
-   |                                 ^^^^^^^^^ can't be applied to `Fn`
+   |                                   ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -90,19 +90,6 @@ LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:86:5
-   |
-LL |     #[link_name = "this_does_not_exist"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:88:5
-   |
-LL |     #[link_name = "rust_dbg_extern_identity_u32"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:14:1
    |
 LL | #![crate_name = "unused_attr_duplicate2"]
@@ -251,6 +238,19 @@ note: attribute also specified here
    |
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:86:5
+   |
+LL |     #[link_name = "this_does_not_exist"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:88:5
+   |
+LL |     #[link_name = "rust_dbg_extern_identity_u32"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:92:1

--- a/tests/ui/parser/bounds-type.stderr
+++ b/tests/ui/parser/bounds-type.stderr
@@ -21,10 +21,10 @@ LL |     T: [const] ?Tr,
    |        there is not a well-defined meaning for a `[const] ?` trait
 
 error: `[const]` may only modify trait bounds, not lifetime bounds
-  --> $DIR/bounds-type.rs:16:6
+  --> $DIR/bounds-type.rs:16:8
    |
 LL |     T: [const] 'a,
-   |      ^^^^^^^^^
+   |        ^^^^^^^
 
 error: `const` may only modify trait bounds, not lifetime bounds
   --> $DIR/bounds-type.rs:17:8

--- a/tests/ui/specialization/const_trait_impl.stderr
+++ b/tests/ui/specialization/const_trait_impl.stderr
@@ -1,55 +1,55 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:34:7
+  --> $DIR/const_trait_impl.rs:34:9
    |
 LL | impl<T: [const] Default> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:40:7
+  --> $DIR/const_trait_impl.rs:40:9
    |
 LL | impl<T: [const] Default + [const] Sup> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:46:7
+  --> $DIR/const_trait_impl.rs:46:9
    |
 LL | impl<T: [const] Default + [const] Sub> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:40:7
+  --> $DIR/const_trait_impl.rs:40:9
    |
 LL | impl<T: [const] Default + [const] Sup> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:34:7
+  --> $DIR/const_trait_impl.rs:34:9
    |
 LL | impl<T: [const] Default> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:46:7
+  --> $DIR/const_trait_impl.rs:46:9
    |
 LL | impl<T: [const] Default + [const] Sub> const A for T {
-   |       ^^^^^^^^^ can't be applied to `Default`
+   |         ^^^^^^^ can't be applied to `Default`
    |
 note: `Default` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/default.rs:LL:COL

--- a/tests/ui/traits/const-traits/conditionally-const-and-const-params.stderr
+++ b/tests/ui/traits/const-traits/conditionally-const-and-const-params.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-and-const-params.rs:8:13
+  --> $DIR/conditionally-const-and-const-params.rs:8:15
    |
 LL |     fn add<A: [const] Add42>(self) -> Foo<{ A::add(N) }> {
-   |             ^^^^^^^^^
+   |               ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-and-const-params.rs:8:8
@@ -11,10 +11,10 @@ LL |     fn add<A: [const] Add42>(self) -> Foo<{ A::add(N) }> {
    |        ^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-and-const-params.rs:26:9
+  --> $DIR/conditionally-const-and-const-params.rs:26:11
    |
 LL | fn bar<A: [const] Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
-   |         ^^^^^^^^^
+   |           ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-and-const-params.rs:26:4

--- a/tests/ui/traits/const-traits/conditionally-const-invalid-places.stderr
+++ b/tests/ui/traits/const-traits/conditionally-const-invalid-places.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:7:24
+  --> $DIR/conditionally-const-invalid-places.rs:7:26
    |
 LL | fn non_const_function<T: [const] Trait>() {}
-   |                        ^^^^^^^^^
+   |                          ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:7:4
@@ -11,66 +11,66 @@ LL | fn non_const_function<T: [const] Trait>() {}
    |    ^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:9:16
+  --> $DIR/conditionally-const-invalid-places.rs:9:18
    |
 LL | struct Struct<T: [const] Trait> { field: T }
-   |                ^^^^^^^^^
+   |                  ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:10:21
+  --> $DIR/conditionally-const-invalid-places.rs:10:23
    |
 LL | struct TupleStruct<T: [const] Trait>(T);
-   |                     ^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:11:20
+  --> $DIR/conditionally-const-invalid-places.rs:11:22
    |
 LL | struct UnitStruct<T: [const] Trait>;
-   |                    ^^^^^^^^^
+   |                      ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:14:12
+  --> $DIR/conditionally-const-invalid-places.rs:14:14
    |
 LL | enum Enum<T: [const] Trait> { Variant(T) }
-   |            ^^^^^^^^^
+   |              ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:16:14
+  --> $DIR/conditionally-const-invalid-places.rs:16:16
    |
 LL | union Union<T: [const] Trait> { field: T }
-   |              ^^^^^^^^^
+   |                ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:19:12
+  --> $DIR/conditionally-const-invalid-places.rs:19:14
    |
 LL | type Type<T: [const] Trait> = T;
-   |            ^^^^^^^^^
+   |              ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:21:17
+  --> $DIR/conditionally-const-invalid-places.rs:21:19
    |
 LL | const CONSTANT<T: [const] Trait>: () = ();
-   |                 ^^^^^^^^^
+   |                   ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:25:16
+  --> $DIR/conditionally-const-invalid-places.rs:25:18
    |
 LL |     type Type<T: [const] Trait>: [const] Trait;
-   |                ^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: associated types in non-`#[const_trait]` traits cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:25:5
@@ -79,10 +79,10 @@ LL |     type Type<T: [const] Trait>: [const] Trait;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:25:32
+  --> $DIR/conditionally-const-invalid-places.rs:25:34
    |
 LL |     type Type<T: [const] Trait>: [const] Trait;
-   |                                ^^^^^^^^^
+   |                                  ^^^^^^^
    |
 note: associated types in non-`#[const_trait]` traits cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:25:5
@@ -91,10 +91,10 @@ LL |     type Type<T: [const] Trait>: [const] Trait;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:28:28
+  --> $DIR/conditionally-const-invalid-places.rs:28:30
    |
 LL |     fn non_const_function<T: [const] Trait>();
-   |                            ^^^^^^^^^
+   |                              ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:28:8
@@ -103,18 +103,18 @@ LL |     fn non_const_function<T: [const] Trait>();
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:29:21
+  --> $DIR/conditionally-const-invalid-places.rs:29:23
    |
 LL |     const CONSTANT<T: [const] Trait>: ();
-   |                     ^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:34:16
+  --> $DIR/conditionally-const-invalid-places.rs:34:18
    |
 LL |     type Type<T: [const] Trait> = ();
-   |                ^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: associated types in non-const impls cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:34:5
@@ -123,10 +123,10 @@ LL |     type Type<T: [const] Trait> = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:36:28
+  --> $DIR/conditionally-const-invalid-places.rs:36:30
    |
 LL |     fn non_const_function<T: [const] Trait>() {}
-   |                            ^^^^^^^^^
+   |                              ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:36:8
@@ -135,18 +135,18 @@ LL |     fn non_const_function<T: [const] Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:37:21
+  --> $DIR/conditionally-const-invalid-places.rs:37:23
    |
 LL |     const CONSTANT<T: [const] Trait>: () = ();
-   |                     ^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:44:16
+  --> $DIR/conditionally-const-invalid-places.rs:44:18
    |
 LL |     type Type<T: [const] Trait> = ();
-   |                ^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: inherent associated types cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:44:5
@@ -155,10 +155,10 @@ LL |     type Type<T: [const] Trait> = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:46:28
+  --> $DIR/conditionally-const-invalid-places.rs:46:30
    |
 LL |     fn non_const_function<T: [const] Trait>() {}
-   |                            ^^^^^^^^^
+   |                              ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:46:8
@@ -167,18 +167,18 @@ LL |     fn non_const_function<T: [const] Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:47:21
+  --> $DIR/conditionally-const-invalid-places.rs:47:23
    |
 LL |     const CONSTANT<T: [const] Trait>: () = ();
-   |                     ^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: this item cannot have `[const]` trait bounds
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:52:13
+  --> $DIR/conditionally-const-invalid-places.rs:52:15
    |
 LL | trait Child0: [const] Trait {}
-   |             ^^^^^^^^^
+   |               ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:52:1
@@ -187,10 +187,10 @@ LL | trait Child0: [const] Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:53:24
+  --> $DIR/conditionally-const-invalid-places.rs:53:26
    |
 LL | trait Child1 where Self: [const] Trait {}
-   |                        ^^^^^^^^^
+   |                          ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:53:1
@@ -199,10 +199,10 @@ LL | trait Child1 where Self: [const] Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:56:7
+  --> $DIR/conditionally-const-invalid-places.rs:56:9
    |
 LL | impl<T: [const] Trait> Trait for T {}
-   |       ^^^^^^^^^
+   |         ^^^^^^^
    |
 note: this impl is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:56:1
@@ -211,10 +211,10 @@ LL | impl<T: [const] Trait> Trait for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/conditionally-const-invalid-places.rs:59:7
+  --> $DIR/conditionally-const-invalid-places.rs:59:9
    |
 LL | impl<T: [const] Trait> Struct<T> {}
-   |       ^^^^^^^^^
+   |         ^^^^^^^
    |
 note: inherent impls cannot have `[const]` trait bounds
   --> $DIR/conditionally-const-invalid-places.rs:59:1

--- a/tests/ui/traits/const-traits/const-bound-on-not-const-associated-fn.stderr
+++ b/tests/ui/traits/const-traits/const-bound-on-not-const-associated-fn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/const-bound-on-not-const-associated-fn.rs:11:38
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:11:40
    |
 LL |     fn do_something_else() where Self: [const] MyTrait;
-   |                                      ^^^^^^^^^
+   |                                        ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/const-bound-on-not-const-associated-fn.rs:11:8
@@ -11,10 +11,10 @@ LL |     fn do_something_else() where Self: [const] MyTrait;
    |        ^^^^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/const-bound-on-not-const-associated-fn.rs:22:30
+  --> $DIR/const-bound-on-not-const-associated-fn.rs:22:32
    |
 LL |     pub fn foo(&self) where T: [const] MyTrait {
-   |                              ^^^^^^^^^
+   |                                ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/const-bound-on-not-const-associated-fn.rs:22:12

--- a/tests/ui/traits/const-traits/const-bounds-non-const-trait.stderr
+++ b/tests/ui/traits/const-traits/const-bounds-non-const-trait.stderr
@@ -1,8 +1,8 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-bounds-non-const-trait.rs:6:19
+  --> $DIR/const-bounds-non-const-trait.rs:6:21
    |
 LL | const fn perform<T: [const] NonConst>() {}
-   |                   ^^^^^^^^^ can't be applied to `NonConst`
+   |                     ^^^^^^^ can't be applied to `NonConst`
    |
 help: mark `NonConst` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -10,10 +10,10 @@ LL | #[const_trait] trait NonConst {}
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-bounds-non-const-trait.rs:6:19
+  --> $DIR/const-bounds-non-const-trait.rs:6:21
    |
 LL | const fn perform<T: [const] NonConst>() {}
-   |                   ^^^^^^^^^ can't be applied to `NonConst`
+   |                     ^^^^^^^ can't be applied to `NonConst`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `NonConst` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
+++ b/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
@@ -1,27 +1,27 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-parse-not-item.rs:7:20
+  --> $DIR/const-closure-parse-not-item.rs:7:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-parse-not-item.rs:7:20
+  --> $DIR/const-closure-parse-not-item.rs:7:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-parse-not-item.rs:7:20
+  --> $DIR/const-closure-parse-not-item.rs:7:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method-fail.rs:14:30
+  --> $DIR/const-closure-trait-method-fail.rs:14:32
    |
 LL | const fn need_const_closure<T: [const] FnOnce(()) -> i32>(x: T) -> i32 {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method-fail.rs:14:30
+  --> $DIR/const-closure-trait-method-fail.rs:14:32
    |
 LL | const fn need_const_closure<T: [const] FnOnce(()) -> i32>(x: T) -> i32 {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/const-closure-trait-method.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method.rs:14:30
+  --> $DIR/const-closure-trait-method.rs:14:32
    |
 LL | const fn need_const_closure<T: [const] FnOnce(()) -> i32>(x: T) -> i32 {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method.rs:14:30
+  --> $DIR/const-closure-trait-method.rs:14:32
    |
 LL | const fn need_const_closure<T: [const] FnOnce(()) -> i32>(x: T) -> i32 {
-   |                              ^^^^^^^^^ can't be applied to `FnOnce`
+   |                                ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/const-closures.stderr
+++ b/tests/ui/traits/const-traits/const-closures.stderr
@@ -1,74 +1,74 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:8:10
+  --> $DIR/const-closures.rs:8:12
    |
 LL |         F: [const] FnOnce() -> u8,
-   |          ^^^^^^^^^ can't be applied to `FnOnce`
+   |            ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:9:10
+  --> $DIR/const-closures.rs:9:12
    |
 LL |         F: [const] FnMut() -> u8,
-   |          ^^^^^^^^^ can't be applied to `FnMut`
+   |            ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:10:10
+  --> $DIR/const-closures.rs:10:12
    |
 LL |         F: [const] Fn() -> u8,
-   |          ^^^^^^^^^ can't be applied to `Fn`
+   |            ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:8:10
+  --> $DIR/const-closures.rs:8:12
    |
 LL |         F: [const] FnOnce() -> u8,
-   |          ^^^^^^^^^ can't be applied to `FnOnce`
+   |            ^^^^^^^ can't be applied to `FnOnce`
    |
 note: `FnOnce` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:9:10
+  --> $DIR/const-closures.rs:9:12
    |
 LL |         F: [const] FnMut() -> u8,
-   |          ^^^^^^^^^ can't be applied to `FnMut`
+   |            ^^^^^^^ can't be applied to `FnMut`
    |
 note: `FnMut` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:10:10
+  --> $DIR/const-closures.rs:10:12
    |
 LL |         F: [const] Fn() -> u8,
-   |          ^^^^^^^^^ can't be applied to `Fn`
+   |            ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:23:18
+  --> $DIR/const-closures.rs:23:20
    |
 LL | const fn answer<F: [const] Fn() -> u8>(f: &F) -> u8 {
-   |                  ^^^^^^^^^ can't be applied to `Fn`
+   |                    ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:23:18
+  --> $DIR/const-closures.rs:23:20
    |
 LL | const fn answer<F: [const] Fn() -> u8>(f: &F) -> u8 {
-   |                  ^^^^^^^^^ can't be applied to `Fn`
+   |                    ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.stderr
+++ b/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.stderr
@@ -5,10 +5,10 @@ LL |     let _: &dyn const Trait;
    |                 ^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/const-trait-bounds-trait-objects.rs:10:13
+  --> $DIR/const-trait-bounds-trait-objects.rs:10:17
    |
 LL |     let _: &dyn [const] Trait;
-   |             ^^^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: trait objects cannot have `[const]` trait bounds
 
@@ -19,10 +19,10 @@ LL | const fn handle(_: &dyn const NonConst) {}
    |                         ^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/const-trait-bounds-trait-objects.rs:17:19
+  --> $DIR/const-trait-bounds-trait-objects.rs:17:23
    |
 LL | const fn take(_: &dyn [const] NonConst) {}
-   |                   ^^^^^^^^^^^
+   |                       ^^^^^^^
    |
    = note: trait objects cannot have `[const]` trait bounds
 

--- a/tests/ui/traits/const-traits/feature-gate.stock.stderr
+++ b/tests/ui/traits/const-traits/feature-gate.stock.stderr
@@ -9,10 +9,10 @@ LL | impl const T for S {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:13:13
+  --> $DIR/feature-gate.rs:13:15
    |
 LL | const fn f<A: [const] T>() {}
-   |             ^^^^^^^^^
+   |               ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
@@ -29,10 +29,10 @@ LL | fn g<A: const T>() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:18:12
+  --> $DIR/feature-gate.rs:18:17
    |
 LL | discard! { impl [const] T }
-   |            ^^^^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable

--- a/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
@@ -9,29 +9,29 @@ LL |     const move || {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:25
    |
 LL | const fn test() -> impl [const] Fn() {
-   |                    ^^^^^^^^^^^^ can't be applied to `Fn`
+   |                         ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/ice-123664-unexpected-bound-var.stderr
+++ b/tests/ui/traits/const-traits/ice-123664-unexpected-bound-var.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-123664-unexpected-bound-var.rs:4:25
+  --> $DIR/ice-123664-unexpected-bound-var.rs:4:27
    |
 LL | const fn with_positive<F: [const] Fn()>() {}
-   |                         ^^^^^^^^^ can't be applied to `Fn`
+   |                           ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-123664-unexpected-bound-var.rs:4:25
+  --> $DIR/ice-123664-unexpected-bound-var.rs:4:27
    |
 LL | const fn with_positive<F: [const] Fn()>() {}
-   |                         ^^^^^^^^^ can't be applied to `Fn`
+   |                           ^^^^^^^ can't be applied to `Fn`
    |
 note: `Fn` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL

--- a/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
@@ -1,17 +1,17 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/non-const-op-in-closure-in-const.rs:10:42
+  --> $DIR/non-const-op-in-closure-in-const.rs:10:44
    |
 LL | impl<A, B> const Convert<B> for A where B: [const] From<A> {
-   |                                          ^^^^^^^^^ can't be applied to `From`
+   |                                            ^^^^^^^ can't be applied to `From`
    |
 note: `From` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/non-const-op-in-closure-in-const.rs:10:42
+  --> $DIR/non-const-op-in-closure-in-const.rs:10:44
    |
 LL | impl<A, B> const Convert<B> for A where B: [const] From<A> {
-   |                                          ^^^^^^^^^ can't be applied to `From`
+   |                                            ^^^^^^^ can't be applied to `From`
    |
 note: `From` can't be used with `[const]` because it isn't annotated with `#[const_trait]`
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL

--- a/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-2.rs:11:1
@@ -11,10 +11,10 @@ LL | trait Bar: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -22,10 +22,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -34,10 +34,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
@@ -1,8 +1,8 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -10,10 +10,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -22,10 +22,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -34,10 +34,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -46,10 +46,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-2.rs:11:10
+  --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-2.rs:11:1

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nnn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nnn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-3.rs:23:1
@@ -11,30 +11,30 @@ LL | trait Bar: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -42,10 +42,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -54,10 +54,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -66,10 +66,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -77,10 +77,10 @@ LL | #[const_trait] trait Bar: [const] Foo {}
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nny.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-3.rs:23:1
@@ -11,30 +11,30 @@ LL | trait Bar: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -42,10 +42,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -54,10 +54,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -66,10 +66,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -77,10 +77,10 @@ LL | #[const_trait] trait Bar: [const] Foo {}
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nyn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nyn.stderr
@@ -1,18 +1,18 @@
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nyy.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nyy.stderr
@@ -1,18 +1,18 @@
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^
+   |                 ^^^^^^^
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable

--- a/tests/ui/traits/const-traits/super-traits-fail-3.ynn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.ynn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-3.rs:23:1
@@ -11,10 +11,10 @@ LL | trait Bar: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -22,10 +22,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -34,10 +34,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -46,10 +46,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
 help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -57,10 +57,10 @@ LL | #[const_trait] trait Bar: [const] Foo {}
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yny.stderr
@@ -1,8 +1,8 @@
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -10,10 +10,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -22,10 +22,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -34,10 +34,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
@@ -46,10 +46,10 @@ LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^ can't be applied to `Foo`
+   |            ^^^^^^^ can't be applied to `Foo`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:23:10
+  --> $DIR/super-traits-fail-3.rs:23:12
    |
 LL | trait Bar: [const] Foo {}
-   |          ^^^^^^^^^
+   |            ^^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `[const]` trait bounds
   --> $DIR/super-traits-fail-3.rs:23:1
@@ -11,10 +11,10 @@ LL | trait Bar: [const] Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
 help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
    |
@@ -22,10 +22,10 @@ LL | #[const_trait] trait Bar: [const] Foo {}
    | ++++++++++++++
 
 error: `[const]` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:32:15
+  --> $DIR/super-traits-fail-3.rs:32:17
    |
 LL | const fn foo<T: [const] Bar>(x: &T) {
-   |               ^^^^^^^^^ can't be applied to `Bar`
+   |                 ^^^^^^^ can't be applied to `Bar`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations

--- a/tests/ui/traits/const-traits/syntactical-unstable.stderr
+++ b/tests/ui/traits/const-traits/syntactical-unstable.stderr
@@ -2,9 +2,9 @@ error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:13:20
    |
 LL | trait Foo: [const] MyTrait {
-   |          --------- ^^^^^^^
-   |          |
-   |          trait is not stable as const yet
+   |            ------- ^^^^^^^
+   |            |
+   |            trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
@@ -13,9 +13,9 @@ error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:19:45
    |
 LL | const fn where_clause<T>() where T: [const] MyTrait {}
-   |                                   --------- ^^^^^^^
-   |                                   |
-   |                                   trait is not stable as const yet
+   |                                     ------- ^^^^^^^
+   |                                     |
+   |                                     trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
@@ -24,9 +24,9 @@ error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:22:53
    |
 LL | const fn nested<T>() where T: Deref<Target: [const] MyTrait> {}
-   |                                           --------- ^^^^^^^
-   |                                           |
-   |                                           trait is not stable as const yet
+   |                                             ------- ^^^^^^^
+   |                                             |
+   |                                             trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
@@ -35,9 +35,9 @@ error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:25:33
    |
 LL | const fn rpit() -> impl [const] MyTrait { Local }
-   |                    ------------ ^^^^^^^
-   |                    |
-   |                    trait is not stable as const yet
+   |                         ------- ^^^^^^^
+   |                         |
+   |                         trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
@@ -55,9 +55,9 @@ error[E0658]: use of unstable const library feature `unstable`
   --> $DIR/syntactical-unstable.rs:15:24
    |
 LL |     type Item: [const] MyTrait;
-   |              --------- ^^^^^^^
-   |              |
-   |              trait is not stable as const yet
+   |                ------- ^^^^^^^
+   |                |
+   |                trait is not stable as const yet
    |
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/traits/const-traits/trait-where-clause.stderr
+++ b/tests/ui/traits/const-traits/trait-where-clause.stderr
@@ -1,8 +1,8 @@
 error: `[const]` is not allowed here
-  --> $DIR/trait-where-clause.rs:8:22
+  --> $DIR/trait-where-clause.rs:8:24
    |
 LL |     fn b() where Self: [const] Bar;
-   |                      ^^^^^^^^^
+   |                        ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/trait-where-clause.rs:8:8
@@ -11,10 +11,10 @@ LL |     fn b() where Self: [const] Bar;
    |        ^
 
 error: `[const]` is not allowed here
-  --> $DIR/trait-where-clause.rs:10:11
+  --> $DIR/trait-where-clause.rs:10:13
    |
 LL |     fn c<T: [const] Bar>();
-   |           ^^^^^^^^^
+   |             ^^^^^^^
    |
 note: this function is not `const`, so it cannot have `[const]` trait bounds
   --> $DIR/trait-where-clause.rs:10:8


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#142021 (Doc: clarify priority of lint level sources)
 - rust-lang/rust#142367 (Add regression test for rust-lang/rust#137857 to ensure that we generate intra doc links for extern crate items.)
 - rust-lang/rust#142641 (Generate symbols.o for proc-macros too)
 - rust-lang/rust#142889 (Clarify doc comment on unix OpenOptions)
 - rust-lang/rust#143063 (explain `ImportData::imported_module`)
 - rust-lang/rust#143088 (Improve documentation of `TagEncoding`)
 - rust-lang/rust#143135 (fix typos on some doc comments)
 - rust-lang/rust#143138 (Port `#[link_name]` to the new attribute parsing infrastructure)
 - rust-lang/rust#143155 (`librustdoc` house-keeping 🧹)
 - rust-lang/rust#143169 (Remove unused feature gates)
 - rust-lang/rust#143171 (Fix the span of trait bound modifier `[const]`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=142021,142367,142641,142889,143063,143088,143135,143138,143155,143169,143171)
<!-- homu-ignore:end -->