### PR TITLE
`rustc_scalable_vector(N)`

### DIFF
--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -60,6 +60,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
     /// This is public so that it can be used in unit tests, but
     /// should generally only be relevant to the ABI details of
     /// specific targets.
+    #[tracing::instrument(skip(cx), level = "debug")]
     pub fn homogeneous_aggregate<C>(&self, cx: &C) -> Result<HomogeneousAggregate, Heterogeneous>
     where
         Ty: TyAbiInterface<'a, C> + Copy,

--- a/compiler/rustc_abi/src/callconv.rs
+++ b/compiler/rustc_abi/src/callconv.rs
@@ -82,6 +82,10 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
                 }))
             }
 
+            BackendRepr::ScalableVector { .. } => {
+                unreachable!("`homogeneous_aggregate` should not be called for scalable vectors")
+            }
+
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { sized: true } => {
                 // Helper for computing `homogeneous_aggregate`, allowing a custom
                 // starting offset (used below for handling variants).

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -172,6 +172,7 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug {
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
     fn is_transparent(this: TyAndLayout<'a, Self>) -> bool;
+    fn is_scalable_vector(this: TyAndLayout<'a, Self>) -> bool;
     /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
     fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'a, Self>) -> bool;
 }
@@ -269,6 +270,13 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty: TyAbiInterface<'a, C>,
     {
         Ty::is_transparent(self)
+    }
+
+    pub fn is_scalable_vector<C>(self) -> bool
+    where
+        Ty: TyAbiInterface<'a, C>,
+    {
+        Ty::is_scalable_vector(self)
     }
 
     /// If this method returns `true`, then this type should always have a `PassMode` of

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -155,7 +155,7 @@ impl<'a, Ty> AsRef<LayoutData<FieldIdx, VariantIdx>> for TyAndLayout<'a, Ty> {
 
 /// Trait that needs to be implemented by the higher-level type representation
 /// (e.g. `rustc_middle::ty::Ty`), to provide `rustc_target::abi` functionality.
-pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug {
+pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug + std::fmt::Display {
     fn ty_and_layout_for_variant(
         this: TyAndLayout<'a, Self>,
         cx: &C,

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1758,6 +1758,10 @@ impl AddressSpace {
 pub enum BackendRepr {
     Scalar(Scalar),
     ScalarPair(Scalar, Scalar),
+    ScalableVector {
+        element: Scalar,
+        count: u64,
+    },
     SimdVector {
         element: Scalar,
         count: u64,
@@ -1776,6 +1780,12 @@ impl BackendRepr {
         match *self {
             BackendRepr::Scalar(_)
             | BackendRepr::ScalarPair(..)
+            // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
+            // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is
+            // fully implemented, scalable vectors will remain `Sized`, they just won't be
+            // `const Sized` - whether `is_unsized` continues to return `false` at that point will
+            // need to be revisited and will depend on what `is_unsized` is used for.
+            | BackendRepr::ScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => !sized,
         }
@@ -1816,7 +1826,9 @@ impl BackendRepr {
             BackendRepr::Scalar(s) => Some(s.align(cx).abi),
             BackendRepr::ScalarPair(s1, s2) => Some(s1.align(cx).max(s2.align(cx)).abi),
             // The align of a Vector can vary in surprising ways
-            BackendRepr::SimdVector { .. } | BackendRepr::Memory { .. } => None,
+            BackendRepr::SimdVector { .. }
+            | BackendRepr::Memory { .. }
+            | BackendRepr::ScalableVector { .. } => None,
         }
     }
 
@@ -1838,7 +1850,9 @@ impl BackendRepr {
                 Some(size)
             }
             // The size of a Vector can vary in surprising ways
-            BackendRepr::SimdVector { .. } | BackendRepr::Memory { .. } => None,
+            BackendRepr::SimdVector { .. }
+            | BackendRepr::Memory { .. }
+            | BackendRepr::ScalableVector { .. } => None,
         }
     }
 
@@ -1853,6 +1867,9 @@ impl BackendRepr {
                 BackendRepr::SimdVector { element: element.to_union(), count }
             }
             BackendRepr::Memory { .. } => BackendRepr::Memory { sized: true },
+            BackendRepr::ScalableVector { element, count } => {
+                BackendRepr::ScalableVector { element: element.to_union(), count }
+            }
         }
     }
 
@@ -2093,7 +2110,9 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
     /// Returns `true` if this is an aggregate type (including a ScalarPair!)
     pub fn is_aggregate(&self) -> bool {
         match self.backend_repr {
-            BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => false,
+            BackendRepr::Scalar(_)
+            | BackendRepr::SimdVector { .. }
+            | BackendRepr::ScalableVector { .. } => false,
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => true,
         }
     }
@@ -2187,6 +2206,19 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
         self.is_sized() && self.size.bytes() == 0 && self.align.bytes() == 1
     }
 
+    /// Returns `true` if the size of the type is only known at runtime.
+    pub fn is_runtime_sized(&self) -> bool {
+        matches!(self.backend_repr, BackendRepr::ScalableVector { .. })
+    }
+
+    /// Returns the elements count of a scalable vector.
+    pub fn scalable_vector_element_count(&self) -> Option<u64> {
+        match self.backend_repr {
+            BackendRepr::ScalableVector { count, .. } => Some(count),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if the type is a ZST and not unsized.
     ///
     /// Note that this does *not* imply that the type is irrelevant for layout! It can still have
@@ -2195,6 +2227,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
         match self.backend_repr {
             BackendRepr::Scalar(_)
             | BackendRepr::ScalarPair(..)
+            | BackendRepr::ScalableVector { .. }
             | BackendRepr::SimdVector { .. } => false,
             BackendRepr::Memory { sized } => sized && self.size.bytes() == 0,
         }

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -270,6 +270,8 @@ ast_passes_precise_capturing_duplicated = duplicate `use<...>` precise capturing
 
 ast_passes_precise_capturing_not_allowed_here = `use<...>` precise capturing syntax not allowed in {$loc}
 
+ast_passes_scalable_vector_not_tuple_struct = scalable vectors must be tuple structs
+
 ast_passes_static_without_body =
     free static item without body
     .suggestion = provide a definition for the static

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -990,3 +990,10 @@ pub(crate) struct AbiX86Interrupt {
     pub spans: Vec<Span>,
     pub param_count: usize,
 }
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_scalable_vector_not_tuple_struct)]
+pub(crate) struct ScalableVectorNotTupleStruct {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -200,6 +200,9 @@ attr_parsing_rustc_allowed_unstable_pairing =
 attr_parsing_rustc_promotable_pairing =
     `rustc_promotable` attribute must be paired with either a `rustc_const_unstable` or a `rustc_const_stable` attribute
 
+attr_parsing_rustc_scalable_vector_count_out_of_range = element count in `rustc_scalable_vector` is too large: `{$n}`
+    .note = the value may not exceed `u16::MAX`
+
 attr_parsing_soft_no_args =
     `soft` should not have any arguments
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -60,7 +60,8 @@ use crate::attributes::prototype::CustomMirParser;
 use crate::attributes::repr::{AlignParser, AlignStaticParser, ReprParser};
 use crate::attributes::rustc_internal::{
     RustcLayoutScalarValidRangeEndParser, RustcLayoutScalarValidRangeStartParser, RustcMainParser,
-    RustcObjectLifetimeDefaultParser, RustcSimdMonomorphizeLaneLimitParser,
+    RustcObjectLifetimeDefaultParser, RustcScalableVectorParser,
+    RustcSimdMonomorphizeLaneLimitParser,
 };
 use crate::attributes::semantics::MayDangleParser;
 use crate::attributes::stability::{
@@ -209,6 +210,7 @@ attribute_parsers!(
         Single<RustcLayoutScalarValidRangeEndParser>,
         Single<RustcLayoutScalarValidRangeStartParser>,
         Single<RustcObjectLifetimeDefaultParser>,
+        Single<RustcScalableVectorParser>,
         Single<RustcSimdMonomorphizeLaneLimitParser>,
         Single<SanitizeParser>,
         Single<ShouldPanicParser>,

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -501,6 +501,15 @@ pub(crate) struct LinkOrdinalOutOfRange {
     pub ordinal: u128,
 }
 
+#[derive(Diagnostic)]
+#[diag(attr_parsing_rustc_scalable_vector_count_out_of_range)]
+#[note]
+pub(crate) struct RustcScalableVectorCountOutOfRange {
+    #[primary_span]
+    pub span: Span,
+    pub n: u128,
+}
+
 pub(crate) enum AttributeParseErrorReason<'a> {
     ExpectedNoArgs,
     ExpectedStringLiteral {

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -943,6 +943,10 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
             .get_address(self.location)
     }
 
+    fn scalable_alloca(&mut self, _elt: u64, _align: Align, _element_ty: Ty<'_>) -> RValue<'gcc> {
+        todo!()
+    }
+
     fn load(&mut self, pointee_ty: Type<'gcc>, ptr: RValue<'gcc>, align: Align) -> RValue<'gcc> {
         let block = self.llbb();
         let function = block.get_function();

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -504,7 +504,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 let layout = self.layout_of(tp_ty).layout;
                 let _use_integer_compare = match layout.backend_repr() {
                     Scalar(_) | ScalarPair(_, _) => true,
-                    SimdVector { .. } => false,
+                    SimdVector { .. } | ScalableVector { .. } => false,
                     Memory { .. } => {
                         // For rusty ABIs, small aggregates are actually passed
                         // as `RegKind::Integer` (see `FnAbi::adjust_for_abi`),

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -85,6 +85,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
             );
         }
         BackendRepr::Memory { .. } => {}
+        BackendRepr::ScalableVector { .. } => todo!(),
     }
 
     let name = match *layout.ty.kind() {
@@ -179,6 +180,8 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
     fn is_gcc_immediate(&self) -> bool {
         match self.backend_repr {
             BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => true,
+            // FIXME(rustc_scalable_vector): Not yet implemented in rustc_codegen_gcc.
+            BackendRepr::ScalableVector { .. } => todo!(),
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => false,
         }
     }
@@ -188,6 +191,7 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
             BackendRepr::ScalarPair(..) => true,
             BackendRepr::Scalar(_)
             | BackendRepr::SimdVector { .. }
+            | BackendRepr::ScalableVector { .. }
             | BackendRepr::Memory { .. } => false,
         }
     }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -998,6 +998,7 @@ unsafe extern "C" {
     // Operations on array, pointer, and vector types (sequence types)
     pub(crate) safe fn LLVMPointerTypeInContext(C: &Context, AddressSpace: c_uint) -> &Type;
     pub(crate) fn LLVMVectorType(ElementType: &Type, ElementCount: c_uint) -> &Type;
+    pub(crate) fn LLVMScalableVectorType(ElementType: &Type, ElementCount: c_uint) -> &Type;
 
     pub(crate) fn LLVMGetElementType(Ty: &Type) -> &Type;
     pub(crate) fn LLVMGetVectorSize(VectorTy: &Type) -> c_uint;

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -68,6 +68,10 @@ impl<'ll, CX: Borrow<SCx<'ll>>> GenericCx<'ll, CX> {
         unsafe { llvm::LLVMVectorType(ty, len as c_uint) }
     }
 
+    pub(crate) fn type_scalable_vector(&self, ty: &'ll Type, count: u64) -> &'ll Type {
+        unsafe { llvm::LLVMScalableVectorType(ty, count as c_uint) }
+    }
+
     pub(crate) fn add_func(&self, name: &str, ty: &'ll Type) -> &'ll Value {
         let name = SmallCStr::new(name);
         unsafe { llvm::LLVMAddFunction(self.llmod(), name.as_ptr(), ty) }

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -549,7 +549,7 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
             registers_for_primitive(scalar1.primitive());
             registers_for_primitive(scalar2.primitive());
         }
-        BackendRepr::SimdVector { .. } => {
+        BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
             // Because no instance of VaArgSafe uses a non-scalar `BackendRepr`.
             unreachable!(
                 "No x86-64 SysV va_arg implementation for {:?}",
@@ -689,7 +689,9 @@ fn emit_x86_64_sysv64_va_arg<'ll, 'tcx>(
             }
         }
         // The Previous match on `BackendRepr` means control flow already escaped.
-        BackendRepr::SimdVector { .. } | BackendRepr::Memory { .. } => unreachable!(),
+        BackendRepr::SimdVector { .. }
+        | BackendRepr::ScalableVector { .. }
+        | BackendRepr::Memory { .. } => unreachable!(),
     };
 
     // AMD64-ABI 3.5.7p5: Step 5. Set:

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -129,6 +129,7 @@ codegen_ssa_invalid_monomorphization_mask_wrong_element_type = invalid monomorph
 
 codegen_ssa_invalid_monomorphization_mismatched_lengths = invalid monomorphization of `{$name}` intrinsic: mismatched lengths: mask length `{$m_len}` != other vector length `{$v_len}`
 
+codegen_ssa_invalid_monomorphization_non_scalable_type = invalid monomorphization of `{$name}` intrinsic: expected non-scalable type, found scalable type `{$ty}`
 codegen_ssa_invalid_monomorphization_return_element = invalid monomorphization of `{$name}` intrinsic: expected return element type `{$in_elem}` (element of input `{$in_ty}`), found `{$ret_ty}` with element type `{$out_ty}`
 
 codegen_ssa_invalid_monomorphization_return_integer_type = invalid monomorphization of `{$name}` intrinsic: expected return type with integer elements, found `{$ret_ty}` with non-integer `{$out_ty}`

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1094,6 +1094,14 @@ pub enum InvalidMonomorphization<'tcx> {
         expected_element: Ty<'tcx>,
         vector_type: Ty<'tcx>,
     },
+
+    #[diag(codegen_ssa_invalid_monomorphization_non_scalable_type, code = E0511)]
+    NonScalableType {
+        #[primary_span]
+        span: Span,
+        name: Symbol,
+        ty: Ty<'tcx>,
+    },
 }
 
 pub enum ExpectedPointerMutability {

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -405,7 +405,9 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                         imm
                     }
                 }
-                BackendRepr::ScalarPair(_, _) | BackendRepr::Memory { .. } => bug!(),
+                BackendRepr::ScalarPair(_, _)
+                | BackendRepr::Memory { .. }
+                | BackendRepr::ScalableVector { .. } => bug!(),
             })
         };
 
@@ -692,7 +694,9 @@ impl<'a, 'tcx, V: CodegenObject> OperandRefBuilder<'tcx, V> {
             BackendRepr::ScalarPair(a, b) => {
                 OperandValueBuilder::Pair(Either::Right(a), Either::Right(b))
             }
-            BackendRepr::SimdVector { .. } => OperandValueBuilder::Vector(Either::Right(())),
+            BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+                OperandValueBuilder::Vector(Either::Right(()))
+            }
             BackendRepr::Memory { .. } => {
                 bug!("Cannot use non-ZST Memory-ABI type in operand builder: {layout:?}");
             }

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -235,6 +235,7 @@ pub trait BuilderMethods<'a, 'tcx>:
     fn to_immediate_scalar(&mut self, val: Self::Value, scalar: Scalar) -> Self::Value;
 
     fn alloca(&mut self, size: Size, align: Align) -> Self::Value;
+    fn scalable_alloca(&mut self, elt: u64, align: Align, element_ty: Ty<'_>) -> Self::Value;
 
     fn load(&mut self, ty: Self::Type, ptr: Self::Value, align: Align) -> Self::Value;
     fn volatile_load(&mut self, ty: Self::Type, ptr: Self::Value) -> Self::Value;

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1315,7 +1315,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                     self.visit_scalar(b, b_layout)?;
                 }
             }
-            BackendRepr::SimdVector { .. } => {
+            BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
                 // No checks here, we assume layout computation gets this right.
                 // (This is harder to check since Miri does not represent these as `Immediate`. We
                 // also cannot use field projections since this might be a newtype around a vector.)

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -119,7 +119,9 @@ fn check_validity_requirement_lax<'tcx>(
             }
             BackendRepr::SimdVector { element: s, count } => count == 0 || scalar_allows_raw_init(s),
             BackendRepr::Memory { .. } => true, // Fields are checked below.
+            BackendRepr::ScalableVector { element, .. } => scalar_allows_raw_init(element),
         };
