### PR TITLE
[EXPERIMENT] require simd types be used in target_feature-annotated functions

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -143,6 +143,7 @@ pub struct ReprOptions {
     pub align: Option<Align>,
     pub pack: Option<Align>,
     pub flags: ReprFlags,
+    pub target_feature: Option<u16>,
     /// The seed to be used for randomizing a type's layout
     ///
     /// Note: This could technically be a `u128` which would

--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -64,7 +64,7 @@ pub enum ReprAttr {
     ReprRust,
     ReprC,
     ReprPacked(Align),
-    ReprSimd,
+    ReprSimd(Option<u16>),
     ReprTransparent,
     ReprAlign(Align),
 }

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -143,11 +143,26 @@ fn parse_repr<S: Stage>(
 
         (Some(sym::Rust), ArgParser::NoArgs) => Some(ReprRust),
         (Some(sym::C), ArgParser::NoArgs) => Some(ReprC),
-        (Some(sym::simd), ArgParser::NoArgs) => Some(ReprSimd),
+        (Some(sym::simd), ArgParser::NoArgs) => Some(ReprSimd(None)),
         (Some(sym::transparent), ArgParser::NoArgs) => Some(ReprTransparent),
         (Some(name @ int_pat!()), ArgParser::NoArgs) => {
             // int_pat!() should make sure it always parses
             Some(ReprInt(int_type_of_word(name).unwrap()))
+        }
+
+        (Some(sym::simd), ArgParser::List(x)) => {
+            let Some(item) = x.single() else {
+                todo!("Handle incorrect syntax");
+            };
+            let Some(lit) = item.lit() else {
+                todo!("Handle invalid lit");
+            };
+            match lit.kind {
+                LitKind::Int(v, _) => {
+                    Some(ReprSimd(Some(v.0 as u16)))
+                }
+                _ => todo!("Handle invalid lit kind"),
+            }
         }
 
         (
@@ -167,7 +182,7 @@ fn parse_repr<S: Stage>(
             Some(
                 name @ sym::Rust
                 | name @ sym::C
-                | name @ sym::simd
+                // | name @ sym::simd
                 | name @ sym::transparent
                 | name @ int_pat!(),
             ),

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -349,6 +349,8 @@ codegen_ssa_thorin_unit_not_in_index = unit {$unit} from input package is not in
 
 codegen_ssa_thorin_unsupported_relocation = unsupported relocation for section {$section} at offset {$offset}
 
+codegen_ssa_type_depends_target_feature = The `{$ty}` type depends on the target feature `{$target_feature}` being enabled
+
 codegen_ssa_unable_to_exe_linker = could not exec the linker `{$linker_path}`
     .note = {$error}
     .command_note = {$command_formatted}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1310,3 +1310,13 @@ pub(crate) struct FeatureNotValid<'a> {
     #[help]
     pub plus_hint: bool,
 }
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_type_depends_target_feature)]
+pub(crate) struct TypeDependsOnTargetFeature<'tcx> {
+    #[primary_span]
+    pub span: Span,
+
+    pub target_feature: String,
+    pub ty: Ty<'tcx>,
+}

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1513,6 +1513,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let mut size = None;
         let mut max_align: Option<Align> = None;
         let mut min_pack: Option<Align> = None;
+        let mut target_feature: Option<u16> = None;
 
         // Generate a deterministically-derived seed from the item's path hash
         // to allow for cross-crate compilation to actually work
@@ -1541,7 +1542,10 @@ impl<'tcx> TyCtxt<'tcx> {
                         ReprFlags::empty()
                     }
                     attr::ReprTransparent => ReprFlags::IS_TRANSPARENT,
