### PR TITLE
fix spelling errors unused-assoc-fns.rs

### DIFF
--- a/tests/ui/lint/dead-code/unused-assoc-fns.rs
+++ b/tests/ui/lint/dead-code/unused-assoc-fns.rs
@@ -10,7 +10,7 @@ impl Foo {
 
     fn two(&self) {}
 
-    // seperation between items
+    // separation between items
     // ...
     // ...
 
@@ -18,7 +18,7 @@ impl Foo {
 
     const CONSTANT: usize = 5;
 
-    // more seperation
+    // more separation
     // ...
     // ...
 


### PR DESCRIPTION
`seperation` - `separation` x2