### PR TITLE
Give all bytes of TypeId provenance

### DIFF
--- a/tests/ui/consts/const_transmute_type_id3.rs
+++ b/tests/ui/consts/const_transmute_type_id3.rs
@@ -1,3 +1,6 @@
+//! Test that all bytes of a TypeId must have the
+//! TypeId marker provenance.
+
 #![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
@@ -10,7 +13,7 @@ const _: () = {
         std::ptr::write(ptr.offset(1), 999);
     }
     assert!(a == b);
-    //~^ ERROR: one of the TypeId arguments is invalid, the hash does not match the type it represents
+    //~^ ERROR: pointer must point to some allocation
 };
 
 fn main() {}

--- a/tests/ui/consts/const_transmute_type_id5.rs
+++ b/tests/ui/consts/const_transmute_type_id5.rs
@@ -1,0 +1,21 @@
+//! Test that we require an equal TypeId to have the same integer
+//! part, even if the provenance matches.
+
+#![feature(const_type_id, const_trait_impl, const_cmp)]
+
+use std::any::TypeId;
+
+const _: () = {
+    let a = TypeId::of::<()>();
+    let mut b = TypeId::of::<()>();
+    unsafe {
+        let ptr = &mut b as *mut TypeId as *mut *const ();
+        // Copy the ptr at index 0 to index 1
+        let val = std::ptr::read(ptr);
+        std::ptr::write(ptr.offset(1), val);
+    }
+    assert!(a == b);
+    //~^ ERROR: type_id_eq: one of the TypeId arguments is invalid, chunk 1 of the hash does not match the type it represents
+};
+
+fn main() {}

--- a/tests/ui/consts/const_transmute_type_id5.stderr
+++ b/tests/ui/consts/const_transmute_type_id5.stderr
@@ -1,5 +1,5 @@
-error[E0080]: pointer not dereferenceable: pointer must point to some allocation, but got 0x3e7[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/const_transmute_type_id3.rs:15:13
+error[E0080]: type_id_eq: one of the TypeId arguments is invalid, chunk 1 of the hash does not match the type it represents
+  --> $DIR/const_transmute_type_id5.rs:17:13
    |
 LL |     assert!(a == b);
    |             ^^^^^^ evaluation of `_` failed inside this call


### PR DESCRIPTION
This makes all bytes of TypeId uninspectable at compile-time.

For context see https://github.com/rust-lang/rust/issues/77125#issuecomment-3057049217

r? @RalfJung 