### PR TITLE
Replace indexing with `get_unchecked` calls

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -69,7 +69,10 @@ unsafe trait GenericRadix: Sized {
                 let n = x % base; // Get the current place value.
                 x = x / base; // Deaccumulate the number.
                 curr -= 1;
-                buf[curr].write(Self::digit(n.to_u8())); // Store the digit in the buffer.
+                // SAFETY: `curr` is always between 0 and `buf`'s length.
+                unsafe {
+                    buf.get_unchecked_mut(curr).write(Self::digit(n.to_u8()));
+                } // Store the digit in the buffer.
                 if x == zero {
                     // No more digits left to accumulate.
                     break;
@@ -81,7 +84,10 @@ unsafe trait GenericRadix: Sized {
                 let n = zero - (x % base); // Get the current place value.
                 x = x / base; // Deaccumulate the number.
                 curr -= 1;
-                buf[curr].write(Self::digit(n.to_u8())); // Store the digit in the buffer.
+                // SAFETY: `curr` is always between 0 and `buf`'s length.
+                unsafe {
+                    buf.get_unchecked_mut(curr).write(Self::digit(n.to_u8()));
+                } // Store the digit in the buffer.
                 if x == zero {
                     // No more digits left to accumulate.
                     break;
@@ -270,10 +276,14 @@ macro_rules! impl_Display {
                     remain /= scale;
                     let pair1 = (quad / 100) as usize;
                     let pair2 = (quad % 100) as usize;
-                    buf[offset + 0].write(DEC_DIGITS_LUT[pair1 * 2 + 0]);
-                    buf[offset + 1].write(DEC_DIGITS_LUT[pair1 * 2 + 1]);
-                    buf[offset + 2].write(DEC_DIGITS_LUT[pair2 * 2 + 0]);
-                    buf[offset + 3].write(DEC_DIGITS_LUT[pair2 * 2 + 1]);
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 0).write(DEC_DIGITS_LUT[pair1 * 2 + 0]); }
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 1).write(DEC_DIGITS_LUT[pair1 * 2 + 1]); }
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 2).write(DEC_DIGITS_LUT[pair2 * 2 + 0]); }
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 3).write(DEC_DIGITS_LUT[pair2 * 2 + 1]); }
                 }
 
                 // Format per two digits from the lookup table.
@@ -288,8 +298,10 @@ macro_rules! impl_Display {
 
                     let pair = (remain % 100) as usize;
                     remain /= 100;
-                    buf[offset + 0].write(DEC_DIGITS_LUT[pair * 2 + 0]);
-                    buf[offset + 1].write(DEC_DIGITS_LUT[pair * 2 + 1]);
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 0).write(DEC_DIGITS_LUT[pair * 2 + 0]); }
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset + 1).write(DEC_DIGITS_LUT[pair * 2 + 1]); }
                 }
 
                 // Format the last remaining digit, if any.
@@ -305,7 +317,8 @@ macro_rules! impl_Display {
                     // Either the compiler sees that remain < 10, or it prevents
                     // a boundary check up next.
                     let last = (remain & 15) as usize;
-                    buf[offset].write(DEC_DIGITS_LUT[last * 2 + 1]);
+                    // SAFETY: `offset` is always between 0 and `buf`'s length.
+                    unsafe { buf.get_unchecked_mut(offset).write(DEC_DIGITS_LUT[last * 2 + 1]); }
                     // not used: remain = 0;
                 }
 
@@ -639,10 +652,22 @@ impl u128 {
             remain /= 1_00_00;
             let pair1 = (quad / 100) as usize;
             let pair2 = (quad % 100) as usize;
-            buf[offset + 0].write(DEC_DIGITS_LUT[pair1 * 2 + 0]);
-            buf[offset + 1].write(DEC_DIGITS_LUT[pair1 * 2 + 1]);
-            buf[offset + 2].write(DEC_DIGITS_LUT[pair2 * 2 + 0]);
-            buf[offset + 3].write(DEC_DIGITS_LUT[pair2 * 2 + 1]);
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 0).write(DEC_DIGITS_LUT[pair1 * 2 + 0]);
+            }
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 1).write(DEC_DIGITS_LUT[pair1 * 2 + 1]);
+            }
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 2).write(DEC_DIGITS_LUT[pair2 * 2 + 0]);
+            }
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 3).write(DEC_DIGITS_LUT[pair2 * 2 + 1]);
+            }
         }
 
         // Format per two digits from the lookup table.
@@ -657,8 +682,14 @@ impl u128 {
 
             let pair = (remain % 100) as usize;
             remain /= 100;
-            buf[offset + 0].write(DEC_DIGITS_LUT[pair * 2 + 0]);
-            buf[offset + 1].write(DEC_DIGITS_LUT[pair * 2 + 1]);
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 0).write(DEC_DIGITS_LUT[pair * 2 + 0]);
+            }
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset + 1).write(DEC_DIGITS_LUT[pair * 2 + 1]);
+            }
         }
 
         // Format the last remaining digit, if any.
