### PR TITLE
[Draft] Supertrait item resolution in subtrait `impl`s

### DIFF
--- a/compiler/rustc_ast_ir/src/lib.rs
+++ b/compiler/rustc_ast_ir/src/lib.rs
@@ -101,3 +101,21 @@ pub enum Pinnedness {
     Not,
     Pinned,
 }
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Copy)]
+#[cfg_attr(
+    feature = "nightly",
+    derive(Encodable_NoContext, Decodable_NoContext, HashStable_NoContext)
+)]
+pub enum TraitRefSource {
+    /// This source excludes all of the other relationships
+    Any,
+    /// The trait ref source establishes a subtrait-supertrait
+    /// relationship
+    Supertrait,
+    /// The trait ref source establishes a subtrait-supertrait
+    /// relationship and we are obliged to assert that the supertrait
+    /// is a marker trait and generate an automatic `impl` for this
+    /// marker trait
+    SupertraitAutoImpl,
+}

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1208,6 +1208,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         bound_generic_params: ThinVec::new(),
                         modifiers: TraitBoundModifiers::NONE,
                         trait_ref: TraitRef { path: path.clone(), ref_id: t.id },
+                        source: TraitRefSource::Any,
                         span: t.span,
                         parens: ast::Parens::No,
                     },
@@ -2018,7 +2019,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let bound_generic_params =
             self.lower_lifetime_binder(p.trait_ref.ref_id, &p.bound_generic_params);
         let trait_ref = self.lower_trait_ref(p.modifiers, &p.trait_ref, itctx);
-        let modifiers = self.lower_trait_bound_modifiers(p.modifiers);
+        let modifiers = self.lower_trait_bound_modifiers(p.modifiers, p.source);
         hir::PolyTraitRef {
             bound_generic_params,
             modifiers,
@@ -2253,8 +2254,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_trait_bound_modifiers(
         &mut self,
         modifiers: TraitBoundModifiers,
+        source: TraitRefSource,
     ) -> hir::TraitBoundModifiers {
-        hir::TraitBoundModifiers { constness: modifiers.constness, polarity: modifiers.polarity }
+        hir::TraitBoundModifiers {
+            constness: modifiers.constness,
+            polarity: modifiers.polarity,
+            source,
+        }
     }
 
     // Helper methods for building HIR.

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -194,6 +194,7 @@ impl<'a> ExtCtxt<'a> {
                 asyncness: ast::BoundAsyncness::Normal,
             },
             trait_ref: self.trait_ref(path),
+            source: ast::TraitRefSource::Any,
             span,
             parens: ast::Parens::No,
         }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1260,6 +1260,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         TEST, pattern_complexity_limit, CrateLevel, template!(NameValueStr: "N"),
         ErrorFollowing, EncodeCrossCrate::No,
     ),
