### PR TITLE
Preserve constness in trait objects up to hir ty lowering

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -49,7 +49,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             } = self.lower_poly_trait_ref(
                 &trait_bound.trait_ref,
                 trait_bound.span,
-                hir::BoundConstness::Never,
+                trait_bound.modifiers.constness,
                 hir::BoundPolarity::Positive,
                 dummy_self,
                 &mut user_written_bounds,

--- a/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.rs
+++ b/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.rs
@@ -14,5 +14,7 @@ fn main() {
 trait NonConst {}
 const fn handle(_: &dyn const NonConst) {}
 //~^ ERROR const trait bounds are not allowed in trait object types
+//~| ERROR `const` can only be applied to `#[const_trait]` traits
 const fn take(_: &dyn [const] NonConst) {}
 //~^ ERROR `[const]` is not allowed here
+//~| ERROR `[const]` can only be applied to `#[const_trait]` traits

--- a/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.stderr
+++ b/tests/ui/traits/const-traits/const-trait-bounds-trait-objects.stderr
@@ -19,12 +19,34 @@ LL | const fn handle(_: &dyn const NonConst) {}
    |                         ^^^^^^^^^^^^^^
 
 error: `[const]` is not allowed here
-  --> $DIR/const-trait-bounds-trait-objects.rs:17:23
+  --> $DIR/const-trait-bounds-trait-objects.rs:18:23
    |
 LL | const fn take(_: &dyn [const] NonConst) {}
    |                       ^^^^^^^
    |
    = note: trait objects cannot have `[const]` trait bounds
 
-error: aborting due to 4 previous errors
+error: `const` can only be applied to `#[const_trait]` traits
+  --> $DIR/const-trait-bounds-trait-objects.rs:15:25
+   |
+LL | const fn handle(_: &dyn const NonConst) {}
+   |                         ^^^^^ can't be applied to `NonConst`
+   |
+help: mark `NonConst` as `#[const_trait]` to allow it to have `const` implementations
+   |
+LL | #[const_trait] trait NonConst {}
+   | ++++++++++++++
+
+error: `[const]` can only be applied to `#[const_trait]` traits
+  --> $DIR/const-trait-bounds-trait-objects.rs:18:23
+   |
+LL | const fn take(_: &dyn [const] NonConst) {}
+   |                       ^^^^^^^ can't be applied to `NonConst`
+   |
+help: mark `NonConst` as `#[const_trait]` to allow it to have `const` implementations
+   |
+LL | #[const_trait] trait NonConst {}
+   | ++++++++++++++
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
r? @compiler-errors 

While we don't support `dyn const Trait`, we can at least also inform the user that `const Trait` is only legal for `#[const_trait] trait Trait {}`