### PR TITLE
Port `#[coverage]` to the new attribute system

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -110,6 +110,22 @@ pub enum DeprecatedSince {
     Err,
 }
 
+#[derive(
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Encodable,
+    Decodable,
+    Clone,
+    HashStable_Generic,
+    PrintAttribute
+)]
+pub enum CoverageStatus {
+    On,
+    Off,
+}
+
 impl Deprecation {
     /// Whether an item marked with #[deprecated(since = "X")] is currently
     /// deprecated (i.e., whether X is not greater than the current rustc
@@ -273,6 +289,9 @@ pub enum AttributeKind {
 
     /// Represents `#[const_trait]`.
     ConstTrait(Span),
+
+    /// Represents `#[coverage]`.
+    Coverage(Span, CoverageStatus),
 
     ///Represents `#[rustc_deny_explicit_impl]`.
     DenyExplicitImpl(Span),

--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -28,6 +28,7 @@ impl AttributeKind {
             ConstStability { .. } => Yes,
             ConstStabilityIndirect => No,
             ConstTrait(..) => No,
+            Coverage(..) => No,
             DenyExplicitImpl(..) => No,
             Deprecation { .. } => Yes,
             DoNotImplementViaObject(..) => No,

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -15,8 +15,9 @@ use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
 
 use crate::attributes::allow_unstable::{AllowConstFnUnstableParser, AllowInternalUnstableParser};
 use crate::attributes::codegen_attrs::{
-    ColdParser, ExportNameParser, NakedParser, NoMangleParser, OmitGdbPrettyPrinterSectionParser,
-    OptimizeParser, TargetFeatureParser, TrackCallerParser, UsedParser,
+    ColdParser, CoverageParser, ExportNameParser, NakedParser, NoMangleParser,
+    OmitGdbPrettyPrinterSectionParser, OptimizeParser, TargetFeatureParser, TrackCallerParser,
+    UsedParser,
 };
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::deprecation::DeprecationParser;
@@ -136,6 +137,7 @@ attribute_parsers!(
         // tidy-alphabetical-end
 
         // tidy-alphabetical-start
+        Single<CoverageParser>,
         Single<DeprecationParser>,
         Single<DummyParser>,
         Single<ExportNameParser>,
@@ -449,6 +451,25 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             reason: AttributeParseErrorReason::ExpectedSpecificArgument {
                 possibilities,
                 strings: false,
+                list: false,
+            },
+        })
+    }
+
+    pub(crate) fn expected_specific_argument_and_list(
+        &self,
+        span: Span,
+        possibilities: Vec<&'static str>,
+    ) -> ErrorGuaranteed {
+        self.emit_err(AttributeParseError {
+            span,
+            attr_span: self.attr_span,
+            template: self.template.clone(),
+            attribute: self.attr_path.clone(),
+            reason: AttributeParseErrorReason::ExpectedSpecificArgument {
+                possibilities,
+                strings: false,
+                list: true,
             },
         })
     }
@@ -466,6 +487,7 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
             reason: AttributeParseErrorReason::ExpectedSpecificArgument {
                 possibilities,
                 strings: true,
+                list: false,
             },
         })
     }

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -318,6 +318,7 @@ pub fn check_builtin_meta_item(
                 | sym::rustc_layout_scalar_valid_range_end
                 | sym::no_implicit_prelude
                 | sym::automatically_derived
+                | sym::coverage
         ) {
             return;
         }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -285,6 +285,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 &Attribute::Parsed(AttributeKind::StdInternalSymbol(attr_span)) => {
                     self.check_rustc_std_internal_symbol(attr_span, span, target)
                 }
