### PR TITLE
compiler: Deduplicate `must_emit_unwind_tables()` comments

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -377,12 +377,11 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     //     that no exceptions passes by it. This is normally the case for the
     //     ELF x86-64 abi, but it can be disabled for some compilation units.
     //
-    // Typically when we're compiling with `-C panic=abort` (which implies this
-    // `no_landing_pads` check) we don't need `uwtable` because we can't
-    // generate any exceptions! On Windows, however, exceptions include other
-    // events such as illegal instructions, segfaults, etc. This means that on
-    // Windows we end up still needing the `uwtable` attribute even if the `-C
-    // panic=abort` flag is passed.
+    // Typically when we're compiling with `-C panic=abort` we don't need
+    // `uwtable` because we can't generate any exceptions! On Windows, however,
+    // exceptions include other events such as illegal instructions, segfaults,
+    // etc. This means that on Windows we end up still needing the `uwtable`
+    // attribute even if the `-C panic=abort` flag is passed.
     //
     // You can also find more info on why Windows always requires uwtables here:
     //      https://bugzilla.mozilla.org/show_bug.cgi?id=1302078

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -370,21 +370,6 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     };
     to_add.extend(inline_attr(cx, inline));
 
-    // The `uwtable` attribute according to LLVM is:
-    //
-    //     This attribute indicates that the ABI being targeted requires that an
-    //     unwind table entry be produced for this function even if we can show
-    //     that no exceptions passes by it. This is normally the case for the
-    //     ELF x86-64 abi, but it can be disabled for some compilation units.
-    //
-    // Typically when we're compiling with `-C panic=abort` we don't need
-    // `uwtable` because we can't generate any exceptions! On Windows, however,
-    // exceptions include other events such as illegal instructions, segfaults,
-    // etc. This means that on Windows we end up still needing the `uwtable`
-    // attribute even if the `-C panic=abort` flag is passed.
-    //
-    // You can also find more info on why Windows always requires uwtables here:
-    //      https://bugzilla.mozilla.org/show_bug.cgi?id=1302078
     if cx.sess().must_emit_unwind_tables() {
         to_add.push(uwtable_attr(cx.llcx, cx.sess().opts.unstable_opts.use_sync_unwind));
     }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -776,8 +776,15 @@ impl Session {
 
     pub fn must_emit_unwind_tables(&self) -> bool {
         // This is used to control the emission of the `uwtable` attribute on
-        // LLVM functions.
+        // LLVM functions. The `uwtable` attribute according to LLVM is:
         //
+        //     This attribute indicates that the ABI being targeted requires that an
+        //     unwind table entry be produced for this function even if we can show
+        //     that no exceptions passes by it. This is normally the case for the
+        //     ELF x86-64 abi, but it can be disabled for some compilation units.
+        //
+        // Typically when we're compiling with `-C panic=abort` we don't need
+        // `uwtable` because we can't generate any exceptions!
         // Unwind tables are needed when compiling with `-C panic=unwind`, but
         // LLVM won't omit unwind tables unless the function is also marked as
         // `nounwind`, so users are allowed to disable `uwtable` emission.


### PR DESCRIPTION
There is one comment at a call site and one comment in the function definition that are mostly saying the same thing. Fold the call site comment into the function definition comment to reduce duplication.

There are actually some inaccuracies in the comments but let's deduplicate before we address the inaccuracies.