### PR TITLE
win7: load synch functions on demand

### DIFF
--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -188,6 +188,8 @@ unsafe extern "system" {
 // These are loaded by `load_synch_functions`.
 #[cfg(target_vendor = "win7")]
 compat_fn_optional! {
+    pub static SYNCH_API: &CStr = c"api-ms-win-core-synch-l1-2-0";
+
     pub fn WaitOnAddress(
         address: *const c_void,
         compareaddress: *const c_void,


### PR DESCRIPTION
Currently, for Windows 7 only, we do a fun thing with pre-main initialisers to optimistically load some functions (used for `park`/`unpark`) which require Windows 8+. This means they're loaded even if unused and can mildly affect start up times (albeit not by much). More of an issue is that someone else's pre-main initialiser could run before our own (we've taken steps to mitigated that but it is just a mitigation). Also the code isn't tested by us (i.e. rust CI) any more so it's prone to bit rot. In any case, failure may not be noticed because if it does fail then the Windows 7 code will be used instead.

This PR changes it to load on demand instead. In the happy case this just means doing one load and two equality checks. In the sad case where we've not yet attempted to load the module, this will be slower. But it's a one time cost, usually taken in `park` (which is "slow" on account of waiting an indefinite period of time).

We could alternatively just use the Windows 7 synchronisation functions exclusively. The issue with that is they're undocumented and technically could be changed or removed at any point, albeit compatibility guarantees make this somewhat unlikely. Still, we should try to be well behaved.

