### PR TITLE
Use the `new` method for `BasicBlockData` and `Statement`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -354,15 +354,15 @@ fn optimize_use_clone<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
             let destination_block = target.unwrap();
 
-            bb.statements.push(mir::Statement {
-                source_info: bb.terminator().source_info,
-                kind: mir::StatementKind::Assign(Box::new((
+            bb.statements.push(mir::Statement::new(
+                bb.terminator().source_info,
+                mir::StatementKind::Assign(Box::new((
                     *destination,
                     mir::Rvalue::Use(mir::Operand::Copy(
                         arg_place.project_deeper(&[mir::ProjectionElem::Deref], tcx),
                     )),
                 ))),
-            });
+            ));
 
             bb.terminator_mut().kind = mir::TerminatorKind::Goto { target: destination_block };
         }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1359,7 +1359,15 @@ pub struct BasicBlockData<'tcx> {
 
 impl<'tcx> BasicBlockData<'tcx> {
     pub fn new(terminator: Option<Terminator<'tcx>>, is_cleanup: bool) -> BasicBlockData<'tcx> {
-        BasicBlockData { statements: vec![], terminator, is_cleanup }
+        BasicBlockData::new_stmts(Vec::new(), terminator, is_cleanup)
+    }
+
+    pub fn new_stmts(
+        statements: Vec<Statement<'tcx>>,
+        terminator: Option<Terminator<'tcx>>,
+        is_cleanup: bool,
+    ) -> BasicBlockData<'tcx> {
+        BasicBlockData { statements, terminator, is_cleanup }
     }
 
     /// Accessor for terminator.

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -16,11 +16,15 @@ pub struct Statement<'tcx> {
     pub kind: StatementKind<'tcx>,
 }
 
-impl Statement<'_> {
+impl<'tcx> Statement<'tcx> {
     /// Changes a statement to a nop. This is both faster than deleting instructions and avoids
     /// invalidating statement indices in `Location`s.
     pub fn make_nop(&mut self) {
         self.kind = StatementKind::Nop
+    }
+
+    pub fn new(source_info: SourceInfo, kind: StatementKind<'tcx>) -> Self {
+        Statement { source_info, kind }
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/cfg.rs
+++ b/compiler/rustc_mir_build/src/builder/cfg.rs
@@ -42,7 +42,7 @@ impl<'tcx> CFG<'tcx> {
     ) {
         self.push(
             block,
-            Statement { source_info, kind: StatementKind::Assign(Box::new((place, rvalue))) },
+            Statement::new(source_info, StatementKind::Assign(Box::new((place, rvalue)))),
         );
     }
 
@@ -88,7 +88,7 @@ impl<'tcx> CFG<'tcx> {
         place: Place<'tcx>,
     ) {
         let kind = StatementKind::FakeRead(Box::new((cause, place)));
-        let stmt = Statement { source_info, kind };
+        let stmt = Statement::new(source_info, kind);
         self.push(block, stmt);
     }
 
@@ -99,7 +99,7 @@ impl<'tcx> CFG<'tcx> {
         place: Place<'tcx>,
     ) {
         let kind = StatementKind::PlaceMention(Box::new(place));
-        let stmt = Statement { source_info, kind };
+        let stmt = Statement::new(source_info, kind);
         self.push(block, stmt);
     }
 
@@ -110,7 +110,7 @@ impl<'tcx> CFG<'tcx> {
     /// syntax (e.g. `continue` or `if !`) that would otherwise not appear in MIR.
     pub(crate) fn push_coverage_span_marker(&mut self, block: BasicBlock, source_info: SourceInfo) {
         let kind = StatementKind::Coverage(coverage::CoverageKind::SpanMarker);
-        let stmt = Statement { source_info, kind };
+        let stmt = Statement::new(source_info, kind);
         self.push(block, stmt);
     }
 

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -61,10 +61,10 @@ impl BlockMarkerGen {
         block: BasicBlock,
     ) -> BlockMarkerId {
         let id = self.next_block_marker_id();
-        let marker_statement = mir::Statement {
+        let marker_statement = mir::Statement::new(
             source_info,
-            kind: mir::StatementKind::Coverage(CoverageKind::BlockMarker { id }),
-        };
+            mir::StatementKind::Coverage(CoverageKind::BlockMarker { id }),
+        );
         cfg.push(block, marker_statement);
 
         id

--- a/compiler/rustc_mir_build/src/builder/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse.rs
@@ -315,10 +315,8 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             let stmt = self.statement_as_expr(*stmt_id)?;
             let span = self.thir[stmt].span;
             let statement = self.parse_statement(stmt)?;
-            data.statements.push(Statement {
-                source_info: SourceInfo { span, scope: self.source_scope },
-                kind: statement,
-            });
+            data.statements
+                .push(Statement::new(SourceInfo { span, scope: self.source_scope }, statement));
         }
 
         let Some(trailing) = block.expr else { return Err(self.expr_error(expr_id, "terminator")) };

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -489,16 +489,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let place = place_builder.to_place(this);
                     this.cfg.push(
                         block,
-                        Statement {
-                            source_info: ty_source_info,
-                            kind: StatementKind::AscribeUserType(
+                        Statement::new(
+                            ty_source_info,
+                            StatementKind::AscribeUserType(
                                 Box::new((
                                     place,
                                     UserTypeProjection { base: annotation_index, projs: vec![] },
                                 )),
                                 Variance::Invariant,
                             ),
-                        },
+                        ),
                     );
                 }
                 block.and(place_builder)
@@ -518,16 +518,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         });
                     this.cfg.push(
                         block,
-                        Statement {
-                            source_info: ty_source_info,
-                            kind: StatementKind::AscribeUserType(
+                        Statement::new(
+                            ty_source_info,
+                            StatementKind::AscribeUserType(
                                 Box::new((
                                     Place::from(temp),
                                     UserTypeProjection { base: annotation_index, projs: vec![] },
                                 )),
                                 Variance::Invariant,
                             ),
-                        },
+                        ),
                     );
                 }
                 block.and(PlaceBuilder::from(temp))

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -175,10 +175,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // and therefore is not considered during coroutine auto-trait
                 // determination. See the comment about `box` at `yield_in_scope`.
                 let result = this.local_decls.push(LocalDecl::new(expr.ty, expr_span));
-                this.cfg.push(
-                    block,
-                    Statement { source_info, kind: StatementKind::StorageLive(result) },
-                );
+                this.cfg
+                    .push(block, Statement::new(source_info, StatementKind::StorageLive(result)));
                 if let Some(scope) = scope.temp_lifetime {
                     // schedule a shallow free of that memory, lest we unwind:
                     this.schedule_drop_storage_and_value(expr_span, scope, result);
@@ -278,12 +276,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         };
                         this.cfg.push(
                             block,
-                            Statement {
+                            Statement::new(
                                 source_info,
-                                kind: StatementKind::Intrinsic(Box::new(
-                                    NonDivergingIntrinsic::Assume(Operand::Move(assert_place)),
-                                )),
-                            },
+                                StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::Assume(
+                                    Operand::Move(assert_place),
+                                ))),
+                            ),
                         );
                     }
 
