### PR TITLE
Add correct span for unsized types

### DIFF
--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -876,10 +876,10 @@ LL | type TestAbiNeSign = (fn(i32), fn(u32));
    | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/debug.rs:68:46
+  --> $DIR/debug.rs:68:47
    |
 LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
-   |                                              ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -876,10 +876,10 @@ LL | type TestAbiNeSign = (fn(i32), fn(u32));
    | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/debug.rs:68:46
+  --> $DIR/debug.rs:68:47
    |
 LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
-   |                                              ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type

--- a/tests/ui/associated-types/defaults-wf.stderr
+++ b/tests/ui/associated-types/defaults-wf.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/defaults-wf.rs:7:15
+  --> $DIR/defaults-wf.rs:7:19
    |
 LL |     type Ty = Vec<[u8]>;
-   |               ^^^^^^^^^ doesn't have a size known at compile-time
+   |                   ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `Vec`

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-20005.rs:10:49
+  --> $DIR/issue-20005.rs:10:54
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
-   |                                                 ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                                      ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `From`
   --> $DIR/issue-20005.rs:1:12

--- a/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/trait-with-supertraits-needing-sized-self.rs:3:22
+  --> $DIR/trait-with-supertraits-needing-sized-self.rs:3:33
    |
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> {}
-   |                      ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                 ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL

--- a/tests/ui/cast/unsized-union-ice.stderr
+++ b/tests/ui/cast/unsized-union-ice.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/unsized-union-ice.rs:6:10
+  --> $DIR/unsized-union-ice.rs:6:33
    |
 LL |     val: std::mem::ManuallyDrop<[u8]>,
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                 ^^^^ doesn't have a size known at compile-time
    |
    = help: within `ManuallyDrop<[u8]>`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `ManuallyDrop<[u8]>`

--- a/tests/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/tests/ui/closures/closure-return-type-must-be-sized.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:54:5
+  --> $DIR/closure-return-type-must-be-sized.rs:54:22
    |
 LL |     a::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:55:14
+  --> $DIR/closure-return-type-must-be-sized.rs:55:22
    |
 LL |     a::bar::<fn() -> dyn A, _>();
-   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -22,28 +22,28 @@ LL |     pub fn bar<F: FnOnce() -> R, R: ?Sized>() {}
    |                   ^^^^^^^^^^^^^ required by this bound in `bar`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:56:5
+  --> $DIR/closure-return-type-must-be-sized.rs:56:22
    |
 LL |     a::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:61:5
+  --> $DIR/closure-return-type-must-be-sized.rs:61:22
    |
 LL |     b::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:62:14
+  --> $DIR/closure-return-type-must-be-sized.rs:62:22
    |
 LL |     b::bar::<fn() -> dyn A, _>();
-   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -54,28 +54,28 @@ LL |     pub fn bar<F: Fn() -> R, R: ?Sized>() {}
    |                   ^^^^^^^^^ required by this bound in `bar`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:63:5
+  --> $DIR/closure-return-type-must-be-sized.rs:63:22
    |
 LL |     b::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:68:5
+  --> $DIR/closure-return-type-must-be-sized.rs:68:22
    |
 LL |     c::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:69:14
+  --> $DIR/closure-return-type-must-be-sized.rs:69:22
    |
 LL |     c::bar::<fn() -> dyn A, _>();
-   |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -86,10 +86,10 @@ LL |     pub fn bar<F: FnMut() -> R, R: ?Sized>() {}
    |                   ^^^^^^^^^^^^ required by this bound in `bar`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
-  --> $DIR/closure-return-type-must-be-sized.rs:70:5
+  --> $DIR/closure-return-type-must-be-sized.rs:70:22
    |
 LL |     c::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`

--- a/tests/ui/closures/missing-body.stderr
+++ b/tests/ui/closures/missing-body.stderr
@@ -5,10 +5,10 @@ LL | fn main() { |b: [str; _]| {}; }
    |                       ^ not allowed in type signatures
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/missing-body.rs:5:17
+  --> $DIR/missing-body.rs:5:18
    |
 LL | fn main() { |b: [str; _]| {}; }
-   |                 ^^^^^^^^ doesn't have a size known at compile-time
+   |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: slice and array elements must have `Sized` type

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -26,10 +26,10 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:15:1
+  --> $DIR/const-unsized.rs:15:20
    |
 LL | static STATIC_BAR: str = *"bar";
-   | ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size

--- a/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
+++ b/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dont-ctfe-unsized-initializer.rs:1:1
+  --> $DIR/dont-ctfe-unsized-initializer.rs:1:11
    |
 LL | static S: str = todo!();
-   | ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size

--- a/tests/ui/dst/dst-sized-trait-param.stderr
+++ b/tests/ui/dst/dst-sized-trait-param.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[isize]` cannot be known at compilation time
-  --> $DIR/dst-sized-trait-param.rs:7:6
+  --> $DIR/dst-sized-trait-param.rs:7:10
    |
 LL | impl Foo<[isize]> for usize { }
