### PR TITLE
remove redundant #[must_use]

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1449,7 +1449,6 @@ pub trait PartialOrd<Rhs: PointeeSized = Self>: PartialEq<Rhs> + PointeeSized {
     /// check `==` and `<` separately to do rather than needing to calculate
     /// (then optimize out) the three-way `Ordering` result.
     #[inline]
-    #[must_use]
     // Added to improve the behaviour of tuples; not necessarily stabilization-track.
     #[unstable(feature = "partial_ord_chaining_methods", issue = "none")]
     #[doc(hidden)]
@@ -1459,7 +1458,6 @@ pub trait PartialOrd<Rhs: PointeeSized = Self>: PartialEq<Rhs> + PointeeSized {
 
     /// Same as `__chaining_lt`, but for `<=` instead of `<`.
     #[inline]
-    #[must_use]
     #[unstable(feature = "partial_ord_chaining_methods", issue = "none")]
     #[doc(hidden)]
     fn __chaining_le(&self, other: &Rhs) -> ControlFlow<bool> {
@@ -1468,7 +1466,6 @@ pub trait PartialOrd<Rhs: PointeeSized = Self>: PartialEq<Rhs> + PointeeSized {
 
     /// Same as `__chaining_lt`, but for `>` instead of `<`.
     #[inline]
-    #[must_use]
     #[unstable(feature = "partial_ord_chaining_methods", issue = "none")]
     #[doc(hidden)]
     fn __chaining_gt(&self, other: &Rhs) -> ControlFlow<bool> {
@@ -1477,7 +1474,6 @@ pub trait PartialOrd<Rhs: PointeeSized = Self>: PartialEq<Rhs> + PointeeSized {
 
     /// Same as `__chaining_lt`, but for `>=` instead of `<`.
     #[inline]
-    #[must_use]
     #[unstable(feature = "partial_ord_chaining_methods", issue = "none")]
     #[doc(hidden)]
     fn __chaining_ge(&self, other: &Rhs) -> ControlFlow<bool> {


### PR DESCRIPTION
Fixes these clippy warnings:
```
warning: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
    --> library/core/src/cmp.rs:1456:5
     |
1456 |     fn __chaining_lt(&self, other: &Rhs) -> ControlFlow<bool> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: either add some descriptive message or remove the attribute
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_must_use
     = note: `-D clippy::double-must-use` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::double_must_use)]`

warning: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
    --> library/core/src/cmp.rs:1465:5
     |
1465 |     fn __chaining_le(&self, other: &Rhs) -> ControlFlow<bool> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: either add some descriptive message or remove the attribute
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_must_use

warning: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
    --> library/core/src/cmp.rs:1474:5
     |
1474 |     fn __chaining_gt(&self, other: &Rhs) -> ControlFlow<bool> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: either add some descriptive message or remove the attribute
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_must_use

warning: this function has a `#[must_use]` attribute with no message, but returns a type already marked as `#[must_use]`
    --> library/core/src/cmp.rs:1483:5
     |
1483 |     fn __chaining_ge(&self, other: &Rhs) -> ControlFlow<bool> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: either add some descriptive message or remove the attribute
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_must_use
```