### PR TITLE
clippy fix: use div-ceil

### DIFF
--- a/library/portable-simd/crates/core_simd/src/lane_count.rs
+++ b/library/portable-simd/crates/core_simd/src/lane_count.rs
@@ -8,7 +8,7 @@ pub struct LaneCount<const N: usize>;
 
 impl<const N: usize> LaneCount<N> {
     /// The number of bytes in a bitmask with this many lanes.
-    pub const BITMASK_LEN: usize = (N + 7) / 8;
+    pub const BITMASK_LEN: usize = N.div_ceil(8);
 }
 
 /// Statically guarantees that a lane count is marked as supported.
@@ -27,7 +27,7 @@ macro_rules! supported_lane_count {
     ($($lanes:literal),+) => {
         $(
             impl SupportedLaneCount for LaneCount<$lanes> {
-                type BitMask = [u8; ($lanes + 7) / 8];
+                type BitMask = [u8; ($lanes as usize).div_ceil(8)];
             }
         )+
     };


### PR DESCRIPTION
This gets rid of 64 clippy warnings from this macro.