### PR TITLE
Stop using `Key` trait unnecessarily

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -1,9 +1,9 @@
 // Not in interpret to make sure we do not use private implementation details
 
 use rustc_abi::{FieldIdx, VariantIdx};
-use rustc_middle::query::Key;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, mir};
+use rustc_span::DUMMY_SP;
 use tracing::instrument;
 
 use crate::interpret::InterpCx;
@@ -71,8 +71,7 @@ pub fn tag_for_variant_provider<'tcx>(
     let (ty, variant_index) = key.value;
     assert!(ty.is_enum());
 
-    let ecx =
-        InterpCx::new(tcx, ty.default_span(tcx), key.typing_env, crate::const_eval::DummyMachine);
+    let ecx = InterpCx::new(tcx, DUMMY_SP, key.typing_env, crate::const_eval::DummyMachine);
 
     let layout = ecx.layout_of(ty).unwrap();
     ecx.tag_for_variant(layout, variant_index).unwrap().map(|(tag, _tag_field)| tag)

--- a/compiler/rustc_lint/src/map_unit_fn.rs
+++ b/compiler/rustc_lint/src/map_unit_fn.rs
@@ -1,5 +1,4 @@
 use rustc_hir::{Expr, ExprKind, HirId, Stmt, StmtKind};
-use rustc_middle::query::Key;
 use rustc_middle::ty::{self, Ty};
 use rustc_session::{declare_lint, declare_lint_pass};
 
@@ -69,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                         .span_of_impl(*id)
                                         .unwrap_or(default_span),
                                     argument_label: args[0].span,
-                                    map_label: arg_ty.default_span(cx.tcx),
+                                    map_label: span,
                                     suggestion: path.ident.span,
                                     replace: "for_each".to_string(),
                                 },
@@ -88,7 +87,7 @@ impl<'tcx> LateLintPass<'tcx> for MapUnitFn {
                                         .span_of_impl(*id)
                                         .unwrap_or(default_span),
                                     argument_label: args[0].span,
-                                    map_label: arg_ty.default_span(cx.tcx),
+                                    map_label: span,
                                     suggestion: path.ident.span,
                                     replace: "for_each".to_string(),
                                 },

--- a/tests/ui/lint/lint_map_unit_fn.stderr
+++ b/tests/ui/lint/lint_map_unit_fn.stderr
@@ -25,19 +25,18 @@ LL +     x.iter_mut().for_each(foo);
 error: `Iterator::map` call that discard the iterator's values
   --> $DIR/lint_map_unit_fn.rs:11:18
    |
-LL |         x.iter_mut().map(|items| {
-   |                      ^   -------
-   |                      |   |
-   |  ____________________|___this function returns `()`, which is likely not what you wanted
-   | |  __________________|
-   | | |
-LL | | |
-LL | | |         items.sort();
-LL | | |     });
-   | | |     -^ after this call to map, the resulting iterator is `impl Iterator<Item = ()>`, which means the only information carried by the iterator is the number of items
-   | | |_____||
-   | |_______|
-   |         called `Iterator::map` with callable that returns `()`
+LL |        x.iter_mut().map(|items| {
+   |                     ^   -------
+   |                     |   |
+   |  ___________________|___this function returns `()`, which is likely not what you wanted
+   | | __________________|
+   | ||
+LL | ||
+LL | ||         items.sort();
+LL | ||     });
+   | ||_____-^ after this call to map, the resulting iterator is `impl Iterator<Item = ()>`, which means the only information carried by the iterator is the number of items
+   | |______|
+   |        called `Iterator::map` with callable that returns `()`
    |
    = note: `Iterator::map`, like many of the methods on `Iterator`, gets executed lazily, meaning that its effects won't be visible until it is iterated
 help: you might have meant to use `Iterator::for_each`


### PR DESCRIPTION
Few places where the `Key` trait was being used but not really for a useful reason. This fixes those usages.

Namely, `<Ty as Key>::default_span()` is `DUMMY_SP` anyways.