### PR TITLE
[DO NOT MEREG] Raise minimum suggest flow stage to 1

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1041,13 +1041,21 @@ impl Config {
             Subcommand::Dist => flags_stage.or(dist_stage).unwrap_or(2),
             Subcommand::Install => flags_stage.or(install_stage).unwrap_or(2),
             Subcommand::Perf { .. } => flags_stage.unwrap_or(1),
+
+            // The suggest flow can try to recommend bootstrap invocations with no explicit stages,
+            // which notably can include `./x {check,build,test}` flows that must not be lower than
+            // one.
+            //
+            // FIXME: this is *very* questionable, the suggest flow should also respect the stage
+            // defaults here, and not try to bypass this handling!
+            Subcommand::Suggest { .. } => flags_stage.unwrap_or(1),
+
             // These are all bootstrap tools, which don't depend on the compiler.
             // The stage we pass shouldn't matter, but use 0 just in case.
             Subcommand::Clean { .. }
             | Subcommand::Run { .. }
             | Subcommand::Setup { .. }
             | Subcommand::Format { .. }
-            | Subcommand::Suggest { .. }
             | Subcommand::Vendor { .. } => flags_stage.unwrap_or(0),
         };
 


### PR DESCRIPTION
> [!CAUTION]
>
> Not intended for merge, just illustrative.

This is **still** a **hack**, the suggest flow does not correctly respect the stage default handling and actually bypasses it!

I'm considering to kill the *current* suggest flow implementation, because the current implementation bypasses default stage handling, and fixing this piecemeal is completely not maintainble.
