### PR TITLE
Preserve the .debug_gdb_scripts section

### DIFF
--- a/compiler/rustc_codegen_gcc/src/debuginfo.rs
+++ b/compiler/rustc_codegen_gcc/src/debuginfo.rs
@@ -254,7 +254,8 @@ impl<'gcc, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         // TODO(antoyo): implement.
     }
 
-    fn debuginfo_finalize(&self) {
+    fn debuginfo_finalize(&mut self) {
+        // TODO: emit section `.debug_gdb_scripts`.
         self.context.set_debug_info(true)
     }
 

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -109,9 +109,14 @@ pub(crate) fn compile_codegen_unit(
             }
 
             // Finalize code coverage by injecting the coverage map. Note, the coverage map will
-            // also be added to the `llvm.compiler.used` variable, created next.
+            // also be added to the `llvm.compiler.used` variable, created below.
             if cx.sess().instrument_coverage() {
                 cx.coverageinfo_finalize();
+            }
+
+            // Finalize debuginfo. This adds to `llvm.used`, created below.
+            if cx.sess().opts.debuginfo != DebugInfo::None {
+                cx.debuginfo_finalize();
             }
 
             // Create the llvm.used and llvm.compiler.used variables.
@@ -129,11 +134,6 @@ pub(crate) fn compile_codegen_unit(
                     llvm::LLVMReplaceAllUsesWith(old_g, new_g);
                     llvm::LLVMDeleteGlobal(old_g);
                 }
-            }
-
-            // Finalize debuginfo
-            if cx.sess().opts.debuginfo != DebugInfo::None {
-                cx.debuginfo_finalize();
             }
         }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -1,13 +1,13 @@
 // .debug_gdb_scripts binary section.
 
+use std::collections::BTreeSet;
 use std::ffi::CString;
 
-use rustc_codegen_ssa::base::collect_debugger_visualizers_transitive;
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::bug;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerType;
-use rustc_session::config::{CrateType, DebugInfo};
+use rustc_session::config::DebugInfo;
 
 use crate::builder::Builder;
 use crate::common::CodegenCx;
@@ -51,10 +51,14 @@ pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
 
         // Next, add the pretty printers that were specified via the `#[debugger_visualizer]`
         // attribute.
-        let visualizers = collect_debugger_visualizers_transitive(
-            cx.tcx,
-            DebuggerVisualizerType::GdbPrettyPrinter,
-        );
+        let visualizers = cx
+            .tcx
+            .debugger_visualizers(LOCAL_CRATE)
+            .iter()
+            .filter(|visualizer| {
+                visualizer.visualizer_type == DebuggerVisualizerType::GdbPrettyPrinter
+            })
+            .collect::<BTreeSet<_>>();
         let crate_name = cx.tcx.crate_name(LOCAL_CRATE);
         for (index, visualizer) in visualizers.iter().enumerate() {
             // The initial byte `4` instructs GDB that the following pretty printer
@@ -91,30 +95,5 @@ pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
 }
 
 pub(crate) fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
-    // We collect pretty printers transitively for all crates, so we make sure
-    // that the section is only emitted for leaf crates.
-    let embed_visualizers = cx.tcx.crate_types().iter().any(|&crate_type| match crate_type {
-        CrateType::Executable | CrateType::Cdylib | CrateType::Staticlib | CrateType::Sdylib => {
-            // These are crate types for which we will embed pretty printers since they
-            // are treated as leaf crates.
-            true
-        }
-        CrateType::ProcMacro => {
-            // We could embed pretty printers for proc macro crates too but it does not
-            // seem like a good default, since this is a rare use case and we don't
-            // want to slow down the common case.
-            false
-        }
-        CrateType::Rlib | CrateType::Dylib => {
-            // Don't embed pretty printers for these crate types; the compiler
-            // can see the `#[debug_visualizer]` attributes when using the
-            // library, and emitting `.debug_gdb_scripts` regardless would
-            // break `#![omit_gdb_pretty_printer_section]`.
-            false
-        }
-    });
-
-    cx.sess().opts.debuginfo != DebugInfo::None
-        && cx.sess().target.emit_debug_gdb_scripts
-        && embed_visualizers
+    cx.sess().opts.debuginfo != DebugInfo::None && cx.sess().target.emit_debug_gdb_scripts
 }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -30,7 +30,7 @@ use tracing::debug;
 
 use self::metadata::{UNKNOWN_COLUMN_NUMBER, UNKNOWN_LINE_NUMBER, file_metadata, type_di_node};
 use self::namespace::mangled_name_of_instance;
