### PR TITLE
Allow the global alloc one TLS slot with a destructor

### DIFF
--- a/tests/ui/threads-sendsync/tls-in-global-alloc.rs
+++ b/tests/ui/threads-sendsync/tls-in-global-alloc.rs
@@ -1,0 +1,48 @@
+//@ run-pass
+//@ needs-threads
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static GLOBAL: AtomicUsize = AtomicUsize::new(0);
+
+struct Local;
+
+thread_local! {
+    static LOCAL: Local = {
+        GLOBAL.fetch_or(1, Ordering::Relaxed);
+        Local
+    };
+}
+
+impl Drop for Local {
+    fn drop(&mut self) {
+        GLOBAL.fetch_or(2, Ordering::Relaxed);
+    }
+}
+
+#[global_allocator]
+static ALLOC: Alloc = Alloc;
+struct Alloc;
+
+unsafe impl GlobalAlloc for Alloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        LOCAL.with(|_local| {});
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LOCAL.with(|_local| {});
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+fn main() {
+    std::thread::spawn(|| {
+        std::hint::black_box(vec![1, 2]);
+        assert!(GLOBAL.load(Ordering::Relaxed) == 1);
+    })
+    .join()
+    .unwrap();
+    assert!(GLOBAL.load(Ordering::Relaxed) == 3);
+}


### PR DESCRIPTION
This is an improvement over https://github.com/rust-lang/rust/pull/116402, which fixed an unsoundness by simply disallowing the global allocator from creating any thread-local variables with destructors. Instead of doing that, with this PR the global allocator is allowed to create exactly **one** thread-local variable with a destructor.

This is actually already a huge improvement over the status quo, as a single thread-local variable with a destructor is sufficient to store arbitrary amounts of thread-local data while allowing cleanup on thread exit.