### PR TITLE
clippy: fix test filtering when TESTNAME is empty

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -680,9 +680,9 @@ impl Step for CargoMiri {
                 cargo.arg("--doc");
             }
         }
-
-        // Finally, pass test-args and run everything.
         cargo.arg("--").args(builder.config.test_args());
+
+        // Finally, run everything.
         let mut cargo = BootstrapCommand::from(cargo);
         {
             let _guard = builder.msg_sysroot_tool(Kind::Test, stage, "cargo-miri", host, target);

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -144,8 +144,17 @@ impl TestContext {
         let target_dir = PathBuf::from(var_os("CARGO_TARGET_DIR").unwrap_or_else(|| "target".into()));
         let mut config = Config {
             output_conflict_handling: error_on_output_conflict,
+            // Pre-fill filters with TESTNAME; will be later extended with `self.args`.
             filter_files: env::var("TESTNAME")
-                .map(|filters| filters.split(',').map(str::to_string).collect())
+                .map(|filters| {
+                    filters
+                        .split(',')
+                        // Make sure that if TESTNAME is empty we produce the empty list here,
+                        // not a list containing an empty string.
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
                 .unwrap_or_default(),
             target: None,
             bless_command: Some(if IS_RUSTC_TEST_SUITE {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/143824. Turns out bootstrap was just fine, the TESTNAME logic in clippy was wrong... I still made this a rustc PR as that's where I did all the debugging.

The bootstrap change is not really related, but it's comment-only so not worth a separate PR... adding the `test_args` is also part of what `prepare_cargo_test` would usually do so let's group the code properly.