### PR TITLE
Add `ty_span` query

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -768,15 +768,14 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(),
                     check_static_inhabited(tcx, def_id);
                     check_static_linkage(tcx, def_id);
                     res = res.and(wfcheck::check_static_item(tcx, def_id));
-
-                    // Only `Node::Item` and `Node::ForeignItem` still have HIR based
-                    // checks. Returning early here does not miss any checks and
-                    // avoids this query from having a direct dependency edge on the HIR
-                    return res;
                 }
-                DefKind::Const => {}
+                DefKind::Const => res = res.and(wfcheck::check_const_item(tcx, def_id)),
                 _ => unreachable!(),
             }
+            // Only `Node::Item` and `Node::ForeignItem` still have HIR based
+            // checks. Returning early here does not miss any checks and
+            // avoids this query from having a direct dependency edge on the HIR
+            return res;
         }
         DefKind::Enum => {
             tcx.ensure_ok().generics_of(def_id);

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -290,7 +290,6 @@ pub(super) fn check_item<'tcx>(
             res
         }
         hir::ItemKind::Fn { sig, .. } => check_item_fn(tcx, def_id, sig.decl),
-        hir::ItemKind::Const(_, _, ty, _) => check_const_item(tcx, def_id, ty.span),
         hir::ItemKind::Struct(..) => check_type_defn(tcx, item, false),
         hir::ItemKind::Union(..) => check_type_defn(tcx, item, true),
         hir::ItemKind::Enum(..) => check_type_defn(tcx, item, true),
