### PR TITLE
Remove some unnecessary `unsafe` in VecCache

### DIFF
--- a/compiler/rustc_data_structures/src/vec_cache.rs
+++ b/compiler/rustc_data_structures/src/vec_cache.rs
@@ -76,8 +76,8 @@ impl SlotIndex {
                 index_in_bucket: idx as usize,
             };
         }
-        // SAFETY: We already ruled out idx 0, so `checked_ilog2` can't return `None`.
-        let bucket = unsafe { idx.checked_ilog2().unwrap_unchecked() as usize };
+        // We already ruled out idx 0, so this `ilog2` never panics (and the check optimizes away)
+        let bucket = idx.ilog2() as usize;
         let entries = 1 << bucket;
         SlotIndex {
             bucket_idx: bucket - FIRST_BUCKET_SHIFT + 1,


### PR DESCRIPTION
I'm pretty sure, but until perf confirms,
r? ghost

cc rust-lang/rust#142095 which added the `unsafe`.