### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1957,9 +1957,11 @@ fn add_linked_symbol_object(
     cmd: &mut dyn Linker,
     sess: &Session,
     tmpdir: &Path,
-    symbols: &[(String, SymbolExportKind)],
+    crate_type: CrateType,
+    linked_symbols: &[(String, SymbolExportKind)],
+    exported_symbols: &[(String, SymbolExportKind)],
 ) {
-    if symbols.is_empty() {
+    if linked_symbols.is_empty() && exported_symbols.is_empty() {
         return;
     }
 
@@ -1996,7 +1998,7 @@ fn add_linked_symbol_object(
         None
     };
 
-    for (sym, kind) in symbols.iter() {
+    for (sym, kind) in linked_symbols.iter() {
         let symbol = file.add_symbol(object::write::Symbol {
             name: sym.clone().into(),
             value: 0,
@@ -2051,6 +2053,41 @@ fn add_linked_symbol_object(
         if let Some(section) = ld64_section_helper {
             apple::add_data_and_relocation(&mut file, section, symbol, &sess.target, *kind)
                 .expect("failed adding relocation");
+        }
+    }
+
+    if sess.target.is_like_msvc {
+        // Symbol visibility takes care of this for executables typically
+        let should_filter_symbols = if crate_type == CrateType::Executable {
+            sess.opts.unstable_opts.export_executable_symbols
+        } else {
+            true
+        };
+        if should_filter_symbols {
+            // Currently the compiler doesn't use `dllexport` (an LLVM attribute) to
+            // export symbols from a dynamic library. When building a dynamic library,
+            // however, we're going to want some symbols exported, so this adds a
+            // `.drectve` section which lists all the symbols using /EXPORT arguments.
+            //
+            // The linker will read these arguments from the `.drectve` section and
+            // export all the symbols from the dynamic library. Note that this is not
+            // as simple as just exporting all the symbols in the current crate (as
+            // specified by `codegen.reachable`) but rather we also need to possibly
+            // export the symbols of upstream crates. Upstream rlibs may be linked
+            // statically to this dynamic library, in which case they may continue to
+            // transitively be used and hence need their symbols exported.
+            let drectve = exported_symbols
+                .into_iter()
+                .map(|(sym, kind)| match kind {
+                    SymbolExportKind::Text | SymbolExportKind::Tls => format!(" /EXPORT:\"{sym}\""),
+                    SymbolExportKind::Data => format!(" /EXPORT:\"{sym}\",DATA"),
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            let section =
+                file.add_section(vec![], b".drectve".to_vec(), object::SectionKind::Linker);
+            file.append_section_data(section, drectve.as_bytes(), 1);
         }
     }
 
@@ -2228,7 +2265,9 @@ fn linker_with_args(
         cmd,
         sess,
         tmpdir,
+        crate_type,
         &codegen_results.crate_info.linked_symbols[&crate_type],
+        &codegen_results.crate_info.exported_symbols[&crate_type],
     );
 
     // Sanitizer libraries.

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1097,53 +1097,13 @@ impl<'a> Linker for MsvcLinker<'a> {
         }
     }
 
-    // Currently the compiler doesn't use `dllexport` (an LLVM attribute) to
-    // export symbols from a dynamic library. When building a dynamic library,
-    // however, we're going to want some symbols exported, so this function
-    // generates a DEF file which lists all the symbols.
-    //
-    // The linker will read this `*.def` file and export all the symbols from
-    // the dynamic library. Note that this is not as simple as just exporting
-    // all the symbols in the current crate (as specified by `codegen.reachable`)
-    // but rather we also need to possibly export the symbols of upstream
-    // crates. Upstream rlibs may be linked statically to this dynamic library,
-    // in which case they may continue to transitively be used and hence need
-    // their symbols exported.
     fn export_symbols(
         &mut self,
-        tmpdir: &Path,
-        crate_type: CrateType,
-        symbols: &[(String, SymbolExportKind)],
+        _tmpdir: &Path,
+        _crate_type: CrateType,
+        _symbols: &[(String, SymbolExportKind)],
     ) {
-        // Symbol visibility takes care of this typically
-        if crate_type == CrateType::Executable {
-            let should_export_executable_symbols =
-                self.sess.opts.unstable_opts.export_executable_symbols;
-            if !should_export_executable_symbols {
-                return;
-            }
-        }
-
-        let path = tmpdir.join("lib.def");
-        let res: io::Result<()> = try {
-            let mut f = File::create_buffered(&path)?;
-
-            // Start off with the standard module name header and then go
-            // straight to exports.
-            writeln!(f, "LIBRARY")?;
-            writeln!(f, "EXPORTS")?;
-            for (symbol, kind) in symbols {
-                let kind_marker = if *kind == SymbolExportKind::Data { " DATA" } else { "" };
-                debug!("  _{symbol}");
-                writeln!(f, "  {symbol}{kind_marker}")?;
-            }
-        };
-        if let Err(error) = res {
-            self.sess.dcx().emit_fatal(errors::LibDefWriteFailure { error });
-        }
-        let mut arg = OsString::from("/DEF:");
-        arg.push(path);
-        self.link_arg(&arg);
+        // We already add /EXPORT arguments to the .drectve section of symbols.o.
     }
 
     fn subsystem(&mut self, subsystem: &str) {

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -219,13 +219,18 @@ fn exported_symbols_provider_local<'tcx>(
 
     // Mark allocator shim symbols as exported only if they were generated.
     if allocator_kind_for_codegen(tcx).is_some() {
-        for symbol_name in ALLOCATOR_METHODS
+        for (symbol_name, export_kind) in ALLOCATOR_METHODS
             .iter()
-            .map(|method| mangle_internal_symbol(tcx, global_fn_name(method.name).as_str()))
+            .map(|method| {
+                (
+                    mangle_internal_symbol(tcx, global_fn_name(method.name).as_str()),
+                    SymbolExportKind::Text,
+                )
+            })
             .chain([
-                mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
-                mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
-                mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
+                (mangle_internal_symbol(tcx, "__rust_alloc_error_handler"), SymbolExportKind::Text),
+                (mangle_internal_symbol(tcx, OomStrategy::SYMBOL), SymbolExportKind::Data),
+                (mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE), SymbolExportKind::Text),
             ])
         {
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(tcx, &symbol_name));
@@ -234,7 +239,7 @@ fn exported_symbols_provider_local<'tcx>(
                 exported_symbol,
                 SymbolExportInfo {
                     level: SymbolExportLevel::Rust,
-                    kind: SymbolExportKind::Text,
+                    kind: export_kind,
                     used: false,
                     rustc_std_internal_symbol: true,
                 },

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -4,7 +4,7 @@ use rustc_abi::{Align, ExternAbi};
 use rustc_ast::expand::autodiff_attrs::{AutoDiffAttrs, DiffActivity, DiffMode};
 use rustc_ast::{LitKind, MetaItem, MetaItemInner, attr};
 use rustc_attr_data_structures::{
-    AttributeKind, InlineAttr, InstructionSetAttr, OptimizeAttr, ReprAttr, UsedBy, find_attr,
+    AttributeKind, InlineAttr, InstructionSetAttr, OptimizeAttr, UsedBy, find_attr,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
@@ -109,14 +109,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
 
         if let hir::Attribute::Parsed(p) = attr {
             match p {
-                AttributeKind::Repr(reprs) => {
-                    codegen_fn_attrs.alignment = reprs
-                        .iter()
-                        .filter_map(
-                            |(r, _)| if let ReprAttr::ReprAlign(x) = r { Some(*x) } else { None },
-                        )
-                        .max();
-                }
                 AttributeKind::Cold(_) => codegen_fn_attrs.flags |= CodegenFnAttrFlags::COLD,
                 AttributeKind::ExportName { name, .. } => {
                     codegen_fn_attrs.export_name = Some(*name);

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -1123,7 +1123,7 @@ pub(super) fn transmute_immediate<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     // While optimizations will remove no-op transmutes, they might still be
     // there in debug or things that aren't no-op in MIR because they change
     // the Rust type but not the underlying layout/niche.
-    if from_scalar == to_scalar {
+    if from_scalar == to_scalar && from_backend_ty == to_backend_ty {
         return imm;
     }
 
@@ -1142,13 +1142,7 @@ pub(super) fn transmute_immediate<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     assume_scalar_range(bx, imm, from_scalar, from_backend_ty);
 
     imm = match (from_scalar.primitive(), to_scalar.primitive()) {
-        (Int(..) | Float(_), Int(..) | Float(_)) => {
-            if from_backend_ty == to_backend_ty {
-                imm
-            } else {
-                bx.bitcast(imm, to_backend_ty)
-            }
-        }
+        (Int(..) | Float(_), Int(..) | Float(_)) => bx.bitcast(imm, to_backend_ty),
         (Pointer(..), Pointer(..)) => bx.pointercast(imm, to_backend_ty),
         (Int(..), Pointer(..)) => bx.ptradd(bx.const_null(bx.type_ptr()), imm),
         (Pointer(..), Int(..)) => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1588,7 +1588,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             &infcx_
         };
 
-        tcx.all_traits()
+        tcx.all_traits_including_private()
             .filter(|trait_def_id| {
                 // Consider only traits with the associated type
                 tcx.associated_items(*trait_def_id)

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1725,7 +1725,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if unsatisfied_predicates.is_empty()
                 // ...or if we already suggested that name because of `rustc_confusable` annotation
                 && Some(similar_candidate.name()) != confusable_suggested
-                // and if the we aren't in an expansion.
+                // and if we aren't in an expansion.
                 && !span.from_expansion()
             {
                 self.find_likely_intended_associated_item(
@@ -3477,9 +3477,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         err: &mut Diag<'_>,
         item_name: Ident,
-        valid_out_of_scope_traits: Vec<DefId>,
+        mut valid_out_of_scope_traits: Vec<DefId>,
         explain: bool,
     ) -> bool {
+        valid_out_of_scope_traits.retain(|id| self.tcx.is_user_visible_dep(id.krate));
         if !valid_out_of_scope_traits.is_empty() {
             let mut candidates = valid_out_of_scope_traits;
             candidates.sort_by_key(|id| self.tcx.def_path_str(id));
@@ -4384,7 +4385,7 @@ pub(crate) struct TraitInfo {
 /// Retrieves all traits in this crate and any dependent crates,
 /// and wraps them into `TraitInfo` for custom sorting.
 pub(crate) fn all_traits(tcx: TyCtxt<'_>) -> Vec<TraitInfo> {
-    tcx.all_traits().map(|def_id| TraitInfo { def_id }).collect()
+    tcx.all_traits_including_private().map(|def_id| TraitInfo { def_id }).collect()
 }
 
 fn print_disambiguation_help<'tcx>(

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1092,13 +1092,6 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    /// Given an impl trait in trait `opaque_ty_def_id`, create and return the corresponding
-    /// associated item.
-    query associated_type_for_impl_trait_in_trait(opaque_ty_def_id: LocalDefId) -> LocalDefId {
-        desc { |tcx| "creating the associated item corresponding to the opaque type `{}`", tcx.def_path_str(opaque_ty_def_id.to_def_id()) }
-        cache_on_disk_if { true }
-    }
-
     /// Given an `impl_id`, return the trait it implements along with some header information.
     /// Return `None` if this is an inherent impl.
     query impl_trait_header(impl_id: DefId) -> Option<ty::ImplTraitHeader<'tcx>> {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2318,7 +2318,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// All traits in the crate graph, including those not visible to the user.
-    pub fn all_traits(self) -> impl Iterator<Item = DefId> {
+    pub fn all_traits_including_private(self) -> impl Iterator<Item = DefId> {
         iter::once(LOCAL_CRATE)
             .chain(self.crates(()).iter().copied())
             .flat_map(move |cnum| self.traits(cnum).iter().copied())

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -13,6 +13,10 @@ passes_abi_ne =
 passes_abi_of =
     fn_abi_of({$fn_name}) = {$fn_abi}
 
+passes_align_attr_application =
+    `#[align(...)]` should be applied to a function item
+    .label = not a function item
+
 passes_align_should_be_repr_align =
     `#[align(...)]` is not supported on {$item} items
     .suggestion = use `#[repr(align(...))]` instead

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1896,10 +1896,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 });
             }
             _ => {
-                self.dcx().emit_err(errors::AttrApplication::StructEnumUnion {
-                    hint_span: repr_span,
-                    span,
-                });
+                self.dcx().emit_err(errors::AlignAttrApplication { hint_span: repr_span, span });
             }
         }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1887,7 +1887,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// Checks if the `#[align]` attributes on `item` are valid.
     fn check_align(&self, span: Span, target: Target, align: Align, repr_span: Span) {
         match target {
-            Target::Fn | Target::Method(_) => {}
+            Target::Fn | Target::Method(_) | Target::ForeignFn => {}
             Target::Struct | Target::Union | Target::Enum => {
                 self.dcx().emit_err(errors::AlignShouldBeReprAlign {
                     span: repr_span,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1838,3 +1838,12 @@ pub(crate) struct AlignShouldBeReprAlign {
     pub item: &'static str,
     pub align_bytes: u64,
 }
+
+#[derive(Diagnostic)]
+#[diag(passes_align_attr_application)]
+pub(crate) struct AlignAttrApplication {
+    #[primary_span]
+    pub hint_span: Span,
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -130,7 +130,11 @@ impl<'tcx> SmirCtxt<'tcx> {
 
     pub fn all_trait_decls(&self) -> stable_mir::TraitDecls {
         let mut tables = self.0.borrow_mut();
-        tables.tcx.all_traits().map(|trait_def_id| tables.trait_def(trait_def_id)).collect()
+        tables
+            .tcx
+            .all_traits_including_private()
+            .map(|trait_def_id| tables.trait_def(trait_def_id))
+            .collect()
     }
 
     pub fn trait_decls(&self, crate_num: CrateNum) -> stable_mir::TraitDecls {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_freebsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnu.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv1".into();
     base.llvm_abiname = "elfv1".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_musl.rs
@@ -12,6 +12,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_openbsd.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_wrs_vxworks.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv1".into();
     base.llvm_abiname = "elfv1".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_freebsd.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_gnu.rs
@@ -8,6 +8,7 @@ pub(crate) fn target() -> Target {
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64le_unknown_linux_musl.rs
@@ -10,6 +10,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     // FIXME(compiler-team#422): musl targets should be dynamically linked by default.
     base.crt_static_default = true;
+    base.abi = "elfv2".into();
     base.llvm_abiname = "elfv2".into();
 
     Target {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1850,7 +1850,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let trait_def_id = trait_pred.def_id();
         let trait_name = self.tcx.item_name(trait_def_id);
         let crate_name = self.tcx.crate_name(trait_def_id.krate);
-        if let Some(other_trait_def_id) = self.tcx.all_traits().find(|def_id| {
+        if let Some(other_trait_def_id) = self.tcx.all_traits_including_private().find(|def_id| {
             trait_name == self.tcx.item_name(trait_def_id)
                 && trait_def_id.krate != def_id.krate
                 && crate_name == self.tcx.crate_name(def_id.krate)

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -1,9 +1,8 @@
-use rustc_data_structures::fx::FxIndexSet;
+use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, DefIdMap, LocalDefId};
 use rustc_hir::definitions::{DefPathData, DisambiguatorState};
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{self as hir, AmbigArg};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{self, ImplTraitInTraitData, TyCtxt};
 use rustc_middle::{bug, span_bug};
@@ -14,7 +13,6 @@ pub(crate) fn provide(providers: &mut Providers) {
         associated_item_def_ids,
         associated_items,
         associated_types_for_impl_traits_in_associated_fn,
-        associated_type_for_impl_trait_in_trait,
         impl_item_implementor_ids,
         ..*providers
     };
@@ -160,20 +158,22 @@ fn associated_item_from_impl_item_ref(impl_item_ref: &hir::ImplItemRef) -> ty::A
         container: ty::AssocItemContainer::Impl,
     }
 }
-struct RPITVisitor {
-    rpits: FxIndexSet<LocalDefId>,
+struct RPITVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    synthetics: Vec<LocalDefId>,
+    data: DefPathData,
+    disambiguator: DisambiguatorState,
 }
 
-impl<'tcx> Visitor<'tcx> for RPITVisitor {
-    fn visit_ty(&mut self, ty: &'tcx hir::Ty<'tcx, AmbigArg>) {
-        if let hir::TyKind::OpaqueDef(opaq) = ty.kind
-            && self.rpits.insert(opaq.def_id)
-        {
-            for bound in opaq.bounds {
-                intravisit::walk_param_bound(self, bound);
-            }
-        }
-        intravisit::walk_ty(self, ty)
+impl<'tcx> Visitor<'tcx> for RPITVisitor<'tcx> {
+    fn visit_opaque_ty(&mut self, opaque: &'tcx hir::OpaqueTy<'tcx>) -> Self::Result {
+        self.synthetics.push(associated_type_for_impl_trait_in_trait(
+            self.tcx,
+            opaque.def_id,
+            self.data,
+            &mut self.disambiguator,
+        ));
+        intravisit::walk_opaque_ty(self, opaque)
     }
 }
 
@@ -194,14 +194,18 @@ fn associated_types_for_impl_traits_in_associated_fn(
 
     match tcx.def_kind(parent_def_id) {
         DefKind::Trait => {
-            let mut visitor = RPITVisitor { rpits: FxIndexSet::default() };
-
             if let Some(output) = tcx.hir_get_fn_output(fn_def_id) {
+                let data = DefPathData::AnonAssocTy(tcx.item_name(fn_def_id.to_def_id()));
+                let mut visitor = RPITVisitor {
+                    tcx,
+                    synthetics: vec![],
+                    data,
+                    disambiguator: DisambiguatorState::with(parent_def_id, data, 0),
+                };
                 visitor.visit_fn_ret_ty(output);
-
-                tcx.arena.alloc_from_iter(visitor.rpits.iter().map(|opaque_ty_def_id| {
-                    tcx.associated_type_for_impl_trait_in_trait(opaque_ty_def_id).to_def_id()
-                }))
+                tcx.arena.alloc_from_iter(
+                    visitor.synthetics.into_iter().map(|def_id| def_id.to_def_id()),
+                )
             } else {
                 &[]
             }
@@ -211,7 +215,6 @@ fn associated_types_for_impl_traits_in_associated_fn(
             let Some(trait_fn_def_id) = tcx.associated_item(fn_def_id).trait_item_def_id else {
                 return &[];
             };
-
             tcx.arena.alloc_from_iter(
                 tcx.associated_types_for_impl_traits_in_associated_fn(trait_fn_def_id).iter().map(
                     move |&trait_assoc_def_id| {
@@ -236,6 +239,8 @@ fn associated_types_for_impl_traits_in_associated_fn(
 fn associated_type_for_impl_trait_in_trait(
     tcx: TyCtxt<'_>,
     opaque_ty_def_id: LocalDefId,
+    data: DefPathData,
+    disambiguator: &mut DisambiguatorState,
 ) -> LocalDefId {
     let (hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
     | hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. }) =
@@ -246,22 +251,15 @@ fn associated_type_for_impl_trait_in_trait(
     let trait_def_id = tcx.local_parent(fn_def_id);
     assert_eq!(tcx.def_kind(trait_def_id), DefKind::Trait);
 
-    // Collect all opaque types in return position for the method and use
-    // the index as the disambiguator to make an unique def path.
-    let mut visitor = RPITVisitor { rpits: FxIndexSet::default() };
-    visitor.visit_fn_ret_ty(tcx.hir_get_fn_output(fn_def_id).unwrap());
-    let disambiguator = visitor.rpits.get_index_of(&opaque_ty_def_id).unwrap().try_into().unwrap();
-
     let span = tcx.def_span(opaque_ty_def_id);
     // Also use the method name to create an unique def path.
-    let data = DefPathData::AnonAssocTy(tcx.item_name(fn_def_id.to_def_id()));
     let trait_assoc_ty = tcx.at(span).create_def(
         trait_def_id,
         // No name because this is an anonymous associated type.
         None,
         DefKind::AssocTy,
         Some(data),
-        &mut DisambiguatorState::with(trait_def_id, data, disambiguator),
+        disambiguator,
     );
 
     let local_def_id = trait_assoc_ty.def_id();

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3011,6 +3011,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(vec_into_chunks)]
+    ///
     /// let vec = vec![0, 1, 2, 3, 4, 5, 6, 7];
     /// assert_eq!(vec.into_chunks::<3>(), [[0, 1, 2], [3, 4, 5]]);
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3024,6 +3024,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let reshaped: Vec<[[[u8; 8]; 8]; 8]> = flat.into_chunks().into_chunks().into_chunks();
     /// assert_eq!(reshaped.len(), 1);
     /// ```
+    #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "vec_into_chunks", issue = "142137")]
     pub fn into_chunks<const N: usize>(mut self) -> Vec<[T; N], A> {
         const {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2999,6 +2999,58 @@ impl<T, A: Allocator> Vec<T, A> {
             (initialized, spare, &mut self.len)
         }
     }
+
+    /// Groups every `N` elements in the `Vec<T>` into chunks to produce a `Vec<[T; N]>`, dropping
+    /// elements in the remainder. `N` must be greater than zero.
+    ///
+    /// If the capacity is not a multiple of the chunk size, the buffer will shrink down to the
+    /// nearest multiple with a reallocation or deallocation.
+    ///
+    /// This function can be used to reverse [`Vec::into_flattened`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let vec = vec![0, 1, 2, 3, 4, 5, 6, 7];
+    /// assert_eq!(vec.into_chunks::<3>(), [[0, 1, 2], [3, 4, 5]]);
+    ///
+    /// let vec = vec![0, 1, 2, 3];
+    /// let chunks: Vec<[u8; 10]> = vec.into_chunks();
+    /// assert!(chunks.is_empty());
+    ///
+    /// let flat = vec![0; 8 * 8 * 8];
+    /// let reshaped: Vec<[[[u8; 8]; 8]; 8]> = flat.into_chunks().into_chunks().into_chunks();
+    /// assert_eq!(reshaped.len(), 1);
+    /// ```
+    #[unstable(feature = "vec_into_chunks", issue = "142137")]
+    pub fn into_chunks<const N: usize>(mut self) -> Vec<[T; N], A> {
+        const {
+            assert!(N != 0, "chunk size should be greater than zero");
+        }
+
+        let (len, cap) = (self.len(), self.capacity());
+
+        let len_remainder = len % N;
+        if len_remainder != 0 {
+            self.truncate(len - len_remainder);
+        }
+
+        let cap_remainder = cap % N;
+        if !T::IS_ZST && cap_remainder != 0 {
+            self.buf.shrink_to_fit(cap - cap_remainder);
+        }
+
+        let (ptr, _, _, alloc) = self.into_raw_parts_with_alloc();
+
+        // SAFETY:
+        // - `ptr` and `alloc` were just returned from `self.into_raw_parts_with_alloc()`
+        // - `[T; N]` has the same alignment as `T`
+        // - `size_of::<[T; N]>() * cap / N == size_of::<T>() * cap`
+        // - `len / N <= cap / N` because `len <= cap`
+        // - the allocated memory consists of `len / N` valid values of type `[T; N]`
+        // - `cap / N` fits the size of the allocated memory after shrinking
+        unsafe { Vec::from_raw_parts_in(ptr.cast(), len / N, cap / N, alloc) }
+    }
 }
 
 impl<T: Clone, A: Allocator> Vec<T, A> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3028,7 +3028,7 @@ impl<T, A: Allocator> Vec<T, A> {
     #[unstable(feature = "vec_into_chunks", issue = "142137")]
     pub fn into_chunks<const N: usize>(mut self) -> Vec<[T; N], A> {
         const {
-            assert!(N != 0, "chunk size should be greater than zero");
+            assert!(N != 0, "chunk size must be greater than zero");
         }
 
         let (len, cap) = (self.len(), self.capacity());

--- a/library/rustc-std-workspace-core/Cargo.toml
+++ b/library/rustc-std-workspace-core/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["public-dependency"]
+
 [package]
 name = "rustc-std-workspace-core"
 version = "1.99.0"
@@ -11,5 +13,7 @@ edition = "2024"
 path = "lib.rs"
 
 [dependencies]
-core = { path = "../core" }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins", features = ["compiler-builtins"] }
+core = { path = "../core", public = true }
+compiler_builtins = { path = "../compiler-builtins/compiler-builtins", features = [
+  "compiler-builtins",
+] }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -4,6 +4,27 @@
 //! filesystem. All methods in this module represent cross-platform filesystem
 //! operations. Extra platform-specific functionality can be found in the
 //! extension traits of `std::os::$platform`.
+//!
+//! # Time of Check to Time of Use (TOCTOU)
+//!
+//! Many filesystem operations are subject to a race condition known as "Time of Check to Time of Use"
+//! (TOCTOU). This occurs when a program checks a condition (like file existence or permissions)
+//! and then uses the result of that check to make a decision, but the condition may have changed
+//! between the check and the use.
+//!
+//! For example, checking if a file exists and then creating it if it doesn't is vulnerable to
+//! TOCTOU - another process could create the file between your check and creation attempt.
+//!
+//! Another example is with symbolic links: when removing a directory, if another process replaces
+//! the directory with a symbolic link between the check and the removal operation, the removal
+//! might affect the wrong location. This is why operations like [`remove_dir_all`] need to use
+//! atomic operations to prevent such race conditions.
+//!
+//! To avoid TOCTOU issues:
+//! - Be aware that metadata operations (like [`metadata`] or [`symlink_metadata`]) may be affected by
+//! changes made by other processes.
+//! - Use atomic operations when possible (like [`File::create_new`] instead of checking existence then creating).
+//! - Keep file open for the duration of operations.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![deny(unsafe_op_in_unsafe_fn)]
@@ -549,13 +570,14 @@ impl File {
     /// non-exhaustive list of likely errors.
     ///
     /// This option is useful because it is atomic. Otherwise between checking whether a file
-    /// exists and creating a new one, the file may have been created by another process (a TOCTOU
+    /// exists and creating a new one, the file may have been created by another process (a [TOCTOU]
     /// race condition / attack).
     ///
     /// This can also be written using
     /// `File::options().read(true).write(true).create_new(true).open(...)`.
     ///
     /// [`AlreadyExists`]: crate::io::ErrorKind::AlreadyExists
+    /// [TOCTOU]: self#time-of-check-to-time-of-use-toctou
     ///
     /// # Examples
     ///
@@ -1580,7 +1602,7 @@ impl OpenOptions {
     ///
     /// This option is useful because it is atomic. Otherwise between checking
     /// whether a file exists and creating a new one, the file may have been
-    /// created by another process (a TOCTOU race condition / attack).
+    /// created by another process (a [TOCTOU] race condition / attack).
     ///
     /// If `.create_new(true)` is set, [`.create()`] and [`.truncate()`] are
     /// ignored.
@@ -1591,6 +1613,7 @@ impl OpenOptions {
     /// [`.create()`]: OpenOptions::create
     /// [`.truncate()`]: OpenOptions::truncate
     /// [`AlreadyExists`]: io::ErrorKind::AlreadyExists
+    /// [TOCTOU]: self#time-of-check-to-time-of-use-toctou
     ///
     /// # Examples
     ///
@@ -2924,17 +2947,17 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// `GetFileInformationByHandleEx`, `SetFileInformationByHandle`, and `NtCreateFile`.
 ///
 /// ## Time-of-check to time-of-use (TOCTOU) race conditions
-/// On a few platforms there is no way to remove a directory's contents without following symlinks
-/// unless you perform a check and then operate on paths based on that directory.
-/// This allows concurrently-running code to replace the directory with a symlink after the check,
-/// causing a removal to instead operate on a path based on the symlink. This is a TOCTOU race.
-/// By default, `fs::remove_dir_all` protects against a symlink TOCTOU race on all platforms
-/// except the following. It should not be used in security-sensitive contexts on these platforms:
-/// - Miri: Even when emulating targets where the underlying implementation will protect against
-/// TOCTOU races, Miri will not do so.
-/// - Redox OS: This function does not protect against TOCTOU races, as Redox does not implement
-/// the required platform support to do so.
+/// See the [module-level TOCTOU explanation](self#time-of-check-to-time-of-use-toctou).
 ///
+/// On most platforms, `fs::remove_dir_all` protects against symlink TOCTOU races by default.
+/// However, on the following platforms, this protection is not provided and the function should
+/// not be used in security-sensitive contexts:
+/// - **Miri**: Even when emulating targets where the underlying implementation will protect against
+///   TOCTOU races, Miri will not do so.
+/// - **Redox OS**: This function does not protect against TOCTOU races, as Redox does not implement
+///   the required platform support to do so.
+///
+/// [TOCTOU]: self#time-of-check-to-time-of-use-toctou
 /// [changes]: io#platform-specific-behavior
 ///
 /// # Errors
@@ -3208,7 +3231,7 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 /// permission is denied on one of the parent directories.
 ///
 /// Note that while this avoids some pitfalls of the `exists()` method, it still can not
-/// prevent time-of-check to time-of-use (TOCTOU) bugs. You should only use it in scenarios
+/// prevent time-of-check to time-of-use ([TOCTOU]) bugs. You should only use it in scenarios
 /// where those bugs are not an issue.
 ///
 /// # Examples
@@ -3221,6 +3244,7 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 /// ```
 ///
 /// [`Path::exists`]: crate::path::Path::exists
+/// [TOCTOU]: self#time-of-check-to-time-of-use-toctou
 #[stable(feature = "fs_try_exists", since = "1.81.0")]
 #[inline]
 pub fn exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3090,7 +3090,7 @@ impl Path {
     /// Returns `true` if the path points at an existing entity.
     ///
     /// Warning: this method may be error-prone, consider using [`try_exists()`] instead!
-    /// It also has a risk of introducing time-of-check to time-of-use (TOCTOU) bugs.
+    /// It also has a risk of introducing time-of-check to time-of-use ([TOCTOU]) bugs.
     ///
     /// This function will traverse symbolic links to query information about the
     /// destination file.
@@ -3111,6 +3111,7 @@ impl Path {
     /// check errors, call [`Path::try_exists`].
     ///
     /// [`try_exists()`]: Self::try_exists
+    /// [TOCTOU]: fs#time-of-check-to-time-of-use-toctou
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[must_use]
     #[inline]
@@ -3130,7 +3131,7 @@ impl Path {
     /// permission is denied on one of the parent directories.
     ///
     /// Note that while this avoids some pitfalls of the `exists()` method, it still can not
-    /// prevent time-of-check to time-of-use (TOCTOU) bugs. You should only use it in scenarios
+    /// prevent time-of-check to time-of-use ([TOCTOU]) bugs. You should only use it in scenarios
     /// where those bugs are not an issue.
     ///
     /// This is an alias for [`std::fs::exists`](crate::fs::exists).
@@ -3143,6 +3144,7 @@ impl Path {
     /// assert!(Path::new("/root/secret_file.txt").try_exists().is_err());
     /// ```
     ///
+    /// [TOCTOU]: fs#time-of-check-to-time-of-use-toctou
     /// [`exists()`]: Self::exists
     #[stable(feature = "path_try_exists", since = "1.63.0")]
     #[inline]

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -4,7 +4,7 @@ use super::hermit_abi;
 use crate::ffi::CStr;
 use crate::mem::ManuallyDrop;
 use crate::num::NonZero;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, ptr};
 
 pub type Tid = hermit_abi::Tid;
@@ -83,6 +83,14 @@ impl Thread {
 
         unsafe {
             hermit_abi::usleep(micros);
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -10,7 +10,7 @@ use crate::mem::ManuallyDrop;
 use crate::num::NonZero;
 use crate::ptr::NonNull;
 use crate::sync::atomic::{Atomic, AtomicUsize, Ordering};
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{hint, io};
 
 pub struct Thread {
@@ -202,6 +202,14 @@ impl Thread {
     pub fn sleep(dur: Duration) {
         for timeout in dur2reltims(dur) {
             expect_success(unsafe { abi::dly_tsk(timeout) }, &"dly_tsk");
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/sgx/thread.rs
+++ b/library/std/src/sys/pal/sgx/thread.rs
@@ -5,7 +5,7 @@ use super::unsupported;
 use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
 pub struct Thread(task_queue::JoinHandle);
 
@@ -130,6 +130,14 @@ impl Thread {
 
     pub fn sleep(dur: Duration) {
         usercalls::wait_timeout(0, dur, || true);
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
+        }
     }
 
     pub fn join(self) {

--- a/library/std/src/sys/pal/teeos/thread.rs
+++ b/library/std/src/sys/pal/teeos/thread.rs
@@ -2,7 +2,7 @@ use crate::ffi::CStr;
 use crate::mem::{self, ManuallyDrop};
 use crate::num::NonZero;
 use crate::sys::os;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{cmp, io, ptr};
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 8 * 1024;
@@ -106,6 +106,14 @@ impl Thread {
             if sleep_millis >= u32::MAX as u128 { u32::MAX } else { sleep_millis as u32 };
         unsafe {
             let _ = TEE_Wait(final_sleep);
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/uefi/thread.rs
+++ b/library/std/src/sys/pal/uefi/thread.rs
@@ -3,7 +3,7 @@ use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::ptr::NonNull;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
 pub struct Thread(!);
 
@@ -36,6 +36,14 @@ impl Thread {
             let ms = crate::cmp::min(dur_ms, usize::MAX as u128);
             let _ = unsafe { ((*boot_services.as_ptr()).stall)(ms as usize) };
             dur_ms -= ms;
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -326,8 +326,12 @@ impl Thread {
         // If we're awoken with a signal and the return value is -1
         // clock_nanosleep needs to be called again.
         unsafe {
-            while libc::clock_nanosleep(libc::CLOCK_MONOTONIC, libc::TIMER_ABSTIME, ts_ptr, ts_ptr)
-                == -1
+            while libc::clock_nanosleep(
+                super::time::Instant::CLOCK_ID,
+                libc::TIMER_ABSTIME,
+                ts_ptr,
+                ts_ptr,
+            ) == -1
             {
                 assert_eq!(
                     os::errno(),

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -292,9 +292,7 @@ impl Instant {
         Some(Instant { t: self.t.checked_sub_duration(other)? })
     }
 
-    // reason for allow(unused): this is needed by the `sleep_until` implementation
-    // for some unix platforms not all.
-    #[allow(unused)]
+    #[allow(unused, reason = "needed by the `sleep_until` on some unix platforms")]
     pub(crate) fn into_timespec(self) -> Timespec {
         self.t
     }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -291,6 +291,13 @@ impl Instant {
     pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
         Some(Instant { t: self.t.checked_sub_duration(other)? })
     }
+
+    // reason for allow(unused): this is needed by the `sleep_until` implementation
+    // for some unix platforms not all.
+    #[allow(unused)]
+    pub(crate) fn into_timespec(self) -> Timespec {
+        self.t
+    }
 }
 
 impl fmt::Debug for Instant {

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -261,6 +261,10 @@ pub struct Instant {
 }
 
 impl Instant {
+    #[cfg(target_vendor = "apple")]
+    pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
+    #[cfg(not(target_vendor = "apple"))]
+    pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
     pub fn now() -> Instant {
         // https://www.manpagez.com/man/3/clock_gettime/
         //
@@ -273,11 +277,7 @@ impl Instant {
         //
         // Instant on macos was historically implemented using mach_absolute_time;
         // we preserve this value domain out of an abundance of caution.
-        #[cfg(target_vendor = "apple")]
-        const clock_id: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
-        #[cfg(not(target_vendor = "apple"))]
-        const clock_id: libc::clockid_t = libc::CLOCK_MONOTONIC;
-        Instant { t: Timespec::now(clock_id) }
+        Instant { t: Timespec::now(Self::CLOCK_ID) }
     }
 
     pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -292,7 +292,10 @@ impl Instant {
         Some(Instant { t: self.t.checked_sub_duration(other)? })
     }
 
-    #[allow(unused, reason = "needed by the `sleep_until` on some unix platforms")]
+    #[cfg_attr(
+        not(target_os = "linux"),
+        allow(unused, reason = "needed by the `sleep_until` on some unix platforms")
+    )]
     pub(crate) fn into_timespec(self) -> Timespec {
         self.t
     }

--- a/library/std/src/sys/pal/unsupported/thread.rs
+++ b/library/std/src/sys/pal/unsupported/thread.rs
@@ -26,6 +26,10 @@ impl Thread {
         panic!("can't sleep");
     }
 
+    pub fn sleep_until(_deadline: Instant) {
+        panic!("can't sleep");
+    }
+
     pub fn join(self) {
         self.0
     }

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -2,7 +2,7 @@
 
 use crate::ffi::CStr;
 use crate::num::NonZero;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, mem};
 
 cfg_if::cfg_if! {
@@ -168,6 +168,14 @@ impl Thread {
                     _ => panic!("thread::sleep(): unexpected result of poll_oneoff"),
                 }
             }
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/wasm/atomics/thread.rs
+++ b/library/std/src/sys/pal/wasm/atomics/thread.rs
@@ -2,7 +2,7 @@ use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
 use crate::sys::unsupported;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
 pub struct Thread(!);
 
@@ -38,6 +38,14 @@ impl Thread {
             let val = unsafe { wasm::memory_atomic_wait32(&mut x, 0, amt as i64) };
             debug_assert_eq!(val, 2);
             nanos -= amt;
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -8,7 +8,7 @@ use crate::os::windows::io::{AsRawHandle, HandleOrNull};
 use crate::sys::handle::Handle;
 use crate::sys::{c, stack_overflow};
 use crate::sys_common::FromInner;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, ptr};
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
@@ -103,6 +103,14 @@ impl Thread {
         // Also preserves the zero duration behavior of `Sleep`.
         if dur.is_zero() || high_precision_sleep(dur).is_err() {
             unsafe { c::Sleep(super::dur2timeout(dur)) }
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/xous/thread.rs
+++ b/library/std/src/sys/pal/xous/thread.rs
@@ -8,7 +8,7 @@ use crate::os::xous::ffi::{
     map_memory, update_memory_flags,
 };
 use crate::os::xous::services::{TicktimerScalar, ticktimer_server};
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 
 pub struct Thread {
     tid: ThreadId,
@@ -125,6 +125,14 @@ impl Thread {
             blocking_scalar(ticktimer_server(), TicktimerScalar::SleepMs(sleep_duration).into())
                 .expect("failed to send message to ticktimer server");
             millis -= sleep_duration as u128;
+        }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -920,8 +920,6 @@ pub fn sleep(dur: Duration) {
 ///
 /// [currently]: crate::io#platform-specific-behavior
 /// [clock_nanosleep]: https://linux.die.net/man/3/clock_nanosleep
-/// [subscription_clock]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-subscription_clock-record
-/// [mach_wait_until]: https://developer.apple.com/library/archive/technotes/tn2169/_index.html
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -897,8 +897,33 @@ pub fn sleep(dur: Duration) {
 ///
 /// # Platform-specific behavior
 ///
-/// This function uses [`sleep`] internally, see its platform-specific behavior.
+/// In most cases this function will call an OS specific function. Where that
+/// is not supported [`sleep`] is used. Those platforms are referred to as other
+/// in the table below.
 ///
+/// # Underlying System calls
+///
+/// The following system calls are [currently] being used:
+///
+/// |  Platform |               System call                                            |
+/// |-----------|----------------------------------------------------------------------|
+/// | Linux     | [clock_nanosleep] (Monotonic clock)                                  |
+/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)]                        |
+/// | Android   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Solaris   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Hurd      | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Fuchsia   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
+///
+/// [currently]: crate::io#platform-specific-behavior
+/// [clock_nanosleep]: https://linux.die.net/man/3/clock_nanosleep
+/// [subscription_clock]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-subscription_clock-record
+/// [mach_wait_until]: https://developer.apple.com/library/archive/technotes/tn2169/_index.html
+///
+/// **Disclaimer:** These system calls might change over time.
 ///
 /// # Examples
 ///
@@ -923,9 +948,9 @@ pub fn sleep(dur: Duration) {
 /// }
 /// ```
 ///
-/// A slow api we must not call too fast and which takes a few
+/// A slow API we must not call too fast and which takes a few
 /// tries before succeeding. By using `sleep_until` the time the
-/// api call takes does not influence when we retry or when we give up
+/// API call takes does not influence when we retry or when we give up
 ///
 /// ```no_run
 /// #![feature(thread_sleep_until)]
@@ -960,11 +985,7 @@ pub fn sleep(dur: Duration) {
 /// ```
 #[unstable(feature = "thread_sleep_until", issue = "113752")]
 pub fn sleep_until(deadline: Instant) {
-    let now = Instant::now();
-
-    if let Some(delay) = deadline.checked_duration_since(now) {
-        sleep(delay);
-    }
+    imp::Thread::sleep_until(deadline)
 }
 
 /// Used to ensure that `park` and `park_timeout` do not unwind, as that can

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -407,6 +407,13 @@ impl Instant {
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
         self.0.checked_sub_duration(&duration).map(Instant)
     }
+
+    // used by platform specific `sleep_until` implementations.
+    // reason for #[allow(unused)]: not every platform has a specific `sleep_until`.
+    #[allow(unused)]
+    pub(crate) fn into_inner(self) -> time::Instant {
+        self.0
+    }
 }
 
 #[stable(feature = "time2", since = "1.8.0")]

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -408,8 +408,11 @@ impl Instant {
         self.0.checked_sub_duration(&duration).map(Instant)
     }
 
-    // used by platform specific `sleep_until` implementations.
-    #[allow(unused, reason = "not every platform has a specific `sleep_until`")]
+    // Used by platform specific `sleep_until` implementations such as the one used on Linux.
+    #[cfg_attr(
+        not(target_os = "linux"),
+        allow(unused, reason = "not every platform has a specific `sleep_until`")
+    )]
     pub(crate) fn into_inner(self) -> time::Instant {
         self.0
     }

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -409,8 +409,7 @@ impl Instant {
     }
 
     // used by platform specific `sleep_until` implementations.
-    // reason for #[allow(unused)]: not every platform has a specific `sleep_until`.
-    #[allow(unused)]
+    #[allow(unused, reason = "not every platform has a specific `sleep_until`")]
     pub(crate) fn into_inner(self) -> time::Instant {
         self.0
     }

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -1,7 +1,8 @@
+#![feature(thread_sleep_until)]
 use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads
@@ -15,6 +16,17 @@ fn sleep_very_long() {
     });
     thread::sleep(Duration::from_millis(100));
     assert_eq!(*finished.lock().unwrap(), false);
+}
+
+#[test]
+fn sleep_until() {
+    let now = Instant::now();
+    let period = Duration::from_millis(100);
+    let deadline = now + period;
+    thread::sleep_until(deadline);
+
+    let elapsed = now.elapsed();
+    assert!(elapsed >= period);
 }
 
 #[test]

--- a/src/ci/citool/src/jobs.rs
+++ b/src/ci/citool/src/jobs.rs
@@ -66,6 +66,8 @@ pub struct JobDatabase {
     pub try_jobs: Vec<Job>,
     #[serde(rename = "auto")]
     pub auto_jobs: Vec<Job>,
+    #[serde(rename = "optional")]
+    pub optional_jobs: Vec<Job>,
 
     /// Shared environments for the individual run types.
     envs: JobEnvironments,
@@ -75,9 +77,10 @@ impl JobDatabase {
     /// Find `auto` jobs that correspond to the passed `pattern`.
     /// Patterns are matched using the glob syntax.
     /// For example `dist-*` matches all jobs starting with `dist-`.
-    fn find_auto_jobs_by_pattern(&self, pattern: &str) -> Vec<Job> {
+    fn find_auto_or_optional_jobs_by_pattern(&self, pattern: &str) -> Vec<Job> {
         self.auto_jobs
             .iter()
+            .chain(self.optional_jobs.iter())
             .filter(|j| glob_match::glob_match(pattern, &j.name))
             .cloned()
             .collect()
@@ -181,7 +184,7 @@ fn calculate_jobs(
                 let mut jobs: Vec<Job> = vec![];
                 let mut unknown_patterns = vec![];
                 for pattern in patterns {
-                    let matched_jobs = db.find_auto_jobs_by_pattern(pattern);
+                    let matched_jobs = db.find_auto_or_optional_jobs_by_pattern(pattern);
                     if matched_jobs.is_empty() {
                         unknown_patterns.push(pattern.clone());
                     } else {

--- a/src/ci/citool/tests/test-jobs.yml
+++ b/src/ci/citool/tests/test-jobs.yml
@@ -139,3 +139,8 @@ auto:
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-windows
+
+# Jobs that only run when explicitly invoked via `@bors try`.
+optional:
+  - name: test-optional-job
+    <<: *job-linux-4c

--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -26,6 +26,5 @@ ENV RUST_CONFIGURE_ARGS \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs
-# FIXME: Skipping cargo panic_abort_doc_tests due to https://github.com/rust-lang/rust/issues/123733
 ENV SCRIPT python3 ../x.py --stage 2 test && \
-  python3 ../x.py --stage 2 test src/tools/cargo --test-args \"--skip panic_abort_doc_tests\"
+  python3 ../x.py --stage 2 test src/tools/cargo

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -160,6 +160,17 @@ pr:
 try:
   - <<: *job-dist-x86_64-linux
 
+# Jobs that only run when explicitly invoked in one of the following ways:
+# - comment `@bors2 try jobs=<job-name>`
+# - `try-job: <job-name>` in the PR description and comment `@bors try` or `@bors2 try`.
+optional:
+  # This job is used just to test optional jobs.
+  # It will be replaced by tier 2 and tier 3 jobs in the future.
+  - name: optional-mingw-check-1
+    env:
+      IMAGE: mingw-check-1
+    <<: *job-linux-4c
+
 # Main CI jobs that have to be green to merge a commit into master
 # These jobs automatically inherit envs.auto, to avoid repeating
 # it in each job definition.

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -23,7 +23,7 @@ pub(crate) fn synthesize_blanket_impls(
     let ty = tcx.type_of(item_def_id);
 
     let mut blanket_impls = Vec::new();
-    for trait_def_id in tcx.all_traits() {
+    for trait_def_id in tcx.visible_traits() {
         if !cx.cache.effective_visibilities.is_reachable(tcx, trait_def_id)
             || cx.generated_synthetics.contains(&(ty.skip_binder(), trait_def_id))
         {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -353,7 +353,7 @@ pub(crate) fn run_global_ctxt(
     rustc_passes::stability::check_unused_or_stable_features(tcx);
 
     let auto_traits =
-        tcx.all_traits().filter(|&trait_def_id| tcx.trait_is_auto(trait_def_id)).collect();
+        tcx.visible_traits().filter(|&trait_def_id| tcx.trait_is_auto(trait_def_id)).collect();
 
     let mut ctxt = DocContext {
         tcx,

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -116,3 +116,17 @@ pub fn align_specified_twice_2() {}
 #[align(32)]
 #[align(256)]
 pub fn align_specified_twice_3() {}
+
+const _: () = {
+    // CHECK-LABEL: align_unmangled
+    // CHECK-SAME: align 256
+    #[unsafe(no_mangle)]
+    #[align(32)]
+    #[align(256)]
+    extern "C" fn align_unmangled() {}
+};
+
+unsafe extern "C" {
+    #[align(256)]
+    fn align_unmangled();
+}

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0 -Clink-dead-code
+//@ edition: 2024
 
 #![crate_type = "lib"]
 #![feature(fn_align)]
@@ -130,3 +131,9 @@ unsafe extern "C" {
     #[align(256)]
     fn align_unmangled();
 }
+
+// CHECK-LABEL: async_align
+// CHECK-SAME: align 64
+#[unsafe(no_mangle)]
+#[align(64)]
+pub async fn async_align() {}

--- a/tests/codegen/align-fn.rs
+++ b/tests/codegen/align-fn.rs
@@ -132,6 +132,7 @@ unsafe extern "C" {
     fn align_unmangled();
 }
 
+// FIXME also check `gen` et al
 // CHECK-LABEL: async_align
 // CHECK-SAME: align 64
 #[unsafe(no_mangle)]

--- a/tests/ui/attributes/fn-align-dyn.rs
+++ b/tests/ui/attributes/fn-align-dyn.rs
@@ -1,0 +1,15 @@
+//@ run-pass
+#![feature(fn_align)]
+
+trait Test {
+    #[align(4096)]
+    fn foo(&self);
+
+    #[align(4096)]
+    fn foo1(&self);
+}
+
+fn main() {
+    assert_eq!((<dyn Test>::foo as fn(_) as usize & !1) % 4096, 0);
+    assert_eq!((<dyn Test>::foo1 as fn(_) as usize & !1) % 4096, 0);
+}

--- a/tests/ui/attributes/malformed-fn-align.rs
+++ b/tests/ui/attributes/malformed-fn-align.rs
@@ -21,6 +21,21 @@ fn f3() {}
 #[repr(align(16))] //~ ERROR `#[repr(align(...))]` is not supported on function items
 fn f4() {}
 
+#[align(-1)] //~ ERROR expected unsuffixed literal, found `-`
+fn f5() {}
+
+#[align(3)] //~ ERROR invalid alignment value: not a power of two
+fn f6() {}
+
+#[align(4usize)] //~ ERROR invalid alignment value: not an unsuffixed integer [E0589]
+//~^ ERROR suffixed literals are not allowed in attributes
+fn f7() {}
+
+#[align(16)]
+#[align(3)] //~ ERROR invalid alignment value: not a power of two
+#[align(16)]
+fn f8() {}
+
 #[align(16)] //~ ERROR `#[align(...)]` is not supported on struct items
 struct S1;
 

--- a/tests/ui/attributes/malformed-fn-align.rs
+++ b/tests/ui/attributes/malformed-fn-align.rs
@@ -23,3 +23,12 @@ fn f4() {}
 
 #[align(16)] //~ ERROR `#[align(...)]` is not supported on struct items
 struct S1;
+
+#[align(32)] //~ ERROR `#[align(...)]` should be applied to a function item
+const FOO: i32 = 42;
+
+#[align(32)] //~ ERROR `#[align(...)]` should be applied to a function item
+mod test {}
+
+#[align(32)] //~ ERROR `#[align(...)]` should be applied to a function item
+use ::std::iter;

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -1,3 +1,17 @@
+error: expected unsuffixed literal, found `-`
+  --> $DIR/malformed-fn-align.rs:24:9
+   |
+LL | #[align(-1)]
+   |         ^
+
+error: suffixed literals are not allowed in attributes
+  --> $DIR/malformed-fn-align.rs:30:9
+   |
+LL | #[align(4usize)]
+   |         ^^^^^^
+   |
+   = help: instead of using a suffixed literal (`1u8`, `1.0f32`, etc.), use an unsuffixed version (`1`, `1.0`, etc.)
+
 error[E0539]: malformed `align` attribute input
   --> $DIR/malformed-fn-align.rs:5:5
    |
@@ -37,6 +51,24 @@ error[E0589]: invalid alignment value: not a power of two
 LL | #[align(0)]
    |         ^
 
+error[E0589]: invalid alignment value: not a power of two
+  --> $DIR/malformed-fn-align.rs:27:9
+   |
+LL | #[align(3)]
+   |         ^
+
+error[E0589]: invalid alignment value: not an unsuffixed integer
+  --> $DIR/malformed-fn-align.rs:30:9
+   |
+LL | #[align(4usize)]
+   |         ^^^^^^
+
+error[E0589]: invalid alignment value: not a power of two
+  --> $DIR/malformed-fn-align.rs:35:9
+   |
+LL | #[align(3)]
+   |         ^
+
 error: `#[repr(align(...))]` is not supported on function items
   --> $DIR/malformed-fn-align.rs:21:8
    |
@@ -50,7 +82,7 @@ LL | #[repr(align(16))]
    |        ^^^^^^^^^
 
 error: `#[align(...)]` is not supported on struct items
-  --> $DIR/malformed-fn-align.rs:24:1
+  --> $DIR/malformed-fn-align.rs:39:1
    |
 LL | #[align(16)]
    | ^^^^^^^^^^^^
@@ -62,7 +94,7 @@ LL + #[repr(align(16))]
    |
 
 error: `#[align(...)]` should be applied to a function item
-  --> $DIR/malformed-fn-align.rs:27:1
+  --> $DIR/malformed-fn-align.rs:42:1
    |
 LL | #[align(32)]
    | ^^^^^^^^^^^^
@@ -70,7 +102,7 @@ LL | const FOO: i32 = 42;
    | -------------------- not a function item
 
 error: `#[align(...)]` should be applied to a function item
-  --> $DIR/malformed-fn-align.rs:30:1
+  --> $DIR/malformed-fn-align.rs:45:1
    |
 LL | #[align(32)]
    | ^^^^^^^^^^^^
@@ -78,14 +110,14 @@ LL | mod test {}
    | ----------- not a function item
 
 error: `#[align(...)]` should be applied to a function item
-  --> $DIR/malformed-fn-align.rs:33:1
+  --> $DIR/malformed-fn-align.rs:48:1
    |
 LL | #[align(32)]
    | ^^^^^^^^^^^^
 LL | use ::std::iter;
    | ---------------- not a function item
 
-error: aborting due to 10 previous errors
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0539, E0589, E0805.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/malformed-fn-align.stderr
+++ b/tests/ui/attributes/malformed-fn-align.stderr
@@ -61,7 +61,31 @@ LL - #[align(16)]
 LL + #[repr(align(16))]
    |
 
-error: aborting due to 7 previous errors
+error: `#[align(...)]` should be applied to a function item
+  --> $DIR/malformed-fn-align.rs:27:1
+   |
+LL | #[align(32)]
+   | ^^^^^^^^^^^^
+LL | const FOO: i32 = 42;
+   | -------------------- not a function item
+
+error: `#[align(...)]` should be applied to a function item
+  --> $DIR/malformed-fn-align.rs:30:1
+   |
+LL | #[align(32)]
+   | ^^^^^^^^^^^^
+LL | mod test {}
+   | ----------- not a function item
+
+error: `#[align(...)]` should be applied to a function item
+  --> $DIR/malformed-fn-align.rs:33:1
+   |
+LL | #[align(32)]
+   | ^^^^^^^^^^^^
+LL | use ::std::iter;
+   | ---------------- not a function item
+
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0539, E0589, E0805.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -129,7 +129,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_abi = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/linking/dll-weak-definition.rs
+++ b/tests/ui/linking/dll-weak-definition.rs
@@ -1,0 +1,20 @@
+// Regression test for MSVC link.exe failing to export weak definitions from dlls.
+// See https://github.com/rust-lang/rust/pull/142568
+
+//@ build-pass
+//@ only-msvc
+//@ revisions: link_exe lld
+//@[lld] needs-rust-lld
+//@[link_exe] compile-flags: -Zunstable-options -Clink-self-contained=-linker -Zlinker-features=-lld
+//@[lld] compile-flags: -Zunstable-options -Clink-self-contained=+linker -Zlinker-features=+lld
+
+#![feature(linkage)]
+#![crate_type = "cdylib"]
+
+#[linkage = "weak"]
+#[no_mangle]
+pub fn weak_function() {}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub static WEAK_STATIC: u8 = 42;

--- a/tests/ui/typeck/auxiliary/private-dep.rs
+++ b/tests/ui/typeck/auxiliary/private-dep.rs
@@ -1,0 +1,3 @@
+pub trait A {
+    fn foo() {}
+}

--- a/tests/ui/typeck/auxiliary/public-dep.rs
+++ b/tests/ui/typeck/auxiliary/public-dep.rs
@@ -1,0 +1,11 @@
+//@ aux-crate:priv:private_dep=private-dep.rs
+//@ compile-flags: -Zunstable-options
+
+extern crate private_dep;
+use private_dep::A;
+
+pub struct B;
+
+impl A for B {
+    fn foo() {}
+}

--- a/tests/ui/typeck/dont-suggest-private-dependencies.rs
+++ b/tests/ui/typeck/dont-suggest-private-dependencies.rs
@@ -1,0 +1,30 @@
+// Don't suggest importing a function from a private dependency.
+// Issues: #138191, #142676
+
+// Avoid suggesting traits from std-private deps
+//@ forbid-output: compiler_builtins
+//@ forbid-output: object
+
+// Check a custom trait to withstand changes in above crates
+//@ aux-crate:public_dep=public-dep.rs
+//@ compile-flags: -Zunstable-options
+//@ forbid-output: private_dep
+
+struct VecReader(Vec<u8>);
+
+impl std::io::Read for VecReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+        //~^ ERROR no method named `read` found for struct `Vec<u8>`
+    }
+}
+
+extern crate public_dep;
+use public_dep::B;
+
+fn main() {
+    let _ = u8::cast_from_lossy(9);
+    //~^ ERROR no function or associated item named `cast_from_lossy` found for type `u8`
+    let _ = B::foo();
+    //~^ ERROR no function or associated item named `foo` found for struct `B`
+}

--- a/tests/ui/typeck/dont-suggest-private-dependencies.stderr
+++ b/tests/ui/typeck/dont-suggest-private-dependencies.stderr
@@ -4,11 +4,6 @@ error[E0599]: no method named `read` found for struct `Vec<u8>` in the current s
 LL |         self.0.read(buf)
    |                ^^^^
    |
-   = help: items from traits can only be used if the trait is in scope
-help: trait `ReadRef` which provides `read` is implemented but not in scope; perhaps you want to import it
-   |
-LL + use object::read::read_ref::ReadRef;
-   |
 help: there is a method `read_at` with a similar name
    |
 LL |         self.0.read_at(buf)
@@ -19,24 +14,12 @@ error[E0599]: no function or associated item named `cast_from_lossy` found for t
    |
 LL |     let _ = u8::cast_from_lossy(9);
    |                 ^^^^^^^^^^^^^^^ function or associated item not found in `u8`
-   |
-   = help: items from traits can only be used if the trait is in scope
-help: trait `CastFrom` which provides `cast_from_lossy` is implemented but not in scope; perhaps you want to import it
-   |
-LL + use compiler_builtins::math::libm_math::support::int_traits::CastFrom;
-   |
 
 error[E0599]: no function or associated item named `foo` found for struct `B` in the current scope
   --> $DIR/dont-suggest-private-dependencies.rs:28:16
    |
 LL |     let _ = B::foo();
    |                ^^^ function or associated item not found in `B`
-   |
-   = help: items from traits can only be used if the trait is in scope
-help: trait `A` which provides `foo` is implemented but not in scope; perhaps you want to import it
-   |
-LL + use private_dep::A;
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/dont-suggest-private-dependencies.stderr
+++ b/tests/ui/typeck/dont-suggest-private-dependencies.stderr
@@ -1,0 +1,43 @@
+error[E0599]: no method named `read` found for struct `Vec<u8>` in the current scope
+  --> $DIR/dont-suggest-private-dependencies.rs:17:16
+   |
+LL |         self.0.read(buf)
+   |                ^^^^
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `ReadRef` which provides `read` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use object::read::read_ref::ReadRef;
+   |
+help: there is a method `read_at` with a similar name
+   |
+LL |         self.0.read_at(buf)
+   |                    +++
+
+error[E0599]: no function or associated item named `cast_from_lossy` found for type `u8` in the current scope
+  --> $DIR/dont-suggest-private-dependencies.rs:26:17
+   |
+LL |     let _ = u8::cast_from_lossy(9);
+   |                 ^^^^^^^^^^^^^^^ function or associated item not found in `u8`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `CastFrom` which provides `cast_from_lossy` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use compiler_builtins::math::libm_math::support::int_traits::CastFrom;
+   |
+
+error[E0599]: no function or associated item named `foo` found for struct `B` in the current scope
+  --> $DIR/dont-suggest-private-dependencies.rs:28:16
+   |
+LL |     let _ = B::foo();
+   |                ^^^ function or associated item not found in `B`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `A` which provides `foo` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use private_dep::A;
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#141829 (Specialize sleep_until implementation for unix (except mac))
 - rust-lang/rust#141847 (Explain `TOCTOU` on the top of `std::fs`, and reference it in functions)
 - rust-lang/rust#142138 (Add `Vec::into_chunks`)
 - rust-lang/rust#142321 (Expose elf abi on ppc64 targets)
 - rust-lang/rust#142568 (Use the .drectve section for exporting symbols from dlls on Windows)
 - rust-lang/rust#142886 (ci: aarch64-gnu: Stop skipping `panic_abort_doc_tests`)
 - rust-lang/rust#143038 (avoid suggesting traits from private dependencies)
 - rust-lang/rust#143194 (fix bitcast of single-element SIMD vectors)
 - rust-lang/rust#143206 (Align attr fixes)
 - rust-lang/rust#143258 (Don't recompute `DisambiguatorState` for every RPITIT in trait definition)
 - rust-lang/rust#143260 (Use the correct export kind for __rust_alloc_error_handler_should_panic)
 - rust-lang/rust#143274 (ci: support optional jobs)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=141829,141847,142138,142321,142568,142886,143038,143194,143206,143258,143260,143274)
<!-- homu-ignore:end -->