### PR TITLE
Emit warning when search path not found in `-L`

### DIFF
--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -131,7 +131,7 @@ impl SearchPath {
         Self::new(PathKind::All, make_target_lib_path(sysroot, triple))
     }
 
-    pub fn new(kind: PathKind, dir: PathBuf) -> Self {
+    fn new(kind: PathKind, dir: PathBuf) -> Self {
         // Get the files within the directory.
         let mut files = match std::fs::read_dir(&dir) {
             Ok(files) => files

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -124,6 +124,11 @@ impl SearchPath {
             early_dcx.early_fatal("empty search path given via `-L`");
         }
 
+        if !dir.exists() {
+            #[allow(rustc::untranslatable_diagnostic)] // FIXME: make this translatable
+            early_dcx.early_warn(format!("search path `{}` does not exist", dir.display()));
+        }
+
         Self::new(kind, dir)
     }
 

--- a/tests/ui/link-native-libs/search-path-not-found.rs
+++ b/tests/ui/link-native-libs/search-path-not-found.rs
@@ -1,0 +1,4 @@
+//@ check-pass
+//@ compile-flags: -L native=does-not-exist -Link-everything-statically
+
+fn main() {}

--- a/tests/ui/link-native-libs/search-path-not-found.rs
+++ b/tests/ui/link-native-libs/search-path-not-found.rs
@@ -2,3 +2,6 @@
 //@ compile-flags: -L native=does-not-exist -Link-everything-statically
 
 fn main() {}
+
+//~? WARN search path `does-not-exist` does not exist
+//~? WARN search path `ink-everything-statically` does not exist

--- a/tests/ui/link-native-libs/search-path-not-found.stderr
+++ b/tests/ui/link-native-libs/search-path-not-found.stderr
@@ -1,0 +1,4 @@
+warning: search path `does-not-exist` does not exist
+
+warning: search path `ink-everything-statically` does not exist
+


### PR DESCRIPTION
cc rust-lang/rust#142812

r? @wesleywiser 