### PR TITLE
New tracking issues for const_ops and const_cmp

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -248,7 +248,7 @@ use crate::ops::ControlFlow;
 )]
 #[rustc_diagnostic_item = "PartialEq"]
 #[const_trait]
-#[rustc_const_unstable(feature = "const_trait_impl", issue = "67792")]
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 pub trait PartialEq<Rhs: PointeeSized = Self>: PointeeSized {
     /// Tests for `self` and `other` values to be equal, and is used by `==`.
     #[must_use]
@@ -1809,7 +1809,7 @@ mod impls {
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
-            #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
             impl const PartialEq for $t {
                 #[inline]
                 fn eq(&self, other: &Self) -> bool { *self == *other }
@@ -2017,7 +2017,7 @@ mod impls {
     // & pointers
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
     impl<A: PointeeSized, B: PointeeSized> const PartialEq<&B> for &A
     where
         A: ~const PartialEq<B>,
@@ -2089,7 +2089,7 @@ mod impls {
     // &mut pointers
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
     impl<A: PointeeSized, B: PointeeSized> const PartialEq<&mut B> for &mut A
     where
         A: ~const PartialEq<B>,
@@ -2159,7 +2159,7 @@ mod impls {
     impl<A: PointeeSized> Eq for &mut A where A: Eq {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
     impl<A: PointeeSized, B: PointeeSized> const PartialEq<&mut B> for &A
     where
         A: ~const PartialEq<B>,
@@ -2175,7 +2175,7 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "92391")]
+    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
     impl<A: PointeeSized, B: PointeeSized> const PartialEq<&B> for &mut A
     where
         A: ~const PartialEq<B>,

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -65,7 +65,7 @@
 /// ```
 #[lang = "add"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+#[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 #[rustc_on_unimplemented(
     on(all(Self = "{integer}", Rhs = "{float}"), message = "cannot add a float to an integer",),
     on(all(Self = "{float}", Rhs = "{integer}"), message = "cannot add an integer to a float",),
@@ -96,7 +96,7 @@ pub trait Add<Rhs = Self> {
 macro_rules! add_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Add for $t {
             type Output = $t;
 
@@ -179,7 +179,7 @@ add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
 /// ```
 #[lang = "sub"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+#[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 #[rustc_on_unimplemented(
     message = "cannot subtract `{Rhs}` from `{Self}`",
     label = "no implementation for `{Self} - {Rhs}`",
@@ -208,7 +208,7 @@ pub trait Sub<Rhs = Self> {
 macro_rules! sub_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Sub for $t {
             type Output = $t;
 
@@ -313,7 +313,7 @@ sub_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
 /// ```
 #[lang = "mul"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+#[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 #[diagnostic::on_unimplemented(
     message = "cannot multiply `{Self}` by `{Rhs}`",
     label = "no implementation for `{Self} * {Rhs}`"
@@ -341,7 +341,7 @@ pub trait Mul<Rhs = Self> {
 macro_rules! mul_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Mul for $t {
             type Output = $t;
 
@@ -450,7 +450,7 @@ mul_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f16 f32 f64 f128
 /// ```
 #[lang = "div"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+#[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 #[diagnostic::on_unimplemented(
     message = "cannot divide `{Self}` by `{Rhs}`",
     label = "no implementation for `{Self} / {Rhs}`"
@@ -484,7 +484,7 @@ macro_rules! div_impl_integer {
         ///
         #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Div for $t {
             type Output = $t;
 
@@ -505,7 +505,7 @@ div_impl_integer! {
 macro_rules! div_impl_float {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Div for $t {
             type Output = $t;
 
@@ -556,7 +556,7 @@ div_impl_float! { f16 f32 f64 f128 }
 /// ```
 #[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+#[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 #[diagnostic::on_unimplemented(
     message = "cannot calculate the remainder of `{Self}` divided by `{Rhs}`",
     label = "no implementation for `{Self} % {Rhs}`"
@@ -590,7 +590,7 @@ macro_rules! rem_impl_integer {
         ///
         #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Rem for $t {
             type Output = $t;
 
@@ -626,7 +626,7 @@ macro_rules! rem_impl_float {
         /// assert_eq!(x % y, remainder);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
         impl const Rem for $t {
             type Output = $t;
 

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -1,6 +1,6 @@
 #![feature(const_type_id)]
 #![feature(generic_const_exprs)]
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 #![feature(core_intrinsics)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/consts/const_cmp_type_id.rs
+++ b/tests/ui/consts/const_cmp_type_id.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-#![feature(const_type_id, const_trait_impl)]
+#![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id.rs
+++ b/tests/ui/consts/const_transmute_type_id.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl)]
+#![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id2.rs
+++ b/tests/ui/consts/const_transmute_type_id2.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "0x(ff)+" -> "<u128::MAX>"
 
-#![feature(const_type_id, const_trait_impl)]
+#![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id3.rs
+++ b/tests/ui/consts/const_transmute_type_id3.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl)]
+#![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id4.rs
+++ b/tests/ui/consts/const_transmute_type_id4.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl)]
+#![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/issue-73976-monomorphic.rs
+++ b/tests/ui/consts/issue-73976-monomorphic.rs
@@ -8,6 +8,7 @@
 #![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_trait_impl)]
+#![feature(const_cmp)]
 
 use std::any::{self, TypeId};
 

--- a/tests/ui/consts/issue-90870.rs
+++ b/tests/ui/consts/issue-90870.rs
@@ -3,9 +3,9 @@
 #![allow(dead_code)]
 
 const fn f(a: &u8, b: &u8) -> bool {
-    //~^ HELP: add `#![feature(const_trait_impl)]` to the crate attributes to enable
-    //~| HELP: add `#![feature(const_trait_impl)]` to the crate attributes to enable
-    //~| HELP: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+    //~^ HELP: add `#![feature(const_cmp)]` to the crate attributes to enable
+    //~| HELP: add `#![feature(const_cmp)]` to the crate attributes to enable
+    //~| HELP: add `#![feature(const_cmp)]` to the crate attributes to enable
     a == b
     //~^ ERROR: cannot call conditionally-const operator in constant functions
     //~| ERROR: `PartialEq` is not yet stable as a const trait

--- a/tests/ui/consts/issue-90870.stderr
+++ b/tests/ui/consts/issue-90870.stderr
@@ -19,9 +19,9 @@ error: `PartialEq` is not yet stable as a const trait
 LL |     a == b
    |     ^^^^^^
    |
-help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+help: add `#![feature(const_cmp)]` to the crate attributes to enable
    |
-LL + #![feature(const_trait_impl)]
+LL + #![feature(const_cmp)]
    |
 
 error[E0658]: cannot call conditionally-const operator in constant functions
@@ -45,9 +45,9 @@ error: `PartialEq` is not yet stable as a const trait
 LL |     a == b
    |     ^^^^^^
    |
-help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+help: add `#![feature(const_cmp)]` to the crate attributes to enable
    |
-LL + #![feature(const_trait_impl)]
+LL + #![feature(const_cmp)]
    |
 
 error[E0658]: cannot call conditionally-const operator in constant functions
@@ -71,9 +71,9 @@ error: `PartialEq` is not yet stable as a const trait
 LL |         if l == r {
    |            ^^^^^^
    |
-help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+help: add `#![feature(const_cmp)]` to the crate attributes to enable
    |
-LL + #![feature(const_trait_impl)]
+LL + #![feature(const_cmp)]
    |
 
 error: aborting due to 6 previous errors

--- a/tests/ui/traits/const-traits/call-const-trait-method-pass.rs
+++ b/tests/ui/traits/const-traits/call-const-trait-method-pass.rs
@@ -1,4 +1,4 @@
-#![feature(const_trait_impl, const_ops)]
+#![feature(const_trait_impl, const_ops, const_cmp)]
 //@ check-pass
 
 struct Int(i32);

--- a/tests/ui/traits/const-traits/call-generic-in-impl.rs
+++ b/tests/ui/traits/const-traits/call-generic-in-impl.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 #[const_trait]
 trait MyPartialEq {

--- a/tests/ui/traits/const-traits/call-generic-method-chain.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.rs
@@ -3,7 +3,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 struct S;
 

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 struct S;
 

--- a/tests/ui/traits/const-traits/call-generic-method-fail.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-fail.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 pub const fn equals_self<T: PartialEq>(t: &T) -> bool {
     *t == *t

--- a/tests/ui/traits/const-traits/call-generic-method-pass.rs
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.rs
@@ -3,7 +3,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 struct S;
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-with-params.rs
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-with-params.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
 #![feature(derive_const)]
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_cmp)]
 
 #[derive_const(PartialEq)]
 pub struct Reverse<T>(T);


### PR DESCRIPTION
Let's do a clean start with new tracking issues to avoid mixing things up with the previous constification.

I assume the fact that the `PartialEq` *trait* and *impls* used different feature names  was a mistake (the feature name on the impl is entirely irrelevant anyway).

Part of https://github.com/rust-lang/rust/issues/143800, https://github.com/rust-lang/rust/issues/143802

r? @oli-obk 