### PR TITLE
Consider param-env for sizedness fast path

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -363,7 +363,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
 
         let infcx = self.selcx.infcx;
 
-        if sizedness_fast_path(infcx.tcx, obligation.predicate) {
+        if sizedness_fast_path(infcx.tcx, obligation.predicate, obligation.param_env) {
             return ProcessResult::Changed(thin_vec![]);
         }
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
@@ -15,7 +15,7 @@ impl<'tcx> super::QueryTypeOp<'tcx> for ProvePredicate<'tcx> {
         tcx: TyCtxt<'tcx>,
         key: &ParamEnvAnd<'tcx, Self>,
     ) -> Option<Self::QueryResponse> {
-        if sizedness_fast_path(tcx, key.value.predicate) {
+        if sizedness_fast_path(tcx, key.value.predicate, key.param_env) {
             return Some(());
         }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -597,7 +597,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             None => self.check_recursion_limit(&obligation, &obligation)?,
         }
 
-        if sizedness_fast_path(self.tcx(), obligation.predicate) {
+        if sizedness_fast_path(self.tcx(), obligation.predicate, obligation.param_env) {
             return Ok(EvaluatedToOk);
         }
 

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -365,7 +365,11 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for PlaceholderReplacer<'_, 'tcx> {
     }
 }
 
-pub fn sizedness_fast_path<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tcx>) -> bool {
+pub fn sizedness_fast_path<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    predicate: ty::Predicate<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+) -> bool {
     // Proving `Sized`/`MetaSized`, very often on "obviously sized" types like
     // `&T`, accounts for about 60% percentage of the predicates we have to prove. No need to
     // canonicalize and all that for such cases.
@@ -389,6 +393,20 @@ pub fn sizedness_fast_path<'tcx>(tcx: TyCtxt<'tcx>, predicate: ty::Predicate<'tc
         if trait_pred.self_ty().has_trivial_sizedness(tcx, sizedness) {
             debug!("fast path -- trivial sizedness");
             return true;
+        }
+
+        if matches!(trait_pred.self_ty().kind(), ty::Param(_) | ty::Placeholder(_)) {
+            for clause in param_env.caller_bounds() {
+                if let ty::ClauseKind::Trait(clause_pred) = clause.kind().skip_binder()
+                    && clause_pred.polarity == ty::PredicatePolarity::Positive
+                    && clause_pred.self_ty() == trait_pred.self_ty()
+                    && (clause_pred.def_id() == trait_pred.def_id()
+                        || (sizedness == SizedTraitKind::MetaSized
+                            && tcx.is_lang_item(clause_pred.def_id(), LangItem::Sized)))
+                {
+                    return true;
+                }
+            }
         }
     }
 

--- a/compiler/rustc_traits/src/evaluate_obligation.rs
+++ b/compiler/rustc_traits/src/evaluate_obligation.rs
@@ -24,7 +24,7 @@ fn evaluate_obligation<'tcx>(
     debug!("evaluate_obligation: goal={:#?}", goal);
     let ParamEnvAnd { param_env, value: predicate } = goal;
 
