### PR TITLE
Disambiguate between rustc vs std having debug assertions in `run-make-support` and `run-make` tests

### DIFF
--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -225,6 +225,19 @@ impl TestCx<'_> {
             cmd.env("RUNNER", runner);
         }
 
+        // Guard against externally-set env vars.
+        cmd.env_remove("__RUSTC_DEBUG_ASSERTIONS_ENABLED");
+        if self.config.with_rustc_debug_assertions {
+            // Used for `run_make_support::env::rustc_debug_assertions_enabled`.
+            cmd.env("__RUSTC_DEBUG_ASSERTIONS_ENABLED", "1");
+        }
+
+        cmd.env_remove("__STD_DEBUG_ASSERTIONS_ENABLED");
+        if self.config.with_std_debug_assertions {
+            // Used for `run_make_support::env::std_debug_assertions_enabled`.
+            cmd.env("__STD_DEBUG_ASSERTIONS_ENABLED", "1");
+        }
+
         // We don't want RUSTFLAGS set from the outside to interfere with
         // compiler flags set in the test cases:
         cmd.env_remove("RUSTFLAGS");

--- a/src/tools/run-make-support/src/env.rs
+++ b/src/tools/run-make-support/src/env.rs
@@ -18,11 +18,20 @@ pub fn env_var_os(name: &str) -> OsString {
     }
 }
 
-/// Check if `NO_DEBUG_ASSERTIONS` is set (usually this may be set in CI jobs).
+/// Check if staged `rustc`-under-test was built with debug assertions.
 #[track_caller]
 #[must_use]
-pub fn no_debug_assertions() -> bool {
-    std::env::var_os("NO_DEBUG_ASSERTIONS").is_some()
+pub fn rustc_debug_assertions_enabled() -> bool {
+    // Note: we assume this env var is set when the test recipe is being executed.
+    std::env::var_os("__RUSTC_DEBUG_ASSERTIONS_ENABLED").is_some()
+}
+
+/// Check if staged `std`-under-test was built with debug assertions.
+#[track_caller]
+#[must_use]
+pub fn std_debug_assertions_enabled() -> bool {
+    // Note: we assume this env var is set when the test recipe is being executed.
+    std::env::var_os("__STD_DEBUG_ASSERTIONS_ENABLED").is_some()
 }
 
 /// A wrapper around [`std::env::set_current_dir`] which includes the directory

--- a/tests/run-make/fmt-write-bloat/rmake.rs
+++ b/tests/run-make/fmt-write-bloat/rmake.rs
@@ -18,7 +18,7 @@
 //@ ignore-cross-compile
 
 use run_make_support::artifact_names::bin_name;
-use run_make_support::env::no_debug_assertions;
+use run_make_support::env::std_debug_assertions_enabled;
 use run_make_support::rustc;
 use run_make_support::symbols::any_symbol_contains;
 
@@ -26,7 +26,7 @@ fn main() {
     rustc().input("main.rs").opt().run();
     // panic machinery identifiers, these should not appear in the final binary
     let mut panic_syms = vec!["panic_bounds_check", "Debug"];
-    if no_debug_assertions() {
+    if std_debug_assertions_enabled() {
         // if debug assertions are allowed, we need to allow these,
         // otherwise, add them to the list of symbols to deny.
         panic_syms.extend_from_slice(&["panicking", "panic_fmt", "pad_integral", "Display"]);


### PR DESCRIPTION
`NO_DEBUG_ASSERTIONS` is set by CI that threads through to the `./configure.py` script, which is somewhat fragile and "spooky action at a distance". For `fmt-write-bloat`, this is actually wrong because the test wants to gate on *std* being built with debug assertions or not, whereas `NO_DEBUG_ASSERTIONS` determines *rustc* being built with debug assertions or not. Instead, use env vars controlled by compiletest, whose debug assertion info comes from bootstrap.

https://github.com/rust-lang/rust/blob/855e0fe46e68d94e9f6147531b75ac2d488c548e/src/ci/run.sh#L137-L146

`NO_DEBUG_ASSERTIONS` controls `--enable-debug-assertions`

https://github.com/rust-lang/rust/blob/855e0fe46e68d94e9f6147531b75ac2d488c548e/src/bootstrap/configure.py#L124

which sets `--rust.debug-assertions`, which controls *rustc* debug assertions.

https://github.com/rust-lang/rust/blob/855e0fe46e68d94e9f6147531b75ac2d488c548e/src/bootstrap/configure.py#L125-L129

`--rust.debug-assertions-std` controls *std* debug assertions.

Noticed while investigating `fmt-write-bloat` in https://github.com/rust-lang/rust/pull/143669#discussion_r2200522215.

Best reviewed commit-by-commit.

r? @ChrisDenton (or compiler/bootstrap)
