### PR TITLE
Retire hir::*ItemRef.

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -62,21 +62,6 @@ pub(crate) struct DelegationResults<'hir> {
 }
 
 impl<'hir> LoweringContext<'_, 'hir> {
-    /// Defines whether the delegatee is an associated function whose first parameter is `self`.
-    pub(crate) fn delegatee_is_method(
-        &self,
-        item_id: NodeId,
-        path_id: NodeId,
-        span: Span,
-        is_in_trait_impl: bool,
-    ) -> bool {
-        let sig_id = self.get_delegation_sig_id(item_id, path_id, span, is_in_trait_impl);
-        let Ok(sig_id) = sig_id else {
-            return false;
-        };
-        self.is_method(sig_id, span)
-    }
-
     fn is_method(&self, def_id: DefId, span: Span) -> bool {
         match self.tcx.def_kind(def_id) {
             DefKind::Fn => false,

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -381,20 +381,12 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         })
     }
 
-    fn visit_trait_item_ref(&mut self, ii: &'hir TraitItemRef) {
-        // Do not visit the duplicate information in TraitItemRef. We want to
-        // map the actual nodes, not the duplicate ones in the *Ref.
-        let TraitItemRef { id, ident: _, span: _ } = *ii;
-
-        self.visit_nested_trait_item(id);
+    fn visit_trait_item_ref(&mut self, id: &'hir TraitItemId) {
+        self.visit_nested_trait_item(*id);
     }
 
-    fn visit_impl_item_ref(&mut self, ii: &'hir ImplItemRef) {
-        // Do not visit the duplicate information in ImplItemRef. We want to
-        // map the actual nodes, not the duplicate ones in the *Ref.
-        let ImplItemRef { id, ident: _, span: _ } = *ii;
-
-        self.visit_nested_impl_item(id);
+    fn visit_impl_item_ref(&mut self, id: &'hir ImplItemId) {
+        self.visit_nested_impl_item(*id);
     }
 
     fn visit_foreign_item_ref(&mut self, id: &'hir ForeignItemId) {

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -392,7 +392,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_impl_item_ref(&mut self, ii: &'hir ImplItemRef) {
         // Do not visit the duplicate information in ImplItemRef. We want to
         // map the actual nodes, not the duplicate ones in the *Ref.
-        let ImplItemRef { id, ident: _, kind: _, span: _, trait_item_def_id: _ } = *ii;
+        let ImplItemRef { id, ident: _, kind: _, span: _ } = *ii;
 
         self.visit_nested_impl_item(id);
     }

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -384,7 +384,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_trait_item_ref(&mut self, ii: &'hir TraitItemRef) {
         // Do not visit the duplicate information in TraitItemRef. We want to
         // map the actual nodes, not the duplicate ones in the *Ref.
-        let TraitItemRef { id, ident: _, kind: _, span: _ } = *ii;
+        let TraitItemRef { id, ident: _, span: _ } = *ii;
 
         self.visit_nested_trait_item(id);
     }
@@ -392,7 +392,7 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_impl_item_ref(&mut self, ii: &'hir ImplItemRef) {
         // Do not visit the duplicate information in ImplItemRef. We want to
         // map the actual nodes, not the duplicate ones in the *Ref.
-        let ImplItemRef { id, ident: _, kind: _, span: _ } = *ii;
+        let ImplItemRef { id, ident: _, span: _ } = *ii;
 
         self.visit_nested_impl_item(id);
     }

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -397,12 +397,8 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         self.visit_nested_impl_item(id);
     }
 
-    fn visit_foreign_item_ref(&mut self, fi: &'hir ForeignItemRef) {
-        // Do not visit the duplicate information in ForeignItemRef. We want to
-        // map the actual nodes, not the duplicate ones in the *Ref.
-        let ForeignItemRef { id, ident: _, span: _ } = *fi;
-
-        self.visit_nested_foreign_item(id);
+    fn visit_foreign_item_ref(&mut self, id: &'hir ForeignItemId) {
+        self.visit_nested_foreign_item(*id);
     }
 
     fn visit_where_predicate(&mut self, predicate: &'hir WherePredicate<'hir>) {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -964,13 +964,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_trait_item_ref(&mut self, i: &AssocItem) -> hir::TraitItemRef {
-        let id = hir::TraitItemId { owner_id: self.owner_id(i.id) };
-        hir::TraitItemRef {
-            id,
-            ident: self.lower_ident(i.kind.ident().unwrap()),
-            span: self.lower_span(i.span),
-        }
+    fn lower_trait_item_ref(&mut self, i: &AssocItem) -> hir::TraitItemId {
+        hir::TraitItemId { owner_id: self.owner_id(i.id) }
     }
 
     /// Construct `ExprKind::Err` for the given `span`.
@@ -1110,14 +1105,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_impl_item_ref(&mut self, i: &AssocItem) -> hir::ImplItemRef {
-        hir::ImplItemRef {
-            id: hir::ImplItemId { owner_id: self.owner_id(i.id) },
-            // `unwrap` is safe because `AssocItemKind::{MacCall,DelegationMac}` are the only
-            // assoc item kinds without an identifier and they cannot reach here.
-            ident: self.lower_ident(i.kind.ident().unwrap()),
-            span: self.lower_span(i.span),
-        }
+    fn lower_impl_item_ref(&mut self, i: &AssocItem) -> hir::ImplItemId {
+        hir::ImplItemId { owner_id: self.owner_id(i.id) }
     }
 
     fn lower_defaultness(

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1128,6 +1128,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
             span: self.lower_span(i.span),
             defaultness,
             has_delayed_lints: !self.delayed_lints.is_empty(),
+            trait_item_def_id: self
+                .resolver
+                .get_partial_res(i.id)
+                .map(|r| r.expect_full_res().opt_def_id())
+                .unwrap_or(None),
         };
         self.arena.alloc(item)
     }
@@ -1157,11 +1162,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     panic!("macros should have been expanded by now")
                 }
             },
-            trait_item_def_id: self
-                .resolver
-                .get_partial_res(i.id)
-                .map(|r| r.expect_full_res().opt_def_id())
-                .unwrap_or(None),
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -704,14 +704,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_foreign_item_ref(&mut self, i: &ForeignItem) -> hir::ForeignItemRef {
-        hir::ForeignItemRef {
-            id: hir::ForeignItemId { owner_id: self.owner_id(i.id) },
-            // `unwrap` is safe because `ForeignItemKind::MacCall` is the only foreign item kind
-            // without an identifier and it cannot reach here.
-            ident: self.lower_ident(i.kind.ident().unwrap()),
-            span: self.lower_span(i.span),
-        }
+    fn lower_foreign_item_ref(&mut self, i: &ForeignItem) -> hir::ForeignItemId {
+        hir::ForeignItemId { owner_id: self.owner_id(i.id) }
     }
 
     fn lower_variant(&mut self, item_kind: &ItemKind, v: &Variant) -> hir::Variant<'hir> {

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -681,46 +681,30 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             return (false, false, None);
         }
         let my_def = self.body.source.def_id();
-        let my_hir = self.infcx.tcx.local_def_id_to_hir_id(my_def.as_local().unwrap());
         let Some(td) =
             self.infcx.tcx.impl_of_method(my_def).and_then(|x| self.infcx.tcx.trait_id_of_impl(x))
         else {
             return (false, false, None);
         };
+
+        let implemented_trait_item = self.infcx.tcx.associated_item(my_def).trait_item_def_id;
+
         (
             true,
             td.is_local(),
-            td.as_local().and_then(|tld| match self.infcx.tcx.hir_node_by_def_id(tld) {
-                Node::Item(hir::Item {
-                    kind: hir::ItemKind::Trait(_, _, _, _, _, items), ..
-                }) => {
-                    let mut f_in_trait_opt = None;
-                    for hir::TraitItemRef { id: fi, kind: k, .. } in *items {
-                        let hi = fi.hir_id();
-                        if !matches!(k, hir::AssocItemKind::Fn { .. }) {
-                            continue;
-                        }
-                        if self.infcx.tcx.hir_name(hi) != self.infcx.tcx.hir_name(my_hir) {
-                            continue;
-                        }
-                        f_in_trait_opt = Some(hi);
-                        break;
-                    }
-                    f_in_trait_opt.and_then(|f_in_trait| {
-                        if let Node::TraitItem(ti) = self.infcx.tcx.hir_node(f_in_trait)
-                            && let hir::TraitItemKind::Fn(sig, _) = ti.kind
-                            && let Some(ty) = sig.decl.inputs.get(local.index() - 1)
-                            && let hir::TyKind::Ref(_, mut_ty) = ty.kind
-                            && let hir::Mutability::Not = mut_ty.mutbl
-                            && sig.decl.implicit_self.has_implicit_self()
-                        {
-                            Some(ty.span)
-                        } else {
-                            None
-                        }
-                    })
+            implemented_trait_item.and_then(|f_in_trait| {
+                let f_in_trait = f_in_trait.as_local()?;
+                if let Node::TraitItem(ti) = self.infcx.tcx.hir_node_by_def_id(f_in_trait)
+                    && let hir::TraitItemKind::Fn(sig, _) = ti.kind
+                    && let Some(ty) = sig.decl.inputs.get(local.index() - 1)
+                    && let hir::TyKind::Ref(_, mut_ty) = ty.kind
+                    && let hir::Mutability::Not = mut_ty.mutbl
+                    && sig.decl.implicit_self.has_implicit_self()
+                {
+                    Some(ty.span)
+                } else {
+                    None
                 }
-                _ => None,
             }),
         )
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3172,6 +3172,8 @@ pub struct ImplItem<'hir> {
     pub span: Span,
     pub vis_span: Span,
     pub has_delayed_lints: bool,
+    /// When we are in a trait impl, link to the trait-item's id.
+    pub trait_item_def_id: Option<DefId>,
 }
 
 impl<'hir> ImplItem<'hir> {
@@ -4429,8 +4431,6 @@ pub struct ImplItemRef {
     pub ident: Ident,
     pub kind: AssocItemKind,
     pub span: Span,
-    /// When we are in a trait impl, link to the trait-item's id.
-    pub trait_item_def_id: Option<DefId>,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, HashStable_Generic)]
@@ -4969,7 +4969,7 @@ mod size_asserts {
     static_assert_size!(GenericBound<'_>, 64);
     static_assert_size!(Generics<'_>, 56);
     static_assert_size!(Impl<'_>, 80);
-    static_assert_size!(ImplItem<'_>, 88);
+    static_assert_size!(ImplItem<'_>, 96);
     static_assert_size!(ImplItemKind<'_>, 40);
     static_assert_size!(Item<'_>, 88);
     static_assert_size!(ItemKind<'_>, 64);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4162,7 +4162,7 @@ impl<'hir> Item<'hir> {
                 Ident,
                 &'hir Generics<'hir>,
                 GenericBounds<'hir>,
-                &'hir [TraitItemRef]
+                &'hir [TraitItemId]
             ),
             ItemKind::Trait(is_auto, safety, ident, generics, bounds, items),
             (*is_auto, *safety, *ident, generics, bounds, items);
@@ -4335,7 +4335,7 @@ pub enum ItemKind<'hir> {
     /// A union definition, e.g., `union Foo<A, B> {x: A, y: B}`.
     Union(Ident, &'hir Generics<'hir>, VariantData<'hir>),
     /// A trait definition.
-    Trait(IsAuto, Safety, Ident, &'hir Generics<'hir>, GenericBounds<'hir>, &'hir [TraitItemRef]),
+    Trait(IsAuto, Safety, Ident, &'hir Generics<'hir>, GenericBounds<'hir>, &'hir [TraitItemId]),
     /// A trait alias.
     TraitAlias(Ident, &'hir Generics<'hir>, GenericBounds<'hir>),
 
@@ -4362,7 +4362,7 @@ pub struct Impl<'hir> {
     pub of_trait: Option<TraitRef<'hir>>,
 
     pub self_ty: &'hir Ty<'hir>,
-    pub items: &'hir [ImplItemRef],
+    pub items: &'hir [ImplItemId],
 }
 
 impl ItemKind<'_> {
@@ -4403,32 +4403,6 @@ impl ItemKind<'_> {
             _ => return None,
         })
     }
-}
-
-/// A reference from an trait to one of its associated items. This
-/// contains the item's id, naturally, but also the item's name and
-/// some other high-level details (like whether it is an associated
-/// type or method, and whether it is public). This allows other
-/// passes to find the impl they want without loading the ID (which
-/// means fewer edges in the incremental compilation graph).
-#[derive(Debug, Clone, Copy, HashStable_Generic)]
-pub struct TraitItemRef {
-    pub id: TraitItemId,
-    pub ident: Ident,
-    pub span: Span,
-}
-
-/// A reference from an impl to one of its associated items. This
-/// contains the item's ID, naturally, but also the item's name and
-/// some other high-level details (like whether it is an associated
-/// type or method, and whether it is public). This allows other
-/// passes to find the impl they want without loading the ID (which
-/// means fewer edges in the incremental compilation graph).
-#[derive(Debug, Clone, Copy, HashStable_Generic)]
-pub struct ImplItemRef {
-    pub id: ImplItemId,
-    pub ident: Ident,
-    pub span: Span,
 }
 
 // The bodies for items are stored "out of line", in a separate

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4138,7 +4138,7 @@ impl<'hir> Item<'hir> {
 
         expect_mod, (Ident, &'hir Mod<'hir>), ItemKind::Mod(ident, m), (*ident, m);
 
-        expect_foreign_mod, (ExternAbi, &'hir [ForeignItemRef]),
+        expect_foreign_mod, (ExternAbi, &'hir [ForeignItemId]),
             ItemKind::ForeignMod { abi, items }, (*abi, items);
 
         expect_global_asm, &'hir InlineAsm<'hir>, ItemKind::GlobalAsm { asm, .. }, asm;
@@ -4315,7 +4315,7 @@ pub enum ItemKind<'hir> {
     /// A module.
     Mod(Ident, &'hir Mod<'hir>),
     /// An external module, e.g. `extern { .. }`.
-    ForeignMod { abi: ExternAbi, items: &'hir [ForeignItemRef] },
+    ForeignMod { abi: ExternAbi, items: &'hir [ForeignItemId] },
     /// Module-level inline assembly (from `global_asm!`).
     GlobalAsm {
         asm: &'hir InlineAsm<'hir>,
@@ -4445,19 +4445,6 @@ impl ForeignItemId {
         // Items are always HIR owners.
         HirId::make_owner(self.owner_id.def_id)
     }
-}
-
-/// A reference from a foreign block to one of its items. This
-/// contains the item's ID, naturally, but also the item's name and
-/// some other high-level details (like whether it is an associated
-/// type or method, and whether it is public). This allows other
-/// passes to find the impl they want without loading the ID (which
-/// means fewer edges in the incremental compilation graph).
-#[derive(Debug, Clone, Copy, HashStable_Generic)]
-pub struct ForeignItemRef {
-    pub id: ForeignItemId,
-    pub ident: Ident,
-    pub span: Span,
 }
 
 #[derive(Debug, Clone, Copy, HashStable_Generic)]

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4415,7 +4415,6 @@ impl ItemKind<'_> {
 pub struct TraitItemRef {
     pub id: TraitItemId,
     pub ident: Ident,
-    pub kind: AssocItemKind,
     pub span: Span,
 }
 
@@ -4429,15 +4428,7 @@ pub struct TraitItemRef {
 pub struct ImplItemRef {
     pub id: ImplItemId,
     pub ident: Ident,
-    pub kind: AssocItemKind,
     pub span: Span,
-}
-
-#[derive(Copy, Clone, PartialEq, Debug, HashStable_Generic)]
-pub enum AssocItemKind {
-    Const,
-    Fn { has_self: bool },
-    Type,
 }
 
 // The bodies for items are stored "out of line", in a separate

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -499,9 +499,6 @@ pub trait Visitor<'v>: Sized {
     fn visit_attribute(&mut self, _attr: &'v Attribute) -> Self::Result {
         Self::Result::output()
     }
-    fn visit_associated_item_kind(&mut self, kind: &'v AssocItemKind) -> Self::Result {
-        walk_associated_item_kind(self, kind)
-    }
     fn visit_defaultness(&mut self, defaultness: &'v Defaultness) -> Self::Result {
         walk_defaultness(self, defaultness)
     }
@@ -1252,10 +1249,9 @@ pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     trait_item_ref: &'v TraitItemRef,
 ) -> V::Result {
-    let TraitItemRef { id, ident, ref kind, span: _ } = *trait_item_ref;
+    let TraitItemRef { id, ident, span: _ } = *trait_item_ref;
     try_visit!(visitor.visit_nested_trait_item(id));
-    try_visit!(visitor.visit_ident(ident));
-    visitor.visit_associated_item_kind(kind)
+    visitor.visit_ident(ident)
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(
@@ -1307,10 +1303,9 @@ pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item_ref: &'v ImplItemRef,
 ) -> V::Result {
-    let ImplItemRef { id, ident, ref kind, span: _ } = *impl_item_ref;
+    let ImplItemRef { id, ident, span: _ } = *impl_item_ref;
     try_visit!(visitor.visit_nested_impl_item(id));
-    try_visit!(visitor.visit_ident(ident));
-    visitor.visit_associated_item_kind(kind)
+    visitor.visit_ident(ident)
 }
 
 pub fn walk_trait_ref<'v, V: Visitor<'v>>(
@@ -1481,13 +1476,6 @@ pub fn walk_assoc_item_constraint<'v, V: Visitor<'v>>(
             walk_list!(visitor, visit_param_bound, bounds)
         }
     }
-    V::Result::output()
-}
-
-pub fn walk_associated_item_kind<'v, V: Visitor<'v>>(_: &mut V, _: &'v AssocItemKind) -> V::Result {
-    // No visitable content here: this fn exists so you can call it if
-    // the right thing to do, should content be added in the future,
-    // would be to walk it.
     V::Result::output()
 }
 

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1271,6 +1271,7 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(
         span: _,
         vis_span: _,
         has_delayed_lints: _,
+        trait_item_def_id: _,
     } = *impl_item;
 
     try_visit!(visitor.visit_ident(ident));
@@ -1306,7 +1307,7 @@ pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     impl_item_ref: &'v ImplItemRef,
 ) -> V::Result {
-    let ImplItemRef { id, ident, ref kind, span: _, trait_item_def_id: _ } = *impl_item_ref;
+    let ImplItemRef { id, ident, ref kind, span: _ } = *impl_item_ref;
     try_visit!(visitor.visit_nested_impl_item(id));
     try_visit!(visitor.visit_ident(ident));
     visitor.visit_associated_item_kind(kind)

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -435,8 +435,8 @@ pub trait Visitor<'v>: Sized {
     fn visit_trait_item(&mut self, ti: &'v TraitItem<'v>) -> Self::Result {
         walk_trait_item(self, ti)
     }
-    fn visit_trait_item_ref(&mut self, ii: &'v TraitItemRef) -> Self::Result {
-        walk_trait_item_ref(self, ii)
+    fn visit_trait_item_ref(&mut self, ii: &'v TraitItemId) -> Self::Result {
+        walk_trait_item_ref(self, *ii)
     }
     fn visit_impl_item(&mut self, ii: &'v ImplItem<'v>) -> Self::Result {
         walk_impl_item(self, ii)
@@ -444,8 +444,8 @@ pub trait Visitor<'v>: Sized {
     fn visit_foreign_item_ref(&mut self, ii: &'v ForeignItemId) -> Self::Result {
         walk_foreign_item_ref(self, *ii)
     }
-    fn visit_impl_item_ref(&mut self, ii: &'v ImplItemRef) -> Self::Result {
-        walk_impl_item_ref(self, ii)
+    fn visit_impl_item_ref(&mut self, ii: &'v ImplItemId) -> Self::Result {
+        walk_impl_item_ref(self, *ii)
     }
     fn visit_trait_ref(&mut self, t: &'v TraitRef<'v>) -> Self::Result {
         walk_trait_ref(self, t)
@@ -1245,13 +1245,8 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(
     V::Result::output()
 }
 
-pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(
-    visitor: &mut V,
-    trait_item_ref: &'v TraitItemRef,
-) -> V::Result {
-    let TraitItemRef { id, ident, span: _ } = *trait_item_ref;
-    try_visit!(visitor.visit_nested_trait_item(id));
-    visitor.visit_ident(ident)
+pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, id: TraitItemId) -> V::Result {
+    visitor.visit_nested_trait_item(id)
 }
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(
@@ -1294,13 +1289,8 @@ pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, id: ForeignIte
     visitor.visit_nested_foreign_item(id)
 }
 
-pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(
-    visitor: &mut V,
-    impl_item_ref: &'v ImplItemRef,
-) -> V::Result {
-    let ImplItemRef { id, ident, span: _ } = *impl_item_ref;
-    try_visit!(visitor.visit_nested_impl_item(id));
-    visitor.visit_ident(ident)
+pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, id: ImplItemId) -> V::Result {
+    visitor.visit_nested_impl_item(id)
 }
 
 pub fn walk_trait_ref<'v, V: Visitor<'v>>(

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -441,8 +441,8 @@ pub trait Visitor<'v>: Sized {
     fn visit_impl_item(&mut self, ii: &'v ImplItem<'v>) -> Self::Result {
         walk_impl_item(self, ii)
     }
-    fn visit_foreign_item_ref(&mut self, ii: &'v ForeignItemRef) -> Self::Result {
-        walk_foreign_item_ref(self, ii)
+    fn visit_foreign_item_ref(&mut self, ii: &'v ForeignItemId) -> Self::Result {
+        walk_foreign_item_ref(self, *ii)
     }
     fn visit_impl_item_ref(&mut self, ii: &'v ImplItemRef) -> Self::Result {
         walk_impl_item_ref(self, ii)
@@ -1290,13 +1290,8 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(
     }
 }
 
-pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(
-    visitor: &mut V,
-    foreign_item_ref: &'v ForeignItemRef,
-) -> V::Result {
-    let ForeignItemRef { id, ident, span: _ } = *foreign_item_ref;
-    try_visit!(visitor.visit_nested_foreign_item(id));
-    visitor.visit_ident(ident)
+pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, id: ForeignItemId) -> V::Result {
+    visitor.visit_nested_foreign_item(id)
 }
 
 pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -59,7 +59,7 @@ fn equate_intrinsic_type<'tcx>(
 
 /// Returns the unsafety of the given intrinsic.
 fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -> hir::Safety {
-    let is_in_list = match tcx.item_name(intrinsic_id.into()) {
+    let is_in_list = match tcx.item_name(intrinsic_id) {
         // When adding a new intrinsic to this list,
         // it's usually worth updating that intrinsic's documentation
         // to note that it's safe to call, since
@@ -144,7 +144,7 @@ fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -> hi
             tcx.def_span(intrinsic_id),
             DiagMessage::from(format!(
                 "intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `{}`",
-                tcx.item_name(intrinsic_id.into())
+                tcx.item_name(intrinsic_id)
             )
         )).emit();
     }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -914,7 +914,7 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
                 let item = items.iter().find(|item| item.ident == *ident);
 
                 match item {
-                    Some(item) if matches!(item.kind, hir::AssocItemKind::Fn { .. }) => {
+                    Some(item) if matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) => {
                         if !tcx.defaultness(item.id.owner_id).has_value() {
                             tcx.dcx().emit_err(errors::FunctionNotHaveDefaultImplementation {
                                 span: item.span,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -844,11 +844,9 @@ fn adt_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::AdtDef<'_> {
 fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
     let item = tcx.hir_expect_item(def_id);
 
-    let (is_alias, is_auto, safety, items) = match item.kind {
-        hir::ItemKind::Trait(is_auto, safety, .., items) => {
-            (false, is_auto == hir::IsAuto::Yes, safety, items)
-        }
-        hir::ItemKind::TraitAlias(..) => (true, false, hir::Safety::Safe, &[][..]),
+    let (is_alias, is_auto, safety) = match item.kind {
+        hir::ItemKind::Trait(is_auto, safety, ..) => (false, is_auto == hir::IsAuto::Yes, safety),
+        hir::ItemKind::TraitAlias(..) => (true, false, hir::Safety::Safe),
         _ => span_bug!(item.span, "trait_def_of_item invoked on non-trait"),
     };
 
@@ -911,13 +909,16 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
         // functions in the trait with default implementations
         .and_then(|(list, attr_span)| {
             let errors = list.iter().filter_map(|ident| {
-                let item = items.iter().find(|item| item.ident == *ident);
+                let item = tcx
+                    .associated_items(def_id)
+                    .filter_by_name_unhygienic(ident.name)
+                    .find(|item| item.ident(tcx) == *ident);
 
                 match item {
-                    Some(item) if matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) => {
-                        if !tcx.defaultness(item.id.owner_id).has_value() {
+                    Some(item) if matches!(item.kind, ty::AssocKind::Fn { .. }) => {
+                        if !item.defaultness(tcx).has_value() {
                             tcx.dcx().emit_err(errors::FunctionNotHaveDefaultImplementation {
-                                span: item.span,
+                                span: tcx.def_span(item.def_id),
                                 note_span: attr_span,
                             });
 
@@ -928,7 +929,7 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
                     }
                     Some(item) => {
                         tcx.dcx().emit_err(errors::MustImplementNotFunction {
-                            span: item.span,
+                            span: tcx.def_span(item.def_id),
                             span_note: errors::MustImplementNotFunctionSpanNote { span: attr_span },
                             note: errors::MustImplementNotFunctionNote {},
                         });

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -730,8 +730,8 @@ impl<'a> State<'a> {
 
                 self.space();
                 self.bopen(ib);
-                for impl_item in items {
-                    self.ann.nested(self, Nested::ImplItem(impl_item.id));
+                for &impl_item in items {
+                    self.ann.nested(self, Nested::ImplItem(impl_item));
                 }
                 self.bclose(item.span, cb);
             }
@@ -746,8 +746,8 @@ impl<'a> State<'a> {
                 self.print_where_clause(generics);
                 self.word(" ");
                 self.bopen(ib);
-                for trait_item in trait_items {
-                    self.ann.nested(self, Nested::TraitItem(trait_item.id));
+                for &trait_item in trait_items {
+                    self.ann.nested(self, Nested::TraitItem(trait_item));
                 }
                 self.bclose(item.span, cb);
             }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -654,8 +654,8 @@ impl<'a> State<'a> {
                 let (cb, ib) = self.head("extern");
                 self.word_nbsp(abi.to_string());
                 self.bopen(ib);
-                for item in items {
-                    self.ann.nested(self, Nested::ForeignItem(item.id));
+                for &foreign_item in items {
+                    self.ann.nested(self, Nested::ForeignItem(foreign_item));
                 }
                 self.bclose(item.span, cb);
             }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -28,7 +28,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LocalDefId};
 use rustc_hir::intravisit::FnKind as HirFnKind;
-use rustc_hir::{Body, FnDecl, GenericParamKind, PatKind, PredicateOrigin};
+use rustc_hir::{Body, FnDecl, PatKind, PredicateOrigin};
 use rustc_middle::bug;
 use rustc_middle::lint::LevelAndSource;
 use rustc_middle::ty::layout::LayoutOf;
@@ -952,36 +952,34 @@ declare_lint! {
 
 declare_lint_pass!(InvalidNoMangleItems => [NO_MANGLE_CONST_ITEMS, NO_MANGLE_GENERIC_ITEMS]);
 
+impl InvalidNoMangleItems {
+    fn check_no_mangle_on_generic_fn(
+        &self,
+        cx: &LateContext<'_>,
+        attr_span: Span,
+        def_id: LocalDefId,
+    ) {
+        let generics = cx.tcx.generics_of(def_id);
+        if generics.requires_monomorphization(cx.tcx) {
+            cx.emit_span_lint(
+                NO_MANGLE_GENERIC_ITEMS,
+                cx.tcx.def_span(def_id),
+                BuiltinNoMangleGeneric { suggestion: attr_span },
+            );
+        }
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for InvalidNoMangleItems {
     fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
         let attrs = cx.tcx.hir_attrs(it.hir_id());
-        let check_no_mangle_on_generic_fn = |attr_span: Span,
-                                             impl_generics: Option<&hir::Generics<'_>>,
-                                             generics: &hir::Generics<'_>,
-                                             span| {
-            for param in
-                generics.params.iter().chain(impl_generics.map(|g| g.params).into_iter().flatten())
-            {
-                match param.kind {
-                    GenericParamKind::Lifetime { .. } => {}
-                    GenericParamKind::Type { .. } | GenericParamKind::Const { .. } => {
-                        cx.emit_span_lint(
-                            NO_MANGLE_GENERIC_ITEMS,
-                            span,
-                            BuiltinNoMangleGeneric { suggestion: attr_span },
-                        );
-                        break;
-                    }
-                }
-            }
-        };
         match it.kind {
-            hir::ItemKind::Fn { generics, .. } => {
+            hir::ItemKind::Fn { .. } => {
                 if let Some(attr_span) =
                     find_attr!(attrs, AttributeKind::ExportName {span, ..} => *span)
                         .or_else(|| find_attr!(attrs, AttributeKind::NoMangle(span) => *span))
                 {
-                    check_no_mangle_on_generic_fn(attr_span, None, generics, it.span);
+                    self.check_no_mangle_on_generic_fn(cx, attr_span, it.owner_id.def_id);
                 }
             }
             hir::ItemKind::Const(..) => {
@@ -1006,24 +1004,19 @@ impl<'tcx> LateLintPass<'tcx> for InvalidNoMangleItems {
                     );
                 }
             }
-            hir::ItemKind::Impl(hir::Impl { generics, items, .. }) => {
-                for it in *items {
-                    if let hir::AssocItemKind::Fn { .. } = it.kind {
-                        let attrs = cx.tcx.hir_attrs(it.id.hir_id());
-                        if let Some(attr_span) =
-                            find_attr!(attrs, AttributeKind::ExportName {span, ..} => *span)
-                                .or_else(
-                                    || find_attr!(attrs, AttributeKind::NoMangle(span) => *span),
-                                )
-                        {
-                            check_no_mangle_on_generic_fn(
-                                attr_span,
-                                Some(generics),
-                                cx.tcx.hir_get_generics(it.id.owner_id.def_id).unwrap(),
-                                it.span,
-                            );
-                        }
-                    }
+            _ => {}
+        }
+    }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'_>, it: &hir::ImplItem<'_>) {
+        let attrs = cx.tcx.hir_attrs(it.hir_id());
+        match it.kind {
+            hir::ImplItemKind::Fn { .. } => {
+                if let Some(attr_span) =
+                    find_attr!(attrs, AttributeKind::ExportName {span, ..} => *span)
+                        .or_else(|| find_attr!(attrs, AttributeKind::NoMangle(span) => *span))
+                {
+                    self.check_no_mangle_on_generic_fn(cx, attr_span, it.owner_id.def_id);
                 }
             }
             _ => {}

--- a/compiler/rustc_metadata/src/foreign_modules.rs
+++ b/compiler/rustc_metadata/src/foreign_modules.rs
@@ -19,7 +19,7 @@ pub(crate) fn collect(tcx: TyCtxt<'_>, LocalCrate: LocalCrate) -> FxIndexMap<Def
         let item = tcx.hir_item(id);
 
         if let hir::ItemKind::ForeignMod { abi, items } = item.kind {
-            let foreign_items = items.iter().map(|it| it.id.owner_id.to_def_id()).collect();
+            let foreign_items = items.iter().map(|it| it.owner_id.to_def_id()).collect();
             modules.insert(def_id, ForeignModule { def_id, abi, foreign_items });
         }
     }

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -258,6 +258,16 @@ impl AssocItems {
     }
 
     /// Returns the associated item with the given identifier and `AssocKind`, if one exists.
+    /// The identifier is ignoring hygiene. This is meant to be used for lints and diagnostics.
+    pub fn filter_by_name_unhygienic_and_kind(
+        &self,
+        name: Symbol,
+        assoc_tag: AssocTag,
+    ) -> impl '_ + Iterator<Item = &ty::AssocItem> {
+        self.filter_by_name_unhygienic(name).filter(move |item| item.as_tag() == assoc_tag)
+    }
+
+    /// Returns the associated item with the given identifier and `AssocKind`, if one exists.
     /// The identifier is matched hygienically.
     pub fn find_by_ident_and_kind(
         &self,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1590,7 +1590,8 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Look up the name of a definition across crates. This does not look at HIR.
-    pub fn opt_item_name(self, def_id: DefId) -> Option<Symbol> {
+    pub fn opt_item_name(self, def_id: impl IntoQueryParam<DefId>) -> Option<Symbol> {
+        let def_id = def_id.into_query_param();
         if let Some(cnum) = def_id.as_crate_root() {
             Some(self.crate_name(cnum))
         } else {
@@ -1610,7 +1611,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// [`opt_item_name`] instead.
     ///
     /// [`opt_item_name`]: Self::opt_item_name
-    pub fn item_name(self, id: DefId) -> Symbol {
+    pub fn item_name(self, id: impl IntoQueryParam<DefId>) -> Symbol {
+        let id = id.into_query_param();
         self.opt_item_name(id).unwrap_or_else(|| {
             bug!("item_name: no name for {:?}", self.def_path(id));
         })
@@ -1619,7 +1621,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Look up the name and span of a definition.
     ///
     /// See [`item_name`][Self::item_name] for more information.
-    pub fn opt_item_ident(self, def_id: DefId) -> Option<Ident> {
+    pub fn opt_item_ident(self, def_id: impl IntoQueryParam<DefId>) -> Option<Ident> {
+        let def_id = def_id.into_query_param();
         let def = self.opt_item_name(def_id)?;
         let span = self
             .def_ident_span(def_id)
@@ -1630,7 +1633,8 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Look up the name and span of a definition.
     ///
     /// See [`item_name`][Self::item_name] for more information.
-    pub fn item_ident(self, def_id: DefId) -> Ident {
+    pub fn item_ident(self, def_id: impl IntoQueryParam<DefId>) -> Ident {
+        let def_id = def_id.into_query_param();
         self.opt_item_ident(def_id).unwrap_or_else(|| {
             bug!("item_ident: no name for {:?}", self.def_path(def_id));
         })

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1683,7 +1683,7 @@ pub fn intrinsic_raw(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ty::Intrinsi
             _ => true,
         };
         Some(ty::IntrinsicDef {
-            name: tcx.item_name(def_id.into()),
+            name: tcx.item_name(def_id),
             must_be_overridden,
             const_stable: tcx.has_attr(def_id, sym::rustc_intrinsic_const_stable_indirect),
         })

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1084,7 +1084,7 @@ fn find_fallback_pattern_typo<'tcx>(
                 && infcx.can_eq(param_env, ty, cx.tcx.type_of(item.owner_id).instantiate_identity())
             {
                 // Look for local consts.
-                let item_name = cx.tcx.item_name(item.owner_id.into());
+                let item_name = cx.tcx.item_name(item.owner_id);
                 let vis = cx.tcx.visibility(item.owner_id);
                 if vis.is_accessible_from(parent, cx.tcx) {
                     accessible.push(item_name);

--- a/compiler/rustc_passes/src/abi_test.rs
+++ b/compiler/rustc_passes/src/abi_test.rs
@@ -79,7 +79,7 @@ fn dump_abi_of_fn_item(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
     for meta_item in meta_items {
         match meta_item.name() {
             Some(sym::debug) => {
-                let fn_name = tcx.item_name(item_def_id.into());
+                let fn_name = tcx.item_name(item_def_id);
                 tcx.dcx().emit_err(AbiOf {
                     span: tcx.def_span(item_def_id),
                     fn_name,
@@ -135,7 +135,7 @@ fn dump_abi_of_fn_type(tcx: TyCtxt<'_>, item_def_id: LocalDefId, attr: &Attribut
                     item_def_id,
                 );
 
-                let fn_name = tcx.item_name(item_def_id.into());
+                let fn_name = tcx.item_name(item_def_id);
                 tcx.dcx().emit_err(AbiOf { span, fn_name, fn_abi: format!("{:#?}", abi) });
             }
             Some(sym::assert_eq) => {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -20,8 +20,8 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalModDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{
-    self as hir, self, AssocItemKind, Attribute, CRATE_HIR_ID, CRATE_OWNER_ID, FnSig, ForeignItem,
-    HirId, Item, ItemKind, MethodKind, Safety, Target, TraitItem,
+    self as hir, self, Attribute, CRATE_HIR_ID, CRATE_OWNER_ID, FnSig, ForeignItem, HirId, Item,
+    ItemKind, MethodKind, Safety, Target, TraitItem,
 };
 use rustc_macros::LintDiagnostic;
 use rustc_middle::hir::nested_filter;
@@ -1151,7 +1151,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 if generics.params.len() != 0 => {}
             ItemKind::Trait(_, _, _, generics, _, items)
                 if generics.params.len() != 0
-                    || items.iter().any(|item| matches!(item.kind, AssocItemKind::Type)) => {}
+                    || items.iter().any(|item| {
+                        matches!(self.tcx.def_kind(item.id.owner_id), DefKind::AssocTy)
+                    }) => {}
             ItemKind::TyAlias(_, generics, _) if generics.params.len() != 0 => {}
             _ => {
                 self.dcx().emit_err(errors::DocSearchUnboxInvalid { span: meta.span() });

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1152,7 +1152,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             ItemKind::Trait(_, _, _, generics, _, items)
                 if generics.params.len() != 0
                     || items.iter().any(|item| {
-                        matches!(self.tcx.def_kind(item.id.owner_id), DefKind::AssocTy)
+                        matches!(self.tcx.def_kind(item.owner_id), DefKind::AssocTy)
                     }) => {}
             ItemKind::TyAlias(_, generics, _) if generics.params.len() != 0 => {}
             _ => {

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -415,8 +415,8 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 hir::ItemKind::Trait(.., trait_item_refs) => {
                     // mark assoc ty live if the trait is live
                     for trait_item in trait_item_refs {
-                        if matches!(self.tcx.def_kind(trait_item.id.owner_id), DefKind::AssocTy) {
-                            self.check_def_id(trait_item.id.owner_id.to_def_id());
+                        if matches!(self.tcx.def_kind(trait_item.owner_id), DefKind::AssocTy) {
+                            self.check_def_id(trait_item.owner_id.to_def_id());
                         }
                     }
                     intravisit::walk_item(self, item)

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -415,7 +415,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 hir::ItemKind::Trait(.., trait_item_refs) => {
                     // mark assoc ty live if the trait is live
                     for trait_item in trait_item_refs {
-                        if matches!(trait_item.kind, hir::AssocItemKind::Type) {
+                        if matches!(self.tcx.def_kind(trait_item.id.owner_id), DefKind::AssocTy) {
                             self.check_def_id(trait_item.id.owner_id.to_def_id());
                         }
                     }

--- a/compiler/rustc_passes/src/input_stats.rs
+++ b/compiler/rustc_passes/src/input_stats.rs
@@ -480,9 +480,9 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_impl_item(self, ii)
     }
 
-    fn visit_foreign_item_ref(&mut self, fi: &'v hir::ForeignItemRef) {
-        self.record("ForeignItemRef", Some(fi.id.hir_id()), fi);
-        hir_visit::walk_foreign_item_ref(self, fi)
+    fn visit_foreign_item_ref(&mut self, fi: &'v hir::ForeignItemId) {
+        self.record("ForeignItemId", Some(fi.hir_id()), fi);
+        hir_visit::walk_foreign_item_ref(self, *fi)
     }
 
     fn visit_impl_item_ref(&mut self, ii: &'v hir::ImplItemRef) {

--- a/compiler/rustc_passes/src/input_stats.rs
+++ b/compiler/rustc_passes/src/input_stats.rs
@@ -467,9 +467,9 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_trait_item(self, ti)
     }
 
-    fn visit_trait_item_ref(&mut self, ti: &'v hir::TraitItemRef) {
-        self.record("TraitItemRef", Some(ti.id.hir_id()), ti);
-        hir_visit::walk_trait_item_ref(self, ti)
+    fn visit_trait_item_ref(&mut self, ti: &'v hir::TraitItemId) {
+        self.record("TraitItemId", Some(ti.hir_id()), ti);
+        hir_visit::walk_trait_item_ref(self, *ti)
     }
 
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem<'v>) {
@@ -485,9 +485,9 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         hir_visit::walk_foreign_item_ref(self, *fi)
     }
 
-    fn visit_impl_item_ref(&mut self, ii: &'v hir::ImplItemRef) {
-        self.record("ImplItemRef", Some(ii.id.hir_id()), ii);
-        hir_visit::walk_impl_item_ref(self, ii)
+    fn visit_impl_item_ref(&mut self, ii: &'v hir::ImplItemId) {
+        self.record("ImplItemId", Some(ii.hir_id()), ii);
+        hir_visit::walk_impl_item_ref(self, *ii)
     }
 
     fn visit_param_bound(&mut self, b: &'v hir::GenericBound<'v>) {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -880,11 +880,16 @@ impl<'tcx> Visitor<'tcx> for Checker<'tcx> {
                 }
 
                 for impl_item_ref in *items {
-                    let impl_item = self.tcx.associated_item(impl_item_ref.id.owner_id);
+                    let impl_item = self.tcx.associated_item(impl_item_ref.owner_id);
 
                     if let Some(def_id) = impl_item.trait_item_def_id {
                         // Pass `None` to skip deprecation warnings.
-                        self.tcx.check_stability(def_id, None, impl_item_ref.span, None);
+                        self.tcx.check_stability(
+                            def_id,
+                            None,
+                            self.tcx.def_span(impl_item_ref.owner_id),
+                            None,
+                        );
                     }
                 }
             }

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -672,14 +672,14 @@ impl<'tcx> Visitor<'tcx> for EmbargoVisitor<'tcx> {
                     self.reach(item.owner_id.def_id, item_ev).generics().predicates();
 
                     for trait_item_ref in trait_item_refs {
-                        self.update(trait_item_ref.id.owner_id.def_id, item_ev, Level::Reachable);
+                        self.update(trait_item_ref.owner_id.def_id, item_ev, Level::Reachable);
 
                         let tcx = self.tcx;
-                        let mut reach = self.reach(trait_item_ref.id.owner_id.def_id, item_ev);
+                        let mut reach = self.reach(trait_item_ref.owner_id.def_id, item_ev);
                         reach.generics().predicates();
 
-                        if let DefKind::AssocTy = tcx.def_kind(trait_item_ref.id.owner_id)
-                            && !tcx.defaultness(trait_item_ref.id.owner_id).has_value()
+                        if let DefKind::AssocTy = tcx.def_kind(trait_item_ref.owner_id)
+                            && !tcx.defaultness(trait_item_ref.owner_id).has_value()
                         {
                             // No type to visit.
                         } else {
@@ -715,7 +715,7 @@ impl<'tcx> Visitor<'tcx> for EmbargoVisitor<'tcx> {
                 self.reach(item.owner_id.def_id, item_ev).generics().predicates().ty().trait_ref();
 
                 for impl_item_ref in impl_.items {
-                    let def_id = impl_item_ref.id.owner_id.def_id;
+                    let def_id = impl_item_ref.owner_id.def_id;
                     let max_vis =
                         impl_.of_trait.is_none().then(|| self.tcx.local_visibility(def_id));
                     self.update_eff_vis(def_id, item_ev, max_vis, Level::Direct);

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -755,8 +755,8 @@ impl<'tcx> Visitor<'tcx> for EmbargoVisitor<'tcx> {
             }
             hir::ItemKind::ForeignMod { items, .. } => {
                 for foreign_item in items {
-                    if let Some(foreign_item_ev) = self.get(foreign_item.id.owner_id.def_id) {
-                        self.reach(foreign_item.id.owner_id.def_id, foreign_item_ev)
+                    if let Some(foreign_item_ev) = self.get(foreign_item.owner_id.def_id) {
+                        self.reach(foreign_item.owner_id.def_id, foreign_item_ev)
                             .generics()
                             .predicates()
                             .ty();
@@ -1658,8 +1658,8 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'_, 'tcx> {
             DefKind::ForeignMod => {
                 let item = tcx.hir_item(id);
                 if let hir::ItemKind::ForeignMod { items, .. } = item.kind {
-                    for foreign_item in items {
-                        let foreign_item = tcx.hir_foreign_item(foreign_item.id);
+                    for &foreign_item in items {
+                        let foreign_item = tcx.hir_foreign_item(foreign_item);
 
                         let ev = self.get(foreign_item.owner_id.def_id);
                         let vis = tcx.local_visibility(foreign_item.owner_id.def_id);

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -288,9 +288,9 @@ fn extend_cause_with_original_assoc_item_obligation<'tcx>(
             && let Some(&impl_item_id) =
                 tcx.impl_item_implementor_ids(impl_def_id).get(&projection_ty.def_id)
             && let Some(impl_item) =
-                items.iter().find(|item| item.id.owner_id.to_def_id() == impl_item_id)
+                items.iter().find(|item| item.owner_id.to_def_id() == impl_item_id)
         {
-            Some(tcx.hir_impl_item(impl_item.id).expect_type().span)
+            Some(tcx.hir_impl_item(*impl_item).expect_type().span)
         } else {
             None
         }

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -154,7 +154,7 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
         ItemKind::Trait(.., trait_item_refs) => trait_item_refs
             .iter()
             .filter_map(move |item| {
-                if !matches!(item.kind, hir::AssocItemKind::Fn { .. }) {
+                if !matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) {
                     return None;
                 }
                 let fn_def_id = item.id.owner_id.def_id;
@@ -185,7 +185,7 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
                 .items
                 .iter()
                 .filter_map(|item| {
-                    if !matches!(item.kind, hir::AssocItemKind::Fn { .. }) {
+                    if !matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) {
                         return None;
                     }
                     let did = item.id.owner_id.def_id.to_def_id();

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -137,12 +137,10 @@ struct RPITVisitor<'a, 'tcx> {
     synthetics: Vec<LocalDefId>,
     data: DefPathData,
     disambiguator: &'a mut DisambiguatorState,
-    depth: u32,
 }
 
 impl<'tcx> Visitor<'tcx> for RPITVisitor<'_, 'tcx> {
     fn visit_opaque_ty(&mut self, opaque: &'tcx hir::OpaqueTy<'tcx>) -> Self::Result {
-        self.depth += 1;
         self.synthetics.push(associated_type_for_impl_trait_in_trait(
             self.tcx,
             opaque.def_id,
@@ -172,8 +170,7 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
                 };
                 let def_name = tcx.item_name(fn_def_id.to_def_id());
                 let data = DefPathData::AnonAssocTy(def_name);
-                let mut visitor =
-                    RPITVisitor { tcx, synthetics: vec![], data, depth: 0, disambiguator };
+                let mut visitor = RPITVisitor { tcx, synthetics: vec![], data, disambiguator };
                 visitor.visit_fn_ret_ty(output);
                 let defs = visitor
                     .synthetics

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -29,7 +29,7 @@ fn associated_item_def_ids(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &[DefId] {
             // query.
             let rpitit_items = tcx.associated_types_for_impl_traits_in_trait_or_impl(def_id);
             tcx.arena.alloc_from_iter(trait_item_refs.iter().flat_map(|trait_item_ref| {
-                let item_def_id = trait_item_ref.id.owner_id.to_def_id();
+                let item_def_id = trait_item_ref.owner_id.to_def_id();
                 [item_def_id]
                     .into_iter()
                     .chain(rpitit_items.get(&item_def_id).into_iter().flatten().copied())
@@ -41,7 +41,7 @@ fn associated_item_def_ids(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &[DefId] {
             // associated_types_for_impl_traits_in_trait_or_impl query.
             let rpitit_items = tcx.associated_types_for_impl_traits_in_trait_or_impl(def_id);
             tcx.arena.alloc_from_iter(impl_.items.iter().flat_map(|impl_item_ref| {
-                let item_def_id = impl_item_ref.id.owner_id.to_def_id();
+                let item_def_id = impl_item_ref.owner_id.to_def_id();
                 [item_def_id]
                     .into_iter()
                     .chain(rpitit_items.get(&item_def_id).into_iter().flatten().copied())
@@ -154,10 +154,10 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
         ItemKind::Trait(.., trait_item_refs) => trait_item_refs
             .iter()
             .filter_map(move |item| {
-                if !matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) {
+                if !matches!(tcx.def_kind(item.owner_id), DefKind::AssocFn) {
                     return None;
                 }
-                let fn_def_id = item.id.owner_id.def_id;
+                let fn_def_id = item.owner_id.def_id;
                 let Some(output) = tcx.hir_get_fn_output(fn_def_id) else {
                     return Some((fn_def_id.to_def_id(), vec![]));
                 };
@@ -185,11 +185,11 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
                 .items
                 .iter()
                 .filter_map(|item| {
-                    if !matches!(tcx.def_kind(item.id.owner_id), DefKind::AssocFn) {
+                    if !matches!(tcx.def_kind(item.owner_id), DefKind::AssocFn) {
                         return None;
                     }
-                    let did = item.id.owner_id.def_id.to_def_id();
-                    let item = tcx.hir_impl_item(item.id);
+                    let did = item.owner_id.def_id.to_def_id();
+                    let item = tcx.hir_impl_item(*item);
                     let Some(trait_item_def_id) = item.trait_item_def_id else {
                         return Some((did, vec![]));
                     };

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -6,6 +6,8 @@ use rustc_hir::{self as hir, ItemKind};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{self, ImplTraitInTraitData, TyCtxt};
 use rustc_middle::{bug, span_bug};
+use rustc_span::Ident;
+use rustc_span::symbol::kw;
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers {
@@ -66,46 +68,33 @@ fn impl_item_implementor_ids(tcx: TyCtxt<'_>, impl_id: DefId) -> DefIdMap<DefId>
 }
 
 fn associated_item(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::AssocItem {
-    let id = tcx.local_def_id_to_hir_id(def_id);
-    let parent_def_id = tcx.hir_get_parent_item(id);
-    let parent_item = tcx.hir_expect_item(parent_def_id.def_id);
-    match parent_item.kind {
-        hir::ItemKind::Impl(impl_) => {
-            if let Some(impl_item_ref) = impl_.items.iter().find(|i| i.id.owner_id.def_id == def_id)
-            {
-                let assoc_item = associated_item_from_impl_item_ref(impl_item_ref);
-                debug_assert_eq!(assoc_item.def_id.expect_local(), def_id);
-                return assoc_item;
-            }
-        }
-
-        hir::ItemKind::Trait(.., trait_item_refs) => {
-            if let Some(trait_item_ref) =
-                trait_item_refs.iter().find(|i| i.id.owner_id.def_id == def_id)
-            {
-                let assoc_item = associated_item_from_trait_item_ref(trait_item_ref);
-                debug_assert_eq!(assoc_item.def_id.expect_local(), def_id);
-                return assoc_item;
-            }
-        }
-
-        _ => {}
-    }
-
-    span_bug!(
-        parent_item.span,
-        "unexpected parent of trait or impl item or item not found: {:?}",
-        parent_item.kind
-    )
+    let assoc_item = match tcx.hir_node_by_def_id(def_id) {
+        hir::Node::TraitItem(ti) => associated_item_from_trait_item(tcx, ti),
+        hir::Node::ImplItem(ii) => associated_item_from_impl_item(tcx, ii),
+        node => span_bug!(tcx.def_span(def_id), "impl item or item not found: {:?}", node,),
+    };
+    debug_assert_eq!(assoc_item.def_id.expect_local(), def_id);
+    assoc_item
 }
 
-fn associated_item_from_trait_item_ref(trait_item_ref: &hir::TraitItemRef) -> ty::AssocItem {
-    let owner_id = trait_item_ref.id.owner_id;
-    let name = trait_item_ref.ident.name;
-    let kind = match trait_item_ref.kind {
-        hir::AssocItemKind::Const => ty::AssocKind::Const { name },
-        hir::AssocItemKind::Fn { has_self } => ty::AssocKind::Fn { name, has_self },
-        hir::AssocItemKind::Type => ty::AssocKind::Type { data: ty::AssocTypeData::Normal(name) },
+fn fn_has_self_parameter(tcx: TyCtxt<'_>, owner_id: hir::OwnerId) -> bool {
+    matches!(tcx.fn_arg_idents(owner_id.def_id), [Some(Ident { name: kw::SelfLower, .. }), ..])
+}
+
+fn associated_item_from_trait_item(
+    tcx: TyCtxt<'_>,
+    trait_item: &hir::TraitItem<'_>,
+) -> ty::AssocItem {
+    let owner_id = trait_item.owner_id;
+    let name = trait_item.ident.name;
+    let kind = match trait_item.kind {
+        hir::TraitItemKind::Const { .. } => ty::AssocKind::Const { name },
+        hir::TraitItemKind::Fn { .. } => {
+            ty::AssocKind::Fn { name, has_self: fn_has_self_parameter(tcx, owner_id) }
+        }
+        hir::TraitItemKind::Type { .. } => {
+            ty::AssocKind::Type { data: ty::AssocTypeData::Normal(name) }
+        }
     };
 
     ty::AssocItem {
@@ -116,19 +105,23 @@ fn associated_item_from_trait_item_ref(trait_item_ref: &hir::TraitItemRef) -> ty
     }
 }
 
-fn associated_item_from_impl_item_ref(impl_item_ref: &hir::ImplItemRef) -> ty::AssocItem {
-    let def_id = impl_item_ref.id.owner_id;
-    let name = impl_item_ref.ident.name;
-    let kind = match impl_item_ref.kind {
-        hir::AssocItemKind::Const => ty::AssocKind::Const { name },
-        hir::AssocItemKind::Fn { has_self } => ty::AssocKind::Fn { name, has_self },
-        hir::AssocItemKind::Type => ty::AssocKind::Type { data: ty::AssocTypeData::Normal(name) },
+fn associated_item_from_impl_item(tcx: TyCtxt<'_>, impl_item: &hir::ImplItem<'_>) -> ty::AssocItem {
+    let owner_id = impl_item.owner_id;
+    let name = impl_item.ident.name;
+    let kind = match impl_item.kind {
+        hir::ImplItemKind::Const { .. } => ty::AssocKind::Const { name },
+        hir::ImplItemKind::Fn { .. } => {
+            ty::AssocKind::Fn { name, has_self: fn_has_self_parameter(tcx, owner_id) }
+        }
+        hir::ImplItemKind::Type { .. } => {
+            ty::AssocKind::Type { data: ty::AssocTypeData::Normal(name) }
+        }
     };
 
     ty::AssocItem {
         kind,
-        def_id: def_id.to_def_id(),
-        trait_item_def_id: impl_item_ref.trait_item_def_id,
+        def_id: owner_id.to_def_id(),
+        trait_item_def_id: impl_item.trait_item_def_id,
         container: ty::AssocItemContainer::Impl,
     }
 }
@@ -196,17 +189,13 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
                         return None;
                     }
                     let did = item.id.owner_id.def_id.to_def_id();
+                    let item = tcx.hir_impl_item(item.id);
                     let Some(trait_item_def_id) = item.trait_item_def_id else {
                         return Some((did, vec![]));
                     };
                     let iter = in_trait_def[&trait_item_def_id].iter().map(|&id| {
-                        associated_type_for_impl_trait_in_impl(
-                            tcx,
-                            id,
-                            item.id.owner_id.def_id,
-                            disambiguator,
-                        )
-                        .to_def_id()
+                        associated_type_for_impl_trait_in_impl(tcx, id, item, disambiguator)
+                            .to_def_id()
                     });
                     Some((did, iter.collect()))
                 })
@@ -285,20 +274,20 @@ fn associated_type_for_impl_trait_in_trait(
 
 /// Given an `trait_assoc_def_id` corresponding to an associated item synthesized
 /// from an `impl Trait` in an associated function from a trait, and an
-/// `impl_fn_def_id` that represents an implementation of the associated function
+/// `impl_fn` that represents an implementation of the associated function
 /// that the `impl Trait` comes from, synthesize an associated type for that `impl Trait`
 /// that inherits properties that we infer from the method and the associated type.
 fn associated_type_for_impl_trait_in_impl(
     tcx: TyCtxt<'_>,
     trait_assoc_def_id: DefId,
-    impl_fn_def_id: LocalDefId,
+    impl_fn: &hir::ImplItem<'_>,
     disambiguator: &mut DisambiguatorState,
 ) -> LocalDefId {
-    let impl_local_def_id = tcx.local_parent(impl_fn_def_id);
+    let impl_local_def_id = tcx.local_parent(impl_fn.owner_id.def_id);
 
-    let decl = tcx.hir_node_by_def_id(impl_fn_def_id).fn_decl().expect("expected decl");
-    let span = match decl.output {
-        hir::FnRetTy::DefaultReturn(_) => tcx.def_span(impl_fn_def_id),
+    let hir::ImplItemKind::Fn(fn_sig, _) = impl_fn.kind else { bug!("expected decl") };
+    let span = match fn_sig.decl.output {
+        hir::FnRetTy::DefaultReturn(_) => tcx.def_span(impl_fn.owner_id),
         hir::FnRetTy::Return(ty) => ty.span,
     };
 
@@ -329,7 +318,7 @@ fn associated_type_for_impl_trait_in_impl(
     impl_assoc_ty.associated_item(ty::AssocItem {
         kind: ty::AssocKind::Type {
             data: ty::AssocTypeData::Rpitit(ImplTraitInTraitData::Impl {
-                fn_def_id: impl_fn_def_id.to_def_id(),
+                fn_def_id: impl_fn.owner_id.to_def_id(),
             }),
         },
         def_id,
@@ -338,10 +327,10 @@ fn associated_type_for_impl_trait_in_impl(
     });
 
     // Copy visility of the containing function.
-    impl_assoc_ty.visibility(tcx.visibility(impl_fn_def_id));
+    impl_assoc_ty.visibility(tcx.visibility(impl_fn.owner_id));
 
     // Copy defaultness of the containing function.
-    impl_assoc_ty.defaultness(tcx.defaultness(impl_fn_def_id));
+    impl_assoc_ty.defaultness(tcx.defaultness(impl_fn.owner_id));
 
     // Copy generics_of the trait's associated item but the impl as the parent.
     // FIXME: This may be detrimental to diagnostics, as we resolve the early-bound vars

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -499,7 +499,7 @@ pub(crate) fn build_impl(
             impl_
                 .items
                 .iter()
-                .map(|item| tcx.hir_impl_item(item.id))
+                .map(|&item| tcx.hir_impl_item(item))
                 .filter(|item| {
                     // Filter out impl items whose corresponding trait item has `doc(hidden)`
                     // not to document such impl items.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2867,7 +2867,7 @@ fn clean_maybe_renamed_item<'tcx>(
             ItemKind::Trait(_, _, _, generics, bounds, item_ids) => {
                 let items = item_ids
                     .iter()
-                    .map(|ti| clean_trait_item(cx.tcx.hir_trait_item(ti.id), cx))
+                    .map(|&ti| clean_trait_item(cx.tcx.hir_trait_item(ti), cx))
                     .collect();
 
                 TraitItem(Box::new(Trait {
@@ -2910,7 +2910,7 @@ fn clean_impl<'tcx>(
     let items = impl_
         .items
         .iter()
-        .map(|ii| clean_impl_item(tcx.hir_impl_item(ii.id), cx))
+        .map(|&ii| clean_impl_item(tcx.hir_impl_item(ii), cx))
         .collect::<Vec<_>>();
 
     // If this impl block is an implementation of the Deref trait, then we

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -469,8 +469,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
 
         match item.kind {
             hir::ItemKind::ForeignMod { items, .. } => {
-                for item in items {
-                    let item = tcx.hir_foreign_item(item.id);
+                for &item in items {
+                    let item = tcx.hir_foreign_item(item);
                     self.visit_foreign_item_inner(item, None, None);
                 }
             }

--- a/src/tools/clippy/clippy_lints/src/derivable_impls.rs
+++ b/src/tools/clippy/clippy_lints/src/derivable_impls.rs
@@ -192,7 +192,7 @@ impl<'tcx> LateLintPass<'tcx> for DerivableImpls {
             && !item.span.from_expansion()
             && let Some(def_id) = trait_ref.trait_def_id()
             && cx.tcx.is_diagnostic_item(sym::Default, def_id)
-            && let impl_item_hir = child.id.hir_id()
+            && let impl_item_hir = child.hir_id()
             && let Node::ImplItem(impl_item) = cx.tcx.hir_node(impl_item_hir)
             && let ImplItemKind::Fn(_, b) = &impl_item.kind
             && let Body { value: func_expr, .. } = cx.tcx.hir_body(*b)

--- a/src/tools/clippy/clippy_lints/src/empty_drop.rs
+++ b/src/tools/clippy/clippy_lints/src/empty_drop.rs
@@ -41,7 +41,7 @@ impl LateLintPass<'_> for EmptyDrop {
             ..
         }) = item.kind
             && trait_ref.trait_def_id() == cx.tcx.lang_items().drop_trait()
-            && let impl_item_hir = child.id.hir_id()
+            && let impl_item_hir = child.hir_id()
             && let Node::ImplItem(impl_item) = cx.tcx.hir_node(impl_item_hir)
             && let ImplItemKind::Fn(_, b) = &impl_item.kind
             && let Body { value: func_expr, .. } = cx.tcx.hir_body(*b)

--- a/src/tools/clippy/clippy_lints/src/from_over_into.rs
+++ b/src/tools/clippy/clippy_lints/src/from_over_into.rs
@@ -9,7 +9,7 @@ use clippy_utils::source::SpanRangeExt;
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::{Visitor, walk_path};
 use rustc_hir::{
-    FnRetTy, GenericArg, GenericArgs, HirId, Impl, ImplItemKind, ImplItemRef, Item, ItemKind, PatKind, Path,
+    FnRetTy, GenericArg, GenericArgs, HirId, Impl, ImplItemKind, ImplItemId, Item, ItemKind, PatKind, Path,
     PathSegment, Ty, TyKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
@@ -102,7 +102,7 @@ impl<'tcx> LateLintPass<'tcx> for FromOverInto {
                         middle_trait_ref.self_ty()
                     );
                     if let Some(suggestions) =
-                        convert_to_from(cx, into_trait_seg, target_ty.as_unambig_ty(), self_ty, impl_item_ref)
+                        convert_to_from(cx, into_trait_seg, target_ty.as_unambig_ty(), self_ty, *impl_item_ref)
                     {
                         diag.multipart_suggestion(message, suggestions, Applicability::MachineApplicable);
                     } else {
@@ -164,14 +164,14 @@ fn convert_to_from(
     into_trait_seg: &PathSegment<'_>,
     target_ty: &Ty<'_>,
     self_ty: &Ty<'_>,
-    impl_item_ref: &ImplItemRef,
+    impl_item_ref: ImplItemId,
 ) -> Option<Vec<(Span, String)>> {
     if !target_ty.find_self_aliases().is_empty() {
         // It's tricky to expand self-aliases correctly, we'll ignore it to not cause a
         // bad suggestion/fix.
         return None;
     }
-    let impl_item = cx.tcx.hir_impl_item(impl_item_ref.id);
+    let impl_item = cx.tcx.hir_impl_item(impl_item_ref);
     let ImplItemKind::Fn(ref sig, body_id) = impl_item.kind else {
         return None;
     };

--- a/src/tools/clippy/clippy_lints/src/functions/renamed_function_params.rs
+++ b/src/tools/clippy/clippy_lints/src/functions/renamed_function_params.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::{Applicability, MultiSpan};
 use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_hir::hir_id::OwnerId;
-use rustc_hir::{Impl, ImplItem, ImplItemKind, ImplItemRef, ItemKind, Node, TraitRef};
+use rustc_hir::{Impl, ImplItem, ImplItemKind, ItemKind, Node, TraitRef};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 use rustc_span::symbol::{Ident, kw};
@@ -15,11 +15,10 @@ pub(super) fn check_impl_item(cx: &LateContext<'_>, item: &ImplItem<'_>, ignored
         && let parent_node = cx.tcx.parent_hir_node(item.hir_id())
         && let Node::Item(parent_item) = parent_node
         && let ItemKind::Impl(Impl {
-            items,
             of_trait: Some(trait_ref),
             ..
         }) = &parent_item.kind
-        && let Some(did) = trait_item_def_id_of_impl(items, item.owner_id)
+        && let Some(did) = trait_item_def_id_of_impl(cx, item.owner_id)
         && !is_from_ignored_trait(trait_ref, ignored_traits)
     {
         let mut param_idents_iter = cx.tcx.hir_body_param_idents(body_id);
@@ -93,14 +92,8 @@ impl RenamedFnArgs {
 }
 
 /// Get the [`trait_item_def_id`](ImplItemRef::trait_item_def_id) of a relevant impl item.
-fn trait_item_def_id_of_impl(items: &[ImplItemRef], target: OwnerId) -> Option<DefId> {
-    items.iter().find_map(|item| {
-        if item.id.owner_id == target {
-            item.trait_item_def_id
-        } else {
-            None
-        }
-    })
+fn trait_item_def_id_of_impl(cx: &LateContext<'_>, target: OwnerId) -> Option<DefId> {
+    cx.tcx.associated_item(target).trait_item_def_id
 }
 
 fn is_from_ignored_trait(of_trait: &TraitRef<'_>, ignored_traits: &DefIdSet) -> bool {

--- a/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
+++ b/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
@@ -130,7 +130,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitHasher {
                     });
 
                     let mut ctr_vis = ImplicitHasherConstructorVisitor::new(cx, target);
-                    for item in impl_.items.iter().map(|item| cx.tcx.hir_impl_item(item.id)) {
+                    for item in impl_.items.iter().map(|&item| cx.tcx.hir_impl_item(item)) {
                         ctr_vis.visit_impl_item(item);
                     }
 

--- a/src/tools/clippy/clippy_lints/src/iter_without_into_iter.rs
+++ b/src/tools/clippy/clippy_lints/src/iter_without_into_iter.rs
@@ -139,13 +139,12 @@ impl LateLintPass<'_> for IterWithoutIntoIter {
                 // We can't check inherent impls for slices, but we know that they have an `iter(_mut)` method
                 ty.peel_refs().is_slice() || get_adt_inherent_method(cx, ty, expected_method_name).is_some()
             })
-            && let Some(iter_assoc_span) = imp.items.iter().find_map(|item| {
-                if item.ident.name == sym::IntoIter {
-                    Some(cx.tcx.hir_impl_item(item.id).expect_type().span)
-                } else {
-                    None
-                }
-            })
+            && let Some(iter_assoc_span) = cx.tcx.associated_items(item.owner_id)
+                .filter_by_name_unhygienic_and_kind(sym::IntoIter, ty::AssocTag::Type)
+                .next()
+                .map(|assoc_item| {
+                    cx.tcx.hir_node_by_def_id(assoc_item.def_id.expect_local()).expect_impl_item().expect_type().span
+                })
             && is_ty_exported(cx, ty)
         {
             span_lint_and_then(

--- a/src/tools/clippy/clippy_lints/src/len_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/len_zero.rs
@@ -12,7 +12,7 @@ use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_hir::{
     BinOpKind, Expr, ExprKind, FnRetTy, GenericArg, GenericBound, HirId, ImplItem, ImplItemKind,
     ImplicitSelfKind, Item, ItemKind, Mutability, Node, OpaqueTyOrigin, PatExprKind, PatKind, PathSegment, PrimTy,
-    QPath, TraitItemRef, TyKind,
+    QPath, TraitItemId, TyKind,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, FnSig, Ty};
@@ -265,11 +265,11 @@ fn span_without_enclosing_paren(cx: &LateContext<'_>, span: Span) -> Span {
     }
 }
 
-fn check_trait_items(cx: &LateContext<'_>, visited_trait: &Item<'_>, ident: Ident, trait_items: &[TraitItemRef]) {
-    fn is_named_self(cx: &LateContext<'_>, item: &TraitItemRef, name: Symbol) -> bool {
-        item.ident.name == name
+fn check_trait_items(cx: &LateContext<'_>, visited_trait: &Item<'_>, ident: Ident, trait_items: &[TraitItemId]) {
+    fn is_named_self(cx: &LateContext<'_>, item: &TraitItemId, name: Symbol) -> bool {
+        cx.tcx.item_name(item.owner_id) == name
             && matches!(
-                cx.tcx.fn_arg_idents(item.id.owner_id),
+                cx.tcx.fn_arg_idents(item.owner_id),
                 [Some(Ident { name: kw::SelfLower, .. })],
             )
     }

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -716,7 +716,7 @@ fn report_extra_impl_lifetimes<'tcx>(cx: &LateContext<'tcx>, impl_: &'tcx Impl<'
         walk_trait_ref(&mut checker, trait_ref);
     }
     walk_unambig_ty(&mut checker, impl_.self_ty);
-    for item in impl_.items {
+    for &item in impl_.items {
         walk_impl_item_ref(&mut checker, item);
     }
 

--- a/src/tools/clippy/clippy_lints/src/missing_inline.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_inline.rs
@@ -104,16 +104,16 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
             hir::ItemKind::Trait(ref _is_auto, ref _unsafe, _ident, _generics, _bounds, trait_items) => {
                 // note: we need to check if the trait is exported so we can't use
                 // `LateLintPass::check_trait_item` here.
-                for tit in trait_items {
-                    let tit_ = cx.tcx.hir_trait_item(tit.id);
+                for &tit in trait_items {
+                    let tit_ = cx.tcx.hir_trait_item(tit);
                     match tit_.kind {
                         hir::TraitItemKind::Const(..) | hir::TraitItemKind::Type(..) => {},
                         hir::TraitItemKind::Fn(..) => {
-                            if cx.tcx.defaultness(tit.id.owner_id).has_value() {
+                            if cx.tcx.defaultness(tit.owner_id).has_value() {
                                 // trait method with default body needs inline in case
                                 // an impl is not provided
                                 let desc = "a default trait method";
-                                let item = cx.tcx.hir_trait_item(tit.id);
+                                let item = cx.tcx.hir_trait_item(tit);
                                 let attrs = cx.tcx.hir_attrs(item.hir_id());
                                 check_missing_inline_attrs(cx, attrs, item.span, desc);
                             }

--- a/src/tools/clippy/clippy_lints/src/missing_trait_methods.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_trait_methods.rs
@@ -61,15 +61,14 @@ impl<'tcx> LateLintPass<'tcx> for MissingTraitMethods {
         if !is_lint_allowed(cx, MISSING_TRAIT_METHODS, item.hir_id())
             && span_is_local(item.span)
             && let ItemKind::Impl(Impl {
-                items,
                 of_trait: Some(trait_ref),
                 ..
             }) = item.kind
             && let Some(trait_id) = trait_ref.trait_def_id()
         {
-            let trait_item_ids: DefIdSet = items
-                .iter()
-                .filter_map(|impl_item| impl_item.trait_item_def_id)
+            let trait_item_ids: DefIdSet = cx.tcx.associated_items(item.owner_id)
+                .in_definition_order()
+                .filter_map(|assoc_item| assoc_item.trait_item_def_id)
                 .collect();
 
             for assoc in cx

--- a/src/tools/clippy/clippy_lints/src/partialeq_ne_impl.rs
+++ b/src/tools/clippy/clippy_lints/src/partialeq_ne_impl.rs
@@ -43,12 +43,12 @@ impl<'tcx> LateLintPass<'tcx> for PartialEqNeImpl {
             && trait_ref.path.res.def_id() == eq_trait
         {
             for impl_item in *impl_items {
-                if impl_item.ident.name == sym::ne {
+                if cx.tcx.item_name(impl_item.owner_id) == sym::ne {
                     span_lint_hir(
                         cx,
                         PARTIALEQ_NE_IMPL,
-                        impl_item.id.hir_id(),
-                        impl_item.span,
+                        impl_item.hir_id(),
+                        cx.tcx.def_span(impl_item.owner_id),
                         "re-implementing `PartialEq::ne` is unnecessary",
                     );
                 }

--- a/src/tools/clippy/clippy_lints/src/serde_api.rs
+++ b/src/tools/clippy/clippy_lints/src/serde_api.rs
@@ -36,9 +36,9 @@ impl<'tcx> LateLintPass<'tcx> for SerdeApi {
                 let mut seen_str = None;
                 let mut seen_string = None;
                 for item in *items {
-                    match item.ident.name {
-                        sym::visit_str => seen_str = Some(item.span),
-                        sym::visit_string => seen_string = Some(item.span),
+                    match cx.tcx.item_name(item.owner_id) {
+                        sym::visit_str => seen_str = Some(cx.tcx.def_span(item.owner_id)),
+                        sym::visit_string => seen_string = Some(cx.tcx.def_span(item.owner_id)),
                         _ => {},
                     }
                 }

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default.stderr
@@ -136,13 +136,13 @@ error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
@@ -172,13 +172,13 @@ error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 15 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default_exp.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.default_exp.stderr
@@ -136,13 +136,13 @@ error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
@@ -172,13 +172,13 @@ error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 15 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.ord_within.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.ord_within.stderr
@@ -211,13 +211,13 @@ error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:155:5
    |
 LL |     const A: bool;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:153:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:171:11
@@ -247,13 +247,13 @@ error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:189:5
    |
 LL |     const A: bool = false;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:187:5
    |
 LL |     type SomeType = ();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed.rs:207:11

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.var_1.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.var_1.stderr
@@ -28,25 +28,25 @@ error: incorrect ordering of impl items (defined order: [Fn, Type, Const])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:119:5
    |
 LL |     type SomeType = ();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `A`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:117:5
    |
 LL |     const A: bool = false;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of impl items (defined order: [Fn, Type, Const])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:122:5
    |
 LL |     fn a() {}
-   |     ^^^^^^^^^
+   |     ^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:119:5
    |
 LL |     type SomeType = ();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of items (must be alphabetically ordered)
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:149:8
@@ -76,13 +76,13 @@ error: incorrect ordering of trait items (defined order: [Fn, Type, Const])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:163:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `A`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:161:5
    |
 LL |     const A: bool;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: incorrect ordering of trait items (defined order: [Fn, Type, Const])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:166:5
@@ -94,7 +94,7 @@ note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_mixed_var_1.rs:163:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.only_impl.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.only_impl.stderr
@@ -16,25 +16,25 @@ error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.rs:46:5
    |
 LL |     type SomeType = i8;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `a`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.rs:43:5
    |
 LL |     fn a() {}
-   |     ^^^^^^^^^
+   |     ^^^^^^
 
 error: incorrect ordering of impl items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.rs:49:5
    |
 LL |     const A: bool = true;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_impl.rs:46:5
    |
 LL |     type SomeType = i8;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_only_trait.only_trait.stderr
+++ b/src/tools/clippy/tests/ui-toml/arbitrary_source_item_ordering/ordering_only_trait.only_trait.stderr
@@ -28,13 +28,13 @@ error: incorrect ordering of trait items (defined order: [Const, Type, Fn])
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_trait.rs:45:5
    |
 LL |     const A: bool;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: should be placed before `SomeType`
   --> tests/ui-toml/arbitrary_source_item_ordering/ordering_only_trait.rs:43:5
    |
 LL |     type SomeType;
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/partialeq_ne_impl.stderr
+++ b/src/tools/clippy/tests/ui/partialeq_ne_impl.stderr
@@ -1,12 +1,8 @@
 error: re-implementing `PartialEq::ne` is unnecessary
   --> tests/ui/partialeq_ne_impl.rs:9:5
    |
-LL | /     fn ne(&self, _: &Foo) -> bool {
-LL | |
-LL | |
-LL | |         false
-LL | |     }
-   | |_____^
+LL |     fn ne(&self, _: &Foo) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::partialeq-ne-impl` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::partialeq_ne_impl)]`

--- a/src/tools/clippy/tests/ui/same_name_method.stderr
+++ b/src/tools/clippy/tests/ui/same_name_method.stderr
@@ -2,13 +2,13 @@ error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:20:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    |
 note: existing `foo` defined here
   --> tests/ui/same_name_method.rs:25:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    = note: `-D clippy::same-name-method` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::same_name_method)]`
 
@@ -16,7 +16,7 @@ error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:35:13
    |
 LL |             fn clone() {}
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^
    |
 note: existing `clone` defined here
   --> tests/ui/same_name_method.rs:31:18
@@ -28,19 +28,19 @@ error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:46:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    |
 note: existing `foo` defined here
   --> tests/ui/same_name_method.rs:51:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
 
 error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:61:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    |
 note: existing `foo` defined here
   --> tests/ui/same_name_method.rs:65:9
@@ -52,7 +52,7 @@ error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:74:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    |
 note: existing `foo` defined here
   --> tests/ui/same_name_method.rs:79:9
@@ -64,7 +64,7 @@ error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:74:13
    |
 LL |             fn foo() {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^
    |
 note: existing `foo` defined here
   --> tests/ui/same_name_method.rs:81:9

--- a/src/tools/clippy/tests/ui/serde.stderr
+++ b/src/tools/clippy/tests/ui/serde.stderr
@@ -5,10 +5,7 @@ LL | /     fn visit_string<E>(self, _v: String) -> Result<Self::Value, E>
 LL | |
 LL | |     where
 LL | |         E: serde::de::Error,
-LL | |     {
-LL | |         unimplemented!()
-LL | |     }
-   | |_____^
+   | |____________________________^
    |
    = note: `-D clippy::serde-api-misuse` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::serde_api_misuse)]`

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -150,7 +150,7 @@ impl Foo {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
 #[rustc_clean(cfg="cfail6")]

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -141,7 +141,7 @@ pub trait ChangeMethodSelfnessTrait {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
+#[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
@@ -179,7 +179,7 @@ pub trait RemoveMethodSelfnessTrait {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
+#[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]

--- a/tests/ui/associated-consts/issue-58022.stderr
+++ b/tests/ui/associated-consts/issue-58022.stderr
@@ -16,7 +16,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/issue-58022.rs:4:25
    |
 LL |     const SIZE: usize;
-   |     ------------------ `Foo::SIZE` defined here
+   |     ----------------- `Foo::SIZE` defined here
 LL |
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |                         ^^^^^^^^^ cannot refer to the associated constant of trait

--- a/tests/ui/associated-consts/issue-63496.stderr
+++ b/tests/ui/associated-consts/issue-63496.stderr
@@ -2,7 +2,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/issue-63496.rs:4:21
    |
 LL |     const C: usize;
-   |     --------------- `A::C` defined here
+   |     -------------- `A::C` defined here
 LL |
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |                     ^^^^ cannot refer to the associated constant of trait
@@ -11,7 +11,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/issue-63496.rs:4:33
    |
 LL |     const C: usize;
-   |     --------------- `A::C` defined here
+   |     -------------- `A::C` defined here
 LL |
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
    |                                 ^^^^ cannot refer to the associated constant of trait

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -18,7 +18,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/issue-48027.rs:3:32
    |
 LL |     const X: usize;
-   |     --------------- `Bar::X` defined here
+   |     -------------- `Bar::X` defined here
 LL |     fn return_n(&self) -> [u8; Bar::X];
    |                                ^^^^^^ cannot refer to the associated constant of trait
 

--- a/tests/ui/associated-types/defaults-in-other-trait-items.stderr
+++ b/tests/ui/associated-types/defaults-in-other-trait-items.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/defaults-in-other-trait-items.rs:9:13
    |
 LL |     type A = ();
-   |     ------------ associated type defaults can't be assumed inside the trait defining them
+   |     ------ associated type defaults can't be assumed inside the trait defining them
 ...
 LL |         let () = p;
    |             ^^   - this expression has type `<Self as Tr>::A`
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> $DIR/defaults-in-other-trait-items.rs:36:25
    |
 LL |     type Ty = u8;
-   |     ------------- associated type defaults can't be assumed inside the trait defining them
+   |     ------- associated type defaults can't be assumed inside the trait defining them
 ...
 LL |     const C: Self::Ty = 0u8;
    |                         ^^^ expected associated type, found `u8`
@@ -28,7 +28,7 @@ error[E0308]: mismatched types
   --> $DIR/defaults-in-other-trait-items.rs:54:9
    |
 LL |     type Res = isize;
-   |     ----------------- associated type defaults can't be assumed inside the trait defining them
+   |     -------- associated type defaults can't be assumed inside the trait defining them
 LL |
 LL |     fn infer_me_correctly() -> Self::Res {
    |                                --------- expected `<Self as Trait>::Res` because of return type

--- a/tests/ui/associated-types/defaults-specialization.stderr
+++ b/tests/ui/associated-types/defaults-specialization.stderr
@@ -31,7 +31,7 @@ error[E0053]: method `make` has an incompatible type for trait
   --> $DIR/defaults-specialization.rs:35:18
    |
 LL |     default type Ty = bool;
-   |     ----------------------- associated type is `default` and may be overridden
+   |     --------------- associated type is `default` and may be overridden
 LL |
 LL |     fn make() -> bool { true }
    |                  ^^^^ expected associated type, found `bool`
@@ -53,7 +53,7 @@ error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:10:9
    |
 LL |     type Ty = u8;
-   |     ------------- associated type defaults can't be assumed inside the trait defining them
+   |     ------- associated type defaults can't be assumed inside the trait defining them
 LL |
 LL |     fn make() -> Self::Ty {
    |                  -------- expected `<Self as Tr>::Ty` because of return type
@@ -80,7 +80,7 @@ error[E0308]: mismatched types
   --> $DIR/defaults-specialization.rs:44:29
    |
 LL |     default type Ty = bool;
-   |     ----------------------- associated type is `default` and may be overridden
+   |     --------------- associated type is `default` and may be overridden
 LL |
 LL |     fn make() -> Self::Ty { true }
    |                  --------   ^^^^ expected associated type, found `bool`

--- a/tests/ui/associated-types/issue-26681.stderr
+++ b/tests/ui/associated-types/issue-26681.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-26681.rs:17:39
    |
 LL |     type Fv: Foo = u8;
-   |     ------------------ associated type defaults can't be assumed inside the trait defining them
+   |     ------------ associated type defaults can't be assumed inside the trait defining them
 LL |     const C: <Self::Fv as Foo>::Bar = 6665;
    |                                       ^^^^ expected associated type, found integer
    |

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -10,14 +10,11 @@ LL |     const fn const_val<T: Sized>() -> usize {
 error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/issue-54954.rs:1:24
    |
-LL |   const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
 ...
-LL | /     const fn const_val<T: Sized>() -> usize {
-LL | |
-LL | |         core::mem::size_of::<T>()
-LL | |     }
-   | |_____- `Tt::const_val` defined here
+LL |     const fn const_val<T: Sized>() -> usize {
+   |     --------------------------------------- `Tt::const_val` defined here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0790.stderr
+++ b/tests/ui/error-codes/E0790.stderr
@@ -16,7 +16,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/E0790.rs:21:17
    |
 LL |         const MY_ASSOC_CONST: ();
-   |         ------------------------- `MyTrait::MY_ASSOC_CONST` defined here
+   |         ------------------------ `MyTrait::MY_ASSOC_CONST` defined here
 ...
 LL |         let _ = MyTrait::MY_ASSOC_CONST;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ cannot refer to the associated constant of trait
@@ -44,7 +44,7 @@ error[E0790]: cannot refer to the associated constant on trait without specifyin
   --> $DIR/E0790.rs:30:13
    |
 LL |         const MY_ASSOC_CONST: ();
-   |         ------------------------- `MyTrait::MY_ASSOC_CONST` defined here
+   |         ------------------------ `MyTrait::MY_ASSOC_CONST` defined here
 ...
 LL |     let _ = inner::MyTrait::MY_ASSOC_CONST;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot refer to the associated constant of trait

--- a/tests/ui/feature-gates/feature-gate-async-drop.stderr
+++ b/tests/ui/feature-gates/feature-gate-async-drop.stderr
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature `async_drop`
   --> $DIR/feature-gate-async-drop.rs:13:5
    |
 LL |     async fn drop(self: Pin<&mut Self>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #126482 <https://github.com/rust-lang/rust/issues/126482> for more information
    = help: add `#![feature(async_drop)]` to the crate attributes to enable

--- a/tests/ui/generics/export-name-on-generics.stderr
+++ b/tests/ui/generics/export-name-on-generics.stderr
@@ -4,7 +4,7 @@ error: functions generic over types or consts must be mangled
 LL | #[export_name = "foo"]
    | ---------------------- help: remove this attribute
 LL | pub fn foo<T>() {}
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/export-name-on-generics.rs:3:9
@@ -18,7 +18,7 @@ error: functions generic over types or consts must be mangled
 LL | #[export_name = "bar"]
    | ---------------------- help: remove this attribute
 LL | pub extern "C" fn bar<T>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:21:5
@@ -26,7 +26,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo"]
    |     ---------------------- help: remove this attribute
 LL |     pub fn foo<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:24:5
@@ -34,7 +34,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "bar"]
    |     ---------------------- help: remove this attribute
 LL |     pub extern "C" fn bar<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:42:5
@@ -42,7 +42,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo"]
    |     ---------------------- help: remove this attribute
 LL |     fn foo<T>() {}
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:45:5
@@ -50,7 +50,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "bar"]
    |     ---------------------- help: remove this attribute
 LL |     extern "C" fn bar<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:64:5
@@ -58,7 +58,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo"]
    |     ---------------------- help: remove this attribute
 LL |     fn foo() {}
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:67:5
@@ -66,7 +66,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo2"]
    |     ----------------------- help: remove this attribute
 LL |     fn foo2<U>() {}
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:70:5
@@ -74,7 +74,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "baz"]
    |     ---------------------- help: remove this attribute
 LL |     extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:73:5
@@ -82,7 +82,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "baz"]
    |     ---------------------- help: remove this attribute
 LL |     fn baz(x: &i32) -> &i32 { x }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:76:5
@@ -90,7 +90,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "qux"]
    |     ---------------------- help: remove this attribute
 LL |     fn qux<'a>(x: &'a i32) -> &i32 { x }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:83:5
@@ -98,7 +98,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo"]
    |     ---------------------- help: remove this attribute
 LL |     pub fn foo() {}
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:86:5
@@ -106,7 +106,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "bar"]
    |     ---------------------- help: remove this attribute
 LL |     pub extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:89:5
@@ -114,7 +114,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "baz"]
    |     ---------------------- help: remove this attribute
 LL |     pub fn baz<U>() {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:105:5
@@ -122,7 +122,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "foo"]
    |     ---------------------- help: remove this attribute
 LL |     fn foo() {}
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:108:5
@@ -130,7 +130,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "bar"]
    |     ---------------------- help: remove this attribute
 LL |     extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/export-name-on-generics.rs:111:5
@@ -138,7 +138,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[export_name = "baz"]
    |     ---------------------- help: remove this attribute
 LL |     fn baz<U>() {}
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/generics/generic-no-mangle.stderr
+++ b/tests/ui/generics/generic-no-mangle.stderr
@@ -4,7 +4,7 @@ error: functions generic over types or consts must be mangled
 LL | #[no_mangle]
    | ------------ help: remove this attribute
 LL | pub fn foo<T>() {}
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/generic-no-mangle.rs:3:9
@@ -18,7 +18,7 @@ error: functions generic over types or consts must be mangled
 LL | #[no_mangle]
    | ------------ help: remove this attribute
 LL | pub extern "C" fn bar<T>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:21:5
@@ -26,7 +26,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     pub fn foo<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:24:5
@@ -34,7 +34,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     pub extern "C" fn bar<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:42:5
@@ -42,7 +42,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn foo<T>() {}
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:45:5
@@ -50,7 +50,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     extern "C" fn bar<T>() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:64:5
@@ -58,7 +58,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn foo() {}
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:67:5
@@ -66,7 +66,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn foo2<U>() {}
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:70:5
@@ -74,7 +74,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:73:5
@@ -82,7 +82,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn baz(x: &i32) -> &i32 { x }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:76:5
@@ -90,7 +90,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn qux<'a>(x: &'a i32) -> &i32 { x }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:83:5
@@ -98,7 +98,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     pub fn foo() {}
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:86:5
@@ -106,7 +106,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     pub extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:89:5
@@ -114,7 +114,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     pub fn baz<U>() {}
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:105:5
@@ -122,7 +122,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn foo() {}
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:108:5
@@ -130,7 +130,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     extern "C" fn bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: functions generic over types or consts must be mangled
   --> $DIR/generic-no-mangle.rs:111:5
@@ -138,7 +138,7 @@ error: functions generic over types or consts must be mangled
 LL |     #[no_mangle]
    |     ------------ help: remove this attribute
 LL |     fn baz<U>() {}
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -290,7 +290,7 @@ error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:179:9
    |
 LL |         fn trait_unstable(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/ui/lint/suggestions.stderr
+++ b/tests/ui/lint/suggestions.stderr
@@ -65,7 +65,7 @@ LL | #[no_mangle]
    | ------------ help: remove this attribute
 LL |
 LL | pub fn defiant<T>(_t: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(no_mangle_generic_items)]` on by default
 
@@ -89,7 +89,7 @@ warning: functions generic over types or consts must be mangled
   --> $DIR/suggestions.rs:26:18
    |
 LL |     #[no_mangle] pub fn val_jean<T>() {}
-   |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ------------ ^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: remove this attribute
 
@@ -105,7 +105,7 @@ warning: functions generic over types or consts must be mangled
   --> $DIR/suggestions.rs:35:18
    |
 LL |     #[no_mangle] pub(crate) fn crossfield<T>() {}
-   |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     help: remove this attribute
 

--- a/tests/ui/specialization/specialization-default-types.current.stderr
+++ b/tests/ui/specialization/specialization-default-types.current.stderr
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:19:9
    |
 LL |     default type Output = Box<T>;
-   |     ----------------------------- associated type is `default` and may be overridden
+   |     ------------------- associated type is `default` and may be overridden
 LL |     default fn generate(self) -> Self::Output {
    |                                  ------------ expected `<T as Example>::Output` because of return type
 LL |         Box::new(self)

--- a/tests/ui/specialization/specialization-default-types.next.stderr
+++ b/tests/ui/specialization/specialization-default-types.next.stderr
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
   --> $DIR/specialization-default-types.rs:19:9
    |
 LL |     default type Output = Box<T>;
-   |     ----------------------------- associated type is `default` and may be overridden
+   |     ------------------- associated type is `default` and may be overridden
 LL |     default fn generate(self) -> Self::Output {
    |                                  ------------ expected `<T as Example>::Output` because of return type
 LL |         Box::new(self)

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -117,7 +117,7 @@ hir-stats ImplItemRef               48 (NN.N%)             2            24
 hir-stats ExprField                 40 (NN.N%)             1            40
 hir-stats Mod                       32 (NN.N%)             1            32
 hir-stats Lifetime                  28 (NN.N%)             1            28
-hir-stats ForeignItemRef            24 (NN.N%)             1            24
+hir-stats ForeignItemId              4 (NN.N%)             1             4
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_684                   173
+hir-stats Total                  8_664                   173
 hir-stats ================================================================

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -107,17 +107,17 @@ hir-stats WherePredicate            72 (NN.N%)             3            24
 hir-stats - BoundPredicate            72 (NN.N%)             3
 hir-stats Local                     72 (NN.N%)             1            72
 hir-stats InlineAsm                 72 (NN.N%)             1            72
-hir-stats ImplItemRef               72 (NN.N%)             2            36
 hir-stats Body                      72 (NN.N%)             3            24
 hir-stats Param                     64 (NN.N%)             2            32
 hir-stats GenericArg                64 (NN.N%)             4            16
 hir-stats - Type                      16 (NN.N%)             1
 hir-stats - Lifetime                  48 (NN.N%)             3
 hir-stats TraitItemRef              56 (NN.N%)             2            28
+hir-stats ImplItemRef               56 (NN.N%)             2            28
 hir-stats ExprField                 40 (NN.N%)             1            40
 hir-stats Mod                       32 (NN.N%)             1            32
 hir-stats Lifetime                  28 (NN.N%)             1            28
 hir-stats ForeignItemRef            24 (NN.N%)             1            24
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_716                   173
+hir-stats Total                  8_700                   173
 hir-stats ================================================================

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -112,12 +112,12 @@ hir-stats Param                     64 (NN.N%)             2            32
 hir-stats GenericArg                64 (NN.N%)             4            16
 hir-stats - Type                      16 (NN.N%)             1
 hir-stats - Lifetime                  48 (NN.N%)             3
-hir-stats TraitItemRef              48 (NN.N%)             2            24
-hir-stats ImplItemRef               48 (NN.N%)             2            24
 hir-stats ExprField                 40 (NN.N%)             1            40
 hir-stats Mod                       32 (NN.N%)             1            32
 hir-stats Lifetime                  28 (NN.N%)             1            28
+hir-stats TraitItemId                8 (NN.N%)             2             4
+hir-stats ImplItemId                 8 (NN.N%)             2             4
 hir-stats ForeignItemId              4 (NN.N%)             1             4
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_664                   173
+hir-stats Total                  8_584                   173
 hir-stats ================================================================

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -112,12 +112,12 @@ hir-stats Param                     64 (NN.N%)             2            32
 hir-stats GenericArg                64 (NN.N%)             4            16
 hir-stats - Type                      16 (NN.N%)             1
 hir-stats - Lifetime                  48 (NN.N%)             3
-hir-stats TraitItemRef              56 (NN.N%)             2            28
-hir-stats ImplItemRef               56 (NN.N%)             2            28
+hir-stats TraitItemRef              48 (NN.N%)             2            24
+hir-stats ImplItemRef               48 (NN.N%)             2            24
 hir-stats ExprField                 40 (NN.N%)             1            40
 hir-stats Mod                       32 (NN.N%)             1            32
 hir-stats Lifetime                  28 (NN.N%)             1            28
 hir-stats ForeignItemRef            24 (NN.N%)             1            24
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_700                   173
+hir-stats Total                  8_684                   173
 hir-stats ================================================================

--- a/tests/ui/suggestions/issue-104327.stderr
+++ b/tests/ui/suggestions/issue-104327.stderr
@@ -2,7 +2,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
   --> $DIR/issue-104327.rs:10:5
    |
 LL |     fn f() {}
-   |     --------- `Foo::f` defined here
+   |     ------ `Foo::f` defined here
 ...
 LL |     Foo::f();
    |     ^^^^^^^^ cannot call associated function of trait

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -50,7 +50,7 @@ error: not a function
   --> $DIR/rustc_must_implement_one_of_misuse.rs:26:5
    |
 LL |     const A: u8 = 1;
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^
    |
 note: required by this annotation
   --> $DIR/rustc_must_implement_one_of_misuse.rs:24:1
@@ -63,7 +63,7 @@ error: not a function
   --> $DIR/rustc_must_implement_one_of_misuse.rs:28:5
    |
 LL |     type B;
-   |     ^^^^^^^
+   |     ^^^^^^
    |
 note: required by this annotation
   --> $DIR/rustc_must_implement_one_of_misuse.rs:24:1

--- a/tests/ui/traits/trait-upcasting/deref-upcast-shadowing-lint.stderr
+++ b/tests/ui/traits/trait-upcasting/deref-upcast-shadowing-lint.stderr
@@ -5,7 +5,7 @@ LL | impl<'a> Deref for dyn Foo + 'a {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Foo` implements `Deref<Target = dyn Bar<u32>>` which conflicts with supertrait `Bar<i32>`
 LL |
 LL |     type Target = dyn Bar<u32> + 'a;
-   |     -------------------------------- target type is a supertrait of `dyn Foo`
+   |     ----------- target type is a supertrait of `dyn Foo`
    |
 note: the lint level is defined here
   --> $DIR/deref-upcast-shadowing-lint.rs:2:9

--- a/tests/ui/traits/trait-upcasting/migrate-lint-deny-regions.stderr
+++ b/tests/ui/traits/trait-upcasting/migrate-lint-deny-regions.stderr
@@ -5,7 +5,7 @@ LL | impl<'a> Deref for dyn Foo<'a> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Foo<'_>` implements `Deref<Target = dyn Bar<'_>>` which conflicts with supertrait `Bar<'_>`
 LL |
 LL |     type Target = dyn Bar<'a>;
-   |     -------------------------- target type is a supertrait of `dyn Foo<'_>`
+   |     ----------- target type is a supertrait of `dyn Foo<'_>`
    |
 note: the lint level is defined here
   --> $DIR/migrate-lint-deny-regions.rs:2:9

--- a/tests/ui/traits/trait-upcasting/migrate-lint-different-substs.stderr
+++ b/tests/ui/traits/trait-upcasting/migrate-lint-different-substs.stderr
@@ -5,7 +5,7 @@ LL | impl<'a> Deref for dyn Foo + 'a {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Foo` implements `Deref<Target = dyn Bar<u32>>` which conflicts with supertrait `Bar<i32>`
 LL |
 LL |     type Target = dyn Bar<u32> + 'a;
-   |     -------------------------------- target type is a supertrait of `dyn Foo`
+   |     ----------- target type is a supertrait of `dyn Foo`
    |
 note: the lint level is defined here
   --> $DIR/migrate-lint-different-substs.rs:2:9


### PR DESCRIPTION
This information was kept for various places that iterate on HIR to know about trait-items and impl-items.

This PR replaces them by uses of the `associated_items` query that contain pretty much the same information.

This shortens many spans to just `def_span`, which can be easier to read.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
