### PR TITLE
remote-test-client: Exit code `128 + <signal-number>` instead of `3`

### DIFF
--- a/src/tools/remote-test-client/src/main.rs
+++ b/src/tools/remote-test-client/src/main.rs
@@ -335,7 +335,9 @@ fn run(support_lib_count: usize, exe: String, all_args: Vec<String>) {
         std::process::exit(code);
     } else {
         println!("died due to signal {}", code);
-        std::process::exit(3);
+        // Behave like bash and other tools and exit with 128 + the signal
+        // number. That way we can avoid special case code in other places.
+        std::process::exit(128 + code);
     }
 }
 


### PR DESCRIPTION
If the remote process is terminated by a signal, make `remote-test-client` exit with the code `128 + <signal-number>` instead of always `3`. This follows common practice among tools such as bash [^1]:

> When a command terminates on a fatal signal whose number is N, Bash uses the
> value 128+N as the exit status.

It also allows us to differentiate between `run-pass` and `run-crash` ui tests without special case code in compiletest for that when `remote-test-client` is used. See https://github.com/rust-lang/rust/pull/143002 and in particular https://github.com/rust-lang/rust/pull/143002#issuecomment-3037061667.

Exiting with code `3` has been done from the start (see https://github.com/rust-lang/rust/pull/39400) and seems arbitrary rather than a deliberate design decision, so changing it does not seem like an extraordinarily big deal.

### Regression testing

Note that https://github.com/rust-lang/rust/pull/143002 will act as a regression test once it is rebased on this PR.

### Why a separate PR

I think it is comforting to know that CI does not break with just this change. But if my reviewer prefers, we can move this commit to be part of https://github.com/rust-lang/rust/pull/143002 instead.

[^1]: https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html