+                &Attribute::Parsed(AttributeKind::Coverage(attr_span, _)) => {
+                    self.check_coverage(attr_span, span, target)
+                }
                 Attribute::Unparsed(attr_item) => {
                     style = Some(attr_item.style);
                     match attr.path().as_slice() {
@@ -294,7 +297,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         [sym::diagnostic, sym::on_unimplemented, ..] => {
                             self.check_diagnostic_on_unimplemented(attr.span(), hir_id, target)
                         }
-                        [sym::coverage, ..] => self.check_coverage(attr, span, target),
                         [sym::no_sanitize, ..] => {
                             self.check_no_sanitize(attr, span, target)
                         }
@@ -585,7 +587,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
 
     /// Checks that `#[coverage(..)]` is applied to a function/closure/method,
     /// or to an impl block or module.
-    fn check_coverage(&self, attr: &Attribute, target_span: Span, target: Target) {
+    fn check_coverage(&self, attr_span: Span, target_span: Span, target: Target) {
         let mut not_fn_impl_mod = None;
         let mut no_body = None;
 
@@ -608,7 +610,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
 
         self.dcx().emit_err(errors::CoverageAttributeNotAllowed {
-            attr_span: attr.span(),
+            attr_span,
             not_fn_impl_mod,
             no_body,
             help: (),

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -37,19 +37,6 @@ error: malformed `crate_name` attribute input
 LL | #[crate_name]
    | ^^^^^^^^^^^^^ help: must be of the form: `#[crate_name = "name"]`
 
-error: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:90:1
-   |
-LL | #[coverage]
-   | ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[coverage(off)]
-   |           +++++
-LL | #[coverage(on)]
-   |           ++++
-
 error: malformed `no_sanitize` attribute input
   --> $DIR/malformed-attrs.rs:92:1
    |
@@ -459,6 +446,19 @@ error[E0539]: malformed `link_section` attribute input
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^ help: must be of the form: `#[link_section = "name"]`
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/malformed-attrs.rs:90:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[coverage(off)]
+   |           +++++
+LL | #[coverage(on)]
+   |           ++++
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
   --> $DIR/malformed-attrs.rs:97:1

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -1,10 +1,10 @@
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-attr-ice.rs:11:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
@@ -13,3 +13,4 @@ LL | #[coverage(on)]
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -1,16 +1,3 @@
-error: malformed `coverage` attribute input
-  --> $DIR/bad-attr-ice.rs:11:1
-   |
-LL | #[coverage]
-   | ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[coverage(off)]
-   |           +++++
-LL | #[coverage(on)]
-   |           ++++
-
 error[E0658]: the `#[coverage]` attribute is an experimental feature
   --> $DIR/bad-attr-ice.rs:11:1
    |
@@ -21,6 +8,20 @@ LL | #[coverage]
    = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/bad-attr-ice.rs:11:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[coverage(off)]
+   |           +++++
+LL | #[coverage(on)]
+   |           ++++
+
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors have detailed explanations: E0539, E0658.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -1,119 +1,3 @@
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:17:1
-   |
-LL | #[coverage]
-   | ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[coverage(off)]
-   |           +++++
-LL | #[coverage(on)]
-   |           ++++
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:20:1
-   |
-LL | #[coverage = true]
-   | ^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage = true]
-LL + #[coverage(off)]
-   |
-LL - #[coverage = true]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:23:1
-   |
-LL | #[coverage()]
-   | ^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL | #[coverage(off)]
-   |            +++
-LL | #[coverage(on)]
-   |            ++
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:26:1
-   |
-LL | #[coverage(off, off)]
-   | ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage(off, off)]
-LL + #[coverage(off)]
-   |
-LL - #[coverage(off, off)]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:29:1
-   |
-LL | #[coverage(off, on)]
-   | ^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage(off, on)]
-LL + #[coverage(off)]
-   |
-LL - #[coverage(off, on)]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:32:1
-   |
-LL | #[coverage(bogus)]
-   | ^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage(bogus)]
-LL + #[coverage(off)]
-   |
-LL - #[coverage(bogus)]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:35:1
-   |
-LL | #[coverage(bogus, off)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage(bogus, off)]
-LL + #[coverage(off)]
-   |
-LL - #[coverage(bogus, off)]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:38:1
-   |
-LL | #[coverage(off, bogus)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL - #[coverage(off, bogus)]
-LL + #[coverage(off)]
-   |
-LL - #[coverage(off, bogus)]
-LL + #[coverage(on)]
-   |
-
 error: expected identifier, found `,`
   --> $DIR/bad-syntax.rs:44:12
    |
@@ -150,5 +34,135 @@ note: attribute also specified here
 LL | #[coverage(on)]
    | ^^^^^^^^^^^^^^^
 
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:17:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[coverage(off)]
+   |           +++++
+LL | #[coverage(on)]
+   |           ++++
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:20:1
+   |
+LL | #[coverage = true]
+   | ^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage = true]
+LL + #[coverage(off)]
+   |
+LL - #[coverage = true]
+LL + #[coverage(on)]
+   |
+
+error[E0805]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:23:1
+   |
+LL | #[coverage()]
+   | ^^^^^^^^^^--^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[coverage(off)]
+   |            +++
+LL | #[coverage(on)]
+   |            ++
+
+error[E0805]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:26:1
+   |
+LL | #[coverage(off, off)]
+   | ^^^^^^^^^^----------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off, off)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off, off)]
+LL + #[coverage(on)]
+   |
+
+error[E0805]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:29:1
+   |
+LL | #[coverage(off, on)]
+   | ^^^^^^^^^^---------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off, on)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off, on)]
+LL + #[coverage(on)]
+   |
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:32:1
+   |
+LL | #[coverage(bogus)]
+   | ^^^^^^^^^^^-----^^
+   |            |
+   |            valid arguments are `on` or `off`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(bogus)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(bogus)]
+LL + #[coverage(on)]
+   |
+
+error[E0805]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:35:1
+   |
+LL | #[coverage(bogus, off)]
+   | ^^^^^^^^^^------------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(bogus, off)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(bogus, off)]
+LL + #[coverage(on)]
+   |
+
+error[E0805]: malformed `coverage` attribute input
+  --> $DIR/bad-syntax.rs:38:1
+   |
+LL | #[coverage(off, bogus)]
+   | ^^^^^^^^^^------------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off, bogus)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off, bogus)]
+LL + #[coverage(on)]
+   |
+
 error: aborting due to 11 previous errors
 
