### PR TITLE
Add `stdarch` bootstrap smoke test

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1077,6 +1077,7 @@ impl<'a> Builder<'a> {
                 test::RustdocJson,
                 test::HtmlCheck,
                 test::RustInstaller,
+                test::Stdarch,
                 test::TestFloatParse,
                 test::CollectLicenseMetadata,
                 // Run bootstrap close to the end as it's unlikely to fail


### PR DESCRIPTION
I spent like two hours trying to reproduce the [previous distcheck failure](https://github.com/rust-lang/rust/pull/141899#issuecomment-3000987499) using the actual CI Docker image, but without luck. I wonder if it was a fluke..

try-job: x86_64-gnu-distcheck