+
     if !valid {
         // This is definitely not okay.
         return Ok(false);

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1422,6 +1422,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
+    rustc_attr!(
+        rustc_scalable_vector, Normal, template!(List: &["count"]), WarnFollowing, EncodeCrossCrate::Yes,
+        "`#[rustc_scalable_vector]` defines a scalable vector type"
+    ),
 
     // ==========================================================================
     // Internal attributes, Testing:

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -878,6 +878,14 @@ pub enum AttributeKind {
     /// Represents `#[rustc_pass_indirectly_in_non_rustic_abis]`
     RustcPassIndirectlyInNonRusticAbis(Span),
 
+    /// Represents `#[rustc_scalable_vector(N)]`
+    RustcScalableVector {
+        /// The base multiple of lanes that are in a scalable vector, if provided. `element_count`
+        /// is not provided for representing tuple types.
+        element_count: Option<u16>,
+        span: Span,
+    },
+
     /// Represents `#[rustc_should_not_be_called_on_const_items]`
     RustcShouldNotBeCalledOnConstItems(Span),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -95,6 +95,7 @@ impl AttributeKind {
             RustcMain => No,
             RustcObjectLifetimeDefault => No,
             RustcPassIndirectlyInNonRusticAbis(..) => No,
+            RustcScalableVector { .. } => Yes,
             RustcShouldNotBeCalledOnConstItems(..) => Yes,
             RustcSimdMonomorphizeLaneLimit(..) => Yes, // Affects layout computation, which needs to work cross-crate
             Sanitize { .. } => No,

--- a/compiler/rustc_hir/src/attrs/pretty_printing.rs
+++ b/compiler/rustc_hir/src/attrs/pretty_printing.rs
@@ -1,4 +1,5 @@
 use std::num::NonZero;
+use std::ops::Deref;
 
 use rustc_abi::Align;
 use rustc_ast::token::{CommentKind, DocFragmentKind};
@@ -35,6 +36,15 @@ impl<T: PrintAttribute> PrintAttribute for &T {
 
     fn print_attribute(&self, p: &mut Printer) {
         T::print_attribute(self, p)
+    }
+}
+impl<T: PrintAttribute> PrintAttribute for Box<T> {
+    fn should_render(&self) -> bool {
+        self.deref().should_render()
+    }
+
+    fn print_attribute(&self, p: &mut Printer) {
+        T::print_attribute(self.deref(), p)
     }
 }
 impl<T: PrintAttribute> PrintAttribute for Option<T> {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1178,6 +1178,10 @@ where
         matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().transparent())
     }
 
+    fn is_scalable_vector(this: TyAndLayout<'tcx>) -> bool {
+        this.ty.is_scalable_vector()
+    }
+
     /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
     fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'tcx>) -> bool {
         matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().flags.contains(ReprFlags::PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS))

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::ops::{ControlFlow, Range};
 
 use hir::def::{CtorKind, DefKind};
-use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
+use rustc_abi::{FIRST_VARIANT, FieldIdx, ScalableElt, VariantIdx};
 use rustc_errors::{ErrorGuaranteed, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::LangItem;
@@ -1267,6 +1267,19 @@ impl<'tcx> Ty<'tcx> {
             Str => tcx.types.u8,
             _ => bug!("`sequence_element_type` called on non-sequence value: {}", self),
         }
+    }
+
+    pub fn scalable_vector_element_count_and_type(self, tcx: TyCtxt<'tcx>) -> (u16, Ty<'tcx>) {
+        let Adt(def, args) = self.kind() else {
+            bug!("`scalable_vector_size_and_type` called on invalid type")
+        };
+        let Some(ScalableElt::ElementCount(element_count)) = def.repr().scalable else {
+            bug!("`scalable_vector_size_and_type` called on non-scalable vector type");
+        };
+        let variant = def.non_enum_variant();
+        assert_eq!(variant.fields.len(), 1);
+        let field_ty = variant.fields[FieldIdx::ZERO].ty(tcx, args);
+        (element_count, field_ty)
     }
 
     pub fn simd_size_and_type(self, tcx: TyCtxt<'tcx>) -> (u64, Ty<'tcx>) {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1253,6 +1253,14 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
+    #[inline]
+    pub fn is_scalable_vector(self) -> bool {
+        match self.kind() {
+            Adt(def, _) => def.repr().scalable(),
+            _ => false,
+        }
+    }
+
     pub fn sequence_element_type(self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
         match self.kind() {
             Array(ty, _) | Slice(ty) => *ty,

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1661,7 +1661,9 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
             BackendRepr::ScalarPair(a, b) => {
                 !a.is_always_valid(&self.ecx) || !b.is_always_valid(&self.ecx)
             }
-            BackendRepr::SimdVector { .. } | BackendRepr::Memory { .. } => false,
+            BackendRepr::SimdVector { .. }
+            | BackendRepr::ScalableVector { .. }
+            | BackendRepr::Memory { .. } => false,
         }
     }
 

--- a/compiler/rustc_monomorphize/messages.ftl
+++ b/compiler/rustc_monomorphize/messages.ftl
@@ -2,7 +2,10 @@ monomorphize_abi_error_disabled_vector_type =
   this function {$is_call ->
     [true] call
     *[false] definition
-  } uses SIMD vector type `{$ty}` which (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled{$is_call ->
+  } uses {$is_scalable ->
+    [true] scalable
+    *[false] SIMD
+  } vector type `{$ty}` which (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled{$is_call ->
     [true] {" "}in the caller
     *[false] {""}
   }

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -78,6 +78,8 @@ pub(crate) struct AbiErrorDisabledVectorType<'a> {
     pub ty: Ty<'a>,
     /// Whether this is a problem at a call site or at a declaration.
     pub is_call: bool,
+    /// Whether this is a problem with a fixed length vector or a scalable vector
+    pub is_scalable: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -252,6 +252,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::MacroEscape( .. )
                     | AttributeKind::RustcLayoutScalarValidRangeStart(..)
                     | AttributeKind::RustcLayoutScalarValidRangeEnd(..)
+                    | AttributeKind::RustcScalableVector { .. }
                     | AttributeKind::RustcSimdMonomorphizeLaneLimit(..)
                     | AttributeKind::RustcShouldNotBeCalledOnConstItems(..)
                     | AttributeKind::ExportStable

--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -225,6 +225,10 @@ pub enum ValueAbi {
         element: Scalar,
         count: u64,
     },
+    ScalableVector {
+        element: Scalar,
+        count: u64,
+    },
     Aggregate {
         /// If true, the size is exact, otherwise it's only a lower bound.
         sized: bool,
@@ -235,7 +239,15 @@ impl ValueAbi {
     /// Returns `true` if the layout corresponds to an unsized type.
     pub fn is_unsized(&self) -> bool {
         match *self {
-            ValueAbi::Scalar(_) | ValueAbi::ScalarPair(..) | ValueAbi::Vector { .. } => false,
+            ValueAbi::Scalar(_)
+            | ValueAbi::ScalarPair(..)
+            | ValueAbi::Vector { .. }
+            // FIXME(rustc_scalable_vector): Scalable vectors are `Sized` while the
+            // `sized_hierarchy` feature is not yet fully implemented. After `sized_hierarchy` is
+            // fully implemented, scalable vectors will remain `Sized`, they just won't be
+            // `const Sized` - whether `is_unsized` continues to return `false` at that point will
+            // need to be revisited and will depend on what `is_unsized` is used for.
+            | ValueAbi::ScalableVector { .. } => false,
             ValueAbi::Aggregate { sized } => !sized,
         }
     }

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -256,6 +256,9 @@ impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
             rustc_abi::BackendRepr::SimdVector { element, count } => {
                 ValueAbi::Vector { element: element.stable(tables, cx), count }
             }
+            rustc_abi::BackendRepr::ScalableVector { element, count } => {
+                ValueAbi::ScalableVector { element: element.stable(tables, cx), count }
+            }
             rustc_abi::BackendRepr::Memory { sized } => ValueAbi::Aggregate { sized },
         }
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1998,6 +1998,7 @@ symbols! {
         rustc_reallocator,
         rustc_regions,
         rustc_reservation_impl,
+        rustc_scalable_vector,
         rustc_serialize,
         rustc_should_not_be_called_on_const_items,
         rustc_simd_monomorphize_lane_limit,

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -9,13 +9,14 @@ use crate::spec::{Abi, HasTargetSpec, Target};
 /// Used to accommodate Apple and Microsoft's deviations from the usual AAPCS ABI.
 ///
 /// Corresponds to Clang's `AArch64ABIInfo::ABIKind`.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum AbiKind {
     AAPCS,
     DarwinPCS,
     Win64,
 }
 
+#[tracing::instrument(skip(cx), level = "debug")]
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>) -> Option<Uniform>
 where
     Ty: TyAbiInterface<'a, C> + Copy,
@@ -73,6 +74,7 @@ fn softfloat_float_abi<Ty>(target: &Target, arg: &mut ArgAbi<'_, Ty>) {
     }
 }
 
+#[tracing::instrument(skip(cx), level = "debug")]
 fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>, kind: AbiKind)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
@@ -105,6 +107,7 @@ where
     ret.make_indirect();
 }
 
+#[tracing::instrument(skip(cx), level = "debug")]
 fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, kind: AbiKind)
 where
     Ty: TyAbiInterface<'a, C> + Copy,

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -78,7 +78,7 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    if !ret.layout.is_sized() {
+    if !ret.layout.is_sized() || ret.layout.is_scalable_vector() {
         // Not touching this...
         return;
     }
@@ -110,7 +110,7 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    if !arg.layout.is_sized() {
+    if !arg.layout.is_sized() || arg.layout.is_scalable_vector() {
         // Not touching this...
         return;
     }

--- a/compiler/rustc_target/src/callconv/loongarch.rs
+++ b/compiler/rustc_target/src/callconv/loongarch.rs
@@ -85,7 +85,10 @@ where
                 }
             }
         },
