### PR TITLE
reduce repetition with macros and document overrides of the default impl of PartialEq::ne

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1898,10 +1898,6 @@ mod impls {
         fn eq(&self, _other: &()) -> bool {
             true
         }
-        #[inline]
-        fn ne(&self, _other: &()) -> bool {
-            false
-        }
     }
 
     macro_rules! eq_impl {

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -2115,185 +2115,101 @@ mod impls {
         }
     }
 
-    // & pointers
+    // reference types
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialEq<&B> for &A
-    where
-        A: [const] PartialEq<B>,
-    {
-        #[inline]
-        fn eq(&self, other: &&B) -> bool {
-            PartialEq::eq(*self, *other)
-        }
-        #[inline]
-        fn ne(&self, other: &&B) -> bool {
-            PartialEq::ne(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialOrd<&B> for &A
-    where
-        A: [const] PartialOrd<B>,
-    {
-        #[inline]
-        fn partial_cmp(&self, other: &&B) -> Option<Ordering> {
-            PartialOrd::partial_cmp(*self, *other)
-        }
-        #[inline]
-        fn lt(&self, other: &&B) -> bool {
-            PartialOrd::lt(*self, *other)
-        }
-        #[inline]
-        fn le(&self, other: &&B) -> bool {
-            PartialOrd::le(*self, *other)
-        }
-        #[inline]
-        fn gt(&self, other: &&B) -> bool {
-            PartialOrd::gt(*self, *other)
-        }
-        #[inline]
-        fn ge(&self, other: &&B) -> bool {
-            PartialOrd::ge(*self, *other)
-        }
-        #[inline]
-        fn __chaining_lt(&self, other: &&B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_lt(*self, *other)
-        }
-        #[inline]
-        fn __chaining_le(&self, other: &&B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_le(*self, *other)
-        }
-        #[inline]
-        fn __chaining_gt(&self, other: &&B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_gt(*self, *other)
-        }
-        #[inline]
-        fn __chaining_ge(&self, other: &&B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_ge(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized> const Ord for &A
-    where
-        A: [const] Ord,
-    {
-        #[inline]
-        fn cmp(&self, other: &Self) -> Ordering {
-            Ord::cmp(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized> const Eq for &A where A: [const] Eq {}
-
-    // &mut pointers
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialEq<&mut B> for &mut A
-    where
-        A: [const] PartialEq<B>,
-    {
-        #[inline]
-        fn eq(&self, other: &&mut B) -> bool {
-            PartialEq::eq(*self, *other)
-        }
-        #[inline]
-        fn ne(&self, other: &&mut B) -> bool {
-            PartialEq::ne(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialOrd<&mut B> for &mut A
-    where
-        A: [const] PartialOrd<B>,
-    {
-        #[inline]
-        fn partial_cmp(&self, other: &&mut B) -> Option<Ordering> {
-            PartialOrd::partial_cmp(*self, *other)
-        }
-        #[inline]
-        fn lt(&self, other: &&mut B) -> bool {
-            PartialOrd::lt(*self, *other)
-        }
-        #[inline]
-        fn le(&self, other: &&mut B) -> bool {
-            PartialOrd::le(*self, *other)
-        }
-        #[inline]
-        fn gt(&self, other: &&mut B) -> bool {
-            PartialOrd::gt(*self, *other)
-        }
-        #[inline]
-        fn ge(&self, other: &&mut B) -> bool {
-            PartialOrd::ge(*self, *other)
-        }
-        #[inline]
-        fn __chaining_lt(&self, other: &&mut B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_lt(*self, *other)
-        }
-        #[inline]
-        fn __chaining_le(&self, other: &&mut B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_le(*self, *other)
-        }
-        #[inline]
-        fn __chaining_gt(&self, other: &&mut B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_gt(*self, *other)
-        }
-        #[inline]
-        fn __chaining_ge(&self, other: &&mut B) -> ControlFlow<bool> {
-            PartialOrd::__chaining_ge(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized> const Ord for &mut A
-    where
-        A: [const] Ord,
-    {
-        #[inline]
-        fn cmp(&self, other: &Self) -> Ordering {
-            Ord::cmp(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized> const Eq for &mut A where A: [const] Eq {}
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialEq<&mut B> for &A
-    where
-        A: [const] PartialEq<B>,
-    {
-        #[inline]
-        fn eq(&self, other: &&mut B) -> bool {
-            PartialEq::eq(*self, *other)
-        }
-        #[inline]
-        fn ne(&self, other: &&mut B) -> bool {
-            PartialEq::ne(*self, *other)
-        }
+    macro_rules! impl_partial_eq {
+        (<$A:ident, $B:ident> for $(($ref_A:ty, $ref_B:ty))*) => ($(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            impl<$A, $B> const PartialEq<$ref_B> for $ref_A
+            where
+                $A: [const] PartialEq<$B> + PointeeSized,
+                $B: PointeeSized,
+            {
+                #[inline]
+                fn eq(&self, other: &$ref_B) -> bool {
+                    PartialEq::eq(*self, *other)
+                }
+                // if <A as PartialEq<B>>::ne uses inline assembly or FFI, then
+                // this forwarding impl may be more efficient than the default impl
+                #[inline]
+                fn ne(&self, other: &$ref_B) -> bool {
+                    PartialEq::ne(*self, *other)
+                }
+            }
+        )*)
     }
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    impl<A: PointeeSized, B: PointeeSized> const PartialEq<&B> for &mut A
-    where
-        A: [const] PartialEq<B>,
-    {
-        #[inline]
-        fn eq(&self, other: &&B) -> bool {
-            PartialEq::eq(*self, *other)
-        }
-        #[inline]
-        fn ne(&self, other: &&B) -> bool {
-            PartialEq::ne(*self, *other)
-        }
+    impl_partial_eq!(<A, B> for (&A, &B) (&A, &mut B) (&mut A, &B) (&mut A, &mut B));
+
+    macro_rules! impl_partial_ord {
+        (<$A:ident, $B:ident> for $(($ref_A:ty, $ref_B:ty))*) => ($(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            impl<$A, $B> const PartialOrd<$ref_B> for $ref_A
+            where
+                $A: [const] PartialOrd<$B> + PointeeSized,
+                $B: PointeeSized,
+            {
+                #[inline]
+                fn partial_cmp(&self, other: &$ref_B) -> Option<Ordering> {
+                    PartialOrd::partial_cmp(*self, *other)
+                }
+                #[inline]
+                fn lt(&self, other: &$ref_B) -> bool {
+                    PartialOrd::lt(*self, *other)
+                }
+                #[inline]
+                fn le(&self, other: &$ref_B) -> bool {
+                    PartialOrd::le(*self, *other)
+                }
+                #[inline]
+                fn gt(&self, other: &$ref_B) -> bool {
+                    PartialOrd::gt(*self, *other)
+                }
+                #[inline]
+                fn ge(&self, other: &$ref_B) -> bool {
+                    PartialOrd::ge(*self, *other)
+                }
+                #[inline]
+                fn __chaining_lt(&self, other: &$ref_B) -> ControlFlow<bool> {
+                    PartialOrd::__chaining_lt(*self, *other)
+                }
+                #[inline]
+                fn __chaining_le(&self, other: &$ref_B) -> ControlFlow<bool> {
+                    PartialOrd::__chaining_le(*self, *other)
+                }
+                #[inline]
+                fn __chaining_gt(&self, other: &$ref_B) -> ControlFlow<bool> {
+                    PartialOrd::__chaining_gt(*self, *other)
+                }
+                #[inline]
+                fn __chaining_ge(&self, other: &$ref_B) -> ControlFlow<bool> {
+                    PartialOrd::__chaining_ge(*self, *other)
+                }
+            }
+        )*)
     }
+
+    impl_partial_ord!(<A, B> for (&A, &B) /*(&A, &mut B) (&mut A, &B)*/ (&mut A, &mut B));
+
+    macro_rules! impl_ord_eq {
+        (<$A:ident> for $($ref_A:ty),*) => ($(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            impl<$A: [const] Ord + PointeeSized> const Ord for $ref_A
+            {
+                #[inline]
+                fn cmp(&self, other: &Self) -> Ordering {
+                    Ord::cmp(*self, *other)
+                }
+            }
+
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            impl<$A: [const] Eq + PointeeSized> const Eq for $ref_A {}
+        )*)
+    }
+
+    impl_ord_eq!(<A> for &A, &mut A);
 }

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -12,7 +12,7 @@ help: the trait `PartialEq<Foo>` is not implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/self-referential-3.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.stderr
@@ -13,7 +13,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/self-referential-4.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.stderr
@@ -12,7 +12,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Foo<'static, 'b>`
   --> $DIR/self-referential-4.rs:13:31
@@ -28,7 +28,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `Moo<'static, 'a>`
   --> $DIR/self-referential-4.rs:20:31
@@ -44,7 +44,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type-alias-impl-trait/self-referential.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential.stderr
@@ -13,7 +13,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Foo<'a, 'b>::{opaque#0}<'a, 'b>)`
   --> $DIR/self-referential.rs:14:31
@@ -30,7 +30,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `&i32` with `(i32, Moo<'b, 'a>::{opaque#0}<'b, 'a>)`
   --> $DIR/self-referential.rs:22:31
@@ -47,7 +47,7 @@ help: the trait `PartialEq` is implemented for `i32`
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `partial_eq_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_partial_eq_for_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<del>Removes manual impls of PartialEq::ne which are equivalent to the default.</del>

- Cleans up documentation of `PartialEq::ne` and documents overrides of the default impl.
- Uses macros to remove duplication.