### PR TITLE
Replace `ItemCtxt::report_placeholder_type_error` match with a call to `TyCtxt::def_descr`

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3141,15 +3141,6 @@ pub enum TraitItemKind<'hir> {
     /// type.
     Type(GenericBounds<'hir>, Option<&'hir Ty<'hir>>),
 }
-impl TraitItemKind<'_> {
-    pub fn descr(&self) -> &'static str {
-        match self {
-            TraitItemKind::Const(..) => "associated constant",
-            TraitItemKind::Fn(..) => "function",
-            TraitItemKind::Type(..) => "associated type",
-        }
-    }
-}
 
 // The bodies for items are stored "out of line", in a separate
 // hashmap in the `Crate`. Here we just record the hir-id of the item
@@ -3210,15 +3201,6 @@ pub enum ImplItemKind<'hir> {
     Fn(FnSig<'hir>, BodyId),
     /// An associated type.
     Type(&'hir Ty<'hir>),
-}
-impl ImplItemKind<'_> {
-    pub fn descr(&self) -> &'static str {
-        match self {
-            ImplItemKind::Const(..) => "associated constant",
-            ImplItemKind::Fn(..) => "function",
-            ImplItemKind::Type(..) => "associated type",
-        }
-    }
 }
 
 /// A constraint on an associated item.
@@ -4543,16 +4525,6 @@ pub enum ForeignItemKind<'hir> {
     Static(&'hir Ty<'hir>, Mutability, Safety),
     /// A foreign type.
     Type,
-}
-
-impl ForeignItemKind<'_> {
-    pub fn descr(&self) -> &'static str {
-        match self {
-            ForeignItemKind::Fn(..) => "function",
-            ForeignItemKind::Static(..) => "static variable",
-            ForeignItemKind::Type => "type",
-        }
-    }
 }
 
 /// A variable captured by a closure.

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -277,17 +277,7 @@ impl<'tcx> ItemCtxt<'tcx> {
             }
             _ => self.item_def_id,
         };
