### PR TITLE
Do not enable LLD by default in the dist profile

### DIFF
--- a/src/bootstrap/defaults/bootstrap.dist.toml
+++ b/src/bootstrap/defaults/bootstrap.dist.toml
@@ -20,7 +20,6 @@ download-ci-llvm = false
 channel = "auto-detect"
 # Never download a rustc, distributions must build a fresh compiler.
 download-rustc = false
-lld = true
 # Build the llvm-bitcode-linker
 llvm-bitcode-linker = true
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -436,4 +436,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "It is no longer possible to combine `rust.lld = true` with configuring external LLVM using `llvm.llvm-config`.",
     },
+    ChangeInfo {
+        change_id: 143255,
+        severity: ChangeSeverity::Warning,
+        summary: "`llvm.lld` is no longer enabled by default for the dist profile.",
+    },
 ];

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -86,13 +86,12 @@ fi
 # space required for CI artifacts.
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --dist-compression-formats=xz"
 
-if [ "$EXTERNAL_LLVM" = "1" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.lld=false"
-fi
-
 # Enable the `c` feature for compiler_builtins, but only when the `compiler-rt` source is available
 # (to avoid spending a lot of time cloning llvm)
 if [ "$EXTERNAL_LLVM" = "" ]; then
+  # Enable building & shipping lld
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.lld=true"
+
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.optimized-compiler-builtins"
   # Likewise, only demand we test all LLVM components if we know we built LLVM with them
   export COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS=1


### PR DESCRIPTION
History of us building & shipping LLD for `dist` builds:
1) We used to unconditionally build & ship LLD in bootstrap
2) This was causing problems for people doing custom `dist` builds (https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/MSVC.20Runtime.20mismatch.20when.20building.20LLD)
3) https://github.com/rust-lang/rust/pull/126701 made shipping of LLD optional, but to preserve previous behavior, it forcefully enabled `rust.lld = true` in the `dist` profile by default, and overwrote the default to `false` on our CI for external LLVM builds.
    - This also didn't match the documentation of `rust.lld` in `bootstrap.example.toml`, which I previously missed.
4) However, since the external LLVM opt-out was only implemented for our CI, and not for all `dist` users, this started causing issues for people `dist`ing with external LLVM (https://github.com/rust-lang/rust/issues/143076). The problem is that the default shouldn't be "true", but "LLD is enabled when LLVM isn't external", but this is not possible to do only in TOML.

So this PR reverses the behavior. LLD is not enabled by default in `dist` anymore. We switch our CI to *opt into* disting LLD, unless an external LLVM is used. External `dist` users can still opt into enabling LLD, but if they do so while also using external LLVM, they will now get a [hard error](https://github.com/rust-lang/rust/pull/143175).

r? @jieyouxu

try-job: `x86_64-mingw*`
try-job: dist-x86_64-linux