### PR TITLE
Ports `#[macro_use]` and `#[macro_escape]` to the new attribute parsing infrastructure

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -157,6 +157,19 @@ pub enum UsedBy {
     Linker,
 }
 
+#[derive(Encodable, Decodable, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(HashStable_Generic, PrintAttribute)]
+pub enum MacroUseArgs {
+    UseAll,
+    UseSpecific(ThinVec<Ident>),
+}
+
+impl Default for MacroUseArgs {
+    fn default() -> Self {
+        Self::UseSpecific(ThinVec::new())
+    }
+}
+
 #[derive(Debug, Clone, Encodable, Decodable, HashStable_Generic)]
 pub struct StrippedCfgItem<ModId = DefId> {
     pub parent_module: ModId,
@@ -351,8 +364,14 @@ pub enum AttributeKind {
     /// Represents `#[loop_match]`.
     LoopMatch(Span),
 
+    /// Represents `#[macro_escape]`.
+    MacroEscape(Span),
+
     /// Represents `#[rustc_macro_transparency]`.
     MacroTransparency(Transparency),
+
+    /// Represents `#[macro_use]`.
+    MacroUse { span: Span, arguments: MacroUseArgs },
 
     /// Represents `#[marker]`.
     Marker(Span),

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -45,7 +45,9 @@ impl AttributeKind {
             LinkOrdinal { .. } => No,
             LinkSection { .. } => Yes, // Needed for rustdoc
             LoopMatch(..) => No,
+            MacroEscape(..) => No,
             MacroTransparency(..) => Yes,
+            MacroUse { .. } => No,
             Marker(..) => No,
             MayDangle(..) => No,
             MustUse { .. } => Yes,

--- a/compiler/rustc_attr_data_structures/src/lib.rs
+++ b/compiler/rustc_attr_data_structures/src/lib.rs
@@ -24,7 +24,7 @@ use rustc_ast::token::CommentKind;
 use rustc_ast::{AttrStyle, IntTy, UintTy};
 use rustc_ast_pretty::pp::Printer;
 use rustc_span::hygiene::Transparency;
-use rustc_span::{ErrorGuaranteed, Span, Symbol};
+use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
 pub use stability::*;
 use thin_vec::ThinVec;
 pub use version::*;
@@ -172,7 +172,7 @@ macro_rules! print_tup {
 print_tup!(A B C D E F G H);
 print_skip!(Span, (), ErrorGuaranteed);
 print_disp!(u16, bool, NonZero<u32>);
-print_debug!(Symbol, UintTy, IntTy, Align, AttrStyle, CommentKind, Transparency);
+print_debug!(Symbol, Ident, UintTy, IntTy, Align, AttrStyle, CommentKind, Transparency);
 
 /// Finds attributes in sequences of attributes by pattern matching.
 ///

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -1,0 +1,115 @@
+use rustc_attr_data_structures::{AttributeKind, MacroUseArgs};
+use rustc_errors::DiagArgValue;
+use rustc_feature::{AttributeTemplate, template};
+use rustc_span::{Span, Symbol, sym};
+use thin_vec::ThinVec;
+
+use crate::attributes::{AcceptMapping, AttributeParser, NoArgsAttributeParser, OnDuplicate};
+use crate::context::{AcceptContext, FinalizeContext, Stage};
+use crate::parser::ArgParser;
+use crate::session_diagnostics;
+
+pub(crate) struct MacroEscapeParser;
+impl<S: Stage> NoArgsAttributeParser<S> for MacroEscapeParser {
+    const PATH: &[Symbol] = &[sym::macro_escape];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::MacroEscape;
+}
+
+/// `#[macro_use]` attributes can either:
+/// - Use all macros from a crate, if provided without arguments
+/// - Use specific macros from a crate, if provided with arguments `#[macro_use(macro1, macro2)]`
+/// A warning should be provided if an use all is combined with specific uses, or if multiple use-alls are used.
+#[derive(Default)]
+pub(crate) struct MacroUseParser {
+    state: MacroUseArgs,
+
+    /// Spans of all `#[macro_use]` arguments with arguments, used for linting
+    uses_attr_spans: ThinVec<Span>,
+    /// If `state` is `UseSpecific`, stores the span of the first `#[macro_use]` argument, used as the span for this attribute
+    /// If `state` is `UseAll`, stores the span of the first `#[macro_use]` arguments without arguments
+    first_span: Option<Span>,
+}
+
+const MACRO_USE_TEMPLATE: AttributeTemplate = template!(Word, List: "name1, name2, ...");
+
+impl<S: Stage> AttributeParser<S> for MacroUseParser {
+    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+        &[sym::macro_use],
+        MACRO_USE_TEMPLATE,
+        |group: &mut Self, cx: &mut AcceptContext<'_, '_, S>, args| {
+            let span = cx.attr_span;
+            group.first_span.get_or_insert(span);
+            match args {
+                ArgParser::NoArgs => {
+                    match group.state {
+                        MacroUseArgs::UseAll => {
+                            let first_span = group.first_span.expect(
+                                "State is UseAll is some so this is not the first attribute",
+                            );
+                            // Since there is a `#[macro_use]` import already, give a warning
+                            cx.warn_unused_duplicate(first_span, span);
+                        }
+                        MacroUseArgs::UseSpecific(_) => {
+                            group.state = MacroUseArgs::UseAll;
+                            group.first_span = Some(span);
+                            // If there is a `#[macro_use]` attribute, warn on all `#[macro_use(...)]` attributes since everything is already imported
+                            for specific_use in group.uses_attr_spans.drain(..) {
+                                cx.warn_unused_duplicate(span, specific_use);
+                            }
+                        }
+                    }
+                }
+                ArgParser::List(list) => {
+                    if list.is_empty() {
+                        cx.warn_empty_attribute(list.span);
+                        return;
+                    }
+
+                    match &mut group.state {
+                        MacroUseArgs::UseAll => {
+                            let first_span = group.first_span.expect(
+                                "State is UseAll is some so this is not the first attribute",
+                            );
+                            cx.warn_unused_duplicate(first_span, span);
+                        }
+                        MacroUseArgs::UseSpecific(arguments) => {
+                            // Store here so if we encounter a `UseAll` later we can still lint this attribute
+                            group.uses_attr_spans.push(cx.attr_span);
+
+                            for item in list.mixed() {
+                                let Some(item) = item.meta_item() else {
+                                    cx.expected_identifier(item.span());
+                                    continue;
+                                };
+                                if let Err(err_span) = item.args().no_args() {
+                                    cx.expected_no_args(err_span);
+                                    continue;
+                                }
+                                let Some(item) = item.path().word() else {
+                                    cx.expected_identifier(item.span());
+                                    continue;
+                                };
+                                arguments.push(item);
+                            }
+                        }
+                    }
+                }
+                ArgParser::NameValue(_) => {
+                    let suggestions = MACRO_USE_TEMPLATE.suggestions(false, sym::macro_use);
+                    cx.emit_err(session_diagnostics::IllFormedAttributeInputLint {
+                        num_suggestions: suggestions.len(),
+                        suggestions: DiagArgValue::StrListSepByAnd(
+                            suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),
+                        ),
+                        span,
+                    });
+                }
+            }
+        },
+    )];
+
+    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+        Some(AttributeKind::MacroUse { span: self.first_span?, arguments: self.state })
+    }
+}

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod inline;
 pub(crate) mod link_attrs;
 pub(crate) mod lint_helpers;
 pub(crate) mod loop_match;
