### PR TITLE
pass --gc-sections if -Zexport-executable-symbols is enabled and improve tests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2543,8 +2543,6 @@ fn add_order_independent_options(
         let keep_metadata =
             crate_type == CrateType::Dylib || sess.opts.cg.profile_generate.enabled();
         cmd.gc_sections(keep_metadata);
-    } else {
-        cmd.no_gc_sections();
     }
 
     cmd.set_output_kind(link_output_kind, crate_type, out_filename);

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2542,12 +2542,9 @@ fn add_order_independent_options(
         // sections to ensure we have all the data for PGO.
         let keep_metadata =
             crate_type == CrateType::Dylib || sess.opts.cg.profile_generate.enabled();
-        if crate_type != CrateType::Executable || !sess.opts.unstable_opts.export_executable_symbols
-        {
-            cmd.gc_sections(keep_metadata);
-        } else {
-            cmd.no_gc_sections();
-        }
+        cmd.gc_sections(keep_metadata);
+    } else {
+        cmd.no_gc_sections();
     }
 
     cmd.set_output_kind(link_output_kind, crate_type, out_filename);

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -326,7 +326,6 @@ pub(crate) trait Linker {
         link_or_cc_args(self, &[path]);
     }
     fn gc_sections(&mut self, keep_metadata: bool);
-    fn no_gc_sections(&mut self);
     fn full_relro(&mut self);
     fn partial_relro(&mut self);
     fn no_relro(&mut self);
@@ -688,12 +687,6 @@ impl<'a> Linker for GccLinker<'a> {
         }
     }
 
