### PR TITLE
Move NaN tests to floats/mod.rs

### DIFF
--- a/library/coretests/tests/floats/f128.rs
+++ b/library/coretests/tests/floats/f128.rs
@@ -56,20 +56,6 @@ fn test_num_f128() {
 // the intrinsics.
 
 #[test]
-fn test_nan() {
-    let nan: f128 = f128::NAN;
-    assert!(nan.is_nan());
-    assert!(!nan.is_infinite());
-    assert!(!nan.is_finite());
-    assert!(nan.is_sign_positive());
-    assert!(!nan.is_sign_negative());
-    assert!(!nan.is_normal());
-    assert_eq!(Fp::Nan, nan.classify());
-    // Ensure the quiet bit is set.
-    assert!(nan.to_bits() & (1 << (f128::MANTISSA_DIGITS - 2)) != 0);
-}
-
-#[test]
 fn test_infinity() {
     let inf: f128 = f128::INFINITY;
     assert!(inf.is_infinite());

--- a/library/coretests/tests/floats/f16.rs
+++ b/library/coretests/tests/floats/f16.rs
@@ -52,20 +52,6 @@ fn test_num_f16() {
 // the intrinsics.
 
 #[test]
-fn test_nan() {
-    let nan: f16 = f16::NAN;
-    assert!(nan.is_nan());
-    assert!(!nan.is_infinite());
-    assert!(!nan.is_finite());
-    assert!(nan.is_sign_positive());
-    assert!(!nan.is_sign_negative());
-    assert!(!nan.is_normal());
-    assert_eq!(Fp::Nan, nan.classify());
-    // Ensure the quiet bit is set.
-    assert!(nan.to_bits() & (1 << (f16::MANTISSA_DIGITS - 2)) != 0);
-}
-
-#[test]
 fn test_infinity() {
     let inf: f16 = f16::INFINITY;
     assert!(inf.is_infinite());

--- a/library/coretests/tests/floats/f32.rs
+++ b/library/coretests/tests/floats/f32.rs
@@ -36,20 +36,6 @@ fn test_num_f32() {
 }
 
 #[test]
-fn test_nan() {
-    let nan: f32 = f32::NAN;
-    assert!(nan.is_nan());
-    assert!(!nan.is_infinite());
-    assert!(!nan.is_finite());
-    assert!(!nan.is_normal());
-    assert!(nan.is_sign_positive());
-    assert!(!nan.is_sign_negative());
-    assert_eq!(Fp::Nan, nan.classify());
-    // Ensure the quiet bit is set.
-    assert!(nan.to_bits() & (1 << (f32::MANTISSA_DIGITS - 2)) != 0);
-}
-
-#[test]
 fn test_infinity() {
     let inf: f32 = f32::INFINITY;
     assert!(inf.is_infinite());

--- a/library/coretests/tests/floats/f64.rs
+++ b/library/coretests/tests/floats/f64.rs
@@ -31,20 +31,6 @@ fn test_num_f64() {
 }
 
 #[test]
-fn test_nan() {
-    let nan: f64 = f64::NAN;
-    assert!(nan.is_nan());
-    assert!(!nan.is_infinite());
-    assert!(!nan.is_finite());
-    assert!(!nan.is_normal());
-    assert!(nan.is_sign_positive());
-    assert!(!nan.is_sign_negative());
-    assert_eq!(Fp::Nan, nan.classify());
-    // Ensure the quiet bit is set.
-    assert!(nan.to_bits() & (1 << (f64::MANTISSA_DIGITS - 2)) != 0);
-}
-
-#[test]
 fn test_infinity() {
     let inf: f64 = f64::INFINITY;
     assert!(inf.is_infinite());

--- a/library/coretests/tests/floats/mod.rs
+++ b/library/coretests/tests/floats/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::FpCategory as Fp;
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
 /// Set the default tolerance for float comparison based on the type.
@@ -187,6 +188,8 @@ macro_rules! float_test {
             mod const_ {
                 #[allow(unused)]
                 use super::Approx;
+                #[allow(unused)]
+                use std::num::FpCategory as Fp;
                 // Shadow the runtime versions of the macro with const-compatible versions.
                 #[allow(unused)]
                 use $crate::floats::{
@@ -249,6 +252,26 @@ mod f128;
 mod f16;
 mod f32;
 mod f64;
+
+float_test! {
+    name: nan,
+    attrs: {
+        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f128: #[cfg(any(miri, target_has_reliable_f128))],
+    },
+    test<Float> {
+        let nan: Float = Float::NAN;
+        assert!(nan.is_nan());
+        assert!(!nan.is_infinite());
+        assert!(!nan.is_finite());
+        assert!(!nan.is_normal());
+        assert!(nan.is_sign_positive());
+        assert!(!nan.is_sign_negative());
+        assert!(matches!(nan.classify(), Fp::Nan));
+        // Ensure the quiet bit is set.
+        assert!(nan.to_bits() & (1 << (Float::MANTISSA_DIGITS - 2)) != 0);
+    }
+}
 
 float_test! {
     name: min,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR moves NaN tests to `floats/mod.rs`, as discussed in rust-lang/rust#141726. Since this is my first PR against Rust, I'm keeping it as small as possible, but I intend to work my way through the remaining tests and can do that work in this PR if that's preferable.

r? RalfJung