### PR TITLE
bump termize dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.104",
  "tempfile",
- "termize",
+ "termize 0.1.1",
  "tokio",
  "toml 0.7.8",
  "ui_test",
@@ -3761,7 +3761,7 @@ dependencies = [
  "serde",
  "serde_json",
  "termcolor",
- "termize",
+ "termize 0.2.0",
  "tracing",
  "windows 0.61.3",
 ]
@@ -4522,7 +4522,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_span",
  "rustc_target",
- "termize",
+ "termize 0.2.0",
  "tracing",
  "windows 0.61.3",
 ]
@@ -5292,6 +5292,16 @@ checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8da106d1a19c5b9c53c03311936568a0439926a7607815bd3461139cbab1cc"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -28,7 +28,7 @@ rustc_type_ir = { path = "../rustc_type_ir" }
 serde = { version = "1.0.125", features = [ "derive" ] }
 serde_json = "1.0.59"
 termcolor = "1.2.0"
-termize = "0.1.1"
+termize = "0.2"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_session/Cargo.toml
+++ b/compiler/rustc_session/Cargo.toml
@@ -22,7 +22,7 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
-termize = "0.1.1"
+termize = "0.2"
 tracing = "0.1"
 # tidy-alphabetical-end
 


### PR DESCRIPTION
Bumps termize to drop one more winapi dep. Only change is really moving from winapi: https://github.com/JohnTitor/termize/releases/tag/v0.2.0

Clippy depends on termize 0.1.1, https://github.com/rust-lang/rust-clippy/pull/15207