@@ -789,7 +787,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let source_info = this.source_info(upvar_span);
         let temp = this.local_decls.push(LocalDecl::new(upvar_ty, upvar_span));
 
-        this.cfg.push(block, Statement { source_info, kind: StatementKind::StorageLive(temp) });
+        this.cfg.push(block, Statement::new(source_info, StatementKind::StorageLive(temp)));
 
         let arg_place_builder = unpack!(block = this.as_place_builder(block, arg));
 

--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -102,8 +102,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if let Block { expr: None, targeted_by_break: false, .. } = this.thir[block]
                     && expr_ty.is_never() => {}
             _ => {
-                this.cfg
-                    .push(block, Statement { source_info, kind: StatementKind::StorageLive(temp) });
+                this.cfg.push(block, Statement::new(source_info, StatementKind::StorageLive(temp)));
 
                 // In constants, `temp_lifetime` is `None` for temporaries that
                 // live for the `'static` lifetime. Thus we do not drop these

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -646,9 +646,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let base = self.canonical_user_type_annotations.push(annotation.clone());
                 self.cfg.push(
                     block,
-                    Statement {
-                        source_info: ty_source_info,
-                        kind: StatementKind::AscribeUserType(
+                    Statement::new(
+                        ty_source_info,
+                        StatementKind::AscribeUserType(
                             Box::new((place, UserTypeProjection { base, projs: Vec::new() })),
                             // We always use invariant as the variance here. This is because the
                             // variance field from the ascription refers to the variance to use
@@ -666,7 +666,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             // `<expr>`.
                             ty::Invariant,
                         ),
-                    },
+                    ),
                 );
 
                 self.schedule_drop_for_binding(var, irrefutable_pat.span, OutsideGuard);
@@ -828,7 +828,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> Place<'tcx> {
         let local_id = self.var_local_id(var, for_guard);
         let source_info = self.source_info(span);
-        self.cfg.push(block, Statement { source_info, kind: StatementKind::StorageLive(local_id) });
+        self.cfg.push(block, Statement::new(source_info, StatementKind::StorageLive(local_id)));
         // Although there is almost always scope for given variable in corner cases
         // like #92893 we might get variable with no scope.
         if let Some(region_scope) = self.region_scope_tree.var_scope(var.0.local_id)
@@ -2578,16 +2578,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let base = self.canonical_user_type_annotations.push(ascription.annotation);
             self.cfg.push(
                 block,
-                Statement {
+                Statement::new(
                     source_info,
-                    kind: StatementKind::AscribeUserType(
+                    StatementKind::AscribeUserType(
                         Box::new((
                             ascription.source,
                             UserTypeProjection { base, projs: Vec::new() },
                         )),
                         ascription.variance,
                     ),
-                },
+                ),
             );
         }
     }

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -431,13 +431,13 @@ impl DropTree {
                     cfg.terminate(block, drop_node.data.source_info, terminator);
                 }
                 DropKind::ForLint => {
-                    let stmt = Statement {
-                        source_info: drop_node.data.source_info,
-                        kind: StatementKind::BackwardIncompatibleDropHint {
+                    let stmt = Statement::new(
+                        drop_node.data.source_info,
+                        StatementKind::BackwardIncompatibleDropHint {
                             place: Box::new(drop_node.data.local.into()),
                             reason: BackwardIncompatibleDropReason::Edition2024,
                         },
-                    };
+                    );
                     cfg.push(block, stmt);
                     let target = blocks[drop_node.next].unwrap();
                     if target != block {
@@ -454,10 +454,10 @@ impl DropTree {
                 // Root nodes don't correspond to a drop.
                 DropKind::Storage if drop_idx == ROOT_NODE => {}
                 DropKind::Storage => {
-                    let stmt = Statement {
-                        source_info: drop_node.data.source_info,
-                        kind: StatementKind::StorageDead(drop_node.data.local),
-                    };
+                    let stmt = Statement::new(
+                        drop_node.data.source_info,
+                        StatementKind::StorageDead(drop_node.data.local),
+                    );
                     cfg.push(block, stmt);
                     let target = blocks[drop_node.next].unwrap();
                     if target != block {
@@ -1124,13 +1124,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     DropKind::ForLint => {
                         self.cfg.push(
                             block,
-                            Statement {
+                            Statement::new(
                                 source_info,
-                                kind: StatementKind::BackwardIncompatibleDropHint {
+                                StatementKind::BackwardIncompatibleDropHint {
                                     place: Box::new(local.into()),
                                     reason: BackwardIncompatibleDropReason::Edition2024,
                                 },
-                            },
+                            ),
                         );
                     }
                     DropKind::Storage => {
@@ -1138,7 +1138,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         assert!(local.index() > self.arg_count);
                         self.cfg.push(
                             block,
-                            Statement { source_info, kind: StatementKind::StorageDead(local) },
+                            Statement::new(source_info, StatementKind::StorageDead(local)),
                         );
                     }
                 }
@@ -1880,13 +1880,13 @@ where
 
                 cfg.push(
                     block,
-                    Statement {
+                    Statement::new(
                         source_info,
-                        kind: StatementKind::BackwardIncompatibleDropHint {
+                        StatementKind::BackwardIncompatibleDropHint {
                             place: Box::new(local.into()),
                             reason: BackwardIncompatibleDropReason::Edition2024,
                         },
-                    },
+                    ),
                 );
             }
             DropKind::Storage => {
@@ -1910,7 +1910,7 @@ where
                 }
                 // Only temps and vars need their storage dead.
                 assert!(local.index() > arg_count);
-                cfg.push(block, Statement { source_info, kind: StatementKind::StorageDead(local) });
+                cfg.push(block, Statement::new(source_info, StatementKind::StorageDead(local)));
             }
         }
     }

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -17,7 +17,7 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
 
     let mut blocks = IndexVec::new();
     let mut block = |n, kind| {
-        let nop = mir::Statement { source_info, kind: mir::StatementKind::Nop };
+        let nop = mir::Statement::new(source_info, mir::StatementKind::Nop);
 
         blocks.push(mir::BasicBlockData {
             statements: std::iter::repeat(&nop).cloned().take(n).collect(),

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -19,11 +19,11 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
     let mut block = |n, kind| {
         let nop = mir::Statement::new(source_info, mir::StatementKind::Nop);
 
-        blocks.push(mir::BasicBlockData {
-            statements: std::iter::repeat(&nop).cloned().take(n).collect(),
-            terminator: Some(mir::Terminator { source_info, kind }),
-            is_cleanup: false,
-        })
+        blocks.push(mir::BasicBlockData::new_stmts(
+            std::iter::repeat(&nop).cloned().take(n).collect(),
+            Some(mir::Terminator { source_info, kind }),
+            false,
+        ))
     };
 
     let dummy_place = mir::Place { local: mir::RETURN_PLACE, projection: ty::List::empty() };

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -44,11 +44,10 @@ impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
 
         let cur_len = body.basic_blocks.len();
         let mut new_block = |source_info: SourceInfo, is_cleanup: bool, target: BasicBlock| {
-            let block = BasicBlockData {
-                statements: vec![],
+            let block = BasicBlockData::new(
+                Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
                 is_cleanup,
-                terminator: Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
-            };
+            );
             let idx = cur_len + new_blocks.len();
             new_blocks.push(block);
             BasicBlock::new(idx)

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -94,7 +94,7 @@ fn add_move_for_packed_drop<'tcx>(
     let temp = patch.new_temp(ty, source_info.span);
 
     let storage_dead_block = patch.new_block(BasicBlockData {
-        statements: vec![Statement { source_info, kind: StatementKind::StorageDead(temp) }],
+        statements: vec![Statement::new(source_info, StatementKind::StorageDead(temp))],
         terminator: Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
         is_cleanup,
     });

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -93,11 +93,11 @@ fn add_move_for_packed_drop<'tcx>(
     let ty = place.ty(body, tcx).ty;
     let temp = patch.new_temp(ty, source_info.span);
 
-    let storage_dead_block = patch.new_block(BasicBlockData {
-        statements: vec![Statement::new(source_info, StatementKind::StorageDead(temp))],
-        terminator: Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
+    let storage_dead_block = patch.new_block(BasicBlockData::new_stmts(
+        vec![Statement::new(source_info, StatementKind::StorageDead(temp))],
+        Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
         is_cleanup,
-    });
+    ));
 
     patch.add_statement(loc, StatementKind::StorageLive(temp));
     patch.add_assign(loc, Place::from(temp), Rvalue::Use(Operand::Move(*place)));

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -81,9 +81,11 @@ impl<'tcx> crate::MirPass<'tcx> for AddRetag {
             // Emit their retags.
             basic_blocks[START_BLOCK].statements.splice(
                 0..0,
-                places.map(|(place, source_info)| Statement {
-                    source_info,
-                    kind: StatementKind::Retag(RetagKind::FnEntry, Box::new(place)),
+                places.map(|(place, source_info)| {
+                    Statement::new(
+                        source_info,
+                        StatementKind::Retag(RetagKind::FnEntry, Box::new(place)),
+                    )
                 }),
             );
         }
@@ -113,10 +115,10 @@ impl<'tcx> crate::MirPass<'tcx> for AddRetag {
         for (source_info, dest_place, dest_block) in returns {
             basic_blocks[dest_block].statements.insert(
                 0,
-                Statement {
+                Statement::new(
                     source_info,
-                    kind: StatementKind::Retag(RetagKind::Default, Box::new(dest_place)),
-                },
+                    StatementKind::Retag(RetagKind::Default, Box::new(dest_place)),
+                ),
             );
         }
 
@@ -174,10 +176,7 @@ impl<'tcx> crate::MirPass<'tcx> for AddRetag {
                 let source_info = block_data.statements[i].source_info;
                 block_data.statements.insert(
                     i + 1,
-                    Statement {
-                        source_info,
-                        kind: StatementKind::Retag(retag_kind, Box::new(place)),
-                    },
+                    Statement::new(source_info, StatementKind::Retag(retag_kind, Box::new(place))),
                 );
             }
         }

--- a/compiler/rustc_mir_transform/src/check_pointers.rs
+++ b/compiler/rustc_mir_transform/src/check_pointers.rs
@@ -235,11 +235,11 @@ fn split_block(
     let block_data = &mut basic_blocks[location.block];
 
     // Drain every statement after this one and move the current terminator to a new basic block.
-    let new_block = BasicBlockData {
-        statements: block_data.statements.split_off(location.statement_index),
-        terminator: block_data.terminator.take(),
-        is_cleanup: block_data.is_cleanup,
-    };
+    let new_block = BasicBlockData::new_stmts(
+        block_data.statements.split_off(location.statement_index),
+        block_data.terminator.take(),
+        block_data.is_cleanup,
+    );
 
     basic_blocks.push(new_block)
 }

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -102,9 +102,9 @@ fn build_pin_fut<'tcx>(
     );
 
     // call Pin<FutTy>::new_unchecked(&mut fut)
-    let pin_fut_bb = body.basic_blocks_mut().push(BasicBlockData {
-        statements: [storage_live, fut_ref_assign].to_vec(),
-        terminator: Some(Terminator {
+    let pin_fut_bb = body.basic_blocks_mut().push(BasicBlockData::new_stmts(
+        [storage_live, fut_ref_assign].to_vec(),
+        Some(Terminator {
             source_info,
             kind: TerminatorKind::Call {
                 func: pin_fut_new_unchecked_fn,
@@ -116,8 +116,8 @@ fn build_pin_fut<'tcx>(
                 fn_span: span,
             },
         }),
-        is_cleanup: false,
-    });
+        false,
+    ));
     (pin_fut_bb, fut_pin_place)
 }
 
@@ -161,9 +161,9 @@ fn build_poll_switch<'tcx>(
     );
     let storage_dead = Statement::new(source_info, StatementKind::StorageDead(fut_pin_place.local));
     let unreachable_block = insert_term_block(body, TerminatorKind::Unreachable);
-    body.basic_blocks_mut().push(BasicBlockData {
-        statements: [storage_dead, discr_assign].to_vec(),
-        terminator: Some(Terminator {
+    body.basic_blocks_mut().push(BasicBlockData::new_stmts(
+        [storage_dead, discr_assign].to_vec(),
+        Some(Terminator {
             source_info,
             kind: TerminatorKind::SwitchInt {
                 discr: Operand::Move(poll_discr_place),
@@ -174,8 +174,8 @@ fn build_poll_switch<'tcx>(
                 ),
             },
         }),
-        is_cleanup: false,
-    })
+        false,
+    ))
 }
 
 // Gather blocks, reachable through 'drop' targets of Yield and Drop terminators (chained)
@@ -546,11 +546,8 @@ pub(super) fn insert_clean_drop<'tcx>(
     };
 
     // Create a block to destroy an unresumed coroutines. This can only destroy upvars.
-    body.basic_blocks_mut().push(BasicBlockData {
-        statements: Vec::new(),
-        terminator: Some(Terminator { source_info, kind: term }),
-        is_cleanup: false,
-    })
+    body.basic_blocks_mut()
+        .push(BasicBlockData::new(Some(Terminator { source_info, kind: term }), false))
 }
 
 pub(super) fn create_coroutine_drop_shim<'tcx>(
@@ -729,11 +726,7 @@ pub(super) fn create_coroutine_drop_shim_proxy_async<'tcx>(
     body.local_decls[RETURN_PLACE] = LocalDecl::with_source_info(poll_enum, source_info);
 
     // call coroutine_drop()
-    let call_bb = body.basic_blocks_mut().push(BasicBlockData {
-        statements: Vec::new(),
-        terminator: None,
-        is_cleanup: false,
-    });
+    let call_bb = body.basic_blocks_mut().push(BasicBlockData::new(None, false));
 
     // return Poll::Ready()
     let ret_bb = insert_poll_ready_block(tcx, &mut body);

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -259,7 +259,7 @@ fn inject_statement(mir_body: &mut mir::Body<'_>, counter_kind: CoverageKind, bb
     debug!("  injecting statement {counter_kind:?} for {bb:?}");
     let data = &mut mir_body[bb];
     let source_info = data.terminator().source_info;
-    let statement = Statement { source_info, kind: StatementKind::Coverage(counter_kind) };
+    let statement = Statement::new(source_info, StatementKind::Coverage(counter_kind));
     data.statements.insert(0, statement);
 }
 

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -68,14 +68,13 @@ impl<'tcx> MockBlocks<'tcx> {
             BytePos(1)
         };
         let next_hi = next_lo + BytePos(1);
-        self.blocks.push(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        self.blocks.push(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(Span::with_root_ctxt(next_lo, next_hi)),
                 kind,
             }),
-            is_cleanup: false,
-        })
+            false,
+        ))
     }
 
     fn link(&mut self, from_block: BasicBlock, to_block: BasicBlock) {

--- a/compiler/rustc_mir_transform/src/ctfe_limit.rs
+++ b/compiler/rustc_mir_transform/src/ctfe_limit.rs
@@ -55,8 +55,8 @@ fn has_back_edge(
 }
 
 fn insert_counter(basic_block_data: &mut BasicBlockData<'_>) {
-    basic_block_data.statements.push(Statement {
-        source_info: basic_block_data.terminator().source_info,
-        kind: StatementKind::ConstEvalCounter,
-    });
+    basic_block_data.statements.push(Statement::new(
+        basic_block_data.terminator().source_info,
+        StatementKind::ConstEvalCounter,
+    ));
 }

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -222,15 +222,14 @@ where
         let span = self.source_info.span;
 
         let pin_obj_bb = bb.unwrap_or_else(|| {
-            self.elaborator.patch().new_block(BasicBlockData {
-                statements: vec![],
-                terminator: Some(Terminator {
+            self.elaborator.patch().new_block(BasicBlockData::new(
+                Some(Terminator {
                     // Temporary terminator, will be replaced by patch
                     source_info: self.source_info,
                     kind: TerminatorKind::Return,
                 }),
-                is_cleanup: false,
-            })
+                false,
+            ))
         });
 
         let (fut_ty, drop_fn_def_id, trait_args) = if call_destructor_only {
@@ -730,17 +729,17 @@ where
 
         let do_drop_bb = self.drop_subpath(interior, interior_path, succ, unwind, dropline);
 
-        let setup_bbd = BasicBlockData {
-            statements: vec![self.assign(
+        let setup_bbd = BasicBlockData::new_stmts(
+            vec![self.assign(
                 Place::from(ptr_local),
                 Rvalue::Cast(CastKind::Transmute, Operand::Copy(nonnull_place), ptr_ty),
             )],
-            terminator: Some(Terminator {
+            Some(Terminator {
                 kind: TerminatorKind::Goto { target: do_drop_bb },
                 source_info: self.source_info,
             }),
-            is_cleanup: unwind.is_cleanup(),
-        };
+            unwind.is_cleanup(),
+        );
         self.elaborator.patch().new_block(setup_bbd)
     }
 
@@ -751,14 +750,13 @@ where
         args: GenericArgsRef<'tcx>,
     ) -> BasicBlock {
         if adt.variants().is_empty() {
-            return self.elaborator.patch().new_block(BasicBlockData {
-                statements: vec![],
-                terminator: Some(Terminator {
+            return self.elaborator.patch().new_block(BasicBlockData::new(
+                Some(Terminator {
                     source_info: self.source_info,
                     kind: TerminatorKind::Unreachable,
                 }),
-                is_cleanup: self.unwind.is_cleanup(),
-            });
+                self.unwind.is_cleanup(),
+            ));
         }
 
         let skip_contents = adt.is_union() || adt.is_manually_drop();
@@ -925,9 +923,9 @@ where
         let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
         let discr = Place::from(self.new_temp(discr_ty));
         let discr_rv = Rvalue::Discriminant(self.place);
-        let switch_block = BasicBlockData {
-            statements: vec![self.assign(discr, discr_rv)],
-            terminator: Some(Terminator {
+        let switch_block = BasicBlockData::new_stmts(
+            vec![self.assign(discr, discr_rv)],
+            Some(Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::SwitchInt {
                     discr: Operand::Move(discr),
@@ -937,8 +935,8 @@ where
                     ),
                 },
             }),
-            is_cleanup: unwind.is_cleanup(),
-        };
+            unwind.is_cleanup(),
+        );
         let switch_block = self.elaborator.patch().new_block(switch_block);
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
@@ -954,8 +952,8 @@ where
         let ref_place = self.new_temp(ref_ty);
         let unit_temp = Place::from(self.new_temp(tcx.types.unit));
 
-        let result = BasicBlockData {
-            statements: vec![self.assign(
+        let result = BasicBlockData::new_stmts(
+            vec![self.assign(
                 Place::from(ref_place),
                 Rvalue::Ref(
                     tcx.lifetimes.re_erased,
@@ -963,7 +961,7 @@ where
                     self.place,
                 ),
             )],
-            terminator: Some(Terminator {
+            Some(Terminator {
                 kind: TerminatorKind::Call {
                     func: Operand::function_handle(
                         tcx,
@@ -981,8 +979,8 @@ where
                 },
                 source_info: self.source_info,
             }),
-            is_cleanup: unwind.is_cleanup(),
-        };
+            unwind.is_cleanup(),
+        );
 
         let destructor_block = self.elaborator.patch().new_block(result);
 
@@ -1045,8 +1043,8 @@ where
         let can_go = Place::from(self.new_temp(tcx.types.bool));
         let one = self.constant_usize(1);
 
-        let drop_block = BasicBlockData {
-            statements: vec![
+        let drop_block = BasicBlockData::new_stmts(
+            vec![
                 self.assign(
                     ptr,
                     Rvalue::RawPtr(RawPtrKind::Mut, tcx.mk_place_index(self.place, cur)),
@@ -1056,26 +1054,26 @@ where
                     Rvalue::BinaryOp(BinOp::Add, Box::new((move_(cur.into()), one))),
                 ),
             ],
-            is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            Some(Terminator {
                 source_info: self.source_info,
                 // this gets overwritten by drop elaboration.
                 kind: TerminatorKind::Unreachable,
             }),
-        };
+            unwind.is_cleanup(),
+        );
         let drop_block = self.elaborator.patch().new_block(drop_block);
 
-        let loop_block = BasicBlockData {
-            statements: vec![self.assign(
+        let loop_block = BasicBlockData::new_stmts(
+            vec![self.assign(
                 can_go,
                 Rvalue::BinaryOp(BinOp::Eq, Box::new((copy(Place::from(cur)), copy(len.into())))),
             )],
-            is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            Some(Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::if_(move_(can_go), succ, drop_block),
             }),
-        };
+            unwind.is_cleanup(),
+        );
         let loop_block = self.elaborator.patch().new_block(loop_block);
 
         let place = tcx.mk_place_deref(ptr);
@@ -1185,8 +1183,8 @@ where
         let slice_ptr_ty = Ty::new_mut_ptr(tcx, slice_ty);
         let slice_ptr = self.new_temp(slice_ptr_ty);
 
-        let mut delegate_block = BasicBlockData {
-            statements: vec![
+        let mut delegate_block = BasicBlockData::new_stmts(
+            vec![
                 self.assign(Place::from(array_ptr), Rvalue::RawPtr(RawPtrKind::Mut, self.place)),
                 self.assign(
                     Place::from(slice_ptr),
@@ -1200,9 +1198,9 @@ where
                     ),
                 ),
             ],
-            is_cleanup: self.unwind.is_cleanup(),
-            terminator: None,
-        };
+            None,
+            self.unwind.is_cleanup(),
+        );
 
         let array_place = mem::replace(
             &mut self.place,
@@ -1244,8 +1242,8 @@ where
         };
 
         let zero = self.constant_usize(0);
-        let block = BasicBlockData {
-            statements: vec![
+        let block = BasicBlockData::new_stmts(
+            vec![
                 self.assign(
                     len.into(),
                     Rvalue::UnaryOp(
@@ -1255,12 +1253,12 @@ where
                 ),
                 self.assign(cur.into(), Rvalue::Use(zero)),
             ],
-            is_cleanup: unwind.is_cleanup(),
-            terminator: Some(Terminator {
+            Some(Terminator {
                 source_info: self.source_info,
                 kind: TerminatorKind::Goto { target: loop_block },
             }),
-        };
+            unwind.is_cleanup(),
+        );
 
         let drop_block = self.elaborator.patch().new_block(block);
         // FIXME(#34708): handle partially-dropped array/slice elements.
@@ -1306,14 +1304,13 @@ where
                     self.source_info.span,
                     "open drop for unsafe binder shouldn't be encountered",
                 );
-                self.elaborator.patch().new_block(BasicBlockData {
-                    statements: vec![],
-                    terminator: Some(Terminator {
+                self.elaborator.patch().new_block(BasicBlockData::new(
+                    Some(Terminator {
                         source_info: self.source_info,
                         kind: TerminatorKind::Unreachable,
                     }),
-                    is_cleanup: self.unwind.is_cleanup(),
-                })
+                    self.unwind.is_cleanup(),
+                ))
             }
 
             _ => span_bug!(self.source_info.span, "open drop from non-ADT `{:?}`", ty),
@@ -1432,11 +1429,10 @@ where
     }
 
     fn new_block(&mut self, unwind: Unwind, k: TerminatorKind<'tcx>) -> BasicBlock {
-        self.elaborator.patch().new_block(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator { source_info: self.source_info, kind: k }),
-            is_cleanup: unwind.is_cleanup(),
-        })
+        self.elaborator.patch().new_block(BasicBlockData::new(
+            Some(Terminator { source_info: self.source_info, kind: k }),
+            unwind.is_cleanup(),
+        ))
     }
 
     fn new_block_with_statements(
@@ -1445,11 +1441,11 @@ where
         statements: Vec<Statement<'tcx>>,
         k: TerminatorKind<'tcx>,
     ) -> BasicBlock {
-        self.elaborator.patch().new_block(BasicBlockData {
+        self.elaborator.patch().new_block(BasicBlockData::new_stmts(
             statements,
-            terminator: Some(Terminator { source_info: self.source_info, kind: k }),
-            is_cleanup: unwind.is_cleanup(),
-        })
+            Some(Terminator { source_info: self.source_info, kind: k }),
+            unwind.is_cleanup(),
+        ))
     }
 
     fn new_temp(&mut self, ty: Ty<'tcx>) -> Local {

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -366,10 +366,8 @@ where
             call_statements.push(self.assign(obj_ptr_place, addr));
             obj_ptr_place
         };
-        call_statements.push(Statement {
-            source_info: self.source_info,
-            kind: StatementKind::StorageLive(fut.local),
-        });
+        call_statements
+            .push(Statement::new(self.source_info, StatementKind::StorageLive(fut.local)));
 
         let call_drop_bb = self.new_block_with_statements(
             unwind,
@@ -1467,9 +1465,6 @@ where
     }
 
     fn assign(&self, lhs: Place<'tcx>, rhs: Rvalue<'tcx>) -> Statement<'tcx> {
-        Statement {
-            source_info: self.source_info,
-            kind: StatementKind::Assign(Box::new((lhs, rhs))),
-        }
+        Statement::new(self.source_info, StatementKind::Assign(Box::new((lhs, rhs))))
     }
 }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -240,15 +240,15 @@ impl<'tcx> InstSimplifyContext<'_, 'tcx> {
 
         let Some(arg_place) = arg.node.place() else { return };
 
-        statements.push(Statement {
-            source_info: terminator.source_info,
-            kind: StatementKind::Assign(Box::new((
+        statements.push(Statement::new(
+            terminator.source_info,
+            StatementKind::Assign(Box::new((
                 *destination,
                 Rvalue::Use(Operand::Copy(
                     arg_place.project_deeper(&[ProjectionElem::Deref], self.tcx),
                 )),
             ))),
-        });
+        ));
         terminator.kind = TerminatorKind::Goto { target: *destination_block };
     }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -259,13 +259,13 @@ fn remap_mir_for_const_eval_select<'tcx>(
                             // (const generic stuff) so we just create a temporary and deconstruct
                             // that.
                             let local = body.local_decls.push(LocalDecl::new(ty, fn_span));
-                            bb.statements.push(Statement {
-                                source_info: SourceInfo::outermost(fn_span),
-                                kind: StatementKind::Assign(Box::new((
+                            bb.statements.push(Statement::new(
+                                SourceInfo::outermost(fn_span),
+                                StatementKind::Assign(Box::new((
                                     local.into(),
                                     Rvalue::Use(tupled_args.node.clone()),
                                 ))),
-                            });
+                            ));
                             (Operand::Move, local.into())
                         }
                         Operand::Move(place) => (Operand::Move, place),

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -25,31 +25,31 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                     }
                     sym::ub_checks => {
                         let target = target.unwrap();
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::NullaryOp(NullOp::UbChecks, tcx.types.bool),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::contract_checks => {
                         let target = target.unwrap();
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::NullaryOp(NullOp::ContractChecks, tcx.types.bool),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::forget => {
                         let target = target.unwrap();
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::Use(Operand::Constant(Box::new(ConstOperand {
                                     span: terminator.source_info.span,
@@ -57,7 +57,7 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                                     const_: Const::zero_sized(tcx.types.unit),
                                 }))),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::copy_nonoverlapping => {
@@ -65,9 +65,9 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                         let Ok([src, dst, count]) = take_array(args) else {
                             bug!("Wrong arguments for copy_non_overlapping intrinsic");
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Intrinsic(Box::new(
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Intrinsic(Box::new(
                                 NonDivergingIntrinsic::CopyNonOverlapping(
                                     rustc_middle::mir::CopyNonOverlapping {
                                         src: src.node,
@@ -76,7 +76,7 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                                     },
                                 ),
                             )),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::assume => {
@@ -84,12 +84,12 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                         let Ok([arg]) = take_array(args) else {
                             bug!("Wrong arguments for assume intrinsic");
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Intrinsic(Box::new(
-                                NonDivergingIntrinsic::Assume(arg.node),
-                            )),
-                        });
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::Assume(
+                                arg.node,
+                            ))),
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::wrapping_add
@@ -121,13 +121,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             sym::unchecked_shr => BinOp::ShrUnchecked,
                             _ => bug!("unexpected intrinsic"),
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::BinaryOp(bin_op, Box::new((lhs.node, rhs.node))),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::add_with_overflow | sym::sub_with_overflow | sym::mul_with_overflow => {
@@ -141,13 +141,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             sym::mul_with_overflow => BinOp::MulWithOverflow,
                             _ => bug!("unexpected intrinsic"),
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::BinaryOp(bin_op, Box::new((lhs.node, rhs.node))),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::size_of | sym::align_of => {
@@ -158,13 +158,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             sym::align_of => NullOp::AlignOf,
                             _ => bug!("unexpected intrinsic"),
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::NullaryOp(null_op, tp_ty),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::read_via_copy => {
@@ -183,13 +183,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                         };
                         // Add new statement at the end of the block that does the read, and patch
                         // up the terminator.
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::Use(Operand::Copy(derefed_place)),
                             ))),
-                        });
+                        ));
                         terminator.kind = match *target {
                             None => {
                                 // No target means this read something uninhabited,
@@ -217,13 +217,10 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                                 "Only passing a local is supported"
                             );
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
-                                derefed_place,
-                                Rvalue::Use(val.node),
-                            ))),
-                        });
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((derefed_place, Rvalue::Use(val.node)))),
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::discriminant_value => {
@@ -236,13 +233,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                         };
                         let arg = arg.node.place().unwrap();
                         let arg = tcx.mk_place_deref(arg);
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::Discriminant(arg),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::offset => {
@@ -253,13 +250,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                                 "Wrong number of arguments for offset intrinsic",
                             );
                         };
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::BinaryOp(BinOp::Offset, Box::new((ptr.node, delta.node))),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::slice_get_unchecked => {
@@ -302,10 +299,10 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             _ => bug!("Unknown return type {ret_ty:?}"),
                         };
 
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((*destination, rvalue))),
-                        });
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((*destination, rvalue))),
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::transmute | sym::transmute_unchecked => {
@@ -320,13 +317,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                         // Always emit the cast, even if we transmute to an uninhabited type,
                         // because that lets CTFE and codegen generate better error messages
                         // when such a transmute actually ends up reachable.
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::Cast(CastKind::Transmute, arg.node, dst_ty),
                             ))),
-                        });
+                        ));
                         if let Some(target) = *target {
                             terminator.kind = TerminatorKind::Goto { target };
                         } else {
@@ -351,13 +348,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             );
                         };
                         let fields = [data.node, meta.node];
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::Aggregate(Box::new(kind), fields.into()),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     sym::ptr_metadata => {
@@ -368,13 +365,13 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
                             );
                         };
                         let target = target.unwrap();
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::Assign(Box::new((
+                        block.statements.push(Statement::new(
+                            terminator.source_info,
+                            StatementKind::Assign(Box::new((
                                 *destination,
                                 Rvalue::UnaryOp(UnOp::PtrMetadata, ptr.node),
                             ))),
-                        });
+                        ));
                         terminator.kind = TerminatorKind::Goto { target };
                     }
                     _ => {}

--- a/compiler/rustc_mir_transform/src/lower_slice_len.rs
+++ b/compiler/rustc_mir_transform/src/lower_slice_len.rs
@@ -56,8 +56,7 @@ fn lower_slice_len_call<'tcx>(block: &mut BasicBlockData<'tcx>, slice_len_fn_ite
         // make new RValue for Len
         let r_value = Rvalue::UnaryOp(UnOp::PtrMetadata, arg.node.clone());
         let len_statement_kind = StatementKind::Assign(Box::new((*destination, r_value)));
-        let add_statement =
-            Statement { kind: len_statement_kind, source_info: terminator.source_info };
+        let add_statement = Statement::new(terminator.source_info, len_statement_kind);
 
         // modify terminator into simple Goto
         let new_terminator_kind = TerminatorKind::Goto { target: *bb };

--- a/compiler/rustc_mir_transform/src/patch.rs
+++ b/compiler/rustc_mir_transform/src/patch.rs
@@ -78,14 +78,13 @@ impl<'tcx> MirPatch<'tcx> {
             return bb;
         }
 
-        let bb = self.new_block(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        let bb = self.new_block(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::UnwindResume,
             }),
-            is_cleanup: true,
-        });
+            true,
+        ));
         self.resume_block = Some(bb);
         bb
     }
