### PR TITLE
std: move NuttX to use arc4random for random number generation

### DIFF
--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -20,6 +20,7 @@ cfg_if::cfg_if! {
         target_os = "rtems",
         target_os = "solaris",
         target_os = "vita",
+        target_os = "nuttx",
     ))] {
         mod arc4random;
         pub use arc4random::fill_bytes;
@@ -44,7 +45,6 @@ cfg_if::cfg_if! {
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",
-        target_os = "nuttx",
     ))] {
         mod unix_legacy;
         pub use unix_legacy::fill_bytes;


### PR DESCRIPTION
arc4random support in libc merged in https://github.com/rust-lang/libc/pull/4464, so:

* Move `target_os = "nuttx"` from unix_legacy to arc4random section
* This aligns NuttX with other POSIX-compliant systems that support arc4random
* Improves random number generation quality on NuttX by using the system's built-in arc4random implementation instead of legacy fallback methods

NuttX supports arc4random_buf which provides better entropy and security compared to the legacy random number generation methods.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