-                    attr::ReprSimd => ReprFlags::IS_SIMD,
+                    attr::ReprSimd(feature) => {
+                        target_feature = feature;
+                        ReprFlags::IS_SIMD
+                    }
                     attr::ReprInt(i) => {
                         size = Some(match i {
                             attr::IntType::SignedInt(x) => match x {
@@ -1586,7 +1590,14 @@ impl<'tcx> TyCtxt<'tcx> {
             flags.insert(ReprFlags::IS_LINEAR);
         }
 
-        ReprOptions { int: size, align: max_align, pack: min_pack, flags, field_shuffle_seed }
+        ReprOptions {
+            int: size,
+            align: max_align,
+            pack: min_pack,
+            flags,
+            field_shuffle_seed,
+            target_feature,
+        }
     }
 
     /// Look up the name of a definition across crates. This does not look at HIR.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1202,6 +1202,24 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
+    pub fn abi_target_feature(self) -> Option<String> {
+        self.ty_adt_def()
+            .map(|adt| {
+                adt.repr().target_feature.map(|id| {
+                    String::from(match id {
+                        0 => "neon",
+                        1 => "sse",
+                        2 => "sse2",
+                        3 => "avx",
+                        4 => "avx512f",
+                        5 => "amx-avx512",
+                        _ => panic!("Unknown ID: {id}"),
+                    })
+                })
+            })
+            .flatten()
+    }
+
     pub fn simd_size_and_type(self, tcx: TyCtxt<'tcx>) -> (u64, Ty<'tcx>) {
         let Adt(def, args) = self.kind() else {
             bug!("`simd_size_and_type` called on invalid type")

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2018,7 +2018,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         continue;
                     }
                 }
-                ReprAttr::ReprSimd => {
+                ReprAttr::ReprSimd(_) => {
                     is_simd = true;
                     if target != Target::Struct {
                         self.dcx().emit_err(errors::AttrApplication::Struct {

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/mod.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/mod.rs
@@ -23,9 +23,9 @@ types! {
     #![stable(feature = "neon_intrinsics", since = "1.59.0")]
 
     /// ARM-specific 64-bit wide vector of one packed `f64`.
-    pub struct float64x1_t(1 x f64); // FIXME: check this!
+    pub struct float64x1_t(1 x f64) feature=0; // FIXME: check this!
     /// ARM-specific 128-bit wide vector of two packed `f64`.
-    pub struct float64x2_t(2 x f64);
+    pub struct float64x2_t(2 x f64) feature=0;
 }
 
 /// ARM-specific type containing two `float64x1_t` vectors.

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/mod.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/mod.rs
@@ -53,63 +53,63 @@ types! {
     #![cfg_attr(target_arch = "arm", unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800"))]
 
     /// Arm-specific 64-bit wide vector of eight packed `i8`.
-    pub struct int8x8_t(8 x pub(crate) i8);
+    pub struct int8x8_t(8 x pub(crate) i8) feature=0;
     /// Arm-specific 64-bit wide vector of eight packed `u8`.
-    pub struct uint8x8_t(8 x pub(crate) u8);
+    pub struct uint8x8_t(8 x pub(crate) u8) feature=0;
     /// Arm-specific 64-bit wide polynomial vector of eight packed `p8`.
-    pub struct poly8x8_t(8 x pub(crate) p8);
+    pub struct poly8x8_t(8 x pub(crate) p8) feature=0;
     /// Arm-specific 64-bit wide vector of four packed `i16`.
-    pub struct int16x4_t(4 x pub(crate) i16);
+    pub struct int16x4_t(4 x pub(crate) i16) feature=0;
     /// Arm-specific 64-bit wide vector of four packed `u16`.
-    pub struct uint16x4_t(4 x pub(crate) u16);
+    pub struct uint16x4_t(4 x pub(crate) u16) feature=0;
     /// Arm-specific 64-bit wide vector of four packed `p16`.
-    pub struct poly16x4_t(4 x pub(crate) p16);
+    pub struct poly16x4_t(4 x pub(crate) p16) feature=0;
     /// Arm-specific 64-bit wide vector of two packed `i32`.
-    pub struct int32x2_t(2 x pub(crate) i32);
+    pub struct int32x2_t(2 x pub(crate) i32) feature=0;
     /// Arm-specific 64-bit wide vector of two packed `u32`.
-    pub struct uint32x2_t(2 x pub(crate) u32);
+    pub struct uint32x2_t(2 x pub(crate) u32) feature=0;
     /// Arm-specific 64-bit wide vector of two packed `f32`.
-    pub struct float32x2_t(2 x pub(crate) f32);
+    pub struct float32x2_t(2 x pub(crate) f32) feature=0;
     /// Arm-specific 64-bit wide vector of one packed `i64`.
-    pub struct int64x1_t(1 x pub(crate) i64);
+    pub struct int64x1_t(1 x pub(crate) i64) feature=0;
     /// Arm-specific 64-bit wide vector of one packed `u64`.
-    pub struct uint64x1_t(1 x pub(crate) u64);
+    pub struct uint64x1_t(1 x pub(crate) u64) feature=0;
     /// Arm-specific 64-bit wide vector of one packed `p64`.
-    pub struct poly64x1_t(1 x pub(crate) p64);
+    pub struct poly64x1_t(1 x pub(crate) p64) feature=0;
 
     /// Arm-specific 128-bit wide vector of sixteen packed `i8`.
-    pub struct int8x16_t(16 x pub(crate) i8);
+    pub struct int8x16_t(16 x pub(crate) i8) feature=0;
     /// Arm-specific 128-bit wide vector of sixteen packed `u8`.
-    pub struct uint8x16_t(16 x pub(crate) u8);
+    pub struct uint8x16_t(16 x pub(crate) u8) feature=0;
     /// Arm-specific 128-bit wide vector of sixteen packed `p8`.
-    pub struct poly8x16_t(16 x pub(crate) p8);
+    pub struct poly8x16_t(16 x pub(crate) p8) feature=0;
     /// Arm-specific 128-bit wide vector of eight packed `i16`.
-    pub struct int16x8_t(8 x pub(crate) i16);
+    pub struct int16x8_t(8 x pub(crate) i16) feature=0;
     /// Arm-specific 128-bit wide vector of eight packed `u16`.
-    pub struct uint16x8_t(8 x pub(crate) u16);
+    pub struct uint16x8_t(8 x pub(crate) u16) feature=0;
     /// Arm-specific 128-bit wide vector of eight packed `p16`.
-    pub struct poly16x8_t(8 x pub(crate) p16);
+    pub struct poly16x8_t(8 x pub(crate) p16) feature=0;
     /// Arm-specific 128-bit wide vector of four packed `i32`.
-    pub struct int32x4_t(4 x pub(crate) i32);
+    pub struct int32x4_t(4 x pub(crate) i32) feature=0;
     /// Arm-specific 128-bit wide vector of four packed `u32`.
-    pub struct uint32x4_t(4 x pub(crate) u32);
+    pub struct uint32x4_t(4 x pub(crate) u32) feature=0;
     /// Arm-specific 128-bit wide vector of four packed `f32`.
-    pub struct float32x4_t(4 x pub(crate) f32);
+    pub struct float32x4_t(4 x pub(crate) f32) feature=0;
     /// Arm-specific 128-bit wide vector of two packed `i64`.
-    pub struct int64x2_t(2 x pub(crate) i64);
+    pub struct int64x2_t(2 x pub(crate) i64) feature=0;
     /// Arm-specific 128-bit wide vector of two packed `u64`.
-    pub struct uint64x2_t(2 x pub(crate) u64);
+    pub struct uint64x2_t(2 x pub(crate) u64) feature=0;
     /// Arm-specific 128-bit wide vector of two packed `p64`.
-    pub struct poly64x2_t(2 x pub(crate) p64);
+    pub struct poly64x2_t(2 x pub(crate) p64) feature=0;
 }
 
 types! {
     #![unstable(feature = "stdarch_neon_f16", issue = "136306")]
 
     /// Arm-specific 64-bit wide vector of four packed `f16`.
-    pub struct float16x4_t(4 x pub(crate) f16);
+    pub struct float16x4_t(4 x pub(crate) f16) feature=0;
     /// Arm-specific 128-bit wide vector of eight packed `f16`.
-    pub struct float16x8_t(8 x pub(crate) f16);
+    pub struct float16x8_t(8 x pub(crate) f16) feature=0;
 }
 
 /// Arm-specific type containing two `int8x8_t` vectors.

--- a/library/stdarch/crates/core_arch/src/macros.rs
+++ b/library/stdarch/crates/core_arch/src/macros.rs
@@ -59,7 +59,7 @@ macro_rules! types {
         $(
             $(#[$doc:meta])*
             $(stability: [$stability_already: meta])*
-            pub struct $name:ident($len:literal x $v:vis $elem_type:ty);
+            pub struct $name:ident($len:literal x $v:vis $elem_type:ty) $(feature=$target_feature:literal)*;
         )*
     ) => (types! {
         $(
@@ -70,7 +70,7 @@ macro_rules! types {
             $(#[$doc])*
             $(stability: [$stability_already])*
             stability: [$stability_first]
-            pub struct $name($len x $v $elem_type);
+            pub struct $name($len x $v $elem_type) $(feature=$target_feature)*;
         )*
     });
 
@@ -78,14 +78,14 @@ macro_rules! types {
         $(
             $(#[$doc:meta])*
             $(stability: [$stability: meta])+
-            pub struct $name:ident($len:literal x $v:vis $elem_type:ty);
+            pub struct $name:ident($len:literal x $v:vis $elem_type:ty) $(feature=$target_feature:literal)*;
         )*
     ) => ($(
         $(#[$doc])*
         $(#[$stability])+
         #[derive(Copy, Clone)]
         #[allow(non_camel_case_types)]
-        #[repr(simd)]
+        #[repr(simd$(($target_feature))*)]
         #[allow(clippy::missing_inline_in_public_items)]
         pub struct $name($v [$elem_type; $len]);
 

--- a/library/stdarch/crates/core_arch/src/x86/mod.rs
+++ b/library/stdarch/crates/core_arch/src/x86/mod.rs
@@ -56,7 +56,7 @@ types! {
     /// # if is_x86_feature_detected!("sse2") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m128i(2 x i64);
+    pub struct __m128i(2 x i64) feature=2;
 
     /// 128-bit wide set of four `f32` types, x86-specific
     ///
@@ -99,7 +99,7 @@ types! {
     /// # if is_x86_feature_detected!("sse") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m128(4 x f32);
+    pub struct __m128(4 x f32) feature=1;
 
     /// 128-bit wide set of two `f64` types, x86-specific
     ///
@@ -142,7 +142,7 @@ types! {
     /// # if is_x86_feature_detected!("sse2") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m128d(2 x f64);
+    pub struct __m128d(2 x f64) feature=1;
 
     /// 256-bit wide integer vector type, x86-specific
     ///
@@ -189,7 +189,7 @@ types! {
     /// # if is_x86_feature_detected!("avx") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m256i(4 x i64);
+    pub struct __m256i(4 x i64) feature=3;
 
     /// 256-bit wide set of eight `f32` types, x86-specific
     ///
@@ -232,7 +232,7 @@ types! {
     /// # if is_x86_feature_detected!("avx") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m256(8 x f32);
+    pub struct __m256(8 x f32) feature=3;
 
     /// 256-bit wide set of four `f64` types, x86-specific
     ///
@@ -275,7 +275,7 @@ types! {
     /// # if is_x86_feature_detected!("avx") { unsafe { foo() } }
     /// # }
     /// ```
-    pub struct __m256d(4 x f64);
+    pub struct __m256d(4 x f64) feature=3;
 }
 
 types! {
@@ -306,7 +306,7 @@ types! {
     ///
     /// Note that this means that an instance of `__m512i` typically just means
     /// a "bag of bits" which is left up to interpretation at the point of use.
-    pub struct __m512i(8 x i64);
+    pub struct __m512i(8 x i64) feature=4;
 
     /// 512-bit wide set of sixteen `f32` types, x86-specific
     ///
@@ -329,7 +329,7 @@ types! {
     /// Most intrinsics using `__m512` are prefixed with `_mm512_` and are
     /// suffixed with "ps" (or otherwise contain "ps"). Not to be confused with
     /// "pd" which is used for `__m512d`.
-    pub struct __m512(16 x f32);
+    pub struct __m512(16 x f32) feature=4;
 
     /// 512-bit wide set of eight `f64` types, x86-specific
     ///
@@ -352,7 +352,7 @@ types! {
     /// Most intrinsics using `__m512d` are prefixed with `_mm512_` and are
     /// suffixed with "pd" (or otherwise contain "pd"). Not to be confused with
     /// "ps" which is used for `__m512`.
-    pub struct __m512d(8 x f64);
+    pub struct __m512d(8 x f64) feature=4;
 }
 
 types! {
@@ -369,7 +369,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m128bh(8 x u16);
+    pub struct __m128bh(8 x u16) feature=2;
 
     /// 256-bit wide set of 16 `u16` types, x86-specific
     ///
@@ -383,7 +383,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m256bh(16 x u16);
+    pub struct __m256bh(16 x u16) feature=3;
 
     /// 512-bit wide set of 32 `u16` types, x86-specific
     ///
@@ -397,7 +397,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m512bh(32 x u16);
+    pub struct __m512bh(32 x u16) feature=5;
 }
 
 types! {
@@ -415,7 +415,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m128h(8 x f16);
+    pub struct __m128h(8 x f16) feature=2;
 
     /// 256-bit wide set of 16 `f16` types, x86-specific
     ///
@@ -429,7 +429,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m256h(16 x f16);
+    pub struct __m256h(16 x f16) feature=3;
 
     /// 512-bit wide set of 32 `f16` types, x86-specific
     ///
@@ -443,7 +443,7 @@ types! {
     /// there is no padding); however, the alignment is different and equal to
     /// the size of the type. Note that the ABI for function calls may *not* be
     /// the same.
-    pub struct __m512h(32 x f16);
+    pub struct __m512h(32 x f16) feature=5;
 }
 
 /// The BFloat16 type used in AVX-512 intrinsics.

--- a/src/tools/rust-analyzer/crates/hir-def/src/attr.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/attr.rs
@@ -331,7 +331,7 @@ fn parse_rustc_legacy_const_generics(tt: &crate::tt::TopSubtree) -> Box<[u32]> {
 }
 
 fn merge_repr(this: &mut ReprOptions, other: ReprOptions) {
-    let ReprOptions { int, align, pack, flags, field_shuffle_seed: _ } = this;
+    let ReprOptions { int, align, pack, flags, field_shuffle_seed: _, target_feature: _ } = this;
     flags.insert(other.flags);
     *align = (*align).max(other.align);
     *pack = match (*pack, other.pack) {

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -94,7 +94,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 3477539199540094892 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , target_feature: None, field_shuffle_seed: 3477539199540094892 }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
@@ -108,7 +108,7 @@ body:
                                                                                                                 did: DefId(0:3 ~ thir_tree_match[fcf8]::Bar)
                                                                                                                 variants: [VariantDef { def_id: DefId(0:4 ~ thir_tree_match[fcf8]::Bar::First), ctor: Some((Const, DefId(0:5 ~ thir_tree_match[fcf8]::Bar::First::{constructor#0}))), name: "First", discr: Relative(0), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:6 ~ thir_tree_match[fcf8]::Bar::Second), ctor: Some((Const, DefId(0:7 ~ thir_tree_match[fcf8]::Bar::Second::{constructor#0}))), name: "Second", discr: Relative(1), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:8 ~ thir_tree_match[fcf8]::Bar::Third), ctor: Some((Const, DefId(0:9 ~ thir_tree_match[fcf8]::Bar::Third::{constructor#0}))), name: "Third", discr: Relative(2), fields: [], tainted: None, flags:  }]
                                                                                                                 flags: IS_ENUM
-                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 10333377570083945360 }
+                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , target_feature: None, field_shuffle_seed: 10333377570083945360 }
                                                                                                         args: []
                                                                                                         variant_index: 0
                                                                                                         subpatterns: []
@@ -156,7 +156,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 3477539199540094892 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , target_feature: None, field_shuffle_seed: 3477539199540094892 }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
@@ -208,7 +208,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 3477539199540094892 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , target_feature: None, field_shuffle_seed: 3477539199540094892 }
                                                                                         args: []
                                                                                         variant_index: 1
                                                                                         subpatterns: []


### PR DESCRIPTION
A hacky patch for a crater run to determine how widespread breakage would be if SIMD types could only be used in functions appropriately annotated with `target_feature`.

r? @davidtwco