+Some errors have detailed explanations: E0539, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/coverage-attr/name-value.rs
+++ b/tests/ui/coverage-attr/name-value.rs
@@ -20,7 +20,6 @@ mod my_mod_inner {
 
 #[coverage = "off"]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR [E0788]
 struct MyStruct;
 
 #[coverage = "off"]
@@ -28,22 +27,18 @@ struct MyStruct;
 impl MyStruct {
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32 = 7;
 }
 
 #[coverage = "off"]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR [E0788]
 trait MyTrait {
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32;
 
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     type T;
 }
 
@@ -52,12 +47,10 @@ trait MyTrait {
 impl MyTrait for MyStruct {
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32 = 8;
 
     #[coverage = "off"]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     type T = ();
 }
 

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -1,10 +1,10 @@
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:12:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage = "off"]
 LL + #[coverage(off)]
@@ -13,43 +13,28 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:17:5
    |
 LL |     #![coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
-   |
-LL -     #![coverage = "off"]
-LL +     #![coverage(off)]
+help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #![coverage = "off"]
-LL +     #![coverage(on)]
+LL +     #[coverage(off)]
+   |
+LL -     #![coverage = "off"]
+LL +     #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:21:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
-   |
-LL - #[coverage = "off"]
-LL + #[coverage(off)]
-   |
-LL - #[coverage = "off"]
-LL + #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:26:1
-   |
-LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage = "off"]
 LL + #[coverage(off)]
@@ -58,28 +43,13 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:29:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL -     #[coverage = "off"]
-LL +     #[coverage(off)]
-   |
-LL -     #[coverage = "off"]
-LL +     #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:35:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:25:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage = "off"]
 LL + #[coverage(off)]
