### PR TITLE
make `-Zmin-function-alignment` a target modifier

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2340,7 +2340,7 @@ options! {
         "gather metadata statistics (default: no)"),
     metrics_dir: Option<PathBuf> = (None, parse_opt_pathbuf, [UNTRACKED],
         "the directory metrics emitted by rustc are dumped into (implicitly enables default set of metrics)"),
-    min_function_alignment: Option<Align> = (None, parse_align, [TRACKED],
+    min_function_alignment: Option<Align> = (None, parse_align, [TRACKED TARGET_MODIFIER],
         "align all functions to at least this many bytes. Must be a power of 2"),
     mir_emit_retag: bool = (false, parse_bool, [TRACKED],
         "emit Retagging MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 \

--- a/src/tools/miri/tests/pass/fn_align.rs
+++ b/src/tools/miri/tests/pass/fn_align.rs
@@ -1,4 +1,4 @@
-//@compile-flags: -Zmin-function-alignment=8
+//@compile-flags: -Zmin-function-alignment=8 -Cunsafe-allow-abi-mismatch=min-function-alignment
 #![feature(fn_align)]
 
 // When a function uses `align(N)`, the function address should be a multiple of `N`.

--- a/tests/codegen/min-function-alignment.rs
+++ b/tests/codegen/min-function-alignment.rs
@@ -1,10 +1,17 @@
+//@ add-core-stubs
 //@ revisions: align16 align1024
 //@ compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0 -Clink-dead-code
 //@ [align16] compile-flags: -Zmin-function-alignment=16
 //@ [align1024] compile-flags: -Zmin-function-alignment=1024
 
-#![crate_type = "lib"]
+#![feature(no_core)]
 #![feature(fn_align)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // Functions without explicit alignment use the global minimum.
 //

--- a/tests/codegen/naked-fn/min-function-alignment.rs
+++ b/tests/codegen/naked-fn/min-function-alignment.rs
@@ -1,9 +1,16 @@
+//@ add-core-stubs
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmin-function-alignment=16
 //@ needs-asm-support
 //@ ignore-arm no "ret" mnemonic
 
+#![feature(no_core)]
 #![feature(fn_align)]
 #![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // functions without explicit alignment use the global minimum
 //
@@ -11,7 +18,7 @@
 #[no_mangle]
 #[unsafe(naked)]
 pub extern "C" fn naked_no_explicit_align() {
-    core::arch::naked_asm!("ret")
+    naked_asm!("ret")
 }
 
 // CHECK: .balign 16
@@ -19,7 +26,7 @@ pub extern "C" fn naked_no_explicit_align() {
 #[align(8)]
 #[unsafe(naked)]
 pub extern "C" fn naked_lower_align() {
-    core::arch::naked_asm!("ret")
+    naked_asm!("ret")
 }
 
 // CHECK: .balign 32
@@ -27,7 +34,7 @@ pub extern "C" fn naked_lower_align() {
 #[align(32)]
 #[unsafe(naked)]
 pub extern "C" fn naked_higher_align() {
-    core::arch::naked_asm!("ret")
+    naked_asm!("ret")
 }
 
 // cold functions follow the same rules as other functions
@@ -40,5 +47,5 @@ pub extern "C" fn naked_higher_align() {
 #[cold]
 #[unsafe(naked)]
 pub extern "C" fn no_explicit_align_cold() {
-    core::arch::naked_asm!("ret")
+    naked_asm!("ret")
 }

--- a/tests/ui/target_modifiers/auxiliary/min_function_alignment.rs
+++ b/tests/ui/target_modifiers/auxiliary/min_function_alignment.rs
@@ -1,0 +1,7 @@
+//@ no-prefer-dynamic
+//@ compile-flags: --target aarch64-unknown-none -Zmin-function-alignment=32
+//@ needs-llvm-components: aarch64
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]

--- a/tests/ui/target_modifiers/incompatible_min_function_alignment.error_mismatch.stderr
+++ b/tests/ui/target_modifiers/incompatible_min_function_alignment.error_mismatch.stderr
@@ -1,0 +1,13 @@
+error: mixing `-Zmin-function-alignment` will cause an ABI mismatch in crate `incompatible_min_function_alignment`
+  --> $DIR/incompatible_min_function_alignment.rs:13:1
+   |
+LL | #![feature(no_core)]
+   | ^
+   |
+   = help: the `-Zmin-function-alignment` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zmin-function-alignment=4` in this crate is incompatible with `-Zmin-function-alignment=32` in dependency `min_function_alignment`
+   = help: set `-Zmin-function-alignment=32` in this crate or `-Zmin-function-alignment=4` in `min_function_alignment`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=min-function-alignment` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/incompatible_min_function_alignment.error_omitted.stderr
+++ b/tests/ui/target_modifiers/incompatible_min_function_alignment.error_omitted.stderr
@@ -1,0 +1,13 @@
+error: mixing `-Zmin-function-alignment` will cause an ABI mismatch in crate `incompatible_min_function_alignment`
+  --> $DIR/incompatible_min_function_alignment.rs:13:1
+   |
+LL | #![feature(no_core)]
+   | ^
+   |
+   = help: the `-Zmin-function-alignment` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: unset `-Zmin-function-alignment` in this crate is incompatible with `-Zmin-function-alignment=32` in dependency `min_function_alignment`
+   = help: set `-Zmin-function-alignment=32` in this crate or unset `-Zmin-function-alignment` in `min_function_alignment`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=min-function-alignment` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/incompatible_min_function_alignment.rs
+++ b/tests/ui/target_modifiers/incompatible_min_function_alignment.rs
@@ -1,0 +1,18 @@
+//@ aux-build:min_function_alignment.rs
+//@ compile-flags: --target aarch64-unknown-none
+//@ needs-llvm-components: aarch64
+
+//@ revisions:allow_match allow_mismatch error_mismatch error_omitted
+//@[allow_match] compile-flags: -Zmin-function-alignment=32
+//@[allow_mismatch] compile-flags: -Cunsafe-allow-abi-mismatch=min-function-alignment
+//@[error_mismatch] compile-flags: -Zmin-function-alignment=4
+//@[error_omitted] compile-flags:
+//@[allow_mismatch] check-pass
+//@[allow_match] check-pass
+
+#![feature(no_core)]
+//[error_mismatch,error_omitted]~^ ERROR mixing `-Zmin-function-alignment` will cause an ABI mismatch in crate `incompatible_min_function_alignment`
+#![crate_type = "rlib"]
+#![no_core]
+
+extern crate min_function_alignment;


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/82232
cc https://github.com/rust-lang/rust/issues/136966 https://github.com/rust-lang/rust/pull/142824

Make `-Zmin-function-alignment` a target modifier, as discussed in https://github.com/rust-lang/rust/issues/136966. This change effectively broadens the definition of what a target modifier can be: combining crates with different values of this flag has no risk of creating UB (so far), but it is logically inconsistent.

It is still up in the air whether the alignment provided by this flag will be a language guarantee.

r? @workingjubilee