### PR TITLE
Fix fallback for CI_JOB_NAME

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -361,7 +361,7 @@ docker \
   --env TOOLSTATE_REPO \
   --env TOOLSTATE_PUBLISH \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
-  --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
+  --env CI_JOB_NAME="${CI_JOB_NAME-$image}" \
   --env CI_JOB_DOC_URL="${CI_JOB_DOC_URL}" \
   --env BASE_COMMIT="$BASE_COMMIT" \
   --env DIST_TRY_BUILD \


### PR DESCRIPTION
If CI_JOB_NAME is not specified, it's supposed to fall back to the image name, which is `$image`, not `$IMAGE`.

Failing to set the correct CI_JOB_NAME causes failures when running `dist-ohos-*` images locally.
