### PR TITLE
Mark all deprecation lints in name resolution as deny-by-default and report-in-deps

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2156,6 +2156,7 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
+        report_in_deps: true,
     };
     crate_level_only
 }
@@ -2887,11 +2888,12 @@ declare_lint! {
     /// struct S { /* fields */ }
     /// ```
     pub LEGACY_DERIVE_HELPERS,
-    Warn,
+    Deny,
     "detects derive helper attributes that are used before they are introduced",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #79202 <https://github.com/rust-lang/rust/issues/79202>",
+        report_in_deps: true,
     };
 }
 
@@ -4624,11 +4626,12 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub PRIVATE_MACRO_USE,
-    Warn,
+    Deny,
     "detects certain macro bindings that should not be re-exported",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #120192 <https://github.com/rust-lang/rust/issues/120192>",
+        report_in_deps: true,
     };
 }
 
@@ -4828,7 +4831,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// #![doc = in_root!()]
     ///
     /// macro_rules! in_root { () => { "" } }
@@ -4853,11 +4856,12 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub OUT_OF_SCOPE_MACRO_CALLS,
-    Warn,
+    Deny,
     "detects out of scope calls to `macro_rules` in key-value attributes",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #124535 <https://github.com/rust-lang/rust/issues/124535>",
+        report_in_deps: true,
     };
 }
 

--- a/tests/ui/attributes/key-value-expansion-scope.rs
+++ b/tests/ui/attributes/key-value-expansion-scope.rs
@@ -1,7 +1,7 @@
-#![doc = in_root!()] //~ WARN cannot find macro `in_root`
+#![doc = in_root!()] //~ ERROR cannot find macro `in_root`
                      //~| WARN this was previously accepted by the compiler
 #![doc = in_mod!()] //~ ERROR cannot find macro `in_mod` in this scope
-#![doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+#![doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                            //~| WARN this was previously accepted by the compiler
 #![doc = in_block!()] //~ ERROR cannot find macro `in_block` in this scope
 
