### PR TITLE
[rustdoc] Make aliases search support partial matching

### DIFF
--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -116,7 +116,7 @@ pub(crate) fn build_index(
     // Set up alias indexes.
     for (i, item) in cache.search_index.iter().enumerate() {
         for alias in &item.aliases[..] {
-            aliases.entry(alias.as_str().to_lowercase()).or_default().push(i);
+            aliases.entry(alias.to_string()).or_default().push(i);
         }
     }
 

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -219,6 +219,8 @@ declare namespace rustdoc {
         crate: string,
         descShard: SearchDescShard,
         id: number,
+        // This is the name of the item. For doc aliases, if you want the name of the aliased
+        // item, take a look at `Row.original.name`.
         name: string,
         normalizedName: string,
         word: string,

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -227,6 +227,11 @@ declare namespace rustdoc {
         path: string,
         ty: number,
         type: FunctionSearchType | null,
+        descIndex: number,
+        bitIndex: number,
+        implDisambiguator: String | null,
+        is_alias?: boolean,
+        original?: Row,
     }
 
     /**

--- a/tests/rustdoc-js-std/alias-lev.js
+++ b/tests/rustdoc-js-std/alias-lev.js
@@ -1,0 +1,11 @@
+// This test ensures that aliases are also allowed to be partially matched.
+
+// ignore-order
+
+const EXPECTED = {
+    // The full alias name is `getcwd`.
+    'query': 'getcw',
+    'others': [
+        { 'path': 'std::env', 'name': 'current_dir', 'alias': 'getcwd' },
+    ],
+};

--- a/tests/rustdoc-js/non-english-identifier.js
+++ b/tests/rustdoc-js/non-english-identifier.js
@@ -115,11 +115,10 @@ const EXPECTED = [
         query: '加法',
         others: [
             {
-                name: "add",
+                name: "加法",
                 path: "non_english_identifier",
-                is_alias: true,
-                alias: "加法",
-                href: "../non_english_identifier/macro.add.html"
+                href: "../non_english_identifier/trait.加法.html",
+                desc: "Add"
             },
             {
                 name: "add",
@@ -129,11 +128,13 @@ const EXPECTED = [
                 href: "../non_english_identifier/fn.add.html"
             },
             {
-                name: "加法",
+                name: "add",
                 path: "non_english_identifier",
-                href: "../non_english_identifier/trait.加法.html",
-                desc: "Add"
-            }],
+                is_alias: true,
+                alias: "加法",
+                href: "../non_english_identifier/macro.add.html"
+            },
+        ],
         in_args: [{
             name: "加上",
             path: "non_english_identifier::加法",


### PR DESCRIPTION
Fixes rust-lang/rust#140782.

To make this work, I moved aliases into the `searchIndex` like any other item. It links to the "original" item with a new `original` field. No so great part is that we need to have some fields like `bitIndex` to be set on the alias to make the description load to work but I consider it minor enough to be ok.

This PR voluntarily doesn't handle de-prioritization of aliases as @lolbinarycat wished to work on this so I'll leave them this part. :wink: 

cc @lolbinarycat 