### PR TITLE
Stabilize `rwlock_downgrade` library feature

### DIFF
--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -638,7 +638,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
     ///
@@ -657,7 +656,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     ///
     /// ```
     /// #![feature(nonpoison_rwlock)]
-    /// #![feature(rwlock_downgrade)]
     ///
     /// use std::sync::Arc;
     /// use std::sync::nonpoison::{RwLock, RwLockWriteGuard};
@@ -690,8 +688,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
-    // #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
+    #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -813,8 +813,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// `downgrade` takes ownership of the `RwLockWriteGuard` and returns a [`RwLockReadGuard`].
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{RwLock, RwLockWriteGuard};
     ///
     /// let rw = RwLock::new(0);
@@ -831,8 +829,6 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// thread calling `downgrade` and any reads it performs after downgrading.
     ///
     /// ```
-    /// #![feature(rwlock_downgrade)]
-    ///
     /// use std::sync::{Arc, RwLock, RwLockWriteGuard};
     ///
     /// let rw = Arc::new(RwLock::new(1));
@@ -863,7 +859,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
     /// # let final_check = rw.read().unwrap();
     /// # assert_eq!(*final_check, 3);
     /// ```
-    #[unstable(feature = "rwlock_downgrade", issue = "128203")]
+    #[stable(feature = "rwlock_downgrade", since = "CURRENT_RUSTC_VERSION")]
     pub fn downgrade(s: Self) -> RwLockReadGuard<'rwlock, T> {
         let lock = s.lock;
 

--- a/library/std/tests/sync/lib.rs
+++ b/library/std/tests/sync/lib.rs
@@ -4,7 +4,6 @@
 #![feature(once_cell_try)]
 #![feature(lock_value_accessors)]
 #![feature(reentrant_lock)]
-#![feature(rwlock_downgrade)]
 #![feature(std_internals)]
 #![feature(sync_nonpoison)]
 #![feature(nonpoison_mutex)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking Issue: https://github.com/rust-lang/rust/issues/128203

Method to be stabilized:

```rust
impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
    pub fn downgrade(s: Self) -> RwLockReadGuard<'a, T> {}
}
```

~~I would like to point out that my documentation comment is longer than ideal, but at the same time I don't really know how else to show why `downgrade` is actually necessary (instead of just unlocking and relocking). If anyone has ideas for making this more concise that would be great!~~ I have made the documentation a bit more clear.

Stabilization report: https://github.com/rust-lang/rust/issues/128203#issuecomment-3016682463