### PR TITLE
Add a mailmap entry for gnzlbg

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -255,6 +255,7 @@ Guillaume Gomez <guillaume1.gomez@gmail.com>
 Guillaume Gomez <guillaume1.gomez@gmail.com> ggomez <ggomez@ggo.ifr.lan>
 Guillaume Gomez <guillaume1.gomez@gmail.com> Guillaume Gomez <ggomez@ggo.ifr.lan>
 Guillaume Gomez <guillaume1.gomez@gmail.com> Guillaume Gomez <guillaume.gomez@huawei.com>
+gnzlbg <gonzalobg88@gmail.com> <gnzlbg@users.noreply.github.com>
 hamidreza kalbasi <hamidrezakalbasi@protonmail.com>
 Hanna Kruppe <hanna.kruppe@gmail.com> <robin.kruppe@gmail.com>
 Heather <heather@cynede.net> <Cynede@Gentoo.org>


### PR DESCRIPTION
The submodule->subtree changes add a lot of commits with the GitHub email.

<!-- homu-ignore:start -->
r? @gnzlbg
<!-- homu-ignore:end -->
