### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue_future.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue_future.md
@@ -14,7 +14,7 @@ it would be `T-libs-api`.
 Also check for any `A-` labels to add.
 -->
 
-This is the **tracking issue** for the `YOUR_LINT_NAME_HERE` future-compatibility warning and other related errors. The goal of this page is describe why this change was made and how you can fix code that is affected by it. It also provides a place to ask questions or register a complaint if you feel the change should not be made. For more information on the policy around future-compatibility warnings, see our [breaking change policy guidelines][guidelines].
+This is the **tracking issue** for the `YOUR_LINT_NAME_HERE` future-compatibility warning and other related errors. The goal of this page is to describe why this change was made and how you can fix code that is affected by it. It also provides a place to ask questions or register a complaint if you feel the change should not be made. For more information on the policy around future-compatibility warnings, see our [breaking change policy guidelines][guidelines].
 
 [guidelines]: https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html
 
@@ -44,7 +44,7 @@ This is the **tracking issue** for the `YOUR_LINT_NAME_HERE` future-compatibilit
 
 - [ ] Implement the lint
 - [ ] Raise lint level to deny
-- [ ] Make lint report in dependencies
+- [ ] Change the lint to report in dependencies
 - [ ] Switch to a hard error
 
 ### Implementation history

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -19,7 +19,6 @@
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
 #![feature(rustc_private)]
-#![allow(broken_intra_doc_links)]
 #![recursion_limit = "256"]
 #![warn(rust_2018_idioms)]
 #![warn(unused_lifetimes)]

--- a/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
@@ -1,4 +1,3 @@
-#![allow(non_camel_case_types)]
 #![expect(dead_code)]
 
 use libc::{c_char, c_uint};

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -331,10 +331,10 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
     fn load_mir(
         ecx: &InterpCx<'tcx, Self>,
         instance: ty::InstanceKind<'tcx>,
-    ) -> InterpResult<'tcx, &'tcx mir::Body<'tcx>> {
+    ) -> &'tcx mir::Body<'tcx> {
         match instance {
-            ty::InstanceKind::Item(def) => interp_ok(ecx.tcx.mir_for_ctfe(def)),
-            _ => interp_ok(ecx.tcx.instance_mir(instance)),
+            ty::InstanceKind::Item(def) => ecx.tcx.mir_for_ctfe(def),
+            _ => ecx.tcx.instance_mir(instance),
         }
     }
 

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -272,7 +272,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             let def = instance.def_id();
             &self.tcx.promoted_mir(def)[promoted]
         } else {
-            M::load_mir(self, instance)?
+            M::load_mir(self, instance)
         };
         // do not continue if typeck errors occurred (can only occur in local crate)
         if let Some(err) = body.tainted_by_errors {

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -189,8 +189,8 @@ pub trait Machine<'tcx>: Sized {
     fn load_mir(
         ecx: &InterpCx<'tcx, Self>,
         instance: ty::InstanceKind<'tcx>,
-    ) -> InterpResult<'tcx, &'tcx mir::Body<'tcx>> {
-        interp_ok(ecx.tcx.instance_mir(instance))
+    ) -> &'tcx mir::Body<'tcx> {
+        ecx.tcx.instance_mir(instance)
     }
 
     /// Entry point to all function calls.

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -3,7 +3,6 @@
 //! This module contains the code for creating and emitting diagnostics.
 
 // tidy-alphabetical-start
-#![allow(incomplete_features)]
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::direct_use_of_rustc_type_ir)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -14,9 +14,7 @@
 
 // tidy-alphabetical-start
 #![allow(internal_features)]
-#![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::direct_use_of_rustc_type_ir)]
-#![allow(rustc::untranslatable_diagnostic)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(assert_matches)]

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -1,6 +1,3 @@
-#![allow(rustc::diagnostic_outside_of_impl)]
-#![allow(rustc::untranslatable_diagnostic)]
-
 use std::borrow::Cow;
 
 use rustc_ast::util::unicode::TEXT_FLOW_CONTROL_CHARS;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1,4 +1,3 @@