-    fn no_gc_sections(&mut self) {
-        if self.is_gnu || self.sess.target.is_like_wasm {
-            self.link_arg("--no-gc-sections");
-        }
-    }
-
     fn optimize(&mut self) {
         if !self.is_gnu && !self.sess.target.is_like_wasm {
             return;
@@ -1010,10 +1003,6 @@ impl<'a> Linker for MsvcLinker<'a> {
         }
     }
 
-    fn no_gc_sections(&mut self) {
-        self.link_arg("/OPT:NOREF,NOICF");
-    }
-
     fn full_relro(&mut self) {
         // noop
     }
@@ -1243,10 +1232,6 @@ impl<'a> Linker for EmLinker<'a> {
         // noop
     }
 
-    fn no_gc_sections(&mut self) {
-        // noop
-    }
-
     fn optimize(&mut self) {
         // Emscripten performs own optimizations
         self.cc_arg(match self.sess.opts.optimize {
@@ -1418,10 +1403,6 @@ impl<'a> Linker for WasmLd<'a> {
         self.link_arg("--gc-sections");
     }
 
-    fn no_gc_sections(&mut self) {
-        self.link_arg("--no-gc-sections");
-    }
-
     fn optimize(&mut self) {
         // The -O flag is, as of late 2023, only used for merging of strings and debuginfo, and
         // only differentiates -O0 and -O1. It does not apply to LTO.
@@ -1565,10 +1546,6 @@ impl<'a> Linker for L4Bender<'a> {
         if !keep_metadata {
             self.link_arg("--gc-sections");
         }
-    }
-
-    fn no_gc_sections(&mut self) {
-        self.link_arg("--no-gc-sections");
     }
 
     fn optimize(&mut self) {
@@ -1732,10 +1709,6 @@ impl<'a> Linker for AixLinker<'a> {
 
     fn gc_sections(&mut self, _keep_metadata: bool) {
         self.link_arg("-bgc");
-    }
-
-    fn no_gc_sections(&mut self) {
-        self.link_arg("-bnogc");
     }
 
     fn optimize(&mut self) {}
@@ -1982,8 +1955,6 @@ impl<'a> Linker for PtxLinker<'a> {
 
     fn gc_sections(&mut self, _keep_metadata: bool) {}
 
-    fn no_gc_sections(&mut self) {}
-
     fn pgo_gen(&mut self) {}
 
     fn no_crt_objects(&mut self) {}
@@ -2056,8 +2027,6 @@ impl<'a> Linker for LlbcLinker<'a> {
     fn no_relro(&mut self) {}
 
     fn gc_sections(&mut self, _keep_metadata: bool) {}
-
-    fn no_gc_sections(&mut self) {}
 
     fn pgo_gen(&mut self) {}
 
@@ -2138,8 +2107,6 @@ impl<'a> Linker for BpfLinker<'a> {
     fn no_relro(&mut self) {}
 
     fn gc_sections(&mut self, _keep_metadata: bool) {}
-
-    fn no_gc_sections(&mut self) {}
 
     fn pgo_gen(&mut self) {}
 

--- a/tests/run-make/export-executable-symbols/rmake.rs
+++ b/tests/run-make/export-executable-symbols/rmake.rs
@@ -5,6 +5,7 @@
 // See https://github.com/rust-lang/rust/pull/85673
 
 //@ ignore-wasm
+//@ ignore-cross-compile
 
 use run_make_support::object::Object;
 use run_make_support::{bin_name, is_darwin, object, rustc};

--- a/tests/ui/linking/export-executable-symbols.rs
+++ b/tests/ui/linking/export-executable-symbols.rs
@@ -1,14 +1,11 @@
 //@ run-pass
-//@ only-linux
-//@ only-gnu
-//@ compile-flags: -Zexport-executable-symbols
+//@ compile-flags: -Ctarget-feature=-crt-static -Zexport-executable-symbols
+//@ ignore-wasm
 //@ edition: 2024
 
 // Regression test for <https://github.com/rust-lang/rust/issues/101610>.
 
 #![feature(rustc_private)]
-
-extern crate libc;
 
 #[unsafe(no_mangle)]
 fn hack() -> u64 {
@@ -16,9 +13,31 @@ fn hack() -> u64 {
 }
 
 fn main() {
+    #[cfg(unix)]
     unsafe {
+        extern crate libc;
         let handle = libc::dlopen(std::ptr::null(), libc::RTLD_NOW);
         let ptr = libc::dlsym(handle, c"hack".as_ptr());
+        let ptr: Option<unsafe fn() -> u64> = std::mem::transmute(ptr);
+        if let Some(f) = ptr {
+            assert!(f() == 998244353);
+            println!("symbol `hack` is found successfully");
+        } else {
+            panic!("symbol `hack` is not found");
+        }
+    }
+    #[cfg(windows)]
+    unsafe {
+        type PCSTR = *const u8;
+        type HMODULE = *mut core::ffi::c_void;
+        type FARPROC = Option<unsafe extern "system" fn() -> isize>;
+        #[link(name = "kernel32", kind = "raw-dylib")]
+        unsafe extern "system" {
+            fn GetModuleHandleA(lpmodulename: PCSTR) -> HMODULE;
+            fn GetProcAddress(hmodule: HMODULE, lpprocname: PCSTR) -> FARPROC;
+        }
+        let handle = GetModuleHandleA(std::ptr::null_mut());
+        let ptr = GetProcAddress(handle, b"hack\0".as_ptr());
         let ptr: Option<unsafe fn() -> u64> = std::mem::transmute(ptr);
         if let Some(f) = ptr {
             assert!(f() == 998244353);

--- a/tests/ui/linking/export-executable-symbols.rs
+++ b/tests/ui/linking/export-executable-symbols.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 //@ compile-flags: -Ctarget-feature=-crt-static -Zexport-executable-symbols
 //@ ignore-wasm
+//@ ignore-cross-compile
 //@ edition: 2024
 
 // Regression test for <https://github.com/rust-lang/rust/issues/101610>.


### PR DESCRIPTION
Exported symbols are added as GC roots in linking, so `--gc-sections` won't hurt `-Zexport-executable-symbols`.

Fixes the run-make test to work on Linux. Enable the ui test on more targets.

cc rust-lang/rust#84161