### PR TITLE
Fix unused_parens false positive

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1062,7 +1062,6 @@ pub(crate) struct UnusedParens {
 /// ```
 /// type Example = Box<dyn Fn() -> &'static dyn Send>;
 /// ```
-#[derive(Copy, Clone)]
 enum NoBoundsException {
     /// The type must be parenthesized.
     None,
@@ -1343,8 +1342,12 @@ impl EarlyLintPass for UnusedParens {
             ast::TyKind::Ref(_, mut_ty) | ast::TyKind::Ptr(mut_ty) => {
                 // If this type itself appears in no-bounds position, we propagate its
                 // potentially tighter constraint or risk a false posive (issue 143653).
-                let own_constraint = self.in_no_bounds_pos.get(&ty.id).copied();
-                let constraint = own_constraint.unwrap_or(NoBoundsException::OneBound);
+                let own_constraint = self.in_no_bounds_pos.get(&ty.id);
+                let constraint = match own_constraint {
+                    Some(NoBoundsException::None) => NoBoundsException::None,
+                    Some(NoBoundsException::OneBound) => NoBoundsException::OneBound,
+                    None => NoBoundsException::OneBound,
+                };
                 self.in_no_bounds_pos.insert(mut_ty.ty.id, constraint);
             }
             ast::TyKind::TraitObject(bounds, _) | ast::TyKind::ImplTrait(_, bounds) => {

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.fixed
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.fixed
@@ -7,6 +7,6 @@ trait MyTrait {}
 fn foo(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait) + Send + Sync>) {}
 
 //~v ERROR unnecessary parentheses around type
-fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+fn bar(_: Box<dyn FnMut(&mut u32) -> &mut dyn MyTrait>) {}
 
 fn main() {}

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.rs
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+
+#![deny(unused_parens)]
+#![allow(warnings)]
+trait MyTrait {}
+
+fn foo(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait) + Send + Sync>) {}
+
+fn main() {}

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.stderr
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.stderr
@@ -1,0 +1,19 @@
+error: unnecessary parentheses around type
+  --> $DIR/unused-parens-false-positive-issue-143653.rs:10:43
+   |
+LL | fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+   |                                           ^           ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-false-positive-issue-143653.rs:3:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL - fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+LL + fn bar(_: Box<dyn FnMut(&mut u32) -> &mut dyn MyTrait>) {}
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Resolves rust-lang/rust#143653.

The "no bounds exception" was indiscriminately set to `OneBound` for referents and pointees. However, if the reference or pointer type itself appears in no-bounds position, any constraints it has must be propagated.

```rust
// unused parens: not in no-bounds position
fn foo(_: Box<(dyn Send)>) {}

// unused parens: in no-bounds position, but one-bound exception applies
fn bar(_: Box<dyn Fn(&u32) -> &(dyn Send)>) {} 

// *NOT* unused parens: in no-bounds position, but no exceptions to be made
fn baz(_: Box<dyn Fn(&u32) -> &(dyn Send) + Send>) {}
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
