### PR TITLE
rustc_type_ir/walk: move docstring to `TypeWalker` itself

### DIFF
--- a/compiler/rustc_type_ir/src/walk.rs
+++ b/compiler/rustc_type_ir/src/walk.rs
@@ -12,12 +12,6 @@ use crate::{self as ty, Interner};
 // avoid heap allocations.
 type TypeWalkerStack<I> = SmallVec<[<I as Interner>::GenericArg; 8]>;
 
-pub struct TypeWalker<I: Interner> {
-    stack: TypeWalkerStack<I>,
-    last_subtree: usize,
-    pub visited: SsoHashSet<I::GenericArg>,
-}
-
 /// An iterator for walking the type tree.
 ///
 /// It's very easy to produce a deeply
@@ -26,6 +20,12 @@ pub struct TypeWalker<I: Interner> {
 /// in this situation walker only visits each type once.
 /// It maintains a set of visited types and
 /// skips any types that are already there.
+pub struct TypeWalker<I: Interner> {
+    stack: TypeWalkerStack<I>,
+    last_subtree: usize,
+    pub visited: SsoHashSet<I::GenericArg>,
+}
+
 impl<I: Interner> TypeWalker<I> {
     pub fn new(root: I::GenericArg) -> Self {
         Self { stack: smallvec![root], last_subtree: 1, visited: SsoHashSet::new() }


### PR DESCRIPTION
having it on the impl block is a bit weird imo