### PR TITLE
fix: Emit suggestion filename if primary diagnostic span is dummy

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2078,7 +2078,9 @@ impl HumanEmitter {
                 // file name, saving in verbosity, but if it *isn't* we do need it, otherwise we're
                 // telling users to make a change but not clarifying *where*.
                 let loc = sm.lookup_char_pos(parts[0].span.lo());
-                if loc.file.name != sm.span_to_filename(span) && loc.file.name.is_real() {
+                if (span.is_dummy() || loc.file.name != sm.span_to_filename(span))
+                    && loc.file.name.is_real()
+                {
                     // --> file.rs:line:col
                     //  |
                     let arrow = self.file_start();

--- a/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
+++ b/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
@@ -2,6 +2,7 @@ error[E0259]: the name `std` is defined multiple times
    |
    = note: `std` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
+  --> $DIR/resolve-conflict-extern-crate-vs-extern-crate.rs:1:17
    |
 LL | extern crate std as other_std;
    |                  ++++++++++++


### PR DESCRIPTION
While working on using `annotate-snippets` as `rustc`'s emitter, I came across [`tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr`](https://github.com/rust-lang/rust/blob/b03b3a7ec92682be2917540b679478d41c95a30c/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr), which lacked a filename for both the annotation and the suggestion, which seemed like a bug to me. After some investigation, I found that this is happening because the primary span is a dummy, so its filename doesn't get output, and its filename matches the one for the suggestion, so the suggestion's filename doesn't get output. To fix this issue, I made it so that the filename for a suggestion will get output if the primary span is a dummy.