### PR TITLE
remove armv5te-unknown-linux-gnueabi target maintainer

### DIFF
--- a/src/doc/rustc/src/platform-support/armv5te-unknown-linux-gnueabi.md
+++ b/src/doc/rustc/src/platform-support/armv5te-unknown-linux-gnueabi.md
@@ -7,7 +7,7 @@ floating-point units.
 
 ## Target maintainers
 
-[@koalatux](https://github.com/koalatux)
+There are currently no formally documented target maintainers.
 
 ## Requirements
 


### PR DESCRIPTION
Sadly my former employer doesn't want to maintain this any more and I have no personal interest in maintaining it.