### PR TITLE
RDR: avoid rebuilding dependent crates after comment changes

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -546,6 +546,10 @@ impl<'a, 'tcx> SpanDecoder for DecodeContext<'a, 'tcx> {
     }
 
     fn decode_span(&mut self) -> Span {
+        if !self.cdata().has_rmeta_extras() {
+            return DUMMY_SP;
+        }
+
         let start = self.position();
         let tag = SpanTag(self.peek_byte());
         let data = if tag.kind() == SpanKind::Indirect {
@@ -1997,6 +2001,10 @@ impl CrateMetadata {
 
     pub(crate) fn has_default_lib_allocator(&self) -> bool {
         self.root.has_default_lib_allocator
+    }
+
+    pub(crate) fn has_rmeta_extras(&self) -> bool {
+        self.root.has_rmeta_extras
     }
 
     pub(crate) fn is_proc_macro_crate(&self) -> bool {

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -260,6 +260,7 @@ pub(crate) struct CrateRoot {
     has_alloc_error_handler: bool,
     has_panic_handler: bool,
     has_default_lib_allocator: bool,
+    has_rmeta_extras: bool,
 
     crate_deps: LazyArray<CrateDep>,
     dylib_dependency_formats: LazyArray<Option<LinkagePreference>>,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2537,6 +2537,8 @@ written to standard error output)"),
                   by the linker"),
     split_lto_unit: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "enable LTO unit splitting (default: no)"),
+    split_rmeta: Option<bool> = (None, parse_opt_bool, [TRACKED],
+        "split extra rmeta data that isn't relevant rlib ABI into a separate file"),
     src_hash_algorithm: Option<SourceFileHashAlgorithm> = (None, parse_src_file_hash, [TRACKED],
         "hash algorithm of source files in debug info (`md5`, `sha1`, or `sha256`)"),
     #[rustc_lint_opt_deny_field_access("use `Session::stack_protector` instead of this field")]

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -400,6 +400,10 @@ impl Session {
         self.opts.unstable_opts.split_lto_unit == Some(true)
     }
 
+    pub fn is_split_rmeta_enabled(&self) -> bool {
+        self.opts.unstable_opts.split_rmeta == Some(true)
+    }
+
     /// Check whether this compile session and crate type use static crt.
     pub fn crt_static(&self, crate_type: Option<CrateType>) -> bool {
         if !self.target.crt_static_respected {

--- a/tests/run-make/rdr-ignores-comments/after.rs
+++ b/tests/run-make/rdr-ignores-comments/after.rs
@@ -1,0 +1,8 @@
+#![crate_name = "foo"]
+#![crate_type = "lib"]
+// bbb
+pub struct Foo;
+
+impl Foo {
+    pub fn bar(self: Foo) {}
+}

--- a/tests/run-make/rdr-ignores-comments/before.rs
+++ b/tests/run-make/rdr-ignores-comments/before.rs
@@ -1,0 +1,8 @@
+#![crate_name = "foo"]
+#![crate_type = "lib"]
+// aaa
+pub struct Foo;
+
+impl Foo {
+    pub fn bar(self: Foo) {}
+}

--- a/tests/run-make/rdr-ignores-comments/rmake.rs
+++ b/tests/run-make/rdr-ignores-comments/rmake.rs
@@ -1,13 +1,15 @@
-// tests that changing the content of a comment will cause a change in the rmeta of a file
-use run_make_support::{rfs, rustc};
+// tests that changing the content of a comment will not cause a change in the rmeta of a library if
+// -Zsplit-rmeta is enabled
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+
+use run_make_support::{rfs, rustc};
 
 fn main() {
     let before = check_and_hash("before.rs");
     let after = check_and_hash("after.rs");
     dbg!(before, after);
-    assert_neq!(before, after);
+    assert_eq!(before, after);
 }
 
 fn check_and_hash<P>(filename: P) -> u64
@@ -15,7 +17,7 @@ where
     P: AsRef<Path>,
 {
     rfs::rename(filename, "foo.rs");
-    rustc().input("foo.rs").emit("metadata").run();
+    rustc().input("foo.rs").emit("metadata").arg("-Zsplit-rmeta").run();
     // hash the output
     let bytes = rfs::read("libfoo.rmeta");
     let mut hasher = std::hash::DefaultHasher::new();

--- a/tests/run-make/rdr-ignores-comments/rmake.rs
+++ b/tests/run-make/rdr-ignores-comments/rmake.rs
@@ -1,0 +1,24 @@
+// tests that changing the content of a comment will cause a change in the rmeta of a file
+use run_make_support::{rfs, rustc};
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+fn main() {
+    let before = check_and_hash("before.rs");
+    let after = check_and_hash("after.rs");
+    dbg!(before, after);
+    assert_neq!(before, after);
+}
+
+fn check_and_hash<P>(filename: P) -> u64
+where
+    P: AsRef<Path>,
+{
+    rfs::rename(filename, "foo.rs");
+    rustc().input("foo.rs").emit("metadata").run();
+    // hash the output
+    let bytes = rfs::read("libfoo.rmeta");
+    let mut hasher = std::hash::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
+}


### PR DESCRIPTION
an initial step of Relink don't Rebuild

The goal is to avoid needing to rebuild downstream crates just because an upstream crate changed a comment. 

Our current plan is to treat a hash of the rmeta as the indicator that "something that would require a rebuild has changed" and add an unstable compiler flag to start moving things that are "relink independent" (I don't know what to call this, "relink compatible" maybe? "relink safe"? /shrug) into a separate file alongside the rmeta.

In this PR I've taken the baby step of simply removing the data that is causing rebuilds from the rmeta (source map and span information). This has a significant detrimental impact on diagnostics and causes code that depends on libraries that depend on span information to disambiguate bindings to fail to compile (libraries that depend on thiserror such as sqlx-core for example). 

This is fine because we don't necessarily care that this initial flag can build all code, as long as it can be used for basic cargo integration and a simple proof of concept cargo project with multiple dependencies where we can enable the flag, edit a comment, and show downstream crates not re-compiling. Once we have that cargo integration we should be able to work on the real impl that moves the data somewhere else rather than simply deleting it and use that with the already setup cargo integration to realize the same gains as the proof of concept against real world codebases.

This is broken down into two commits as follows:

1. Tests for current behavior and the impact of editing comments on the hash of the output rmeta file
2. The changes to remove sourcemap and span information alongside an updated version of the test to enable the associated flag and verify that the hashes no longer change.
