### PR TITLE
clippy fix: rely on autoderef

### DIFF
--- a/library/core/src/borrow.rs
+++ b/library/core/src/borrow.rs
@@ -223,20 +223,20 @@ impl<T: ?Sized> BorrowMut<T> for T {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Borrow<T> for &T {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Borrow<T> for &mut T {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> BorrowMut<T> for &mut T {
     fn borrow_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -590,7 +590,7 @@ mod impls {
         #[inline(always)]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {
-            *self
+            self
         }
     }
 

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -158,7 +158,7 @@ impl<T: ?Sized> const Deref for &T {
 
     #[rustc_diagnostic_item = "noop_method_deref"]
     fn deref(&self) -> &T {
-        *self
+        self
     }
 }
 
@@ -171,7 +171,7 @@ impl<T: ?Sized> const Deref for &mut T {
     type Target = T;
 
     fn deref(&self) -> &T {
-        *self
+        self
     }
 }
 
@@ -280,7 +280,7 @@ pub trait DerefMut: ~const Deref + PointeeSized {
 #[rustc_const_unstable(feature = "const_deref", issue = "88955")]
 impl<T: ?Sized> const DerefMut for &mut T {
     fn deref_mut(&mut self) -> &mut T {
-        *self
+        self
     }
 }
 


### PR DESCRIPTION
Changes instances of `&**self` to `self`.