-   |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |          ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[isize]`
 note: required by an implicit `Sized` bound in `Foo`

--- a/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
+++ b/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/supertrait-mentions-Self.rs:8:13
+  --> $DIR/supertrait-mentions-Self.rs:8:17
    |
 LL | trait Baz : Bar<Self> {
-   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |                 ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/supertrait-mentions-Self.rs:4:11

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -38,10 +38,10 @@ LL | fn assert_sized<T: ?Sized>() {}
    |                  ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/extern-types-unsized.rs:28:20
+  --> $DIR/extern-types-unsized.rs:28:24
    |
 LL |     assert_sized::<Bar<A>>();
-   |                    ^^^^^^ doesn't have a size known at compile-time
+   |                        ^ doesn't have a size known at compile-time
    |
    = help: within `Bar<A>`, the trait `Sized` is not implemented for `A`
 note: required because it appears within the type `Bar<A>`
@@ -73,10 +73,10 @@ LL | struct Bar<T: ?Sized> {
    |            ^ required by this bound in `Bar`
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/extern-types-unsized.rs:32:20
+  --> $DIR/extern-types-unsized.rs:32:28
    |
 LL |     assert_sized::<Bar<Bar<A>>>();
-   |                    ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^ doesn't have a size known at compile-time
    |
    = help: within `Bar<Bar<A>>`, the trait `Sized` is not implemented for `A`
 note: required because it appears within the type `Bar<A>`

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[usize]` cannot be known at compilation time
-  --> $DIR/issue-36122-accessing-externed-dst.rs:3:9
+  --> $DIR/issue-36122-accessing-externed-dst.rs:3:24
    |
 LL |         static symbol: [usize];
-   |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                        ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[usize]`
    = note: statics and constants must have a statically known size

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -105,7 +105,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/feature-gate-trivial_bounds.rs:52:32
    |
 LL | struct TwoStrs(str, str) where str: Sized;
-   |                                ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214
@@ -136,7 +136,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/feature-gate-trivial_bounds.rs:59:30
    |
 LL | fn return_str() -> str where str: Sized {
-   |                              ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                              ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: see issue #48214

--- a/tests/ui/function-pointer/unsized-ret.stderr
+++ b/tests/ui/function-pointer/unsized-ret.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-ret.rs:10:11
+  --> $DIR/unsized-ret.rs:10:19
    |
 LL |     foo::<fn() -> str, _>(None, ());
-   |           ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                   ^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> str`, the trait `Sized` is not implemented for `str`
    = note: required because it appears within the type `fn() -> str`
