### PR TITLE
remove special-casing of boxes from match exhaustiveness/usefulness analysis

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -319,9 +319,10 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 }
                 PatKind::Deref { subpattern }
             }
-            hir::PatKind::Box(subpattern) => {
-                PatKind::Deref { subpattern: self.lower_pattern(subpattern) }
-            }
+            hir::PatKind::Box(subpattern) => PatKind::DerefPattern {
+                subpattern: self.lower_pattern(subpattern),
+                borrow: hir::ByRef::No,
+            },
 
             hir::PatKind::Slice(prefix, slice, suffix) => {
                 self.slice_or_array_pattern(pat.span, ty, prefix, slice, suffix)

--- a/tests/ui/uninhabited/uninhabited-patterns.rs
+++ b/tests/ui/uninhabited/uninhabited-patterns.rs
@@ -27,7 +27,11 @@ fn main() {
 
     let x: Result<Box<NotSoSecretlyEmpty>, &[Result<!, !>]> = Err(&[]);
     match x {
-        Ok(box _) => (), //~ ERROR unreachable pattern
+        Ok(box _) => (), // We'd get a non-exhaustiveness error if this arm was removed; don't lint.
+        Err(&[]) => (),
+        Err(&[..]) => (),
+    }
+    match x { //~ ERROR non-exhaustive patterns
         Err(&[]) => (),
         Err(&[..]) => (),
     }

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -1,8 +1,26 @@
-error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:30:9
+error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
+  --> $DIR/uninhabited-patterns.rs:34:11
    |
-LL |         Ok(box _) => (),
-   |         ^^^^^^^^^-------
+LL |     match x {
+   |           ^ pattern `Ok(_)` not covered
+   |
+note: `Result<Box<NotSoSecretlyEmpty>, &[Result<!, !>]>` defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+  ::: $SRC_DIR/core/src/result.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Result<Box<NotSoSecretlyEmpty>, &[Result<!, !>]>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         Err(&[..]) => (),
+LL ~         Ok(_) => todo!(),
+   |
+
+error: unreachable pattern
+  --> $DIR/uninhabited-patterns.rs:43:9
+   |
+LL |         Err(Ok(_y)) => (),
+   |         ^^^^^^^^^^^-------
    |         |
    |         matches no values because `NotSoSecretlyEmpty` is uninhabited
    |         help: remove the match arm
@@ -15,18 +33,7 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:39:9
-   |
-LL |         Err(Ok(_y)) => (),
-   |         ^^^^^^^^^^^-------
-   |         |
-   |         matches no values because `NotSoSecretlyEmpty` is uninhabited
-   |         help: remove the match arm
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:42:15
+  --> $DIR/uninhabited-patterns.rs:46:15
    |
 LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
@@ -35,3 +42,4 @@ LL |     while let Some(_y) = foo() {
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
As a first step in replacing `box_patterns` with `deref_patterns`, this treats box patterns as deref patterns in the THIR and exhaustiveness analysis. This allows a bunch of special-casing to be removed. The emitted MIR is unchanged.

Incidentally, this fixes a bug caused by box patterns being treated like structs rather than pointers, where enabling `exhaustive_patterns` (rust-lang/rust#51085) could give rise to spurious `unreachable_patterns` lints on arms required for exhaustiveness. Following the lint's advice to remove the match arm would result in an error. I'm not sure what the current state of `exhaustive_patterns` is with regard to reference/box opsem, or whether there's any intention to have `unreachable_patterns` be more granular than the whole arm, but regardless this should hopefully make them easier to handle consistently.

Tracking issue for deref patterns: rust-lang/rust#87121

r? @Nadrieril 