### PR TITLE
Guarantee 8 bytes of alignment in Thread::into_raw

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1380,6 +1380,11 @@ where
 }
 
 /// The internal representation of a `Thread` handle
+/// 
+/// We explicitly set the alignment for our guarantee in Thread::into_raw. This
+/// allows applications to stuff extra metadata bits into the alignment, which
+/// can be rather useful when working with atomics.
+#[repr(align(8))]
 struct Inner {
     name: Option<ThreadNameString>,
     id: ThreadId,
@@ -1563,7 +1568,8 @@ impl Thread {
     /// Consumes the `Thread`, returning a raw pointer.
     ///
     /// To avoid a memory leak the pointer must be converted
-    /// back into a `Thread` using [`Thread::from_raw`].
+    /// back into a `Thread` using [`Thread::from_raw`]. The pointer is
+    /// guaranteed to be aligned to at least 8 bytes.
     ///
     /// # Examples
     ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1380,7 +1380,7 @@ where
 }
 
 /// The internal representation of a `Thread` handle
-/// 
+///
 /// We explicitly set the alignment for our guarantee in Thread::into_raw. This
 /// allows applications to stuff extra metadata bits into the alignment, which
 /// can be rather useful when working with atomics.


### PR DESCRIPTION
When using `AtomicPtr` for synchronization it's incredibly useful when you've got a couple bits you can stuff metadata in. By guaranteeing that `Thread`'s `Inner` struct is aligned to 8 bytes everyone can use the bottom 3 bits to signal other things, such as a critical section, etc.

This guarantee is thus very useful and costs us nothing.