-#![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 use std::num::NonZero;
 

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1275,7 +1275,7 @@ extern "C" void LLVMRustSetModuleCodeModel(LLVMModuleRef M,
 //
 // Otherwise I'll apologize in advance, it probably requires a relatively
 // significant investment on your part to "truly understand" what's going on
-// here. Not saying I do myself, but it took me awhile staring at LLVM's source
+// here. Not saying I do myself, but it took me a while staring at LLVM's source
 // and various online resources about ThinLTO to make heads or tails of all
 // this.
 

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -1,5 +1,3 @@
-#![allow(rustc::usage_of_ty_tykind)]
-
 /// This higher-order macro declares a list of types which can be allocated by `Arena`.
 ///
 /// Specifying the `decode` modifier will add decode impls for `&T` and `&[T]` where `T` is the type

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -936,7 +936,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                 valtree
             }
-            Err(ErrorHandled::Reported(..)) => return self.cfg.start_new_block().unit(),
+            Err(ErrorHandled::Reported(..)) => {
+                return block.unit();
+            }
             Err(ErrorHandled::TooGeneric(_)) => {
                 self.tcx.dcx().emit_fatal(ConstContinueBadConst { span: constant.span });
             }

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -1,7 +1,6 @@
 //! The main parser interface.
 
 // tidy-alphabetical-start
-#![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![feature(assert_matches)]

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -2,7 +2,6 @@
 
 // tidy-alphabetical-start
 #![allow(internal_features)]
-#![allow(unused_parens)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(min_specialization)]

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1187,6 +1187,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         has_custom_message: bool,
     ) -> bool {
         let span = obligation.cause.span;
+        let param_env = obligation.param_env;
+
+        let mk_result = |trait_pred_and_new_ty| {
+            let obligation =
+                self.mk_trait_obligation_with_new_self_ty(param_env, trait_pred_and_new_ty);
+            self.predicate_must_hold_modulo_regions(&obligation)
+        };
 
         let code = match obligation.cause.code() {
             ObligationCauseCode::FunctionArg { parent_code, .. } => parent_code,
@@ -1195,13 +1202,74 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             c @ ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, _)
                 if self.tcx.hir_span(*hir_id).lo() == span.lo() =>
             {
+                // `hir_id` corresponds to the HIR node that introduced a `where`-clause obligation.
+                // If that obligation comes from a type in an associated method call, we need
+                // special handling here.
                 if let hir::Node::Expr(expr) = self.tcx.parent_hir_node(*hir_id)
                     && let hir::ExprKind::Call(base, _) = expr.kind
-                    && let hir::ExprKind::Path(hir::QPath::TypeRelative(ty, _)) = base.kind
+                    && let hir::ExprKind::Path(hir::QPath::TypeRelative(ty, segment)) = base.kind
+                    && let hir::Node::Expr(outer) = self.tcx.parent_hir_node(expr.hir_id)
+                    && let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, mtbl, _) = outer.kind
                     && ty.span == span
                 {
-                    // Do not suggest borrowing when we already do so. This would happen with
-                    // `let _ = &str::from("");` where the expression corresponds to the `str`.
+                    // We've encountered something like `&str::from("")`, where the intended code
+                    // was likely `<&str>::from("")`. The former is interpreted as "call method
+                    // `from` on `str` and borrow the result", while the latter means "call method
+                    // `from` on `&str`".
+
+                    let trait_pred_and_imm_ref = poly_trait_pred.map_bound(|p| {
+                        (p, Ty::new_imm_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
+                    });
+                    let trait_pred_and_mut_ref = poly_trait_pred.map_bound(|p| {
+                        (p, Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_static, p.self_ty()))
+                    });
+
+                    let imm_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_imm_ref);
+                    let mut_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_mut_ref);
+                    let sugg_msg = |pre: &str| {
+                        format!(
+                            "you likely meant to call the associated function `{FN}` for type \
+                             `&{pre}{TY}`, but the code as written calls associated function `{FN}` on \
+                             type `{TY}`",
+                            FN = segment.ident,
+                            TY = poly_trait_pred.self_ty(),
+                        )
+                    };
+                    match (imm_ref_self_ty_satisfies_pred, mut_ref_self_ty_satisfies_pred, mtbl) {
+                        (true, _, hir::Mutability::Not) | (_, true, hir::Mutability::Mut) => {
+                            err.multipart_suggestion_verbose(
+                                sugg_msg(mtbl.prefix_str()),
+                                vec![
+                                    (outer.span.shrink_to_lo(), "<".to_string()),
+                                    (span.shrink_to_hi(), ">".to_string()),
+                                ],
+                                Applicability::MachineApplicable,
+                            );
+                        }
+                        (true, _, hir::Mutability::Mut) => {
+                            // There's an associated function found on the immutable borrow of the
+                            err.multipart_suggestion_verbose(
+                                sugg_msg("mut "),
+                                vec![
+                                    (outer.span.shrink_to_lo().until(span), "<&".to_string()),
+                                    (span.shrink_to_hi(), ">".to_string()),
+                                ],
+                                Applicability::MachineApplicable,
+                            );
+                        }
+                        (_, true, hir::Mutability::Not) => {
+                            err.multipart_suggestion_verbose(
+                                sugg_msg(""),
+                                vec![
+                                    (outer.span.shrink_to_lo().until(span), "<&mut ".to_string()),
+                                    (span.shrink_to_hi(), ">".to_string()),
+                                ],
+                                Applicability::MachineApplicable,
+                            );
+                        }
+                        _ => {}
+                    }
+                    // If we didn't return early here, we would instead suggest `&&str::from("")`.
                     return false;
                 }
                 c
