### PR TITLE
Point to correct argument in Func Call when Self type fails trait bound

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -184,9 +184,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return true;
                 }
 
-                for param in [param_to_point_at, fallback_param_to_point_at, self_param_to_point_at]
-                    .into_iter()
-                    .flatten()
+                for param in [
+                    predicate_self_type_to_point_at,
+                    param_to_point_at,
+                    fallback_param_to_point_at,
+                    self_param_to_point_at,
+                ]
+                .into_iter()
+                .flatten()
                 {
                     if self.blame_specific_arg_if_possible(
                         error,

--- a/tests/ui/associated-type-bounds/dedup-normalized-2-higher-ranked.current.stderr
+++ b/tests/ui/associated-type-bounds/dedup-normalized-2-higher-ranked.current.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/dedup-normalized-2-higher-ranked.rs:28:5
    |
 LL |     impls(rigid);
-   |     ^^^^^ cannot infer type of the type parameter `U` declared on the function `impls`
+   |     ^^^^^ ----- type must be known at this point
+   |     |
+   |     cannot infer type of the type parameter `U` declared on the function `impls`
    |
    = note: cannot satisfy `for<'b> <P as Trait>::Rigid: Bound<'b, _>`
 note: required by a bound in `impls`

--- a/tests/ui/const-generics/infer/issue-77092.stderr
+++ b/tests/ui/const-generics/infer/issue-77092.stderr
@@ -20,7 +20,7 @@ error[E0284]: type annotations needed
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
    |                   ----   ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the const parameter `N` declared on the function `take_array_from_mut`
    |                   |
-   |                   type must be known at this point
+   |                   required by this formatting parameter
    |
    = note: required for `[i32; _]` to implement `Debug`
    = note: 1 redundant requirement hidden

--- a/tests/ui/impl-trait/auto-trait-selection-freeze.old.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection-freeze.old.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/auto-trait-selection-freeze.rs:19:16
    |
 LL |     if false { is_trait(foo()) } else { Default::default() }
-   |                ^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `is_trait`
+   |                ^^^^^^^^ ----- type must be known at this point
+   |                |
+   |                cannot infer type of the type parameter `U` declared on the function `is_trait`
    |
 note: multiple `impl`s satisfying `impl Sized: Trait<_>` found
   --> $DIR/auto-trait-selection-freeze.rs:16:1

--- a/tests/ui/impl-trait/auto-trait-selection.old.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection.old.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/auto-trait-selection.rs:15:16
    |
 LL |     if false { is_trait(foo()) } else { Default::default() }
-   |                ^^^^^^^^ cannot infer type of the type parameter `U` declared on the function `is_trait`
+   |                ^^^^^^^^ ----- type must be known at this point
+   |                |
+   |                cannot infer type of the type parameter `U` declared on the function `is_trait`
    |
 note: multiple `impl`s satisfying `impl Sized: Trait<_>` found
   --> $DIR/auto-trait-selection.rs:12:1

--- a/tests/ui/trait-bounds/false-span-in-trait-bound-label.rs
+++ b/tests/ui/trait-bounds/false-span-in-trait-bound-label.rs
@@ -1,0 +1,10 @@
+// In this test, the span of the trait bound label should point to `1`, not `""`.
+// See issue #1433376
+
+trait A<T> {
+    fn f(self, x: T);
+}
+
+fn main() {
+    A::f(1, ""); //~ ERROR the trait bound `{integer}: A<_>` is not satisfied [E0277]
+}

--- a/tests/ui/trait-bounds/false-span-in-trait-bound-label.rs
+++ b/tests/ui/trait-bounds/false-span-in-trait-bound-label.rs
@@ -1,5 +1,5 @@
 // In this test, the span of the trait bound label should point to `1`, not `""`.
-// See issue #1433376
+// See issue #143336
 
 trait A<T> {
     fn f(self, x: T);

--- a/tests/ui/trait-bounds/false-span-in-trait-bound-label.stderr
+++ b/tests/ui/trait-bounds/false-span-in-trait-bound-label.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `{integer}: A<_>` is not satisfied
-  --> $DIR/false-span-in-trait-bound-label.rs:9:13
+  --> $DIR/false-span-in-trait-bound-label.rs:9:10
    |
 LL |     A::f(1, "");
-   |     ----    ^^ the trait `A<_>` is not implemented for `{integer}`
+   |     ---- ^ the trait `A<_>` is not implemented for `{integer}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/trait-bounds/false-span-in-trait-bound-label.stderr
+++ b/tests/ui/trait-bounds/false-span-in-trait-bound-label.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `{integer}: A<_>` is not satisfied
+  --> $DIR/false-span-in-trait-bound-label.rs:9:13
+   |
+LL |     A::f(1, "");
+   |     ----    ^^ the trait `A<_>` is not implemented for `{integer}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/false-span-in-trait-bound-label.rs:4:1
+   |
+LL | trait A<T> {
+   | ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -34,10 +34,10 @@ LL |     <dyn CompareToInts>::same_as(c, 22)
              `i64` implements `CompareTo<u64>`
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
-  --> $DIR/repeated-supertrait-ambig.rs:38:27
+  --> $DIR/repeated-supertrait-ambig.rs:38:24
    |
 LL |     CompareTo::same_as(c, 22)
-   |     ------------------    ^^ the trait `CompareTo<i32>` is not implemented for `C`
+   |     ------------------ ^ the trait `CompareTo<i32>` is not implemented for `C`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
+++ b/tests/ui/traits/multidispatch-convert-ambig-dest.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/multidispatch-convert-ambig-dest.rs:26:5
    |
 LL |     test(22, std::default::Default::default());
-   |     ^^^^     -------------------------------- type must be known at this point
+   |     ^^^^ -- type must be known at this point
    |     |
    |     cannot infer type of the type parameter `U` declared on the function `test`
    |


### PR DESCRIPTION
Fixes rust-lang/rust#143336 

When a trait bound fails due to the `Self` type parameter, `adjust_fulfillment_errors` now correctly points to the corresponding function argument instead of incorrectly pointing to other arguments. This is because `Call` may also need to handle the `self` parameter, and not just `MethodCall` needs to be handled, as rust-lang/rust#143336.


r? compiler