### PR TITLE
Port streaming commands in bootstrap to `BootstrapCommand` and remove `as_command_mut`

### DIFF
--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -211,15 +211,6 @@ impl<'a> BootstrapCommand {
         exec_ctx.as_ref().start(self, OutputMode::Capture, OutputMode::Print)
     }
 
-    /// Spawn the command in background, while capturing and returns a handle to stream the output.
-    #[track_caller]
-    pub fn stream_capture(
-        &'a mut self,
-        exec_ctx: impl AsRef<ExecutionContext>,
-    ) -> Option<StreamingCommand> {
-        exec_ctx.as_ref().stream(self, OutputMode::Capture, OutputMode::Capture)
-    }
-
     /// Spawn the command in background, while capturing and returning stdout, and printing stderr.
     /// Returns None in dry-mode
     #[track_caller]
@@ -232,7 +223,7 @@ impl<'a> BootstrapCommand {
 
     /// Mark the command as being executed, disarming the drop bomb.
     /// If this method is not called before the command is dropped, its drop will panic.
-    pub fn mark_as_executed(&mut self) {
+    fn mark_as_executed(&mut self) {
         self.drop_bomb.defuse();
     }
 
@@ -664,7 +655,7 @@ impl ExecutionContext {
 
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
-        return Some(StreamingCommand { child, stdout, stderr });
+        Some(StreamingCommand { child, stdout, stderr })
     }
 }
 

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -223,7 +223,7 @@ impl<'a> BootstrapCommand {
 
     /// Mark the command as being executed, disarming the drop bomb.
     /// If this method is not called before the command is dropped, its drop will panic.
-    fn mark_as_executed(&mut self) {
+    pub fn mark_as_executed(&mut self) {
         self.drop_bomb.defuse();
     }
 
@@ -625,18 +625,12 @@ impl ExecutionContext {
         exit!(1);
     }
 
-<<<<<<< HEAD
-    pub fn stream<'a>(
-=======
     /// Spawns the command with configured stdout and stderr handling.
     ///
-    /// Returns `None` if in dry-run mode and the command is not allowed to run.
-    ///
-    /// Panics if the command fails to spawn.
+    /// Returns None if in dry-run mode or Panics if the command fails to spawn.
     pub fn stream(
->>>>>>> c2e83361cec (add comment to exec)
         &self,
-        command: &'a mut BootstrapCommand,
+        command: &mut BootstrapCommand,
         stdout: OutputMode,
         stderr: OutputMode,
     ) -> Option<StreamingCommand> {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -221,6 +221,7 @@ impl<'a> BootstrapCommand {
     }
 
     /// Spawn the command in background, while capturing and returning stdout, and printing stderr.
+    /// Returns None in dry-mode
     #[track_caller]
     pub fn stream_capture_stdout(
         &'a mut self,

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -13,7 +13,9 @@ use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::panic::Location;
 use std::path::Path;
-use std::process::{Child, Command, CommandArgs, CommandEnvs, ExitStatus, Output, Stdio};
+use std::process::{
+    Child, ChildStderr, ChildStdout, Command, CommandArgs, CommandEnvs, ExitStatus, Output, Stdio,
+};
 use std::sync::{Arc, Mutex};
 
 use build_helper::ci::CiEnv;
@@ -209,15 +211,22 @@ impl<'a> BootstrapCommand {
         exec_ctx.as_ref().start(self, OutputMode::Capture, OutputMode::Print)
     }
 
-    /// Provides access to the stdlib Command inside.
-    /// FIXME: This function should be eventually removed from bootstrap.
-    pub fn as_command_mut(&mut self) -> &mut Command {
-        // We proactively mark this command as executed since we can't be certain how the returned
-        // command will be handled. Caching must also be avoided here, as the inner command could be
-        // modified externally without us being aware.
-        self.mark_as_executed();
-        self.do_not_cache();
-        &mut self.command
+    /// Spawn the command in background, while capturing and returns a handle to stream the output.
+    #[track_caller]
+    pub fn stream_capture(
+        &'a mut self,
+        exec_ctx: impl AsRef<ExecutionContext>,
+    ) -> Option<StreamingCommand> {
+        exec_ctx.as_ref().stream(self, OutputMode::Capture, OutputMode::Capture)
+    }
+
+    /// Spawn the command in background, while capturing and returning stdout, and printing stderr.
+    #[track_caller]
+    pub fn stream_capture_stdout(
+        &'a mut self,
+        exec_ctx: impl AsRef<ExecutionContext>,
+    ) -> Option<StreamingCommand> {
+        exec_ctx.as_ref().stream(self, OutputMode::Capture, OutputMode::Print)
     }
 
     /// Mark the command as being executed, disarming the drop bomb.
@@ -449,6 +458,12 @@ enum CommandState<'a> {
     },
 }
 
+pub struct StreamingCommand {
+    child: Child,
+    pub stdout: Option<ChildStdout>,
+    pub stderr: Option<ChildStderr>,
+}
+
 #[must_use]
 pub struct DeferredCommand<'a> {
     state: CommandState<'a>,
@@ -617,11 +632,50 @@ impl ExecutionContext {
         }
         exit!(1);
     }
