### PR TITLE
lib: more eagerly return `self.len()` from `ceil_char_boundary`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -446,7 +446,7 @@ impl str {
     #[unstable(feature = "round_char_boundary", issue = "93743")]
     #[inline]
     pub fn ceil_char_boundary(&self, index: usize) -> usize {
-        if index > self.len() {
+        if index >= self.len() {
             self.len()
         } else {
             let upper_bound = Ord::min(index + 4, self.len());


### PR DESCRIPTION
There is no reason to go through the complicated branch as it would
always return `self.len()` in this case. Also helps debug code somewhat
and I guess might make optimizations easier (although I haven't really a
sample to demonstrate this.)

ref. https://github.com/rust-lang/rust/issues/93743
Suggested by @chrisduerr