### PR TITLE
Store the type of each GVN value

### DIFF
--- a/tests/mir-opt/const_prop/transmute.rs
+++ b/tests/mir-opt/const_prop/transmute.rs
@@ -56,7 +56,7 @@ pub unsafe fn undef_union_as_integer() -> u32 {
 pub unsafe fn unreachable_direct() -> ! {
     // CHECK-LABEL: fn unreachable_direct(
     // CHECK: = const ();
-    // CHECK: = const () as Never (Transmute);
+    // CHECK: = const ZeroSized: Never;
     let x: Never = unsafe { transmute(()) };
     match x {}
 }

--- a/tests/mir-opt/const_prop/transmute.unreachable_direct.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_direct.GVN.32bit.diff
@@ -15,7 +15,7 @@
 -         _2 = ();
 -         _1 = move _2 as Never (Transmute);
 +         _2 = const ();
-+         _1 = const () as Never (Transmute);
++         _1 = const ZeroSized: Never;
           unreachable;
       }
   }

--- a/tests/mir-opt/const_prop/transmute.unreachable_direct.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_direct.GVN.64bit.diff
@@ -15,7 +15,7 @@
 -         _2 = ();
 -         _1 = move _2 as Never (Transmute);
 +         _2 = const ();
-+         _1 = const () as Never (Transmute);
++         _1 = const ZeroSized: Never;
           unreachable;
       }
   }

--- a/tests/mir-opt/gvn.generic_cast_metadata.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.generic_cast_metadata.GVN.panic-abort.diff
@@ -18,7 +18,8 @@
   
       bb0: {
           _4 = copy _1 as *const T (PtrToPtr);
-          _5 = PtrMetadata(copy _4);
+-         _5 = PtrMetadata(copy _4);
++         _5 = const ();
           _6 = copy _1 as *const (&A, [T]) (PtrToPtr);
 -         _7 = PtrMetadata(copy _6);
 +         _7 = PtrMetadata(copy _1);

--- a/tests/mir-opt/gvn.generic_cast_metadata.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.generic_cast_metadata.GVN.panic-unwind.diff
@@ -18,7 +18,8 @@
   
       bb0: {
           _4 = copy _1 as *const T (PtrToPtr);
-          _5 = PtrMetadata(copy _4);
+-         _5 = PtrMetadata(copy _4);
++         _5 = const ();
           _6 = copy _1 as *const (&A, [T]) (PtrToPtr);
 -         _7 = PtrMetadata(copy _6);
 +         _7 = PtrMetadata(copy _1);

--- a/tests/mir-opt/gvn.rs
+++ b/tests/mir-opt/gvn.rs
@@ -869,7 +869,7 @@ fn generic_cast_metadata<T, A: ?Sized, B: ?Sized>(ps: *const [T], pa: *const A, 
 
             // Metadata usize -> (), do not optimize.
             // CHECK: [[T:_.+]] = copy _1 as
-            // CHECK-NEXT: PtrMetadata(copy [[T]])
+            // CHECK-NEXT: const ();
             let t1 = CastPtrToPtr::<_, *const T>(ps);
             let m1 = PtrMetadata(t1);
 

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -109,7 +109,6 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb4: {
-        StorageLive(_15);
         _14 = &mut _13;
         _15 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _14) -> [return: bb5, unwind: bb11];
     }
@@ -120,7 +119,6 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     }
 
     bb6: {
-        StorageDead(_15);
         StorageDead(_13);
         drop(_2) -> [return: bb7, unwind continue];
     }
@@ -135,14 +133,13 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         StorageLive(_19);
         _19 = &_2;
         StorageLive(_20);
-        _20 = (copy _17, copy _18);
+        _20 = copy ((_15 as Some).0: (usize, &T));
         _21 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _19, move _20) -> [return: bb9, unwind: bb11];
     }
 
     bb9: {
         StorageDead(_20);
         StorageDead(_19);
-        StorageDead(_15);
         goto -> bb4;
     }
 

--- a/tests/ui/mir/gvn-nonsensical-coroutine-layout.rs
+++ b/tests/ui/mir/gvn-nonsensical-coroutine-layout.rs
@@ -1,15 +1,19 @@
-//@ known-bug: rust-lang/rust#128094
+//! Verify that we do not ICE when a coroutine body is malformed.
 //@ compile-flags: -Zmir-enable-passes=+GVN
 //@ edition: 2018
 
 pub enum Request {
     TestSome(T),
+    //~^ ERROR cannot find type `T` in this scope [E0412]
 }
 
 pub async fn handle_event(event: Request) {
     async move {
         static instance: Request = Request { bar: 17 };
+        //~^ ERROR expected struct, variant or union type, found enum `Request` [E0574]
         &instance
     }
     .await;
 }
+
+fn main() {}

--- a/tests/ui/mir/gvn-nonsensical-coroutine-layout.stderr
+++ b/tests/ui/mir/gvn-nonsensical-coroutine-layout.stderr
@@ -1,0 +1,26 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/gvn-nonsensical-coroutine-layout.rs:6:14
+   |
+LL |     TestSome(T),
+   |              ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | pub enum Request<T> {
+   |                 +++
+
+error[E0574]: expected struct, variant or union type, found enum `Request`
+  --> $DIR/gvn-nonsensical-coroutine-layout.rs:12:36
+   |
+LL |         static instance: Request = Request { bar: 17 };
+   |                                    ^^^^^^^ not a struct, variant or union type
+   |
+help: consider importing this struct instead
+   |
+LL + use std::error::Request;
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0412, E0574.
+For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/mir/gvn-nonsensical-sized-str.rs
+++ b/tests/ui/mir/gvn-nonsensical-sized-str.rs
@@ -1,13 +1,16 @@
-//@ known-bug: #135128
+//! Verify that we do not ICE when optimizing bodies with nonsensical bounds.
 //@ compile-flags: -Copt-level=1
 //@ edition: 2021
+//@ build-pass
 
 #![feature(trivial_bounds)]
 
 async fn return_str() -> str
 where
     str: Sized,
+    //~^ WARN trait bound str: Sized does not depend on any type or lifetime parameters
 {
     *"Sized".to_string().into_boxed_str()
 }
+
 fn main() {}

--- a/tests/ui/mir/gvn-nonsensical-sized-str.stderr
+++ b/tests/ui/mir/gvn-nonsensical-sized-str.stderr
@@ -1,0 +1,10 @@
+warning: trait bound str: Sized does not depend on any type or lifetime parameters
+  --> $DIR/gvn-nonsensical-sized-str.rs:10:10
+   |
+LL |     str: Sized,
+   |          ^^^^^
+   |
+   = note: `#[warn(trivial_bounds)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
MIR is fully typed, so type information is an integral part of what defines a value. GVN currently tries to circumvent storing types, which creates all sorts of complexities.

This PR stores the type along with the enum `Value` when defining a value index. This allows to simplify a lot of code.

Fixes rust-lang/rust#128094
Fixes rust-lang/rust#135128

r? @ghost for perf

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