@@ -18,10 +18,10 @@ fn before() {
 
 macro_rules! in_root { () => { "" } }
 
-#[doc = in_mod!()] //~ WARN cannot find macro `in_mod`
+#[doc = in_mod!()] //~ ERROR cannot find macro `in_mod`
                    //~| WARN this was previously accepted by the compiler
 mod macros_stay {
-    #![doc = in_mod!()] //~ WARN cannot find macro `in_mod`
+    #![doc = in_mod!()] //~ ERROR cannot find macro `in_mod`
                         //~| WARN this was previously accepted by the compiler
 
     macro_rules! in_mod { () => { "" } }
@@ -33,10 +33,10 @@ mod macros_stay {
 }
 
 #[macro_use]
-#[doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+#[doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                           //~| WARN this was previously accepted by the compiler
 mod macros_escape {
-    #![doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+    #![doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                                //~| WARN this was previously accepted by the compiler
 
     macro_rules! in_mod_escape { () => { "" } }

--- a/tests/ui/attributes/key-value-expansion-scope.stderr
+++ b/tests/ui/attributes/key-value-expansion-scope.stderr
@@ -126,7 +126,7 @@ LL |     #![doc = in_block!()]
    |
    = help: have you added the `#[macro_use]` on the module/import?
 
-warning: cannot find macro `in_root` in the current scope when looking from the crate root
+error: cannot find macro `in_root` in the current scope when looking from the crate root
   --> $DIR/key-value-expansion-scope.rs:1:10
    |
 LL | #![doc = in_root!()]
@@ -135,9 +135,9 @@ LL | #![doc = in_root!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[warn(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
+error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
   --> $DIR/key-value-expansion-scope.rs:4:10
    |
 LL | #![doc = in_mod_escape!()]
@@ -147,7 +147,7 @@ LL | #![doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:21:9
    |
 LL | #[doc = in_mod!()]
@@ -157,7 +157,7 @@ LL | #[doc = in_mod!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:24:14
    |
 LL |     #![doc = in_mod!()]
@@ -167,7 +167,7 @@ LL |     #![doc = in_mod!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:36:9
    |
 LL | #[doc = in_mod_escape!()]
@@ -177,7 +177,7 @@ LL | #[doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:39:14
    |
 LL |     #![doc = in_mod_escape!()]
@@ -187,5 +187,77 @@ LL |     #![doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-error: aborting due to 16 previous errors; 6 warnings emitted
+error: aborting due to 22 previous errors
+
+Future incompatibility report: Future breakage diagnostic:
+error: cannot find macro `in_root` in the current scope when looking from the crate root
+  --> $DIR/key-value-expansion-scope.rs:1:10
+   |
+LL | #![doc = in_root!()]
+   |          ^^^^^^^ not found from the crate root
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
+  --> $DIR/key-value-expansion-scope.rs:4:10
+   |
+LL | #![doc = in_mod_escape!()]
+   |          ^^^^^^^^^^^^^ not found from the crate root
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+  --> $DIR/key-value-expansion-scope.rs:21:9
+   |
+LL | #[doc = in_mod!()]
+   |         ^^^^^^ not found from module `macros_stay`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+  --> $DIR/key-value-expansion-scope.rs:24:14
+   |
+LL |     #![doc = in_mod!()]
+   |              ^^^^^^ not found from module `macros_stay`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+  --> $DIR/key-value-expansion-scope.rs:36:9
+   |
+LL | #[doc = in_mod_escape!()]
+   |         ^^^^^^^^^^^^^ not found from module `macros_escape`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+  --> $DIR/key-value-expansion-scope.rs:39:14
+   |
+LL |     #![doc = in_mod_escape!()]
+   |              ^^^^^^^^^^^^^ not found from module `macros_escape`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
 

--- a/tests/ui/extern/issue-80074.rs
+++ b/tests/ui/extern/issue-80074.rs
@@ -11,7 +11,7 @@ extern crate issue_80074_2;
 
 fn main() {
     foo!();
-    //~^ WARN: macro `foo` is private
+    //~^ ERROR: macro `foo` is private
     //~| WARN: it will become a hard error in a future release!
     bar!();
     //~^ ERROR: cannot find macro `bar` in this scope

--- a/tests/ui/extern/issue-80074.stderr
+++ b/tests/ui/extern/issue-80074.stderr
@@ -16,7 +16,7 @@ error: cannot find macro `m` in this scope
 LL |     m!();
    |     ^
 
-warning: macro `foo` is private
+error: macro `foo` is private
   --> $DIR/issue-80074.rs:13:5
    |
 LL |     foo!();
@@ -24,8 +24,19 @@ LL |     foo!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #120192 <https://github.com/rust-lang/rust/issues/120192>
-   = note: `#[warn(private_macro_use)]` on by default
+   = note: `#[deny(private_macro_use)]` on by default
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0469`.
+Future incompatibility report: Future breakage diagnostic:
+error: macro `foo` is private
+  --> $DIR/issue-80074.rs:13:5
+   |
+LL |     foo!();
+   |     ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #120192 <https://github.com/rust-lang/rust/issues/120192>
+   = note: `#[deny(private_macro_use)]` on by default
+

--- a/tests/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -41,3 +41,47 @@ LL |   define_exported!();
 
 error: aborting due to 2 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-2.rs:13:9
+   |
+LL |     use crate::exported;
+   |         ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-2.rs:5:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------ in this macro invocation
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-2.rs:19:5
+   |
+LL |     crate::exported!();
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-2.rs:5:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------ in this macro invocation
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/tests/ui/proc-macro/derive-helper-shadowing.rs
+++ b/tests/ui/proc-macro/derive-helper-shadowing.rs
@@ -17,7 +17,7 @@ macro_rules! gen_helper_use {
 }
 
 #[empty_helper] //~ ERROR `empty_helper` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[derive(Empty)]
 struct S {

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -58,7 +58,7 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/derive-helper-shadowing.rs:19:3
    |
 LL | #[empty_helper]
@@ -69,8 +69,22 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/derive-helper-shadowing.rs:19:3
+   |
+LL | #[empty_helper]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Empty)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.rs
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.rs
@@ -5,7 +5,7 @@ extern crate test_macros;
 use test_macros::empty_attr as empty_helper;
 
 #[empty_helper] //~ ERROR `empty_helper` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[derive(Empty)]
 struct S;

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
@@ -17,7 +17,7 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:3
    |
 LL | #[empty_helper]
@@ -28,8 +28,22 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:3
+   |
+LL | #[empty_helper]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Empty)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.rs
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.rs
@@ -6,7 +6,7 @@
 // Tests that we cfg-strip all targets before invoking
 // a derive macro
 // FIXME: We currently lose spans here (see issue #43081)
-
+#![warn(legacy_derive_helpers)]
 #![no_std] // Don't load unnecessary hygiene information from std
 extern crate std;
 

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -9,7 +9,11 @@ LL | #[derive(Print)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: derive helper attribute is used before it is introduced
   --> $DIR/issue-75930-derive-cfg.rs:46:3
@@ -25,4 +29,40 @@ LL | #[derive(Print)]
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 2 warnings emitted
+
+Future incompatibility report: Future breakage diagnostic:
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:46:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:46:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/proc-macro/proc-macro-attributes.rs
+++ b/tests/ui/proc-macro/proc-macro-attributes.rs
@@ -4,17 +4,17 @@
 extern crate derive_b;
 
 #[B] //~ ERROR `B` is ambiguous
-     //~| WARN derive helper attribute is used before it is introduced
+     //~| ERROR derive helper attribute is used before it is introduced
      //~| WARN this was previously accepted
 #[C] //~ ERROR cannot find attribute `C` in this scope
 #[B(D)] //~ ERROR `B` is ambiguous
-        //~| WARN derive helper attribute is used before it is introduced
+        //~| ERROR derive helper attribute is used before it is introduced
         //~| WARN this was previously accepted
 #[B(E = "foo")] //~ ERROR `B` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[B(arbitrary tokens)] //~ ERROR `B` is ambiguous
-                       //~| WARN derive helper attribute is used before it is introduced
+                       //~| ERROR derive helper attribute is used before it is introduced
                        //~| WARN this was previously accepted
 #[derive(B)]
 struct B;

--- a/tests/ui/proc-macro/proc-macro-attributes.stderr
+++ b/tests/ui/proc-macro/proc-macro-attributes.stderr
@@ -76,7 +76,7 @@ note: `B` could also refer to the derive macro imported here
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:6:3
    |
 LL | #[B]
@@ -87,9 +87,9 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:10:3
    |
 LL | #[B(D)]
@@ -101,7 +101,7 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:13:3
    |
 LL | #[B(E = "foo")]
@@ -113,7 +113,7 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:16:3
    |
 LL | #[B(arbitrary tokens)]
@@ -125,6 +125,62 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-error: aborting due to 5 previous errors; 4 warnings emitted
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:6:3
+   |
+LL | #[B]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:10:3
+   |
+LL | #[B(D)]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:13:3
+   |
+LL | #[B(E = "foo")]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:16:3
+   |
+LL | #[B(arbitrary tokens)]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+


### PR DESCRIPTION
This affects the next lints:
- `MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS` - https://github.com/rust-lang/rust/issues/144408
- `LEGACY_DERIVE_HELPERS` - https://github.com/rust-lang/rust/issues/79202
- `PRIVATE_MACRO_USE` - https://github.com/rust-lang/rust/issues/120192
- `OUT_OF_SCOPE_MACRO_CALLS` - https://github.com/rust-lang/rust/issues/144406