### PR TITLE
fix typos and improve clarity in documentation

### DIFF
--- a/library/stdarch/crates/intrinsic-test/README.md
+++ b/library/stdarch/crates/intrinsic-test/README.md
@@ -7,7 +7,7 @@ USAGE:
     intrinsic-test [FLAGS] [OPTIONS] <INPUT>
 
 FLAGS:
-        --a32              Run tests for A32 instrinsics instead of A64
+        --a32              Run tests for A32 intrinsics instead of A64
         --generate-only    Regenerate test programs, but don't build or run them
     -h, --help             Prints help information
     -V, --version          Prints version information

--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -499,7 +499,7 @@ This directive takes comma-separated issue numbers as arguments, or `"unknown"`:
 - `//@ known-bug: rust-lang/chalk#123456`
   (allows arbitrary text before the `#`, which is useful when the issue is on another repo)
 - `//@ known-bug: unknown`
-  (when there is no known issue yet; preferrably open one if it does not already exist)
+  (when there is no known issue yet; preferably open one if it does not already exist)
 
 Do not include [error annotations](#error-annotations) in a test with
 `known-bug`. The test should still include other normal directives and

--- a/src/doc/unstable-book/src/language-features/type-alias-impl-trait.md
+++ b/src/doc/unstable-book/src/language-features/type-alias-impl-trait.md
@@ -64,7 +64,7 @@ struct HaveAlias {
 
 In this example, the concrete type referred to by `Alias` is guaranteed to be the same wherever `Alias` occurs.
 
-> Orginally this feature included type aliases as an associated type of a trait. In [#110237] this was split off to [`impl_trait_in_assoc_type`].
+> Originally this feature included type aliases as an associated type of a trait. In [#110237] this was split off to [`impl_trait_in_assoc_type`].
 
 ### `type_alias_impl_trait` in argument position.
 

--- a/src/tools/rust-installer/README.md
+++ b/src/tools/rust-installer/README.md
@@ -51,7 +51,7 @@ To combine installers.
 
 * Make install.sh not have to be customized, pull it's data from a
   config file.
-* Be more resiliant to installation failures, particularly if the disk
+* Be more resilient to installation failures, particularly if the disk
   is full.
 * Pre-install and post-uninstall scripts.
 * Allow components to depend on or contradict other components.


### PR DESCRIPTION




```
Description:

This pull request corrects minor typos and improves wording for clarity across several documentation files, including:

- Correcting instrinsics → intrinsics
- Correcting preferrably → preferably
- Correcting Orginally → Originally
-  Correcting resiliant → resilient

```
