### PR TITLE
Selectively replace instances of `error-pattern` with `check-run-results`

### DIFF
--- a/tests/ui/array-slice-vec/bounds-check-no-overflow.rs
+++ b/tests/ui/array-slice-vec/bounds-check-no-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds
+//@ check-run-results
 //@ needs-subprocess
 
 use std::mem::size_of;

--- a/tests/ui/array-slice-vec/dst-raw-slice.rs
+++ b/tests/ui/array-slice-vec/dst-raw-slice.rs
@@ -1,7 +1,7 @@
 // Test bounds checking for DST raw slices
 
 //@ run-fail
-//@ error-pattern:index out of bounds
+//@ check-run-results
 //@ needs-subprocess
 
 #[allow(unconditional_panic)]

--- a/tests/ui/array-slice-vec/vec-overrun.rs
+++ b/tests/ui/array-slice-vec/vec-overrun.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 1 but the index is 2
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-completion.rs
+++ b/tests/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-completion.rs
@@ -2,8 +2,7 @@
 // be talking about `async fn`s instead.
 
 //@ run-fail
-//@ error-pattern: thread 'main' panicked
-//@ error-pattern: `async fn` resumed after completion
+//@ check-run-results
 //@ edition:2018
 
 #![feature(coroutines, coroutine_trait)]

--- a/tests/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/tests/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -3,8 +3,7 @@
 
 //@ run-fail
 //@ needs-unwind
-//@ error-pattern: thread 'main' panicked
-//@ error-pattern: `async fn` resumed after panicking
+//@ check-run-results
 //@ edition:2018
 
 #![feature(coroutines, coroutine_trait)]

--- a/tests/ui/async-await/issues/issue-65419/issue-65419-coroutine-resume-after-completion.rs
+++ b/tests/ui/async-await/issues/issue-65419/issue-65419-coroutine-resume-after-completion.rs
@@ -3,7 +3,7 @@
 // panic when resumed after completion.
 
 //@ run-fail
-//@ error-pattern:coroutine resumed after completion
+//@ check-run-results
 //@ edition:2018
 
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]