-        BackendRepr::SimdVector { .. } => return Err(CannotUseFpConv),
+        BackendRepr::SimdVector { .. } => {
+            return Err(CannotUseFpConv);
+        }
+        BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
         BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -393,6 +393,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             ),
             BackendRepr::SimdVector { .. } => PassMode::Direct(ArgAttributes::new()),
             BackendRepr::Memory { .. } => Self::indirect_pass_mode(&layout),
+            BackendRepr::ScalableVector { .. } => PassMode::Direct(ArgAttributes::new()),
         };
         ArgAbi { layout, mode }
     }

--- a/compiler/rustc_target/src/callconv/riscv.rs
+++ b/compiler/rustc_target/src/callconv/riscv.rs
@@ -91,7 +91,9 @@ where
                 }
             }
         },
-        BackendRepr::SimdVector { .. } => return Err(CannotUseFpConv),
+        BackendRepr::SimdVector { .. } | BackendRepr::ScalableVector { .. } => {
+            return Err(CannotUseFpConv);
+        }
         BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => match arg_layout.fields {
             FieldsShape::Primitive => {
                 unreachable!("aggregates can't have `FieldsShape::Primitive`")

--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -103,6 +103,9 @@ where
                         }
                         false
                     }
+                    BackendRepr::ScalableVector { .. } => {
+                        panic!("scalable vectors are unsupported")
+                    }
                 }
             }
 