-use self::utils::{DIB, create_DIArray, is_node_local_to_unit};
+use self::utils::{DIB, create_DIArray, debug_context, is_node_local_to_unit};
 use crate::builder::Builder;
 use crate::common::{AsCCharPtr, CodegenCx};
 use crate::llvm;
@@ -131,20 +131,28 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
 }
 
 /// Creates any deferred debug metadata nodes
-pub(crate) fn finalize(cx: &CodegenCx<'_, '_>) {
-    if let Some(dbg_cx) = &cx.dbg_cx {
-        debug!("finalize");
-
-        if gdb::needs_gdb_debug_scripts_section(cx) {
-            // Add a .debug_gdb_scripts section to this compile-unit. This will
-            // cause GDB to try and load the gdb_load_rust_pretty_printers.py file,
-            // which activates the Rust pretty printers for binary this section is
-            // contained in.
-            gdb::get_or_insert_gdb_debug_scripts_section_global(cx);
-        }
-
-        dbg_cx.finalize(cx.sess());
+pub(crate) fn finalize(cx: &mut CodegenCx<'_, '_>) {
+    if cx.dbg_cx.is_none() {
+        return;
     }
+
+    debug!("finalize");
+
+    if gdb::needs_gdb_debug_scripts_section(cx) {
+        // Add a .debug_gdb_scripts section to this compile-unit. This will
+        // cause GDB to try and load the gdb_load_rust_pretty_printers.py file,
+        // which activates the Rust pretty printers for binary this section is
+        // contained in.
+        let section_var = gdb::get_or_insert_gdb_debug_scripts_section_global(cx);
+
+        // Make sure that the linker doesn't optimize the global away. Adding
+        // it to `llvm.used` has the advantage that it works even in no_std
+        // binaries, where we don't have a main shim and thus don't emit a
+        // volatile load to preserve the global.
+        cx.add_used_global(section_var);
+    }
+
+    debug_context(cx).finalize(cx.sess());
 }
 
 impl<'ll> Builder<'_, 'll, '_> {
@@ -614,7 +622,7 @@ impl<'ll, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         metadata::extend_scope_to_file(self, scope_metadata, file)
     }
 
-    fn debuginfo_finalize(&self) {
+    fn debuginfo_finalize(&mut self) {
         finalize(self)
     }
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -609,7 +609,15 @@ pub fn collect_debugger_visualizers_transitive(
 ) -> BTreeSet<DebuggerVisualizerFile> {
     tcx.debugger_visualizers(LOCAL_CRATE)
         .iter()
-        .chain(tcx.crates(()).iter().flat_map(|&cnum| tcx.debugger_visualizers(cnum)))
+        .chain(
+            tcx.crates(())
+                .iter()
+                .filter(|&cnum| {
+                    let used_crate_source = tcx.used_crate_source(*cnum);
+                    used_crate_source.rlib.is_some() || used_crate_source.rmeta.is_some()
+                })
+                .flat_map(|&cnum| tcx.debugger_visualizers(cnum)),
+        )
         .filter(|visualizer| visualizer.visualizer_type == visualizer_type)
         .cloned()
         .collect::<BTreeSet<_>>()

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -609,15 +609,7 @@ pub fn collect_debugger_visualizers_transitive(
 ) -> BTreeSet<DebuggerVisualizerFile> {
     tcx.debugger_visualizers(LOCAL_CRATE)
         .iter()
-        .chain(
-            tcx.crates(())
-                .iter()
-                .filter(|&cnum| {
-                    let used_crate_source = tcx.used_crate_source(*cnum);
-                    used_crate_source.rlib.is_some() || used_crate_source.rmeta.is_some()
-                })
-                .flat_map(|&cnum| tcx.debugger_visualizers(cnum)),
-        )
+        .chain(tcx.crates(()).iter().flat_map(|&cnum| tcx.debugger_visualizers(cnum)))
         .filter(|visualizer| visualizer.visualizer_type == visualizer_type)
         .cloned()
         .collect::<BTreeSet<_>>()

--- a/compiler/rustc_codegen_ssa/src/traits/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/debuginfo.rs
@@ -50,7 +50,7 @@ pub trait DebugInfoCodegenMethods<'tcx>: BackendTypes {
         scope_metadata: Self::DIScope,
         file: &SourceFile,
     ) -> Self::DIScope;
-    fn debuginfo_finalize(&self);
+    fn debuginfo_finalize(&mut self);
 
     // FIXME(eddyb) find a common convention for all of the debuginfo-related
     // names (choose between `dbg`, `debug`, `debuginfo`, `debug_info` etc.).

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -68,6 +68,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-gnu",
     "ignore-haiku",
     "ignore-horizon",
+    "ignore-i586-unknown-linux-gnu",
     "ignore-i686-pc-windows-gnu",
     "ignore-i686-pc-windows-msvc",
     "ignore-illumos",

--- a/tests/codegen-llvm/gdb_debug_script_load.rs
+++ b/tests/codegen-llvm/gdb_debug_script_load.rs
@@ -9,6 +9,8 @@
 #![feature(lang_items)]
 #![no_std]
 
+// CHECK: @llvm.used = {{.+}} @__rustc_debug_gdb_scripts_section
+
 #[panic_handler]
 fn panic_handler(_: &core::panic::PanicInfo) -> ! {
     loop {}
@@ -22,7 +24,7 @@ extern "C" fn rust_eh_personality() {
 // Needs rustc to generate `main` as that's where the magic load is inserted.
 // IOW, we cannot write this test with `#![no_main]`.
 // CHECK-LABEL: @main
-// CHECK: load volatile i8, {{.+}} @__rustc_debug_gdb_scripts_section__
+// CHECK: load volatile i8, {{.+}} @__rustc_debug_gdb_scripts_section
 
 #[lang = "start"]
 fn lang_start<T: 'static>(

--- a/tests/debuginfo/embedded-visualizer.rs
+++ b/tests/debuginfo/embedded-visualizer.rs
@@ -1,6 +1,8 @@
 //@ compile-flags:-g
 //@ ignore-lldb
 //@ ignore-windows-gnu: #128981
+//@ ignore-musl: linker too old in CI
+//@ ignore-i586-unknown-linux-gnu: linker too old in CI
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -35,13 +35,7 @@ fn symbols_check_archive(path: &str) {
             continue; // All compiler-builtins symbols must remain unmangled
         }
 
-        if name.contains("rust_eh_personality") {
-            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
-        }
-
-        if name.contains(".llvm.") {
-            // Starting in LLVM 21 we get various implementation-detail functions which
-            // contain .llvm. that are not a problem.
+        if symbol_ok_everywhere(name) {
             continue;
         }
 
@@ -71,13 +65,7 @@ fn symbols_check(path: &str) {
             continue;
         }
 
-        if name.contains("rust_eh_personality") {
-            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
-        }
-
-        if name.contains(".llvm.") {
-            // Starting in LLVM 21 we get various implementation-detail functions which
-            // contain .llvm. that are not a problem.
+        if symbol_ok_everywhere(name) {
             continue;
         }
 
@@ -87,4 +75,23 @@ fn symbols_check(path: &str) {
 
 fn strip_underscore_if_apple(symbol: &str) -> &str {
     if cfg!(target_vendor = "apple") { symbol.strip_prefix("_").unwrap() } else { symbol }
+}
+
+fn symbol_ok_everywhere(name: &str) -> bool {
+    if name.contains("rust_eh_personality") {
+        return true; // Unfortunately LLVM doesn't allow us to mangle this symbol
+    }
+
+    if name.contains(".llvm.") {
+        // Starting in LLVM 21 we get various implementation-detail functions which
+        // contain .llvm. that are not a problem.
+        return true;
+    }
+
+    if name.starts_with("__rustc_debug_gdb_scripts_section") {
+        // These symbols are fine; they're made unique by the crate ID.
+        return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
Make sure that compiler and linker don't optimize the section's contents
away by adding the global holding the data to `llvm.used`. This
eliminates the need for a volatile load in the main shim; since the LLVM
codegen backend is the only implementer of the corresponding trait
function, remove it entirely.

Pretty printers in dylib dependencies are now emitted by the main crate
instead of the dylib; apart from matching how rlibs are handled, this
approach has the advantage that `omit_gdb_pretty_printer_section` keeps
working with dylib dependencies.

r? @bjorn3 