### PR TITLE
Use relative visibility when noting sealed trait to reduce false positive

### DIFF
--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
@@ -1,0 +1,13 @@
+// when we impl TraitA for Struct, it can compile, we should not emit sealed traits note, see issue #143392
+
+mod inner {
+    pub trait TraitA {}
+
+    pub trait TraitB: TraitA {}
+}
+
+struct Struct;
+
+impl inner::TraitB for Struct {} //~ ERROR the trait bound `Struct: TraitA` is not satisfied [E0277]
+
+fn main(){}

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
@@ -1,4 +1,4 @@
-// when we impl TraitA for Struct, it can compile, we should not emit sealed traits note, see issue #143392
+// We should not emit sealed traits note, see issue #143392
 
 mod inner {
     pub trait TraitA {}

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
@@ -14,7 +14,6 @@ note: required by a bound in `TraitB`
    |
 LL |     pub trait TraitB: TraitA {}
    |                       ^^^^^^ required by this bound in `TraitB`
-   = note: `TraitB` is a "sealed trait", because to implement it you also need to implement `inner::TraitA`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Struct: TraitA` is not satisfied
+  --> $DIR/false-sealed-traits-note.rs:11:24
+   |
+LL | impl inner::TraitB for Struct {}
+   |                        ^^^^^^ the trait `TraitA` is not implemented for `Struct`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/false-sealed-traits-note.rs:4:5
+   |
+LL |     pub trait TraitA {}
+   |     ^^^^^^^^^^^^^^^^
+note: required by a bound in `TraitB`
+  --> $DIR/false-sealed-traits-note.rs:6:23
+   |
+LL |     pub trait TraitB: TraitA {}
+   |                       ^^^^^^ required by this bound in `TraitB`
+   = note: `TraitB` is a "sealed trait", because to implement it you also need to implement `inner::TraitA`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#143392

I used relative visibility instead of just determining if it's public or not.

r? compiler