### PR TITLE
Improve `otherwise` handling in `MaybeInitializedPlaces`/`MaybeUninitializedPlaces`

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -511,11 +511,9 @@ fn get_flow_results<'a, 'tcx>(
         body,
         Some("borrowck"),
     );
-    let uninits = MaybeUninitializedPlaces::new(tcx, body, move_data).iterate_to_fixpoint(
-        tcx,
-        body,
-        Some("borrowck"),
-    );
+    let uninits = MaybeUninitializedPlaces::new(tcx, body, move_data)
+        .include_inactive_in_otherwise()
+        .iterate_to_fixpoint(tcx, body, Some("borrowck"));
     let ever_inits = EverInitializedPlaces::new(body, move_data).iterate_to_fixpoint(
         tcx,
         body,

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -485,6 +485,7 @@ impl<'a, 'typeck, 'tcx> LivenessContext<'a, 'typeck, 'tcx> {
             // case), there are a few dozens compared to e.g. thousands or tens of thousands of
             // locals and move paths.
             let flow_inits = MaybeInitializedPlaces::new(tcx, body, self.move_data)
+                .exclude_inactive_in_otherwise()
                 .iterate_to_fixpoint(tcx, body, Some("borrowck"))
                 .into_results_cursor(body);
             flow_inits

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -1,5 +1,6 @@
 use std::sync::OnceLock;
 
+use rustc_abi::VariantIdx;
 use rustc_data_structures::graph;
 use rustc_data_structures::graph::dominators::{Dominators, dominators};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -23,7 +24,7 @@ type Predecessors = IndexVec<BasicBlock, SmallVec<[BasicBlock; 4]>>;
 #[derive(Debug, Clone, Copy)]
 pub enum SwitchTargetValue {
     // A normal switch value.
-    Normal(u128),
+    Normal(VariantIdx),
     // The final "otherwise" fallback value.
     Otherwise,
 }

--- a/compiler/rustc_mir_dataflow/src/framework/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/mod.rs
@@ -34,6 +34,7 @@
 
 use std::cmp::Ordering;
 
+use rustc_abi::VariantIdx;
 use rustc_data_structures::work_queue::WorkQueue;
 use rustc_index::bit_set::{DenseBitSet, MixedBitSet};
 use rustc_index::{Idx, IndexVec};
@@ -214,17 +215,24 @@ pub trait Analysis<'tcx> {
         &mut self,
         _block: mir::BasicBlock,
         _discr: &mir::Operand<'tcx>,
+        _targets: &mir::SwitchTargets,
     ) -> Option<Self::SwitchIntData> {
         None
+    }
+
+    /// Returns an iterator over `SwitchInt` target variants stored in `Self::SwitchIntData`.
+    fn switch_int_target_variants(
+        _data: &Self::SwitchIntData,
+    ) -> impl Iterator<Item = &(VariantIdx, mir::BasicBlock)> {
+        [].iter()
     }
 
     /// See comments on `get_switch_int_data`.
     fn apply_switch_int_edge_effect(
         &mut self,
-        _data: &mut Self::SwitchIntData,
+        _data: &Self::SwitchIntData,
         _state: &mut Self::Domain,
         _value: SwitchTargetValue,
-        _targets: &mir::SwitchTargets,
     ) {
         unreachable!();
     }


### PR DESCRIPTION
This PR adds a couple small changes to dataflow analysis intended to make the `otherwise` edge handling from rust-lang/rust#142707 more tidy and efficient:

- Filter discriminants involved in a `SwitchInt` and map their values to `VariantIdx` while building `MaybePlacesSwitchIntData` instead of in `apply_effects_in_block` using `next_discr`. Use that `Vec` when handling the `otherwise` target instead of making a new `SmallVec`.
- Enable `otherwise` edge effects in MIR type check and borrow check.