### PR TITLE
use unsigned_abs instead of `abs` on signed int to silence clippy

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2572,7 +2572,7 @@ macro_rules! uint_impl {
             if size_of::<Self>() == 1 {
                 // Trick LLVM into generating the psadbw instruction when SSE2
                 // is available and this function is autovectorized for u8's.
-                (self as i32).wrapping_sub(other as i32).abs() as Self
+                (self as i32).wrapping_sub(other as i32).unsigned_abs() as Self
             } else {
                 if self < other {
                     other - self


### PR DESCRIPTION
Use `unsigned_abs` instead of `abs` on signed int to silence clippy. Alternatively we could allow the lint, but if codegen is not affected, then this seems preferable.