### PR TITLE
use `--dynamic-list` for exporting executable symbols

### DIFF
--- a/tests/ui/linking/export-executable-symbols.rs
+++ b/tests/ui/linking/export-executable-symbols.rs
@@ -1,0 +1,30 @@
+//@ run-pass
+//@ only-linux
+//@ only-gnu
+//@ compile-flags: -Zexport-executable-symbols
+//@ edition: 2024
+
+// Regression test for <https://github.com/rust-lang/rust/issues/101610>.
+
+#![feature(rustc_private)]
+
+extern crate libc;
+
+#[unsafe(no_mangle)]
+fn hack() -> u64 {
+    998244353
+}
+
+fn main() {
+    unsafe {
+        let handle = libc::dlopen(std::ptr::null(), libc::RTLD_NOW);
+        let ptr = libc::dlsym(handle, c"hack".as_ptr());
+        let ptr: Option<unsafe fn() -> u64> = std::mem::transmute(ptr);
+        if let Some(f) = ptr {
+            assert!(f() == 998244353);
+            println!("symbol `hack` is found successfully");
+        } else {
+            panic!("symbol `hack` is not found");
+        }
+    }
+}


### PR DESCRIPTION
closes rust-lang/rust#101610
cc rust-lang/rust#84161

https://sourceware.org/binutils/docs-2.39/ld/VERSION.html:

> --dynamic-list=dynamic-list-file
Specify the name of a dynamic list file to the linker. This is typically used when creating shared libraries to specify a list of global symbols whose references shouldn’t be bound to the definition within the shared library, or creating dynamically linked executables to specify a list of symbols which should be added to the symbol table in the executable. This option is only meaningful on ELF platforms which support shared libraries.

`ld.lld --help`:

>   --dynamic-list=<file>: Similar to --export-dynamic-symbol-list. When creating a shared object, this additionally implies -Bsymbolic but does not set DF_SYMBOLIC

>  --export-dynamic-symbol-list=file: Read a list of dynamic symbol patterns. Apply --export-dynamic-symbol on each pattern

>  --export-dynamic-symbol=glob: (executable) Put matched symbols in the dynamic symbol table. (shared object) References to matched non-local STV_DEFAULT symbols shouldn't be bound to definitions within the shared object. Does not imply -Bsymbolic.

>  --export-dynamic: Put symbols in the dynamic symbol table

Use `--dynamic-list` because it's older than `--export-dynamic-symbol-list` (binutils 2.35)

try-job: dist-i586-gnu-i586-i686-musl