--- a/compiler/rustc_target/src/callconv/x86_64.rs
+++ b/compiler/rustc_target/src/callconv/x86_64.rs
@@ -59,6 +59,8 @@ where
 
             BackendRepr::SimdVector { .. } => Class::Sse,
 
+            BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
+
             BackendRepr::ScalarPair(..) | BackendRepr::Memory { .. } => {
                 for i in 0..layout.fields.count() {
                     let field_off = off + layout.fields.offset(i);

--- a/compiler/rustc_target/src/callconv/x86_win64.rs
+++ b/compiler/rustc_target/src/callconv/x86_win64.rs
@@ -25,6 +25,7 @@ where
                 // FIXME(eddyb) there should be a size cap here
                 // (probably what clang calls "illegal vectors").
             }
+            BackendRepr::ScalableVector { .. } => panic!("scalable vectors are unsupported"),
             BackendRepr::Scalar(scalar) => {
                 if is_ret && matches!(scalar.primitive(), Primitive::Int(Integer::I128, _)) {
                     if cx.target_spec().rustc_abi == Some(RustcAbi::X86Softfloat) {

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -911,18 +911,24 @@ pub fn all_rust_features() -> impl Iterator<Item = (&'static str, Stability)> {
 // These arrays represent the least-constraining feature that is required for vector types up to a
 // certain size to have their "proper" ABI on each architecture.
 // Note that they must be kept sorted by vector size.
-const X86_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =
+const X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[(128, "sse"), (256, "avx"), (512, "avx512f")]; // FIXME: might need changes for AVX10.
-const AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "neon")];
+const AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "neon")];
 
 // We might want to add "helium" too.
-const ARM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "neon")];
+const ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "neon")];
 
-const AMDGPU_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(1024, "")];
-const POWERPC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "altivec")];
-const WASM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "simd128")];
-const S390X_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "vector")];
-const RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[
+const AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(1024, "")];
+const POWERPC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "altivec")];
+const WASM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "simd128")];
+const S390X_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "vector")];
+const RISCV_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] = &[
     (32, "zvl32b"),
     (64, "zvl64b"),
     (128, "zvl128b"),
@@ -937,13 +943,16 @@ const RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[
     (65536, "zvl65536b"),
 ];
 // Always error on SPARC, as the necessary target features cannot be enabled in Rust at the moment.
-const SPARC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[/*(64, "vis")*/];
+const SPARC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[/*(64, "vis")*/];
 
-const HEXAGON_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =
+const HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[/*(512, "hvx-length64b"),*/ (1024, "hvx-length128b")];
-const MIPS_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "msa")];
-const CSKY_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "vdspv1")];
-const LOONGARCH_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =
+const MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "msa")];
+const CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[(128, "vdspv1")];
+const LOONGARCH_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
     &[(128, "lsx"), (256, "lasx")];
 
 #[derive(Copy, Clone, Debug)]
@@ -982,24 +991,26 @@ impl Target {
         }
     }
 
-    pub fn features_for_correct_vector_abi(&self) -> &'static [(u64, &'static str)] {
+    pub fn features_for_correct_fixed_length_vector_abi(&self) -> &'static [(u64, &'static str)] {
         match &self.arch {
-            Arch::X86 | Arch::X86_64 => X86_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::AArch64 | Arch::Arm64EC => AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::Arm => ARM_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::PowerPC | Arch::PowerPC64 => POWERPC_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::LoongArch32 | Arch::LoongArch64 => LOONGARCH_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::RiscV32 | Arch::RiscV64 => RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::Wasm32 | Arch::Wasm64 => WASM_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::S390x => S390X_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::Sparc | Arch::Sparc64 => SPARC_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::Hexagon => HEXAGON_FEATURES_FOR_CORRECT_VECTOR_ABI,
-            Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => {
-                MIPS_FEATURES_FOR_CORRECT_VECTOR_ABI
+            Arch::X86 | Arch::X86_64 => X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::AArch64 | Arch::Arm64EC => AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::Arm => ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::PowerPC | Arch::PowerPC64 => POWERPC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::LoongArch32 | Arch::LoongArch64 => {
+                LOONGARCH_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI
             }
-            Arch::AmdGpu => AMDGPU_FEATURES_FOR_CORRECT_VECTOR_ABI,
+            Arch::RiscV32 | Arch::RiscV64 => RISCV_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::Wasm32 | Arch::Wasm64 => WASM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::S390x => S390X_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::Sparc | Arch::Sparc64 => SPARC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::Hexagon => HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
+            Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => {
+                MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI
+            }
+            Arch::AmdGpu => AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
             Arch::Nvptx64 | Arch::Bpf | Arch::M68k => &[], // no vector ABI
-            Arch::CSky => CSKY_FEATURES_FOR_CORRECT_VECTOR_ABI,
+            Arch::CSky => CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
             // FIXME: for some tier3 targets, we are overly cautious and always give warnings
             // when passing args in vector registers.
             Arch::Avr
@@ -1008,6 +1019,14 @@ impl Target {
             | Arch::SpirV
             | Arch::Xtensa
             | Arch::Other(_) => &[],
+        }
+    }
+
+    pub fn features_for_correct_scalable_vector_abi(&self) -> Option<&'static str> {
+        match &self.arch {
+            Arch::AArch64 | Arch::Arm64EC => Some("sve"),
+            // Other targets have no scalable vectors or they are unimplemented.
+            _ => None,
         }
     }
 

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -407,7 +407,9 @@ fn fn_abi_sanity_check<'tcx>(
                 // `layout.backend_repr` and ignore everything else. We should just reject
                 //`Aggregate` entirely here, but some targets need to be fixed first.
                 match arg.layout.backend_repr {
-                    BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => {}
+                    BackendRepr::Scalar(_)
+                    | BackendRepr::SimdVector { .. }
+                    | BackendRepr::ScalableVector { .. } => {}
                     BackendRepr::ScalarPair(..) => {
                         panic!("`PassMode::Direct` used for ScalarPair type {}", arg.layout.ty)
                     }

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -250,7 +250,7 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 // And the size has to be element * count plus alignment padding, of course
                 assert!(size == (element_size * count).align_to(align));
             }
-            BackendRepr::Memory { .. } => {} // Nothing to check.
+            BackendRepr::Memory { .. } | BackendRepr::ScalableVector { .. } => {} // Nothing to check.
         }
     }
 

