### PR TITLE
Properly track the depth when expanding free alias types

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1052,9 +1052,11 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for FreeAliasTypeExpander<'tcx> {
         }
 
         self.depth += 1;
-        ensure_sufficient_stack(|| {
+        let ty = ensure_sufficient_stack(|| {
             self.tcx.type_of(alias.def_id).instantiate(self.tcx, alias.args).fold_with(self)
-        })
+        });
+        self.depth -= 1;
+        ty
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {

--- a/tests/ui/lazy-type-alias/deep-expansion.rs
+++ b/tests/ui/lazy-type-alias/deep-expansion.rs
@@ -1,0 +1,20 @@
+// In several type analysis passes we employ a specialized expansion procedure.
+// This procedure used to incorrectly track expansion depth (growing much faster
+// than normalization depth) resulting in its internal assertion triggering.
+//
+// issue: <https://github.com/rust-lang/rust/issues/142419>
+//@ check-pass
+#![feature(lazy_type_alias)]
+#![expect(incomplete_features)]
+
+type T0 = (T1, T1, T1, T1);
+type T1 = (T2, T2, T2, T2);
+type T2 = (T3, T3, T3, T3);
+type T3 = (T4, T4, T4, T4);
+type T4 = (T5, T5, T5, T5);
+type T5 = (T6, T6, T6, T6);
+type T6 = (T7, T7, T7, T7);
+type T7 = ();
+
+fn accept(_: T0) {}
+fn main() {}


### PR DESCRIPTION
Decrease the depth after the fold so as not to affect the depth for unrelated same-level constituent types. My bad.

Fixes rust-lang/rust#142419.