@@ -674,7 +705,10 @@ impl u128 {
             // Either the compiler sees that remain < 10, or it prevents
             // a boundary check up next.
             let last = (remain & 15) as usize;
-            buf[offset].write(DEC_DIGITS_LUT[last * 2 + 1]);
+            // SAFETY: `offset` is always between 0 and `buf`'s length.
+            unsafe {
+                buf.get_unchecked_mut(offset).write(DEC_DIGITS_LUT[last * 2 + 1]);
+            }
             // not used: remain = 0;
         }
 
@@ -703,10 +737,22 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
         remain /= 1_00_00;
         let pair1 = (quad / 100) as usize;
         let pair2 = (quad % 100) as usize;
-        buf[quad_index * 4 + OFFSET + 0].write(DEC_DIGITS_LUT[pair1 * 2 + 0]);
-        buf[quad_index * 4 + OFFSET + 1].write(DEC_DIGITS_LUT[pair1 * 2 + 1]);
-        buf[quad_index * 4 + OFFSET + 2].write(DEC_DIGITS_LUT[pair2 * 2 + 0]);
-        buf[quad_index * 4 + OFFSET + 3].write(DEC_DIGITS_LUT[pair2 * 2 + 1]);
+        // SAFETY: `quad_index * 4 + OFFSET` is always between 0 and `buf`'s length.
+        unsafe {
+            buf.get_unchecked_mut(quad_index * 4 + OFFSET + 0).write(DEC_DIGITS_LUT[pair1 * 2 + 0]);
+        }
+        // SAFETY: `quad_index * 4 + OFFSET` is always between 0 and `buf`'s length.
+        unsafe {
+            buf.get_unchecked_mut(quad_index * 4 + OFFSET + 1).write(DEC_DIGITS_LUT[pair1 * 2 + 1]);
+        }
+        // SAFETY: `quad_index * 4 + OFFSET` is always between 0 and `buf`'s length.
+        unsafe {
+            buf.get_unchecked_mut(quad_index * 4 + OFFSET + 2).write(DEC_DIGITS_LUT[pair2 * 2 + 0]);
+        }
+        // SAFETY: `quad_index * 4 + OFFSET` is always between 0 and `buf`'s length.
+        unsafe {
+            buf.get_unchecked_mut(quad_index * 4 + OFFSET + 3).write(DEC_DIGITS_LUT[pair2 * 2 + 1]);
+        }
     }
 }
 


### PR DESCRIPTION
Results are not very impressive though:

| bench name | current | new | diff |
|-|-|-|-|
| bench_i128 | 17.74 ns/iter (+/- 0.02) | 17.5 ns/iter (+/- 0.24) | -1.4% |
| bench_i128_max | 38.81 ns/iter (+/- 0.05) | 37.65 ns/iter (+/- 0.51) | -3.0% |
| bench_i128_min | 38.85 ns/iter (+/- 0.06) | 37.47 ns/iter (+/- 0.75) | -3.6% |
| bench_i16 | 17.61 ns/iter (+/- 0.02) | 17.55 ns/iter (+/- 0.64) | -0.3% |
| bench_i16_max | 18.1 ns/iter (+/- 0.03) | 18.07 ns/iter (+/- 0.46) | -0.2% |
| bench_i16_min | 18.47 ns/iter (+/- 0.15) | 18.34 ns/iter (+/- 0.47) | -0.7% |
| bench_i32 | 17.56 ns/iter (+/- 0.48) | 17.64 ns/iter (+/- 0.06) | 0.5% |
| bench_i32_max | 21.04 ns/iter (+/- 0.12) | 21.04 ns/iter (+/- 0.14) | 0.0% |
| bench_i32_min | 21.3 ns/iter (+/- 0.7) | 21.12 ns/iter (+/- 0.06) | -0.8% |
| bench_i64 | 17.61 ns/iter (+/- 0.07) | 17.54 ns/iter (+/- 0.06) | -0.4% |
| bench_i64_max | 24.7 ns/iter (+/- 0.04) | 24.72 ns/iter (+/- 0.29) | 0.1% |
| bench_i64_min | 25.28 ns/iter (+/- 0.04) | 25.28 ns/iter (+/- 0.03) | 0.0% |
| bench_i8 | 17.67 ns/iter (+/- 0.05) | 17.62 ns/iter (+/- 0.02) | -0.3% |
| bench_i8_max | 17.63 ns/iter (+/- 0.09) | 17.52 ns/iter (+/- 0.3) | -0.6% |
| bench_i8_min | 17.91 ns/iter (+/- 0.03) | 17.79 ns/iter (+/- 0.06) | -0.7% |
| bench_isize | 17.62 ns/iter (+/- 0.07) | 17.58 ns/iter (+/- 0.05) | -0.2% |
| bench_isize_max | 24.71 ns/iter (+/- 0.03) | 24.72 ns/iter (+/- 0.03) | 0.0% |
| bench_isize_min | 25.28 ns/iter (+/- 0.04) | 25.29 ns/iter (+/- 0.05) | 0.0% |
| bench_u128 | 16.36 ns/iter (+/- 0.02) | 16.05 ns/iter (+/- 0.03) | -1.9% |
| bench_u128_max | 38.97 ns/iter (+/- 0.25) | 37.08 ns/iter (+/- 0.06) | -4.8% |
| bench_u128_min | 14.51 ns/iter (+/- 0.18) | 13.8 ns/iter (+/- 0.27) | -4.9% |
| bench_u16 | 14.73 ns/iter (+/- 0.27) | 15.18 ns/iter (+/- 0.03) | 3.1% |
| bench_u16_max | 14.96 ns/iter (+/- 0.02) | 14.97 ns/iter (+/- 0.05) | 0.1% |
| bench_u16_min | 14.78 ns/iter (+/- 0.24) | 15.02 ns/iter (+/- 0.13) | 1.6% |
| bench_u32 | 14.64 ns/iter (+/- 0.27) | 14.66 ns/iter (+/- 0.11) | 0.1% |
| bench_u32_max | 17.5 ns/iter (+/- 0.69) | 17.81 ns/iter (+/- 0.31) | 1.8% |
| bench_u32_min | 14.67 ns/iter (+/- 0.11) | 15.01 ns/iter (+/- 0.11) | 2.3% |
| bench_u64 | 15.01 ns/iter (+/- 0.03) | 14.96 ns/iter (+/- 0.16) | -0.3% |
| bench_u64_max | 21.83 ns/iter (+/- 0.03) | 21.84 ns/iter (+/- 0.17) | 0.0% |
| bench_u64_min | 14.63 ns/iter (+/- 0.04) | 14.62 ns/iter (+/- 0.01) | -0.1% |
| bench_u8 | 14.41 ns/iter (+/- 0.04) | 14.53 ns/iter (+/- 0.34) | 0.8% |
| bench_u8_max | 14.7 ns/iter (+/- 0.07) | 14.58 ns/iter (+/- 0.12) | -0.8% |
| bench_u8_min | 13.8 ns/iter (+/- 0.25) | 14.43 ns/iter (+/- 0.31) | 4.6% |
| bench_usize | 14.8 ns/iter (+/- 0.04) | 14.81 ns/iter (+/- 0.1) | 0.1% |
| bench_usize_max | 21.86 ns/iter (+/- 0.02) | 21.83 ns/iter (+/- 0.02) | -0.1% |
| bench_usize_min | 14.62 ns/iter (+/- 0.19) | 15.52 ns/iter (+/- 0.23) | 6.2% |

<details><summary>Benchmark code</summary>

```rust
#![feature(test)]

extern crate test;

use test::{Bencher, black_box};

#[inline(always)]
fn convert_to_string<T: ToString>(n: T) -> String {
    n.to_string()
}

macro_rules! decl_benches {
    ($($name:ident $name_min:ident $name_max:ident: $ty:ident,)+) => {
        $(
            #[bench]
            fn $name(c: &mut Bencher) {
                c.iter(|| convert_to_string(black_box({ let nb: $ty = 20; nb })));
            }
            #[bench]
            fn $name_min(c: &mut Bencher) {
                c.iter(|| convert_to_string(black_box({ let nb: $ty = $ty::MIN; nb })));
            }
            #[bench]
            fn $name_max(c: &mut Bencher) {
                c.iter(|| convert_to_string(black_box({ let nb: $ty = $ty::MAX; nb })));
            }
        )+
    }
}

decl_benches! {
    bench_u8 bench_u8_min bench_u8_max: u8,
    bench_i8 bench_i8_min bench_i8_max: i8,
    bench_u16 bench_u16_min bench_u16_max: u16,
    bench_i16 bench_i16_min bench_i16_max: i16,
    bench_u32 bench_u32_min bench_u32_max: u32,
    bench_i32 bench_i32_min bench_i32_max: i32,
    bench_u64 bench_u64_min bench_u64_max: u64,
    bench_i64 bench_i64_min bench_i64_max: i64,
    bench_u128 bench_u128_min bench_u128_max: u128,
    bench_i128 bench_i128_min bench_i128_max: i128,
    bench_usize bench_usize_min bench_usize_max: usize,
    bench_isize bench_isize_min bench_isize_max: isize,
}
```

</details>

And there is no difference in the generated asm, so opening it and closing it right away to be able to link to it.

r? ghost