### PR TITLE
diag: improvements to patterns in bare fn ptr and trait decl

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -222,8 +222,10 @@ ast_passes_out_of_order_params = {$param_ord} parameters must be declared prior 
 
 ast_passes_pattern_in_bodiless = patterns aren't allowed in functions without bodies
     .label = pattern not allowed in function without body
+    .suggestion = give this argument a name or use an underscore to ignore it
 
 ast_passes_pattern_in_fn_pointer = patterns aren't allowed in function pointer types
+    .suggestion = give this argument a name or use an underscore to ignore it
 
 ast_passes_pattern_in_foreign = patterns aren't allowed in foreign function declarations
     .label = pattern not allowed in foreign function

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -788,8 +788,11 @@ impl<'a> AstValidator<'a> {
             TyKind::BareFn(bfty) => {
                 self.check_bare_fn_safety(bfty.decl_span, bfty.safety);
                 self.check_fn_decl(&bfty.decl, SelfSemantic::No);
-                Self::check_decl_no_pat(&bfty.decl, |span, _, _| {
-                    self.dcx().emit_err(errors::PatternFnPointer { span });
+                Self::check_decl_no_pat(&bfty.decl, |span, ident, _| {
+                    // `self` in bare fn ptr is already an error; don't add an extra one.
+                    if !ident.is_some_and(|ident| ident.name == kw::SelfLower) {
+                        self.dcx().emit_err(errors::PatternFnPointer { span });
+                    }
                 });
                 if let Extern::Implicit(extern_span) = bfty.ext {
                     self.handle_missing_abi(extern_span, ty.id);

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -404,6 +404,7 @@ impl Subdiagnostic for EmptyLabelManySpans {
 #[diag(ast_passes_pattern_in_fn_pointer, code = E0561)]
 pub(crate) struct PatternFnPointer {
     #[primary_span]
+    #[suggestion(code = "_", style = "verbose")]
     pub span: Span,
 }
 
@@ -685,6 +686,7 @@ pub(crate) struct PatternInForeign {
 pub(crate) struct PatternInBodiless {
     #[primary_span]
     #[label]
+    #[suggestion(code = "_", style = "verbose")]
     pub span: Span,
 }
 

--- a/compiler/rustc_error_codes/src/error_codes/E0642.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0642.md
@@ -1,8 +1,12 @@
-Trait methods currently cannot take patterns as arguments.
+Trait methods cannot take patterns as arguments.
+
+Traits cannot control the way in which implementations take arguments, only the
+types of those arguments. A pattern here has no effect, because the
+implementation can bind its arguments however it would like.
 
 Erroneous code example:
 
-```compile_fail,E0642
+```compile_fail,E0642,edition2024
 trait Foo {
     fn foo((x, y): (i32, i32)); // error: patterns aren't allowed
                                 //        in trait methods
@@ -16,3 +20,9 @@ trait Foo {
     fn foo(x_and_y: (i32, i32)); // ok!
 }
 ```
+
+And you can use patterns in its implementations:
+
+impl Foo for Bar {
+    fn foo((x, y): (i32, i32)) { /* ... */ } // ok!
+}

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -753,8 +753,9 @@ parse_path_found_c_variadic_params = `Trait(...)` syntax does not support c_vari
 parse_path_found_named_params = `Trait(...)` syntax does not support named parameters
     .suggestion = remove the parameter name
 
-parse_pattern_method_param_without_body = patterns aren't allowed in methods without bodies
-    .suggestion = give this argument a name or use an underscore to ignore it
+parse_pattern_in_trait_fn_in_2015 = patterns aren't allowed in trait methods in the 2015 edition
+    .note = upgrading editions will fix this error
+    .suggestion = in this edition, give this argument a name or use an underscore to ignore it
 
 parse_pattern_on_wrong_side_of_at = pattern on wrong side of `@`
     .label_pattern = pattern on the left, should be on the right

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1490,10 +1490,11 @@ pub(crate) struct AttributeOnParamType {
 }
 
 #[derive(Diagnostic)]
-#[diag(parse_pattern_method_param_without_body, code = E0642)]
-pub(crate) struct PatternMethodParamWithoutBody {
+#[diag(parse_pattern_in_trait_fn_in_2015)]
+#[note]
+pub(crate) struct PatternInTraitFnIn2015 {
     #[primary_span]
-    #[suggestion(code = "_", applicability = "machine-applicable", style = "verbose")]
+    #[suggestion(code = "_", style = "verbose")]
     pub span: Span,
 }
 

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -400,7 +400,7 @@ impl<'a> Parser<'a> {
 
                     let dcx = self.dcx();
                     let parse_params_result = self.parse_paren_comma_seq(|p| {
-                        let param = p.parse_param_general(|_| false, false, false);
+                        let param = p.parse_param_general(|_| false, false, false, false);
                         param.map(move |param| {
                             if !matches!(param.pat.kind, PatKind::Missing) {
                                 dcx.emit_err(FnPathFoundNamedParams {

--- a/tests/ui/error-codes/E0642-2015.fixed
+++ b/tests/ui/error-codes/E0642-2015.fixed
@@ -1,0 +1,19 @@
+//@ run-rustfix
+
+#![allow(unused)] // for rustfix
+
+#[derive(Clone, Copy)]
+struct S;
+
+trait T {
+    fn foo(_: (i32, i32)); //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+
+    fn bar(_: (i32, i32)) {} //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+    fn method(_: S) {} //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+
+    fn f(&ident: &S) {} // ok
+    fn g(&&ident: &&S) {} // ok
+    fn h(mut ident: S) {} // ok
+}
+
+fn main() {}

--- a/tests/ui/error-codes/E0642-2015.rs
+++ b/tests/ui/error-codes/E0642-2015.rs
@@ -1,0 +1,19 @@
+//@ run-rustfix
+
+#![allow(unused)] // for rustfix
+
+#[derive(Clone, Copy)]
+struct S;
+
+trait T {
+    fn foo((x, y): (i32, i32)); //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+
+    fn bar((x, y): (i32, i32)) {} //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+    fn method(S { .. }: S) {} //~ ERROR patterns aren't allowed in trait methods in the 2015 edition
+
+    fn f(&ident: &S) {} // ok
+    fn g(&&ident: &&S) {} // ok
+    fn h(mut ident: S) {} // ok
+}
+
+fn main() {}

--- a/tests/ui/error-codes/E0642-2015.stderr
+++ b/tests/ui/error-codes/E0642-2015.stderr
@@ -1,0 +1,41 @@
+error: patterns aren't allowed in trait methods in the 2015 edition
+  --> $DIR/E0642-2015.rs:9:12
+   |
+LL |     fn foo((x, y): (i32, i32));
+   |            ^^^^^^
+   |
+   = note: upgrading editions will fix this error
+help: in this edition, give this argument a name or use an underscore to ignore it
+   |
+LL -     fn foo((x, y): (i32, i32));
+LL +     fn foo(_: (i32, i32));
+   |
+
+error: patterns aren't allowed in trait methods in the 2015 edition
+  --> $DIR/E0642-2015.rs:11:12
+   |
+LL |     fn bar((x, y): (i32, i32)) {}
+   |            ^^^^^^
+   |
+   = note: upgrading editions will fix this error
+help: in this edition, give this argument a name or use an underscore to ignore it
+   |
+LL -     fn bar((x, y): (i32, i32)) {}
+LL +     fn bar(_: (i32, i32)) {}
+   |
+
+error: patterns aren't allowed in trait methods in the 2015 edition
+  --> $DIR/E0642-2015.rs:12:15
+   |
+LL |     fn method(S { .. }: S) {}
+   |               ^^^^^^^^
+   |
+   = note: upgrading editions will fix this error
+help: in this edition, give this argument a name or use an underscore to ignore it
+   |
+LL -     fn method(S { .. }: S) {}
+LL +     fn method(_: S) {}
+   |
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/error-codes/E0642.fixed
+++ b/tests/ui/error-codes/E0642.fixed
@@ -1,3 +1,4 @@
+//@ edition:2024
 //@ run-rustfix
 
 #![allow(unused)] // for rustfix
@@ -6,11 +7,10 @@
 struct S;
 
 trait T {
-    fn foo(_: (i32, i32)); //~ ERROR patterns aren't allowed in methods without bodies
+    fn foo(_: (i32, i32)); //~ ERROR patterns aren't allowed in functions without bodies [E0642]
 
-    fn bar(_: (i32, i32)) {} //~ ERROR patterns aren't allowed in methods without bodies
-
-    fn method(_: S) {} //~ ERROR patterns aren't allowed in methods without bodies
+    fn bar((x, y): (i32, i32)) {} // ok
+    fn method(S { .. }: S) {} // ok
 
     fn f(&ident: &S) {} // ok
     fn g(&&ident: &&S) {} // ok

--- a/tests/ui/error-codes/E0642.rs
+++ b/tests/ui/error-codes/E0642.rs
@@ -1,3 +1,4 @@
+//@ edition:2024
 //@ run-rustfix
 
 #![allow(unused)] // for rustfix
@@ -6,11 +7,10 @@
 struct S;
 
 trait T {
-    fn foo((x, y): (i32, i32)); //~ ERROR patterns aren't allowed in methods without bodies
+    fn foo((x, y): (i32, i32)); //~ ERROR patterns aren't allowed in functions without bodies [E0642]
 
-    fn bar((x, y): (i32, i32)) {} //~ ERROR patterns aren't allowed in methods without bodies
-
-    fn method(S { .. }: S) {} //~ ERROR patterns aren't allowed in methods without bodies
+    fn bar((x, y): (i32, i32)) {} // ok
+    fn method(S { .. }: S) {} // ok
 
     fn f(&ident: &S) {} // ok
     fn g(&&ident: &&S) {} // ok

--- a/tests/ui/error-codes/E0642.stderr
+++ b/tests/ui/error-codes/E0642.stderr
@@ -1,8 +1,8 @@
-error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:9:12
+error[E0642]: patterns aren't allowed in functions without bodies
+  --> $DIR/E0642.rs:10:12
    |
 LL |     fn foo((x, y): (i32, i32));
-   |            ^^^^^^
+   |            ^^^^^^ pattern not allowed in function without body
    |
 help: give this argument a name or use an underscore to ignore it
    |
@@ -10,30 +10,6 @@ LL -     fn foo((x, y): (i32, i32));
 LL +     fn foo(_: (i32, i32));
    |
 
-error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:11:12
-   |
-LL |     fn bar((x, y): (i32, i32)) {}
-   |            ^^^^^^
-   |
-help: give this argument a name or use an underscore to ignore it
-   |
-LL -     fn bar((x, y): (i32, i32)) {}
-LL +     fn bar(_: (i32, i32)) {}
-   |
-
-error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/E0642.rs:13:15
-   |
-LL |     fn method(S { .. }: S) {}
-   |               ^^^^^^^^
-   |
-help: give this argument a name or use an underscore to ignore it
-   |
-LL -     fn method(S { .. }: S) {}
-LL +     fn method(_: S) {}
-   |
-
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0642`.

--- a/tests/ui/issues/issue-50571.fixed
+++ b/tests/ui/issues/issue-50571.fixed
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 trait Foo {
     fn foo(_: [i32; 2]) {}
-    //~^ ERROR: patterns aren't allowed in methods without bodies
+    //~^ ERROR: patterns aren't allowed in trait methods in the 2015 edition
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-50571.rs
+++ b/tests/ui/issues/issue-50571.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 trait Foo {
     fn foo([a, b]: [i32; 2]) {}
-    //~^ ERROR: patterns aren't allowed in methods without bodies
+    //~^ ERROR: patterns aren't allowed in trait methods in the 2015 edition
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-50571.stderr
+++ b/tests/ui/issues/issue-50571.stderr
@@ -1,10 +1,11 @@
-error[E0642]: patterns aren't allowed in methods without bodies
+error: patterns aren't allowed in trait methods in the 2015 edition
   --> $DIR/issue-50571.rs:6:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^
    |
-help: give this argument a name or use an underscore to ignore it
+   = note: upgrading editions will fix this error
+help: in this edition, give this argument a name or use an underscore to ignore it
    |
 LL -     fn foo([a, b]: [i32; 2]) {}
 LL +     fn foo(_: [i32; 2]) {}
@@ -12,4 +13,3 @@ LL +     fn foo(_: [i32; 2]) {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0642`.

--- a/tests/ui/macros/no-patterns-in-args-macro.stderr
+++ b/tests/ui/macros/no-patterns-in-args-macro.stderr
@@ -3,12 +3,24 @@ error[E0642]: patterns aren't allowed in functions without bodies
    |
 LL |     m!((bad, pat));
    |        ^^^^^^^^^^ pattern not allowed in function without body
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     m!((bad, pat));
+LL +     m!(_);
+   |
 
 error[E0561]: patterns aren't allowed in function pointer types
   --> $DIR/no-patterns-in-args-macro.rs:20:8
    |
 LL |     m!((bad, pat));
    |        ^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     m!((bad, pat));
+LL +     m!(_);
+   |
 
 error[E0130]: patterns aren't allowed in foreign function declarations
   --> $DIR/no-patterns-in-args-macro.rs:20:8

--- a/tests/ui/parser/self-param-semantic-fail.rs
+++ b/tests/ui/parser/self-param-semantic-fail.rs
@@ -40,15 +40,14 @@ extern "C" {
     fn f7(self: u8);
     //~^ ERROR `self` parameter is only allowed in associated functions
     fn f8(mut self: u8);
-//~^ ERROR `self` parameter is only allowed in associated functions
-//~| ERROR patterns aren't allowed in
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR patterns aren't allowed in
 }
 
 type X1 = fn(self);
 //~^ ERROR `self` parameter is only allowed in associated functions
 type X2 = fn(mut self);
 //~^ ERROR `self` parameter is only allowed in associated functions
-//~| ERROR patterns aren't allowed in
 type X3 = fn(&self);
 //~^ ERROR `self` parameter is only allowed in associated functions
 type X4 = fn(&mut self);
@@ -61,4 +60,3 @@ type X7 = fn(self: u8);
 //~^ ERROR `self` parameter is only allowed in associated functions
 type X8 = fn(mut self: u8);
 //~^ ERROR `self` parameter is only allowed in associated functions
-//~| ERROR patterns aren't allowed in

--- a/tests/ui/parser/self-param-semantic-fail.stderr
+++ b/tests/ui/parser/self-param-semantic-fail.stderr
@@ -154,14 +154,8 @@ LL | type X2 = fn(mut self);
    |
    = note: associated functions are those in `impl` or `trait` definitions
 
-error[E0561]: patterns aren't allowed in function pointer types
-  --> $DIR/self-param-semantic-fail.rs:49:14
-   |
-LL | type X2 = fn(mut self);
-   |              ^^^^^^^^
-
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:52:14
+  --> $DIR/self-param-semantic-fail.rs:51:14
    |
 LL | type X3 = fn(&self);
    |              ^^^^^ not semantically valid as function parameter
@@ -169,7 +163,7 @@ LL | type X3 = fn(&self);
    = note: associated functions are those in `impl` or `trait` definitions
 
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:54:14
+  --> $DIR/self-param-semantic-fail.rs:53:14
    |
 LL | type X4 = fn(&mut self);
    |              ^^^^^^^^^ not semantically valid as function parameter
@@ -177,7 +171,7 @@ LL | type X4 = fn(&mut self);
    = note: associated functions are those in `impl` or `trait` definitions
 
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:56:22
+  --> $DIR/self-param-semantic-fail.rs:55:22
    |
 LL | type X5 = for<'a> fn(&'a self);
    |                      ^^^^^^^^ not semantically valid as function parameter
@@ -185,7 +179,7 @@ LL | type X5 = for<'a> fn(&'a self);
    = note: associated functions are those in `impl` or `trait` definitions
 
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:58:22
+  --> $DIR/self-param-semantic-fail.rs:57:22
    |
 LL | type X6 = for<'a> fn(&'a mut self);
    |                      ^^^^^^^^^^^^ not semantically valid as function parameter
@@ -193,7 +187,7 @@ LL | type X6 = for<'a> fn(&'a mut self);
    = note: associated functions are those in `impl` or `trait` definitions
 
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:60:14
+  --> $DIR/self-param-semantic-fail.rs:59:14
    |
 LL | type X7 = fn(self: u8);
    |              ^^^^ not semantically valid as function parameter
@@ -201,20 +195,13 @@ LL | type X7 = fn(self: u8);
    = note: associated functions are those in `impl` or `trait` definitions
 
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/self-param-semantic-fail.rs:62:14
+  --> $DIR/self-param-semantic-fail.rs:61:14
    |
 LL | type X8 = fn(mut self: u8);
    |              ^^^^^^^^ not semantically valid as function parameter
    |
    = note: associated functions are those in `impl` or `trait` definitions
 
-error[E0561]: patterns aren't allowed in function pointer types
-  --> $DIR/self-param-semantic-fail.rs:62:14
-   |
-LL | type X8 = fn(mut self: u8);
-   |              ^^^^^^^^
+error: aborting due to 26 previous errors
 
-error: aborting due to 28 previous errors
-
-Some errors have detailed explanations: E0130, E0561.
-For more information about an error, try `rustc --explain E0130`.
+For more information about this error, try `rustc --explain E0130`.

--- a/tests/ui/pattern/no-patterns-in-args-2.stderr
+++ b/tests/ui/pattern/no-patterns-in-args-2.stderr
@@ -3,6 +3,12 @@ error[E0642]: patterns aren't allowed in functions without bodies
    |
 LL |     fn f2(&arg: u8);
    |           ^^^^ pattern not allowed in function without body
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     fn f2(&arg: u8);
+LL +     fn f2(_: u8);
+   |
 
 error: patterns aren't allowed in functions without bodies
   --> $DIR/no-patterns-in-args-2.rs:4:11

--- a/tests/ui/pattern/no-patterns-in-args.rs
+++ b/tests/ui/pattern/no-patterns-in-args.rs
@@ -7,8 +7,16 @@ extern "C" {
 // fn g3(u8); // Not yet
 }
 
-type A1 = fn(mut arg: u8); //~ ERROR patterns aren't allowed in function pointer types
-type A2 = fn(&arg: u8); //~ ERROR patterns aren't allowed in function pointer types
+struct Foo {
+    bar: u32
+}
+
+type A1 = fn(mut arg: u8); //~ ERROR patterns aren't allowed in function pointer types [E0561]
+type A2 = fn(&arg: u8); //~ ERROR patterns aren't allowed in function pointer types [E0561]
+type A3 = fn(&_: ()); //~ ERROR patterns aren't allowed in function pointer types [E0561]
+type A4 = fn((): ()); //~ ERROR patterns aren't allowed in function pointer types [E0561]
+type A5 = fn(Foo { bar }: Foo); //~ ERROR patterns aren't allowed in function pointer types [E0561]
+
 type B1 = fn(arg: u8); // OK
 type B2 = fn(_: u8); // OK
 type B3 = fn(u8); // OK

--- a/tests/ui/pattern/no-patterns-in-args.stderr
+++ b/tests/ui/pattern/no-patterns-in-args.stderr
@@ -17,18 +17,66 @@ LL |     fn f3(arg @ _: u8);
    |           ^^^^^^^ pattern not allowed in foreign function
 
 error[E0561]: patterns aren't allowed in function pointer types
-  --> $DIR/no-patterns-in-args.rs:10:14
+  --> $DIR/no-patterns-in-args.rs:14:14
    |
 LL | type A1 = fn(mut arg: u8);
    |              ^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL - type A1 = fn(mut arg: u8);
+LL + type A1 = fn(_: u8);
+   |
 
 error[E0561]: patterns aren't allowed in function pointer types
-  --> $DIR/no-patterns-in-args.rs:11:14
+  --> $DIR/no-patterns-in-args.rs:15:14
    |
 LL | type A2 = fn(&arg: u8);
    |              ^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL - type A2 = fn(&arg: u8);
+LL + type A2 = fn(_: u8);
+   |
 
-error: aborting due to 5 previous errors
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/no-patterns-in-args.rs:16:14
+   |
+LL | type A3 = fn(&_: ());
+   |              ^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL - type A3 = fn(&_: ());
+LL + type A3 = fn(_: ());
+   |
+
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/no-patterns-in-args.rs:17:14
+   |
+LL | type A4 = fn((): ());
+   |              ^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL - type A4 = fn((): ());
+LL + type A4 = fn(_: ());
+   |
+
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/no-patterns-in-args.rs:18:14
+   |
+LL | type A5 = fn(Foo { bar }: Foo);
+   |              ^^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL - type A5 = fn(Foo { bar }: Foo);
+LL + type A5 = fn(_: Foo);
+   |
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0130, E0561.
 For more information about an error, try `rustc --explain E0130`.


### PR DESCRIPTION
This PR addresses two diagnostic issues.

1. In edition 2015, trait fn declarations with function bodies can receive the "patterns aren't allowed in methods without bodies". This behaviour is correct (in edition 2015, trait functions have only a limited subset of patterns because of syntactic ambiguity wrt optional named parameters), but the diagnostic is confusing. This PR changes the message to explain that patterns are not allowed (even with function bodies) in edition 2015.

2. In bare function pointers (`fn(T) -> U`), patterns are not allowed (except for `_` and plain argument names). Currently, this error sometimes gives the "patterns aren't allowed in methods without bodies error". This PR ensures we always get the proper error for patterns in function pointers.

- UI test coverage improved.
- `rust_error_codes` docs improved per rust-lang/rust#97282.

Fixes rust-lang/rust#143113 and fixes rust-lang/rust#97282.
