### PR TITLE
Make combining LLD with external LLVM config a hard error

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2241,7 +2241,7 @@ impl Step for Assemble {
         debug!("copying codegen backends to sysroot");
         copy_codegen_backends_to_sysroot(builder, build_compiler, target_compiler);
 
-        if builder.config.lld_enabled && !builder.config.is_system_llvm(target_compiler.host) {
+        if builder.config.lld_enabled {
             builder.ensure(crate::core::build_steps::tool::LldWrapper {
                 build_compiler,
                 target_compiler,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1003,9 +1003,7 @@ impl Config {
         }
 
         if config.lld_enabled && config.is_system_llvm(config.host_target) {
-            eprintln!(
-                "Warning: LLD is enabled when using external llvm-config. LLD will not be built and copied to the sysroot."
-            );
+            panic!("Cannot enable LLD with `rust.lld = true` when using external llvm-config.");
         }
 
         config.optimized_compiler_builtins =

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -431,4 +431,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "It is no longer possible to `x build` with stage 0. All build commands have to be on stage 1+.",
     },
+    ChangeInfo {
+        change_id: 143175,
+        severity: ChangeSeverity::Info,
+        summary: "It is no longer possible to combine `rust.lld = true` with configuring external LLVM using `llvm.llvm-config`.",
+    },
 ];

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -72,6 +72,8 @@ change-id = 115898
 [rust]
 channel = "{channel}"
 verbose-tests = true
+# rust-lld cannot be combined with an external LLVM
+lld = false
 
 [build]
 rustc = "{rustc}"


### PR DESCRIPTION
Younger me made this only a warning in https://github.com/rust-lang/rust/pull/139853, because our post-dist tests were relying on this. But that was not a good idea, because there are a bunch of places in bootstrap that outright try to build LLD/copy LLD to sysroot when `lld_enabled` is true (rightfully so), which is causing issues (https://github.com/rust-lang/rust/issues/143076). Instead of piling more hacks, I'd like to just disallow this, and if we need to use a hack, do it only for our CI.

If this breaks the CI post-dist tests, I'll either add some special environment variable for it, or, as an alternative, make the error back into a warning, but also disable `lld_enabled` when this situation happens.

try-job: dist-x86_64-linux

Fixes: https://github.com/rust-lang/rust/pull/143175