### PR TITLE
Show auto trait and blanket impls for `!`

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -316,6 +316,11 @@ mod prim_bool {}
 #[unstable(feature = "never_type", issue = "35121")]
 mod prim_never {}
 
+// Required to make auto trait impls render.
+// See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
+#[doc(hidden)]
+impl ! {}
+
 #[rustc_doc_primitive = "char"]
 #[allow(rustdoc::invalid_rust_codeblocks)]
 /// A character type.


### PR DESCRIPTION
Add an empty `impl ! {}` so rustdoc shows auto trait impls and blanket impls on `!`'s documentation page.

This is already done for [unit](https://github.com/zachs18/rust/blob/2f0ad2a71e4a4528bb80bcb24bf8fa4e50cb87c2/library/core/src/primitive_docs.rs#L493), [tuples](https://github.com/zachs18/rust/blob/2f0ad2a71e4a4528bb80bcb24bf8fa4e50cb87c2/library/core/src/primitive_docs.rs#L1148), and [`fn` pointers](https://github.com/zachs18/rust/blob/2f0ad2a71e4a4528bb80bcb24bf8fa4e50cb87c2/library/core/src/primitive_docs.rs#L1874).

cc https://github.com/rust-lang/rust/pull/97842 @notriddle which added the same for unit and tuple.

<details><summary>Comparison</summary>

[Before (current):](https://doc.rust-lang.org/nightly/std/primitive.never.html)
![image](https://github.com/user-attachments/assets/eab8126d-8d65-46d4-8dc7-3680f3162ce3)

After:
![image](https://github.com/user-attachments/assets/e0868113-ebef-4c64-ac30-dfe740d7ea38)
</details>


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label A-docs F-never_type