@@ -88,13 +58,13 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:39:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:28:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[coverage = "off"]
 LL +     #[coverage(off)]
@@ -103,28 +73,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:44:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL -     #[coverage = "off"]
-LL +     #[coverage(off)]
-   |
-LL -     #[coverage = "off"]
-LL +     #[coverage(on)]
-   |
-
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:50:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:33:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage = "off"]
 LL + #[coverage(off)]
@@ -133,13 +88,13 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:53:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:36:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[coverage = "off"]
 LL +     #[coverage(off)]
@@ -148,13 +103,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:58:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:40:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL -     #[coverage = "off"]
 LL +     #[coverage(off)]
@@ -163,13 +118,13 @@ LL -     #[coverage = "off"]
 LL +     #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:64:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:45:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage = "off"]
 LL + #[coverage(off)]
@@ -178,87 +133,51 @@ LL - #[coverage = "off"]
 LL + #[coverage(on)]
    |
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:21:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:48:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL -     #[coverage = "off"]
+LL +     #[coverage(off)]
+   |
+LL -     #[coverage = "off"]
+LL +     #[coverage(on)]
+   |
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:52:5
+   |
+LL |     #[coverage = "off"]
+   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL -     #[coverage = "off"]
+LL +     #[coverage(off)]
+   |
+LL -     #[coverage = "off"]
+LL +     #[coverage(on)]
+   |
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/name-value.rs:57:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^
-...
-LL | struct MyStruct;
-   | ---------------- not a function, impl block, or module
+   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage = "off"]
+LL + #[coverage(off)]
+   |
+LL - #[coverage = "off"]
+LL + #[coverage(on)]
+   |
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:35:1
-   |
-LL |   #[coverage = "off"]
-   |   ^^^^^^^^^^^^^^^^^^^
-...
-LL | / trait MyTrait {
-LL | |     #[coverage = "off"]
-...  |
-LL | |     type T;
-LL | | }
-   | |_- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
+error: aborting due to 12 previous errors
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:39:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-...
-LL |     const X: u32;
-   |     ------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:44:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-...
-LL |     type T;
-   |     ------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:29:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-...
-LL |     const X: u32 = 7;
-   |     ----------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:53:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-...
-LL |     const X: u32 = 8;
-   |     ----------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/name-value.rs:58:5
-   |
-LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^
-...
-LL |     type T = ();
-   |     ------------ not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error: aborting due to 19 previous errors
-
-For more information about this error, try `rustc --explain E0788`.
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/coverage-attr/subword.stderr
+++ b/tests/ui/coverage-attr/subword.stderr
@@ -1,10 +1,12 @@
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/subword.rs:8:1
    |
 LL | #[coverage(yes(milord))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^-----------^^
+   |            |
+   |            valid arguments are `on` or `off`
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage(yes(milord))]
 LL + #[coverage(off)]
@@ -13,13 +15,15 @@ LL - #[coverage(yes(milord))]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/subword.rs:11:1
    |
 LL | #[coverage(no(milord))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^----------^^
+   |            |
+   |            valid arguments are `on` or `off`
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage(no(milord))]
 LL + #[coverage(off)]
@@ -28,13 +32,15 @@ LL - #[coverage(no(milord))]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/subword.rs:14:1
    |
 LL | #[coverage(yes = "milord")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^--------------^^
+   |            |
+   |            valid arguments are `on` or `off`
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage(yes = "milord")]
 LL + #[coverage(off)]
@@ -43,13 +49,15 @@ LL - #[coverage(yes = "milord")]
 LL + #[coverage(on)]
    |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/subword.rs:17:1
    |
 LL | #[coverage(no = "milord")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^-------------^^
+   |            |
+   |            valid arguments are `on` or `off`
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[coverage(no = "milord")]
 LL + #[coverage(off)]
