### PR TITLE
Update to LLVM 21

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/20.1-2025-07-13
+	branch = rustc/21.1-2025-08-01
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/src/ci/docker/scripts/build-clang.sh
+++ b/src/ci/docker/scripts/build-clang.sh
@@ -44,8 +44,10 @@ hide_output \
       -DLLVM_INCLUDE_BENCHMARKS=OFF \
       -DLLVM_INCLUDE_TESTS=OFF \
       -DLLVM_INCLUDE_EXAMPLES=OFF \
-      -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt;bolt" \
+      -DLLVM_ENABLE_PROJECTS="clang;lld;bolt" \
+      -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
       -DLLVM_BINUTILS_INCDIR="/rustroot/lib/gcc/$GCC_PLUGIN_TARGET/$GCC_VERSION/plugin/include/" \
+      -DRUNTIMES_CMAKE_ARGS="-DCMAKE_CXX_FLAGS=\"--gcc-toolchain=/rustroot\"" \
       -DC_INCLUDE_DIRS="$INC"
 
 hide_output make -j$(nproc)

--- a/src/ci/docker/scripts/build-clang.sh
+++ b/src/ci/docker/scripts/build-clang.sh
@@ -5,7 +5,7 @@ set -ex
 source shared.sh
 
 # Try to keep the LLVM version here in sync with src/ci/scripts/install-clang.sh
-LLVM=llvmorg-20.1.0-rc2
+LLVM=llvmorg-21.1.0-rc2
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
Timeline: LLVM 21.1.0 is scheduled to release on Aug 26th. Rust 1.90 branches on Aug 1st and releases September 18.

Depends on:
 * [x] https://github.com/llvm/llvm-project/issues/147781
 * [x] https://github.com/llvm/llvm-project/issues/147935
 * [x] https://github.com/llvm/llvm-project/issues/139443
 * [x] https://github.com/llvm/llvm-project/pull/148207
 * [x] https://github.com/llvm/llvm-project/pull/148607
 * [x] https://github.com/llvm/llvm-project/pull/149046
 * [x] https://github.com/llvm/llvm-project/issues/149097
 * [x] https://github.com/rust-lang/rust/pull/144116

r? @ghost