### PR TITLE
Show AtomicU128/AtomicI128 in std docs regardless of target

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3820,7 +3820,7 @@ atomic_int! {
     16,
     i128 AtomicI128
 }
-#[cfg(target_has_atomic_load_store = "128", doc)]
+#[cfg(any(target_has_atomic_load_store = "128", doc))]
 atomic_int! {
     cfg(any(target_has_atomic = "128", doc)),
     cfg(target_has_atomic_equal_alignment = "128"),

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3801,9 +3801,9 @@ atomic_int! {
     8,
     u64 AtomicU64
 }
-#[cfg(target_has_atomic_load_store = "128")]
+#[cfg(any(target_has_atomic_load_store = "128", doc))]
 atomic_int! {
-    cfg(target_has_atomic = "128"),
+    cfg(any(target_has_atomic = "128", doc)),
     cfg(target_has_atomic_equal_alignment = "128"),
     unstable(feature = "integer_atomics", issue = "99069"),
     unstable(feature = "integer_atomics", issue = "99069"),
@@ -3820,9 +3820,9 @@ atomic_int! {
     16,
     i128 AtomicI128
 }
-#[cfg(target_has_atomic_load_store = "128")]
+#[cfg(target_has_atomic_load_store = "128", doc)]
 atomic_int! {
-    cfg(target_has_atomic = "128"),
+    cfg(any(target_has_atomic = "128", doc)),
     cfg(target_has_atomic_equal_alignment = "128"),
     unstable(feature = "integer_atomics", issue = "99069"),
     unstable(feature = "integer_atomics", issue = "99069"),


### PR DESCRIPTION
Fixes rust-lang/rust#130474

Ensures `AtomicU128` and `AtomicI128` appear in documentation even when docs are built for targets without native 128-bit atomic support (like x86_64-unknown-linux-gnu). The fix adds `cfg(doc)` to existing conditional compilation checks.

Changes:
- Added `cfg(doc)` to `#[cfg(target_has_atomic_load_store = "128")]`
- Added `cfg(doc)` to internal `cfg(target_has_atomic = "128")` in `atomic_int!` macro