### PR TITLE
Test fixes for Arm64EC Windows

### DIFF
--- a/tests/ui/cfg/conditional-compile-arch.rs
+++ b/tests/ui/cfg/conditional-compile-arch.rs
@@ -38,3 +38,6 @@ pub fn main() { }
 
 #[cfg(target_arch = "loongarch64")]
 pub fn main() { }
+
+#[cfg(target_arch = "arm64ec")]
+pub fn main() { }

--- a/tests/ui/linkage-attr/incompatible-flavor.rs
+++ b/tests/ui/linkage-attr/incompatible-flavor.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: --target=x86_64-unknown-linux-gnu -C linker-flavor=msvc --crate-type=rlib
-//@ needs-llvm-components:
+//@ needs-llvm-components: x86
 
 #![feature(no_core)]
 #![no_core]

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -43,12 +43,13 @@ macro_rules! dump_and_die {
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
         //
-        // aarch64-msvc is broken as its backtraces are truncated.
+        // aarch64-msvc/arm64ec-msvc is broken as its backtraces are truncated.
         // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
                     all(target_env = "msvc", target_arch = "aarch64"),
+                    all(target_env = "msvc", target_arch = "arm64ec"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {


### PR DESCRIPTION
* `tests/ui/cfg/conditional-compile-arch.rs` needs an Arm64EC case.
* `tests/ui/runtime/backtrace-debuginfo.rs` should skip Arm64EC as it suffers from the same truncated backtraces as Arm64 Windows.
* `tests/ui/linkage-attr/incompatible-flavor.rs` is a general issue: it assumes that the Rust compiler is always built with the x86 target enabled in the backend, but I only enabled AArch64 when building locally to speed up the LLVM compilation.