+pub(crate) mod macro_attrs;
 pub(crate) mod must_use;
 pub(crate) mod no_implicit_prelude;
 pub(crate) mod non_exhaustive;

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -34,7 +34,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
                 ArgParser::List(_) => {
                     let suggestions =
                         <Self as SingleAttributeParser<S>>::TEMPLATE.suggestions(false, "must_use");
-                    cx.emit_err(session_diagnostics::MustUseIllFormedAttributeInput {
+                    cx.emit_err(session_diagnostics::IllFormedAttributeInputLint {
                         num_suggestions: suggestions.len(),
                         suggestions: DiagArgValue::StrListSepByAnd(
                             suggestions.into_iter().map(|s| format!("`{s}`").into()).collect(),

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -33,6 +33,7 @@ use crate::attributes::lint_helpers::{
     AsPtrParser, AutomaticallyDerivedParser, PassByValueParser, PubTransparentParser,
 };
 use crate::attributes::loop_match::{ConstContinueParser, LoopMatchParser};
+use crate::attributes::macro_attrs::{MacroEscapeParser, MacroUseParser};
 use crate::attributes::must_use::MustUseParser;
 use crate::attributes::no_implicit_prelude::NoImplicitPreludeParser;
 use crate::attributes::non_exhaustive::NonExhaustiveParser;
@@ -126,6 +127,7 @@ attribute_parsers!(
         BodyStabilityParser,
         ConfusablesParser,
         ConstStabilityParser,
+        MacroUseParser,
         NakedParser,
         StabilityParser,
         UsedParser,
@@ -174,6 +176,7 @@ attribute_parsers!(
         Single<WithoutArgs<FfiPureParser>>,
         Single<WithoutArgs<FundamentalParser>>,
         Single<WithoutArgs<LoopMatchParser>>,
+        Single<WithoutArgs<MacroEscapeParser>>,
         Single<WithoutArgs<MarkerParser>>,
         Single<WithoutArgs<MayDangleParser>>,
         Single<WithoutArgs<NoImplicitPreludeParser>>,
@@ -383,6 +386,17 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             template: self.template.clone(),
             attribute: self.attr_path.clone(),
             reason: AttributeParseErrorReason::ExpectedNoArgs,
+        })
+    }
+
+    /// emit an error that a `name` was expected here
+    pub(crate) fn expected_identifier(&self, span: Span) -> ErrorGuaranteed {
+        self.emit_err(AttributeParseError {
+            span,
+            attr_span: self.attr_span,
+            template: self.template.clone(),
+            attribute: self.attr_path.clone(),
+            reason: AttributeParseErrorReason::ExpectedIdentifier,
         })
     }
 

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -438,7 +438,7 @@ pub(crate) struct IllFormedAttributeInput {
 
 #[derive(Diagnostic)]
 #[diag(attr_parsing_ill_formed_attribute_input)]
-pub(crate) struct MustUseIllFormedAttributeInput {
+pub(crate) struct IllFormedAttributeInputLint {
     #[primary_span]
     pub span: Span,
     pub num_suggestions: usize,
@@ -549,6 +549,7 @@ pub(crate) enum AttributeParseErrorReason {
         /// Should we tell the user to write a list when they didn't?
         list: bool,
     },
+    ExpectedIdentifier,
 }
 
 pub(crate) struct AttributeParseError {
@@ -600,11 +601,11 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError {
                 diag.code(E0538);
             }
             AttributeParseErrorReason::UnexpectedLiteral => {
-                diag.span_label(self.span, format!("didn't expect a literal here"));
+                diag.span_label(self.span, "didn't expect a literal here");
                 diag.code(E0565);
             }
             AttributeParseErrorReason::ExpectedNoArgs => {
-                diag.span_label(self.span, format!("didn't expect any arguments here"));
+                diag.span_label(self.span, "didn't expect any arguments here");
                 diag.code(E0565);
             }
             AttributeParseErrorReason::ExpectedNameValue(None) => {
@@ -683,6 +684,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError {
                         diag.span_label(self.span, format!("this attribute is only valid with one of the following arguments: {res}"));
                     }
                 }
+            }
+            AttributeParseErrorReason::ExpectedIdentifier => {
+                diag.span_label(self.span, "expected a valid identifier here");
             }
         }
 

--- a/compiler/rustc_error_codes/src/error_codes/E0466.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0466.md
@@ -1,8 +1,10 @@
+#### Note: this error code is no longer emitted by the compiler.
+
 Macro import declaration was malformed.
 
 Erroneous code examples:
 
-```compile_fail,E0466
+```compile_fail
 #[macro_use(a_macro(another_macro))] // error: invalid import declaration
 extern crate core as some_crate;
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1302,6 +1302,7 @@ impl AttributeExt for Attribute {
             // FIXME: should not be needed anymore when all attrs are parsed
             Attribute::Parsed(AttributeKind::Deprecation { span, .. }) => *span,
             Attribute::Parsed(AttributeKind::DocComment { span, .. }) => *span,
+            Attribute::Parsed(AttributeKind::MacroUse { span, .. }) => *span,
             Attribute::Parsed(AttributeKind::MayDangle(span)) => *span,
             Attribute::Parsed(AttributeKind::Ignore { span, .. }) => *span,
             Attribute::Parsed(AttributeKind::AutomaticallyDerived(span)) => *span,

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -303,6 +303,8 @@ pub fn check_builtin_meta_item(
                 | sym::cold
                 | sym::target_feature
                 | sym::rustc_allow_const_fn_unstable
+                | sym::macro_use
+                | sym::macro_escape
                 | sym::naked
                 | sym::no_mangle
                 | sym::non_exhaustive

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -41,8 +41,6 @@ resolve_attempt_to_use_non_constant_value_in_constant_without_suggestion =
 resolve_attributes_starting_with_rustc_are_reserved =
     attributes starting with `rustc` are reserved for use by the `rustc` compiler
 
-resolve_bad_macro_import = bad macro import
-
 resolve_binding_in_never_pattern =
     never patterns cannot contain variable bindings
     .suggestion = use a wildcard `_` instead

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -11,11 +11,14 @@ use std::sync::Arc;
 use rustc_ast::visit::{self, AssocCtxt, Visitor, WalkItemKind};
 use rustc_ast::{
     self as ast, AssocItem, AssocItemKind, Block, ConstItem, Delegation, Fn, ForeignItem,
-    ForeignItemKind, Impl, Item, ItemKind, MetaItemKind, NodeId, StaticItem, StmtKind, TyAlias,
+    ForeignItemKind, Impl, Item, ItemKind, NodeId, StaticItem, StmtKind, TyAlias,
 };
+use rustc_attr_data_structures::{AttributeKind, MacroUseArgs};
 use rustc_attr_parsing as attr;
+use rustc_attr_parsing::AttributeParser;
 use rustc_expand::base::ResolverExpand;
 use rustc_expand::expand::AstFragment;
+use rustc_hir::Attribute;
 use rustc_hir::def::{self, *};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LocalDefId};
 use rustc_index::bit_set::DenseBitSet;
@@ -25,6 +28,7 @@ use rustc_middle::metadata::ModChild;
 use rustc_middle::ty::{Feed, Visibility};
 use rustc_span::hygiene::{ExpnId, LocalExpnId, MacroKind};
 use rustc_span::{Ident, Span, Symbol, kw, sym};
+use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::Namespace::{MacroNS, TypeNS, ValueNS};
@@ -1019,42 +1023,31 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
     /// Returns `true` if we should consider the underlying `extern crate` to be used.
     fn process_macro_use_imports(&mut self, item: &Item, module: Module<'ra>) -> bool {
         let mut import_all = None;
-        let mut single_imports = Vec::new();
-        for attr in &item.attrs {
-            if attr.has_name(sym::macro_use) {
-                if self.parent_scope.module.parent.is_some() {
-                    self.r.dcx().emit_err(errors::ExternCrateLoadingMacroNotAtCrateRoot {
-                        span: item.span,
-                    });
-                }
-                if let ItemKind::ExternCrate(Some(orig_name), _) = item.kind
-                    && orig_name == kw::SelfLower
-                {
-                    self.r.dcx().emit_err(errors::MacroUseExternCrateSelf { span: attr.span });
-                }
-                let ill_formed = |span| {
-                    self.r.dcx().emit_err(errors::BadMacroImport { span });
-                };
-                match attr.meta() {
-                    Some(meta) => match meta.kind {
-                        MetaItemKind::Word => {
-                            import_all = Some(meta.span);
-                            break;
-                        }
-                        MetaItemKind::List(meta_item_inners) => {
-                            for meta_item_inner in meta_item_inners {
-                                match meta_item_inner.ident() {
-                                    Some(ident) if meta_item_inner.is_word() => {
-                                        single_imports.push(ident)
-                                    }
-                                    _ => ill_formed(meta_item_inner.span()),
-                                }
-                            }
-                        }
-                        MetaItemKind::NameValue(..) => ill_formed(meta.span),
-                    },
-                    None => ill_formed(attr.span),
-                }
+        let mut single_imports = ThinVec::new();
+        if let Some(Attribute::Parsed(AttributeKind::MacroUse { span, arguments })) =
+            AttributeParser::parse_limited(
+                self.r.tcx.sess,
+                &item.attrs,
+                sym::macro_use,
+                item.span,
+                item.id,
+                None,
+            )
+        {
+            if self.parent_scope.module.parent.is_some() {
+                self.r
+                    .dcx()
+                    .emit_err(errors::ExternCrateLoadingMacroNotAtCrateRoot { span: item.span });
+            }
+            if let ItemKind::ExternCrate(Some(orig_name), _) = item.kind
+                && orig_name == kw::SelfLower
+            {
+                self.r.dcx().emit_err(errors::MacroUseExternCrateSelf { span });
+            }
+
+            match arguments {
+                MacroUseArgs::UseAll => import_all = Some(span),
+                MacroUseArgs::UseSpecific(imports) => single_imports = imports,
             }
         }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -816,13 +816,6 @@ pub(crate) struct ExternCrateLoadingMacroNotAtCrateRoot {
 }
 
 #[derive(Diagnostic)]
-#[diag(resolve_bad_macro_import, code = E0466)]
-pub(crate) struct BadMacroImport {
-    #[primary_span]
-    pub(crate) span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(resolve_extern_crate_self_requires_renaming)]
 pub(crate) struct ExternCrateSelfRequiresRenaming {
     #[primary_span]

--- a/src/tools/clippy/clippy_lints/src/macro_use.rs
+++ b/src/tools/clippy/clippy_lints/src/macro_use.rs
@@ -7,8 +7,9 @@ use rustc_hir::{self as hir, AmbigArg};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::impl_lint_pass;
 use rustc_span::edition::Edition;
-use rustc_span::{Span, sym};
+use rustc_span::{Span};
 use std::collections::BTreeMap;
+use rustc_attr_data_structures::{AttributeKind, find_attr};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -99,15 +100,14 @@ impl LateLintPass<'_> for MacroUseImports {
             && let hir::ItemKind::Use(path, _kind) = &item.kind
             && let hir_id = item.hir_id()
             && let attrs = cx.tcx.hir_attrs(hir_id)
-            && let Some(mac_attr) = attrs.iter().find(|attr| attr.has_name(sym::macro_use))
+            && let Some(mac_attr_span) = find_attr!(attrs, AttributeKind::MacroUse {span, ..} => *span)
             && let Some(Res::Def(DefKind::Mod, id)) = path.res.type_ns
             && !id.is_local()
         {
             for kid in cx.tcx.module_children(id) {
                 if let Res::Def(DefKind::Macro(_mac_type), mac_id) = kid.res {
-                    let span = mac_attr.span();
                     let def_path = cx.tcx.def_path_str(mac_id);
-                    self.imports.push((def_path, span, hir_id));
+                    self.imports.push((def_path, mac_attr_span, hir_id));
                 }
             }
         } else if item.span.from_expansion() {

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -6,7 +6,7 @@
 #![feature(fn_delegation)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 fn b<C>(e: C) { }

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -5,7 +5,7 @@
 #![feature(c_variadic)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 extern "C" {

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -7,7 +7,7 @@
 #![allow(unused)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 struct Foo<'a> {

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ pretty-compare-only
 //@ pretty-mode:hir,typed

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 // Test to print lifetimes on HIR pretty-printing.
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -6,7 +6,7 @@
 #![allow(dead_code, incomplete_features)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 use std::pin::Pin;

--- a/tests/ui/attributes/invalid-macro-use.rs
+++ b/tests/ui/attributes/invalid-macro-use.rs
@@ -1,0 +1,53 @@
+#![deny(unused_attributes)]
+//~^ NOTE the lint level is defined here
+
+#[macro_use = 5]
+//~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+extern crate std as s1;
+
+#[macro_use(5)]
+//~^ ERROR malformed `macro_use` attribute input
+//~| NOTE expected a valid identifier here
+extern crate std as s2;
+
+#[macro_use(a = "b")]
+//~^ ERROR malformed `macro_use` attribute input
+//~| NOTE didn't expect any arguments here
+extern crate std as s3;
+
+#[macro_use(a(b))]
+//~^ ERROR malformed `macro_use` attribute input
+//~| NOTE didn't expect any arguments here
+extern crate std as s4;
+
+#[macro_use(a::b)]
+//~^ ERROR malformed `macro_use` attribute input
+//~| NOTE expected a valid identifier here
+extern crate std as s5;
+
+#[macro_use(a)]
+//~^ ERROR unused attribute
+#[macro_use]
+//~^ NOTE attribute also specified here
+extern crate std as s6;
+
+#[macro_use]
+//~^ NOTE attribute also specified here
+#[macro_use(a)]
+//~^ ERROR unused attribute
+extern crate std as s7;
+
+#[macro_use]
+//~^ NOTE attribute also specified here
+#[macro_use]
+//~^ ERROR unused attribute
+extern crate std as s8;
+
+// This is fine, both are importing different names
+#[macro_use(a)]
+//~^ ERROR imported macro not found
+#[macro_use(b)]
+//~^ ERROR imported macro not found
+extern crate std as s9;
+
+fn main() {}

--- a/tests/ui/attributes/invalid-macro-use.stderr
+++ b/tests/ui/attributes/invalid-macro-use.stderr
@@ -1,0 +1,131 @@
+error[E0469]: imported macro not found
+  --> $DIR/invalid-macro-use.rs:47:13
+   |
+LL | #[macro_use(a)]
+   |             ^
+
+error[E0469]: imported macro not found
+  --> $DIR/invalid-macro-use.rs:49:13
+   |
+LL | #[macro_use(b)]
+   |             ^
+
+error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+  --> $DIR/invalid-macro-use.rs:4:1
+   |
+LL | #[macro_use = 5]
+   | ^^^^^^^^^^^^^^^^
+
+error[E0539]: malformed `macro_use` attribute input
+  --> $DIR/invalid-macro-use.rs:8:1
+   |
+LL | #[macro_use(5)]
+   | ^^^^^^^^^^^^-^^
+   |             |
+   |             expected a valid identifier here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(5)]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(5)]
+LL + #[macro_use]
+   |
+
+error[E0565]: malformed `macro_use` attribute input
+  --> $DIR/invalid-macro-use.rs:13:1
+   |
+LL | #[macro_use(a = "b")]
+   | ^^^^^^^^^^^^^^-----^^
+   |               |
+   |               didn't expect any arguments here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(a = "b")]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(a = "b")]
+LL + #[macro_use]
+   |
+
+error[E0565]: malformed `macro_use` attribute input
+  --> $DIR/invalid-macro-use.rs:18:1
+   |
+LL | #[macro_use(a(b))]
+   | ^^^^^^^^^^^^^---^^
+   |              |
+   |              didn't expect any arguments here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(a(b))]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(a(b))]
+LL + #[macro_use]
+   |
+
+error[E0539]: malformed `macro_use` attribute input
+  --> $DIR/invalid-macro-use.rs:23:1
+   |
+LL | #[macro_use(a::b)]
+   | ^^^^^^^^^^^^----^^
+   |             |
+   |             expected a valid identifier here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(a::b)]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(a::b)]
+LL + #[macro_use]
+   |
+
+error: unused attribute
+  --> $DIR/invalid-macro-use.rs:28:1
+   |
+LL | #[macro_use(a)]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/invalid-macro-use.rs:30:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/invalid-macro-use.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/invalid-macro-use.rs:36:1
+   |
+LL | #[macro_use(a)]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/invalid-macro-use.rs:34:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/invalid-macro-use.rs:42:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/invalid-macro-use.rs:40:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0469, E0539, E0565.
+For more information about an error, try `rustc --explain E0469`.

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -208,7 +208,7 @@ static mut TLS: u8 = 42;
 #[no_link()]
 //~^ ERROR malformed
 #[macro_use = 1]
-//~^ ERROR malformed
+//~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
 extern crate wloop;
 //~^ ERROR can't find crate for `wloop` [E0463]
 

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -154,21 +154,6 @@ error: malformed `no_link` attribute input
 LL | #[no_link()]
    | ^^^^^^^^^^^^ help: must be of the form: `#[no_link]`
 
-error: malformed `macro_use` attribute input
-  --> $DIR/malformed-attrs.rs:210:1
-   |
-LL | #[macro_use = 1]
-   | ^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[macro_use = 1]
-LL + #[macro_use(name1, name2, ...)]
-   |
-LL - #[macro_use = 1]
-LL + #[macro_use]
-   |
-
 error: malformed `macro_export` attribute input
   --> $DIR/malformed-attrs.rs:215:1
    |
@@ -566,6 +551,12 @@ LL | #[non_exhaustive = 1]
    | |                |
    | |                didn't expect any arguments here
    | help: must be of the form: `#[non_exhaustive]`
+
+error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
+  --> $DIR/malformed-attrs.rs:210:1
+   |
+LL | #[macro_use = 1]
+   | ^^^^^^^^^^^^^^^^
 
 error[E0565]: malformed `type_const` attribute input
   --> $DIR/malformed-attrs.rs:144:5

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
@@ -13,7 +13,7 @@ mod macro_escape {
     //~^ ERROR arguments to `macro_use` are not allowed here
 
     #[macro_use = "2700"] struct S;
-    //~^ ERROR malformed `macro_use` attribute
+    //~^ ERROR valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
 
     #[macro_use] fn f() { }
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -16,20 +16,11 @@ error: arguments to `macro_use` are not allowed here
 LL | #![macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: malformed `macro_use` attribute input
+error: valid forms for the attribute are `#[macro_use(name1, name2, ...)]` and `#[macro_use]`
   --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
    |
 LL |     #[macro_use = "2700"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL -     #[macro_use = "2700"] struct S;
-LL +     #[macro_use(name1, name2, ...)] struct S;
-   |
-LL -     #[macro_use = "2700"] struct S;
-LL +     #[macro_use] struct S;
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -16,18 +16,6 @@ LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
-  --> $DIR/unused-attr-duplicate.rs:37:1
-   |
-LL | #[macro_use]
-   | ^^^^^^^^^^^^ help: remove this attribute
-   |
-note: attribute also specified here
-  --> $DIR/unused-attr-duplicate.rs:36:1
-   |
-LL | #[macro_use]
-   | ^^^^^^^^^^^^
-
-error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:55:1
    |
 LL | #[should_panic(expected = "values don't match")]
@@ -127,6 +115,18 @@ note: attribute also specified here
    |
 LL |     #[macro_export]
    |     ^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:37:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:36:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^
 
 error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:47:1

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -1,8 +1,8 @@
-error: `#[macro_use]` only has an effect on `extern crate` and modules
-  --> $DIR/unused-attr-macro-rules.rs:7:1
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
+  --> $DIR/unused-attr-macro-rules.rs:9:1
    |
-LL | #[macro_use]
-   | ^^^^^^^^^^^^
+LL | #[recursion_limit="1"]
+   | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-attr-macro-rules.rs:1:9
@@ -10,11 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/unused-attr-macro-rules.rs:9:1
+error: `#[macro_use]` only has an effect on `extern crate` and modules
+  --> $DIR/unused-attr-macro-rules.rs:7:1
    |
-LL | #[recursion_limit="1"]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+LL | #[macro_use]
+   | ^^^^^^^^^^^^
 
 error: `#[path]` only has an effect on modules
   --> $DIR/unused-attr-macro-rules.rs:8:1

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ edition: 2015

--- a/tests/ui/macros/macro-use-all-and-none.stderr
+++ b/tests/ui/macros/macro-use-all-and-none.stderr
@@ -1,10 +1,9 @@
 warning: unused attribute
-  --> $DIR/macro-use-all-and-none.rs:7:1
+  --> $DIR/macro-use-all-and-none.rs:7:12
    |
 LL | #[macro_use()]
-   | ^^^^^^^^^^^^^^ help: remove this attribute
+   |            ^^ help: remove this attribute
    |
-   = note: attribute `macro_use` with an empty list has no effect
 note: the lint level is defined here
   --> $DIR/macro-use-all-and-none.rs:4:9
    |

--- a/tests/ui/macros/macro-use-bad-args-1.rs
+++ b/tests/ui/macros/macro-use-bad-args-1.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[macro_use(foo(bar))]  //~ ERROR bad macro import
+#[macro_use(foo(bar))]  //~ ERROR malformed `macro_use` attribute input
 extern crate std;
 
 fn main() {}

--- a/tests/ui/macros/macro-use-bad-args-1.stderr
+++ b/tests/ui/macros/macro-use-bad-args-1.stderr
@@ -1,9 +1,20 @@
-error[E0466]: bad macro import
-  --> $DIR/macro-use-bad-args-1.rs:3:13
+error[E0565]: malformed `macro_use` attribute input
+  --> $DIR/macro-use-bad-args-1.rs:3:1
    |
 LL | #[macro_use(foo(bar))]
-   |             ^^^^^^^^
+   | ^^^^^^^^^^^^^^^-----^^
+   |                |
+   |                didn't expect any arguments here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(foo(bar))]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(foo(bar))]
+LL + #[macro_use]
+   |
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0466`.
+For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/macros/macro-use-bad-args-2.rs
+++ b/tests/ui/macros/macro-use-bad-args-2.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-#[macro_use(foo="bar")]  //~ ERROR bad macro import
+#[macro_use(foo="bar")]  //~ ERROR malformed `macro_use` attribute input
 extern crate std;
 
 fn main() {}

--- a/tests/ui/macros/macro-use-bad-args-2.stderr
+++ b/tests/ui/macros/macro-use-bad-args-2.stderr
@@ -1,9 +1,20 @@
-error[E0466]: bad macro import
-  --> $DIR/macro-use-bad-args-2.rs:3:13
+error[E0565]: malformed `macro_use` attribute input
+  --> $DIR/macro-use-bad-args-2.rs:3:1
    |
 LL | #[macro_use(foo="bar")]
-   |             ^^^^^^^^^
+   | ^^^^^^^^^^^^^^^------^^
+   |                |
+   |                didn't expect any arguments here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[macro_use(foo="bar")]
+LL + #[macro_use(name1, name2, ...)]
+   |
+LL - #[macro_use(foo="bar")]
+LL + #[macro_use]
+   |
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0466`.
+For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -5,7 +5,7 @@
 #![feature(type_alias_impl_trait)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 trait Animal { }

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use std::prelude::rust_2024::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -30,7 +30,7 @@
 #![allow(incomplete_features)]
 #[prelude_import]
 use std::prelude::rust_2024::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 #[prelude_import]

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,6 +1,6 @@
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -10,7 +10,7 @@
 #![allow(dead_code)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;
-#[macro_use]
+#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 
 fn main() ({ } as ())


### PR DESCRIPTION
Ports `#[macro_use]` and `#[macro_escape]` to the new attribute parsing infrastructure for https://github.com/rust-lang/rust/issues/131229#issuecomment-2971351163

r? @jdonszelmann @oli-obk 