### PR TITLE
Capitalize "dag" as "DAG"

### DIFF
--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -11,7 +11,7 @@
 //! This is because `sys_common` not only contains platform-independent code,
 //! but also code that is shared between the different platforms in `sys`.
 //! Ideally all that shared code should be moved to `sys::common`,
-//! and the dependencies between `std`, `sys_common` and `sys` all would form a dag.
+//! and the dependencies between `std`, `sys_common` and `sys` all would form a DAG.
 //! Progress on this is tracked in #84187.
 
 #![allow(missing_docs)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR makes a minor improvement to the module-level documentation of std::sys_common:

Replaces the lowercase “dag” with the more standard and explicit form “DAG (Directed Acyclic Graph)” for clarity.


