### PR TITLE
const-block-as-pattern: do not refer to no-longer-existing nightly feature

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1293,8 +1293,10 @@ impl<'a> Parser<'a> {
         let kind = if pat {
             let guar = self
                 .dcx()
-                .struct_span_err(blk_span, "`inline_const_pat` has been removed")
-                .with_help("use a named `const`-item or an `if`-guard instead")
+                .struct_span_err(blk_span, "const blocks cannot be used as patterns")
+                .with_help(
+                    "use a named `const`-item or an `if`-guard (`x if x == const { ... }`) instead",
+                )
                 .emit();
             ExprKind::Err(guar)
         } else {

--- a/tests/ui/inline-const/in-pat-recovery.rs
+++ b/tests/ui/inline-const/in-pat-recovery.rs
@@ -4,7 +4,7 @@
 fn main() {
     match 1 {
         const { 1 + 7 } => {}
-        //~^ ERROR `inline_const_pat` has been removed
+        //~^ ERROR const blocks cannot be used as patterns
         2 => {}
         _ => {}
     }

--- a/tests/ui/inline-const/in-pat-recovery.stderr
+++ b/tests/ui/inline-const/in-pat-recovery.stderr
@@ -1,10 +1,10 @@
-error: `inline_const_pat` has been removed
+error: const blocks cannot be used as patterns
   --> $DIR/in-pat-recovery.rs:6:15
    |
 LL |         const { 1 + 7 } => {}
    |               ^^^^^^^^^
    |
-   = help: use a named `const`-item or an `if`-guard instead
+   = help: use a named `const`-item or an `if`-guard (`x if x == const { ... }`) instead
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Surely everyone who used this nightly feature has fixed their code by now. So let's not confused people on stable that try to use a const block as a pattern by referring to some dead nightly feature.