### PR TITLE
Dont resolve instance of root in `mir_callgraph_cyclic`

### DIFF
--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -155,15 +155,8 @@ pub(crate) fn mir_callgraph_cyclic<'tcx>(
     let recursion_limit = tcx.recursion_limit() / 2;
     let mut involved = FxHashSet::default();
     let typing_env = ty::TypingEnv::post_analysis(tcx, root);
-    let Ok(Some(root_instance)) = ty::Instance::try_resolve(
-        tcx,
-        typing_env,
-        root.to_def_id(),
-        ty::GenericArgs::identity_for_item(tcx, root.to_def_id()),
-    ) else {
-        trace!("cannot resolve, skipping");
-        return involved.into();
-    };
+    let root_instance =
+        ty::Instance::new_raw(root.to_def_id(), ty::GenericArgs::identity_for_item(tcx, root));
     if !should_recurse(tcx, root_instance) {
         trace!("cannot walk, skipping");
         return involved.into();

--- a/tests/mir-opt/inline_default_trait_body.Trait-a.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_default_trait_body.Trait-a.Inline.panic-abort.diff
@@ -1,0 +1,27 @@
+- // MIR for `Trait::a` before Inline
++ // MIR for `Trait::a` after Inline
+  
+  fn Trait::a(_1: &Self) -> () {
+      debug self => _1;
+      let mut _0: ();
+      let _2: ();
+      let mut _3: &();
+      let _4: ();
+      let mut _5: &();
+  
+      bb0: {
+          StorageLive(_2);
+          StorageLive(_3);
+          _5 = const <Self as Trait>::a::promoted[0];
+          _3 = &(*_5);
+          _2 = <() as Trait>::b(move _3) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          StorageDead(_2);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline_default_trait_body.Trait-a.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_default_trait_body.Trait-a.Inline.panic-unwind.diff
@@ -1,0 +1,27 @@
+- // MIR for `Trait::a` before Inline
++ // MIR for `Trait::a` after Inline
+  
+  fn Trait::a(_1: &Self) -> () {
+      debug self => _1;
+      let mut _0: ();
+      let _2: ();
+      let mut _3: &();
+      let _4: ();
+      let mut _5: &();
+  
+      bb0: {
+          StorageLive(_2);
+          StorageLive(_3);
+          _5 = const <Self as Trait>::a::promoted[0];
+          _3 = &(*_5);
+          _2 = <() as Trait>::b(move _3) -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          StorageDead(_2);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline_default_trait_body.Trait-b.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_default_trait_body.Trait-b.Inline.panic-abort.diff
@@ -1,0 +1,27 @@
+- // MIR for `Trait::b` before Inline
++ // MIR for `Trait::b` after Inline
+  
+  fn Trait::b(_1: &Self) -> () {
+      debug self => _1;
+      let mut _0: ();
+      let _2: ();
+      let mut _3: &();
+      let _4: ();
+      let mut _5: &();
+  
+      bb0: {
+          StorageLive(_2);
+          StorageLive(_3);
+          _5 = const <Self as Trait>::b::promoted[0];
+          _3 = &(*_5);
+          _2 = <() as Trait>::a(move _3) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          StorageDead(_2);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline_default_trait_body.Trait-b.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_default_trait_body.Trait-b.Inline.panic-unwind.diff
@@ -1,0 +1,27 @@
+- // MIR for `Trait::b` before Inline
++ // MIR for `Trait::b` after Inline
+  
+  fn Trait::b(_1: &Self) -> () {
+      debug self => _1;
+      let mut _0: ();
+      let _2: ();
+      let mut _3: &();
+      let _4: ();
+      let mut _5: &();
+  
+      bb0: {
+          StorageLive(_2);
+          StorageLive(_3);
+          _5 = const <Self as Trait>::b::promoted[0];
+          _3 = &(*_5);
+          _2 = <() as Trait>::a(move _3) -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          StorageDead(_2);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline_default_trait_body.rs
+++ b/tests/mir-opt/inline_default_trait_body.rs
@@ -1,0 +1,19 @@
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// skip-filecheck
+//@ test-mir-pass: Inline
+//@ edition: 2021
+//@ compile-flags: -Zinline-mir --crate-type=lib
+
+// EMIT_MIR inline_default_trait_body.Trait-a.Inline.diff
+// EMIT_MIR inline_default_trait_body.Trait-b.Inline.diff
+pub trait Trait {
+    fn a(&self) {
+        ().b();
+    }
+
+    fn b(&self) {
+        ().a();
+    }
+}
+
+impl Trait for () {}


### PR DESCRIPTION
`Instance::try_resolve` on a default trait body method will always fail, since it's still possible to further substitute. This leads to a cycle, since in `tests/mir-opt/inline_default_trait_body.rs`, both `Trait::a` and `Trait::b` need to consider the other to be cyclical, but since we couldn't resolve a body, we'd just consider *nothing* to be cyclical.

The root instance we care about when computing `mir_callgraph_cyclic` is trivial to compute (it's just `InstanceKind::Item`), so just replace it with a call to `Instance::new_raw`.

r? @cjgillot @oli-obk

Fixes rust-lang/rust#143534