### PR TITLE
Mention more APIs in `ParseIntError` docs

### DIFF
--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -45,8 +45,11 @@ impl From<!> for TryFromIntError {
 
 /// An error which can be returned when parsing an integer.
 ///
-/// This error is used as the error type for the `from_str_radix()` functions
-/// on the primitive integer types, such as [`i8::from_str_radix`].
+/// For example, this error is returned by the `from_str_radix()` functions
+/// on the primitive integer types (such as [`i8::from_str_radix`])
+/// and is used as the error type in their [`FromStr`] implementations.
+///
+/// [`FromStr`]: crate::str::FromStr
 ///
 /// # Potential causes
 ///


### PR DESCRIPTION
Fixes rust-lang/rust#143602

r? @lolbinarycat 

@rustbot label +A-docs