--- a/tests/codegen-llvm/scalable-vectors/simple.rs
+++ b/tests/codegen-llvm/scalable-vectors/simple.rs
@@ -1,0 +1,49 @@
+//@ edition: 2021
+//@ only-aarch64
+#![crate_type = "lib"]
+#![allow(incomplete_features, internal_features)]
+#![feature(simd_ffi, rustc_attrs, link_llvm_intrinsics)]
+
+#[derive(Copy, Clone)]
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[inline(never)]
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+#[inline]
+#[target_feature(enable = "sve,sve2")]
+pub unsafe fn svxar_n_s32<const IMM3: i32>(op1: svint32_t, op2: svint32_t) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.xar.nxv4i32")]
+        fn _svxar_n_s32(op1: svint32_t, op2: svint32_t, imm3: i32) -> svint32_t;
+    }
+    unsafe { _svxar_n_s32(op1, op2, IMM3) }
+}
+
+#[inline(never)]
+#[no_mangle]
+#[target_feature(enable = "sve,sve2")]
+// CHECK: define <vscale x 4 x i32> @pass_as_ref(ptr {{.*}}align 16{{.*}} %a, <vscale x 4 x i32> %b)
+pub unsafe fn pass_as_ref(a: &svint32_t, b: svint32_t) -> svint32_t {
+    // CHECK: load <vscale x 4 x i32>, ptr %a, align 16
+    svxar_n_s32::<1>(*a, b)
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve,sve2")]
+// CHECK: define <vscale x 4 x i32> @test()
+pub unsafe fn test() -> svint32_t {
+    let a = svdup_n_s32(1);
+    let b = svdup_n_s32(2);
+    // CHECK: %_0 = call <vscale x 4 x i32> @pass_as_ref(ptr {{.*}}align 16{{.*}} %a, <vscale x 4 x i32> %b)
+    pass_as_ref(&a, b)
+}

--- a/tests/ui/scalable-vectors/async.rs
+++ b/tests/ui/scalable-vectors/async.rs
@@ -1,0 +1,44 @@
+//@ only-aarch64
+//@ edition:2021
+
+#![allow(incomplete_features, internal_features)]
+#![feature(
+    core_intrinsics,
+    simd_ffi,
+    rustc_attrs,
+    link_llvm_intrinsics
+)]
+
+use core::intrinsics::transmute_unchecked;
+
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+#[target_feature(enable = "sve")]
+async fn another() -> i32 {
+    42
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+pub async fn test_function() {
+    unsafe {
+        let x = svdup_n_s32(1); //~ ERROR: scalable vectors cannot be held over await points
+        let temp = another().await;
+        let y: svint32_t = transmute_unchecked(x);
+    }
+}
+
+fn main() {
+    let _ = unsafe { test_function() };
+}

--- a/tests/ui/scalable-vectors/async.stderr
+++ b/tests/ui/scalable-vectors/async.stderr
@@ -1,0 +1,8 @@
+error: scalable vectors cannot be held over await points
+  --> $DIR/async.rs:36:13
+   |
+LL |         let x = svdup_n_s32(1);
+   |             ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/scalable-vectors/closure-capture.rs
+++ b/tests/ui/scalable-vectors/closure-capture.rs
@@ -1,0 +1,51 @@
+//@ compile-flags: --crate-type=lib
+//@ only-aarch64
+
+#![allow(incomplete_features, internal_features)]
+#![feature(
+    link_llvm_intrinsics,
+    rustc_attrs,
+    simd_ffi
+)]
+
+#[derive(Copy, Clone)]
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[inline(never)]
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+#[inline]
+#[target_feature(enable = "sve,sve2")]
+pub unsafe fn svxar_n_s32<const IMM3: i32>(op1: svint32_t, op2: svint32_t) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.xar.nxv4i32")]
+        fn _svxar_n_s32(op1: svint32_t, op2: svint32_t, imm3: i32) -> svint32_t;
+    }
+    unsafe { _svxar_n_s32(op1, op2, IMM3) }
+}
+
+#[inline(never)]
+#[target_feature(enable = "sve,sve2")]
+fn run(f: impl Fn() -> ()) {
+    f();
+}
+
+#[target_feature(enable = "sve,sve2")]
+fn foo() {
+    unsafe {
+        let a = svdup_n_s32(42);
+        run(move || {
+//~^ ERROR: scalable vectors cannot be tuple fields
+            svxar_n_s32::<2>(a, a);
+        });
+    }
+}

--- a/tests/ui/scalable-vectors/closure-capture.stderr
+++ b/tests/ui/scalable-vectors/closure-capture.stderr
@@ -1,0 +1,8 @@
+error: scalable vectors cannot be tuple fields
+  --> $DIR/closure-capture.rs:46:9
+   |
+LL |         run(move || {
+   |         ^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/scalable-vectors/copy-clone.rs
+++ b/tests/ui/scalable-vectors/copy-clone.rs
@@ -1,0 +1,31 @@
+//@ build-pass
+//@ only-aarch64
+#![feature(simd_ffi, rustc_attrs, link_llvm_intrinsics)]
+
+#[derive(Copy, Clone)]
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+//~^ WARN: `extern` block uses type `svint32_t`, which is not FFI-safe
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+#[target_feature(enable = "sve")]
+fn require_copy<T: Copy>(t: T) {}
+
+#[target_feature(enable = "sve")]
+fn test() {
+    unsafe {
+        let a = svdup_n_s32(1);
+        require_copy(a);
+    }
+}
+
+fn main() {}

--- a/tests/ui/scalable-vectors/copy-clone.stderr
+++ b/tests/ui/scalable-vectors/copy-clone.stderr
@@ -1,0 +1,17 @@
+warning: `extern` block uses type `svint32_t`, which is not FFI-safe
+  --> $DIR/copy-clone.rs:14:37
+   |
+LL |         fn _svdup_n_s32(op: i32) -> svint32_t;
+   |                                     ^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/copy-clone.rs:8:1
+   |
+LL | pub struct svint32_t(i32);
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(improper_ctypes)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/scalable-vectors/fn-trait.rs
+++ b/tests/ui/scalable-vectors/fn-trait.rs
@@ -1,0 +1,13 @@
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(4)]
+pub struct ScalableSimdFloat(f32);
+
+unsafe fn test<T>(f: T)
+where
+    T: Fn(ScalableSimdFloat), //~ ERROR: scalable vectors cannot be tuple fields
+{
+}
+
+fn main() {}

--- a/tests/ui/scalable-vectors/fn-trait.stderr
+++ b/tests/ui/scalable-vectors/fn-trait.stderr
@@ -1,0 +1,8 @@
+error: scalable vectors cannot be tuple fields
+  --> $DIR/fn-trait.rs:9:8
+   |
+LL |     T: Fn(ScalableSimdFloat),
+   |        ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/scalable-vectors/illformed-element-type.rs
+++ b/tests/ui/scalable-vectors/illformed-element-type.rs
@@ -1,0 +1,93 @@
+//@ compile-flags: --crate-type=lib
+#![allow(internal_features)]
+#![feature(extern_types)]
+#![feature(never_type)]
+#![feature(rustc_attrs)]
+
+struct Foo;
+enum Bar {}
+union Baz { x: u16 }
+extern "C" {
+    type Qux;
+}
+
+#[rustc_scalable_vector(4)]
+struct TyChar(char);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(2)]
+struct TyConstPtr(*const u8);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(2)]
+struct TyMutPtr(*mut u8);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyStruct(Foo);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyEnum(Bar);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyUnion(Baz);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyForeign(Qux);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyArray([u32; 4]);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TySlice([u32]);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyRef<'a>(&'a u32);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyFnPtr(fn(u32) -> u32);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyDyn(dyn std::io::Write);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyNever(!);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+#[rustc_scalable_vector(4)]
+struct TyTuple((u32, u32));
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+type ValidAlias = u32;
+type InvalidAlias = String;
+
+#[rustc_scalable_vector(4)]
+struct TyValidAlias(ValidAlias);
+
+#[rustc_scalable_vector(4)]
+struct TyInvalidAlias(InvalidAlias);
+//~^ ERROR: element type of a scalable vector must be a primitive scalar
+
+trait Tr {
+    type Valid;
+    type Invalid;
+}
+
+impl Tr for () {
+    type Valid = u32;
+    type Invalid = String;
+}
+
+struct TyValidProjection(<() as Tr>::Valid);
+
+struct TyInvalidProjection(<() as Tr>::Invalid);
+// FIXME: element type of a scalable vector must be a primitive scalar

--- a/tests/ui/scalable-vectors/illformed-element-type.stderr
+++ b/tests/ui/scalable-vectors/illformed-element-type.stderr
@@ -1,0 +1,122 @@
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:15:1
+   |
+LL | struct TyChar(char);
+   | ^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:19:1
+   |
+LL | struct TyConstPtr(*const u8);
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:23:1
+   |
+LL | struct TyMutPtr(*mut u8);
+   | ^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:27:1
+   |
+LL | struct TyStruct(Foo);
+   | ^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:31:1
+   |
+LL | struct TyEnum(Bar);
+   | ^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:35:1
+   |
+LL | struct TyUnion(Baz);
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:39:1
+   |
+LL | struct TyForeign(Qux);
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:43:1
+   |
+LL | struct TyArray([u32; 4]);
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:47:1
+   |
+LL | struct TySlice([u32]);
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:51:1
+   |
+LL | struct TyRef<'a>(&'a u32);
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:55:1
+   |
+LL | struct TyFnPtr(fn(u32) -> u32);
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:59:1
+   |
+LL | struct TyDyn(dyn std::io::Write);
+   | ^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:63:1
+   |
+LL | struct TyNever(!);
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:67:1
+   |
+LL | struct TyTuple((u32, u32));
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: element type of a scalable vector must be a primitive scalar
+  --> $DIR/illformed-element-type.rs:77:1
+   |
+LL | struct TyInvalidAlias(InvalidAlias);
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only `u*`, `i*`, `f*` and `bool` types are accepted
+
+error: aborting due to 15 previous errors
+

