### PR TITLE
Run `tests/rustdoc-json/attrs/target_features` on all hosts.

### DIFF
--- a/tests/rustdoc-json/attrs/target_feature.rs
+++ b/tests/rustdoc-json/attrs/target_feature.rs
@@ -1,5 +1,3 @@
-//@ only-x86_64
-
 //@ is "$.index[?(@.name=='test1')].attrs" '["#[target_feature(enable=\"avx\")]"]'
 #[target_feature(enable = "avx")]
 pub fn test1() {}


### PR DESCRIPTION
Makes it more convenient to test rustdoc on non x86_64. I mainly care about the aarch64 dev-desktops.

This works because rustdoc uses all target features, not just that of the target.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
