### PR TITLE
[COMPILETEST-UNTANGLE 6/N] Use `TestSuite` enum instead of stringly-typed test suites

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -53,6 +53,32 @@ impl TestMode {
     }
 }
 
+// Note that coverage tests use the same test files for multiple test modes.
+string_enum! {
+    #[derive(Clone, Copy, PartialEq, Debug)]
+    pub enum TestSuite {
+        Assembly => "assembly",
+        Codegen => "codegen",
+        CodegenUnits => "codegen-units",
+        Coverage => "coverage",
+        CoverageRunRustdoc => "coverage-run-rustdoc",
+        Crashes => "crashes",
+        Debuginfo => "debuginfo",
+        Incremental => "incremental",
+        MirOpt => "mir-opt",
+        Pretty => "pretty",
+        RunMake => "run-make",
+        Rustdoc => "rustdoc",
+        RustdocGui => "rustdoc-gui",
+        RustdocJs => "rustdoc-js",
+        RustdocJsStd=> "rustdoc-js-std",
+        RustdocJson => "rustdoc-json",
+        RustdocUi => "rustdoc-ui",
+        Ui => "ui",
+        UiFullDeps => "ui-fulldeps",
+    }
+}
+
 string_enum! {
     #[derive(Clone, Copy, PartialEq, Debug, Hash)]
     pub enum PassMode {
@@ -276,15 +302,13 @@ pub struct Config {
 
     /// The test suite.
     ///
-    /// Example: `tests/ui/` is the "UI" test *suite*, which happens to also be of the
+    /// Example: `tests/ui/` is [`TestSuite::Ui`] test *suite*, which happens to also be of the
     /// [`TestMode::Ui`] test *mode*.
     ///
-    /// Note that the same test directory (e.g. `tests/coverage/`) may correspond to multiple test
+    /// Note that the same test suite (e.g. `tests/coverage/`) may correspond to multiple test
     /// modes, e.g. `tests/coverage/` can be run under both [`TestMode::CoverageRun`] and
     /// [`TestMode::CoverageMap`].
-    ///
-    /// FIXME: stop using stringly-typed test suites!
-    pub suite: String,
+    pub suite: TestSuite,
 
     /// When specified, **only** the specified [`Debugger`] will be used to run against the
     /// `tests/debuginfo` test suite. When unspecified, `compiletest` will attempt to find all three
@@ -537,8 +561,8 @@ pub struct Config {
     // Configuration for various run-make tests frobbing things like C compilers or querying about
     // various LLVM component information.
     //
-    // FIXME: this really should be better packaged together. FIXME: these need better docs, e.g.
-    // for *host*, or for *target*?
+    // FIXME: this really should be better packaged together.
+    // FIXME: these need better docs, e.g. for *host*, or for *target*?
     pub cc: String,
     pub cxx: String,
     pub cflags: String,
@@ -617,6 +641,8 @@ impl Config {
         // For instance, `//@ ignore-stage1` will not work at all.
         Config {
             mode: TestMode::Rustdoc,
+            // E.g. this has no sensible default tbh.
+            suite: TestSuite::Ui,
 
             // Dummy values.
             edition: Default::default(),
@@ -642,7 +668,6 @@ impl Config {
             sysroot_base: Utf8PathBuf::default(),
             stage: Default::default(),
             stage_id: String::default(),
-            suite: Default::default(),
             debugger: Default::default(),
             run_ignored: Default::default(),
             with_rustc_debug_assertions: Default::default(),

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -56,7 +56,6 @@ impl EarlyProps {
         let mut poisoned = false;
         iter_directives(
             config.mode,
-            &config.suite,
             &mut poisoned,
             testfile,
             rdr,
@@ -349,7 +348,6 @@ impl TestProps {
 
             iter_directives(
                 config.mode,
-                &config.suite,
                 &mut poisoned,
                 testfile,
                 file,
@@ -869,7 +867,6 @@ const COMPILETEST_DIRECTIVE_PREFIX: &str = "//@";
 
 fn iter_directives(
     mode: TestMode,
-    _suite: &str,
     poisoned: &mut bool,
     testfile: &Utf8Path,
     rdr: impl Read,
@@ -1388,7 +1385,6 @@ pub(crate) fn make_test_description<R: Read>(
     // Scan through the test file to handle `ignore-*`, `only-*`, and `needs-*` directives.
     iter_directives(
         config.mode,
-        &config.suite,
         &mut local_poisoned,
         path,
         src,

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -785,7 +785,7 @@ fn threads_support() {
 
 fn run_path(poisoned: &mut bool, path: &Utf8Path, buf: &[u8]) {
     let rdr = std::io::Cursor::new(&buf);
-    iter_directives(TestMode::Ui, "ui", poisoned, path, rdr, &mut |_| {});
+    iter_directives(TestMode::Ui, poisoned, path, rdr, &mut |_| {});
 }
 
 #[test]

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -360,7 +360,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         stage_id: matches.opt_str("stage-id").unwrap(),
 
         mode,
-        suite: matches.opt_str("suite").unwrap(),
+        suite: matches.opt_str("suite").unwrap().parse().expect("invalid suite"),
         debugger: matches.opt_str("debugger").map(|debugger| {
             debugger
                 .parse::<Debugger>()

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -16,9 +16,9 @@ use regex::{Captures, Regex};
 use tracing::*;
 
 use crate::common::{
-    CompareMode, Config, Debugger, FailMode, PassMode, TestMode, TestPaths, UI_EXTENSIONS,
-    UI_FIXED, UI_RUN_STDERR, UI_RUN_STDOUT, UI_STDERR, UI_STDOUT, UI_SVG, UI_WINDOWS_SVG,
-    expected_output_path, incremental_dir, output_base_dir, output_base_name,
+    CompareMode, Config, Debugger, FailMode, PassMode, TestMode, TestPaths, TestSuite,
+    UI_EXTENSIONS, UI_FIXED, UI_RUN_STDERR, UI_RUN_STDOUT, UI_STDERR, UI_STDOUT, UI_SVG,
+    UI_WINDOWS_SVG, expected_output_path, incremental_dir, output_base_dir, output_base_name,
     output_testname_unique,
 };
 use crate::compute_diff::{DiffLine, make_diff, write_diff, write_filtered_diff};
@@ -1494,7 +1494,10 @@ impl<'test> TestCx<'test> {
     }
 
     fn is_rustdoc(&self) -> bool {
-        matches!(self.config.suite.as_str(), "rustdoc-ui" | "rustdoc-js" | "rustdoc-json")
+        matches!(
+            self.config.suite,
+            TestSuite::RustdocUi | TestSuite::RustdocJs | TestSuite::RustdocJson
+        )
     }
 
     fn make_compile_args(

--- a/src/tools/compiletest/src/runtest/coverage.rs
+++ b/src/tools/compiletest/src/runtest/coverage.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use camino::{Utf8Path, Utf8PathBuf};
 use glob::glob;
 
-use crate::common::{UI_COVERAGE, UI_COVERAGE_MAP};
+use crate::common::{TestSuite, UI_COVERAGE, UI_COVERAGE_MAP};
 use crate::runtest::{Emit, ProcRes, TestCx, WillExecute};
 use crate::util::static_regex;
 
@@ -91,7 +91,7 @@ impl<'test> TestCx<'test> {
         let mut profraw_paths = vec![profraw_path];
         let mut bin_paths = vec![self.make_exe_name()];
 
-        if self.config.suite == "coverage-run-rustdoc" {
+        if self.config.suite == TestSuite::CoverageRunRustdoc {
             self.run_doctests_for_coverage(&mut profraw_paths, &mut bin_paths);
         }
 


### PR DESCRIPTION
This is part of a patch series to untangle `compiletest` to hopefully nudge it towards being more maintainable.

This PR should contain no functional changes.