### PR TITLE
[COMPILETEST-UNTANGLE 2/N] Make some compiletest errors/warnings/help more visually obvious

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -11,6 +11,7 @@ use serde::de::{Deserialize, Deserializer, Error as _};
 
 pub use self::Mode::*;
 use crate::executor::{ColorConfig, OutputFormat};
+use crate::fatal;
 use crate::util::{Utf8PathBufExt, add_dylib_path};
 
 macro_rules! string_enum {
@@ -783,11 +784,13 @@ fn rustc_output(config: &Config, args: &[&str], envs: HashMap<String, String>) -
 
     let output = match command.output() {
         Ok(output) => output,
-        Err(e) => panic!("error: failed to run {command:?}: {e}"),
+        Err(e) => {
+            fatal!("failed to run {command:?}: {e}");
+        }
     };
     if !output.status.success() {
-        panic!(
-            "error: failed to run {command:?}\n--- stdout\n{}\n--- stderr\n{}",
+        fatal!(
+            "failed to run {command:?}\n--- stdout\n{}\n--- stderr\n{}",
             String::from_utf8(output.stdout).unwrap(),
             String::from_utf8(output.stderr).unwrap(),
         );

--- a/src/tools/compiletest/src/diagnostics.rs
+++ b/src/tools/compiletest/src/diagnostics.rs
@@ -1,0 +1,46 @@
+//! Collection of diagnostics helpers for `compiletest` *itself*.
+
+#[macro_export]
+macro_rules! fatal {
+    ($($arg:tt)*) => {
+        let status = ::colored::Colorize::bright_red("FATAL: ");
+        let status = ::colored::Colorize::bold(status);
+        eprint!("{status}");
+        eprintln!($($arg)*);
+        // This intentionally uses a seemingly-redundant panic to include backtrace location.
+        //
+        // FIXME: in the long term, we should handle "logic bug in compiletest itself" vs "fatal
+        // user error" separately.
+        panic!("fatal error");
+    };
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {
+        let status = ::colored::Colorize::red("ERROR: ");
+        let status = ::colored::Colorize::bold(status);
+        eprint!("{status}");
+        eprintln!($($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! warning {
+    ($($arg:tt)*) => {
+        let status = ::colored::Colorize::yellow("WARNING: ");
+        let status = ::colored::Colorize::bold(status);
+        eprint!("{status}");
+        eprintln!($($arg)*);
+    };
+}
+
+#[macro_export]
+macro_rules! help {
+    ($($arg:tt)*) => {
+        let status = ::colored::Colorize::cyan("HELP: ");
+        let status = ::colored::Colorize::bold(status);
+        eprint!("{status}");
+        eprintln!($($arg)*);
+    };
+}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -27,7 +27,7 @@ use crate::errors::{Error, ErrorKind, load_errors};
 use crate::header::TestProps;
 use crate::read2::{Truncated, read2_abbreviated};
 use crate::util::{Utf8PathBufExt, add_dylib_path, logv, static_regex};
-use crate::{ColorConfig, json, stamp_file_path};
+use crate::{ColorConfig, help, json, stamp_file_path, warning};
 
 mod debugger;
 
@@ -485,12 +485,15 @@ impl<'test> TestCx<'test> {
                 .windows(2)
                 .any(|args| args == cfg_arg || args[0] == arg || args[1] == arg)
             {
-                panic!(
-                    "error: redundant cfg argument `{normalized_revision}` is already created by the revision"
+                error!(
+                    "redundant cfg argument `{normalized_revision}` is already created by the \
+                    revision"
                 );
+                panic!("redundant cfg argument");
             }
             if self.config.builtin_cfg_names().contains(&normalized_revision) {
-                panic!("error: revision `{normalized_revision}` collides with a builtin cfg");
+                error!("revision `{normalized_revision}` collides with a built-in cfg");
+                panic!("revision collides with built-in cfg");
             }
             cmd.args(cfg_arg);
         }
@@ -2167,9 +2170,10 @@ impl<'test> TestCx<'test> {
             println!("{}", String::from_utf8_lossy(&output.stdout));
             eprintln!("{}", String::from_utf8_lossy(&output.stderr));
         } else {
-            eprintln!("warning: no pager configured, falling back to unified diff");
-            eprintln!(
-                "help: try configuring a git pager (e.g. `delta`) with `git config --global core.pager delta`"
+            warning!("no pager configured, falling back to unified diff");
+            help!(
+                "try configuring a git pager (e.g. `delta`) with \
+                `git config --global core.pager delta`"
             );
             let mut out = io::stdout();
             let mut diff = BufReader::new(File::open(&diff_filename).unwrap());

--- a/src/tools/compiletest/src/runtest/codegen_units.rs
+++ b/src/tools/compiletest/src/runtest/codegen_units.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use super::{Emit, TestCx, WillExecute};
-use crate::errors;
 use crate::util::static_regex;
+use crate::{errors, fatal};
 
 impl TestCx<'_> {
     pub(super) fn run_codegen_units_test(&self) {
@@ -100,7 +100,7 @@ impl TestCx<'_> {
         }
 
         if !(missing.is_empty() && unexpected.is_empty() && wrong_cgus.is_empty()) {
-            panic!();
+            fatal!("!(missing.is_empty() && unexpected.is_empty() && wrong_cgus.is_empty())");
         }
 
         #[derive(Clone, Eq, PartialEq)]


### PR DESCRIPTION
This is part of a patch series to untangle `compiletest` to hopefully nudge it towards being more maintainable.

This PR makes some compiletest errors/warnings/help more visually obvious. Note that this is only intended to help visually -- the error handling in compiletest is still a mess.

![Screenshot 2025-06-30 170010](https://github.com/user-attachments/assets/a56b7857-1926-48f8-a309-9e7fcf84df7f)

r? ghost