### PR TITLE
rustdoc: never link to unnamable items

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -486,8 +486,14 @@ fn is_unnamable(tcx: TyCtxt<'_>, did: DefId) -> bool {
     let mut cur_did = did;
     while let Some(parent) = tcx.opt_parent(cur_did) {
         match tcx.def_kind(parent) {
-            // items defined in these can be linked to
-            DefKind::Mod | DefKind::Impl { .. } | DefKind::ForeignMod => cur_did = parent,
+            // items defined in these can be linked to, as long as they are visible
+            DefKind::Mod | DefKind::ForeignMod => cur_did = parent,
+            // items in impls can be linked to,
+            // as long as we can link to the item the impl is on.
+            // since associated traits are not a thing,
+            // it should not be possible to refer to an impl item if
+            // the base type is not namable.
+            DefKind::Impl { .. } => return false,
             // everything else does not have docs generated for it
             _ => return true,
         }

--- a/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
+++ b/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
@@ -4,7 +4,7 @@ pub trait Assoc {
 
 pub struct Foo(<Foo as crate::Assoc>::Ty);
 
-const _: () = {
+const _X: () = {
     impl crate::Assoc for Foo {
         type Ty = Bar;
     }

--- a/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
+++ b/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
@@ -1,0 +1,12 @@
+pub trait Assoc {
+    type Ty;
+}
+
+pub struct Foo(<Foo as crate::Assoc>::Ty);
+
+const _: () = {
+    impl crate::Assoc for Foo {
+        type Ty = Bar;
+    }
+    pub struct Bar;
+};

--- a/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
+++ b/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Z normalize-docs --document-private-items -Zunstable-options --show-type-layout
+//@ aux-build:wrap-unnamable-type.rs
+//@ build-aux-docs
+
+#![crate_name = "foo"]
+
+extern crate wrap_unnamable_type as helper;
+//extern crate helper;
+//@ has 'foo/struct.Foo.html'
+//@ !hasraw - '_/struct.Bar.html'
+#[doc(inline)]
+pub use helper::Foo;

--- a/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
+++ b/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
@@ -2,11 +2,15 @@
 //@ aux-build:wrap-unnamable-type.rs
 //@ build-aux-docs
 
+// regression test for https://github.com/rust-lang/rust/issues/143222
+// makes sure normalizing docs does not cause us to link to unnamable types
+// in cross-crate reexports.
+
 #![crate_name = "foo"]
 
 extern crate wrap_unnamable_type as helper;
-//extern crate helper;
+
 //@ has 'foo/struct.Foo.html'
-//@ !hasraw - '_/struct.Bar.html'
+//@ !hasraw - 'struct.Bar.html'
 #[doc(inline)]
 pub use helper::Foo;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fixes rust-lang/rust#143222
