### PR TITLE
type_id_eq: check that the hash fully matches the type

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -951,12 +951,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub fn get_ptr_type_id(
         &self,
         ptr: Pointer<Option<M::Provenance>>,
-    ) -> InterpResult<'tcx, (Ty<'tcx>, Size)> {
+    ) -> InterpResult<'tcx, (Ty<'tcx>, u64)> {
         let (alloc_id, offset, _meta) = self.ptr_get_alloc_id(ptr, 0)?;
         let GlobalAlloc::TypeId { ty } = self.tcx.global_alloc(alloc_id) else {
-            throw_ub_format!("type_id_eq: `TypeId` provenance is not a type id")
+            throw_ub_format!("invalid `TypeId` value: not all bytes carry type id metadata")
         };
-        interp_ok((ty, offset))
+        interp_ok((ty, offset.bytes()))
     }
 
     pub fn get_ptr_fn(

--- a/tests/ui/consts/const_transmute_type_id4.rs
+++ b/tests/ui/consts/const_transmute_type_id4.rs
@@ -10,7 +10,7 @@ const _: () = {
         std::ptr::write(ptr.offset(0), main as fn() as *const ());
     }
     assert!(a == b);
-    //~^ ERROR: type_id_eq: `TypeId` provenance is not a type id
+    //~^ ERROR: invalid `TypeId` value
 };
 
 fn main() {}

--- a/tests/ui/consts/const_transmute_type_id4.stderr
+++ b/tests/ui/consts/const_transmute_type_id4.stderr
@@ -1,4 +1,4 @@
-error[E0080]: type_id_eq: `TypeId` provenance is not a type id
+error[E0080]: invalid `TypeId` value: not all bytes carry type id metadata
   --> $DIR/const_transmute_type_id4.rs:12:13
    |
 LL |     assert!(a == b);

--- a/tests/ui/consts/const_transmute_type_id5.rs
+++ b/tests/ui/consts/const_transmute_type_id5.rs
@@ -1,12 +1,11 @@
-//! Test that we require an equal TypeId to have the same integer
-//! part, even if the provenance matches.
+//! Test that we require an equal TypeId to have an integer part that properly
+//! reflects the type id hash.
 
 #![feature(const_type_id, const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 
 const _: () = {
-    let a = TypeId::of::<()>();
     let mut b = TypeId::of::<()>();
     unsafe {
         let ptr = &mut b as *mut TypeId as *mut *const ();
@@ -14,8 +13,8 @@ const _: () = {
         let val = std::ptr::read(ptr);
         std::ptr::write(ptr.offset(1), val);
     }
-    assert!(a == b);
-    //~^ ERROR: type_id_eq: one of the TypeId arguments is invalid, chunk 1 of the hash does not match the type it represents
+    assert!(b == b);
+    //~^ ERROR: invalid `TypeId` value
 };
 
 fn main() {}

--- a/tests/ui/consts/const_transmute_type_id5.stderr
+++ b/tests/ui/consts/const_transmute_type_id5.stderr
@@ -1,7 +1,7 @@
-error[E0080]: type_id_eq: one of the TypeId arguments is invalid, chunk 1 of the hash does not match the type it represents
-  --> $DIR/const_transmute_type_id5.rs:17:13
+error[E0080]: invalid `TypeId` value: the hash does not match the type id metadata
+  --> $DIR/const_transmute_type_id5.rs:16:13
    |
-LL |     assert!(a == b);
+LL |     assert!(b == b);
    |             ^^^^^^ evaluation of `_` failed inside this call
    |
 note: inside `<TypeId as PartialEq>::eq`


### PR DESCRIPTION
The previous logic wouldn't always detect when the hash mismatches the provenance. Fix that by adding a new helper, `read_type_id`, that reads a single type ID while fully checking it for validity and consistency.

r? @oli-obk 