### PR TITLE
Do not visit impl-trait when looking for self-type elision.

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2417,6 +2417,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         trace!("FindReferenceVisitor inserting res={:?}", lt_res);
                         self.lifetime.insert(lt_res);
                     }
+                } else if let TyKind::ImplTrait(..) = ty.kind {
+                    // Do not attempt to look inside impl-trait.
+                    return;
                 }
                 visit::walk_ty(self, ty)
             }
@@ -2457,6 +2460,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 if self.is_self_ty(ty) {
                     trace!("SelfVisitor found Self");
                     self.self_found = true;
+                }
+                if let TyKind::ImplTrait(..) = ty.kind {
+                    // Do not attempt to look inside impl-trait.
+                    return;
                 }
                 visit::walk_ty(self, ty)
             }

--- a/tests/crashes/122903-1.rs
+++ b/tests/crashes/122903-1.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #122903
-impl Struct {
-    fn box_box_ref_Struct(
-        self: impl FnMut(Box<impl FnMut(&mut Self)>),
-    ) -> &u32 {
-        f
-    }
-}

--- a/tests/ui/lifetimes/could-not-resolve-issue-121503.rs
+++ b/tests/ui/lifetimes/could-not-resolve-issue-121503.rs
@@ -5,6 +5,7 @@ struct Struct;
 impl Struct {
     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32 {
     //~^ ERROR Box<Struct, impl FnMut(&mut Self)>` cannot be used as the type of `self` without
+    //~| ERROR missing lifetime specifier
         &1
     }
 }

--- a/tests/ui/lifetimes/could-not-resolve-issue-121503.stderr
+++ b/tests/ui/lifetimes/could-not-resolve-issue-121503.stderr
@@ -1,3 +1,24 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/could-not-resolve-issue-121503.rs:6:72
+   |
+LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32 {
+   |                                                                        ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+   |
+LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &'static u32 {
+   |                                                                         +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL |     async fn box_ref_Struct(self: &Box<Self, impl FnMut(&mut Self)>) -> &u32 {
+   |                                   +
+help: ...or alternatively, you might want to return an owned value
+   |
+LL -     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32 {
+LL +     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> u32 {
+   |
+
 error[E0658]: `Box<Struct, impl FnMut(&mut Self)>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
   --> $DIR/could-not-resolve-issue-121503.rs:6:35
    |
@@ -9,6 +30,7 @@ LL |     async fn box_ref_Struct(self: Box<Self, impl FnMut(&mut Self)>) -> &u32
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors have detailed explanations: E0106, E0658.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/lifetimes/elided-lifetime-in-apit.rs
+++ b/tests/ui/lifetimes/elided-lifetime-in-apit.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/122903>
+//!
+//! Late resolver has a special case for `self` parameters where it looks for `&mut? Self`.
+//! If that type appears inside an impl-trait, AST->HIR lowering could ICE bacause it cannot
+//! find the definition of that lifetime.
+
+struct Struct;
+
+impl Struct {
+    fn box_box_ref_Struct(
+        self: impl FnMut(Box<impl FnMut(&mut Self)>),
+        //~^ ERROR nested `impl Trait` is not allowed
+        //~| ERROR `impl Trait` is not allowed in the parameters of `Fn` trait bounds
+        //~| ERROR invalid generic `self` parameter type: `impl FnMut(Box<impl FnMut(&mut Self)>)`
+    ) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        &1
+    }
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/elided-lifetime-in-apit.stderr
+++ b/tests/ui/lifetimes/elided-lifetime-in-apit.stderr
@@ -1,0 +1,56 @@
+error[E0666]: nested `impl Trait` is not allowed
+  --> $DIR/elided-lifetime-in-apit.rs:11:30
+   |
+LL |         self: impl FnMut(Box<impl FnMut(&mut Self)>),
+   |               ---------------^^^^^^^^^^^^^^^^^^^^^--
+   |               |              |
+   |               |              nested `impl Trait` here
+   |               outer `impl Trait`
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/elided-lifetime-in-apit.rs:15:10
+   |
+LL |     ) -> &u32 {
+   |          ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+   |
+LL |     ) -> &'static u32 {
+   |           +++++++
+help: consider introducing a named lifetime parameter
+   |
+LL ~     fn box_box_ref_Struct<'a>(
+LL ~         self: impl FnMut(Box<impl FnMut(&'a Self)>),
+LL |
+LL |
+LL |
+LL ~     ) -> &'a u32 {
+   |
+help: alternatively, you might want to return an owned value
+   |
+LL -     ) -> &u32 {
+LL +     ) -> u32 {
+   |
+
+error[E0562]: `impl Trait` is not allowed in the parameters of `Fn` trait bounds
+  --> $DIR/elided-lifetime-in-apit.rs:11:30
+   |
+LL |         self: impl FnMut(Box<impl FnMut(&mut Self)>),
+   |                              ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `impl Trait` is only allowed in arguments and return types of functions and methods
+
+error[E0801]: invalid generic `self` parameter type: `impl FnMut(Box<impl FnMut(&mut Self)>)`
+  --> $DIR/elided-lifetime-in-apit.rs:11:15
+   |
+LL |         self: impl FnMut(Box<impl FnMut(&mut Self)>),
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: type of `self` must not be a method generic parameter type
+   = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0562, E0666, E0801.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
The linked ICE happens when self-param lifetime elision triggers on a type that has `&Self` appear in an APIT.

This PR is the minimal fix: do not attempt to look inside impl-trait. It should be complemented by a more principled fix where we attach the lifetime elision logic to the rib-based resolution logic. This should lead to better error messages for lifetimes that appear in `fn(&mut Self)`. (The current error is "invalid `self` parameter type".)

Fixes https://github.com/rust-lang/rust/issues/122903

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
