### PR TITLE
Change bootstrap's `tool.TOOL_NAME.features` to work on any subcommand

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -392,7 +392,8 @@
 # For example, to build Miri with tracing support, use `tool.miri.features = ["tracing"]`
 #
 # The default value for the `features` array is `[]`. However, please note that other flags in
-# `bootstrap.toml` might influence the features enabled for some tools.
+# `bootstrap.toml` might influence the features enabled for some tools. Also, enabling features
+# in tools which are not part of the internal "extra-features" preset might not always work.
 #build.tool.TOOL_NAME.features = [FEATURE1, FEATURE2]
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose, 3 == print environment variables on each rustc invocation

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -9,6 +9,7 @@
 //! Each Rust tool **MUST** utilize `ToolBuild` inside their `Step` logic,
 //! return `ToolBuildResult` and should never prepare `cargo` invocations manually.
 
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -258,7 +259,7 @@ pub fn prepare_tool_cargo(
         .config
         .tool
         .iter()
-        .filter(|(tool_name, _)| path.ends_with(tool_name))
+        .filter(|(tool_name, _)| path.file_name().and_then(OsStr::to_str) == Some(tool_name))
         .for_each(|(_, tool)| features.extend(tool.features.clone().unwrap_or_default()));
 
     // clippy tests need to know about the stage sysroot. Set them consistently while building to

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -471,4 +471,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "A --compile-time-deps flag has been added to reduce the time it takes rust-analyzer to start",
     },
+    ChangeInfo {
+        change_id: 143733,
+        severity: ChangeSeverity::Info,
+        summary: "Option `tool.TOOL_NAME.features` now works on any subcommand, not just `build`.",
+    },
 ];


### PR DESCRIPTION
This is a followup to rust-lang/rust#142379 to make the bootstrap option `tool.TOOL_NAME.features` work on any subcommand instead of just build (so also run/test/...). The `TOOL_NAME` comparisons look at the last part of a tool's path to determine to which tool a `TOOL_NAME` refers to.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