@@ -1229,8 +1297,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             never_suggest_borrow.push(def_id);
         }
 
-        let param_env = obligation.param_env;
-
         // Try to apply the original trait bound by borrowing.
         let mut try_borrowing = |old_pred: ty::PolyTraitPredicate<'tcx>,
                                  blacklist: &[DefId]|
@@ -1252,11 +1318,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 )
             });
 
-            let mk_result = |trait_pred_and_new_ty| {
-                let obligation =
-                    self.mk_trait_obligation_with_new_self_ty(param_env, trait_pred_and_new_ty);
-                self.predicate_must_hold_modulo_regions(&obligation)
-            };
             let imm_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_imm_ref);
             let mut_ref_self_ty_satisfies_pred = mk_result(trait_pred_and_mut_ref);
 

--- a/library/std/src/sync/mpmc/mod.rs
+++ b/library/std/src/sync/mpmc/mod.rs
@@ -187,7 +187,7 @@ use crate::time::{Duration, Instant};
 ///     sender.send(expensive_computation()).unwrap();
 /// });
 ///
-/// // Do some useful work for awhile
+/// // Do some useful work for a while
 ///
 /// // Let's see what that answer was
 /// println!("{:?}", receiver.recv().unwrap());

--- a/library/std/src/sync/mpsc.rs
+++ b/library/std/src/sync/mpsc.rs
@@ -509,7 +509,7 @@ pub enum TrySendError<T> {
 ///     sender.send(expensive_computation()).unwrap();
 /// });
 ///
-/// // Do some useful work for awhile
+/// // Do some useful work for a while
 ///
 /// // Let's see what that answer was
 /// println!("{:?}", receiver.recv().unwrap());

--- a/src/doc/rustc/src/platform-support/netbsd.md
+++ b/src/doc/rustc/src/platform-support/netbsd.md
@@ -1,7 +1,5 @@
 # \*-unknown-netbsd
 
-**Tier: 3**
-
 [NetBSD] multi-platform 4.4BSD-based UNIX-like operating system.
 
 [NetBSD]: https://www.NetBSD.org/
@@ -11,19 +9,19 @@ where `$ARCH` specifies the target processor architecture and
 `-$SUFFIX` (optional) might indicate the ABI. The following targets
 are currently defined running NetBSD:
 
-|          Target name           | NetBSD Platform |
-|--------------------------------|-----------------|
-| `x86_64-unknown-netbsd`        | [amd64 / x86_64 systems](https://wiki.netbsd.org/ports/amd64/) |
-| `armv7-unknown-netbsd-eabihf`  | [32-bit ARMv7 systems with hard-float](https://wiki.netbsd.org/ports/evbarm/) |
-| `armv6-unknown-netbsd-eabihf`  | [32-bit ARMv6 systems with hard-float](https://wiki.netbsd.org/ports/evbarm/) |
-| `aarch64-unknown-netbsd`       | [64-bit ARM systems, little-endian](https://wiki.netbsd.org/ports/evbarm/) |
-| `aarch64_be-unknown-netbsd`    | [64-bit ARM systems, big-endian](https://wiki.netbsd.org/ports/evbarm/) |
-| `i586-unknown-netbsd`          | [32-bit i386, restricted to Pentium](https://wiki.netbsd.org/ports/i386/) |
-| `i686-unknown-netbsd`          | [32-bit i386 with SSE](https://wiki.netbsd.org/ports/i386/) |
-| `mipsel-unknown-netbsd`        | [32-bit mips, requires mips32 cpu support](https://wiki.netbsd.org/ports/evbmips/) |
-| `powerpc-unknown-netbsd`       | [Various 32-bit PowerPC systems, e.g. MacPPC](https://wiki.netbsd.org/ports/macppc/) |
-| `riscv64gc-unknown-netbsd`     | [64-bit RISC-V](https://wiki.netbsd.org/ports/riscv/) |
-| `sparc64-unknown-netbsd`       | [Sun UltraSPARC systems](https://wiki.netbsd.org/ports/sparc64/) |
+| Target tier         | Target name                   | NetBSD Platform                                                                      |
+|---------------------|-------------------------------|--------------------------------------------------------------------------------------|
+| 2 (with host tools) | `x86_64-unknown-netbsd`       | [amd64 / x86_64 systems](https://wiki.netbsd.org/ports/amd64/)                       |
+| 3                   | `armv7-unknown-netbsd-eabihf` | [32-bit ARMv7 systems with hard-float](https://wiki.netbsd.org/ports/evbarm/)        |
+| 3                   | `armv6-unknown-netbsd-eabihf` | [32-bit ARMv6 systems with hard-float](https://wiki.netbsd.org/ports/evbarm/)        |
+| 3                   | `aarch64-unknown-netbsd`      | [64-bit ARM systems, little-endian](https://wiki.netbsd.org/ports/evbarm/)           |
+| 3                   | `aarch64_be-unknown-netbsd`   | [64-bit ARM systems, big-endian](https://wiki.netbsd.org/ports/evbarm/)              |
+| 3                   | `i586-unknown-netbsd`         | [32-bit i386, restricted to Pentium](https://wiki.netbsd.org/ports/i386/)            |
+| 3                   | `i686-unknown-netbsd`         | [32-bit i386 with SSE](https://wiki.netbsd.org/ports/i386/)                          |
+| 3                   | `mipsel-unknown-netbsd`       | [32-bit mips, requires mips32 cpu support](https://wiki.netbsd.org/ports/evbmips/)   |
+| 3                   | `powerpc-unknown-netbsd`      | [Various 32-bit PowerPC systems, e.g. MacPPC](https://wiki.netbsd.org/ports/macppc/) |
+| 3                   | `riscv64gc-unknown-netbsd`    | [64-bit RISC-V](https://wiki.netbsd.org/ports/riscv/)                                |
+| 3                   | `sparc64-unknown-netbsd`      | [Sun UltraSPARC systems](https://wiki.netbsd.org/ports/sparc64/)                     |
 
 All use the "native" `stdc++` library which goes along with the natively
 supplied GNU C++ compiler for the given OS version.  Many of the bootstraps

--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -1,3 +1,3 @@
 % Rust Documentation
 
-This has been moved [into the book](book/documentation.html).
+This has been moved [into the rustdoc book](rustdoc/index.html).

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -2,8 +2,6 @@
 //! the `clean` types but with some fields removed or stringified to simplify the output and not
 //! expose unstable compiler internals.
 
-#![allow(rustc::default_hash_types)]
-
 use rustc_abi::ExternAbi;
 use rustc_ast::ast;
 use rustc_attr_data_structures::{self as attrs, DeprecatedSince};

--- a/src/tools/rust-analyzer/crates/ide/src/file_structure.rs
+++ b/src/tools/rust-analyzer/crates/ide/src/file_structure.rs
@@ -329,7 +329,7 @@ macro_rules! mcexp {
 #[deprecated]
 fn obsolete() {}
 
-#[deprecated(note = "for awhile")]
+#[deprecated(note = "for a while")]
 fn very_obsolete() {}
 
 // region: Some region name
@@ -608,8 +608,8 @@ fn let_statements() {
                     StructureNode {
                         parent: None,
                         label: "very_obsolete",
-                        navigation_range: 511..524,
-                        node_range: 473..529,
+                        navigation_range: 512..525,
+                        node_range: 473..530,
                         kind: SymbolKind(
                             Function,
                         ),
@@ -621,8 +621,8 @@ fn let_statements() {
                     StructureNode {
                         parent: None,
                         label: "Some region name",
-                        navigation_range: 531..558,
-                        node_range: 531..558,
+                        navigation_range: 532..559,
+                        node_range: 532..559,
                         kind: Region,
                         detail: None,
                         deprecated: false,
@@ -630,8 +630,8 @@ fn let_statements() {
                     StructureNode {
                         parent: None,
                         label: "m",
-                        navigation_range: 598..599,
-                        node_range: 573..636,
+                        navigation_range: 599..600,
+                        node_range: 574..637,
                         kind: SymbolKind(
                             Module,
                         ),
@@ -643,8 +643,8 @@ fn let_statements() {
                             22,
                         ),
                         label: "dontpanic",
-                        navigation_range: 573..593,
-                        node_range: 573..593,
+                        navigation_range: 574..594,
+                        node_range: 574..594,
                         kind: Region,
                         detail: None,
                         deprecated: false,
@@ -654,8 +654,8 @@ fn let_statements() {
                             22,
                         ),
                         label: "f",
-                        navigation_range: 605..606,
-                        node_range: 602..611,
+                        navigation_range: 606..607,
+                        node_range: 603..612,
                         kind: SymbolKind(
                             Function,
                         ),
@@ -669,8 +669,8 @@ fn let_statements() {
                             22,
                         ),
                         label: "g",
-                        navigation_range: 628..629,
-                        node_range: 612..634,
+                        navigation_range: 629..630,
+                        node_range: 613..635,
                         kind: SymbolKind(
                             Function,
                         ),
@@ -682,8 +682,8 @@ fn let_statements() {
                     StructureNode {
                         parent: None,
                         label: "extern \"C\"",
-                        navigation_range: 638..648,
-                        node_range: 638..651,
+                        navigation_range: 639..649,
+                        node_range: 639..652,
                         kind: ExternBlock,
                         detail: None,
                         deprecated: false,
@@ -691,8 +691,8 @@ fn let_statements() {
                     StructureNode {
                         parent: None,
                         label: "let_statements",
-                        navigation_range: 656..670,
-                        node_range: 653..813,
+                        navigation_range: 657..671,
+                        node_range: 654..814,
                         kind: SymbolKind(
                             Function,
                         ),
@@ -706,8 +706,8 @@ fn let_statements() {
                             27,
                         ),
                         label: "x",
-                        navigation_range: 683..684,
-                        node_range: 679..690,
+                        navigation_range: 684..685,
+                        node_range: 680..691,
                         kind: SymbolKind(
                             Local,
                         ),
@@ -719,8 +719,8 @@ fn let_statements() {
                             27,
                         ),
                         label: "mut y",
-                        navigation_range: 699..704,
-                        node_range: 695..709,
+                        navigation_range: 700..705,
+                        node_range: 696..710,
                         kind: SymbolKind(
                             Local,
                         ),
@@ -732,8 +732,8 @@ fn let_statements() {
                             27,
                         ),
                         label: "Foo { .. }",
-                        navigation_range: 718..740,
-                        node_range: 714..753,
+                        navigation_range: 719..741,
+                        node_range: 715..754,
                         kind: SymbolKind(
                             Local,
                         ),
@@ -745,8 +745,8 @@ fn let_statements() {
                             27,
                         ),
                         label: "_",
-                        navigation_range: 803..804,
-                        node_range: 799..811,
+                        navigation_range: 804..805,
+                        node_range: 800..812,
                         kind: SymbolKind(
                             Local,
                         ),

--- a/tests/ui/attributes/malformed-reprs.rs
+++ b/tests/ui/attributes/malformed-reprs.rs
@@ -1,0 +1,14 @@
+// Tests a few different invalid repr attributes
+
+// This is a regression test for https://github.com/rust-lang/rust/issues/143522
+#![repr]
+//~^ ERROR malformed `repr` attribute input [E0539]
+//~| ERROR `repr` attribute cannot be used at crate level
+
+// This is a regression test for https://github.com/rust-lang/rust/issues/143479
+#[repr(align(0))]
+//~^ ERROR invalid `repr(align)` attribute: not a power of two
+//~| ERROR unsupported representation for zero-variant enum [E0084]
+enum Foo {}
+
+fn main() {}

--- a/tests/ui/attributes/malformed-reprs.stderr
+++ b/tests/ui/attributes/malformed-reprs.stderr
@@ -1,0 +1,43 @@
+error[E0539]: malformed `repr` attribute input
+  --> $DIR/malformed-reprs.rs:4:1
+   |
+LL | #![repr]
+   | ^^^^^^^^
+   | |
+   | expected this to be a list
+   | help: must be of the form: `#[repr(C | Rust | align(...) | packed(...) | <integer type> | transparent)]`
+
+error[E0589]: invalid `repr(align)` attribute: not a power of two
+  --> $DIR/malformed-reprs.rs:9:14
+   |
+LL | #[repr(align(0))]
+   |              ^
+
+error: `repr` attribute cannot be used at crate level
+  --> $DIR/malformed-reprs.rs:4:1
+   |
+LL | #![repr]
+   | ^^^^^^^^
+...
+LL | enum Foo {}
+   |      --- the inner attribute doesn't annotate this enum
+   |
+help: perhaps you meant to use an outer attribute
+   |
+LL - #![repr]
+LL + #[repr]
+   |
+
+error[E0084]: unsupported representation for zero-variant enum
+  --> $DIR/malformed-reprs.rs:9:1
+   |
+LL | #[repr(align(0))]
+   | ^^^^^^^^^^^^^^^^^
+...
+LL | enum Foo {}
+   | -------- zero-variant enum
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0084, E0539, E0589.
+For more information about an error, try `rustc --explain E0084`.

--- a/tests/ui/loop-match/panic-in-const.rs
+++ b/tests/ui/loop-match/panic-in-const.rs
@@ -1,0 +1,22 @@
+#![allow(incomplete_features)]
+#![feature(loop_match)]
+#![crate_type = "lib"]
+
+const CONST_THAT_PANICS: u8 = panic!("diverge!");
+//~^ ERROR: evaluation panicked: diverge!
+
+fn test(mut state: u8) {
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                0 => {
+                    #[const_continue]
+                    break 'blk CONST_THAT_PANICS;
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+}

--- a/tests/ui/loop-match/panic-in-const.stderr
+++ b/tests/ui/loop-match/panic-in-const.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation panicked: diverge!
+  --> $DIR/panic-in-const.rs:5:31
+   |
+LL | const CONST_THAT_PANICS: u8 = panic!("diverge!");
+   |                               ^^^^^^^^^^^^^^^^^^ evaluation of `CONST_THAT_PANICS` failed here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/process/core-run-destroy.rs
+++ b/tests/ui/process/core-run-destroy.rs
@@ -37,7 +37,7 @@ pub fn sleeper() -> Child {
 pub fn sleeper() -> Child {
     // There's a `timeout` command on windows, but it doesn't like having
     // its output piped, so instead just ping ourselves a few times with
-    // gaps in between so we're sure this process is alive for awhile
+    // gaps in between so we're sure this process is alive for a while
     t!(Command::new("ping").arg("127.0.0.1").arg("-n").arg("1000").spawn())
 }
 

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.fixed
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.fixed
@@ -7,11 +7,11 @@ trait Trait {
 impl Trait for &S {}
 impl Trait for &mut S {}
 fn main() {
-    let _ = &str::from("value");
+    let _ = <&str>::from("value");
     //~^ ERROR the trait bound `str: From<_>` is not satisfied
     //~| ERROR the size for values of type `str` cannot be known at compilation time
-    let _ = &mut S::foo();
+    let _ = <&mut S>::foo();
     //~^ ERROR the trait bound `S: Trait` is not satisfied
-    let _ = &S::foo();
+    let _ = <&S>::foo();
     //~^ ERROR the trait bound `S: Trait` is not satisfied
 }

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.rs
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let _ = &str::from("value");
+    //~^ ERROR the trait bound `str: From<_>` is not satisfied
+    //~| ERROR the size for values of type `str` cannot be known at compilation time
+}

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `str: From<_>` is not satisfied
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:2:14
+   |
+LL |     let _ = &str::from("value");
+   |              ^^^ the trait `From<_>` is not implemented for `str`
+   |
+   = help: the following other types implement trait `From<T>`:
+             `String` implements `From<&String>`
+             `String` implements `From<&mut str>`
+             `String` implements `From<&str>`
+             `String` implements `From<Box<str>>`
+             `String` implements `From<Cow<'_, str>>`
+             `String` implements `From<char>`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:2:14
+   |
+LL |     let _ = &str::from("value");
+   |              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
+++ b/tests/ui/suggestions/dont-suggest-borrowing-existing-borrow.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `str: From<_>` is not satisfied
-  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:2:14
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:10:14
    |
 LL |     let _ = &str::from("value");
    |              ^^^ the trait `From<_>` is not implemented for `str`
@@ -11,9 +11,41 @@ LL |     let _ = &str::from("value");
              `String` implements `From<Box<str>>`
              `String` implements `From<Cow<'_, str>>`
              `String` implements `From<char>`
+help: you likely meant to call the associated function `from` for type `&str`, but the code as written calls associated function `from` on type `str`
+   |
+LL |     let _ = <&str>::from("value");
+   |             +    +
+
+error[E0277]: the trait bound `S: Trait` is not satisfied
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:13:18
+   |
+LL |     let _ = &mut S::foo();
+   |                  ^ the trait `Trait` is not implemented for `S`
+   |
+   = help: the following other types implement trait `Trait`:
+             &S
+             &mut S
+help: you likely meant to call the associated function `foo` for type `&mut S`, but the code as written calls associated function `foo` on type `S`
+   |
+LL |     let _ = <&mut S>::foo();
+   |             +      +
+
+error[E0277]: the trait bound `S: Trait` is not satisfied
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:15:14
+   |
+LL |     let _ = &S::foo();
+   |              ^ the trait `Trait` is not implemented for `S`
+   |
+   = help: the following other types implement trait `Trait`:
+             &S
+             &mut S
+help: you likely meant to call the associated function `foo` for type `&S`, but the code as written calls associated function `foo` on type `S`
+   |
+LL |     let _ = <&S>::foo();
+   |             +  +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:2:14
+  --> $DIR/dont-suggest-borrowing-existing-borrow.rs:10:14
    |
 LL |     let _ = &str::from("value");
    |              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -21,6 +53,6 @@ LL |     let _ = &str::from("value");
    = help: the trait `Sized` is not implemented for `str`
    = note: the return type of a function must have a statically known size
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#132469 (Do not suggest borrow that is already there in fully-qualified call)
 - rust-lang/rust#143340 (awhile -> a while where appropriate)
 - rust-lang/rust#143438 (Fix the link in `rustdoc.md`)
 - rust-lang/rust#143539 (Regression tests for repr ICEs)
 - rust-lang/rust#143566 (Fix `x86_64-unknown-netbsd` platform support page)
 - rust-lang/rust#143572 (Remove unused allow attrs)
 - rust-lang/rust#143583 (`loop_match`: fix 'no terminator on block')
 - rust-lang/rust#143584 (make `Machine::load_mir` infallible)
 - rust-lang/rust#143591 (Fix missing words in future tracking issue)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132469,143340,143438,143539,143566,143572,143583,143584,143591)
<!-- homu-ignore:end -->