### PR TITLE
[WIP] Lint self-overlapping or-patterns under guard

### DIFF
--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -129,6 +129,16 @@ pub trait PatCx: Sized + fmt::Debug {
         deref_pat: &DeconstructedPat<Self>,
         normal_pat: &DeconstructedPat<Self>,
     ) -> Self::Error;
+
+    /// Lint that an or-pattern will cause a guard to be tried several times because there's a value
+    /// that matches several of the or-alternatives.
+    /// The default implementation does nothing.
+    fn lint_overlapping_alternatives_under_guard(
+        &self,
+        _pat1: &DeconstructedPat<Self>,
+        _pat2: &DeconstructedPat<Self>,
+    ) {
+    }
 }
 
 /// The arm of a match expression.

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -1039,6 +1039,21 @@ impl<'p, 'tcx: 'p> PatCx for RustcPatCtxt<'p, 'tcx> {
             normal_constructor_label,
         })
     }
+
+    fn lint_overlapping_alternatives_under_guard(
+        &self,
+        pat1: &crate::pat::DeconstructedPat<Self>,
+        pat2: &crate::pat::DeconstructedPat<Self>,
+    ) {
+        self.tcx
+            .dcx()
+            .struct_span_err(
+                pat1.data().span,
+                format!("pattern overlaps with or-alternative under a guard"),
+            )
+            .with_span_label(pat2.data().span, "overlaps with")
+            .emit();
+    }
 }
 
 /// Recursively expand this pattern into its subpatterns. Only useful for or-patterns.


### PR DESCRIPTION
This adds an error on or-patterns under match guard that may cause the guard to be run more than once, such as `true | true if f()`. This is for crater purposes.

r? ghost