### PR TITLE
`loop_match`: fix 'no terminator on block'

### DIFF
--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -936,7 +936,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 valtree
             }
-            Err(ErrorHandled::Reported(..)) => return self.cfg.start_new_block().unit(),
+            Err(ErrorHandled::Reported(..)) => {
+                return block.unit();
+            }
             Err(ErrorHandled::TooGeneric(_)) => {
                 self.tcx.dcx().emit_fatal(ConstContinueBadConst { span: constant.span });
             }

--- a/tests/ui/loop-match/panic-in-const.rs
+++ b/tests/ui/loop-match/panic-in-const.rs
@@ -1,0 +1,22 @@
+#![allow(incomplete_features)]
+#![feature(loop_match)]
+#![crate_type = "lib"]
+
+const CONST_THAT_PANICS: u8 = panic!("diverge!");
+//~^ ERROR: evaluation panicked: diverge!
+
+fn test(mut state: u8) {
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                0 => {
+                    #[const_continue]
+                    break 'blk CONST_THAT_PANICS;
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/tests/ui/loop-match/panic-in-const.stderr
+++ b/tests/ui/loop-match/panic-in-const.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation panicked: diverge!
+  --> $DIR/panic-in-const.rs:5:31
+   |
+LL | const CONST_THAT_PANICS: u8 = panic!("diverge!");
+   |                               ^^^^^^^^^^^^^^^^^^ evaluation of `CONST_THAT_PANICS` failed here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/132306
fixes https://github.com/rust-lang/rust/issues/143435
fixes https://github.com/rust-lang/rust/issues/143204

The argument `block` was not properly closed on an error path.

r? @bjorn3 