### PR TITLE
mbe: Refactors and function extractions in `compile_declarative_macro`

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -373,17 +373,10 @@ pub fn compile_declarative_macro(
     node_id: NodeId,
     edition: Edition,
 ) -> (SyntaxExtension, usize) {
+    let is_local = node_id != DUMMY_NODE_ID;
     let mk_syn_ext = |expander| {
-        SyntaxExtension::new(
-            sess,
-            SyntaxExtensionKind::LegacyBang(expander),
-            span,
-            Vec::new(),
-            edition,
-            ident.name,
-            attrs,
-            node_id != DUMMY_NODE_ID,
-        )
+        let kind = SyntaxExtensionKind::LegacyBang(expander);
+        SyntaxExtension::new(sess, kind, span, Vec::new(), edition, ident.name, attrs, is_local)
     };
     let dummy_syn_ext = |guar| (mk_syn_ext(Arc::new(DummyExpander(guar))), 0);
 
@@ -454,7 +447,7 @@ pub fn compile_declarative_macro(
     }
 
     // Return the number of rules for unused rule linting, if this is a local macro.
-    let nrules = if node_id != DUMMY_NODE_ID { rules.len() } else { 0 };
+    let nrules = if is_local { rules.len() } else { 0 };
 
     let expander =
         Arc::new(MacroRulesMacroExpander { name: ident, span, node_id, transparency, rules });

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -397,8 +397,7 @@ pub fn compile_declarative_macro(
         let lhs_tt = parse_one_tt(lhs_tt, RulePart::Pattern, sess, node_id, features, edition);
         // We don't handle errors here, the driver will abort after parsing/expansion. We can
         // report every error in every macro this way.
-        check_emission(check_lhs_nt_follows(sess, node_id, &lhs_tt));
-        check_emission(check_lhs_no_empty_seq(sess, slice::from_ref(&lhs_tt)));
+        check_emission(check_lhs(sess, node_id, &lhs_tt));
         if let Err(e) = p.expect(exp!(FatArrow)) {
             return dummy_syn_ext(e.emit());
         }
@@ -452,6 +451,12 @@ pub fn compile_declarative_macro(
     let expander =
         Arc::new(MacroRulesMacroExpander { name: ident, span, node_id, transparency, rules });
     (mk_syn_ext(expander), nrules)
+}
+
+fn check_lhs(sess: &Session, node_id: NodeId, lhs: &mbe::TokenTree) -> Result<(), ErrorGuaranteed> {
+    let e1 = check_lhs_nt_follows(sess, node_id, lhs);
+    let e2 = check_lhs_no_empty_seq(sess, slice::from_ref(lhs));
+    e1.and(e2)
 }
 
 fn check_lhs_nt_follows(


### PR DESCRIPTION
These refactors help pave the way for parsing attribute rules.

Best reviewed commit-by-commit.

- **mbe: Simplify compile_declarative_macro by factoring out some variables**
- **mbe: Factor out a helper to check an LHS**
- **mbe: Factor out a helper to check for unexpected EOF in definition**
- **mbe: Clarify comments about error handling in `compile_declarative_macro`**