-        // FIXME: just invoke `tcx.def_descr` instead of going through the HIR
-        // Can also remove most `descr` methods then.
-        let kind = match self.tcx.hir_node_by_def_id(kind_id) {
-            Node::Item(it) => it.kind.descr(),
-            Node::ImplItem(it) => it.kind.descr(),
-            Node::TraitItem(it) => it.kind.descr(),
-            Node::ForeignItem(it) => it.kind.descr(),
-            Node::OpaqueTy(_) => "opaque type",
-            Node::Synthetic => self.tcx.def_descr(kind_id.into()),
-            node => todo!("{node:#?}"),
-        };
+        let kind = self.tcx.def_descr(kind_id.into());
         let mut diag = placeholder_type_error_diag(
             self,
             generics,

--- a/tests/rustdoc-ui/invalid_infered_static_and_const.stderr
+++ b/tests/rustdoc-ui/invalid_infered_static_and_const.stderr
@@ -1,10 +1,10 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/invalid_infered_static_and_const.rs:1:24
    |
 LL | const FOO: dyn Fn() -> _ = "";
    |                        ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/invalid_infered_static_and_const.rs:2:25
    |
 LL | static BOO: dyn Fn() -> _ = "";

--- a/tests/ui/closures/missing-body.rs
+++ b/tests/ui/closures/missing-body.rs
@@ -1,0 +1,7 @@
+// Checks that the compiler complains about the missing closure body and does not
+// crash.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/143128>.
+
+fn main() { |b: [str; _]| {}; }
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for closures
+//~| ERROR the size for values of type `str` cannot be known at compilation time

--- a/tests/ui/closures/missing-body.stderr
+++ b/tests/ui/closures/missing-body.stderr
@@ -1,0 +1,19 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for closures
+  --> $DIR/missing-body.rs:5:23
+   |
+LL | fn main() { |b: [str; _]| {}; }
+   |                       ^ not allowed in type signatures
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/missing-body.rs:5:17
+   |
+LL | fn main() { |b: [str; _]| {}; }
+   |                 ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: slice and array elements must have `Sized` type
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0277.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -302,7 +302,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/bad-assoc-ty.rs:88:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
@@ -284,7 +284,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/bad-assoc-ty.rs:88:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -86,7 +86,7 @@ trait P<F> where F: Fn() -> _ {
 
 trait Q {
     fn foo<F>(_: F) where F: Fn() -> _ {}
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
 }
 
 fn main() {}

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
@@ -7,7 +7,7 @@ trait Foo<T>: Sized {
 
 impl Foo<usize> for () {
     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
-        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
         //~| ERROR type annotations needed
         (1, 2)
     }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
@@ -7,7 +7,7 @@ trait Foo<T>: Sized {
 
 impl Foo<usize> for () {
     fn bar(i: _, t: _, s: _) -> _ {
-        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
         //~| ERROR type annotations needed
         (1, 2)
     }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/replace-impl-infer-ty-from-trait.rs:9:15
    |
 LL |     fn bar(i: _, t: _, s: _) -> _ {

--- a/tests/ui/fn/error-recovery-mismatch.stderr
+++ b/tests/ui/fn/error-recovery-mismatch.stderr
@@ -29,7 +29,7 @@ LL |     fn fold<T>(&self, _: T, &self._) {}
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
    = note: `#[warn(anonymous_parameters)]` on by default
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/error-recovery-mismatch.rs:11:35
    |
 LL |     fn fold<T>(&self, _: T, &self._) {}

--- a/tests/ui/self/self-infer.rs
+++ b/tests/ui/self/self-infer.rs
@@ -1,8 +1,8 @@
 struct S;
 
 impl S {
-    fn f(self: _) {} //~ERROR the placeholder `_` is not allowed within types on item signatures for functions
-    fn g(self: &_) {} //~ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    fn f(self: _) {} //~ERROR the placeholder `_` is not allowed within types on item signatures for methods
+    fn g(self: &_) {} //~ERROR the placeholder `_` is not allowed within types on item signatures for methods
 }
 
 fn main() {}

--- a/tests/ui/self/self-infer.stderr
+++ b/tests/ui/self/self-infer.stderr
@@ -1,10 +1,10 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/self-infer.rs:4:16
    |
 LL |     fn f(self: _) {}
    |                ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/self-infer.rs:5:17
    |
 LL |     fn g(self: &_) {}

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.rs
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.rs
@@ -4,7 +4,7 @@ trait Foo {
 
 impl Foo for () {
     fn bar(s: _) {}
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
     //~| ERROR has 1 parameter but the declaration in trait `Foo::bar` has 0
 }
 

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/bad-infer-in-trait-impl.rs:6:15
    |
 LL |     fn bar(s: _) {}

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.stderr
@@ -16,7 +16,7 @@ LL | impl<T> const FromResidual for T {
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/ice-119717-constant-lifetime.rs:9:31
    |
 LL |     fn from_residual(t: T) -> _ {

--- a/tests/ui/traits/method-argument-mismatch-variance-ice-119867.stderr
+++ b/tests/ui/traits/method-argument-mismatch-variance-ice-119867.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/method-argument-mismatch-variance-ice-119867.rs:8:23
    |
 LL |     fn deserialize(s: _) {}

--- a/tests/ui/typeck/issue-74086.rs
+++ b/tests/ui/typeck/issue-74086.rs
@@ -1,4 +1,4 @@
 fn main() {
     static BUG: fn(_) -> u8 = |_| 8;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for statics
 }

--- a/tests/ui/typeck/issue-74086.stderr
+++ b/tests/ui/typeck/issue-74086.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-74086.rs:2:20
    |
 LL |     static BUG: fn(_) -> u8 = |_| 8;

--- a/tests/ui/typeck/issue-75889.stderr
+++ b/tests/ui/typeck/issue-75889.stderr
@@ -1,10 +1,10 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/issue-75889.rs:3:24
    |
 LL | const FOO: dyn Fn() -> _ = "";
    |                        ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-75889.rs:4:25
    |
 LL | static BOO: dyn Fn() -> _ = "";

--- a/tests/ui/typeck/issue-81885.rs
+++ b/tests/ui/typeck/issue-81885.rs
@@ -1,7 +1,7 @@
 const TEST4: fn() -> _ = 42;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 
 fn main() {
     const TEST5: fn() -> _ = 42;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 }

--- a/tests/ui/typeck/issue-81885.stderr
+++ b/tests/ui/typeck/issue-81885.stderr
@@ -1,10 +1,10 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/issue-81885.rs:1:22
    |
 LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/issue-81885.rs:5:26
    |
 LL |     const TEST5: fn() -> _ = 42;

--- a/tests/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
+++ b/tests/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
@@ -1,4 +1,4 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-83621-placeholder-static-in-extern.rs:4:15
    |
 LL |     static x: _;

--- a/tests/ui/typeck/issue-88643.rs
+++ b/tests/ui/typeck/issue-88643.rs
@@ -8,12 +8,12 @@ use std::collections::HashMap;
 pub trait T {}
 
 static CALLBACKS: HashMap<*const dyn T, dyn FnMut(&mut _) + 'static> = HashMap::new();
-//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for static items [E0121]
+//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for statics [E0121]
 
 static CALLBACKS2: Vec<dyn Fn(& _)> = Vec::new();
-//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for static items [E0121]
+//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for statics [E0121]
 
 static CALLBACKS3: Option<dyn Fn(& _)> = None;
-//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for static items [E0121]
+//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for statics [E0121]
 
 fn main() {}

--- a/tests/ui/typeck/issue-88643.stderr
+++ b/tests/ui/typeck/issue-88643.stderr
@@ -1,16 +1,16 @@
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-88643.rs:10:56
    |
 LL | static CALLBACKS: HashMap<*const dyn T, dyn FnMut(&mut _) + 'static> = HashMap::new();
    |                                                        ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-88643.rs:13:33
    |
 LL | static CALLBACKS2: Vec<dyn Fn(& _)> = Vec::new();
    |                                 ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for static items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for statics
   --> $DIR/issue-88643.rs:16:36
    |
 LL | static CALLBACKS3: Option<dyn Fn(& _)> = None;

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -41,7 +41,7 @@ impl Test9 {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
 
     fn test10(&self, _x : _) { }
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
 }
 
 fn test11(x: &usize) -> &_ {
@@ -56,10 +56,10 @@ unsafe fn test12(x: *const usize) -> *const *const _ {
 
 impl Clone for Test9 {
     fn clone(&self) -> _ { Test9 }
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
 
     fn clone_from(&mut self, other: _) { *self = Test9; }
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
 }
 
 struct Test10 {
@@ -108,15 +108,15 @@ pub fn main() {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
 
         fn fn_test10(&self, _x : _) { }
-        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
     }
 
     impl Clone for FnTest9 {
         fn clone(&self) -> _ { FnTest9 }
-        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
 
         fn clone_from(&mut self, other: _) { *self = FnTest9; }
-        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
     }
 
     struct FnTest10 {
@@ -140,19 +140,19 @@ pub fn main() {
 
 trait T {
     fn method_test1(&self, x: _);
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
     fn method_test2(&self, x: _) -> _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for methods
     fn method_test3(&self) -> _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for methods
     fn assoc_fn_test1(x: _);
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
     fn assoc_fn_test2(x: _) -> _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-    //~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
+    //~| ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
     fn assoc_fn_test3() -> _;
-    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated functions
 }
 
 struct BadStruct<_>(_);

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -203,7 +203,7 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      |             not allowed in type signatures
    |                                      help: replace with the correct return type: `*const *const usize`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:58:24
    |
 LL |     fn clone(&self) -> _ { Test9 }
@@ -215,7 +215,7 @@ LL -     fn clone(&self) -> _ { Test9 }
 LL +     fn clone(&self) -> Test9 { Test9 }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:61:37
    |
 LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
@@ -332,7 +332,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     fn fn_test8(_f: fn() -> _) { }
    |                             ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:115:28
    |
 LL |         fn clone(&self) -> _ { FnTest9 }
@@ -344,7 +344,7 @@ LL -         fn clone(&self) -> _ { FnTest9 }
 LL +         fn clone(&self) -> FnTest9 { FnTest9 }
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:118:41
    |
 LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
@@ -389,49 +389,49 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:142:31
    |
 LL |     fn method_test1(&self, x: _);
    |                               ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:144:31
    |
 LL |     fn method_test2(&self, x: _) -> _;
    |                               ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:144:37
    |
 LL |     fn method_test2(&self, x: _) -> _;
    |                                     ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:147:31
    |
 LL |     fn method_test3(&self) -> _;
    |                               ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/typeck_type_placeholder_item.rs:149:26
    |
 LL |     fn assoc_fn_test1(x: _);
    |                          ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/typeck_type_placeholder_item.rs:151:26
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
    |                          ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/typeck_type_placeholder_item.rs:151:32
    |
 LL |     fn assoc_fn_test2(x: _) -> _;
    |                                ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated functions
   --> $DIR/typeck_type_placeholder_item.rs:154:28
    |
 LL |     fn assoc_fn_test3() -> _;
@@ -575,7 +575,7 @@ LL |     fn test9(&self) -> _ { () }
    |                        not allowed in type signatures
    |                        help: replace with the correct return type: `()`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:43:27
    |
 LL |     fn test10(&self, _x : _) { }
@@ -590,7 +590,7 @@ LL |         fn fn_test9(&self) -> _ { () }
    |                               not allowed in type signatures
    |                               help: replace with the correct return type: `()`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for methods
   --> $DIR/typeck_type_placeholder_item.rs:110:34
    |
 LL |         fn fn_test10(&self, _x : _) { }

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -11,7 +11,7 @@ const TEST3: _ = Some(42);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 
 const TEST4: fn() -> _ = 42;
-//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constant items
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
 
 trait Test5 {
     const TEST5: _ = 42;

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -31,7 +31,7 @@ LL - const TEST3: _ = Some(42);
 LL + const TEST3: Option<i32> = Some(42);
    |
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constant items
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
    |
 LL | const TEST4: fn() -> _ = 42;


### PR DESCRIPTION
Fixes rust-lang/rust#143128.

We could likely use `tcx.def_descr` in more places (and therefore remove more `descr` methods). If it's something that we want to do, I can send a follow-up.

r? @oli-obk