### PR TITLE
tidy: use --bless for tidy spellcheck instead of spellcheck:fix

### DIFF
--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -446,4 +446,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Added new option `build.tidy-extra-checks` to specify a default value for the --extra-checks cli flag.",
     },
+    ChangeInfo {
+        change_id: 143493,
+        severity: ChangeSeverity::Warning,
+        summary: "The `spellcheck:fix` tidy extra check argument has been removed, use `--bless` instead",
+    },
 ];

--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -72,8 +72,7 @@ fn check_impl(
     let shell_lint = lint_args.contains(&"shell:lint") || shell_all;
     let cpp_all = lint_args.contains(&"cpp");
     let cpp_fmt = lint_args.contains(&"cpp:fmt") || cpp_all;
-    let spellcheck_all = lint_args.contains(&"spellcheck");
-    let spellcheck_fix = lint_args.contains(&"spellcheck:fix");
+    let spellcheck = lint_args.contains(&"spellcheck");
 
     let mut py_path = None;
 
@@ -226,7 +225,7 @@ fn check_impl(
         shellcheck_runner(&merge_args(&cfg_args, &file_args_shc))?;
     }
 
-    if spellcheck_all || spellcheck_fix {
+    if spellcheck {
         let config_path = root_path.join("typos.toml");
         // sync target files with .github/workflows/spellcheck.yml
         let mut args = vec![
@@ -238,11 +237,11 @@ fn check_impl(
             "./src/librustdoc",
         ];
 
-        if spellcheck_all {
-            eprintln!("spellcheck files");
-        } else if spellcheck_fix {
+        if bless {
             eprintln!("spellcheck files and fix");
             args.push("--write-changes");
+        } else {
+            eprintln!("spellcheck files");
         }
         spellcheck_runner(&args)?;
     }

--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -65,6 +65,13 @@ fn check_impl(
         None => vec![],
     };
 
+    if lint_args.contains(&"spellcheck:fix") {
+        return Err(Error::Generic(
+            "`spellcheck:fix` is no longer valid, use `--extra=check=spellcheck --bless`"
+                .to_string(),
+        ));
+    }
+
     let python_all = lint_args.contains(&"py");
     let python_lint = lint_args.contains(&"py:lint") || python_all;
     let python_fmt = lint_args.contains(&"py:fmt") || python_all;


### PR DESCRIPTION
previous behavior was inconsistent with existing extra checks.

unsure if this needs a change tracker entry or a warning for people who try to use the old behavior.

unsure if we should call this `spellcheck:lint` for consistency.

making this consistent is a prerequisite for https://github.com/rust-lang/rust/pull/143398

cc @nnethercote 

r? @Kobzol 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
