### PR TITLE
tests/codegen/enum/enum-match.rs: accept negative range attribute

### DIFF
--- a/tests/codegen/enum/enum-match.rs
+++ b/tests/codegen/enum/enum-match.rs
@@ -98,7 +98,7 @@ pub enum Enum2 {
     E,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match2(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, -?[0-9]+\))?}} i8 @match2(i8{{.+}}%0)
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %0, 2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64


### PR DESCRIPTION
The test current fails when `rustc` is built with HEAD LLVM: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/38097/steps/canvas?sid=0197c492-5661-4c42-8ae7-3d789e85c6ca

I suspect the change was caused by https://github.com/llvm/llvm-project/commit/545cdca4883552b147a0f1adfac713f76fc22305

@rustbot label llvm-main