### PR TITLE
mbe: Gracefully handle macro rules that end after `=>`

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -411,6 +411,15 @@ pub fn compile_declarative_macro(
         if let Err(e) = p.expect(exp!(FatArrow)) {
             return dummy_syn_ext(e.emit());
         }
+        if p.token == token::Eof {
+            let err_sp = p.token.span.shrink_to_hi();
+            let guar = sess
+                .dcx()
+                .struct_span_err(err_sp, "macro definition ended unexpectedly")
+                .with_span_label(err_sp, "expected right-hand side of macro rule")
+                .emit();
+            return dummy_syn_ext(guar);
+        }
         let rhs_tt = p.parse_token_tree();
         let rhs_tt = mbe::quoted::parse(
             &TokenStream::new(vec![rhs_tt]),

--- a/tests/ui/parser/macro/bad-macro-definition.rs
+++ b/tests/ui/parser/macro/bad-macro-definition.rs
@@ -1,0 +1,22 @@
+#![crate_type = "lib"]
+
+macro_rules! a { {} => }
+//~^ ERROR: macro definition ended unexpectedly
+
+macro_rules! b { 0 => }
+//~^ ERROR: macro definition ended unexpectedly
+//~| ERROR: invalid macro matcher
+
+macro_rules! c { x => }
+//~^ ERROR: macro definition ended unexpectedly
+//~| ERROR: invalid macro matcher
+
+macro_rules! d { _ => }
+//~^ ERROR: macro definition ended unexpectedly
+//~| ERROR: invalid macro matcher
+
+macro_rules! e { {} }
+//~^ ERROR: expected `=>`, found end of macro arguments
+
+macro_rules! f {}
+//~^ ERROR: macros must contain at least one rule

--- a/tests/ui/parser/macro/bad-macro-definition.stderr
+++ b/tests/ui/parser/macro/bad-macro-definition.stderr
@@ -1,0 +1,56 @@
+error: macro definition ended unexpectedly
+  --> $DIR/bad-macro-definition.rs:3:23
+   |
+LL | macro_rules! a { {} => }
+   |                       ^ expected right-hand side of macro rule
+
+error: invalid macro matcher; matchers must be contained in balanced delimiters
+  --> $DIR/bad-macro-definition.rs:6:18
+   |
+LL | macro_rules! b { 0 => }
+   |                  ^
+
+error: macro definition ended unexpectedly
+  --> $DIR/bad-macro-definition.rs:6:22
+   |
+LL | macro_rules! b { 0 => }
+   |                      ^ expected right-hand side of macro rule
+
+error: invalid macro matcher; matchers must be contained in balanced delimiters
+  --> $DIR/bad-macro-definition.rs:10:18
+   |
+LL | macro_rules! c { x => }
+   |                  ^
+
+error: macro definition ended unexpectedly
+  --> $DIR/bad-macro-definition.rs:10:22
+   |
+LL | macro_rules! c { x => }
+   |                      ^ expected right-hand side of macro rule
+
+error: invalid macro matcher; matchers must be contained in balanced delimiters
+  --> $DIR/bad-macro-definition.rs:14:18
+   |
+LL | macro_rules! d { _ => }
+   |                  ^
+
+error: macro definition ended unexpectedly
+  --> $DIR/bad-macro-definition.rs:14:22
+   |
+LL | macro_rules! d { _ => }
+   |                      ^ expected right-hand side of macro rule
+
+error: expected `=>`, found end of macro arguments
+  --> $DIR/bad-macro-definition.rs:18:20
+   |
+LL | macro_rules! e { {} }
+   |                    ^ expected `=>`
+
+error: macros must contain at least one rule
+  --> $DIR/bad-macro-definition.rs:21:1
+   |
+LL | macro_rules! f {}
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
Add a test for various cases of invalid macro definitions.

Closes: https://github.com/rust-lang/rust/issues/143351
