### PR TITLE
Port `#[rustc_pass_by_value]` to the new attribute system

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -284,6 +284,9 @@ pub enum AttributeKind {
     /// Represents `#[optimize(size|speed)]`
     Optimize(OptimizeAttr, Span),
 
+    /// Represents `#[rustc_pass_by_value]` (used by the `rustc_pass_by_value` lint).
+    PassByValue(Span),
+
     /// Represents `#[rustc_pub_transparent]` (used by the `repr_transparent_external_private_fields` lint).
     PubTransparent(Span),
 

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -36,6 +36,7 @@ impl AttributeKind {
             Naked(..) => No,
             NoMangle(..) => No,
             Optimize(..) => No,
+            PassByValue(..) => Yes,
             PubTransparent(..) => Yes,
             Repr(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -12,39 +12,41 @@ impl AttributeKind {
         use EncodeCrossCrate::*;
 
         match self {
+            // tidy-alphabetical-start
             Align { .. } => No,
             AllowConstFnUnstable(..) => No,
             AllowInternalUnstable(..) => Yes,
             AsPtr(..) => Yes,
             BodyStability { .. } => No,
+            Cold(..) => No,
             Confusables { .. } => Yes,
+            ConstContinue(..) => No,
             ConstStability { .. } => Yes,
             ConstStabilityIndirect => No,
             Deprecation { .. } => Yes,
             DocComment { .. } => Yes,
             ExportName { .. } => Yes,
             Inline(..) => No,
-            LinkSection { .. } => No,
-            MacroTransparency(..) => Yes,
-            Repr(..) => No,
-            Stability { .. } => Yes,
-            Cold(..) => No,
-            ConstContinue(..) => No,
             LinkName { .. } => Yes,
+            LinkSection { .. } => No,
             LoopMatch(..) => No,
+            MacroTransparency(..) => Yes,
             MayDangle(..) => No,
             MustUse { .. } => Yes,
             Naked(..) => No,
             NoMangle(..) => No,
             Optimize(..) => No,
             PubTransparent(..) => Yes,
+            Repr(..) => No,
             RustcLayoutScalarValidRangeEnd(..) => Yes,
             RustcLayoutScalarValidRangeStart(..) => Yes,
             RustcObjectLifetimeDefault => No,
             SkipDuringMethodDispatch { .. } => No,
+            Stability { .. } => Yes,
             TargetFeature(..) => No,
             TrackCaller(..) => Yes,
             Used { .. } => No,
+            // tidy-alphabetical-end
         }
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -17,3 +17,10 @@ impl<S: Stage> NoArgsAttributeParser<S> for PubTransparentParser {
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::PubTransparent;
 }
+
+pub(crate) struct PassByValueParser;
+impl<S: Stage> NoArgsAttributeParser<S> for PassByValueParser {
+    const PATH: &[Symbol] = &[sym::rustc_pass_by_value];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::PassByValue;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -23,7 +23,7 @@ use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
 use crate::attributes::inline::{InlineParser, RustcForceInlineParser};
 use crate::attributes::link_attrs::{LinkNameParser, LinkSectionParser};
-use crate::attributes::lint_helpers::{AsPtrParser, PubTransparentParser};
+use crate::attributes::lint_helpers::{AsPtrParser, PassByValueParser, PubTransparentParser};
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
 use crate::attributes::must_use::MustUseParser;
 use crate::attributes::repr::{AlignParser, ReprParser};
@@ -142,6 +142,7 @@ attribute_parsers!(
         Single<WithoutArgs<LoopMatchParser>>,
         Single<WithoutArgs<MayDangleParser>>,
         Single<WithoutArgs<NoMangleParser>>,
+        Single<WithoutArgs<PassByValueParser>>,
         Single<WithoutArgs<PubTransparentParser>>,
         Single<WithoutArgs<TrackCallerParser>>,
         // tidy-alphabetical-end

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -293,6 +293,7 @@ fn emit_malformed_attribute(
             | sym::rustc_force_inline
             | sym::rustc_confusables
             | sym::rustc_skip_during_method_dispatch
+            | sym::rustc_pass_by_value
             | sym::repr
             | sym::align
             | sym::deprecated


### PR DESCRIPTION
Part of rust-lang/rust#131229

r? @oli-obk