### PR TITLE
Opaque type collection: Guard against endlessly recursing free alias types

### DIFF
--- a/tests/ui/lazy-type-alias/opaq-ty-collection-infinite-recur.rs
+++ b/tests/ui/lazy-type-alias/opaq-ty-collection-infinite-recur.rs
@@ -1,0 +1,18 @@
+// The opaque type collector used to expand free alias types (in situ) without guarding against
+// endlessly recursing aliases which lead to the compiler overflowing its stack in certain
+// situations.
+//
+// In most situations we wouldn't even reach the collector when there's an overflow because we
+// would've already bailed out early during the item's wfcheck due to the normalization failure.
+//
+// In the case below however, while collecting the opaque types defined by the AnonConst, we
+// descend into its nested items (here: type alias `Recur`) to acquire their opaque types --
+// meaning we get there before we wfcheck `Recur`.
+//
+// issue: <https://github.com/rust-lang/rust/issues/131994>
+#![feature(lazy_type_alias)]
+#![expect(incomplete_features)]
+
+struct Hold([(); { type Recur = Recur; 0 }]); //~ ERROR overflow normalizing the type alias `Recur`
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/opaq-ty-collection-infinite-recur.stderr
+++ b/tests/ui/lazy-type-alias/opaq-ty-collection-infinite-recur.stderr
@@ -1,0 +1,11 @@
+error[E0275]: overflow normalizing the type alias `Recur`
+  --> $DIR/opaq-ty-collection-infinite-recur.rs:16:20
+   |
+LL | struct Hold([(); { type Recur = Recur; 0 }]);
+   |                    ^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
See test description for technical details.

Fixes https://github.com/rust-lang/rust/issues/131994.

r? oli-obk (sry, your queue is large, so no rush & feel free to reassign)