### PR TITLE
Limited nonzero coercion

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -428,6 +428,8 @@ language_item_table! {
     String,                  sym::String,              string,                     Target::Struct,         GenericRequirement::None;
     CStr,                    sym::CStr,                c_str,                      Target::Struct,         GenericRequirement::None;
 
+    NonZero,                 sym::NonZero,             non_zero,                   Target::Struct,         GenericRequirement::Exact(1);
+
     // Experimental lang items for implementing contract pre- and post-condition checking.
     ContractBuildCheckEnsures, sym::contract_build_check_ensures, contract_build_check_ensures_fn, Target::Fn, GenericRequirement::None;
     ContractCheckRequires,     sym::contract_check_requires,      contract_check_requires_fn,      Target::Fn, GenericRequirement::None;

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -854,6 +854,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     };
                     self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
                 }
+
+                adjustment::Adjust::NonZeroIntoInner => {}
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;
         }
@@ -1344,6 +1346,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
             adjustment::Adjust::NeverToAny
             | adjustment::Adjust::Pointer(_)
             | adjustment::Adjust::Borrow(_)
+            | adjustment::Adjust::NonZeroIntoInner
             | adjustment::Adjust::ReborrowPin(..) => {
                 // Result is an rvalue.
                 Ok(self.cat_rvalue(expr.hir_id, target))

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -284,7 +284,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // FIXME(const_trait_impl): We could enforce these; they correspond to
                     // `&mut T: DerefMut` tho, so it's kinda moot.
                 }
-                Adjust::Borrow(_) => {
+                Adjust::NonZeroIntoInner | Adjust::Borrow(_) => {
                     // No effects to enforce here.
                 }
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2581,7 +2581,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => return false,
         };
 
-        if !self.tcx.is_diagnostic_item(sym::NonZero, adt.did()) {
+        if !self.tcx.is_lang_item(adt.did(), LangItem::NonZero) {
             return false;
         }
 

--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -171,6 +171,7 @@ fn has_implicit_borrow(Adjustment { kind, .. }: &Adjustment<'_>) -> Option<(Muta
         | Adjust::Pointer(..)
         | Adjust::ReborrowPin(..)
         | Adjust::Deref(None)
+        | Adjust::NonZeroIntoInner
         | Adjust::Borrow(AutoBorrow::RawPtr(..)) => None,
     }
 }

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -105,6 +105,9 @@ pub enum Adjust {
 
     /// Take a pinned reference and reborrow as a `Pin<&mut T>` or `Pin<&T>`.
     ReborrowPin(hir::Mutability),
+
+    /// Turn a `NonZero<T>` into `T`
+    NonZeroIntoInner,
 }
 
 /// An overloaded autoderef step, representing a `Deref(Mut)::deref(_mut)`

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -240,6 +240,34 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 debug!(?kind);
                 kind
             }
