### PR TITLE
Remove named lifetimes in some `PartialOrd` & `PartialEq` `impl`s

### DIFF
--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -477,9 +477,8 @@ impl PartialEq for ByteString {
 
 macro_rules! impl_partial_eq_ord_cow {
     ($lhs:ty, $rhs:ty) => {
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 let other: &[u8] = (&**other).as_ref();
@@ -487,9 +486,8 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 let this: &[u8] = (&**self).as_ref();
@@ -497,9 +495,8 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialOrd<$rhs> for $lhs {
+        impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
                 let other: &[u8] = (&**other).as_ref();
@@ -507,9 +504,8 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialOrd<$lhs> for $rhs {
+        impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
                 let this: &[u8] = (&**self).as_ref();
@@ -667,9 +663,9 @@ impl From<Arc<ByteStr>> for Arc<[u8]> {
 impl_partial_eq!(ByteStr, Vec<u8>);
 // PartialOrd with `String` omitted to avoid inference failures
 impl_partial_eq!(ByteStr, String);
-impl_partial_eq_ord_cow!(&'a ByteStr, Cow<'a, ByteStr>);
-impl_partial_eq_ord_cow!(&'a ByteStr, Cow<'a, str>);
-impl_partial_eq_ord_cow!(&'a ByteStr, Cow<'a, [u8]>);
+impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, ByteStr>);
+impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, str>);
+impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, [u8]>);
 
 #[unstable(feature = "bstr", issue = "134915")]
 impl<'a> TryFrom<&'a ByteStr> for String {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2661,8 +2661,7 @@ impl<'b> Pattern for &'b String {
 macro_rules! impl_eq {
     ($lhs:ty, $rhs: ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[allow(unused_lifetimes)]
-        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
@@ -2674,8 +2673,7 @@ macro_rules! impl_eq {
         }
 
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[allow(unused_lifetimes)]
-        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
@@ -2689,13 +2687,13 @@ macro_rules! impl_eq {
 }
 
 impl_eq! { String, str }
-impl_eq! { String, &'a str }
+impl_eq! { String, &str }
 #[cfg(not(no_global_oom_handling))]
-impl_eq! { Cow<'a, str>, str }
+impl_eq! { Cow<'_, str>, str }
 #[cfg(not(no_global_oom_handling))]
-impl_eq! { Cow<'a, str>, &'b str }
+impl_eq! { Cow<'_, str>, &'_ str }
 #[cfg(not(no_global_oom_handling))]
-impl_eq! { Cow<'a, str>, String }
+impl_eq! { Cow<'_, str>, String }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]

--- a/library/core/src/bstr/traits.rs
+++ b/library/core/src/bstr/traits.rs
@@ -45,8 +45,7 @@ impl hash::Hash for ByteStr {
 #[unstable(feature = "bstr_internals", issue = "none")]
 macro_rules! impl_partial_eq {
     ($lhs:ty, $rhs:ty) => {
-        #[allow(unused_lifetimes)]
-        impl<'a> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 let other: &[u8] = other.as_ref();
@@ -54,8 +53,7 @@ macro_rules! impl_partial_eq {
             }
         }
 
-        #[allow(unused_lifetimes)]
-        impl<'a> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 let this: &[u8] = self.as_ref();
@@ -76,9 +74,8 @@ macro_rules! impl_partial_eq_ord {
     ($lhs:ty, $rhs:ty) => {
         $crate::bstr::impl_partial_eq!($lhs, $rhs);
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialOrd<$rhs> for $lhs {
+        impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
                 let other: &[u8] = other.as_ref();
@@ -86,9 +83,8 @@ macro_rules! impl_partial_eq_ord {
             }
         }
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
-        impl<'a> PartialOrd<$lhs> for $rhs {
+        impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
                 let this: &[u8] = self.as_ref();
@@ -107,7 +103,6 @@ pub use impl_partial_eq_ord;
 #[unstable(feature = "bstr_internals", issue = "none")]
 macro_rules! impl_partial_eq_n {
     ($lhs:ty, $rhs:ty) => {
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
         impl<const N: usize> PartialEq<$rhs> for $lhs {
             #[inline]
@@ -117,7 +112,6 @@ macro_rules! impl_partial_eq_n {
             }
         }
 
-        #[allow(unused_lifetimes)]
         #[unstable(feature = "bstr", issue = "134915")]
         impl<const N: usize> PartialEq<$lhs> for $rhs {
             #[inline]

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1565,7 +1565,7 @@ impl Ord for OsStr {
 macro_rules! impl_cmp {
     ($lhs:ty, $rhs: ty) => {
         #[stable(feature = "cmp_os_str", since = "1.8.0")]
-        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 <OsStr as PartialEq>::eq(self, other)
@@ -1573,7 +1573,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "cmp_os_str", since = "1.8.0")]
-        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 <OsStr as PartialEq>::eq(self, other)
@@ -1581,7 +1581,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "cmp_os_str", since = "1.8.0")]
-        impl<'a, 'b> PartialOrd<$rhs> for $lhs {
+        impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
                 <OsStr as PartialOrd>::partial_cmp(self, other)
@@ -1589,7 +1589,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "cmp_os_str", since = "1.8.0")]
-        impl<'a, 'b> PartialOrd<$lhs> for $rhs {
+        impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
                 <OsStr as PartialOrd>::partial_cmp(self, other)
@@ -1599,10 +1599,10 @@ macro_rules! impl_cmp {
 }
 
 impl_cmp!(OsString, OsStr);
-impl_cmp!(OsString, &'a OsStr);
-impl_cmp!(Cow<'a, OsStr>, OsStr);
-impl_cmp!(Cow<'a, OsStr>, &'b OsStr);
-impl_cmp!(Cow<'a, OsStr>, OsString);
+impl_cmp!(OsString, &OsStr);
+impl_cmp!(Cow<'_, OsStr>, OsStr);
+impl_cmp!(Cow<'_, OsStr>, &OsStr);
+impl_cmp!(Cow<'_, OsStr>, OsString);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Hash for OsStr {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3841,9 +3841,9 @@ impl<'a> IntoIterator for &'a Path {
 }
 
 macro_rules! impl_cmp {
-    (<$($life:lifetime),*> $lhs:ty, $rhs: ty) => {
+    ($lhs:ty, $rhs: ty) => {
         #[stable(feature = "partialeq_path", since = "1.6.0")]
-        impl<$($life),*> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 <Path as PartialEq>::eq(self, other)
@@ -3851,7 +3851,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "partialeq_path", since = "1.6.0")]
-        impl<$($life),*> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 <Path as PartialEq>::eq(self, other)
@@ -3859,7 +3859,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialOrd<$rhs> for $lhs {
+        impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
                 <Path as PartialOrd>::partial_cmp(self, other)
@@ -3867,7 +3867,7 @@ macro_rules! impl_cmp {
         }
 
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialOrd<$lhs> for $rhs {
+        impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
                 <Path as PartialOrd>::partial_cmp(self, other)
@@ -3876,16 +3876,16 @@ macro_rules! impl_cmp {
     };
 }
 
-impl_cmp!(<> PathBuf, Path);
-impl_cmp!(<'a> PathBuf, &'a Path);
-impl_cmp!(<'a> Cow<'a, Path>, Path);
-impl_cmp!(<'a, 'b> Cow<'a, Path>, &'b Path);
-impl_cmp!(<'a> Cow<'a, Path>, PathBuf);
+impl_cmp!(PathBuf, Path);
+impl_cmp!(PathBuf, &Path);
+impl_cmp!(Cow<'_, Path>, Path);
+impl_cmp!(Cow<'_, Path>, &Path);
+impl_cmp!(Cow<'_, Path>, PathBuf);
 
 macro_rules! impl_cmp_os_str {
-    (<$($life:lifetime),*> $lhs:ty, $rhs: ty) => {
+    ($lhs:ty, $rhs: ty) => {
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialEq<$rhs> for $lhs {
+        impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
                 <Path as PartialEq>::eq(self, other.as_ref())
@@ -3893,7 +3893,7 @@ macro_rules! impl_cmp_os_str {
         }
 
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialEq<$lhs> for $rhs {
+        impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 <Path as PartialEq>::eq(self.as_ref(), other)
@@ -3901,7 +3901,7 @@ macro_rules! impl_cmp_os_str {
         }
 
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialOrd<$rhs> for $lhs {
+        impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<cmp::Ordering> {
                 <Path as PartialOrd>::partial_cmp(self, other.as_ref())
@@ -3909,7 +3909,7 @@ macro_rules! impl_cmp_os_str {
         }
 
         #[stable(feature = "cmp_path", since = "1.8.0")]
-        impl<$($life),*> PartialOrd<$lhs> for $rhs {
+        impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<cmp::Ordering> {
                 <Path as PartialOrd>::partial_cmp(self.as_ref(), other)
@@ -3918,20 +3918,20 @@ macro_rules! impl_cmp_os_str {
     };
 }
 
-impl_cmp_os_str!(<> PathBuf, OsStr);
-impl_cmp_os_str!(<'a> PathBuf, &'a OsStr);
-impl_cmp_os_str!(<'a> PathBuf, Cow<'a, OsStr>);
-impl_cmp_os_str!(<> PathBuf, OsString);
-impl_cmp_os_str!(<> Path, OsStr);
-impl_cmp_os_str!(<'a> Path, &'a OsStr);
-impl_cmp_os_str!(<'a> Path, Cow<'a, OsStr>);
-impl_cmp_os_str!(<> Path, OsString);
-impl_cmp_os_str!(<'a> &'a Path, OsStr);
-impl_cmp_os_str!(<'a, 'b> &'a Path, Cow<'b, OsStr>);
-impl_cmp_os_str!(<'a> &'a Path, OsString);
-impl_cmp_os_str!(<'a> Cow<'a, Path>, OsStr);
-impl_cmp_os_str!(<'a, 'b> Cow<'a, Path>, &'b OsStr);
-impl_cmp_os_str!(<'a> Cow<'a, Path>, OsString);
+impl_cmp_os_str!(PathBuf, OsStr);
+impl_cmp_os_str!(PathBuf, &OsStr);
+impl_cmp_os_str!(PathBuf, Cow<'_, OsStr>);
+impl_cmp_os_str!(PathBuf, OsString);
+impl_cmp_os_str!(Path, OsStr);
+impl_cmp_os_str!(Path, &OsStr);
+impl_cmp_os_str!(Path, Cow<'_, OsStr>);
+impl_cmp_os_str!(Path, OsString);
+impl_cmp_os_str!(&Path, OsStr);
+impl_cmp_os_str!(&Path, Cow<'_, OsStr>);
+impl_cmp_os_str!(&Path, OsString);
+impl_cmp_os_str!(Cow<'_, Path>, OsStr);
+impl_cmp_os_str!(Cow<'_, Path>, &OsStr);
+impl_cmp_os_str!(Cow<'_, Path>, OsString);
 
 #[stable(since = "1.7.0", feature = "strip_prefix")]
 impl fmt::Display for StripPrefixError {

--- a/tests/ui/inference/issue-72616.stderr
+++ b/tests/ui/inference/issue-72616.stderr
@@ -8,8 +8,11 @@ LL |         if String::from("a") == "a".try_into().unwrap() {}
    |
    = note: multiple `impl`s satisfying `String: PartialEq<_>` found in the following crates: `alloc`, `std`:
            - impl PartialEq for String;
+           - impl PartialEq<ByteStr> for String;
+           - impl PartialEq<ByteString> for String;
            - impl PartialEq<Path> for String;
            - impl PartialEq<PathBuf> for String;
+           - impl PartialEq<str> for String;
 help: try using a fully qualified path to specify the expected types
    |
 LL -         if String::from("a") == "a".try_into().unwrap() {}


### PR DESCRIPTION
Makes [the docs](https://doc.rust-lang.org/1.88.0/std/cmp/trait.PartialOrd.html#impl-PartialOrd%3CPathBuf%3E-for-Cow%3C'a,+Path%3E) way easier to look at, gets rid of a few `#[allow(unused_lifetimes)]`, and AFAICT is completely equivalent.