### PR TITLE
Make `int_format_into` API more flexible

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -608,6 +608,8 @@ pub use core::fmt::{FromFn, from_fn};
 pub use core::fmt::{LowerExp, UpperExp};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{LowerHex, Pointer, UpperHex};
+#[unstable(feature = "int_format_into", issue = "138215")]
+pub use core::fmt::{NumBuffer, NumBufferTrait};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::string;

--- a/library/alloctests/tests/num.rs
+++ b/library/alloctests/tests/num.rs
@@ -15,6 +15,10 @@ macro_rules! assert_nb {
 
         let mut buffer = NumBuffer::<$int>::new();
         assert_eq!(value.format_into(&mut buffer), s.as_str());
+
+        // We check that bigger buffers can be used in `format_into`.
+        let mut buffer = NumBuffer::<i128>::new();
+        assert_eq!(value.format_into(&mut buffer), s.as_str());
     };
 }
 

--- a/tests/ui/numeric/fmt.rs
+++ b/tests/ui/numeric/fmt.rs
@@ -1,0 +1,17 @@
+// Test to ensure that if you use a `NumBuffer` with a too small integer, it
+// will fail at compilation time.
+
+//@ build-fail
+//@ ignore-pass
+
+#![feature(int_format_into)]
+
+use std::fmt::NumBuffer;
+
+fn main() {
+    let x = 0u32;
+    let mut buf = NumBuffer::<u8>::new();
+    x.format_into(&mut buf);
+}
+
+//~? ERROR evaluation panicked

--- a/tests/ui/numeric/fmt.stderr
+++ b/tests/ui/numeric/fmt.stderr
@@ -1,0 +1,22 @@
+error[E0080]: evaluation panicked: buffer is not big enough
+  --> $SRC_DIR/core/src/fmt/num.rs:LL:COL
+  ::: $SRC_DIR/core/src/fmt/num.rs:LL:COL
+   |
+   = note: evaluation of `core::fmt::num::imp::<impl u32>::format_into::<u8>::{constant#0}` failed here
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `impl_Display` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $SRC_DIR/core/src/fmt/num.rs:LL:COL
+   |
+   = note: this note originates in the macro `impl_Display` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn core::fmt::num::imp::<impl u32>::format_into::<u8>`
+  --> $DIR/fmt.rs:14:5
+   |
+LL |     x.format_into(&mut buf);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/142098.
Part of https://github.com/rust-lang/rust/issues/138215.

This change allows to pass `NumBuffer<u128>` for any smaller integers, making the API much more flexible overall.

r? @Amanieu 