@@ -60,3 +68,4 @@ LL + #[coverage(on)]
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/coverage-attr/word-only.rs
+++ b/tests/ui/coverage-attr/word-only.rs
@@ -20,7 +20,6 @@ mod my_mod_inner {
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR [E0788]
 struct MyStruct;
 
 #[coverage]
@@ -28,22 +27,18 @@ struct MyStruct;
 impl MyStruct {
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32 = 7;
 }
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//~| ERROR [E0788]
 trait MyTrait {
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32;
 
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     type T;
 }
 
@@ -52,12 +47,10 @@ trait MyTrait {
 impl MyTrait for MyStruct {
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     const X: u32 = 8;
 
     #[coverage]
     //~^ ERROR malformed `coverage` attribute input
-    //~| ERROR [E0788]
     type T = ();
 }
 

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -1,240 +1,161 @@
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:12:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
 LL | #[coverage(on)]
    |           ++++
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:17:5
    |
 LL |     #![coverage]
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
-LL |     #![coverage(off)]
-   |                +++++
-LL |     #![coverage(on)]
-   |                ++++
+LL -     #![coverage]
+LL +     #[coverage(off)]
+   |
+LL -     #![coverage]
+LL +     #[coverage(on)]
+   |
 
-error: malformed `coverage` attribute input
+error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:21:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
-   |
-LL | #[coverage(off)]
-   |           +++++
-LL | #[coverage(on)]
-   |           ++++
-
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:26:1
-   |
-LL | #[coverage]
-   | ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
 LL | #[coverage(on)]
    |           ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:29:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL |     #[coverage(off)]
-   |               +++++
-LL |     #[coverage(on)]
-   |               ++++
-
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:35:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:25:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
 LL | #[coverage(on)]
    |           ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:39:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:28:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL |     #[coverage(off)]
    |               +++++
 LL |     #[coverage(on)]
    |               ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:44:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-LL |     #[coverage(off)]
-   |               +++++
-LL |     #[coverage(on)]
-   |               ++++
-
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:50:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:33:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
 LL | #[coverage(on)]
    |           ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:53:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:36:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL |     #[coverage(off)]
    |               +++++
 LL |     #[coverage(on)]
    |               ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:58:5
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:40:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL |     #[coverage(off)]
    |               +++++
 LL |     #[coverage(on)]
    |               ++++
 
-error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:64:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:45:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-help: the following are the possible correct uses
+help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[coverage(off)]
    |           +++++
 LL | #[coverage(on)]
    |           ++++
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:21:1
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:48:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL |     #[coverage(off)]
+   |               +++++
+LL |     #[coverage(on)]
+   |               ++++
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:52:5
+   |
+LL |     #[coverage]
+   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL |     #[coverage(off)]
+   |               +++++
+LL |     #[coverage(on)]
+   |               ++++
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/word-only.rs:57:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^
-...
-LL | struct MyStruct;
-   | ---------------- not a function, impl block, or module
+   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
    |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[coverage(off)]
+   |           +++++
+LL | #[coverage(on)]
+   |           ++++
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:35:1
-   |
-LL |   #[coverage]
-   |   ^^^^^^^^^^^
-...
-LL | / trait MyTrait {
-LL | |     #[coverage]
-...  |
-LL | |     type T;
-LL | | }
-   | |_- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
+error: aborting due to 12 previous errors
 
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:39:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-...
-LL |     const X: u32;
-   |     ------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:44:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-...
-LL |     type T;
-   |     ------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:29:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-...
-LL |     const X: u32 = 7;
-   |     ----------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:53:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-...
-LL |     const X: u32 = 8;
-   |     ----------------- not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error[E0788]: coverage attribute not allowed here
-  --> $DIR/word-only.rs:58:5
-   |
-LL |     #[coverage]
-   |     ^^^^^^^^^^^
-...
-LL |     type T = ();
-   |     ------------ not a function, impl block, or module
-   |
-   = help: coverage attribute can be applied to a function (with body), impl block, or module
-
-error: aborting due to 19 previous errors
-
-For more information about this error, try `rustc --explain E0788`.
+For more information about this error, try `rustc --explain E0539`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @jdonszelmann 
