### PR TITLE
slice: Mark `rotate_left`, `rotate_right` unstably const

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3668,7 +3668,8 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'c', 'd', 'e', 'b', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
-    pub fn rotate_left(&mut self, mid: usize) {
+    #[rustc_const_unstable(feature = "const_slice_rotate", issue = "143812")]
+    pub const fn rotate_left(&mut self, mid: usize) {
         assert!(mid <= self.len());
         let k = self.len() - mid;
         let p = self.as_mut_ptr();
@@ -3713,7 +3714,8 @@ impl<T> [T] {
     /// assert_eq!(a, ['a', 'e', 'b', 'c', 'd', 'f']);
     /// ```
     #[stable(feature = "slice_rotate", since = "1.26.0")]
-    pub fn rotate_right(&mut self, k: usize) {
+    #[rustc_const_unstable(feature = "const_slice_rotate", issue = "143812")]
+    pub const fn rotate_right(&mut self, k: usize) {
         assert!(k <= self.len());
         let mid = self.len() - k;
         let p = self.as_mut_ptr();


### PR DESCRIPTION
Tracking issue rust-lang/rust#143812

- Add the const unstable `const_slice_rotate` feature
- Mark `<[T]>::rotate_left` and `<[T]>::rotate_right` as const unstable

The internal rotate functions use [`<*mut T>::replace`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.replace) and [`ptr::swap_nonoverlapping`](https://doc.rust-lang.org/stable/core/ptr/fn.swap_nonoverlapping.html) which were const-stabilized in 1.88.

Two changes were needed in the `rotate.rs` module to make these functions const:
1. A usage of `cmp::min` was replaced with a local function implementation of [`Ord::min`](https://doc.rust-lang.org/1.88.0/src/core/cmp.rs.html#1048-1053).
2. A `for start in 1..gcd` loop was changed to a while loop with an increment variable.

This needs libs-api approval and cc-ing const-eval.