@@ -13,10 +13,10 @@ LL | fn foo<F: Fn<T>, T:std::marker::Tuple>(f: Option<F>, t: T) {
    |           ^^^^^ required by this bound in `foo`
 
 error[E0277]: the size for values of type `(dyn std::fmt::Display + 'a)` cannot be known at compilation time
-  --> $DIR/unsized-ret.rs:13:11
+  --> $DIR/unsized-ret.rs:13:33
    |
 LL |     foo::<for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a), _>(None, (&(),));
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`, the trait `for<'a> Sized` is not implemented for `(dyn std::fmt::Display + 'a)`
    = note: required because it appears within the type `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`

--- a/tests/ui/higher-ranked/well-formed-aliases.stderr
+++ b/tests/ui/higher-ranked/well-formed-aliases.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/well-formed-aliases.rs:5:52
+  --> $DIR/well-formed-aliases.rs:5:53
    |
 LL | fn test<T>(f: for<'a> fn(<&'a T as Trait>::Gat<&'a [str]>)) where for<'a> &'a T: Trait {}
-   |                                                    ^^^^^ doesn't have a size known at compile-time
+   |                                                     ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: slice and array elements must have `Sized` type

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -1,18 +1,18 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/wf-bounds.rs:12:22
+  --> $DIR/wf-bounds.rs:12:29
    |
 LL |     fn nya() -> impl Wf<Vec<[u8]>>;
-   |                      ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/wf-bounds.rs:15:23
+  --> $DIR/wf-bounds.rs:15:26
    |
 LL |     fn nya2() -> impl Wf<[u8]>;
-   |                       ^^^^^^^^ doesn't have a size known at compile-time
+   |                          ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `Wf`
@@ -26,10 +26,10 @@ LL | trait Wf<T: ?Sized> {
    |           ++++++++
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/wf-bounds.rs:18:44
+  --> $DIR/wf-bounds.rs:18:51
    |
 LL |     fn nya3() -> impl Wf<(), Output = impl Wf<Vec<[u8]>>>;
-   |                                            ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                                   ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `Vec`

--- a/tests/ui/issues/issue-20433.stderr
+++ b/tests/ui/issues/issue-20433.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/issue-20433.rs:6:18
+  --> $DIR/issue-20433.rs:6:22
    |
 LL |     fn iceman(c: Vec<[i32]>) {}
-   |                  ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                      ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
 note: required by an implicit `Sized` bound in `Vec`

--- a/tests/ui/issues/issue-22874.stderr
+++ b/tests/ui/issues/issue-22874.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[String]` cannot be known at compilation time
-  --> $DIR/issue-22874.rs:2:11
+  --> $DIR/issue-22874.rs:2:12
    |
 LL |     rows: [[String]],
-   |           ^^^^^^^^^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[String]`
    = note: slice and array elements must have `Sized` type

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
-  --> $DIR/issue-54410.rs:2:5
+  --> $DIR/issue-54410.rs:2:28
    |
 LL |     pub static mut symbol: [i8];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i8]`
    = note: statics and constants must have a statically known size

--- a/tests/ui/layout/debug.stderr
+++ b/tests/ui/layout/debug.stderr
@@ -584,10 +584,10 @@ LL | const C: () = ();
    | ^^^^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/debug.rs:80:19
+  --> $DIR/debug.rs:80:20
    |
 LL | type Impossible = (str, str);
-   |                   ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -21,28 +21,28 @@ LL + use std::path::Path;
    |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:9:12
+  --> $DIR/issue-84108.rs:9:20
    |
 LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
-   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:15:13
+  --> $DIR/issue-84108.rs:15:14
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
-   |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |              ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:9:12
+  --> $DIR/issue-84108.rs:9:20
    |
 LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
-   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
@@ -58,10 +58,10 @@ LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
               found array `[_; 0]`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:15:13
+  --> $DIR/issue-84108.rs:15:14
    |
 LL | static BAZ: ([u8], usize) = ([], 0);
-   |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |              ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type

--- a/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
+++ b/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
@@ -5,10 +5,10 @@ LL | type Alias<T = Vec<str>, const N: usize = { 0 - 1 }> = T;
    |                                             ^^^^^ evaluation of `Alias::{constant#0}` failed here
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/def-site-param-defaults-wf.rs:5:16
+  --> $DIR/def-site-param-defaults-wf.rs:5:20
    |
 LL | type Alias<T = Vec<str>, const N: usize = { 0 - 1 }> = T;
-   |                ^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by an implicit `Sized` bound in `Vec`

--- a/tests/ui/lazy-type-alias/def-site-predicates-wf.stderr
+++ b/tests/ui/lazy-type-alias/def-site-predicates-wf.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/def-site-predicates-wf.rs:7:5
+  --> $DIR/def-site-predicates-wf.rs:7:9
    |
 LL |     Vec<str>:;
