### PR TITLE
configure.py: Write last key in each section

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -746,7 +746,7 @@ def write_uncommented(target, f):
     block = []
 
     def flush(last):
-        # If the block is entiry made of comments, ignore it
+        # If the block is entirely made of comments, ignore it
         entire_block_comments = all(ln.startswith("#") or ln == "" for ln in block)
         if not entire_block_comments and len(block) > 0:
             for line in block:

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -752,6 +752,10 @@ def write_uncommented(target, f):
             is_comment = True
             continue
         is_comment = is_comment and line.startswith("#")
+    # Write the last accumulated block
+    if len(block) > 0 and not is_comment:
+        for ln in block:
+            f.write(ln + "\n")
     return f
 
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -739,6 +739,10 @@ def configure_file(sections, top_level_keys, targets, config):
 
 
 def write_uncommented(target, f):
+    """Writes each block in 'target' that is not composed entirely of comments to 'f'.
+
+    A block is a sequence of non-empty lines separated by empty lines.
+    """
     block = []
     is_comment = True
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -744,22 +744,24 @@ def write_uncommented(target, f):
     A block is a sequence of non-empty lines separated by empty lines.
     """
     block = []
-    is_comment = True
+
+    def flush(last):
+        # If the block is entiry made of comments, ignore it
+        entire_block_comments = all(ln.startswith("#") or ln == "" for ln in block)
+        if not entire_block_comments and len(block) > 0:
+            for line in block:
+                f.write(line + "\n")
+            # Required to output a newline before the start of a new section
+            if last:
+                f.write("\n")
+        block.clear()
 
     for line in target:
         block.append(line)
         if len(line) == 0:
-            if not is_comment:
-                for ln in block:
-                    f.write(ln + "\n")
-            block = []
-            is_comment = True
-            continue
-        is_comment = is_comment and line.startswith("#")
-    # Write the last accumulated block
-    if len(block) > 0 and not is_comment:
-        for ln in block:
-            f.write(ln + "\n")
+            flush(last=False)
+
+    flush(last=True)
     return f
 
 


### PR DESCRIPTION
The loop that writes the keys in each section of bootstrap.toml accumulates all the commented lines before a given key and emits them when it reaches the next key in the section.  This ends up dropping lines accumulated for the last key

Fixes rust-lang/rust#143605

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
