### PR TITLE
bootstrap: make comment more clear

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -120,14 +120,14 @@ impl Step for ToolBuild {
 
         match self.mode {
             Mode::ToolRustc => {
-                // If compiler was forced, its artifacts should be prepared earlier.
+                // If compiler was forced, its artifacts should have been prepared earlier.
                 if !self.compiler.is_forced_compiler() {
                     builder.std(self.compiler, self.compiler.host);
                     builder.ensure(compile::Rustc::new(self.compiler, target));
                 }
             }
             Mode::ToolStd => {
-                // If compiler was forced, its artifacts should be prepared earlier.
+                // If compiler was forced, its artifacts should have been prepared earlier.
                 if !self.compiler.is_forced_compiler() {
                     builder.std(self.compiler, target)
                 }


### PR DESCRIPTION
Reading that at first made me think the code block ensures that the said artefacts are created