@@ -95,14 +94,13 @@ impl<'tcx> MirPatch<'tcx> {
             return bb;
         }
 
-        let bb = self.new_block(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        let bb = self.new_block(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::Unreachable,
             }),
-            is_cleanup: true,
-        });
+            true,
+        ));
         self.unreachable_cleanup_block = Some(bb);
         bb
     }
@@ -112,14 +110,13 @@ impl<'tcx> MirPatch<'tcx> {
             return bb;
         }
 
-        let bb = self.new_block(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        let bb = self.new_block(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::Unreachable,
             }),
-            is_cleanup: false,
-        });
+            false,
+        ));
         self.unreachable_no_cleanup_block = Some(bb);
         bb
     }
@@ -131,14 +128,13 @@ impl<'tcx> MirPatch<'tcx> {
             return cached_bb;
         }
 
-        let bb = self.new_block(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        let bb = self.new_block(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::UnwindTerminate(reason),
             }),
-            is_cleanup: true,
-        });
+            true,
+        ));
         self.terminate_block = Some((bb, reason));
         bb
     }

--- a/compiler/rustc_mir_transform/src/patch.rs
+++ b/compiler/rustc_mir_transform/src/patch.rs
@@ -280,7 +280,7 @@ impl<'tcx> MirPatch<'tcx> {
             let source_info = Self::source_info_for_index(&body[loc.block], loc);
             body[loc.block]
                 .statements
-                .insert(loc.statement_index, Statement { source_info, kind: stmt });
+                .insert(loc.statement_index, Statement::new(source_info, stmt));
             delta += 1;
         }
     }

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -744,10 +744,10 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
     fn assign(&mut self, dest: Local, rvalue: Rvalue<'tcx>, span: Span) {
         let last = self.promoted.basic_blocks.last_index().unwrap();
         let data = &mut self.promoted[last];
-        data.statements.push(Statement {
-            source_info: SourceInfo::outermost(span),
-            kind: StatementKind::Assign(Box::new((Place::from(dest), rvalue))),
-        });
+        data.statements.push(Statement::new(
+            SourceInfo::outermost(span),
+            StatementKind::Assign(Box::new((Place::from(dest), rvalue))),
+        ));
     }
 
     fn is_temp_kind(&self, local: Local) -> bool {
@@ -914,13 +914,13 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             assert_eq!(self.temps.push(TempState::Unpromotable), promoted_ref);
 
             let promoted_operand = promoted_operand(ref_ty, span);
-            let promoted_ref_statement = Statement {
-                source_info: statement.source_info,
-                kind: StatementKind::Assign(Box::new((
+            let promoted_ref_statement = Statement::new(
+                statement.source_info,
+                StatementKind::Assign(Box::new((
                     Place::from(promoted_ref),
                     Rvalue::Use(Operand::Constant(Box::new(promoted_operand))),
                 ))),
-            };
+            );
             self.extra_statements.push((loc, promoted_ref_statement));
 
             (

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -731,14 +731,13 @@ struct Promoter<'a, 'tcx> {
 impl<'a, 'tcx> Promoter<'a, 'tcx> {
     fn new_block(&mut self) -> BasicBlock {
         let span = self.promoted.span;
-        self.promoted.basic_blocks_mut().push(BasicBlockData {
-            statements: vec![],
-            terminator: Some(Terminator {
+        self.promoted.basic_blocks_mut().push(BasicBlockData::new(
+            Some(Terminator {
                 source_info: SourceInfo::outermost(span),
                 kind: TerminatorKind::Return,
             }),
-            is_cleanup: false,
-        })
+            false,
+        ))
     }
 
     fn assign(&mut self, dest: Local, rvalue: Rvalue<'tcx>, span: Span) {

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -115,10 +115,10 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
                 for bb_idx in new_targets.all_targets() {
                     storage_deads_to_insert.push((
                         *bb_idx,
-                        Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::StorageDead(opt.to_switch_on.local),
-                        },
+                        Statement::new(
+                            terminator.source_info,
+                            StatementKind::StorageDead(opt.to_switch_on.local),
+                        ),
                     ));
                 }
             }


### PR DESCRIPTION
This is the NFC part of rust-lang/rust#142771. I split it to make it easier to review for rust-lang/rust#142771. Even without rust-lang/rust#142771, I think this change is worthwhile.