### PR TITLE
Assemble const bounds via normal item bounds in old solver too

### DIFF
--- a/tests/ui/traits/const-traits/const-via-item-bound.rs
+++ b/tests/ui/traits/const-traits/const-via-item-bound.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Bar {}
+
+trait Baz: const Bar {}
+
+trait Foo {
+    // Well-formedenss of `Baz` requires `<Self as Foo>::Bar: const Bar`.
+    // Make sure we assemble a candidate for that via the item bounds.
+    type Bar: Baz;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes the first example in https://rust-lang.zulipchat.com/#narrow/channel/144729-t-types/topic/elaboration.20of.20const.20bounds.3F/with/526378135

The code duplication here is not that nice, but it's at least very localized.

cc @davidtwco 

r? oli-obk