-    if sizedness_fast_path(tcx, predicate) {
+    if sizedness_fast_path(tcx, predicate, param_env) {
         return Ok(EvaluationResult::EvaluatedToOk);
     }
 

--- a/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.current_sized_hierarchy.stderr
+++ b/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.current_sized_hierarchy.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/incomplete-inference-issue-143992.rs:27:28
+  --> $DIR/incomplete-inference-issue-143992.rs:30:28
    |
 LL |     let _x = T::Assoc::new(());
    |              ------------- ^^ expected `[u32; 1]`, found `()`
@@ -7,7 +7,7 @@ LL |     let _x = T::Assoc::new(());
    |              arguments to this function are incorrect
    |
 note: associated function defined here
-  --> $DIR/incomplete-inference-issue-143992.rs:18:8
+  --> $DIR/incomplete-inference-issue-143992.rs:21:8
    |
 LL |     fn new(r: R) -> R {
    |        ^^^ ----

--- a/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.next_sized_hierarchy.stderr
+++ b/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.next_sized_hierarchy.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/incomplete-inference-issue-143992.rs:30:28
+   |
+LL |     let _x = T::Assoc::new(());
+   |              ------------- ^^ expected `[u32; 1]`, found `()`
+   |              |
+   |              arguments to this function are incorrect
+   |
+note: associated function defined here
+  --> $DIR/incomplete-inference-issue-143992.rs:21:8
+   |
+LL |     fn new(r: R) -> R {
+   |        ^^^ ----
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.rs
+++ b/tests/ui/sized-hierarchy/incomplete-inference-issue-143992.rs
@@ -1,9 +1,12 @@
 //@ compile-flags: --crate-type=lib
-//@ revisions: current next
+//@ revisions: current next current_sized_hierarchy next_sized_hierarchy
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[current] check-pass
+//@[next] check-pass
 //@[next] compile-flags: -Znext-solver
-//@[next] check-fail
+//@[next_sized_hierarchy] compile-flags: -Znext-solver
+
+#![cfg_attr(any(current_sized_hierarchy, next_sized_hierarchy), feature(sized_hierarchy))]
 
 // Test that we avoid incomplete inference when normalizing. Without this,
 // `Trait`'s implicit `MetaSized` supertrait requires proving `T::Assoc<_>: MetaSized`
@@ -25,5 +28,6 @@ where
     T::Assoc<[u32; 1]>: Clone,
 {
     let _x = T::Assoc::new(());
-//[next]~^ ERROR mismatched types
+    //[next_sized_hierarchy]~^ ERROR mismatched types
+    //[current_sized_hierarchy]~^^ ERROR mismatched types
 }

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -12,13 +12,6 @@ LL | impl<T: Bound, U> Trait<U> for T {
    |         -----     ^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-note: required by a bound in `Bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:8:1
-   |
-LL | / trait Bound {
-LL | |     fn method();
-LL | | }
-   | |_^ required by this bound in `Bound`
 
 error[E0277]: the trait bound `Foo: Bound` is not satisfied
   --> $DIR/normalizes-to-is-not-productive.rs:47:19

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-2.stderr
@@ -19,23 +19,6 @@ error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: A<T>`
 LL |         Self::Assoc: A<T>,
    |                      ^^^^
 
-error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: MetaSized`
-  --> $DIR/normalize-param-env-2.rs:24:22
-   |
-LL |         Self::Assoc: A<T>,
-   |                      ^^^^
-   |
-note: required by a bound in `A`
-  --> $DIR/normalize-param-env-2.rs:9:1
-   |
-LL | / trait A<T> {
-LL | |     type Assoc;
-LL | |
-LL | |     fn f()
-...  |
-LL | | }
-   | |_^ required by this bound in `A`
-
 error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc well-formed`
   --> $DIR/normalize-param-env-2.rs:24:22
    |
@@ -63,6 +46,6 @@ LL |     where
 LL |         Self::Assoc: A<T>,
    |                      ^^^^ required by this bound in `A::f`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
+++ b/tests/ui/traits/next-solver/normalize/normalize-param-env-4.next.stderr
@@ -4,20 +4,6 @@ error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc: Trait`
 LL |     <T as Trait>::Assoc: Trait,
    |                          ^^^^^
 
-error[E0275]: overflow evaluating the requirement `<T as Trait>::Assoc: MetaSized`
-  --> $DIR/normalize-param-env-4.rs:19:26
-   |
-LL |     <T as Trait>::Assoc: Trait,
-   |                          ^^^^^
-   |
-note: required by a bound in `Trait`
-  --> $DIR/normalize-param-env-4.rs:7:1
-   |
-LL | / trait Trait {
-LL | |     type Assoc;
-LL | | }
-   | |_^ required by this bound in `Trait`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/where-clauses/ignore-err-clauses.rs
+++ b/tests/ui/where-clauses/ignore-err-clauses.rs
@@ -1,13 +1,13 @@
 use std::ops::Add;
 
 fn dbl<T>(x: T) -> <T as Add>::Output
-//~^ ERROR type annotations needed
 where
     T: Copy + Add,
     UUU: Copy,
     //~^ ERROR cannot find type `UUU` in this scope
 {
     x + x
+    //~^ ERROR use of moved value: `x`
 }
 
 fn main() {

--- a/tests/ui/where-clauses/ignore-err-clauses.stderr
+++ b/tests/ui/where-clauses/ignore-err-clauses.stderr
@@ -1,16 +1,33 @@
 error[E0412]: cannot find type `UUU` in this scope
-  --> $DIR/ignore-err-clauses.rs:7:5
+  --> $DIR/ignore-err-clauses.rs:6:5
    |
 LL |     UUU: Copy,
    |     ^^^ not found in this scope
 
-error[E0282]: type annotations needed
-  --> $DIR/ignore-err-clauses.rs:3:14
+error[E0382]: use of moved value: `x`
+  --> $DIR/ignore-err-clauses.rs:9:9
    |
 LL | fn dbl<T>(x: T) -> <T as Add>::Output
-   |              ^ cannot infer type for type parameter `T`
+   |           - move occurs because `x` has type `T`, which does not implement the `Copy` trait
+...
+LL |     x + x
+   |     ----^
+   |     |   |
+   |     |   value used here after move
+   |     `x` moved due to usage in operator
+   |
+help: if `T` implemented `Clone`, you could clone the value
+  --> $DIR/ignore-err-clauses.rs:3:8
+   |
+LL | fn dbl<T>(x: T) -> <T as Add>::Output
+   |        ^ consider constraining this type parameter with `Clone`
+...
+LL |     x + x
+   |     - you could clone this value
+note: calling this operator moves the left-hand side
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0282, E0412.
-For more information about an error, try `rustc --explain E0282`.
+Some errors have detailed explanations: E0382, E0412.
+For more information about an error, try `rustc --explain E0382`.


### PR DESCRIPTION
Look up `T: Sized` in param-env if `T` is a param or placeholder (the latter is for use in the new solver).