### PR TITLE
[rustdoc-json] Add tests for `#[doc(hidden)]` handling of items.

### DIFF
--- a/tests/rustdoc-json/visibility/doc_hidden_default.rs
+++ b/tests/rustdoc-json/visibility/doc_hidden_default.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+// Without `--document-hidden-items`,
+// none of these items are present in rustdoc JSON.
+
+//@ !has "$.index[?(@.name=='func')]"
+#[doc(hidden)]
+pub fn func() {}
+
+//@ !has "$.index[?(@.name=='Unit')]"
+#[doc(hidden)]
+pub struct Unit;
+
+//@ !has "$.index[?(@.name=='hidden')]"
+#[doc(hidden)]
+pub mod hidden {
+    //@ !has "$.index[?(@.name=='Inner')]"
+    pub struct Inner;
+}

--- a/tests/rustdoc-json/visibility/doc_hidden_documented.rs
+++ b/tests/rustdoc-json/visibility/doc_hidden_documented.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: --document-hidden-items
+#![no_std]
+
+//@ is "$.index[?(@.name=='func')].attrs" '["#[doc(hidden)]"]'
+#[doc(hidden)]
+pub fn func() {}
+
+//@ is "$.index[?(@.name=='Unit')].attrs" '["#[doc(hidden)]"]'
+#[doc(hidden)]
+pub struct Unit;
+
+//@ is "$.index[?(@.name=='hidden')].attrs" '["#[doc(hidden)]"]'
+#[doc(hidden)]
+pub mod hidden {
+    //@ is "$.index[?(@.name=='Inner')].attrs" '[]'
+    pub struct Inner;
+}


### PR DESCRIPTION
Add tests which check:
- `#[doc(hidden)]` items are not present in rustdoc JSON output by default.
- Invoking rustdoc with `--document-hidden-items` makes `#[doc(hidden)]` items appear, and they show their `#[doc(hidden)]` status appropriately.

r? @aDotInTheVoid 
