### PR TITLE
bootstrap/miri: avoid rebuilds for test builds

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1299,7 +1299,7 @@ tool_extended!(Miri {
     tool_name: "miri",
     stable: false,
     add_bins_to_sysroot: ["miri"],
-    // Avoid costly rebuilds by always including the tests.
+    // Always compile also tests when building miri. Otherwise feature unification can cause rebuilds between building and testing miri.
     cargo_args: &["--all-targets"],
 });
 tool_extended!(CargoMiri {


### PR DESCRIPTION
When building Miri in its own repo, we always build with `--all-targets`:
https://github.com/rust-lang/rust/blob/a00961269107703772c4e8f071f0accbe0f1a7e5/src/tools/miri/miri-script/src/util.rs#L167-L174
This saves a bunch of time since some of Miri's dependencies get more features enabled by some of Miri's dev-dependencies, and they all get built twice otherwise if you do `cargo build && cargo test` (which is typically what you end up doing inside `./miri test` and also inside `./x test miri`).

This applies the same approach to bootstrap, drastically reducing the edit-compile cycle for Miri work here. :)