--- a/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.rs
+++ b/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.rs
@@ -1,0 +1,36 @@
+//@ compile-flags: --crate-type=lib
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(2)]
+struct ValidI64(i64);
+
+#[rustc_scalable_vector(4)]
+struct ValidI32(i32);
+
+#[rustc_scalable_vector]
+struct ValidTuple(ValidI32, ValidI32, ValidI32);
+
+#[rustc_scalable_vector]
+struct Struct { x: ValidI64, y: ValidI64 }
+//~^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector]
+struct DifferentVectorTypes(ValidI64, ValidI32);
+//~^ ERROR: all fields in a scalable vector struct must be the same type
+
+#[rustc_scalable_vector]
+struct NonVectorTypes(u32, u64);
+//~^ ERROR: scalable vector structs can only have scalable vector fields
+
+#[rustc_scalable_vector]
+struct DifferentNonVectorTypes(u32, u64);
+//~^ ERROR: scalable vector structs can only have scalable vector fields
+
+#[rustc_scalable_vector]
+struct SomeVectorTypes(ValidI64, u64);
+//~^ ERROR: scalable vector structs can only have scalable vector fields
+
+#[rustc_scalable_vector]
+struct NestedTuple(ValidTuple, ValidTuple);
+//~^ ERROR: scalable vector structs cannot contain other scalable vector structs

--- a/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.stderr
+++ b/tests/ui/scalable-vectors/illformed-tuples-of-scalable-vectors.stderr
@@ -1,0 +1,38 @@
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:15:1
+   |
+LL | struct Struct { x: ValidI64, y: ValidI64 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: all fields in a scalable vector struct must be the same type
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:19:39
+   |
+LL | struct DifferentVectorTypes(ValidI64, ValidI32);
+   |                                       ^^^^^^^^
+
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:23:23
+   |
+LL | struct NonVectorTypes(u32, u64);
+   |                       ^^^
+
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:27:32
+   |
+LL | struct DifferentNonVectorTypes(u32, u64);
+   |                                ^^^
+
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:31:34
+   |
+LL | struct SomeVectorTypes(ValidI64, u64);
+   |                                  ^^^
+
+error: scalable vector structs cannot contain other scalable vector structs
+  --> $DIR/illformed-tuples-of-scalable-vectors.rs:35:20
+   |
+LL | struct NestedTuple(ValidTuple, ValidTuple);
+   |                    ^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/scalable-vectors/illformed-within-types.rs
+++ b/tests/ui/scalable-vectors/illformed-within-types.rs
@@ -1,0 +1,23 @@
+//@ compile-flags: --crate-type=lib
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(2)]
+struct ValidI64(i64);
+
+struct Struct {
+    x: ValidI64,
+//~^ ERROR: scalable vectors cannot be fields of a struct
+    in_tuple: (ValidI64,),
+//~^ ERROR: scalable vectors cannot be tuple fields
+}
+
+struct TupleStruct(ValidI64);
+//~^ ERROR: scalable vectors cannot be fields of a struct
+
+enum Enum {
+    StructVariant { _ty: ValidI64 },
+//~^ ERROR: scalable vectors cannot be fields of a variant
+    TupleVariant(ValidI64),
+//~^ ERROR: scalable vectors cannot be fields of a variant
+}

--- a/tests/ui/scalable-vectors/illformed-within-types.stderr
+++ b/tests/ui/scalable-vectors/illformed-within-types.stderr
@@ -1,0 +1,32 @@
+error: scalable vectors cannot be fields of a struct
+  --> $DIR/illformed-within-types.rs:9:8
+   |
+LL |     x: ValidI64,
+   |        ^^^^^^^^
+
+error: scalable vectors cannot be tuple fields
+  --> $DIR/illformed-within-types.rs:11:15
+   |
+LL |     in_tuple: (ValidI64,),
+   |               ^^^^^^^^^^^
+
+error: scalable vectors cannot be fields of a struct
+  --> $DIR/illformed-within-types.rs:15:20
+   |
+LL | struct TupleStruct(ValidI64);
+   |                    ^^^^^^^^
+
+error: scalable vectors cannot be fields of a variant
+  --> $DIR/illformed-within-types.rs:19:26
+   |
+LL |     StructVariant { _ty: ValidI64 },
+   |                          ^^^^^^^^
+
+error: scalable vectors cannot be fields of a variant
+  --> $DIR/illformed-within-types.rs:21:18
+   |
+LL |     TupleVariant(ValidI64),
+   |                  ^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/scalable-vectors/illformed.rs
+++ b/tests/ui/scalable-vectors/illformed.rs
@@ -1,0 +1,59 @@
+//@ compile-flags: --crate-type=lib
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(4)]
+struct NoFieldsStructWithElementCount {}
+//~^ ERROR: scalable vectors must have a single field
+//~^^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector(4)]
+struct NoFieldsTupleWithElementCount();
+//~^ ERROR: scalable vectors must have a single field
+
+#[rustc_scalable_vector(4)]
+struct NoFieldsUnitWithElementCount;
+//~^ ERROR: scalable vectors must have a single field
+//~^^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector]
+struct NoFieldsStructWithoutElementCount {}
+//~^ ERROR: scalable vectors must have a single field
+//~^^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector]
+struct NoFieldsTupleWithoutElementCount();
+//~^ ERROR: scalable vectors must have a single field
+
+#[rustc_scalable_vector]
+struct NoFieldsUnitWithoutElementCount;
+//~^ ERROR: scalable vectors must have a single field
+//~^^ ERROR: scalable vectors must be tuple structs
+
+#[rustc_scalable_vector(4)]
+struct MultipleFieldsStructWithElementCount {
+//~^ ERROR: scalable vectors cannot have multiple fields
+//~^^ ERROR: scalable vectors must be tuple structs
+    _ty: f32,
+    other: u32,
+}
+
+#[rustc_scalable_vector(4)]
+struct MultipleFieldsTupleWithElementCount(f32, u32);
+//~^ ERROR: scalable vectors cannot have multiple fields
+
+#[rustc_scalable_vector]
+struct MultipleFieldsStructWithoutElementCount {
+//~^ ERROR: scalable vectors must be tuple structs
+    _ty: f32,
+//~^ ERROR: scalable vector structs can only have scalable vector fields
+    other: u32,
+}
+
+#[rustc_scalable_vector]
+struct MultipleFieldsTupleWithoutElementCount(f32, u32);
+//~^ ERROR: scalable vector structs can only have scalable vector fields
+
+#[rustc_scalable_vector(2)]
+struct SingleFieldStruct { _ty: f64 }
+//~^ ERROR: scalable vectors must be tuple structs

