### PR TITLE
Suggest use another lifetime specifier instead of underscore lifetime

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -432,6 +432,7 @@ resolve_undeclared_label =
 
 resolve_underscore_lifetime_is_reserved = `'_` cannot be used here
     .label = `'_` is a reserved lifetime name
+    .help = use another lifetime specifier
 
 resolve_unexpected_res_change_ty_to_const_param_sugg =
     you might have meant to write a const parameter here

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -934,6 +934,7 @@ pub(crate) struct ImplicitElidedLifetimeNotAllowedHere {
 
 #[derive(Diagnostic)]
 #[diag(resolve_underscore_lifetime_is_reserved, code = E0637)]
+#[help]
 pub(crate) struct UnderscoreLifetimeIsReserved {
     #[primary_span]
     #[label]

--- a/tests/ui/error-codes/E0637.stderr
+++ b/tests/ui/error-codes/E0637.stderr
@@ -3,6 +3,8 @@ error[E0637]: `'_` cannot be used here
    |
 LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
    |                        ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0106]: missing lifetime specifier
   --> $DIR/E0637.rs:1:62

--- a/tests/ui/underscore-lifetime/in-binder.stderr
+++ b/tests/ui/underscore-lifetime/in-binder.stderr
@@ -3,36 +3,48 @@ error[E0637]: `'_` cannot be used here
    |
 LL | impl<'_> IceCube<'_> {}
    |      ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/in-binder.rs:12:15
    |
 LL | struct Struct<'_> {
    |               ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/in-binder.rs:17:11
    |
 LL | enum Enum<'_> {
    |           ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/in-binder.rs:22:13
    |
 LL | union Union<'_> {
    |             ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/in-binder.rs:27:13
    |
 LL | trait Trait<'_> {
    |             ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/in-binder.rs:31:8
    |
 LL | fn foo<'_>() {
    |        ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -15,12 +15,16 @@ error[E0637]: `'_` cannot be used here
    |
 LL | fn foo<'_>
    |        ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0637]: `'_` cannot be used here
   --> $DIR/underscore-lifetime-binders.rs:10:25
    |
 LL | fn meh() -> Box<dyn for<'_> Meh<'_>>
    |                         ^^ `'_` is a reserved lifetime name
+   |
+   = help: use another lifetime specifier
 
 error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:10:33


### PR DESCRIPTION
cc rust-lang/rust#143152 

r? compiler
