### PR TITLE
Fix command trace

### DIFF
--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -861,12 +861,16 @@ impl<'a> DeferredCommand<'a> {
                 executed_at,
                 fingerprint,
                 start_time,
-                ..
+                #[cfg(feature = "tracing")]
+                _span_guard,
             } => {
                 let exec_ctx = exec_ctx.as_ref();
 
                 let output =
                     Self::finish_process(process, command, stdout, stderr, executed_at, exec_ctx);
+
+                #[cfg(feature = "tracing")]
+                drop(_span_guard);
 
                 if (!exec_ctx.dry_run() || command.run_in_dry_run)
                     && output.status().is_some()


### PR DESCRIPTION
With the recent developments in centralization of command execution, we somehow broke the traces for command execution. This PR fixes that and add trace to stream command execution as well.

r? @Kobzol 