### PR TITLE
compiletest: print slightly more information on fs::write failure

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1918,7 +1918,8 @@ impl<'test> TestCx<'test> {
 
     fn dump_output_file(&self, out: &str, extension: &str) {
         let outfile = self.make_out_name(extension);
-        fs::write(outfile.as_std_path(), out).unwrap();
+        fs::write(outfile.as_std_path(), out)
+            .unwrap_or_else(|err| panic!("failed to write {outfile}: {err:?}"));
     }
 
     /// Creates a filename for output with the given extension.


### PR DESCRIPTION
See [#t-infra > compiletest: panic in dump_output_file: No such file or dire @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/compiletest.3A.20panic.20in.20dump_output_file.3A.20No.20such.20file.20or.20dire/near/527294714)