### PR TITLE
Docs: Adding document to push method in string.rs

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1392,6 +1392,8 @@ impl String {
 
     /// Appends the given [`char`] to the end of this `String`.
     ///
+    /// Note: When pushing a char, it is automatically converted to its UTF-8 byte representation since Rust strings are UTF-8 encoded.
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1392,7 +1392,7 @@ impl String {
 
     /// Appends the given [`char`] to the end of this `String`.
     ///
-    /// Note: When pushing a char, it is automatically converted to its UTF-8 byte representation since Rust strings are UTF-8 encoded.
+    ///  Since Rust strings are UTF-8 encoded, the pushed char will automatically converted to its UTF-8 byte representation.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This PR aims to resolve issue rust-lang/rust#143677 by adding an extra comment line to clarify that when inserting a 4-byte character, it is converted to UTF-8.

This PR does not modify any other part of the code and therefore will not cause any runtime issues.