@@ -1185,7 +1184,8 @@ pub(super) fn check_static_item(
 ) -> Result<(), ErrorGuaranteed> {
     enter_wf_checking_ctxt(tcx, item_id, |wfcx| {
         let ty = tcx.type_of(item_id).instantiate_identity();
-        let item_ty = wfcx.deeply_normalize(DUMMY_SP, Some(WellFormedLoc::Ty(item_id)), ty);
+        let span = tcx.ty_span(item_id);
+        let item_ty = wfcx.deeply_normalize(span, Some(WellFormedLoc::Ty(item_id)), ty);
 
         let is_foreign_item = tcx.is_foreign_item(item_id);
 
@@ -1194,7 +1194,7 @@ pub(super) fn check_static_item(
             !matches!(tail.kind(), ty::Foreign(_))
         };
 
-        wfcx.register_wf_obligation(DUMMY_SP, Some(WellFormedLoc::Ty(item_id)), item_ty.into());
+        wfcx.register_wf_obligation(span, Some(WellFormedLoc::Ty(item_id)), item_ty.into());
         if forbid_unsized {
             let span = tcx.def_span(item_id);
             wfcx.register_bound(
@@ -1216,7 +1216,6 @@ pub(super) fn check_static_item(
             && !tcx.is_thread_local_static(item_id.to_def_id());
 
         if should_check_for_sync {
-            let span = tcx.def_span(item_id);
             wfcx.register_bound(
                 traits::ObligationCause::new(
                     span,
@@ -1232,13 +1231,10 @@ pub(super) fn check_static_item(
     })
 }
 
-fn check_const_item(
-    tcx: TyCtxt<'_>,
-    def_id: LocalDefId,
-    ty_span: Span,
-) -> Result<(), ErrorGuaranteed> {
+pub(crate) fn check_const_item(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
     enter_wf_checking_ctxt(tcx, def_id, |wfcx| {
         let ty = tcx.type_of(def_id).instantiate_identity();
+        let ty_span = tcx.ty_span(def_id);
         let ty = wfcx.deeply_normalize(ty_span, Some(WellFormedLoc::Ty(def_id)), ty);
 
         wfcx.register_wf_obligation(ty_span, Some(WellFormedLoc::Ty(def_id)), ty.into());
@@ -1505,7 +1501,7 @@ pub(super) fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, def_id:
             let cause = traits::ObligationCause::new(
                 sp,
                 wfcx.body_def_id,
-                ObligationCauseCode::WhereClause(def_id.to_def_id(), DUMMY_SP),
+                ObligationCauseCode::WhereClause(def_id.to_def_id(), sp),
             );
             Obligation::new(tcx, cause, wfcx.param_env, pred)
         });

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1452,6 +1452,13 @@ rustc_queries! {
         feedable
     }
 
+    /// Gets the span for the type of the definition.
+    /// Panics if it is not a definition that has a single type.
+    query ty_span(def_id: LocalDefId) -> Span {
+        desc { |tcx| "looking up span for `{}`'s type", tcx.def_path_str(def_id) }
+        cache_on_disk_if { true }
+    }
+
     query lookup_stability(def_id: DefId) -> Option<attr::Stability> {
         desc { |tcx| "looking up stability of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }

--- a/tests/ui/const-generics/defaults/wfness.stderr
+++ b/tests/ui/const-generics/defaults/wfness.stderr
@@ -12,6 +12,14 @@ LL |     (): Trait<N>;
    |
    = help: the trait `Trait<2>` is not implemented for `()`
            but trait `Trait<3>` is implemented for it
+note: required by a bound in `WhereClause`
+  --> $DIR/wfness.rs:8:9
+   |
+LL | struct WhereClause<const N: u8 = 2>
+   |        ----------- required by a bound in this struct
+LL | where
+LL |     (): Trait<N>;
+   |         ^^^^^^^^ required by this bound in `WhereClause`
 
 error[E0277]: the trait bound `(): Trait<1>` is not satisfied
   --> $DIR/wfness.rs:18:13

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `RefCell<isize>` cannot be shared between threads safely
-  --> $DIR/issue-7364.rs:4:1
+  --> $DIR/issue-7364.rs:4:15
    |
 LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
+   |               ^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<isize>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
-  --> $DIR/issue-24446.rs:2:5
+  --> $DIR/issue-24446.rs:2:17
    |
 LL |     static foo: dyn Fn() -> u32 = || -> u32 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
+   |                 ^^^^^^^^^^^^^^^ `(dyn Fn() -> u32 + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn Fn() -> u32 + 'static)`
    = note: shared static variables must have a type that implements `Sync`

--- a/tests/ui/statics/issue-17718-static-sync.stderr
+++ b/tests/ui/statics/issue-17718-static-sync.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Foo` cannot be shared between threads safely
-  --> $DIR/issue-17718-static-sync.rs:9:1
+  --> $DIR/issue-17718-static-sync.rs:9:13
    |
 LL | static BAR: Foo = Foo;
-   | ^^^^^^^^^^^^^^^ `Foo` cannot be shared between threads safely
+   |             ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `Foo`
    = note: shared static variables must have a type that implements `Sync`

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -22,10 +22,10 @@ LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++
 
 error[E0277]: `(dyn Qux + 'static)` cannot be shared between threads safely
-  --> $DIR/unsizing-wfcheck-issue-127299.rs:12:1
+  --> $DIR/unsizing-wfcheck-issue-127299.rs:12:13
    |
 LL | static FOO: &Lint = &Lint { desc: "desc" };
-   | ^^^^^^^^^^^^^^^^^ `(dyn Qux + 'static)` cannot be shared between threads safely
+   |             ^^^^^ `(dyn Qux + 'static)` cannot be shared between threads safely
    |
    = help: within `&'static Lint`, the trait `Sync` is not implemented for `(dyn Qux + 'static)`
    = note: required because it appears within the type `&'static (dyn Qux + 'static)`

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -29,18 +29,36 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
    |
 LL | struct Bounds<T:Copy=String>(T);
    |                 ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `Bounds`
+  --> $DIR/type-check-defaults.rs:11:17
+   |
+LL | struct Bounds<T:Copy=String>(T);
+   |                 ^^^^ required by this bound in `Bounds`
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:14:42
    |
 LL | struct WhereClause<T=String>(T) where T: Copy;
    |                                          ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `WhereClause`
+  --> $DIR/type-check-defaults.rs:14:42
+   |
+LL | struct WhereClause<T=String>(T) where T: Copy;
+   |                                          ^^^^ required by this bound in `WhereClause`
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:17:20
    |
 LL | trait TraitBound<T:Copy=String> {}
    |                    ^^^^ the trait `Copy` is not implemented for `String`
+   |
+note: required by a bound in `TraitBound`
+  --> $DIR/type-check-defaults.rs:17:20
+   |
+LL | trait TraitBound<T:Copy=String> {}
+   |                    ^^^^ required by this bound in `TraitBound`
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:25
@@ -70,6 +88,11 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
              `&i32` implements `Add`
              `i32` implements `Add<&i32>`
              `i32` implements `Add`
+note: required by a bound in `ProjectionPred`
+  --> $DIR/type-check-defaults.rs:24:66
+   |
+LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
+   |                                                                  ^^^^^^^ required by this bound in `ProjectionPred`
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
r? @compiler-errors 

fixes diagnostic regressions from https://github.com/rust-lang/rust/pull/142030

Also uses the new query in `check_const_item`