### PR TITLE
add reference id to test, and fix filename

### DIFF
--- a/tests/ui/const-generics/generic_arg_infer/paren_infer.rs
+++ b/tests/ui/const-generics/generic_arg_infer/paren_infer.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@ reference: items.generics.const.inferred
 
 struct Foo<const N: usize>;
 


### PR DESCRIPTION
Noticed the filename is wrong, then took advantage of being there by adding Reference id