### PR TITLE
More carefully consider span context when suggesting remove `&mut`

### DIFF
--- a/tests/ui/suggestions/suggest-remove-refs-6.rs
+++ b/tests/ui/suggestions/suggest-remove-refs-6.rs
@@ -1,0 +1,12 @@
+// Regression test for #143523.
+
+trait Trait {}
+
+impl Trait for Vec<i32> {}
+
+fn foo(_: impl Trait) {}
+
+fn main() {
+    foo(&mut vec![1]);
+    //~^ ERROR the trait bound `&mut Vec<{integer}>: Trait` is not satisfied
+}

--- a/tests/ui/suggestions/suggest-remove-refs-6.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-6.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `&mut Vec<{integer}>: Trait` is not satisfied
+  --> $DIR/suggest-remove-refs-6.rs:10:9
+   |
+LL |     foo(&mut vec![1]);
+   |     --- ^^^^^^^^^^^^ the trait `Trait` is not implemented for `&mut Vec<{integer}>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `foo`
+  --> $DIR/suggest-remove-refs-6.rs:7:16
+   |
+LL | fn foo(_: impl Trait) {}
+   |                ^^^^^ required by this bound in `foo`
+help: consider removing the leading `&`-reference
+   |
+LL -     foo(&mut vec![1]);
+LL +     foo(vec![1]);
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Use `find_ancestor_inside` to compute a relative span that is macro-aware, rather than falling back to using BytePos arithmetic which is wrong for `&mut`.

Fixes https://github.com/rust-lang/rust/issues/143523