### PR TITLE
fix typo in Apache License link in README

### DIFF
--- a/library/compiler-builtins/README.md
+++ b/library/compiler-builtins/README.md
@@ -24,4 +24,4 @@ More details are in [LICENSE.txt](LICENSE.txt) and
 [libm/LICENSE.txt](libm/LICENSE.txt).
 
 [MIT License]: https://opensource.org/license/mit
-[Apache License, Version 2.0]: htps://www.apache.org/licenses/LICENSE-2.0
+[Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION


**Description:**  
Corrected a typo in the Apache License URL in `library/compiler-builtins/README.md` (`htps` → `https`).  
This ensures the link is valid and accessible.