### PR TITLE
fix: Remove newline from multiple crate versions note

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1933,7 +1933,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     StringPart::highlighted("multiple different versions".to_string()),
                     StringPart::normal(" of crate `".to_string()),
                     StringPart::highlighted(format!("{crate_name}")),
-                    StringPart::normal("` in the dependency graph\n".to_string()),
+                    StringPart::normal("` in the dependency graph".to_string()),
                 ],
             );
             if points_at_type {


### PR DESCRIPTION
While working on getting `annotate-snippets` to match `rustc`, `annotate-snippets` was adding an extra new line after [this line](https://github.com/rust-lang/rust/blob/a2d45f73c70d9dec57140c9412f83586eda895f8/tests/run-make/crate-loading/multiple-dep-versions.stderr#L9) for [`run-make/crate-loading/multiple-dep-versions.rs`](https://github.com/rust-lang/rust/blob/a2d45f73c70d9dec57140c9412f83586eda895f8/tests/run-make/crate-loading/multiple-dep-versions.rs). I found out this was because there was an explicit `\n` in the message that `annotate-snippets` was respecting, while `rustc` was [skipping it](https://github.com/rust-lang/rust/blob/2f8eeb2bba86b8f457ec602c578473c711f85628/compiler/rustc_errors/src/emitter.rs#L1542). After talking with @estebank, I was told to remove the newline from the error message.


r? @estebank