### PR TITLE
Pretend in bootstrap snapshot tests that we always build in-tree LLVM

### DIFF
--- a/src/bootstrap/src/utils/tests/mod.rs
+++ b/src/bootstrap/src/utils/tests/mod.rs
@@ -7,6 +7,7 @@ use tempfile::TempDir;
 
 use crate::core::builder::Builder;
 use crate::core::config::DryRun;
+use crate::utils::helpers::get_host_target;
 use crate::{Build, Config, Flags, t};
 
 pub mod git;
@@ -90,6 +91,13 @@ impl ConfigBuilder {
         // Ignore submodules
         self.args.push("--set".to_string());
         self.args.push("build.submodules=false".to_string());
+
+        // Override any external LLVM set and inhibit CI LLVM; pretend that we're always building
+        // in-tree LLVM from sources.
+        self.args.push("--set".to_string());
+        self.args.push("llvm.download-ci-llvm=false".to_string());
+        self.args.push("--set".to_string());
+        self.args.push(format!("target.'{}'.llvm-config=false", get_host_target()));
 
         // Do not mess with the local rustc checkout build directory
         self.args.push("--build-dir".to_string());


### PR DESCRIPTION
Otherwise, depending on whether CI LLVM is inhibited or if an externally-provided LLVM is used, bootstrap host LLVM build step could be missing in step snapshots.

Note that I'm not sure if this is the *right* solution (this might be *a* solution). I imagine we do want to control for the set of configuration that these snapshot tests are run, as much as possible.

r? @Kobzol