### PR TITLE
Auto-add `S-waiting-on-author` when the PR is/switches to draft state

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -535,6 +535,9 @@ trigger_files = [
 [autolabel."S-waiting-on-review"]
 new_pr = true
 
+[autolabel."S-waiting-on-author"]
+new_draft = true
+
 [autolabel."needs-triage"]
 new_issue = true
 exclude_labels = [


### PR DESCRIPTION
This PR adds the `S-waiting-on-author` as a `new_draft` when the PR is/switches to draft state.

Related to https://github.com/rust-lang/triagebot/issues/2102 & https://github.com/rust-lang/triagebot/pull/2104

cc @jieyouxu 
r? @Kobzol 