-   |     ^^^^^^^^ doesn't have a size known at compile-time
+   |         ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by an implicit `Sized` bound in `Vec`

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -82,10 +82,10 @@ LL + fn generic_with_maybe_sized<T>() -> usize {
    |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/offset-of-dst-field.rs:55:16
+  --> $DIR/offset-of-dst-field.rs:55:17
    |
 LL |     offset_of!(([u8], u8), 1);
-   |                ^^^^^^^^^^ doesn't have a size known at compile-time
+   |                 ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type

--- a/tests/ui/sized-hierarchy/impls.stderr
+++ b/tests/ui/sized-hierarchy/impls.stderr
@@ -172,28 +172,28 @@ LL | fn needs_metasized<T: MetaSized>() { }
    |                       ^^^^^^^^^ required by this bound in `needs_metasized`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/impls.rs:193:19
+  --> $DIR/impls.rs:193:20
    |
 LL |     needs_sized::<([u8], [u8])>();
-   |                   ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/impls.rs:195:23
+  --> $DIR/impls.rs:195:24
    |
 LL |     needs_metasized::<([u8], [u8])>();
-   |                       ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                        ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/impls.rs:197:26
+  --> $DIR/impls.rs:197:27
    |
 LL |     needs_pointeesized::<([u8], [u8])>();
-   |                          ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
@@ -240,10 +240,10 @@ LL |     needs_pointeesized::<(Foo, Foo)>();
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/impls.rs:210:19
+  --> $DIR/impls.rs:210:25
    |
 LL |     needs_sized::<(u32, [u8])>();
-   |                   ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                         ^^^^ doesn't have a size known at compile-time
    |
    = help: within `(u32, [u8])`, the trait `Sized` is not implemented for `[u8]`
    = note: required because it appears within the type `(u32, [u8])`

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/adt-param-with-implicit-sized-bound.rs:25:9
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:25:11
    |
 LL | struct Struct5<T: ?Sized>{
    |                - this type parameter needs to be `Sized`
 LL |     _t: X<T>,
-   |         ^^^^ doesn't have a size known at compile-time
+   |           ^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `X`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
@@ -25,10 +25,10 @@ LL + struct Struct5<T>{
    |
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/adt-param-with-implicit-sized-bound.rs:2:19
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:2:27
    |
 LL |     fn func1() -> Struct1<Self>;
-   |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Struct1`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
@@ -45,10 +45,10 @@ LL | struct Struct1<T: ?Sized>{
    |                 ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/adt-param-with-implicit-sized-bound.rs:3:23
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:3:35
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self>;
-   |                       ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Struct2`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
@@ -65,10 +65,10 @@ LL | struct Struct2<'a, T: ?Sized>{
    |                     ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/adt-param-with-implicit-sized-bound.rs:4:19
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:4:27
    |
 LL |     fn func3() -> Struct3<Self>;
-   |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Struct3`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
@@ -88,10 +88,10 @@ LL |     fn func3() -> Struct3<Self> where Self: Sized;
    |                                 +++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/adt-param-with-implicit-sized-bound.rs:5:19
+  --> $DIR/adt-param-with-implicit-sized-bound.rs:5:27
    |
 LL |     fn func4() -> Struct4<Self>;
-   |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^ doesn't have a size known at compile-time
    |
 note: required by an implicit `Sized` bound in `Struct4`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16

--- a/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:5:10
+  --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:5:12
    |
 LL | struct B(A<[u8]>);
-   |          ^^^^^^^ doesn't have a size known at compile-time
+   |            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `A`

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:3:16
+  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:3:24
    |
 LL | fn foo<T>(foo: Wrapper<T>)
-   |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
+   |        -               ^ doesn't have a size known at compile-time
    |        |
    |        this type parameter needs to be `Sized`
    |
@@ -28,10 +28,10 @@ LL -     Sized
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:14:16
+  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:14:24
    |
 LL | fn bar<T>(foo: Wrapper<T>)
-   |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
+   |        -               ^ doesn't have a size known at compile-time
    |        |
    |        this type parameter needs to be `Sized`
    |
@@ -53,10 +53,10 @@ LL - where T: ?Sized
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:21:16
+  --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:21:24
    |
 LL | fn qux<T>(foo: Wrapper<T>)
-   |        -       ^^^^^^^^^^ doesn't have a size known at compile-time
+   |        -               ^ doesn't have a size known at compile-time
    |        |
    |        this type parameter needs to be `Sized`
    |

--- a/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
+++ b/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/suggest-maybe-sized-bound.rs:8:12
+  --> $DIR/suggest-maybe-sized-bound.rs:8:27
    |
 LL |         a: StructA<isize, [u8]>,
-   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `StructA`

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `B` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:2:30
+  --> $DIR/unsized-bound.rs:2:34
    |
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
-   |         -                    ^^^^^^ doesn't have a size known at compile-time
+   |         -                        ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -23,10 +23,10 @@ LL | trait Trait<A: ?Sized> {}
    |              ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:2:30
+  --> $DIR/unsized-bound.rs:2:31
    |
 LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
-   |      -                       ^^^^^^ doesn't have a size known at compile-time
+   |      -                        ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |
@@ -38,10 +38,10 @@ LL + impl<A, B> Trait<(A, B)> for (A, B) where B: ?Sized, {}
    |
 
 error[E0277]: the size for values of type `C` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:5:52
+  --> $DIR/unsized-bound.rs:5:59
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |                    -                               ^^^^^^^^^ doesn't have a size known at compile-time
+   |                    -                                      ^ doesn't have a size known at compile-time
    |                    |
    |                    this type parameter needs to be `Sized`
    |
@@ -62,10 +62,10 @@ LL | trait Trait<A: ?Sized> {}
    |              ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:5:52
+  --> $DIR/unsized-bound.rs:5:53
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |      - this type parameter needs to be `Sized`     ^^^^^^^^^ doesn't have a size known at compile-time
+   |      - this type parameter needs to be `Sized`      ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -75,10 +75,10 @@ LL + impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C)  {}
    |
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:5:52
+  --> $DIR/unsized-bound.rs:5:56
    |
 LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |         - this type parameter needs to be `Sized`  ^^^^^^^^^ doesn't have a size known at compile-time
+   |         - this type parameter needs to be `Sized`      ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -88,10 +88,10 @@ LL + impl<A, B, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
    |
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:10:47
+  --> $DIR/unsized-bound.rs:10:51
    |
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-   |                 -                             ^^^^^^ doesn't have a size known at compile-time
+   |                 -                                 ^ doesn't have a size known at compile-time
    |                 |
    |                 this type parameter needs to be `Sized`
    |
@@ -112,12 +112,10 @@ LL | trait Trait2<A: ?Sized> {}
    |               ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:10:47
+  --> $DIR/unsized-bound.rs:10:48
    |
 LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-   |      -                                        ^^^^^^ doesn't have a size known at compile-time
-   |      |
-   |      this type parameter needs to be `Sized`
+   |      - this type parameter needs to be `Sized` ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -219,10 +217,10 @@ LL | trait Trait6<A: ?Sized, B> {}
    |               ++++++++
 
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:26:12
+  --> $DIR/unsized-bound.rs:26:22
    |
 LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
-   |         -  ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |         -            ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -242,10 +240,10 @@ LL | trait Trait7<A, B: ?Sized> {}
    |                  ++++++++
 
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:29:20
+  --> $DIR/unsized-bound.rs:29:30
    |
 LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
-   |         -          ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |         -                    ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |

--- a/tests/ui/traits/next-solver/builtin-fn-must-return-sized.stderr
+++ b/tests/ui/traits/next-solver/builtin-fn-must-return-sized.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/builtin-fn-must-return-sized.rs:15:11
+  --> $DIR/builtin-fn-must-return-sized.rs:15:19
    |
 LL |     foo::<fn() -> str, _>(None, ());
-   |           ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                   ^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> str`, the trait `Sized` is not implemented for `str`
    = note: required because it appears within the type `fn() -> str`

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -16,13 +16,13 @@ LL + fn check<T: Iterator, U>() {
    |
 
 error[E0277]: the size for values of type `U` cannot be known at compilation time
-  --> $DIR/suggest-where-clause.rs:10:20
+  --> $DIR/suggest-where-clause.rs:10:25
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
    |                       - this type parameter needs to be `Sized`
 ...
 LL |     mem::size_of::<Misc<U>>();
-   |                    ^^^^^^^ doesn't have a size known at compile-time
+   |                         ^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `Misc<U>`
   --> $DIR/suggest-where-clause.rs:3:8

--- a/tests/ui/traits/trivial-unsized-projection.bad.stderr
+++ b/tests/ui/traits/trivial-unsized-projection.bad.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/trivial-unsized-projection.rs:20:12
+  --> $DIR/trivial-unsized-projection.rs:20:13
    |
 LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Bad::Assert`
@@ -19,10 +19,10 @@ LL |     type Assert: ?Sized
    |                ++++++++
 
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/trivial-unsized-projection.rs:20:12
+  --> $DIR/trivial-unsized-projection.rs:20:13
    |
 LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Bad::Assert`

--- a/tests/ui/traits/trivial-unsized-projection.bad_new.stderr
+++ b/tests/ui/traits/trivial-unsized-projection.bad_new.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/trivial-unsized-projection.rs:20:12
+  --> $DIR/trivial-unsized-projection.rs:20:13
    |
 LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Bad::Assert`
@@ -19,10 +19,10 @@ LL |     type Assert: ?Sized
    |                ++++++++
 
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/trivial-unsized-projection.rs:20:12
+  --> $DIR/trivial-unsized-projection.rs:20:13
    |
 LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Bad::Assert`

--- a/tests/ui/union/union-sized-field.stderr
+++ b/tests/ui/union/union-sized-field.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/union-sized-field.rs:4:12
+  --> $DIR/union-sized-field.rs:4:25
    |
 LL | union Foo<T: ?Sized> {
    |           - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
-   |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                         ^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `ManuallyDrop<T>`
   --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
@@ -25,12 +25,12 @@ LL |     value: Box<ManuallyDrop<T>>,
    |            ++++               +
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/union-sized-field.rs:9:12
+  --> $DIR/union-sized-field.rs:9:25
    |
 LL | struct Foo2<T: ?Sized> {
    |             - this type parameter needs to be `Sized`
 LL |     value: ManuallyDrop<T>,
-   |            ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                         ^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `ManuallyDrop<T>`
   --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL
@@ -51,12 +51,12 @@ LL |     value: Box<ManuallyDrop<T>>,
    |            ++++               +
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/union-sized-field.rs:15:11
+  --> $DIR/union-sized-field.rs:15:24
    |
 LL | enum Foo3<T: ?Sized> {
    |           - this type parameter needs to be `Sized`
 LL |     Value(ManuallyDrop<T>),
-   |           ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                        ^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `ManuallyDrop<T>`
   --> $SRC_DIR/core/src/mem/manually_drop.rs:LL:COL

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/unsized-enum.rs:6:36
+  --> $DIR/unsized-enum.rs:6:40
    |
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-   |         -                          ^^^^^^ doesn't have a size known at compile-time
+   |         -                              ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized-enum2.stderr
+++ b/tests/ui/unsized/unsized-enum2.stderr
@@ -243,10 +243,10 @@ LL |     VP{u: isize, x: Box<dyn BarFoo>},
    |                     ++++          +
 
 error[E0277]: the size for values of type `[i8]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:63:8
+  --> $DIR/unsized-enum2.rs:63:18
    |
 LL |     VQ(<&'static [i8] as Deref>::Target),
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                  ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i8]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -261,10 +261,10 @@ LL |     VQ(Box<<&'static [i8] as Deref>::Target>),
    |        ++++                                +
 
 error[E0277]: the size for values of type `[char]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:65:11
+  --> $DIR/unsized-enum2.rs:65:21
    |
 LL |     VR{x: <&'static [char] as Deref>::Target},
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[char]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -279,10 +279,10 @@ LL |     VR{x: Box<<&'static [char] as Deref>::Target>},
    |           ++++                                  +
 
 error[E0277]: the size for values of type `[f64]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:67:15
+  --> $DIR/unsized-enum2.rs:67:25
    |
 LL |     VS(isize, <&'static [f64] as Deref>::Target),
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                         ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[f64]`
    = note: no field of an enum variant may have a dynamically sized type
@@ -297,10 +297,10 @@ LL |     VS(isize, Box<<&'static [f64] as Deref>::Target>),
    |               ++++                                 +
 
 error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
-  --> $DIR/unsized-enum2.rs:69:21
+  --> $DIR/unsized-enum2.rs:69:31
    |
 LL |     VT{u: isize, x: <&'static [i32] as Deref>::Target},
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
    = note: no field of an enum variant may have a dynamically sized type

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized-inherent-impl-self-type.rs:7:17
+  --> $DIR/unsized-inherent-impl-self-type.rs:7:20
    |
 LL | impl<X: ?Sized> S5<X> {
-   |      -          ^^^^^ doesn't have a size known at compile-time
+   |      -             ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/unsized-struct.rs:6:36
+  --> $DIR/unsized-struct.rs:6:40
    |
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
-   |         -                          ^^^^^^ doesn't have a size known at compile-time
+   |         -                              ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -25,10 +25,10 @@ LL + fn foo2<T>() { not_sized::<Foo<T>>() }
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/unsized-struct.rs:13:35
+  --> $DIR/unsized-struct.rs:13:39
    |
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
-   |         -                         ^^^^^^ doesn't have a size known at compile-time
+   |         -                             ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -8,10 +8,10 @@ LL | impl<X: ?Sized> T3<X> for S5<X> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized-trait-impl-self-type.rs:10:27
+  --> $DIR/unsized-trait-impl-self-type.rs:10:30
    |
 LL | impl<X: ?Sized> T3<X> for S5<X> {
-   |      -                    ^^^^^ doesn't have a size known at compile-time
+   |      -                       ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -8,10 +8,10 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `foo` in implementation
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized-trait-impl-trait-arg.rs:8:17
+  --> $DIR/unsized-trait-impl-trait-arg.rs:8:20
    |
 LL | impl<X: ?Sized> T2<X> for S4<X> {
-   |      -          ^^^^^ doesn't have a size known at compile-time
+   |      -             ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -19,13 +19,13 @@ LL |     let y: &Y;
    |            +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:7:12
+  --> $DIR/unsized6.rs:7:21
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
    |                  - this type parameter needs to be `Sized`
 LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
-   |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -35,13 +35,13 @@ LL + fn f1<W: ?Sized, X, Y: ?Sized, Z: ?Sized>(x: &X) {
    |
 
 error[E0277]: the size for values of type `Z` cannot be known at compilation time
-  --> $DIR/unsized6.rs:11:12
+  --> $DIR/unsized6.rs:11:21
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
    |                                        - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Z, usize));
-   |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -70,13 +70,13 @@ LL |     let y: &X;
    |            +
 
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
-  --> $DIR/unsized6.rs:17:12
+  --> $DIR/unsized6.rs:17:21
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
    |                  - this type parameter needs to be `Sized`
 ...
 LL |     let y: (isize, (Y, isize));
-   |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^ doesn't have a size known at compile-time
    |
    = note: only the last element of a tuple may have a dynamically sized type
 help: consider removing the `?Sized` bound to make the type parameter `Sized`

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -8,10 +8,10 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `dummy` in implementation
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized7.rs:12:21
+  --> $DIR/unsized7.rs:12:24
    |
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
-   |      -              ^^^^^ doesn't have a size known at compile-time
+   |      -                 ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/wf/wf-array-elem-sized.stderr
+++ b/tests/ui/wf/wf-array-elem-sized.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/wf-array-elem-sized.rs:7:10
+  --> $DIR/wf-array-elem-sized.rs:7:11
    |
 LL |     foo: [[u8]],
-   |          ^^^^^^ doesn't have a size known at compile-time
+   |           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: slice and array elements must have `Sized` type

--- a/tests/ui/wf/wf-impl-self-type.stderr
+++ b/tests/ui/wf/wf-impl-self-type.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/wf-impl-self-type.rs:5:14
+  --> $DIR/wf-impl-self-type.rs:5:21
    |
 LL | impl Foo for Option<[u8]> {}
-   |              ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by an implicit `Sized` bound in `Option`

--- a/tests/ui/wf/wf-normalization-sized.next.stderr
+++ b/tests/ui/wf/wf-normalization-sized.next.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
-  --> $DIR/wf-normalization-sized.rs:19:11
+  --> $DIR/wf-normalization-sized.rs:19:12
    |
 LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
-   |           ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[[[[[u8]]]]]`
    = note: slice and array elements must have `Sized` type
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/wf-normalization-sized.rs:21:11
+  --> $DIR/wf-normalization-sized.rs:21:15
    |
 LL | const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
-   |           ^^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by an implicit `Sized` bound in `Vec`


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Hello, here is my first PR to rust compiler, so any feedback will be appreciated

This small fix is changes span with unsized types to show only unsized type instead of showing entire type

I also get through all test updates to see if there were any regression, but everything seems good to me, I also think that no new tests needs to be added here because current tests are pretty good covers this case

fixes rust-lang/rust#141234

r? compiler 