### PR TITLE
Update GitHub Actions Cache to v4

### DIFF
--- a/compiler/rustc_codegen_gcc/.github/workflows/ci.yml
+++ b/compiler/rustc_codegen_gcc/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests
       #if: ${{ contains(matrix.commands, 'rustc') }}
-      #uses: actions/cache@v3
+      #uses: actions/cache@v4
       #id: cache-rust-repository
       #with:
         #path: rust

--- a/compiler/rustc_codegen_gcc/.github/workflows/failures.yml
+++ b/compiler/rustc_codegen_gcc/.github/workflows/failures.yml
@@ -74,7 +74,7 @@ jobs:
         echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
 
     #- name: Cache rust repository
-      #uses: actions/cache@v3
+      #uses: actions/cache@v4
       #id: cache-rust-repository
       #with:
         #path: rust

--- a/compiler/rustc_codegen_gcc/.github/workflows/gcc12.yml
+++ b/compiler/rustc_codegen_gcc/.github/workflows/gcc12.yml
@@ -60,7 +60,7 @@ jobs:
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests
       #if: ${{ contains(matrix.commands, 'rustc') }}
-      #uses: actions/cache@v3
+      #uses: actions/cache@v4
       #id: cache-rust-repository
       #with:
         #path: rust

--- a/compiler/rustc_codegen_gcc/.github/workflows/m68k.yml
+++ b/compiler/rustc_codegen_gcc/.github/workflows/m68k.yml
@@ -71,7 +71,7 @@ jobs:
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests
       #if: ${{ contains(matrix.commands, 'rustc') }}
-      #uses: actions/cache@v3
+      #uses: actions/cache@v4
       #id: cache-rust-repository
       #with:
         #path: rust


### PR DESCRIPTION


---


## Description
This pull request updates the commented cache action references in all relevant GitHub workflow files from `actions/cache@v3` to `actions/cache@v4` for improved performance and compatibility.

- Updated: `ci.yml`, `failures.yml`, `gcc12.yml`, `m68k.yml`


---