--- a/tests/ui/binop/binop-fail-3.rs
+++ b/tests/ui/binop/binop-fail-3.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:quux
+//@ check-run-results
 //@ needs-subprocess
 
 fn foo() -> ! {

--- a/tests/ui/binop/binop-panic.rs
+++ b/tests/ui/binop/binop-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:quux
+//@ check-run-results
 //@ needs-subprocess
 
 fn my_err(s: String) -> ! {

--- a/tests/ui/borrowck/borrowck-local-borrow.rs
+++ b/tests/ui/borrowck/borrowck-local-borrow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:panic 1
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/borrowck/issue-28934.rs
+++ b/tests/ui/borrowck/issue-28934.rs
@@ -2,7 +2,7 @@
 // which were not being considered during the contraction phase.
 
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 struct Parser<'i: 't, 't>(&'i u8, &'t u8);

--- a/tests/ui/closures/diverging-closure.rs
+++ b/tests/ui/closures/diverging-closure.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:oops
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/consts/issue-29798.rs
+++ b/tests/ui/consts/issue-29798.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 5 but the index is 5
+//@ check-run-results
 //@ needs-subprocess
 
 const fn test(x: usize) -> i32 {

--- a/tests/ui/coroutine/coroutine-resume-after-panic.rs
+++ b/tests/ui/coroutine/coroutine-resume-after-panic.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ needs-unwind
-//@ error-pattern:coroutine resumed after panicking
+//@ check-run-results
 //@ needs-subprocess
 
 // Test that we get the correct message for resuming a panicked coroutine.

--- a/tests/ui/errors/remap-path-prefix-reverse.rs
+++ b/tests/ui/errors/remap-path-prefix-reverse.rs
@@ -6,7 +6,7 @@
 //@ [remapped-self] remap-src-base
 
 // Verify that the expected source code is shown.
-//@ error-pattern: pub struct SomeStruct {} // This line should be show
+//@ check-run-results
 
 extern crate remapped_dep;
 

--- a/tests/ui/expr/copy.rs
+++ b/tests/ui/expr/copy.rs
@@ -1,3 +1,4 @@
+// FLUFFY
 //@ run-pass
 
 fn f(arg: &mut A) {

--- a/tests/ui/expr/if/expr-if-panic-fn.rs
+++ b/tests/ui/expr/if/expr-if-panic-fn.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn f() -> ! {

--- a/tests/ui/expr/if/expr-if-panic.rs
+++ b/tests/ui/expr/if/expr-if-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/expr/if/if-check-panic.rs
+++ b/tests/ui/expr/if/if-check-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:Number is odd
+//@ check-run-results
 //@ needs-subprocess
 
 fn even(x: usize) -> bool {

--- a/tests/ui/expr/if/if-cond-bot.rs
+++ b/tests/ui/expr/if/if-cond-bot.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:quux
+//@ check-run-results
 //@ needs-subprocess
 
 fn my_err(s: String) -> ! {

--- a/tests/ui/extern/issue-18576.rs
+++ b/tests/ui/extern/issue-18576.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:stop
+//@ check-run-results
 //@ needs-subprocess
 
 // #18576

--- a/tests/ui/fn/expr-fn-panic.rs
+++ b/tests/ui/fn/expr-fn-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn f() -> ! {

--- a/tests/ui/generic-associated-types/static-lifetime-tip-with-default-type.rs
+++ b/tests/ui/generic-associated-types/static-lifetime-tip-with-default-type.rs
@@ -1,6 +1,4 @@
-//@ error-pattern: r#T: 'static
-//@ error-pattern: r#K: 'static
-//@ error-pattern: T: 'static=
+//@ check-run-results
 
 // https://github.com/rust-lang/rust/issues/124785
 

--- a/tests/ui/imports/glob-use-std.rs
+++ b/tests/ui/imports/glob-use-std.rs
@@ -1,7 +1,7 @@
 // Issue #7580
 
 //@ run-fail
-//@ error-pattern:panic works
+//@ check-run-results
 //@ needs-subprocess
 
 use std::*;

--- a/tests/ui/issues/issue-12920.rs
+++ b/tests/ui/issues/issue-12920.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 pub fn main() {

--- a/tests/ui/issues/issue-13202.rs
+++ b/tests/ui/issues/issue-13202.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:bad input
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/issues/issue-20971.rs
+++ b/tests/ui/issues/issue-20971.rs
@@ -1,7 +1,7 @@
 // Regression test for Issue #20971.
 
 //@ run-fail
-//@ error-pattern:Hello, world!
+//@ check-run-results
 //@ needs-subprocess
 
 pub trait Parser {

--- a/tests/ui/issues/issue-23354-2.rs
+++ b/tests/ui/issues/issue-23354-2.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:panic evaluated
+//@ check-run-results
 //@ needs-subprocess
 
 #[allow(unused_variables)]

--- a/tests/ui/issues/issue-23354.rs
+++ b/tests/ui/issues/issue-23354.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:panic evaluated
+//@ check-run-results
 //@ needs-subprocess
 
 #[allow(unused_variables)]

--- a/tests/ui/issues/issue-2470-bounds-check-overflow.rs
+++ b/tests/ui/issues/issue-2470-bounds-check-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds
+//@ check-run-results
 //@ needs-subprocess
 
 use std::mem;

--- a/tests/ui/issues/issue-2761.rs
+++ b/tests/ui/issues/issue-2761.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:custom message
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/issues/issue-3029.rs
+++ b/tests/ui/issues/issue-3029.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:so long
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(unreachable_code)]

--- a/tests/ui/issues/issue-30380.rs
+++ b/tests/ui/issues/issue-30380.rs
@@ -2,7 +2,7 @@
 // destroyed values lying around for other destructors to observe.
 
 //@ run-fail
-//@ error-pattern:panicking destructors ftw!
+//@ check-run-results
 //@ needs-subprocess
 
 struct Observer<'a>(&'a mut FilledOnDrop);

--- a/tests/ui/issues/issue-44216-add-instant.rs
+++ b/tests/ui/issues/issue-44216-add-instant.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:overflow
+//@ check-run-results
 
 use std::time::{Duration, Instant};
 

--- a/tests/ui/issues/issue-44216-add-system-time.rs
+++ b/tests/ui/issues/issue-44216-add-system-time.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:overflow
+//@ check-run-results
 //@ needs-subprocess
 
 use std::time::{Duration, SystemTime};

--- a/tests/ui/issues/issue-44216-sub-instant.rs
+++ b/tests/ui/issues/issue-44216-sub-instant.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:overflow
+//@ check-run-results
 //@ needs-subprocess
 
 use std::time::{Instant, Duration};

--- a/tests/ui/issues/issue-44216-sub-system-time.rs
+++ b/tests/ui/issues/issue-44216-sub-system-time.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:overflow
+//@ check-run-results
 //@ needs-subprocess
 
 use std::time::{Duration, SystemTime};

--- a/tests/ui/loops/for-each-loop-panic.rs
+++ b/tests/ui/loops/for-each-loop-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:moop
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/loops/issue-69225-SCEVAddExpr-wrap-flag.rs
+++ b/tests/ui/loops/issue-69225-SCEVAddExpr-wrap-flag.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C opt-level=3
-//@ error-pattern: index out of bounds: the len is 0 but the index is 16777216
+//@ check-run-results
 
 fn do_test(x: usize) {
     let mut arr = vec![vec![0u8; 3]];

--- a/tests/ui/loops/issue-69225-layout-repeated-checked-add.rs
+++ b/tests/ui/loops/issue-69225-layout-repeated-checked-add.rs
@@ -3,7 +3,7 @@
 
 //@ run-fail
 //@ compile-flags: -C opt-level=3
-//@ error-pattern: index out of bounds: the len is 0 but the index is 16777216
+//@ check-run-results
 
 fn do_test(x: usize) {
     let arr = vec![vec![0u8; 3]];

--- a/tests/ui/macros/assert-as-macro.rs
+++ b/tests/ui/macros/assert-as-macro.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion failed: 1 == 2
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-msg.rs
+++ b/tests/ui/macros/assert-eq-macro-msg.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion `left == right` failed: 1 + 1 definitely should be 3
-//@ error-pattern:  left: 2
-//@ error-pattern: right: 3
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-eq-macro-panic.rs
+++ b/tests/ui/macros/assert-eq-macro-panic.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion `left == right` failed
-//@ error-pattern:  left: 14
-//@ error-pattern: right: 15
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-macro-explicit.rs
+++ b/tests/ui/macros/assert-macro-explicit.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion failed: false
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-macro-fmt.rs
+++ b/tests/ui/macros/assert-macro-fmt.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern: panicked
-//@ error-pattern: test-assert-fmt 42 rust
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-macro-owned.rs
+++ b/tests/ui/macros/assert-macro-owned.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:test-assert-owned
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(non_fmt_panics)]

--- a/tests/ui/macros/assert-macro-static.rs
+++ b/tests/ui/macros/assert-macro-static.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:test-assert-static
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion `left matches right` failed: 1 + 1 definitely should be 3
-//@ error-pattern:  left: 2
-//@ error-pattern: right: 3
+//@ check-run-results
 //@ needs-subprocess
 
 #![feature(assert_matches)]

--- a/tests/ui/macros/assert-ne-macro-msg.rs
+++ b/tests/ui/macros/assert-ne-macro-msg.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion `left != right` failed: 1 + 1 definitely should not be 2
-//@ error-pattern:  left: 2
-//@ error-pattern: right: 2
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/assert-ne-macro-panic.rs
+++ b/tests/ui/macros/assert-ne-macro-panic.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:assertion `left != right` failed
-//@ error-pattern:  left: 14
-//@ error-pattern: right: 14
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/borrowck-error-in-macro.rs
+++ b/tests/ui/macros/borrowck-error-in-macro.rs
@@ -1,5 +1,5 @@
 //@ aux-build: borrowck-error-in-macro.rs
-//@ error-pattern: a call in this macro requires a mutable binding due to mutable borrow of `d`
+//@ check-run-results
 //FIXME: remove error-pattern (see #141896)
 
 extern crate borrowck_error_in_macro as a;

--- a/tests/ui/macros/die-macro-2.rs
+++ b/tests/ui/macros/die-macro-2.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:test
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/die-macro-expr.rs
+++ b/tests/ui/macros/die-macro-expr.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:test
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/die-macro-pure.rs
+++ b/tests/ui/macros/die-macro-pure.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:test
+//@ check-run-results
 //@ needs-subprocess
 
 fn f() {

--- a/tests/ui/macros/unimplemented-macro-panic.rs
+++ b/tests/ui/macros/unimplemented-macro-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:not implemented
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/unreachable-fmt-msg.rs
+++ b/tests/ui/macros/unreachable-fmt-msg.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:internal error: entered unreachable code: 6 is not prime
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/unreachable-macro-panic.rs
+++ b/tests/ui/macros/unreachable-macro-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:internal error: entered unreachable code
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/unreachable-static-msg.rs
+++ b/tests/ui/macros/unreachable-static-msg.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:internal error: entered unreachable code: uhoh
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/macros/unreachable.rs
+++ b/tests/ui/macros/unreachable.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:internal error: entered unreachable code
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/match/expr-match-panic-fn.rs
+++ b/tests/ui/match/expr-match-panic-fn.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn f() -> ! {

--- a/tests/ui/match/expr-match-panic.rs
+++ b/tests/ui/match/expr-match-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/match/match-bot-panic.rs
+++ b/tests/ui/match/match-bot-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(unreachable_code)]

--- a/tests/ui/match/match-disc-bot.rs
+++ b/tests/ui/match/match-disc-bot.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:quux
+//@ check-run-results
 //@ needs-subprocess
 
 fn f() -> ! {

--- a/tests/ui/match/match-wildcards.rs
+++ b/tests/ui/match/match-wildcards.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:squirrelcupcake
+//@ check-run-results
 //@ needs-subprocess
 
 fn cmp() -> isize {

--- a/tests/ui/mir/alignment/borrow_misaligned_field_projection.rs
+++ b/tests/ui/mir/alignment/borrow_misaligned_field_projection.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 struct Misalignment {
     a: u32,

--- a/tests/ui/mir/alignment/misaligned_borrow.rs
+++ b/tests/ui/mir/alignment/misaligned_borrow.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 fn main() {
     let x = [0u32; 2];

--- a/tests/ui/mir/alignment/misaligned_lhs.rs
+++ b/tests/ui/mir/alignment/misaligned_lhs.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 fn main() {
     let mut x = [0u32; 2];

--- a/tests/ui/mir/alignment/misaligned_mut_borrow.rs
+++ b/tests/ui/mir/alignment/misaligned_mut_borrow.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 fn main() {
     let mut x = [0u32; 2];

--- a/tests/ui/mir/alignment/misaligned_rhs.rs
+++ b/tests/ui/mir/alignment/misaligned_rhs.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 fn main() {
     let mut x = [0u32; 2];

--- a/tests/ui/mir/alignment/two_pointers.rs
+++ b/tests/ui/mir/alignment/two_pointers.rs
@@ -1,7 +1,7 @@
 //@ run-fail
 //@ ignore-i686-pc-windows-msvc: #112480
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: misaligned pointer dereference: address must be a multiple of 0x4 but is
+//@ check-run-results
 
 fn main() {
     let x = [0u32; 2];

--- a/tests/ui/mir/enum/convert_non_enum_break.rs
+++ b/tests/ui/mir/enum/convert_non_enum_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x10000
+//@ check-run-results
 
 #[allow(dead_code)]
 #[repr(u32)]

--- a/tests/ui/mir/enum/convert_non_enum_niche_break.rs
+++ b/tests/ui/mir/enum/convert_non_enum_niche_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x5
+//@ check-run-results
 
 #[allow(dead_code)]
 #[repr(u16)]

--- a/tests/ui/mir/enum/negative_discr_break.rs
+++ b/tests/ui/mir/enum/negative_discr_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0xfd
+//@ check-run-results
 
 #[allow(dead_code)]
 enum Foo {

--- a/tests/ui/mir/enum/niche_option_tuple_break.rs
+++ b/tests/ui/mir/enum/niche_option_tuple_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x3
+//@ check-run-results
 
 #[allow(dead_code)]
 enum Foo {

--- a/tests/ui/mir/enum/numbered_variants_break.rs
+++ b/tests/ui/mir/enum/numbered_variants_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x3
+//@ check-run-results
 
 #[allow(dead_code)]
 enum Foo {

--- a/tests/ui/mir/enum/option_with_bigger_niche_break.rs
+++ b/tests/ui/mir/enum/option_with_bigger_niche_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x0
+//@ check-run-results
 
 #[repr(u32)]
 #[allow(dead_code)]

--- a/tests/ui/mir/enum/plain_no_data_break.rs
+++ b/tests/ui/mir/enum/plain_no_data_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x1
+//@ check-run-results
 
 #[repr(u32)]
 #[allow(dead_code)]

--- a/tests/ui/mir/enum/single_with_repr_break.rs
+++ b/tests/ui/mir/enum/single_with_repr_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x1
+//@ check-run-results
 
 #[allow(dead_code)]
 #[repr(u16)]

--- a/tests/ui/mir/enum/with_niche_int_break.rs
+++ b/tests/ui/mir/enum/with_niche_int_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x4
+//@ check-run-results
 
 #[allow(dead_code)]
 #[repr(u16)]

--- a/tests/ui/mir/enum/wrap_break.rs
+++ b/tests/ui/mir/enum/wrap_break.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: trying to construct an enum from an invalid value 0x0
+//@ check-run-results
 #![feature(never_type)]
 #![allow(invalid_value)]
 

--- a/tests/ui/mir/mir_codegen_calls_converging_drops.rs
+++ b/tests/ui/mir/mir_codegen_calls_converging_drops.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:converging_fn called
-//@ error-pattern:0 dropped
-//@ error-pattern:exit
+//@ check-run-results
 //@ needs-subprocess
 
 struct Droppable(u8);

--- a/tests/ui/mir/mir_codegen_calls_converging_drops_2.rs
+++ b/tests/ui/mir/mir_codegen_calls_converging_drops_2.rs
@@ -1,7 +1,5 @@
 //@ run-fail
-//@ error-pattern:complex called
-//@ error-pattern:dropped
-//@ error-pattern:exit
+//@ check-run-results
 //@ needs-subprocess
 
 struct Droppable;

--- a/tests/ui/mir/mir_codegen_calls_diverging.rs
+++ b/tests/ui/mir/mir_codegen_calls_diverging.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:diverging_fn called
+//@ check-run-results
 //@ needs-subprocess
 
 fn diverging_fn() -> ! {

--- a/tests/ui/mir/mir_codegen_calls_diverging_drops.rs
+++ b/tests/ui/mir/mir_codegen_calls_diverging_drops.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:diverging_fn called
-//@ error-pattern:0 dropped
+//@ check-run-results
 //@ needs-unwind this test checks that a destructor is called after panicking
 
 struct Droppable(u8);

--- a/tests/ui/mir/mir_drop_panics.rs
+++ b/tests/ui/mir/mir_drop_panics.rs
@@ -1,7 +1,6 @@
 //@ run-fail
 //@ needs-unwind
-//@ error-pattern:panic 1
-//@ error-pattern:drop 2
+//@ check-run-results
 
 struct Droppable(u32);
 impl Drop for Droppable {

--- a/tests/ui/mir/mir_dynamic_drops_1.rs
+++ b/tests/ui/mir/mir_dynamic_drops_1.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:drop 1
-//@ error-pattern:drop 2
+//@ check-run-results
 //@ needs-subprocess
 
 /// Structure which will not allow to be dropped twice.

--- a/tests/ui/mir/mir_dynamic_drops_2.rs
+++ b/tests/ui/mir/mir_dynamic_drops_2.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:drop 1
+//@ check-run-results
 //@ needs-subprocess
 
 /// Structure which will not allow to be dropped twice.

--- a/tests/ui/mir/mir_dynamic_drops_3.rs
+++ b/tests/ui/mir/mir_dynamic_drops_3.rs
@@ -1,9 +1,6 @@
 //@ run-fail
 //@ needs-unwind
-//@ error-pattern:unwind happens
-//@ error-pattern:drop 3
-//@ error-pattern:drop 2
-//@ error-pattern:drop 1
+//@ check-run-results
 //@ needs-subprocess
 
 /// Structure which will not allow to be dropped twice.

--- a/tests/ui/mir/mir_indexing_oob_1.rs
+++ b/tests/ui/mir/mir_indexing_oob_1.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 5 but the index is 10
+//@ check-run-results
 //@ needs-subprocess
 
 const C: [u32; 5] = [0; 5];

--- a/tests/ui/mir/mir_indexing_oob_2.rs
+++ b/tests/ui/mir/mir_indexing_oob_2.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 5 but the index is 10
+//@ check-run-results
 //@ needs-subprocess
 
 const C: &'static [u8; 5] = b"hello";

--- a/tests/ui/mir/mir_indexing_oob_3.rs
+++ b/tests/ui/mir/mir_indexing_oob_3.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 5 but the index is 10
+//@ check-run-results
 //@ needs-subprocess
 
 const C: &'static [u8; 5] = b"hello";

--- a/tests/ui/mir/null/borrowed_mut_null.rs
+++ b/tests/ui/mir/null/borrowed_mut_null.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/borrowed_null.rs
+++ b/tests/ui/mir/null/borrowed_null.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr: *const u32 = std::ptr::null();

--- a/tests/ui/mir/null/borrowed_null_zst.rs
+++ b/tests/ui/mir/null/borrowed_null_zst.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr: *const () = std::ptr::null();

--- a/tests/ui/mir/null/null_lhs.rs
+++ b/tests/ui/mir/null/null_lhs.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/null_rhs.rs
+++ b/tests/ui/mir/null/null_rhs.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/two_pointers.rs
+++ b/tests/ui/mir/null/two_pointers.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occurred
+//@ check-run-results
 
 fn main() {
     let ptr = std::ptr::null();

--- a/tests/ui/never_type/return-never-coerce.rs
+++ b/tests/ui/never_type/return-never-coerce.rs
@@ -1,7 +1,7 @@
 // Test that ! coerces to other types.
 
 //@ run-fail
-//@ error-pattern:aah!
+//@ check-run-results
 //@ needs-subprocess
 
 fn call_another_fn<T, F: FnOnce() -> T>(f: F) -> T {

--- a/tests/ui/nll/issue-51345-2.rs
+++ b/tests/ui/nll/issue-51345-2.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/numbers-arithmetic/divide-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/divide-by-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:attempt to divide by zero
+//@ check-run-results
 //@ needs-subprocess
 
 #[allow(unconditional_panic)]

--- a/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-add-assign-overflow.rs
+//@ check-run-results
 
 fn main() {
     let mut a: u8 = 255;

--- a/tests/ui/numbers-arithmetic/location-add-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-add-overflow.rs
+//@ check-run-results
 
 fn main() {
     let _: u8 = 255 + &1;

--- a/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-divide-assign-by-zero.rs
+//@ check-run-results
 
 fn main() {
     let mut a = 1;

--- a/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-divide-by-zero.rs
+//@ check-run-results
 
 // https://github.com/rust-lang/rust/issues/114814
 

--- a/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-mod-assign-by-zero.rs
+//@ check-run-results
 
 fn main() {
     let mut a = 1;

--- a/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-mod-by-zero.rs
+//@ check-run-results
 
 fn main() {
     let _ = 1 % &0;

--- a/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-mul-assign-overflow.rs
+//@ check-run-results
 
 fn main() {
     let mut a: u8 = 255;

--- a/tests/ui/numbers-arithmetic/location-mul-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-mul-overflow.rs
+//@ check-run-results
 
 fn main() {
     let _: u8 = 255 * &2;

--- a/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-sub-assign-overflow.rs
+//@ check-run-results
 
 fn main() {
     let mut a: u8 = 0;

--- a/tests/ui/numbers-arithmetic/location-sub-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-overflow.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:location-sub-overflow.rs
+//@ check-run-results
 
 fn main() {
     let _: u8 = 0 - &1;

--- a/tests/ui/numbers-arithmetic/mod-zero.rs
+++ b/tests/ui/numbers-arithmetic/mod-zero.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:attempt to calculate the remainder with a divisor of zero
+//@ check-run-results
 //@ needs-subprocess
 
 #[allow(unconditional_panic)]

--- a/tests/ui/numbers-arithmetic/overflowing-add.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-add.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:attempt to add with overflow
+//@ check-run-results
 //@ compile-flags: -C debug-assertions
 //@ needs-subprocess
 

--- a/tests/ui/numbers-arithmetic/overflowing-mul.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-mul.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:attempt to multiply with overflow
+//@ check-run-results
 //@ needs-subprocess
 //@ compile-flags: -C debug-assertions
 

--- a/tests/ui/numbers-arithmetic/overflowing-sub.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-sub.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:attempt to subtract with overflow
+//@ check-run-results
 //@ needs-subprocess
 //@ compile-flags: -C debug-assertions
 

--- a/tests/ui/numbers-arithmetic/promoted_overflow.rs
+++ b/tests/ui/numbers-arithmetic/promoted_overflow.rs
@@ -1,7 +1,7 @@
 #![allow(arithmetic_overflow)]
 
 //@ run-fail
-//@ error-pattern: overflow
+//@ check-run-results
 //@ compile-flags: -C overflow-checks=yes
 // for some reason, fails to match error string on
 // wasm32-unknown-unknown with stripped debuginfo and symbols,

--- a/tests/ui/panic-runtime/unwind-interleaved.rs
+++ b/tests/ui/panic-runtime/unwind-interleaved.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn a() {}

--- a/tests/ui/panic-runtime/unwind-rec.rs
+++ b/tests/ui/panic-runtime/unwind-rec.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn build() -> Vec<isize> {

--- a/tests/ui/panic-runtime/unwind-rec2.rs
+++ b/tests/ui/panic-runtime/unwind-rec2.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn build1() -> Vec<isize> {

--- a/tests/ui/panic-runtime/unwind-unique.rs
+++ b/tests/ui/panic-runtime/unwind-unique.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn failfn() {

--- a/tests/ui/panics/args-panic.rs
+++ b/tests/ui/panics/args-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:meep
+//@ check-run-results
 //@ needs-subprocess
 
 fn f(_a: isize, _b: isize, _c: Box<isize>) {

--- a/tests/ui/panics/doublepanic.rs
+++ b/tests/ui/panics/doublepanic.rs
@@ -1,7 +1,7 @@
 #![allow(unreachable_code)]
 
 //@ run-fail
-//@ error-pattern:One
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/explicit-panic-msg.rs
+++ b/tests/ui/panics/explicit-panic-msg.rs
@@ -3,7 +3,7 @@
 #![allow(non_fmt_panics)]
 
 //@ run-fail
-//@ error-pattern:wooooo
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/explicit-panic.rs
+++ b/tests/ui/panics/explicit-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:explicit
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/fmt-panic.rs
+++ b/tests/ui/panics/fmt-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:meh
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/main-panic.rs
+++ b/tests/ui/panics/main-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked at
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-arg.rs
+++ b/tests/ui/panics/panic-arg.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:woe
+//@ check-run-results
 //@ needs-subprocess
 
 fn f(a: isize) {

--- a/tests/ui/panics/panic-in-cleanup.rs
+++ b/tests/ui/panics/panic-in-cleanup.rs
@@ -1,7 +1,6 @@
 //@ run-fail
 //@ exec-env:RUST_BACKTRACE=0
 //@ check-run-results
-//@ error-pattern: panic in a destructor during cleanup
 //@ normalize-stderr: "\n +[0-9]+:[^\n]+" -> ""
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"

--- a/tests/ui/panics/panic-in-ffi.rs
+++ b/tests/ui/panics/panic-in-ffi.rs
@@ -1,8 +1,6 @@
 //@ run-fail
 //@ exec-env:RUST_BACKTRACE=0
 //@ check-run-results
-//@ error-pattern: panic in a function that cannot unwind
-//@ error-pattern: Noisy Drop
 //@ normalize-stderr: "\n +[0-9]+:[^\n]+" -> ""
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"

--- a/tests/ui/panics/panic-in-message-fmt.rs
+++ b/tests/ui/panics/panic-in-message-fmt.rs
@@ -3,7 +3,6 @@
 //@ run-fail
 //@ exec-env:RUST_BACKTRACE=0
 //@ check-run-results
-//@ error-pattern: panicked while processing panic
 //@ normalize-stderr: "\n +[0-9]+:[^\n]+" -> ""
 //@ normalize-stderr: "\n +at [^\n]+" -> ""
 //@ normalize-stderr: "(core/src/panicking\.rs):[0-9]+:[0-9]+" -> "$1:$$LINE:$$COL"

--- a/tests/ui/panics/panic-macro-any-wrapped.rs
+++ b/tests/ui/panics/panic-macro-any-wrapped.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:Box<dyn Any>
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(non_fmt_panics)]

--- a/tests/ui/panics/panic-macro-any.rs
+++ b/tests/ui/panics/panic-macro-any.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:Box<dyn Any>
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(non_fmt_panics)]

--- a/tests/ui/panics/panic-macro-explicit.rs
+++ b/tests/ui/panics/panic-macro-explicit.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:explicit panic
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-macro-fmt.rs
+++ b/tests/ui/panics/panic-macro-fmt.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:test-fail-fmt 42 rust
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-macro-owned.rs
+++ b/tests/ui/panics/panic-macro-owned.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:test-fail-owned
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-macro-static.rs
+++ b/tests/ui/panics/panic-macro-static.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:panicked
-//@ error-pattern:test-fail-static
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-main.rs
+++ b/tests/ui/panics/panic-main.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:moop
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/panic-parens.rs
+++ b/tests/ui/panics/panic-parens.rs
@@ -2,7 +2,7 @@
 // certain positions
 
 //@ run-fail
-//@ error-pattern:oops
+//@ check-run-results
 //@ needs-subprocess
 
 fn bigpanic() {

--- a/tests/ui/panics/panic-set-handler.rs
+++ b/tests/ui/panics/panic-set-handler.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:greetings from the panic handler
+//@ check-run-results
 //@ needs-subprocess
 
 use std::panic;

--- a/tests/ui/panics/panic-set-unset-handler.rs
+++ b/tests/ui/panics/panic-set-unset-handler.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:foobar
+//@ check-run-results
 //@ needs-subprocess
 
 use std::panic;

--- a/tests/ui/panics/panic-take-handler-nop.rs
+++ b/tests/ui/panics/panic-take-handler-nop.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'main' panicked
-//@ error-pattern:foobar
+//@ check-run-results
 //@ needs-subprocess
 
 use std::panic;

--- a/tests/ui/panics/panic-task-name-none.rs
+++ b/tests/ui/panics/panic-task-name-none.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread '<unnamed>' panicked
-//@ error-pattern:test
+//@ check-run-results
 //@ needs-threads
 
 use std::thread;

--- a/tests/ui/panics/panic-task-name-owned.rs
+++ b/tests/ui/panics/panic-task-name-owned.rs
@@ -1,6 +1,5 @@
 //@ run-fail
-//@ error-pattern:thread 'owned name' panicked
-//@ error-pattern:test
+//@ check-run-results
 //@ needs-threads
 
 use std::thread::Builder;

--- a/tests/ui/panics/panic.rs
+++ b/tests/ui/panics/panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:1 == 2
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/result-get-panic.rs
+++ b/tests/ui/panics/result-get-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:called `Result::unwrap()` on an `Err` value
+//@ check-run-results
 //@ needs-subprocess
 
 use std::result::Result::Err;

--- a/tests/ui/panics/unique-panic.rs
+++ b/tests/ui/panics/unique-panic.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern: panic
+//@ check-run-results
 // for some reason, fails to match error string on
 // wasm32-unknown-unknown with stripped debuginfo and symbols,
 // so don't strip it

--- a/tests/ui/panics/while-body-panics.rs
+++ b/tests/ui/panics/while-body-panics.rs
@@ -1,7 +1,7 @@
 #![allow(while_true)]
 
 //@ run-fail
-//@ error-pattern:quux
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/panics/while-panic.rs
+++ b/tests/ui/panics/while-panic.rs
@@ -1,7 +1,7 @@
 #![allow(while_true)]
 
 //@ run-fail
-//@ error-pattern:giraffe
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/precondition-checks/alignment.rs
+++ b/tests/ui/precondition-checks/alignment.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: Alignment::new_unchecked requires
+//@ check-run-results
 
 #![feature(ptr_alignment_type)]
 

--- a/tests/ui/precondition-checks/ascii-char-digit_unchecked.rs
+++ b/tests/ui/precondition-checks/ascii-char-digit_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: `ascii::Char::digit_unchecked` input cannot exceed 9
+//@ check-run-results
 
 #![feature(ascii_char)]
 

--- a/tests/ui/precondition-checks/assert_unchecked.rs
+++ b/tests/ui/precondition-checks/assert_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: hint::assert_unchecked must never be called when the condition is false
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/char-from_u32_unchecked.rs
+++ b/tests/ui/precondition-checks/char-from_u32_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: invalid value for `char`
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/copy.rs
+++ b/tests/ui/precondition-checks/copy.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::copy requires
+//@ check-run-results
 //@ revisions: null_src null_dst misaligned_src misaligned_dst
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/layout.rs
+++ b/tests/ui/precondition-checks/layout.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: Layout::from_size_align_unchecked requires
+//@ check-run-results
 //@ revisions: toolarge badalign
 
 fn main() {

--- a/tests/ui/precondition-checks/nonnull.rs
+++ b/tests/ui/precondition-checks/nonnull.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonNull::new_unchecked requires
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/nonzero-from_mut_unchecked.rs
+++ b/tests/ui/precondition-checks/nonzero-from_mut_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonZero::from_mut_unchecked requires
+//@ check-run-results
 
 #![feature(nonzero_from_mut)]
 

--- a/tests/ui/precondition-checks/nonzero-new_unchecked.rs
+++ b/tests/ui/precondition-checks/nonzero-new_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonZero::new_unchecked requires
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/read.rs
+++ b/tests/ui/precondition-checks/read.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::read requires
+//@ check-run-results
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/read_volatile.rs
+++ b/tests/ui/precondition-checks/read_volatile.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::read_volatile requires
+//@ check-run-results
 //@ revisions: null misaligned
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/replace.rs
+++ b/tests/ui/precondition-checks/replace.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::replace requires
+//@ check-run-results
 //@ revisions: null misaligned
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-from-raw-parts-mut.rs
+++ b/tests/ui/precondition-checks/slice-from-raw-parts-mut.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::from_raw_parts_mut requires
+//@ check-run-results
 //@ revisions: null misaligned toolarge
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-from-raw-parts.rs
+++ b/tests/ui/precondition-checks/slice-from-raw-parts.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::from_raw_parts requires
+//@ check-run-results
 //@ revisions: null misaligned toolarge
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-get_unchecked.rs
+++ b/tests/ui/precondition-checks/slice-get_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::get_unchecked requires
+//@ check-run-results
 //@ revisions: usize range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/slice-get_unchecked_mut.rs
+++ b/tests/ui/precondition-checks/slice-get_unchecked_mut.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::get_unchecked_mut requires
+//@ check-run-results
 //@ revisions: usize range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/slice-swap_unchecked.rs
+++ b/tests/ui/precondition-checks/slice-swap_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: index out of bounds: the len is 2 but the index is 2
+//@ check-run-results
 //@ revisions: oob_a oob_b
 
 fn main() {

--- a/tests/ui/precondition-checks/str-get_unchecked_mut.rs
+++ b/tests/ui/precondition-checks/str-get_unchecked_mut.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: str::get_unchecked_mut requires
+//@ check-run-results
 //@ revisions: range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/swap-nonoverlapping.rs
+++ b/tests/ui/precondition-checks/swap-nonoverlapping.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::swap_nonoverlapping requires
+//@ check-run-results
 //@ revisions: null_src null_dst misaligned_src misaligned_dst overlapping
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/unchecked_add.rs
+++ b/tests/ui/precondition-checks/unchecked_add.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_add cannot overflow
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_mul.rs
+++ b/tests/ui/precondition-checks/unchecked_mul.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_add cannot overflow
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_shl.rs
+++ b/tests/ui/precondition-checks/unchecked_shl.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shl cannot overflow
+//@ check-run-results
 
 #![feature(unchecked_shifts)]
 

--- a/tests/ui/precondition-checks/unchecked_shr.rs
+++ b/tests/ui/precondition-checks/unchecked_shr.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shr cannot overflow
+//@ check-run-results
 
 #![feature(unchecked_shifts)]
 

--- a/tests/ui/precondition-checks/unchecked_sub.rs
+++ b/tests/ui/precondition-checks/unchecked_sub.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_sub cannot overflow
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unreachable_unchecked.rs
+++ b/tests/ui/precondition-checks/unreachable_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: hint::unreachable_unchecked must never be reached
+//@ check-run-results
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/write.rs
+++ b/tests/ui/precondition-checks/write.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write requires
+//@ check-run-results
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/write_bytes.rs
+++ b/tests/ui/precondition-checks/write_bytes.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write requires
+//@ check-run-results
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/write_volatile.rs
+++ b/tests/ui/precondition-checks/write_volatile.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write_volatile requires
+//@ check-run-results
 //@ revisions: null misaligned
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/process/tls-exit-status.rs
+++ b/tests/ui/process/tls-exit-status.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:nonzero
+//@ check-run-results
 //@ exec-env:RUST_NEWRT=1
 //@ needs-subprocess
 

--- a/tests/ui/reachable/issue-948.rs
+++ b/tests/ui/reachable/issue-948.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:beep boop
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(unused_variables)]

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-box-dyn-error-err.rs
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-box-dyn-error-err.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:returned Box<dyn Error> from main()
+//@ check-run-results
 //@ failure-status: 1
 //@ needs-subprocess
 

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-never.rs
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-never.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:oh, dear
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() -> ! {

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-result-box-error_err.rs
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-result-box-error_err.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:returned Box<Error> from main()
+//@ check-run-results
 //@ failure-status: 1
 //@ needs-subprocess
 

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-str-err.rs
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-str-err.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern: An error message for you
+//@ check-run-results
 //@ failure-status: 1
 //@ needs-subprocess
 

--- a/tests/ui/sanitizer/address.rs
+++ b/tests/ui/sanitizer/address.rs
@@ -5,8 +5,7 @@
 //@ compile-flags: -Z sanitizer=address -O -g
 //
 //@ run-fail
-//@ error-pattern: AddressSanitizer: stack-buffer-overflow
-//@ error-pattern: 'xs' (line 14) <== Memory access at offset
+//@ check-run-results
 
 use std::hint::black_box;
 

--- a/tests/ui/sanitizer/hwaddress.rs
+++ b/tests/ui/sanitizer/hwaddress.rs
@@ -8,7 +8,7 @@
 //@ compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16
 //
 //@ run-fail
-//@ error-pattern: HWAddressSanitizer: tag-mismatch
+//@ check-run-results
 
 use std::hint::black_box;
 

--- a/tests/ui/sanitizer/leak.rs
+++ b/tests/ui/sanitizer/leak.rs
@@ -4,7 +4,7 @@
 //@ compile-flags: -Z sanitizer=leak -O
 //
 //@ run-fail
-//@ error-pattern: LeakSanitizer: detected memory leaks
+//@ check-run-results
 
 use std::hint::black_box;
 use std::mem;

--- a/tests/ui/sanitizer/memory-eager.rs
+++ b/tests/ui/sanitizer/memory-eager.rs
@@ -7,7 +7,7 @@
 //@ [unoptimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins
 //
 //@ run-fail
-//@ error-pattern: MemorySanitizer: use-of-uninitialized-value
+//@ check-run-results
 //@ [optimized]error-pattern: Uninitialized value was created by an allocation
 //@ [optimized]error-pattern: in the stack frame
 //

--- a/tests/ui/sanitizer/memory.rs
+++ b/tests/ui/sanitizer/memory.rs
@@ -7,9 +7,7 @@
 //@ [unoptimized]compile-flags: -Z sanitizer=memory -Zsanitizer-memory-track-origins
 //
 //@ run-fail
-//@ error-pattern: MemorySanitizer: use-of-uninitialized-value
-//@ error-pattern: Uninitialized value was created by an allocation
-//@ error-pattern: in the stack frame
+//@ check-run-results
 //
 // This test case intentionally limits the usage of the std,
 // since it will be linked with an uninstrumented version of it.

--- a/tests/ui/sanitizer/new-llvm-pass-manager-thin-lto.rs
+++ b/tests/ui/sanitizer/new-llvm-pass-manager-thin-lto.rs
@@ -12,7 +12,7 @@
 //@[opt0]compile-flags: -Copt-level=0
 //@[opt1]compile-flags: -Copt-level=1
 //@ run-fail
-//@ error-pattern: ERROR: AddressSanitizer: stack-use-after-scope
+//@ check-run-results
 
 static mut P: *mut usize = std::ptr::null_mut();
 

--- a/tests/ui/sanitizer/thread.rs
+++ b/tests/ui/sanitizer/thread.rs
@@ -16,9 +16,7 @@
 //@ compile-flags: -Z sanitizer=thread -O
 //
 //@ run-fail
-//@ error-pattern: WARNING: ThreadSanitizer: data race
-//@ error-pattern: Location is heap block of size 4
-//@ error-pattern: allocated by main thread
+//@ check-run-results
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/ui/sanitizer/use-after-scope.rs
+++ b/tests/ui/sanitizer/use-after-scope.rs
@@ -4,7 +4,7 @@
 //
 //@ compile-flags: -Zsanitizer=address
 //@ run-fail
-//@ error-pattern: ERROR: AddressSanitizer: stack-use-after-scope
+//@ check-run-results
 
 static mut P: *mut usize = std::ptr::null_mut();
 

--- a/tests/ui/str/str-overrun.rs
+++ b/tests/ui/str/str-overrun.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:index out of bounds: the len is 5 but the index is 5
+//@ check-run-results
 //@ needs-subprocess
 
 fn main() {

--- a/tests/ui/structs/rhs-type.rs
+++ b/tests/ui/structs/rhs-type.rs
@@ -2,7 +2,7 @@
 // as a _|_-typed thing, not a str-typed thing
 
 //@ run-fail
-//@ error-pattern:bye
+//@ check-run-results
 //@ needs-subprocess
 
 #![allow(unreachable_code)]

--- a/tests/ui/threads-sendsync/task-spawn-barefn.rs
+++ b/tests/ui/threads-sendsync/task-spawn-barefn.rs
@@ -1,5 +1,5 @@
 //@ run-fail
-//@ error-pattern:Ensure that the child thread runs by panicking
+//@ check-run-results
 //@ needs-threads
 
 use std::thread;


### PR DESCRIPTION
I combed through the stderr of every `error-pattern` test, looking for patterns that would be troublesome in a `check-run-results` context.

The following should keep `error-pattern`:

`hashmap-capacity-overflow.rs`
`overflowing-neg-nonzero.rs`
`overflowing-pow-signed.rs`
`overflowing-pow-unsigned.rs`
`copy-nonoverlapping.rs`
`copy.rs`
`str-get_unchecked.rs`
`test-tasks-invalid-value.rs`

The reason these are problematic is because they contain line numbers in their `stderr` which refers to parts of the Rust compiler. For example, `copy-nonoverlapping.rs`'s error message starts with`thread 'main' panicked at /rustc/FAKE_PREFIX/library/core/src/ptr/mod.rs:522:5:`. That means that changing this unrelated file at any point in the future would result in this test failing.

After this, there are hundreds of tests which contain lines such as `thread 'main' panicked at /checkout/tests/ui/precondition-checks/slice-from-raw-parts-mut.rs:13:30:`

These would start failing if the test was ever modified to have additional lines. However, this vulnerability is contained to the test itself, and in almost all cases, the line number is actually important for the test's purpose. Therefore, I think this would be unwise to normalize away these numbers.

If we aim to remove `error-pattern` completely, a possible approach would be to normalize the stderr of these flaky tests to remove the paths leading to the Rust compiler files.

If you would like to review my methodology, here is the log I used to review the test stderrs: https://triage.rust-lang.org/gha-logs/rust-lang/rust/45509161982

Closes [#134889](https://github.com/rust-lang/rust/issues/134889)