+
+<<<<<<< HEAD
+    pub fn stream<'a>(
+=======
+    /// Spawns the command with configured stdout and stderr handling.
+    ///
+    /// Returns `None` if in dry-run mode and the command is not allowed to run.
+    ///
+    /// Panics if the command fails to spawn.
+    pub fn stream(
+>>>>>>> c2e83361cec (add comment to exec)
+        &self,
+        command: &'a mut BootstrapCommand,
+        stdout: OutputMode,
+        stderr: OutputMode,
+    ) -> Option<StreamingCommand> {
+        command.mark_as_executed();
+        if !command.run_in_dry_run && self.dry_run() {
+            return None;
+        }
+        let cmd = &mut command.command;
+        cmd.stdout(stdout.stdio());
+        cmd.stderr(stderr.stdio());
+        let child = cmd.spawn();
+        let mut child = match child {
+            Ok(child) => child,
+            Err(e) => panic!("failed to execute command: {cmd:?}\nERROR: {e}"),
+        };
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        return Some(StreamingCommand { child, stdout, stderr });
+    }
 }
 
 impl AsRef<ExecutionContext> for ExecutionContext {
     fn as_ref(&self) -> &ExecutionContext {
         self
+    }
+}
+
+impl StreamingCommand {
+    pub fn wait(mut self) -> Result<ExitStatus, std::io::Error> {
+        self.child.wait()
     }
 }
 

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -34,11 +34,6 @@ pub(crate) fn try_run_tests(
     cmd: &mut BootstrapCommand,
     stream: bool,
 ) -> bool {
-    if builder.config.dry_run() {
-        cmd.mark_as_executed();
-        return true;
-    }
-
     if !run_tests(builder, cmd, stream) {
         if builder.fail_fast {
             crate::exit!(1);
@@ -54,7 +49,9 @@ pub(crate) fn try_run_tests(
 fn run_tests(builder: &Builder<'_>, cmd: &mut BootstrapCommand, stream: bool) -> bool {
     builder.verbose(|| println!("running: {cmd:?}"));
 
-    let mut streaming_command = cmd.stream_capture_stdout(&builder.config.exec_ctx).unwrap();
+    let Some(mut streaming_command) = cmd.stream_capture_stdout(&builder.config.exec_ctx) else {
+        return true;
+    };
 
     // This runs until the stdout of the child is closed, which means the child exited. We don't
     // run this on another thread since the builder is not Sync.

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -34,16 +34,17 @@ pub(crate) fn try_run_tests(
     cmd: &mut BootstrapCommand,
     stream: bool,
 ) -> bool {
-    if !run_tests(builder, cmd, stream) {
-        if builder.fail_fast {
-            crate::exit!(1);
-        } else {
-            builder.config.exec_ctx().add_to_delay_failure(format!("{cmd:?}"));
-            false
-        }
-    } else {
-        true
+    if run_tests(builder, cmd, stream) {
+        return true;
     }
+
+    if builder.fail_fast {
+        crate::exit!(1);
+    }
+
+    builder.config.exec_ctx().add_to_delay_failure(format!("{cmd:?}"));
+
+    false
 }
 
 fn run_tests(builder: &Builder<'_>, cmd: &mut BootstrapCommand, stream: bool) -> bool {

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -7,7 +7,7 @@
 //! to reimplement all the rendering logic in this module because of that.
 
 use std::io::{BufRead, BufReader, Read, Write};
-use std::process::{ChildStdout, Stdio};
+use std::process::ChildStdout;
 use std::time::Duration;
 
 use termcolor::{Color, ColorSpec, WriteColor};
@@ -52,32 +52,28 @@ pub(crate) fn try_run_tests(
 }
 
 fn run_tests(builder: &Builder<'_>, cmd: &mut BootstrapCommand, stream: bool) -> bool {
-    let cmd = cmd.as_command_mut();
-    cmd.stdout(Stdio::piped());
-
     builder.verbose(|| println!("running: {cmd:?}"));
 
-    let mut process = cmd.spawn().unwrap();
+    let mut streaming_command = cmd.stream_capture_stdout(&builder.config.exec_ctx).unwrap();
 
     // This runs until the stdout of the child is closed, which means the child exited. We don't
     // run this on another thread since the builder is not Sync.
-    let renderer = Renderer::new(process.stdout.take().unwrap(), builder);
+    let renderer = Renderer::new(streaming_command.stdout.take().unwrap(), builder);
     if stream {
         renderer.stream_all();
     } else {
         renderer.render_all();
     }
 
-    let result = process.wait_with_output().unwrap();
-    if !result.status.success() && builder.is_verbose() {
+    let status = streaming_command.wait().unwrap();
+    if !status.success() && builder.is_verbose() {
         println!(
             "\n\ncommand did not execute successfully: {cmd:?}\n\
-             expected success, got: {}",
-            result.status
+             expected success, got: {status}",
         );
     }
 
-    result.status.success()
+    status.success()
 }
 
 struct Renderer<'a> {


### PR DESCRIPTION
This PR adds streaming capabilities to BootstrapCommand and migrate existing command streaming scenario's used in bootstrap.

r? @Kobzol 
