### PR TITLE
test passing a `VaList` from rust to C

### DIFF
--- a/tests/run-make/c-link-to-rust-va-list-fn/test.c
+++ b/tests/run-make/c-link-to-rust-va-list-fn/test.c
@@ -15,6 +15,11 @@ extern size_t check_varargs_3(int fixed, ...);
 extern size_t check_varargs_4(double fixed, ...);
 extern size_t check_varargs_5(int fixed, ...);
 
+extern size_t run_test_variadic();
+extern size_t run_test_va_list_by_value();
+extern size_t run_test_va_list_by_pointer();
+extern size_t run_test_va_list_by_pointer_pointer();
+
 int test_rust(size_t (*fn)(va_list), ...) {
     size_t ret = 0;
     va_list ap;
@@ -46,6 +51,54 @@ int main(int argc, char* argv[]) {
 
     assert(check_varargs_5(0, 1.0, 1, 2.0, 2, 3.0, 3, 4.0, 4, 5, 5.0, 6, 6.0, 7, 7.0, 8, 8.0,
                            9, 9.0, 10, 10.0, 11, 11.0, 12, 12.0, 13, 13.0) == 0);
+
+    assert(run_test_variadic() == 0);
+    assert(run_test_va_list_by_value() == 0);
+    assert(run_test_va_list_by_pointer() == 0);
+    assert(run_test_va_list_by_pointer_pointer() == 0);
+
+    return 0;
+}
+
+#define continue_if_else_end(cond) \
+    do { if (!(cond)) { va_end(ap); return 0xff; } } while (0)
+
+size_t test_variadic(int unused, ...) {
+    va_list ap;
+    va_start(ap, unused);
+
+    continue_if_else_end(va_arg(ap, long long) == 1);
+    continue_if_else_end(va_arg(ap, int) == 2);
+    continue_if_else_end(va_arg(ap, long long) == 3);
+
+    va_end(ap);
+
+    return 0;
+}
+
+#define continue_if(cond) \
+    do { if (!(cond)) { return 0xff; } } while (0)
+
+size_t test_va_list_by_value(va_list ap) {
+    continue_if(va_arg(ap, long long) == 1);
+    continue_if(va_arg(ap, int) == 2);
+    continue_if(va_arg(ap, long long) == 3);
+
+    return 0;
+}
+
+size_t test_va_list_by_pointer(va_list *ap) {
+    continue_if(va_arg(*ap, long long) == 1);
+    continue_if(va_arg(*ap, int) == 2);
+    continue_if(va_arg(*ap, long long) == 3);
+
+    return 0;
+}
+
+size_t test_va_list_by_pointer_pointer(va_list **ap) {
+    continue_if(va_arg(**ap, long long) == 1);
+    continue_if(va_arg(**ap, int) == 2);
+    continue_if(va_arg(**ap, long long) == 3);
 
     return 0;
 }


### PR DESCRIPTION
Have C define various functions that take a `...` or `va_list` as an argument, and call them from rust. As far as I can see, this just wasn't actually tested before.

In particular this tests a difference between rust `VaList` and C `va_list` where C uses array-to-pointer decay, but rust cannot.

I've locally tested this for

- `x86_64-unknown-linux-gnu`
- `aarch64-unknown-linux-gnu`
- `s390x-unknown-linux-gnu`
- `powerpc64-unknown-linux-gnu`
- `powerpc64le-unknown-linux-gnu`

The latter 2 use an opaque pointer, the first 3 use a single-element array. 

cc @beetrees if you see anything incorrect here

r? @workingjubilee 

