### PR TITLE
tests: Don't check for self-printed output in std-backtrace.rs test

### DIFF
--- a/tests/ui/backtrace/std-backtrace.rs
+++ b/tests/ui/backtrace/std-backtrace.rs
@@ -13,9 +13,9 @@ use std::str;
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() >= 2 && args[1] == "force" {
-        println!("stack backtrace:\n{}", std::backtrace::Backtrace::force_capture());
+        println!("{}", std::backtrace::Backtrace::force_capture());
     } else if args.len() >= 2 {
-        println!("stack backtrace:\n{}", std::backtrace::Backtrace::capture());
+        println!("{}", std::backtrace::Backtrace::capture());
     } else {
         runtest(&args[0]);
         println!("test ok");
@@ -28,7 +28,6 @@ fn runtest(me: &str) {
 
     let p = Command::new(me).arg("a").env("RUST_BACKTRACE", "1").output().unwrap();
     assert!(p.status.success());
-    assert!(String::from_utf8_lossy(&p.stdout).contains("stack backtrace:\n"));
     assert!(String::from_utf8_lossy(&p.stdout).contains("backtrace::main"));
 
     let p = Command::new(me).arg("a").env("RUST_BACKTRACE", "0").output().unwrap();
@@ -46,7 +45,6 @@ fn runtest(me: &str) {
         .output()
         .unwrap();
     assert!(p.status.success());
-    assert!(String::from_utf8_lossy(&p.stdout).contains("stack backtrace:\n"));
 
     let p = Command::new(me)
         .arg("a")
@@ -64,9 +62,7 @@ fn runtest(me: &str) {
         .output()
         .unwrap();
     assert!(p.status.success());
-    assert!(String::from_utf8_lossy(&p.stdout).contains("stack backtrace:\n"));
 
     let p = Command::new(me).arg("force").output().unwrap();
     assert!(p.status.success());
-    assert!(String::from_utf8_lossy(&p.stdout).contains("stack backtrace:\n"));
 }


### PR DESCRIPTION
The `Display` implementation for `Backtrace` used to print

    stack backtrace:

but that print was since removed. See https://github.com/rust-lang/backtrace-rs/pull/286 and https://github.com/rust-lang/rust/pull/69042. To make the existing test pass, the print was added to the test instead. But it doesn't make sense to check for something that the test itself does since that will not detect any regressions in the implementation of `Backtrace`.

What the test _should_ check is that "stack backtrace:" is _not_ printed in `Display` of `Backtrace`. So do that instead.

This is one small steps towards resolving https://github.com/rust-lang/rust/issues/71706. The next steps after this step involves extending and hardening that test further.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
