### PR TITLE
Region constraint nits

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -159,6 +159,9 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                     }
 
                     GenericArgKind::Type(mut t1) => {
+                        // Scraped constraints may have had inference vars.
+                        t1 = self.infcx.resolve_vars_if_possible(t1);
+
                         // Normalize the type we receive from a `TypeOutlives` obligation
                         // in the new trait solver.
                         if infcx.next_trait_solver() {

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -166,6 +166,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     /// Trait queries just want to pass back type obligations "as is"
     pub fn take_registered_region_obligations(&self) -> Vec<TypeOutlivesConstraint<'tcx>> {
+        assert!(!self.in_snapshot(), "cannot take registered region obligations in a snapshot");
         std::mem::take(&mut self.inner.borrow_mut().region_obligations)
     }
 

--- a/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
@@ -1,3 +1,4 @@
+use std::assert_matches::assert_matches;
 use std::marker::PhantomData;
 
 use rustc_data_structures::undo_log::{Rollback, UndoLogs};
@@ -73,7 +74,8 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
             }
             UndoLog::ProjectionCache(undo) => self.projection_cache.reverse(undo),
             UndoLog::PushTypeOutlivesConstraint => {
-                self.region_obligations.pop();
+                let popped = self.region_obligations.pop();
+                assert_matches!(popped, Some(_), "pushed region constraint but could not pop it");
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -213,13 +213,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         // inside of a `probe` whenever we have multiple choices inside of the solver.
         let region_obligations = self.0.inner.borrow().region_obligations().to_owned();
         let region_constraints = self.0.with_region_constraints(|region_constraints| {
-            make_query_region_constraints(
-                self.tcx,
-                region_obligations
-                    .iter()
-                    .map(|r_o| (r_o.sup_type, r_o.sub_region, r_o.origin.to_constraint_category())),
-                region_constraints,
-            )
+            make_query_region_constraints(self.tcx, region_obligations, region_constraints)
         });
 
         let mut seen = FxHashSet::default();

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
@@ -103,10 +103,7 @@ where
     let region_constraint_data = infcx.take_and_reset_region_constraints();
     let region_constraints = query_response::make_query_region_constraints(
         infcx.tcx,
-        region_obligations
-            .iter()
-            .map(|r_o| (r_o.sup_type, r_o.sub_region, r_o.origin.to_constraint_category()))
-            .map(|(ty, r, cc)| (infcx.resolve_vars_if_possible(ty), r, cc)),
+        region_obligations,
         &region_constraint_data,
     );
 


### PR DESCRIPTION
Couple miscellaneous region constraints that have a bit to do with rust-lang/rust#143545 but stand on their own.