### PR TITLE
Use `object` crate from crates.io to fix windows build error

### DIFF
--- a/compiler/rustc_codegen_gcc/Cargo.lock
+++ b/compiler/rustc_codegen_gcc/Cargo.lock
@@ -144,6 +144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fd943161069e1768b4b3d050890ba48730e590f57e56d4aa04e7e090e61b4a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +188,7 @@ dependencies = [
  "boml",
  "gccjit",
  "lang_tester",
+ "object",
  "tempfile",
 ]
 

--- a/compiler/rustc_codegen_gcc/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/Cargo.toml
@@ -23,6 +23,7 @@ default = ["master"]
 
 [dependencies]
 object = { version = "0.37.0", default-features = false, features = ["std", "read"] }
+tempfile = "3.20"
 gccjit = "2.7"
 #gccjit = { git = "https://github.com/rust-lang/gccjit.rs" }
 
@@ -32,7 +33,6 @@ gccjit = "2.7"
 [dev-dependencies]
 boml = "0.3.1"
 lang_tester = "0.8.0"
-tempfile = "3.20"
 
 [profile.dev]
 # By compiling dependencies with optimizations, performing tests gets much faster.

--- a/compiler/rustc_codegen_gcc/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/Cargo.toml
@@ -22,6 +22,7 @@ master = ["gccjit/master"]
 default = ["master"]
 
 [dependencies]
+object = { version = "0.37.0", default-features = false, features = ["std", "read"] }
 gccjit = "2.7"
 #gccjit = { git = "https://github.com/rust-lang/gccjit.rs" }
 

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -27,7 +27,6 @@
 #![allow(clippy::needless_lifetimes, clippy::uninlined_format_args)]
 
 // Some "regular" crates we want to share with rustc
-extern crate object;
 extern crate smallvec;
 // FIXME(antoyo): clippy bug: remove the #[allow] when it's fixed.
 #[allow(unused_extern_crates)]

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -26,11 +26,9 @@
 #![deny(clippy::pattern_type_mismatch)]
 #![allow(clippy::needless_lifetimes, clippy::uninlined_format_args)]
 
-// Some "regular" crates we want to share with rustc
+// These crates are pulled from the sysroot because they are part of
+// rustc's public API, so we need to ensure version compatibility.
 extern crate smallvec;
-// FIXME(antoyo): clippy bug: remove the #[allow] when it's fixed.
-#[allow(unused_extern_crates)]
-extern crate tempfile;
 #[macro_use]
 extern crate tracing;
 


### PR DESCRIPTION
See https://rust-lang.zulipchat.com/#narrow/channel/386786-rustc-codegen-gcc/topic/Cannot.20compile.20rustc.20on.20Windows.2010/with/527240094
