### PR TITLE
Disable download-rustc for library profile

### DIFF
--- a/src/bootstrap/defaults/bootstrap.library.toml
+++ b/src/bootstrap/defaults/bootstrap.library.toml
@@ -12,7 +12,8 @@ lto = "off"
 #
 # If compiler-affecting directories are not modified, use precompiled rustc to speed up
 # library development by skipping compiler builds.
-download-rustc = "if-unchanged"
+# FIXME: download-rustc is currently broken: https://github.com/rust-lang/rust/issues/142505
+download-rustc = false
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -456,4 +456,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "The default check stage has been changed to 1. It is no longer possible to `x check` with stage 0. All check commands have to be on stage 1+. Bootstrap tools can now also only be checked for the host target.",
     },
+    ChangeInfo {
+        change_id: 143577,
+        severity: ChangeSeverity::Warning,
+        summary: "`download-rustc` has been temporarily disabled for the library profile due to implementation bugs (see #142505).",
+    },
 ];


### PR DESCRIPTION
The feature currently completely breaks `x test` (rust-lang/rust#142505), core functionality of working on the standard library. Therefore it should be disabled by default until that problem is fixed. Having to wait a bit longer for a check build is nothing compared to completely mysterious build errors when testing.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