--- a/tests/ui/scalable-vectors/illformed.stderr
+++ b/tests/ui/scalable-vectors/illformed.stderr
@@ -1,0 +1,125 @@
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:6:1
+   |
+LL | struct NoFieldsStructWithElementCount {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:15:1
+   |
+LL | struct NoFieldsUnitWithElementCount;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:20:1
+   |
+LL | struct NoFieldsStructWithoutElementCount {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:29:1
+   |
+LL | struct NoFieldsUnitWithoutElementCount;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:34:1
+   |
+LL | / struct MultipleFieldsStructWithElementCount {
+LL | |
+LL | |
+LL | |     _ty: f32,
+LL | |     other: u32,
+LL | | }
+   | |_^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:46:1
+   |
+LL | / struct MultipleFieldsStructWithoutElementCount {
+LL | |
+LL | |     _ty: f32,
+...  |
+LL | | }
+   | |_^
+
+error: scalable vectors must be tuple structs
+  --> $DIR/illformed.rs:58:1
+   |
+LL | struct SingleFieldStruct { _ty: f64 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:6:1
+   |
+LL | struct NoFieldsStructWithElementCount {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: scalable vector types' only field must be a primitive scalar type
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:11:1
+   |
+LL | struct NoFieldsTupleWithElementCount();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: scalable vector types' only field must be a primitive scalar type
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:15:1
+   |
+LL | struct NoFieldsUnitWithElementCount;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: scalable vector types' only field must be a primitive scalar type
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:20:1
+   |
+LL | struct NoFieldsStructWithoutElementCount {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:25:1
+   |
+LL | struct NoFieldsTupleWithoutElementCount();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
+
+error: scalable vectors must have a single field
+  --> $DIR/illformed.rs:29:1
+   |
+LL | struct NoFieldsUnitWithoutElementCount;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: tuples of scalable vectors can only contain multiple of the same scalable vector type
+
+error: scalable vectors cannot have multiple fields
+  --> $DIR/illformed.rs:34:1
+   |
+LL | struct MultipleFieldsStructWithElementCount {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vectors cannot have multiple fields
+  --> $DIR/illformed.rs:42:1
+   |
+LL | struct MultipleFieldsTupleWithElementCount(f32, u32);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/illformed.rs:48:5
+   |
+LL |     _ty: f32,
+   |     ^^^^^^^^
+
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/illformed.rs:54:47
+   |
+LL | struct MultipleFieldsTupleWithoutElementCount(f32, u32);
+   |                                               ^^^
+
+error: aborting due to 17 previous errors
+

--- a/tests/ui/scalable-vectors/invalid.rs
+++ b/tests/ui/scalable-vectors/invalid.rs
@@ -160,3 +160,4 @@ struct Okay(f32);
 
 #[rustc_scalable_vector]
 struct OkayNoArg(f32);
+//~^ ERROR: scalable vector structs can only have scalable vector fields

--- a/tests/ui/scalable-vectors/invalid.rs
+++ b/tests/ui/scalable-vectors/invalid.rs
@@ -1,0 +1,162 @@
+//@ edition: 2024
+#![allow(internal_features, unused_imports, unused_macros)]
+#![feature(extern_types)]
+#![feature(gen_blocks)]
+#![feature(rustc_attrs)]
+#![feature(stmt_expr_attributes)]
+#![feature(trait_alias)]
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on extern crates
+extern crate std as other_std;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on use statements
+use std::vec::Vec;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on statics
+static _X: u32 = 0;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on constants
+const _Y: u32 = 0;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on modules
+mod bar {
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign modules
+unsafe extern "C" {
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign statics
+    static X: &'static u32;
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign types
+    type Y;
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on foreign functions
+    fn foo();
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on type aliases
+type Foo = u32;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enums
+enum Bar<#[rustc_scalable_vector(4)] T> {
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on function params
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
+    Baz(std::marker::PhantomData<T>),
+}
+
+struct Qux {
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on struct fields
+    field: u32,
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on unions
+union FooBar {
+    x: u32,
+    y: u32,
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on traits
+trait FooBaz {
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on associated types
+    type Foo;
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on associated consts
+    const Bar: i32;
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on provided trait methods
+    fn foo() {}
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on trait aliases
+trait FooQux = FooBaz;
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on inherent impl blocks
+impl<T> Bar<T> {
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on inherent methods
+    fn foo() {}
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on trait impl blocks
+impl<T> FooBaz for Bar<T> {
+    type Foo = u32;
+    const Bar: i32 = 3;
+}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on macro defs
+macro_rules! barqux { ($foo:tt) => { $foo }; }
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on function params
+//~^^ ERROR: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+async fn async_foo() {}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+gen fn gen_foo() {}
+
+#[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on functions
+async gen fn async_gen_foo() {}
+
+fn main() {
+    let _x = #[rustc_scalable_vector(4)] || { };
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on closures
+    let _y = #[rustc_scalable_vector(4)] 3 + 4;
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on expressions
+    #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on statements
+    let _z = 3;
+
+    match _z {
+        #[rustc_scalable_vector(4)]
+//~^ ERROR: `#[rustc_scalable_vector]` attribute cannot be used on match arms
+        1 => (),
+        _ => (),
+    }
+}
+
+#[rustc_scalable_vector("4")]
+//~^ ERROR: malformed `rustc_scalable_vector` attribute input
+struct ArgNotLit(f32);
+
+#[rustc_scalable_vector(4, 2)]
+//~^ ERROR: malformed `rustc_scalable_vector` attribute input
+struct ArgMultipleLits(f32);
+
+#[rustc_scalable_vector(count = "4")]
+//~^ ERROR: malformed `rustc_scalable_vector` attribute input
+struct ArgKind(f32);
+
+#[rustc_scalable_vector(65536)]
+//~^ ERROR: element count in `rustc_scalable_vector` is too large: `65536`
+struct CountTooLarge(f32);
+
+#[rustc_scalable_vector(4)]
+struct Okay(f32);
+
+#[rustc_scalable_vector]
+struct OkayNoArg(f32);

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -1,0 +1,333 @@
+error: allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters
+  --> $DIR/invalid.rs:109:11
+   |
+LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on extern crates
+  --> $DIR/invalid.rs:9:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on use statements
+  --> $DIR/invalid.rs:13:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on statics
+  --> $DIR/invalid.rs:17:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on constants
+  --> $DIR/invalid.rs:21:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on modules
+  --> $DIR/invalid.rs:25:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on foreign modules
+  --> $DIR/invalid.rs:30:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on foreign statics
+  --> $DIR/invalid.rs:33:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on foreign types
+  --> $DIR/invalid.rs:36:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on foreign functions
+  --> $DIR/invalid.rs:39:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on type aliases
+  --> $DIR/invalid.rs:44:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on enums
+  --> $DIR/invalid.rs:48:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on function params
+  --> $DIR/invalid.rs:50:10
+   |
+LL | enum Bar<#[rustc_scalable_vector(4)] T> {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on enum variants
+  --> $DIR/invalid.rs:52:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on struct fields
+  --> $DIR/invalid.rs:58:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on unions
+  --> $DIR/invalid.rs:63:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on traits
+  --> $DIR/invalid.rs:70:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on associated types
+  --> $DIR/invalid.rs:73:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on associated consts
+  --> $DIR/invalid.rs:76:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on provided trait methods
+  --> $DIR/invalid.rs:79:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on trait aliases
+  --> $DIR/invalid.rs:84:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on inherent impl blocks
+  --> $DIR/invalid.rs:88:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on inherent methods
+  --> $DIR/invalid.rs:91:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on trait impl blocks
+  --> $DIR/invalid.rs:96:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on macro defs
+  --> $DIR/invalid.rs:103:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+  --> $DIR/invalid.rs:107:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on function params
+  --> $DIR/invalid.rs:109:11
+   |
+LL | fn barqux(#[rustc_scalable_vector(4)] _x: u32) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+  --> $DIR/invalid.rs:113:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+  --> $DIR/invalid.rs:117:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on functions
+  --> $DIR/invalid.rs:121:1
+   |
+LL | #[rustc_scalable_vector(4)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on closures
+  --> $DIR/invalid.rs:126:14
+   |
+LL |     let _x = #[rustc_scalable_vector(4)] || { };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on expressions
+  --> $DIR/invalid.rs:128:14
+   |
+LL |     let _y = #[rustc_scalable_vector(4)] 3 + 4;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on statements
+  --> $DIR/invalid.rs:130:5
+   |
+LL |     #[rustc_scalable_vector(4)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error: `#[rustc_scalable_vector]` attribute cannot be used on match arms
+  --> $DIR/invalid.rs:135:9
+   |
+LL |         #[rustc_scalable_vector(4)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_scalable_vector]` can only be applied to structs
+
+error[E0539]: malformed `rustc_scalable_vector` attribute input
+  --> $DIR/invalid.rs:142:1
+   |
+LL | #[rustc_scalable_vector("4")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^---^^
+   |                         |
+   |                         expected an integer literal here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_scalable_vector("4")]
+LL + #[rustc_scalable_vector(count)]
+   |
+LL - #[rustc_scalable_vector("4")]
+LL + #[rustc_scalable_vector]
+   |
+
+error[E0805]: malformed `rustc_scalable_vector` attribute input
+  --> $DIR/invalid.rs:146:1
+   |
+LL | #[rustc_scalable_vector(4, 2)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^------^
+   |                        |
+   |                        expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_scalable_vector(4, 2)]
+LL + #[rustc_scalable_vector(count)]
+   |
+LL - #[rustc_scalable_vector(4, 2)]
+LL + #[rustc_scalable_vector]
+   |
+
+error[E0539]: malformed `rustc_scalable_vector` attribute input
+  --> $DIR/invalid.rs:150:1
+   |
+LL | #[rustc_scalable_vector(count = "4")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^-----------^^
+   |                         |
+   |                         expected an integer literal here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_scalable_vector(count = "4")]
+LL + #[rustc_scalable_vector(count)]
+   |
+LL - #[rustc_scalable_vector(count = "4")]
+LL + #[rustc_scalable_vector]
+   |
+
+error: element count in `rustc_scalable_vector` is too large: `65536`
+  --> $DIR/invalid.rs:154:1
+   |
+LL | #[rustc_scalable_vector(65536)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the value may not exceed `u16::MAX`
+
+error: aborting due to 38 previous errors
+
+Some errors have detailed explanations: E0539, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/scalable-vectors/invalid.stderr
+++ b/tests/ui/scalable-vectors/invalid.stderr
@@ -327,7 +327,13 @@ LL | #[rustc_scalable_vector(65536)]
    |
    = note: the value may not exceed `u16::MAX`
 
-error: aborting due to 38 previous errors
+error: scalable vector structs can only have scalable vector fields
+  --> $DIR/invalid.rs:162:18
+   |
+LL | struct OkayNoArg(f32);
+   |                  ^^^
+
+error: aborting due to 39 previous errors
 
 Some errors have detailed explanations: E0539, E0805.
 For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/scalable-vectors/require-target-feature.rs
+++ b/tests/ui/scalable-vectors/require-target-feature.rs
@@ -1,0 +1,40 @@
+//@ build-fail
+//@ compile-flags: --crate-type=lib
+//@ only-aarch64
+#![allow(incomplete_features, internal_features)]
+#![feature(
+    simd_ffi,
+    rustc_attrs,
+    link_llvm_intrinsics
+)]
+
+#[derive(Copy, Clone)]
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[inline(never)]
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+//~^ WARN: `extern` block uses type `svint32_t`, which is not FFI-safe
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+pub fn non_annotated_callee(x: svint32_t) {}
+//~^ ERROR: this function definition uses scalable vector type `svint32_t`
+
+#[target_feature(enable = "sve")]
+pub fn annotated_callee(x: svint32_t) {} // okay!
+
+#[target_feature(enable = "sve")]
+pub fn caller() {
+    unsafe {
+        let a = svdup_n_s32(42);
+        non_annotated_callee(a);
+        annotated_callee(a);
+    }
+}

--- a/tests/ui/scalable-vectors/require-target-feature.stderr
+++ b/tests/ui/scalable-vectors/require-target-feature.stderr
@@ -1,0 +1,25 @@
+warning: `extern` block uses type `svint32_t`, which is not FFI-safe
+  --> $DIR/require-target-feature.rs:21:37
+   |
+LL |         fn _svdup_n_s32(op: i32) -> svint32_t;
+   |                                     ^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/require-target-feature.rs:14:1
+   |
+LL | pub struct svint32_t(i32);
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(improper_ctypes)]` on by default
+
+error: this function definition uses scalable vector type `svint32_t` which (with the chosen ABI) requires the `sve` target feature, which is not enabled
+  --> $DIR/require-target-feature.rs:27:1
+   |
+LL | pub fn non_annotated_callee(x: svint32_t) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
+   |
+   = help: consider enabling it globally (`-C target-feature=+sve`) or locally (`#[target_feature(enable="sve")]`)
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/scalable-vectors/value-type.rs
+++ b/tests/ui/scalable-vectors/value-type.rs
@@ -1,0 +1,37 @@
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ only-aarch64
+#![allow(internal_features)]
+#![feature(
+    link_llvm_intrinsics,
+    rustc_attrs,
+    simd_ffi,
+)]
+
+#[derive(Copy, Clone)]
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svint32_t(i32);
+
+#[target_feature(enable = "sve")]
+pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
+    extern "C" {
+        #[cfg_attr(target_arch = "aarch64", link_name = "llvm.aarch64.sve.dup.x.nxv4i32")]
+        fn _svdup_n_s32(op: i32) -> svint32_t;
+//~^ WARN: `extern` block uses type `svint32_t`, which is not FFI-safe
+    }
+    unsafe { _svdup_n_s32(op) }
+}
+
+// Tests that scalable vectors can be locals, arguments and return types.
+
+#[target_feature(enable = "sve")]
+fn id(v: svint32_t) -> svint32_t { v }
+
+#[target_feature(enable = "sve")]
+fn foo() {
+    unsafe {
+        let v = svdup_n_s32(1);
+        let v = id(v);
+    }
+}

--- a/tests/ui/scalable-vectors/value-type.stderr
+++ b/tests/ui/scalable-vectors/value-type.stderr
@@ -1,0 +1,17 @@
+warning: `extern` block uses type `svint32_t`, which is not FFI-safe
+  --> $DIR/value-type.rs:20:37
+   |
+LL |         fn _svdup_n_s32(op: i32) -> svint32_t;
+   |                                     ^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/value-type.rs:14:1
+   |
+LL | pub struct svint32_t(i32);
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(improper_ctypes)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/scalable-vectors/wellformed-arrays.rs
+++ b/tests/ui/scalable-vectors/wellformed-arrays.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(16)]
+struct ScalableU8(u8);
+
+fn main() {
+    let x: [ScalableU8; 4] = todo!();
+}

--- a/tests/ui/scalable-vectors/wellformed.rs
+++ b/tests/ui/scalable-vectors/wellformed.rs
@@ -1,0 +1,48 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(16)]
+struct ScalableU8(u8);
+
+#[rustc_scalable_vector(8)]
+struct ScalableU16(u16);
+
+#[rustc_scalable_vector(4)]
+struct ScalableU32(u32);
+
+#[rustc_scalable_vector(2)]
+struct ScalableU64(u64);
+
+#[rustc_scalable_vector(1)]
+struct ScalableU128(u128);
+
+#[rustc_scalable_vector(16)]
+struct ScalableI8(i8);
+
+#[rustc_scalable_vector(8)]
+struct ScalableI16(i16);
+
+#[rustc_scalable_vector(4)]
+struct ScalableI32(i32);
+
+#[rustc_scalable_vector(2)]
+struct ScalableI64(i64);
+
+#[rustc_scalable_vector(1)]
+struct ScalableI128(i128);
+
+#[rustc_scalable_vector(8)]
+struct ScalableF16(f32);
+
+#[rustc_scalable_vector(4)]
+struct ScalableF32(f32);
+
+#[rustc_scalable_vector(2)]
+struct ScalableF64(f64);
+
+#[rustc_scalable_vector(16)]
+struct ScalableBool(bool);
+
+#[rustc_scalable_vector]
+struct ScalableTuple(ScalableU8, ScalableU8, ScalableU8);

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -95,7 +95,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 13397682652773712997 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
@@ -109,7 +109,7 @@ body:
                                                                                                                 did: DefId(0:3 ~ thir_tree_match[fcf8]::Bar)
                                                                                                                 variants: [VariantDef { def_id: DefId(0:4 ~ thir_tree_match[fcf8]::Bar::First), ctor: Some((Const, DefId(0:5 ~ thir_tree_match[fcf8]::Bar::First::{constructor#0}))), name: "First", discr: Relative(0), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:6 ~ thir_tree_match[fcf8]::Bar::Second), ctor: Some((Const, DefId(0:7 ~ thir_tree_match[fcf8]::Bar::Second::{constructor#0}))), name: "Second", discr: Relative(1), fields: [], tainted: None, flags:  }, VariantDef { def_id: DefId(0:8 ~ thir_tree_match[fcf8]::Bar::Third), ctor: Some((Const, DefId(0:9 ~ thir_tree_match[fcf8]::Bar::Third::{constructor#0}))), name: "Third", discr: Relative(2), fields: [], tainted: None, flags:  }]
                                                                                                                 flags: IS_ENUM
-                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 7908585036048874241 }
+                                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 7908585036048874241 }
                                                                                                         args: []
                                                                                                         variant_index: 0
                                                                                                         subpatterns: []
@@ -157,7 +157,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 13397682652773712997 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
                                                                                         args: []
                                                                                         variant_index: 0
                                                                                         subpatterns: [
@@ -209,7 +209,7 @@ body:
                                                                                                 did: DefId(0:10 ~ thir_tree_match[fcf8]::Foo)
                                                                                                 variants: [VariantDef { def_id: DefId(0:11 ~ thir_tree_match[fcf8]::Foo::FooOne), ctor: Some((Fn, DefId(0:12 ~ thir_tree_match[fcf8]::Foo::FooOne::{constructor#0}))), name: "FooOne", discr: Relative(0), fields: [FieldDef { did: DefId(0:13 ~ thir_tree_match[fcf8]::Foo::FooOne::0), name: "0", vis: Restricted(DefId(0:0 ~ thir_tree_match[fcf8])), safety: Safe, value: None }], tainted: None, flags:  }, VariantDef { def_id: DefId(0:14 ~ thir_tree_match[fcf8]::Foo::FooTwo), ctor: Some((Const, DefId(0:15 ~ thir_tree_match[fcf8]::Foo::FooTwo::{constructor#0}))), name: "FooTwo", discr: Relative(1), fields: [], tainted: None, flags:  }]
                                                                                                 flags: IS_ENUM
-                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , field_shuffle_seed: 13397682652773712997 }
+                                                                                                repr: ReprOptions { int: None, align: None, pack: None, flags: , scalable: None, field_shuffle_seed: 13397682652773712997 }
                                                                                         args: []
                                                                                         variant_index: 1
                                                                                         subpatterns: []


### PR DESCRIPTION
Supercedes rust-lang/rust#118917.

Initial experimental implementation of rust-lang/rfcs#3838. Introduces a `rustc_scalable_vector(N)` attribute that can be applied to types with a single `[$ty]` field (for `u{16,32,64}`, `i{16,32,64}`, `f{32,64}`, `bool`). `rustc_scalable_vector` types are lowered to scalable vectors in the codegen backend.

As with any unstable feature, there will necessarily be follow-ups as we experiment and find cases that we've not considered or still need some logic to handle, but this aims to be a decent baseline to start from.

See rust-lang/rust#145052 for request for a lang experiment.