### PR TITLE
Port `#[no_implicit_prelude]` to the new attribute parsing infrastructure

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -278,6 +278,9 @@ pub enum AttributeKind {
     /// Represents `#[naked]`
     Naked(Span),
 
+    /// Represents `#[no_implicit_prelude]`
+    NoImplicitPrelude(Span),
+
     /// Represents `#[no_mangle]`
     NoMangle(Span),
 

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -35,6 +35,7 @@ impl AttributeKind {
             MayDangle(..) => No,
             MustUse { .. } => Yes,
             Naked(..) => No,
+            NoImplicitPrelude(..) => No,
             NoMangle(..) => No,
             Optimize(..) => No,
             PubTransparent(..) => Yes,

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod link_attrs;
 pub(crate) mod lint_helpers;
 pub(crate) mod loop_match;
 pub(crate) mod must_use;
+pub(crate) mod no_implicit_prelude;
 pub(crate) mod repr;
 pub(crate) mod rustc_internal;
 pub(crate) mod semantics;

--- a/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
@@ -1,0 +1,13 @@
+use rustc_attr_data_structures::AttributeKind;
+use rustc_span::{Span, sym};
+
+use crate::attributes::{NoArgsAttributeParser, OnDuplicate};
+use crate::context::Stage;
+
+pub(crate) struct NoImplicitPreludeParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for NoImplicitPreludeParser {
+    const PATH: &[rustc_span::Symbol] = &[sym::no_implicit_prelude];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoImplicitPrelude;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -26,6 +26,7 @@ use crate::attributes::link_attrs::{LinkNameParser, LinkSectionParser};
 use crate::attributes::lint_helpers::{AsPtrParser, PubTransparentParser};
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
 use crate::attributes::must_use::MustUseParser;
+use crate::attributes::no_implicit_prelude::NoImplicitPreludeParser;
 use crate::attributes::repr::{AlignParser, ReprParser};
 use crate::attributes::rustc_internal::{
     RustcLayoutScalarValidRangeEnd, RustcLayoutScalarValidRangeStart,
@@ -141,6 +142,7 @@ attribute_parsers!(
         Single<WithoutArgs<ConstStabilityIndirectParser>>,
         Single<WithoutArgs<LoopMatchParser>>,
         Single<WithoutArgs<MayDangleParser>>,
+        Single<WithoutArgs<NoImplicitPreludeParser>>,
         Single<WithoutArgs<NoMangleParser>>,
         Single<WithoutArgs<PubTransparentParser>>,
         Single<WithoutArgs<TrackCallerParser>>,

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -310,6 +310,7 @@ fn emit_malformed_attribute(
             | sym::link_section
             | sym::rustc_layout_scalar_valid_range_start
             | sym::rustc_layout_scalar_valid_range_end
+            | sym::no_implicit_prelude
     ) {
         return;
     }

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -65,12 +65,6 @@ error: malformed `no_sanitize` attribute input
 LL | #[no_sanitize]
    | ^^^^^^^^^^^^^^ help: must be of the form: `#[no_sanitize(address, kcfi, memory, thread)]`
 
-error: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:96:1
-   |
-LL | #[no_implicit_prelude = 23]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[no_implicit_prelude]`
-
 error: malformed `proc_macro` attribute input
   --> $DIR/malformed-attrs.rs:98:1
    |
@@ -513,6 +507,15 @@ error[E0539]: malformed `link_section` attribute input
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
+
+error[E0565]: malformed `no_implicit_prelude` attribute input
+  --> $DIR/malformed-attrs.rs:96:1
+   |
+LL | #[no_implicit_prelude = 23]
+   | ^^^^^^^^^^^^^^^^^^^^^^----^
+   | |                     |
+   | |                     didn't expect any arguments here
+   | help: must be of the form: `#[no_implicit_prelude]`
 
 error[E0539]: malformed `must_use` attribute input
   --> $DIR/malformed-attrs.rs:118:1

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -141,18 +141,6 @@ LL | #![no_std]
    | ^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:25:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:24:1
-   |
-LL | #![no_implicit_prelude]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:27:1
    |
 LL | #![windows_subsystem = "windows"]
@@ -301,6 +289,18 @@ note: attribute also specified here
 LL | #[link_section = ".bss"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:25:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:24:1
+   |
+LL | #![no_implicit_prelude]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Ports no_implicit_prelude to the new attribute parsing infrastructure for https://github.com/rust-lang/rust/issues/131229#issuecomment-2971353197

r? @oli-obk 
cc @jdonszelmann 