+            Adjust::NonZeroIntoInner => {
+                // These only happen on `NonZero`
+                let ty::Adt(adt, args) = expr.ty.kind() else {
+                    span_bug!(span, "nonzero adjustment not based on adt: {expr:#?}")
+                };
+                // Find the right field type
+                let ty = self
+                    .tcx
+                    .type_of(adt.variant(FIRST_VARIANT).fields[FieldIdx::ZERO].did)
+                    .instantiate(self.tcx, args);
+                // Get rid of the `ZeroablePrimitive` projection
+                let ty = self.tcx.normalize_erasing_regions(self.typing_env, ty);
+                let lhs = self.thir.exprs.push(expr);
+                ExprKind::Field {
+                    lhs: self.thir.exprs.push(Expr {
+                        span,
+                        temp_lifetime,
+                        ty,
+                        kind: ExprKind::Field {
+                            lhs,
+                            variant_index: FIRST_VARIANT,
+                            name: FieldIdx::ZERO,
+                        },
+                    }),
+                    variant_index: FIRST_VARIANT,
+                    name: FieldIdx::ZERO,
+                }
+            }
         };
 
         Expr { temp_lifetime, ty: adjustment.target, span, kind }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -123,7 +123,7 @@ impl_zeroable_primitive!(
 #[stable(feature = "generic_nonzero", since = "1.79.0")]
 #[repr(transparent)]
 #[rustc_nonnull_optimization_guaranteed]
-#[rustc_diagnostic_item = "NonZero"]
+#[lang = "NonZero"]
 pub struct NonZero<T: ZeroablePrimitive>(T::NonZeroInner);
 
 macro_rules! impl_nonzero_fmt {

--- a/src/tools/clippy/clippy_lints/src/methods/useless_nonzero_new_unchecked.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/useless_nonzero_new_unchecked.rs
@@ -7,6 +7,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{Block, BlockCheckMode, Expr, ExprKind, Node, QPath, UnsafeSource};
 use rustc_lint::LateContext;
 use rustc_span::sym;
+use rustc_hir::LangItem;
 
 use super::USELESS_NONZERO_NEW_UNCHECKED;
 
@@ -15,7 +16,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, func: &Expr<'
         && segment.ident.name == sym::new_unchecked
         && let [init_arg] = args
         && is_inside_always_const_context(cx.tcx, expr.hir_id)
-        && cx.typeck_results().node_type(ty.hir_id).is_diag_item(cx, sym::NonZero)
+        && cx.typeck_results().node_type(ty.hir_id).is_lang_item(cx, LangItem::NonZero)
         && msrv.meets(cx, msrvs::CONST_UNWRAP)
     {
         let mut app = Applicability::MachineApplicable;

--- a/src/tools/clippy/clippy_lints/src/non_zero_suggestions.rs
+++ b/src/tools/clippy/clippy_lints/src/non_zero_suggestions.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::snippet;
 use clippy_utils::sym;
 use rustc_ast::ast::BinOpKind;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, LangItem};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::declare_lint_pass;
@@ -81,7 +81,7 @@ fn check_non_zero_conversion(cx: &LateContext<'_>, expr: &Expr<'_>, applicabilit
         // Check if the receiver type is a NonZero type
         if let ty::Adt(adt_def, _) = receiver_ty.kind()
             && adt_def.is_struct()
-            && cx.tcx.get_diagnostic_name(adt_def.did()) == Some(sym::NonZero)
+            && cx.tcx.is_lang_item(adt_def.did(), LangItem::NonZero)
             && let Some(target_non_zero_type) = get_target_non_zero_type(target_ty)
         {
             let arg_snippet = get_arg_snippet(cx, arg, rcv_path);

--- a/src/tools/clippy/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -5,6 +5,7 @@ use clippy_utils::diagnostics::span_lint;
 use clippy_utils::res::MaybeDef;
 use clippy_utils::{expr_or_init, is_from_proc_macro, is_lint_allowed, peel_hir_expr_refs, peel_hir_expr_unary, sym};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_hir::LangItem;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::impl_lint_pass;
@@ -90,7 +91,7 @@ impl ArithmeticSideEffects {
 
     fn is_non_zero_u(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
         if let ty::Adt(adt, substs) = ty.kind()
-            && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+            && cx.tcx.is_lang_item(adt.did(),LangItem::NonZero)
             && let int_type = substs.type_at(0)
             && matches!(int_type.kind(), ty::Uint(_))
         {

--- a/src/tools/clippy/clippy_lints/src/operators/integer_division.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/integer_division.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::res::MaybeDef;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
-use rustc_span::symbol::sym;
+use rustc_hir::LangItem;
 
 use super::INTEGER_DIVISION;
 
@@ -16,7 +16,7 @@ pub(crate) fn check<'tcx>(
     if op == hir::BinOpKind::Div
         && cx.typeck_results().expr_ty(left).is_integral()
         && let right_ty = cx.typeck_results().expr_ty(right)
-        && (right_ty.is_integral() || right_ty.is_diag_item(cx, sym::NonZero))
+        && (right_ty.is_integral() || right_ty.is_lang_item(cx, LangItem::NonZero))
     {
         #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
         span_lint_and_then(cx, INTEGER_DIVISION, expr.span, "integer division", |diag| {

--- a/src/tools/clippy/clippy_lints/src/transmute/transmute_int_to_non_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/transmute_int_to_non_zero.rs
@@ -2,10 +2,11 @@ use super::TRANSMUTE_INT_TO_NON_ZERO;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::sugg::Sugg;
 use rustc_errors::Applicability;
-use rustc_hir::Expr;
+use rustc_hir::{Expr};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::symbol::sym;
+use rustc_hir::LangItem;
 
 /// Checks for `transmute_int_to_non_zero` lint.
 /// Returns `true` if it's triggered, otherwise returns `false`.
@@ -18,7 +19,7 @@ pub(super) fn check<'tcx>(
 ) -> bool {
     if let ty::Int(_) | ty::Uint(_) = from_ty.kind()
         && let ty::Adt(adt, substs) = to_ty.kind()
-        && cx.tcx.is_diagnostic_item(sym::NonZero, adt.did())
+        && cx.tcx.is_lang_item( adt.did(), LangItem::NonZero)
         && let int_ty = substs.type_at(0)
         && from_ty == int_ty
     {

--- a/tests/ui/mismatched_types/non_zero_assigned_lit.rs
+++ b/tests/ui/mismatched_types/non_zero_assigned_lit.rs
@@ -1,0 +1,8 @@
+#![allow(overflowing_literals)]
+
+fn main() {
+    let x: std::num::NonZero<i8> = -128;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    assert_eq!(x.get(), -128_i8);
+}

--- a/tests/ui/mismatched_types/non_zero_assigned_lit.stderr
+++ b/tests/ui/mismatched_types/non_zero_assigned_lit.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_lit.rs:4:36
+   |
+LL |     let x: std::num::NonZero<i8> = -128;
+   |            ---------------------   ^^^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let x: std::num::NonZero<i8> = NonZero::new(-128).unwrap();
+   |                                    +++++++++++++    ++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/mismatched_types/non_zero_assigned_oflo_lit.rs
+++ b/tests/ui/mismatched_types/non_zero_assigned_oflo_lit.rs
@@ -1,0 +1,14 @@
+#![allow(overflowing_literals)]
+
+fn main() {
+    let _: std::num::NonZero<u8> = 256;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
+    let _: std::num::NonZero<i8> = -128;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<i8> = -129;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+}

--- a/tests/ui/mismatched_types/non_zero_assigned_oflo_lit.stderr
+++ b/tests/ui/mismatched_types/non_zero_assigned_oflo_lit.stderr
@@ -1,0 +1,48 @@
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_oflo_lit.rs:4:36
+   |
+LL |     let _: std::num::NonZero<u8> = 256;
+   |            ---------------------   ^^^ expected `NonZero<u8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u8> = NonZero::new(256).unwrap();
+   |                                    +++++++++++++   ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_oflo_lit.rs:8:36
+   |
+LL |     let _: std::num::NonZero<i8> = -128;
+   |            ---------------------   ^^^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(-128).unwrap();
+   |                                    +++++++++++++    ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_oflo_lit.rs:11:36
+   |
+LL |     let _: std::num::NonZero<i8> = -129;
+   |            ---------------------   ^^^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(-129).unwrap();
+   |                                    +++++++++++++    ++++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/mismatched_types/non_zero_assigned_something.rs
+++ b/tests/ui/mismatched_types/non_zero_assigned_something.rs
@@ -1,5 +1,45 @@
 fn main() {
+    let _: std::num::NonZero<u64> = 0;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
+    let _: Option<std::num::NonZero<u64>> = 0;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
     let _: std::num::NonZero<u64> = 1;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<u64> = 1u8;
+    //~^ ERROR mismatched types
+    let _: std::num::NonZero<u64> = 1u64;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
+    let _: std::num::NonZero<u8> = 255;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<u8> = 256;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
+    let _: std::num::NonZero<u8> = -10;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+
+    let _: std::num::NonZero<i8> = -128;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<i8> = -129;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<i8> = -1;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<i8> = 0;
+    //~^ ERROR mismatched types
+    //~| HELP  consider calling `NonZero::new`
+    let _: std::num::NonZero<i8> = 1;
     //~^ ERROR mismatched types
     //~| HELP  consider calling `NonZero::new`
 

--- a/tests/ui/mismatched_types/non_zero_assigned_something.stderr
+++ b/tests/ui/mismatched_types/non_zero_assigned_something.stderr
@@ -1,6 +1,36 @@
 error[E0308]: mismatched types
   --> $DIR/non_zero_assigned_something.rs:2:37
    |
+LL |     let _: std::num::NonZero<u64> = 0;
+   |            ----------------------   ^ expected `NonZero<u64>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u64>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u64> = NonZero::new(0).unwrap();
+   |                                     +++++++++++++ ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:6:45
+   |
+LL |     let _: Option<std::num::NonZero<u64>> = 0;
+   |            ------------------------------   ^ expected `Option<NonZero<u64>>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<NonZero<u64>>`
+              found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: Option<std::num::NonZero<u64>> = NonZero::new(0);
+   |                                             +++++++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:10:37
+   |
 LL |     let _: std::num::NonZero<u64> = 1;
    |            ----------------------   ^ expected `NonZero<u64>`, found integer
    |            |
@@ -14,7 +44,153 @@ LL |     let _: std::num::NonZero<u64> = NonZero::new(1).unwrap();
    |                                     +++++++++++++ ++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/non_zero_assigned_something.rs:6:45
+  --> $DIR/non_zero_assigned_something.rs:13:37
+   |
+LL |     let _: std::num::NonZero<u64> = 1u8;
+   |            ----------------------   ^^^ expected `NonZero<u64>`, found `u8`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u64>`
+                found type `u8`
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:15:37
+   |
+LL |     let _: std::num::NonZero<u64> = 1u64;
+   |            ----------------------   ^^^^ expected `NonZero<u64>`, found `u64`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u64>`
+                found type `u64`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u64> = NonZero::new(1u64).unwrap();
+   |                                     +++++++++++++    ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:19:36
+   |
+LL |     let _: std::num::NonZero<u8> = 255;
+   |            ---------------------   ^^^ expected `NonZero<u8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u8> = NonZero::new(255).unwrap();
+   |                                    +++++++++++++   ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:22:36
+   |
+LL |     let _: std::num::NonZero<u8> = 256;
+   |            ---------------------   ^^^ expected `NonZero<u8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u8> = NonZero::new(256).unwrap();
+   |                                    +++++++++++++   ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:26:36
+   |
+LL |     let _: std::num::NonZero<u8> = -10;
+   |            ---------------------   ^^^ expected `NonZero<u8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<u8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<u8> = NonZero::new(-10).unwrap();
+   |                                    +++++++++++++   ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:30:36
+   |
+LL |     let _: std::num::NonZero<i8> = -128;
+   |            ---------------------   ^^^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(-128).unwrap();
+   |                                    +++++++++++++    ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:33:36
+   |
+LL |     let _: std::num::NonZero<i8> = -129;
+   |            ---------------------   ^^^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(-129).unwrap();
+   |                                    +++++++++++++    ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:36:36
+   |
+LL |     let _: std::num::NonZero<i8> = -1;
+   |            ---------------------   ^^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(-1).unwrap();
+   |                                    +++++++++++++  ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:39:36
+   |
+LL |     let _: std::num::NonZero<i8> = 0;
+   |            ---------------------   ^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(0).unwrap();
+   |                                    +++++++++++++ ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:42:36
+   |
+LL |     let _: std::num::NonZero<i8> = 1;
+   |            ---------------------   ^ expected `NonZero<i8>`, found integer
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `NonZero<i8>`
+                found type `{integer}`
+help: consider calling `NonZero::new`
+   |
+LL |     let _: std::num::NonZero<i8> = NonZero::new(1).unwrap();
+   |                                    +++++++++++++ ++++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_assigned_something.rs:46:45
    |
 LL |     let _: Option<std::num::NonZero<u64>> = 1;
    |            ------------------------------   ^ expected `Option<NonZero<u64>>`, found integer
@@ -28,6 +204,6 @@ help: consider calling `NonZero::new`
 LL |     let _: Option<std::num::NonZero<u64>> = NonZero::new(1);
    |                                             +++++++++++++ +
 
-error: aborting due to 2 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/mismatched_types/non_zero_coerce.rs
+++ b/tests/ui/mismatched_types/non_zero_coerce.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+use std::num::NonZero;
+
+trait Foo<T>: Sized {
+    fn bar(self, other: T) {}
+}
+
+impl Foo<u8> for u8 {}
+impl Foo<u16> for u16 {}
+
+trait Bar {}
+impl Bar for u8 {}
+impl Bar for u16 {}
+fn foo(_: impl Bar) {}
+
+fn main() {
+    // Check that we can coerce
+    let x = NonZero::new(5_u8).unwrap();
+    let y: u8 = x;
+
+    // Can coerce by looking at the trait
+    let x = NonZero::new(5_u8).unwrap();
+    5_u8.bar(x);
+
+    // Check that we can infer the nonzero wrapped type through the coercion
+    let a = NonZero::new(5).unwrap();
+    let b: u8 = a;
+
+    let a = NonZero::new(5).unwrap();
+    5_u8.bar(a);
+}

--- a/tests/ui/mismatched_types/non_zero_coerce_fail.rs
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail.rs
@@ -1,0 +1,31 @@
+use std::num::NonZero;
+
+trait Foo: Sized {
+    fn foo(&self) {}
+    fn bar(self) {}
+}
+
+impl Foo for u8 {}
+impl Foo for u16 {}
+
+fn foo(_: impl Foo) {}
+
+fn main() {
+    let x = NonZero::new(5_u8).unwrap();
+    x.foo();
+    //~^ ERROR: no method named `foo` found for struct `NonZero` in the current scope
+    x.bar();
+    //~^ ERROR: no method named `bar` found for struct `NonZero` in the current scope
+    foo(x);
+    //~^ ERROR: the trait bound `NonZero<u8>: Foo` is not satisfied
+    foo(x as _);
+
+    let a = NonZero::new(5).unwrap();
+    a.foo();
+    //~^ ERROR: no method named `foo` found for struct `NonZero` in the current scope
+    a.bar();
+    //~^ ERROR: no method named `bar` found for struct `NonZero` in the current scope
+    foo(a);
+    //~^ ERROR: the trait bound `NonZero<{integer}>: Foo` is not satisfied
+    foo(a as _);
+}

--- a/tests/ui/mismatched_types/non_zero_coerce_fail.stderr
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail.stderr
@@ -1,0 +1,90 @@
+error[E0599]: no method named `foo` found for struct `NonZero` in the current scope
+  --> $DIR/non_zero_coerce_fail.rs:15:7
+   |
+LL |     x.foo();
+   |       ^^^ method not found in `NonZero<u8>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Foo` defines an item `foo`, perhaps you need to implement it
+  --> $DIR/non_zero_coerce_fail.rs:3:1
+   |
+LL | trait Foo: Sized {
+   | ^^^^^^^^^^^^^^^^
+
+error[E0599]: no method named `bar` found for struct `NonZero` in the current scope
+  --> $DIR/non_zero_coerce_fail.rs:17:7
+   |
+LL |     x.bar();
+   |       ^^^ method not found in `NonZero<u8>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Foo` defines an item `bar`, perhaps you need to implement it
+  --> $DIR/non_zero_coerce_fail.rs:3:1
+   |
+LL | trait Foo: Sized {
+   | ^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `NonZero<u8>: Foo` is not satisfied
+  --> $DIR/non_zero_coerce_fail.rs:19:9
+   |
+LL |     foo(x);
+   |     --- ^ the trait `Foo` is not implemented for `NonZero<u8>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo`:
+             u16
+             u8
+note: required by a bound in `foo`
+  --> $DIR/non_zero_coerce_fail.rs:11:16
+   |
+LL | fn foo(_: impl Foo) {}
+   |                ^^^ required by this bound in `foo`
+
+error[E0599]: no method named `foo` found for struct `NonZero` in the current scope
+  --> $DIR/non_zero_coerce_fail.rs:24:7
+   |
+LL |     a.foo();
+   |       ^^^ method not found in `NonZero<{integer}>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Foo` defines an item `foo`, perhaps you need to implement it
+  --> $DIR/non_zero_coerce_fail.rs:3:1
+   |
+LL | trait Foo: Sized {
+   | ^^^^^^^^^^^^^^^^
+
+error[E0599]: no method named `bar` found for struct `NonZero` in the current scope
+  --> $DIR/non_zero_coerce_fail.rs:26:7
+   |
+LL |     a.bar();
+   |       ^^^ method not found in `NonZero<{integer}>`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Foo` defines an item `bar`, perhaps you need to implement it
+  --> $DIR/non_zero_coerce_fail.rs:3:1
+   |
+LL | trait Foo: Sized {
+   | ^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `NonZero<{integer}>: Foo` is not satisfied
+  --> $DIR/non_zero_coerce_fail.rs:28:9
+   |
+LL |     foo(a);
+   |     --- ^ the trait `Foo` is not implemented for `NonZero<{integer}>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo`:
+             u16
+             u8
+note: required by a bound in `foo`
+  --> $DIR/non_zero_coerce_fail.rs:11:16
+   |
+LL | fn foo(_: impl Foo) {}
+   |                ^^^ required by this bound in `foo`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/non_zero_coerce_fail2.rs
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail2.rs
@@ -1,0 +1,29 @@
+use std::num::NonZero;
+
+trait Foo<T>: Sized {
+    fn foo(&self, other: &T) {}
+    fn bar(self, other: T) {}
+}
+
+impl Foo<u8> for u8 {}
+impl Foo<u16> for u16 {}
+
+fn main() {
+    let x = NonZero::new(5_u8).unwrap();
+    5_u8.foo(&x);
+    //~^ ERROR: mismatched types
+    5_u8.bar(x);
+    5.foo(&x);
+    //~^ ERROR: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+    5.bar(x);
+    //~^ ERROR: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+
+    let a = NonZero::new(5).unwrap();
+    5_u8.foo(&a);
+    //~^ ERROR: mismatched types
+    5_u8.bar(a);
+    5.foo(&a);
+    //~^ ERROR: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+    5.bar(a);
+    //~^ ERROR: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+}

--- a/tests/ui/mismatched_types/non_zero_coerce_fail2.stderr
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail2.stderr
@@ -1,0 +1,84 @@
+error[E0308]: mismatched types
+  --> $DIR/non_zero_coerce_fail2.rs:13:14
+   |
+LL |     5_u8.foo(&x);
+   |          --- ^^ expected `&u8`, found `&NonZero<u8>`
+   |          |
+   |          arguments to this method are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&NonZero<u8>`
+note: method defined here
+  --> $DIR/non_zero_coerce_fail2.rs:4:8
+   |
+LL |     fn foo(&self, other: &T) {}
+   |        ^^^        ---------
+
+error[E0277]: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+  --> $DIR/non_zero_coerce_fail2.rs:16:11
+   |
+LL |     5.foo(&x);
+   |       --- ^^ the trait `Foo<NonZero<u8>>` is not implemented for `{integer}`
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo<T>`:
+             `u16` implements `Foo<u16>`
+             `u8` implements `Foo<u8>`
+
+error[E0277]: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+  --> $DIR/non_zero_coerce_fail2.rs:18:11
+   |
+LL |     5.bar(x);
+   |       --- ^ the trait `Foo<NonZero<u8>>` is not implemented for `{integer}`
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo<T>`:
+             `u16` implements `Foo<u16>`
+             `u8` implements `Foo<u8>`
+
+error[E0308]: mismatched types
+  --> $DIR/non_zero_coerce_fail2.rs:22:14
+   |
+LL |     5_u8.foo(&a);
+   |          --- ^^ expected `&u8`, found `&NonZero<{integer}>`
+   |          |
+   |          arguments to this method are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&NonZero<{integer}>`
+note: method defined here
+  --> $DIR/non_zero_coerce_fail2.rs:4:8
+   |
+LL |     fn foo(&self, other: &T) {}
+   |        ^^^        ---------
+
+error[E0277]: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+  --> $DIR/non_zero_coerce_fail2.rs:25:11
+   |
+LL |     5.foo(&a);
+   |       --- ^^ the trait `Foo<NonZero<u8>>` is not implemented for `{integer}`
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo<T>`:
+             `u16` implements `Foo<u16>`
+             `u8` implements `Foo<u8>`
+
+error[E0277]: the trait bound `{integer}: Foo<NonZero<u8>>` is not satisfied
+  --> $DIR/non_zero_coerce_fail2.rs:27:11
+   |
+LL |     5.bar(a);
+   |       --- ^ the trait `Foo<NonZero<u8>>` is not implemented for `{integer}`
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `Foo<T>`:
+             `u16` implements `Foo<u16>`
+             `u8` implements `Foo<u8>`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/non_zero_coerce_fail_infer.rs
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail_infer.rs
@@ -1,0 +1,14 @@
+use std::num::NonZero;
+
+trait Foo {}
+
+impl Foo for u8 {}
+impl Foo for u16 {}
+
+fn foo(_: impl Foo) {}
+
+fn main() {
+    let x = NonZero::new(5_u8).unwrap();
+    foo(x as _);
+    //~^ ERROR: type annotations needed
+}

--- a/tests/ui/mismatched_types/non_zero_coerce_fail_infer.stderr
+++ b/tests/ui/mismatched_types/non_zero_coerce_fail_infer.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/non_zero_coerce_fail_infer.rs:12:14
+   |
+LL |     foo(x as _);
+   |              ^ cannot infer type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
coercing `NonZero<T>` to `T` if all the types are available at the cast site.

This is fairly limited, as (as the tests show), this does not allow "reborrowing" `&NonZero<T>` as `&T`. It also fails quickly if the types aren't fully clear at the coercion site, but only resolved later.

Also cannot aid in trait selection or similar, even if there is clearly only one option.

Related:

* https://github.com/rust-lang/rust/pull/143594
* https://github.com/rust-lang/rfcs/pull/3786

cc @traviscross 