### PR TITLE
minicore: use core's `diagnostic::on_unimplemented` messages

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -19,6 +19,9 @@ use crate::fmt::Debug;
 use crate::hash::{Hash, Hasher};
 use crate::pin::UnsafePinned;
 
+// NOTE: for consistent error messages between `core` and `minicore`, all `diagnostic` attributes
+// should be replicated exactly in `minicore` (if `minicore` defines the item).
+
 /// Implements a given marker trait for multiple types at the same time.
 ///
 /// The basic syntax looks like this:

--- a/src/doc/rustc-dev-guide/src/tests/minicore.md
+++ b/src/doc/rustc-dev-guide/src/tests/minicore.md
@@ -39,6 +39,12 @@ If you find a `core` item to be missing from the [`minicore`] stub, consider
 adding it to the test auxiliary if it's likely to be used or is already needed
 by more than one test.
 
+## Staying in sync with `core`
+
+The `minicore` items must be kept up to date with `core`. For consistent
+diagnostic output between using `core` and `minicore`, any `diagnostic`
+attributes (e.g. `on_unimplemented`) should be replicated exactly in `minicore`.
+
 ## Example codegen test that uses `minicore`
 
 ```rust,no_run

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -5,7 +5,8 @@
 //! # Important notes
 //!
 //! - `minicore` is **only** intended for `core` items, and the stubs should match the actual `core`
-//!   items.
+//!   items. For identical error output, any `diagnostic` attributes (e.g. `on_unimplemented`)
+//!   should also be replicated here.
 //! - Be careful of adding new features and things that are only available for a subset of targets.
 //!
 //! # References
@@ -41,12 +42,24 @@ macro_rules! impl_marker_trait {
 }
 
 #[lang = "pointee_sized"]
+#[diagnostic::on_unimplemented(
+    message = "values of type `{Self}` may or may not have a size",
+    label = "may or may not have a known size"
+)]
 pub trait PointeeSized {}
 
 #[lang = "meta_sized"]
+#[diagnostic::on_unimplemented(
+    message = "the size for values of type `{Self}` cannot be known",
+    label = "doesn't have a known size"
+)]
 pub trait MetaSized: PointeeSized {}
 
 #[lang = "sized"]
+#[diagnostic::on_unimplemented(
+    message = "the size for values of type `{Self}` cannot be known at compilation time",
+    label = "doesn't have a size known at compile-time"
+)]
 pub trait Sized: MetaSized {}
 
 #[lang = "legacy_receiver"]
@@ -64,6 +77,10 @@ pub trait BikeshedGuaranteedNoDrop {}
 pub unsafe auto trait Freeze {}
 
 #[lang = "unpin"]
+#[diagnostic::on_unimplemented(
+    note = "consider using the `pin!` macro\nconsider using `Box::pin` if you need to access the pinned value outside of the current scope",
+    message = "`{Self}` cannot be unpinned"
+)]
 pub auto trait Unpin {}
 
 impl_marker_trait!(
@@ -110,6 +127,7 @@ pub struct UnsafeCell<T: PointeeSized> {
 impl<T: PointeeSized> !Freeze for UnsafeCell<T> {}
 
 #[lang = "tuple_trait"]
+#[diagnostic::on_unimplemented(message = "`{Self}` is not a tuple")]
 pub trait Tuple {}
 
 #[rustc_builtin_macro]

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ normalize-stderr: "(abi|pref|unadjusted_abi_align): Align\([1-8] bytes\)" -> "$1: $$SOME_ALIGN"
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
 //@ normalize-stderr: "(size): Size\([48] bytes\)" -> "$1: $$SOME_SIZE"
@@ -9,17 +10,26 @@
 //@ compile-flags: -O
 #![feature(rustc_attrs)]
 #![crate_type = "lib"]
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 struct S(u16);
 
 #[rustc_abi(debug)]
-fn test(_x: u8) -> bool { true } //~ ERROR: fn_abi
+fn test(_x: u8) -> bool {
+    //~^ ERROR: fn_abi
+    true
+}
 
 #[rustc_abi(debug)]
 type TestFnPtr = fn(bool) -> u8; //~ ERROR: fn_abi
 
 #[rustc_abi(debug)]
-fn test_generic<T>(_x: *const T) { } //~ ERROR: fn_abi
+fn test_generic<T>(_x: *const T) {} //~ ERROR: fn_abi
 
 #[rustc_abi(debug)]
 const C: () = (); //~ ERROR: can only be applied to
@@ -31,7 +41,7 @@ impl S {
 
 impl S {
     #[rustc_abi(debug)]
-    fn assoc_test(&self) { } //~ ERROR: fn_abi
+    fn assoc_test(&self) {} //~ ERROR: fn_abi
 }
 
 #[rustc_abi(assert_eq)]

--- a/tests/ui/abi/debug.stderr
+++ b/tests/ui/abi/debug.stderr
@@ -89,9 +89,9 @@ error: fn_abi_of(test) = FnAbi {
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:16:1
+  --> $DIR/debug.rs:23:1
    |
-LL | fn test(_x: u8) -> bool { true }
+LL | fn test(_x: u8) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: fn_abi_of(TestFnPtr) = FnAbi {
@@ -185,7 +185,7 @@ error: fn_abi_of(TestFnPtr) = FnAbi {
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:19:1
+  --> $DIR/debug.rs:29:1
    |
 LL | type TestFnPtr = fn(bool) -> u8;
    | ^^^^^^^^^^^^^^
@@ -263,13 +263,13 @@ error: fn_abi_of(test_generic) = FnAbi {
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:22:1
+  --> $DIR/debug.rs:32:1
    |
-LL | fn test_generic<T>(_x: *const T) { }
+LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
-  --> $DIR/debug.rs:25:1
+  --> $DIR/debug.rs:35:1
    |
 LL | const C: () = ();
    | ^^^^^^^^^^^
@@ -419,7 +419,7 @@ error: ABIs are not compatible
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:41:1
+  --> $DIR/debug.rs:51:1
    |
 LL | type TestAbiNe = (fn(u8), fn(u32));
    | ^^^^^^^^^^^^^^
@@ -571,7 +571,7 @@ error: ABIs are not compatible
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:44:1
+  --> $DIR/debug.rs:54:1
    |
 LL | type TestAbiNeLarger = (fn([u8; 32]), fn([u32; 32]));
    | ^^^^^^^^^^^^^^^^^^^^
@@ -720,7 +720,7 @@ error: ABIs are not compatible
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:47:1
+  --> $DIR/debug.rs:57:1
    |
 LL | type TestAbiNeFloat = (fn(f32), fn(u32));
    | ^^^^^^^^^^^^^^^^^^^
@@ -870,13 +870,13 @@ error: ABIs are not compatible
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:51:1
+  --> $DIR/debug.rs:61:1
    |
 LL | type TestAbiNeSign = (fn(i32), fn(u32));
    | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/debug.rs:54:46
+  --> $DIR/debug.rs:64:46
    |
 LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    |                                              ^^^^^^^^^^ doesn't have a size known at compile-time
@@ -885,13 +885,13 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = note: only the last element of a tuple may have a dynamically sized type
 
 error: unrecognized argument
-  --> $DIR/debug.rs:56:13
+  --> $DIR/debug.rs:66:13
    |
 LL | #[rustc_abi("assert_eq")]
    |             ^^^^^^^^^^^
 
 error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
-  --> $DIR/debug.rs:29:5
+  --> $DIR/debug.rs:39:5
    |
 LL |     const C: () = ();
    |     ^^^^^^^^^^^
@@ -981,9 +981,9 @@ error: fn_abi_of(assoc_test) = FnAbi {
            conv: Rust,
            can_unwind: $SOME_BOOL,
        }
-  --> $DIR/debug.rs:34:5
+  --> $DIR/debug.rs:44:5
    |
-LL |     fn assoc_test(&self) { }
+LL |     fn assoc_test(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 12 previous errors

--- a/tests/ui/abi/rust-cold-works-with-rustic-args.rs
+++ b/tests/ui/abi/rust-cold-works-with-rustic-args.rs
@@ -1,6 +1,15 @@
-//@build-pass
-//@compile-flags: -Clink-dead-code=true --crate-type lib
+//@ add-core-stubs
+//@ build-pass
+//@ compile-flags: -Clink-dead-code=true
 // We used to not handle all "rustic" ABIs in a (relatively) uniform way,
 // so we failed to fix up arguments for actually passing through the ABI...
 #![feature(rust_cold_cc)]
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
 pub extern "rust-cold" fn foo(_: [usize; 3]) {}


### PR DESCRIPTION
Without these attributes, the error message is different. Keeping the diagnostics up-to-date seems related to https://github.com/rust-lang/rust/issues/137531.

The modified test files are reported in https://github.com/rust-lang/rust/issues/143319 as failing for `--target=riscv64gc-unknown-linux-gnu`. Using `minicore` for them makes it easier to troubleshoot this sort of issue.

r? @jieyouxu 