+    rustc_attr!(
+        TEST, rustc_supertrait_in_subtrait_impl, Normal, template!(Word),
+        WarnFollowing, EncodeCrossCrate::Yes,
+    ),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -12,7 +12,7 @@ use rustc_ast::{
 pub use rustc_ast::{
     AssignOp, AssignOpKind, AttrId, AttrStyle, BinOp, BinOpKind, BindingMode, BorrowKind,
     BoundConstness, BoundPolarity, ByRef, CaptureBy, DelimArgs, ImplPolarity, IsAuto,
-    MetaItemInner, MetaItemLit, Movability, Mutability, UnOp,
+    MetaItemInner, MetaItemLit, Movability, Mutability, TraitRefSource, UnOp,
 };
 use rustc_attr_data_structures::AttributeKind;
 use rustc_data_structures::fingerprint::Fingerprint;
@@ -707,11 +707,15 @@ pub enum GenericArgsParentheses {
 pub struct TraitBoundModifiers {
     pub constness: BoundConstness,
     pub polarity: BoundPolarity,
+    pub source: TraitRefSource,
 }
 
 impl TraitBoundModifiers {
-    pub const NONE: Self =
-        TraitBoundModifiers { constness: BoundConstness::Never, polarity: BoundPolarity::Positive };
+    pub const NONE: Self = TraitBoundModifiers {
+        constness: BoundConstness::Never,
+        polarity: BoundPolarity::Positive,
+        source: TraitRefSource::Any,
+    };
 }
 
 #[derive(Clone, Copy, Debug, HashStable_Generic)]
@@ -4966,7 +4970,7 @@ mod size_asserts {
     static_assert_size!(ForeignItem<'_>, 96);
     static_assert_size!(ForeignItemKind<'_>, 56);
     static_assert_size!(GenericArg<'_>, 16);
-    static_assert_size!(GenericBound<'_>, 64);
+    static_assert_size!(GenericBound<'_>, 72);
     static_assert_size!(Generics<'_>, 56);
     static_assert_size!(Impl<'_>, 80);
     static_assert_size!(ImplItem<'_>, 88);

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -79,6 +79,7 @@ pub(crate) fn provide(providers: &mut Providers) {
         predicates_of: predicates_of::predicates_of,
         explicit_predicates_of: predicates_of::explicit_predicates_of,
         explicit_super_predicates_of: predicates_of::explicit_super_predicates_of,
+        supertrait_auto_impls: predicates_of::supertrait_auto_impls,
         explicit_implied_predicates_of: predicates_of::explicit_implied_predicates_of,
         explicit_supertraits_containing_assoc_item:
             predicates_of::explicit_supertraits_containing_assoc_item,

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -779,7 +779,14 @@ impl<'a> State<'a> {
     }
 
     fn print_poly_trait_ref(&mut self, t: &hir::PolyTraitRef<'_>) {
-        let hir::TraitBoundModifiers { constness, polarity } = t.modifiers;
+        let hir::TraitBoundModifiers { constness, polarity, source } = t.modifiers;
+        match source {
+            ast::TraitRefSource::Any | ast::TraitRefSource::Supertrait => {}
+            ast::TraitRefSource::SupertraitAutoImpl => {
+                self.word("auto");
+                self.word("impl");
+            }
+        }
         match constness {
             hir::BoundConstness::Never => {}
             hir::BoundConstness::Always(_) => self.word("const"),

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1312,6 +1312,11 @@ impl<'a> CrateMetadataRef<'a> {
         }
     }
 
+    fn get_module_supertraits(self, id: DefIndex, sess: &'a Session) -> impl Iterator<Item = DefId> {
+        let supertraits = self.root.tables.module_supertraits.get(self, id);
+        supertraits.decode((self, sess)).into_iter()
+    }
+
     fn is_ctfe_mir_available(self, id: DefIndex) -> bool {
         self.root.tables.mir_for_ctfe.get(self, id).is_some()
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -247,6 +247,7 @@ provide! { tcx, def_id, other, cdata,
     inferred_outlives_of => { table_defaulted_array }
     explicit_super_predicates_of => { table_defaulted_array }
     explicit_implied_predicates_of => { table_defaulted_array }
+    supertrait_auto_impls => { table_defaulted_array }
     type_of => { table }
     type_alias_is_lazy => { table_direct }
     variances_of => { table }
@@ -388,6 +389,9 @@ provide! { tcx, def_id, other, cdata,
     dep_kind => { cdata.dep_kind }
     module_children => {
         tcx.arena.alloc_from_iter(cdata.get_module_children(def_id.index, tcx.sess))
+    }
+    module_supertraits => {
+        tcx.arena.alloc_from_iter(cdata.get_module_supertraits(def_id.index, tcx.sess))
     }
     lib_features => { cdata.get_lib_features() }
     stability_implications => {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1534,6 +1534,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 let module_children = self.tcx.module_children_local(local_id);
                 record_array!(self.tables.module_children_non_reexports[def_id] <-
                     module_children.iter().map(|child| child.res.def_id().index));
+                record_defaulted_array!(self.tables.module_supertraits[def_id] <-
+                    self.tcx.module_supertraits_local(local_id));
+                record_defaulted_array!(self.tables.supertrait_auto_impls[def_id] <-
+                    self.tcx.supertrait_auto_impls(local_id).skip_binder());
                 if self.tcx.is_const_trait(def_id) {
                     record_defaulted_array!(self.tables.explicit_implied_const_bounds[def_id]
                         <- self.tcx.explicit_implied_const_bounds(def_id).skip_binder());

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -410,6 +410,10 @@ define_tables! {
     // That's why the encoded list needs to contain `ModChild` structures describing all the names
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
+    // We only propagate just supertrait defs in spite of multiplicity
+    // because this is only to help with name resolution
+    module_supertraits: Table<DefIndex, LazyArray<DefId>>,
+    supertrait_auto_impls: Table<DefIndex, LazyArray<(ty::Clause<'static>, ty::TraitRefSource)>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
 
 - optional:

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -824,6 +824,12 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    query supertrait_auto_impls(key: DefId) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, ty::TraitRefSource)]> {
+        desc { |tcx| "computing the supertrait auto-impls of `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { key.is_local() }
+        separate_provide_extern
+    }
+
     /// The predicates of the trait that are implied during elaboration.
     ///
     /// This is a superset of the super-predicates of the trait, but a subset of the predicates
@@ -2138,6 +2144,10 @@ rustc_queries! {
     }
     query module_children(def_id: DefId) -> &'tcx [ModChild] {
         desc { |tcx| "collecting child items of module `{}`", tcx.def_path_str(def_id) }
+        separate_provide_extern
+    }
+    query module_supertraits(def_id: DefId) -> &'tcx [DefId] {
+        desc { |tcx| "collecting supertraits of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
     query extern_mod_stmt_cnum(def_id: LocalDefId) -> Option<CrateNum> {

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -804,6 +804,7 @@ impl_ref_decoder! {<'tcx>
     rustc_span::def_id::DefId,
     rustc_span::def_id::LocalDefId,
     (rustc_middle::middle::exported_symbols::ExportedSymbol<'tcx>, rustc_middle::middle::exported_symbols::SymbolExportInfo),
+    (ty::Clause<'tcx>, ty::TraitRefSource),
     ty::DeducedParamAttrs,
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -415,6 +415,17 @@ impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for [(ty::Clause<'tcx>, Spa
     }
 }
 
+impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D>
+    for [(ty::Clause<'tcx>, ty::TraitRefSource)]
+{
+    fn decode(decoder: &mut D) -> &'tcx Self {
+        decoder
+            .interner()
+            .arena
+            .alloc_from_iter((0..decoder.read_usize()).map(|_| Decodable::decode(decoder)))
+    }
+}
+
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for [(ty::PolyTraitRef<'tcx>, Span)] {
     fn decode(decoder: &mut D) -> &'tcx Self {
         decoder

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -3357,6 +3357,10 @@ impl<'tcx> TyCtxt<'tcx> {
         self.resolutions(()).module_children.get(&def_id).map_or(&[], |v| &v[..])
     }
 
+    pub fn module_supertraits_local(self, def_id: LocalDefId) -> &'tcx [DefId] {
+        self.resolutions(()).module_supertraits.get(&def_id).map_or(&[], |v| &v[..])
+    }
+
     pub fn resolver_for_lowering(self) -> &'tcx Steal<(ty::ResolverAstLowering, Arc<ast::Crate>)> {
         self.resolver_for_lowering_raw(()).0
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -27,7 +27,7 @@ pub use intrinsic::IntrinsicDef;
 use rustc_abi::{Align, FieldIdx, Integer, IntegerType, ReprFlags, ReprOptions, VariantIdx};
 use rustc_ast::expand::StrippedCfgItem;
 use rustc_ast::node_id::NodeMap;
-pub use rustc_ast_ir::{Movability, Mutability, try_visit};
+pub use rustc_ast_ir::{Movability, Mutability, TraitRefSource, try_visit};
 use rustc_attr_data_structures::AttributeKind;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
@@ -185,6 +185,7 @@ pub struct ResolverGlobalCtxt {
     pub extern_crate_map: UnordMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxIndexSet<LocalDefId>,
     pub module_children: LocalDefIdMap<Vec<ModChild>>,
+    pub module_supertraits: LocalDefIdMap<Vec<DefId>>,
     pub glob_map: FxIndexMap<LocalDefId, FxIndexSet<Symbol>>,
     pub main_def: Option<MainDefinition>,
     pub trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -83,6 +83,7 @@ trivially_parameterized_over_tcx! {
     ty::IntrinsicDef,
     rustc_ast::Attribute,
     rustc_ast::DelimArgs,
+    rustc_ast::TraitRefSource,
     rustc_ast::expand::StrippedCfgItem<rustc_hir::def_id::DefIndex>,
     rustc_attr_data_structures::ConstStability,
     rustc_attr_data_structures::DefaultBodyStability,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1670,7 +1670,7 @@ impl<'a> Parser<'a> {
         }
 
         self.bump(); // `+`
-        let _bounds = self.parse_generic_bounds()?;
+        let _bounds = self.parse_generic_bounds(false)?;
         let sub = match &ty.kind {
             TyKind::Ref(_lifetime, mut_ty) => {
                 let lo = mut_ty.ty.span.shrink_to_lo();

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -84,7 +84,7 @@ impl<'a> Parser<'a> {
                 }
                 self.restore_snapshot(snapshot);
             }
-            self.parse_generic_bounds()?
+            self.parse_generic_bounds(false)?
         } else {
             Vec::new()
         };
@@ -528,7 +528,7 @@ impl<'a> Parser<'a> {
         // or with mandatory equality sign and the second type.
         let ty = self.parse_ty_for_where_clause()?;
         if self.eat(exp!(Colon)) {
-            let bounds = self.parse_generic_bounds()?;
+            let bounds = self.parse_generic_bounds(false)?;
             Ok(ast::WherePredicateKind::BoundPredicate(ast::WhereBoundPredicate {
                 bound_generic_params: lifetime_defs,
                 bounded_ty: ty,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -898,7 +898,7 @@ impl<'a> Parser<'a> {
         // Parse optional colon and supertrait bounds.
         let had_colon = self.eat(exp!(Colon));
         let span_at_colon = self.prev_token.span;
-        let bounds = if had_colon { self.parse_generic_bounds()? } else { Vec::new() };
+        let bounds = if had_colon { self.parse_generic_bounds(true)? } else { Vec::new() };
 
         let span_before_eq = self.prev_token.span;
         if self.eat(exp!(Eq)) {
@@ -908,7 +908,8 @@ impl<'a> Parser<'a> {
                 self.dcx().emit_err(errors::BoundsNotAllowedOnTraitAliases { span });
             }
 
-            let bounds = self.parse_generic_bounds()?;
+            // We should collect trait aliases as supertraits.
+            let bounds = self.parse_generic_bounds(true)?;
             generics.where_clause = self.parse_where_clause()?;
             self.expect_semi()?;
 
@@ -995,7 +996,8 @@ impl<'a> Parser<'a> {
         let mut generics = self.parse_generics()?;
 
         // Parse optional colon and param bounds.
-        let bounds = if self.eat(exp!(Colon)) { self.parse_generic_bounds()? } else { Vec::new() };
+        let bounds =
+            if self.eat(exp!(Colon)) { self.parse_generic_bounds(false)? } else { Vec::new() };
         let before_where_clause = self.parse_where_clause()?;
 
         let ty = if self.eat(exp!(Eq)) { Some(self.parse_ty()?) } else { None };

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -745,7 +745,7 @@ impl<'a> Parser<'a> {
                         ));
                     }
                     let kind = if self.eat(exp!(Colon)) {
-                        AssocItemConstraintKind::Bound { bounds: self.parse_generic_bounds()? }
+                        AssocItemConstraintKind::Bound { bounds: self.parse_generic_bounds(false)? }
                     } else if self.eat(exp!(Eq)) {
                         self.parse_assoc_equality_term(
                             ident,

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -403,6 +403,9 @@ resolve_tool_was_already_registered =
     tool `{$tool}` was already registered
     .label = already registered here
 
+resolve_supertrait_impl_ambiguous =
+    `{$name}` is ambiguous among supertraits, it could refer to either `{$one}` or `{$another}`
+
 resolve_trait_impl_duplicate =
     duplicate definitions with name `{$name}`:
     .label = duplicate definition

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -201,6 +201,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let parent_scope = ParentScope::module(module, self);
             self.build_reduced_graph_for_external_crate_res(child, parent_scope)
         }
+        // Populate the supertrait `DefId`s if the module is allowed
+        // to refer to their associated items.
+        module.supertraits.borrow_mut().extend(self.tcx.module_supertraits(module.def_id()));
     }
 
     /// Builds the reduced graph for a single item in an external crate.
@@ -1427,7 +1430,7 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
             self.r.feed_visibility(feed, vis);
         }
 
-        if ctxt == AssocCtxt::Trait {
+        if matches!(ctxt, AssocCtxt::Trait) {
             let parent = self.parent_scope.module;
             let expansion = self.parent_scope.expansion;
             self.r.define(parent, ident, ns, (self.res(def_id), vis, item.span, expansion));

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1231,6 +1231,16 @@ pub(crate) struct ItemWasCfgOut {
 }
 
 #[derive(Diagnostic)]
+#[diag(resolve_supertrait_impl_ambiguous)]
+pub(crate) struct SupertraitImplAmbiguous {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) name: Ident,
+    pub(crate) another: String,
+    pub(crate) one: String,
+}
+
+#[derive(Diagnostic)]
 #[diag(resolve_trait_impl_mismatch)]
 pub(crate) struct TraitImplMismatch {
     #[primary_span]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3831,6 +3831,7 @@ fn mk_where_bound_predicate(
                 path: ast::Path { segments: modified_segments, span: DUMMY_SP, tokens: None },
                 ref_id: DUMMY_NODE_ID,
             },
+            source: ast::TraitRefSource::Any,
             span: DUMMY_SP,
             parens: ast::Parens::No,
         })],

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1899,6 +1899,7 @@ symbols! {
         rustc_specialization_trait,
         rustc_std_internal_symbol,
         rustc_strict_coherence,
+        rustc_supertrait_in_subtrait_impl,
         rustc_symbol_name,
         rustc_test_marker,
         rustc_then_this_would_need,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1279,6 +1279,7 @@ impl GenericBound {
             hir::TraitBoundModifiers {
                 polarity: hir::BoundPolarity::Maybe(DUMMY_SP),
                 constness: hir::BoundConstness::Never,
+                source: hir::TraitRefSource::Any,
             },
         )
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -269,7 +269,7 @@ impl clean::GenericBound {
             clean::GenericBound::Outlives(lt) => write!(f, "{}", lt.print()),
             clean::GenericBound::TraitBound(ty, modifiers) => {
                 // `const` and `[const]` trait bounds are experimental; don't render them.
-                let hir::TraitBoundModifiers { polarity, constness: _ } = modifiers;
+                let hir::TraitBoundModifiers { polarity, constness: _, source: _ } = modifiers;
                 f.write_str(match polarity {
                     hir::BoundPolarity::Positive => "",
                     hir::BoundPolarity::Maybe(_) => "?",

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -517,7 +517,7 @@ impl FromClean<rustc_hir::TraitBoundModifiers> for TraitBoundModifier {
         _renderer: &JsonRenderer<'_>,
     ) -> Self {
         use rustc_hir as hir;
-        let hir::TraitBoundModifiers { constness, polarity } = modifiers;
+        let hir::TraitBoundModifiers { constness, polarity, source: _ } = modifiers;
         match (constness, polarity) {
             (hir::BoundConstness::Never, hir::BoundPolarity::Positive) => TraitBoundModifier::None,
             (hir::BoundConstness::Never, hir::BoundPolarity::Maybe(_)) => TraitBoundModifier::Maybe,

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -1223,9 +1223,14 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_modifiers(&mut self, modifiers: TraitBoundModifiers) {
-        let TraitBoundModifiers { constness, polarity } = modifiers;
+        let TraitBoundModifiers {
+            constness,
+            polarity,
+            source,
+        } = modifiers;
         std::mem::discriminant(&polarity).hash(&mut self.s);
         std::mem::discriminant(&constness).hash(&mut self.s);
+        std::mem::discriminant(&source).hash(&mut self.s);
     }
 
     pub fn hash_stmt(&mut self, b: &Stmt<'_>) {

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -90,9 +90,9 @@ hir-stats Pat                      360 (NN.N%)             5            72
 hir-stats - Struct                    72 (NN.N%)             1
 hir-stats - Wild                      72 (NN.N%)             1
 hir-stats - Binding                  216 (NN.N%)             3
+hir-stats GenericBound             288 (NN.N%)             4            72
+hir-stats - Trait                    288 (NN.N%)             4
 hir-stats Block                    288 (NN.N%)             6            48
-hir-stats GenericBound             256 (NN.N%)             4            64
-hir-stats - Trait                    256 (NN.N%)             4
 hir-stats Attribute                200 (NN.N%)             5            40
 hir-stats Variant                  144 (NN.N%)             2            72
 hir-stats GenericArgs              144 (NN.N%)             3            48
@@ -119,5 +119,5 @@ hir-stats Mod                       32 (NN.N%)             1            32
 hir-stats Lifetime                  28 (NN.N%)             1            28
 hir-stats ForeignItemRef            24 (NN.N%)             1            24
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_716                   173
+hir-stats Total                  8_748                   173
 hir-stats ================================================================

--- a/tests/ui/traits/super-subtraits/supertrait-in-subtrait-impl.rs
+++ b/tests/ui/traits/super-subtraits/supertrait-in-subtrait-impl.rs
@@ -1,0 +1,17 @@
+#![feature(rustc_attrs)]
+
+trait Sup {
+    type A;
+}
+
+#[rustc_supertrait_in_subtrait_impl]
+trait Sub: Sup {}
+
+struct S;
+impl Sub for S {
+    //~^ ERROR: the trait bound `S: Sup` is not satisfied
+    type A = ();
+    //~^ ERROR: the trait bound `S: Sup` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/super-subtraits/supertrait-in-subtrait-impl.stderr
+++ b/tests/ui/traits/super-subtraits/supertrait-in-subtrait-impl.stderr
@@ -1,0 +1,32 @@
+error[E0277]: the trait bound `S: Sup` is not satisfied
+  --> $DIR/supertrait-in-subtrait-impl.rs:13:14
+   |
+LL |     type A = ();
+   |              ^^ the trait `Sup` is not implemented for `S`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/supertrait-in-subtrait-impl.rs:3:1
+   |
+LL | trait Sup {
+   | ^^^^^^^^^
+
+error[E0277]: the trait bound `S: Sup` is not satisfied
+  --> $DIR/supertrait-in-subtrait-impl.rs:11:14
+   |
+LL | impl Sub for S {
+   |              ^ the trait `Sup` is not implemented for `S`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/supertrait-in-subtrait-impl.rs:3:1
+   |
+LL | trait Sup {
+   | ^^^^^^^^^
+note: required by a bound in `Sub`
+  --> $DIR/supertrait-in-subtrait-impl.rs:8:12
+   |
+LL | trait Sub: Sup {}
+   |            ^^^ required by this bound in `Sub`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @ghost

cc @cramertj @petrochenkov

This is pertaining to implementable trait aliases, `Deref`/`Receiver` trait migration and supertrait items in subtrait `impl`s.

This is a draft for the resolver and crate metadata changes. Through this patch, the resolver will pick up supertrait items, collected from the trait super-bounds and trait alias in a future extension. This information will be encoded so that the resolver can resolve names in the downstream crates.

I would like to post this draft earlier because there are already significant design changes, which may warrant collecting opinions ahead of time.

Next steps would be
- teach `hir-analysis` to collect associated items in subtrait items into implied supertrait `impl`s;
- adapt the syntax so that associated items can be paths instead of just identifies today, because associate items on paths is essential for the disambiguation of the design.