### PR TITLE
Fix typos in documentation files

### DIFF
--- a/tests/mir-opt/pre-codegen/README.md
+++ b/tests/mir-opt/pre-codegen/README.md
@@ -1,3 +1,3 @@
-The goal of this directory is to track the quality of MIR that is given to codegen in a standard `-O` condiguration.
+The goal of this directory is to track the quality of MIR that is given to codegen in a standard `-O` configuration.
 
 As such, feel free to `--bless` whatever changes you get here, so long as doing so doesn't add substantially more MIR.

--- a/tests/ui/SUMMARY.md
+++ b/tests/ui/SUMMARY.md
@@ -410,7 +410,7 @@ These tests revolve around command-line flags which change the way error/warning
 
 ## `tests/ui/diagnostic_namespace/`
 
-Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic attribute namepsace](https://github.com/rust-lang/rfcs/blob/master/text/3368-diagnostic-attribute-namespace.md).
+Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic attribute namespace](https://github.com/rust-lang/rfcs/blob/master/text/3368-diagnostic-attribute-namespace.md).
 
 ## `tests/ui/diagnostic-width/`: `--diagnostic-width`
 


### PR DESCRIPTION
## Summary
Fix minor typos in documentation files to improve readability.

## Changes
- **tests/mir-opt/pre-codegen/README.md**: Fix typo `condiguration` → `configuration`
- **tests/ui/SUMMARY.md**: Fix typo in RFC link URL (`namepsace ` → `namespace`)

## Type of Change
- [x] Documentation update
- [x] Bug fix (typo correction)

