### PR TITLE
Fix typos in function names in the `target_feature` test

### DIFF
--- a/tests/rustdoc-json/attrs/target_feature.rs
+++ b/tests/rustdoc-json/attrs/target_feature.rs
@@ -6,17 +6,17 @@
 pub fn test1() {}
 
 //@ is "$.index[?(@.name=='test2')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ is "$.index[?(@.name=='test2')].inner.function.header.is_unsafe" false
 #[target_feature(enable = "avx,avx2")]
 pub fn test2() {}
 
 //@ is "$.index[?(@.name=='test3')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ is "$.index[?(@.name=='test3')].inner.function.header.is_unsafe" false
 #[target_feature(enable = "avx", enable = "avx2")]
 pub fn test3() {}
 
 //@ is "$.index[?(@.name=='test4')].attrs" '["#[target_feature(enable=\"avx\", enable=\"avx2\", enable=\"avx512f\")]"]'
-//@ is "$.index[?(@.name=='test1')].inner.function.header.is_unsafe" false
+//@ is "$.index[?(@.name=='test4')].inner.function.header.is_unsafe" false
 #[target_feature(enable = "avx", enable = "avx2,avx512f")]
 pub fn test4() {}
 


### PR DESCRIPTION
Seems like `test1` was copy-pasted but forgotten to be renamed after.