### PR TITLE
Remove format short command trait

### DIFF
--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -76,8 +76,10 @@ pub struct CommandFingerprint {
     cwd: Option<PathBuf>,
 }
 
-impl FormatShortCmd for CommandFingerprint {
-    fn format_short_cmd(&self) -> String {
+impl CommandFingerprint {
+    /// Helper method to format both Command and BootstrapCommand as a short execution line,
+    /// without all the other details (e.g. environment variables).
+    pub fn format_short_cmd(&self) -> String {
         let program = Path::new(&self.program);
         let mut line = vec![program.file_name().unwrap().to_str().unwrap().to_owned()];
         line.extend(self.args.iter().map(|arg| arg.to_string_lossy().into_owned()));
@@ -542,29 +544,6 @@ impl Default for CommandOutput {
             stdout: Some(vec![]),
             stderr: Some(vec![]),
         }
-    }
-}
-
-/// Helper trait to format both Command and BootstrapCommand as a short execution line,
-/// without all the other details (e.g. environment variables).
-pub trait FormatShortCmd {
-    fn format_short_cmd(&self) -> String;
-}
-
-#[cfg(feature = "tracing")]
-impl FormatShortCmd for BootstrapCommand {
-    fn format_short_cmd(&self) -> String {
-        self.command.format_short_cmd()
-    }
-}
-
-#[cfg(feature = "tracing")]
-impl FormatShortCmd for Command {
-    fn format_short_cmd(&self) -> String {
-        let program = Path::new(self.get_program());
-        let mut line = vec![program.file_name().unwrap().to_str().unwrap()];
-        line.extend(self.get_args().map(|arg| arg.to_str().unwrap()));
-        line.join(" ")
     }
 }
 

--- a/src/bootstrap/src/utils/tracing.rs
+++ b/src/bootstrap/src/utils/tracing.rs
@@ -52,8 +52,6 @@ macro_rules! error {
 macro_rules! trace_cmd {
     ($cmd:expr) => {
         {
-            use $crate::utils::exec::FormatShortCmd;
-
             ::tracing::span!(
                 target: "COMMAND",
                 ::tracing::Level::TRACE,

--- a/src/bootstrap/src/utils/tracing.rs
+++ b/src/bootstrap/src/utils/tracing.rs
@@ -58,7 +58,7 @@ macro_rules! trace_cmd {
                 target: "COMMAND",
                 ::tracing::Level::TRACE,
                 "executing command",
-                cmd = $cmd.format_short_cmd(),
+                cmd = $cmd.fingerprint().format_short_cmd(),
                 full_cmd = ?$cmd
             ).entered()
         }


### PR DESCRIPTION
Since we no longer have traces of the vanilla command, and we're already implementing format_short_command for CommandFingerprint, we can use it directly from the fingerprint. This PR removes the standalone format_short_command trait and moves its implementation under CommandFingerprint.