### PR TITLE
clarify wording of match ergonomics diagnostics (`rust_2024_incompatible_pat` lint and error)

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1601,7 +1601,7 @@ declare_lint! {
     "detects patterns whose meaning will change in Rust 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>",
     };
 }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -858,8 +858,10 @@ impl<'tcx> std::fmt::Display for UserTypeKind<'tcx> {
 pub struct Rust2024IncompatiblePatInfo {
     /// Labeled spans for `&`s, `&mut`s, and binding modifiers incompatible with Rust 2024.
     pub primary_labels: Vec<(Span, String)>,
-    /// Whether any binding modifiers occur under a non-`move` default binding mode.
-    pub bad_modifiers: bool,
+    /// Whether any `mut` binding modifiers occur under a non-`move` default binding mode.
+    pub bad_mut_modifiers: bool,
+    /// Whether any `ref`/`ref mut` binding modifiers occur under a non-`move` default binding mode.
+    pub bad_ref_modifiers: bool,
     /// Whether any `&` or `&mut` patterns occur under a non-`move` default binding mode.
     pub bad_ref_pats: bool,
     /// If `true`, we can give a simpler suggestion solely by eliding explicit binding modifiers.

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -322,17 +322,6 @@ mir_build_pointer_pattern = function pointers and raw pointers not derived from 
 
 mir_build_privately_uninhabited = pattern `{$witness_1}` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
 
-mir_build_rust_2024_incompatible_pat = {$bad_modifiers ->
-        *[true] binding modifiers{$bad_ref_pats ->
-            *[true] {" "}and reference patterns
-            [false] {""}
-        }
-        [false] reference patterns
-    } may only be written when the default binding mode is `move`{$is_hard_error ->
-        *[true] {""}
-        [false] {" "}in Rust 2024
-    }
-
 mir_build_static_in_pattern = statics cannot be referenced in patterns
     .label = can't be used in patterns
 mir_build_static_in_pattern_def = `static` defined here

--- a/compiler/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/migration.rs
@@ -1,14 +1,11 @@
 //! Automatic migration of Rust 2021 patterns to a form valid in both Editions 2021 and 2024.
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_errors::MultiSpan;
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan, pluralize};
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
 use rustc_lint as lint;
 use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
 use rustc_span::{Ident, Span};
-
-use crate::errors::{Rust2024IncompatiblePat, Rust2024IncompatiblePatSugg};
-use crate::fluent_generated as fluent;
 
 /// For patterns flagged for migration during HIR typeck, this handles constructing and emitting
 /// a diagnostic suggestion.
@@ -49,39 +46,90 @@ impl<'a> PatMigration<'a> {
         for (span, label) in self.info.primary_labels.iter() {
             spans.push_span_label(*span, label.clone());
         }
-        let sugg = Rust2024IncompatiblePatSugg {
-            suggest_eliding_modes: self.info.suggest_eliding_modes,
-            suggestion: self.suggestion,
-            ref_pattern_count: self.ref_pattern_count,
-            binding_mode_count: self.binding_mode_count,
-            default_mode_labels: self.default_mode_labels,
-        };
         // If a relevant span is from at least edition 2024, this is a hard error.
         let is_hard_error = spans.primary_spans().iter().any(|span| span.at_least_rust_2024());
+        let primary_message = self.primary_message(is_hard_error);
         if is_hard_error {
-            let mut err =
-                tcx.dcx().struct_span_err(spans, fluent::mir_build_rust_2024_incompatible_pat);
-            if let Some(info) = lint::builtin::RUST_2024_INCOMPATIBLE_PAT.future_incompatible {
-                // provide the same reference link as the lint
-                err.note(format!("for more information, see {}", info.reference));
-            }
-            err.arg("bad_modifiers", self.info.bad_modifiers);
-            err.arg("bad_ref_pats", self.info.bad_ref_pats);
-            err.arg("is_hard_error", true);
-            err.subdiagnostic(sugg);
+            let mut err = tcx.dcx().struct_span_err(spans, primary_message);
+            err.note("for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>");
+            self.format_subdiagnostics(&mut err);
             err.emit();
         } else {
-            tcx.emit_node_span_lint(
-                lint::builtin::RUST_2024_INCOMPATIBLE_PAT,
-                pat_id,
-                spans,
-                Rust2024IncompatiblePat {
-                    sugg,
-                    bad_modifiers: self.info.bad_modifiers,
-                    bad_ref_pats: self.info.bad_ref_pats,
-                    is_hard_error,
-                },
-            );
+            tcx.node_span_lint(lint::builtin::RUST_2024_INCOMPATIBLE_PAT, pat_id, spans, |diag| {
+                diag.primary_message(primary_message);
+                self.format_subdiagnostics(diag);
+            });
+        }
+    }
+
+    fn primary_message(&self, is_hard_error: bool) -> String {
+        let verb1 = match (self.info.bad_mut_modifiers, self.info.bad_ref_modifiers) {
+            (true, true) => "write explicit binding modifiers",
+            (true, false) => "mutably bind by value",
+            (false, true) => "explicitly borrow",
+            (false, false) => "explicitly dereference",
+        };
+        let or_verb2 = match (
+            self.info.bad_mut_modifiers,
+            self.info.bad_ref_modifiers,
+            self.info.bad_ref_pats,
+        ) {
+            // We only need two verb phrases if mentioning both modifiers and reference patterns.
+            (false, false, _) | (_, _, false) => "",
+            // If mentioning `mut`, we don't have an "explicitly" yet.
+            (true, _, true) => " or explicitly dereference",
+            // If mentioning `ref`/`ref mut` but not `mut`, we already have an "explicitly".
+            (false, true, true) => " or dereference",
+        };
+        let in_rust_2024 = if is_hard_error { "" } else { " in Rust 2024" };
+        format!("cannot {verb1}{or_verb2} within an implicitly-borrowing pattern{in_rust_2024}")
+    }
+
+    fn format_subdiagnostics(self, diag: &mut Diag<'_, impl EmissionGuarantee>) {
+        // Format and emit explanatory notes about default binding modes. Reversing the spans' order
+        // means if we have nested spans, the innermost ones will be visited first.
+        for (span, def_br_mutbl) in self.default_mode_labels.into_iter().rev() {
+            // Don't point to a macro call site.
+            if !span.from_expansion() {
+                let note_msg = "matching on a reference type with a non-reference pattern implicitly borrows the contents";
+                let label_msg = format!(
+                    "this non-reference pattern matches on a reference type `{}_`",
+                    def_br_mutbl.ref_prefix_str()
+                );
+                let mut label = MultiSpan::from(span);
+                label.push_span_label(span, label_msg);
+                diag.span_note(label, note_msg);
+            }
+        }
+
+        // Format and emit the suggestion.
+        let applicability =
+            if self.suggestion.iter().all(|(span, _)| span.can_be_used_for_suggestions()) {
+                Applicability::MachineApplicable
+            } else {
+                Applicability::MaybeIncorrect
+            };
+        let plural_modes = pluralize!(self.binding_mode_count);
+        let msg = if self.info.suggest_eliding_modes {
+            format!("remove the unnecessary binding modifier{plural_modes}")
+        } else {
+            let match_on_these_references = if self.ref_pattern_count == 1 {
+                "match on the reference with a reference pattern"
+            } else {
+                "match on these references with reference patterns"
+            };
+            let and_explain_modes = if self.binding_mode_count > 0 {
+                let a = if self.binding_mode_count == 1 { "a " } else { "" };
+                format!(" and borrow explicitly using {a}variable binding mode{plural_modes}")
+            } else {
+                " to avoid implicitly borrowing".to_owned()
+            };
+            format!("{match_on_these_references}{and_explain_modes}")
+        };
+        // FIXME(dianne): for peace of mind, don't risk emitting a 0-part suggestion (that panics!)
+        debug_assert!(!self.suggestion.is_empty());
+        if !self.suggestion.is_empty() {
+            diag.multipart_suggestion_verbose(msg, self.suggestion, applicability);
         }
     }
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2021.stderr
@@ -59,20 +59,20 @@ LL |     let [&bind_ref_mut!(x)] = &mut [0];
    |          |
    |          help: replace this `&` with `&mut`: `&mut`
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/mixed-editions.rs:30:10
    |
 LL |     let [bind_ref!(y)] = &[0];
    |          ^^^^^^^^^^^^ occurs within macro expansion
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/mixed-editions.rs:30:9
    |
 LL |     let [bind_ref!(y)] = &[0];
-   |         ^^^^^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
    = note: this error originates in the macro `bind_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: make the implied reference pattern explicit
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[bind_ref!(y)] = &[0];
    |         +

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.classic2024.stderr
@@ -58,14 +58,14 @@ LL |     let [&bind_ref_mut!(x)] = &mut [0];
    |          |
    |          help: replace this `&` with `&mut`: `&mut`
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/mixed-editions.rs:26:21
    |
 LL |     let match_ctor!(ref x) = &[0];
-   |                     ^^^ binding modifier not allowed under `ref` default binding mode
+   |                     ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-help: make the implied reference pattern explicit
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+help: match on the reference with a reference pattern to avoid implicitly borrowing
   --> $DIR/auxiliary/mixed-editions-macros.rs:11:9
    |
 LL |         &[$p]

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.rs
@@ -24,11 +24,11 @@ fn assert_type_eq<T, U: Eq<T>>(_: T, _: U) {}
 /// only when the binding is from edition 2024.
 fn ref_binding_tests() {
     let match_ctor!(ref x) = &[0];
-    //[classic2024,structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2024,structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(classic2021, structural2021))] assert_type_eq(x, &0u32);
 
     let [bind_ref!(y)] = &[0];
-    //[classic2021,structural2021]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2021,structural2021]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(classic2024, structural2024))] assert_type_eq(y, &0u32);
 }
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.structural2021.stderr
@@ -37,20 +37,20 @@ LL |     let [&bind_ref_mut!(x)] = &mut [0];
    |          |
    |          help: replace this `&` with `&mut`: `&mut`
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/mixed-editions.rs:30:10
    |
 LL |     let [bind_ref!(y)] = &[0];
    |          ^^^^^^^^^^^^ occurs within macro expansion
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/mixed-editions.rs:30:9
    |
 LL |     let [bind_ref!(y)] = &[0];
-   |         ^^^^^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
    = note: this error originates in the macro `bind_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: make the implied reference pattern explicit
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[bind_ref!(y)] = &[0];
    |         +

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mixed-editions.structural2024.stderr
@@ -36,14 +36,14 @@ LL |     let [&bind_ref_mut!(x)] = &mut [0];
    |          |
    |          help: replace this `&` with `&mut`: `&mut`
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/mixed-editions.rs:26:21
    |
 LL |     let match_ctor!(ref x) = &[0];
-   |                     ^^^ binding modifier not allowed under `ref` default binding mode
+   |                     ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-help: make the implied reference pattern explicit
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+help: match on the reference with a reference pattern to avoid implicitly borrowing
   --> $DIR/auxiliary/mixed-editions-macros.rs:11:9
    |
 LL |         &[$p]

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
@@ -11,19 +11,19 @@ LL -     let [&mut ref x] = &[&mut 0];
 LL +     let [&ref x] = &[&mut 0];
    |
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:9
    |
 LL |     let [ref mut x] = &[0];
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[ref mut x] = &[0];
    |         +
@@ -34,53 +34,53 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10
    |
 LL |     let [ref x] = &[0];
-   |          ^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:9
    |
 LL |     let [ref x] = &[0];
-   |         ^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[ref x] = &[0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:85:10
    |
 LL |     let [ref x] = &mut [0];
-   |          ^^^ binding modifier not allowed under `ref mut` default binding mode
+   |          ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:85:9
    |
 LL |     let [ref x] = &mut [0];
-   |         ^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [ref x] = &mut [0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:89:10
    |
 LL |     let [ref mut x] = &mut [0];
-   |          ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
+   |          ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:89:9
    |
 LL |     let [ref mut x] = &mut [0];
-   |         ^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [ref mut x] = &mut [0];
    |         ++++

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.rs
@@ -17,22 +17,22 @@
 /// The eat-outer variant eats the inherited reference, so binding with `ref` isn't a problem.
 fn errors_from_eating_the_real_reference() {
     let [&ref x] = &[&0];
-    //[structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&u32 = x;
 
     let [&ref x] = &mut [&0];
-    //[structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&u32 = x;
 
     let [&mut ref x] = &mut [&mut 0];
-    //[structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&mut u32 = x;
 
     let [&mut ref mut x] = &mut [&mut 0];
-    //[structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &mut u32 = x;
     #[cfg(classic2024)] let _: &mut &mut u32 = x;
 }
@@ -43,14 +43,14 @@ fn errors_from_eating_the_real_reference_caught_in_hir_typeck_on_stable() {
     let [&ref x] = &[&mut 0];
     //[stable2021]~^ ERROR: mismatched types
     //[stable2021]~| NOTE types differ in mutability
-    //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^^^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&mut u32 = x;
 
     let [&ref x] = &mut [&mut 0];
     //[stable2021]~^ ERROR: mismatched types
     //[stable2021]~| NOTE types differ in mutability
-    //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^^^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&mut u32 = x;
 }
@@ -60,7 +60,7 @@ fn errors_dependent_on_eating_order_caught_in_hir_typeck_when_eating_outer() {
     let [&mut ref x] = &[&mut 0];
     //[classic2024]~^ ERROR: mismatched types
     //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
-    //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[structural2024]~^^^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
 }
 
@@ -72,21 +72,21 @@ fn errors_dependent_on_eating_order_caught_in_hir_typeck_when_eating_outer() {
 fn borrowck_errors_in_old_editions() {
     let [ref mut x] = &[0];
     //~^ ERROR: cannot borrow data in a `&` reference as mutable
-    //[classic2024,structural2024]~| ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2024,structural2024]~| ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
 }
 
 /// The remaining tests are purely for testing `ref` bindings in the presence of an inherited
 /// reference. These should always fail on edition 2024 and succeed on edition 2021.
 pub fn main() {
     let [ref x] = &[0];
-    //[classic2024,structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2024,structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
 
     let [ref x] = &mut [0];
-    //[classic2024,structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2024,structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
 
     let [ref mut x] = &mut [0];
-    //[classic2024,structural2024]~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //[classic2024,structural2024]~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &mut u32 = x;
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
@@ -1,135 +1,135 @@
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:19:11
    |
 LL |     let [&ref x] = &[&0];
-   |           ^^^ binding modifier not allowed under `ref` default binding mode
+   |           ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:19:9
    |
 LL |     let [&ref x] = &[&0];
-   |         ^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[&ref x] = &[&0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:24:11
    |
 LL |     let [&ref x] = &mut [&0];
-   |           ^^^ binding modifier not allowed under `ref` default binding mode
+   |           ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:24:9
    |
 LL |     let [&ref x] = &mut [&0];
-   |         ^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [&ref x] = &mut [&0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:29:15
    |
 LL |     let [&mut ref x] = &mut [&mut 0];
-   |               ^^^ binding modifier not allowed under `ref mut` default binding mode
+   |               ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:29:9
    |
 LL |     let [&mut ref x] = &mut [&mut 0];
-   |         ^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [&mut ref x] = &mut [&mut 0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:34:15
    |
 LL |     let [&mut ref mut x] = &mut [&mut 0];
-   |               ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
+   |               ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:34:9
    |
 LL |     let [&mut ref mut x] = &mut [&mut 0];
-   |         ^^^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [&mut ref mut x] = &mut [&mut 0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:43:11
    |
 LL |     let [&ref x] = &[&mut 0];
-   |           ^^^ binding modifier not allowed under `ref` default binding mode
+   |           ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:43:9
    |
 LL |     let [&ref x] = &[&mut 0];
-   |         ^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[&ref x] = &[&mut 0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:50:11
    |
 LL |     let [&ref x] = &mut [&mut 0];
-   |           ^^^ binding modifier not allowed under `ref` default binding mode
+   |           ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:50:9
    |
 LL |     let [&ref x] = &mut [&mut 0];
-   |         ^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [&ref x] = &mut [&mut 0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:60:15
    |
 LL |     let [&mut ref x] = &[&mut 0];
-   |               ^^^ binding modifier not allowed under `ref` default binding mode
+   |               ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:60:9
    |
 LL |     let [&mut ref x] = &[&mut 0];
-   |         ^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[&mut ref x] = &[&mut 0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
-   |          ^^^^^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:73:9
    |
 LL |     let [ref mut x] = &[0];
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[ref mut x] = &[0];
    |         +
@@ -140,53 +140,53 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10
    |
 LL |     let [ref x] = &[0];
-   |          ^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:81:9
    |
 LL |     let [ref x] = &[0];
-   |         ^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[ref x] = &[0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:85:10
    |
 LL |     let [ref x] = &mut [0];
-   |          ^^^ binding modifier not allowed under `ref mut` default binding mode
+   |          ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:85:9
    |
 LL |     let [ref x] = &mut [0];
-   |         ^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [ref x] = &mut [0];
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/ref-binding-on-inh-ref-errors.rs:89:10
    |
 LL |     let [ref mut x] = &mut [0];
-   |          ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
+   |          ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/ref-binding-on-inh-ref-errors.rs:89:9
    |
 LL |     let [ref mut x] = &mut [0];
-   |         ^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut [ref mut x] = &mut [0];
    |         ++++

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -23,22 +23,22 @@ fn main() {
     assert_type_eq(x, &mut 0u8);
 
     let &Foo(mut x) = &Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let &mut Foo(mut x) = &mut Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(x) = &Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, &0u8);
 
     let &mut Foo(ref x) = &mut Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, &0u8);
 
@@ -55,22 +55,22 @@ fn main() {
     assert_type_eq(x, &0u8);
 
     let &Foo(&x) = &Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let &Foo(&mut x) = &Foo(&mut 0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let &mut Foo(&x) = &mut Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let &mut Foo(&mut x) = &mut Foo(&mut 0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
@@ -79,25 +79,25 @@ fn main() {
     }
 
     if let &&&&&Some(&x) = &&&&&Some(&0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let &&&&&Some(&mut x) = &&&&&Some(&mut 0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let &&&&&mut Some(&x) = &&&&&mut Some(&0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let &mut Some(&mut Some(&mut Some(ref mut x))) = &mut Some(&mut Some(&mut Some(0u8))) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, &mut 0u8);
     }
@@ -109,20 +109,20 @@ fn main() {
     }
 
     let &Struct { ref a, mut b, ref c } = &Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, 0u32);
 
     let &Struct { a: &a, ref b, ref c } = &Struct { a: &0, b: &0, c: &0 };
-    //~^ ERROR: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &&0u32);
     assert_type_eq(c, &&0u32);
 
     if let &Struct { a: &Some(a), b: &Some(&b), c: &Some(ref c) } =
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         &(Struct { a: &Some(&0), b: &Some(&0), c: &Some(&0) })
     {
@@ -135,7 +135,7 @@ fn main() {
         // The two patterns are the same syntactically, but because they're defined in different
         // editions they don't mean the same thing.
         &(Some(mut x), migration_lint_macros::mixed_edition_pat!(y)) => {
-            //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+            //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern
             assert_type_eq(x, 0u32);
             assert_type_eq(y, 0u32);
         }
@@ -143,26 +143,26 @@ fn main() {
     }
 
     let &mut [&mut &[ref a]] = &mut [&mut &[0]];
-    //~^ ERROR: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
 
     let &[&(_)] = &[&0];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
 
     // NB: Most of the following tests are for possible future improvements to migration suggestions
 
     // Test removing multiple binding modifiers.
     let Struct { a, b, c } = &Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(c, &0u32);
 
     // Test that we don't change bindings' modes when removing binding modifiers.
     let &mut Struct { ref a, ref mut b, ref mut c } = &mut Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &mut 0u32);
@@ -170,7 +170,7 @@ fn main() {
 
     // Test removing multiple reference patterns of various mutabilities, plus a binding modifier.
     let &mut &Struct { a: &[ref a], b: &mut [&[ref b]], ref c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -178,13 +178,13 @@ fn main() {
 
     // Test that we don't change bindings' types when removing reference patterns.
     let &Foo(&ref a) = &Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
 
     // Test that we don't change bindings' modes when adding reference paterns (caught early).
     let &(&a, ref b, &[ref c], &mut [&mut (ref d, &[ref e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
@@ -194,7 +194,7 @@ fn main() {
 
     // Test that we don't change bindings' modes when adding reference patterns (caught late).
     let &(ref a, &mut [ref b], &[mut c]) = &(0, &mut [0], &[0]);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -202,7 +202,7 @@ fn main() {
 
     // Test featuring both additions and removals.
     let &(&a, &mut (ref b, &[ref c])) = &(&0, &mut (0, &[0]));
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
@@ -210,21 +210,21 @@ fn main() {
 
     // Test that bindings' subpatterns' modes are updated properly.
     let &[mut a @ ref b] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
 
     // Test that bindings' subpatterns' modes are checked properly.
     let &[ref a @ mut b] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, 0u32);
 
     // Test that we respect bindings' subpatterns' types when rewriting `&ref x` to `x`.
     let [&Foo(&ref a @ ref b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -233,7 +233,7 @@ fn main() {
 
     // Test that we respect bindings' subpatterns' modes when rewriting `&ref x` to `x`.
     let [&Foo(&ref a @ [ref b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &[0u32]);
     assert_type_eq(b, &0u32);
@@ -242,12 +242,32 @@ fn main() {
 
     // Test that we use the correct message and suggestion style when pointing inside expansions.
     let &[migration_lint_macros::bind_ref!(a)] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     assert_type_eq(a, &0u32);
 
     // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
+
+    // Test the primary diagnostic message for mixes of `mut`/`ref`/`&`.
+    let &(mut a, ref b) = &(0, 0);
+    //~^ ERROR: cannot write explicit binding modifiers within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, &0u32);
+
+    let &(mut a, &b) = &(0, &0);
+    //~^ ERROR: cannot mutably bind by value or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, 0u32);
+
+    let &(mut a, ref b, &c) = &(0, 0, &0);
+    //~^ ERROR: cannot write explicit binding modifiers or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, &0u32);
+    assert_type_eq(c, 0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
@@ -23,22 +23,22 @@ fn main() {
     assert_type_eq(x, &mut 0u8);
 
     let Foo(mut x) = &Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(mut x) = &mut Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(ref x) = &Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, &0u8);
 
     let Foo(ref x) = &mut Foo(0);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, &0u8);
 
@@ -55,22 +55,22 @@ fn main() {
     assert_type_eq(x, &0u8);
 
     let Foo(&x) = &Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(&mut x) = &Foo(&mut 0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(&x) = &mut Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
     let Foo(&mut x) = &mut Foo(&mut 0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(x, 0u8);
 
@@ -79,25 +79,25 @@ fn main() {
     }
 
     if let Some(&x) = &&&&&Some(&0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let Some(&mut x) = &&&&&Some(&mut 0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let Some(&x) = &&&&&mut Some(&0u8) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, 0u8);
     }
 
     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, &mut 0u8);
     }
@@ -109,20 +109,20 @@ fn main() {
     }
 
     let Struct { a, mut b, c } = &Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, 0u32);
 
     let Struct { a: &a, b, ref c } = &Struct { a: &0, b: &0, c: &0 };
-    //~^ ERROR: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &&0u32);
     assert_type_eq(c, &&0u32);
 
     if let Struct { a: &Some(a), b: Some(&b), c: Some(c) } =
-        //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+        //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         &(Struct { a: &Some(&0), b: &Some(&0), c: &Some(&0) })
     {
@@ -135,7 +135,7 @@ fn main() {
         // The two patterns are the same syntactically, but because they're defined in different
         // editions they don't mean the same thing.
         (Some(mut x), migration_lint_macros::mixed_edition_pat!(y)) => {
-            //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+            //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern
             assert_type_eq(x, 0u32);
             assert_type_eq(y, 0u32);
         }
@@ -143,26 +143,26 @@ fn main() {
     }
 
     let [&mut [ref a]] = &mut [&mut &[0]];
-    //~^ ERROR: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
 
     let [&(_)] = &[&0];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
 
     // NB: Most of the following tests are for possible future improvements to migration suggestions
 
     // Test removing multiple binding modifiers.
     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(c, &0u32);
 
     // Test that we don't change bindings' modes when removing binding modifiers.
     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &mut 0u32);
@@ -170,7 +170,7 @@ fn main() {
 
     // Test removing multiple reference patterns of various mutabilities, plus a binding modifier.
     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -178,13 +178,13 @@ fn main() {
 
     // Test that we don't change bindings' types when removing reference patterns.
     let Foo(&ref a) = &Foo(&0);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
 
     // Test that we don't change bindings' modes when adding reference paterns (caught early).
     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
@@ -194,7 +194,7 @@ fn main() {
 
     // Test that we don't change bindings' modes when adding reference patterns (caught late).
     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -202,7 +202,7 @@ fn main() {
 
     // Test featuring both additions and removals.
     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
@@ -210,21 +210,21 @@ fn main() {
 
     // Test that bindings' subpatterns' modes are updated properly.
     let [mut a @ b] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
     assert_type_eq(b, &0u32);
 
     // Test that bindings' subpatterns' modes are checked properly.
     let [a @ mut b] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, 0u32);
 
     // Test that we respect bindings' subpatterns' types when rewriting `&ref x` to `x`.
     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
     assert_type_eq(b, &0u32);
@@ -233,7 +233,7 @@ fn main() {
 
     // Test that we respect bindings' subpatterns' modes when rewriting `&ref x` to `x`.
     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &[0u32]);
     assert_type_eq(b, &0u32);
@@ -242,12 +242,32 @@ fn main() {
 
     // Test that we use the correct message and suggestion style when pointing inside expansions.
     let [migration_lint_macros::bind_ref!(a)] = &[0];
-    //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
+    //~^ ERROR: cannot explicitly borrow within an implicitly-borrowing pattern
     assert_type_eq(a, &0u32);
 
     // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
-    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~^ ERROR: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
+
+    // Test the primary diagnostic message for mixes of `mut`/`ref`/`&`.
+    let (mut a, ref b) = &(0, 0);
+    //~^ ERROR: cannot write explicit binding modifiers within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, &0u32);
+
+    let (mut a, &b) = &(0, &0);
+    //~^ ERROR: cannot mutably bind by value or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, 0u32);
+
+    let (mut a, ref b, &c) = &(0, 0, &0);
+    //~^ ERROR: cannot write explicit binding modifiers or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, 0u32);
+    assert_type_eq(b, &0u32);
+    assert_type_eq(c, 0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -1,602 +1,663 @@
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:25:13
    |
 LL |     let Foo(mut x) = &Foo(0);
-   |             ^^^ binding modifier not allowed under `ref` default binding mode
+   |             ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:25:9
    |
 LL |     let Foo(mut x) = &Foo(0);
-   |         ^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
 note: the lint level is defined here
   --> $DIR/migration_lint.rs:7:9
    |
 LL | #![deny(rust_2024_incompatible_pat)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: make the implied reference pattern explicit
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &Foo(mut x) = &Foo(0);
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:30:13
    |
 LL |     let Foo(mut x) = &mut Foo(0);
-   |             ^^^ binding modifier not allowed under `ref mut` default binding mode
+   |             ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:30:9
    |
 LL |     let Foo(mut x) = &mut Foo(0);
-   |         ^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut Foo(mut x) = &mut Foo(0);
    |         ++++
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:35:13
    |
 LL |     let Foo(ref x) = &Foo(0);
-   |             ^^^ binding modifier not allowed under `ref` default binding mode
+   |             ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:35:9
    |
 LL |     let Foo(ref x) = &Foo(0);
-   |         ^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
 help: remove the unnecessary binding modifier
    |
 LL -     let Foo(ref x) = &Foo(0);
 LL +     let Foo(x) = &Foo(0);
    |
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:40:13
    |
 LL |     let Foo(ref x) = &mut Foo(0);
-   |             ^^^ binding modifier not allowed under `ref mut` default binding mode
+   |             ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:40:9
    |
 LL |     let Foo(ref x) = &mut Foo(0);
-   |         ^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut Foo(ref x) = &mut Foo(0);
    |         ++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:57:13
    |
 LL |     let Foo(&x) = &Foo(&0);
-   |             ^ reference pattern not allowed under `ref` default binding mode
+   |             ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:57:9
    |
 LL |     let Foo(&x) = &Foo(&0);
-   |         ^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &Foo(&x) = &Foo(&0);
    |         +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:62:13
    |
 LL |     let Foo(&mut x) = &Foo(&mut 0);
-   |             ^^^^ reference pattern not allowed under `ref` default binding mode
+   |             ^^^^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:62:9
    |
 LL |     let Foo(&mut x) = &Foo(&mut 0);
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &Foo(&mut x) = &Foo(&mut 0);
    |         +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:67:13
    |
 LL |     let Foo(&x) = &mut Foo(&0);
-   |             ^ reference pattern not allowed under `ref mut` default binding mode
+   |             ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:67:9
    |
 LL |     let Foo(&x) = &mut Foo(&0);
-   |         ^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut Foo(&x) = &mut Foo(&0);
    |         ++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:72:13
    |
 LL |     let Foo(&mut x) = &mut Foo(&mut 0);
-   |             ^^^^ reference pattern not allowed under `ref mut` default binding mode
+   |             ^^^^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:72:9
    |
 LL |     let Foo(&mut x) = &mut Foo(&mut 0);
-   |         ^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &mut Foo(&mut x) = &mut Foo(&mut 0);
    |         ++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:81:17
    |
 LL |     if let Some(&x) = &&&&&Some(&0u8) {
-   |                 ^ reference pattern not allowed under `ref` default binding mode
+   |                 ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:81:12
    |
 LL |     if let Some(&x) = &&&&&Some(&0u8) {
-   |            ^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+   |            ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     if let &&&&&Some(&x) = &&&&&Some(&0u8) {
    |            +++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:87:17
    |
 LL |     if let Some(&mut x) = &&&&&Some(&mut 0u8) {
-   |                 ^^^^ reference pattern not allowed under `ref` default binding mode
+   |                 ^^^^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:87:12
    |
 LL |     if let Some(&mut x) = &&&&&Some(&mut 0u8) {
-   |            ^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+   |            ^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     if let &&&&&Some(&mut x) = &&&&&Some(&mut 0u8) {
    |            +++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:93:17
    |
 LL |     if let Some(&x) = &&&&&mut Some(&0u8) {
-   |                 ^ reference pattern not allowed under `ref` default binding mode
+   |                 ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:93:12
    |
 LL |     if let Some(&x) = &&&&&mut Some(&0u8) {
-   |            ^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+   |            ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     if let &&&&&mut Some(&x) = &&&&&mut Some(&0u8) {
    |            ++++++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:99:17
    |
 LL |     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
-   |                 ^^^^ reference pattern not allowed under `ref mut` default binding mode
+   |                 ^^^^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:99:12
    |
 LL |     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference patterns and variable binding mode explicit
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on these references with reference patterns and borrow explicitly using a variable binding mode
    |
 LL |     if let &mut Some(&mut Some(&mut Some(ref mut x))) = &mut Some(&mut Some(&mut Some(0u8))) {
    |            ++++                ++++      +++++++
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:111:21
    |
 LL |     let Struct { a, mut b, c } = &Struct { a: 0, b: 0, c: 0 };
-   |                     ^^^ binding modifier not allowed under `ref` default binding mode
+   |                     ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:111:9
    |
 LL |     let Struct { a, mut b, c } = &Struct { a: 0, b: 0, c: 0 };
-   |         ^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern and variable binding modes explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern and borrow explicitly using variable binding modes
    |
 LL |     let &Struct { ref a, mut b, ref c } = &Struct { a: 0, b: 0, c: 0 };
    |         +         +++           +++
 
-error: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:117:21
    |
 LL |     let Struct { a: &a, b, ref c } = &Struct { a: &0, b: &0, c: &0 };
-   |                     ^      ^^^ binding modifier not allowed under `ref` default binding mode
+   |                     ^      ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |                     |
-   |                     reference pattern not allowed under `ref` default binding mode
+   |                     reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:117:9
    |
 LL |     let Struct { a: &a, b, ref c } = &Struct { a: &0, b: &0, c: &0 };
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern and variable binding mode explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern and borrow explicitly using a variable binding mode
    |
 LL |     let &Struct { a: &a, ref b, ref c } = &Struct { a: &0, b: &0, c: &0 };
    |         +                +++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:124:24
    |
 LL |     if let Struct { a: &Some(a), b: Some(&b), c: Some(c) } =
-   |                        ^                 ^ reference pattern not allowed under `ref` default binding mode
+   |                        ^                 ^ reference pattern not allowed when implicitly borrowing
    |                        |
-   |                        reference pattern not allowed under `ref` default binding mode
+   |                        reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:124:12
    |
 LL |     if let Struct { a: &Some(a), b: Some(&b), c: Some(c) } =
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding mode explicit
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns and borrow explicitly using a variable binding mode
    |
 LL |     if let &Struct { a: &Some(a), b: &Some(&b), c: &Some(ref c) } =
    |            +                         +             +     +++
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot mutably bind by value within an implicitly-borrowing pattern
   --> $DIR/migration_lint.rs:137:15
    |
 LL |         (Some(mut x), migration_lint_macros::mixed_edition_pat!(y)) => {
    |               ^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
    |               |
-   |               binding modifier not allowed under `ref` default binding mode
+   |               `mut` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:137:9
    |
 LL |         (Some(mut x), migration_lint_macros::mixed_edition_pat!(y)) => {
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
    = note: this error originates in the macro `migration_lint_macros::mixed_edition_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: make the implied reference pattern explicit
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |         &(Some(mut x), migration_lint_macros::mixed_edition_pat!(y)) => {
    |         +
 
-error: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow or dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:145:10
    |
 LL |     let [&mut [ref a]] = &mut [&mut &[0]];
-   |          ^^^^  ^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^^  ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |          |
-   |          reference pattern not allowed under `ref mut` default binding mode
+   |          reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:145:15
    |
 LL |     let [&mut [ref a]] = &mut [&mut &[0]];
-   |               ^^^^^^^ this matches on type `&_`
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   |               ^^^^^^^ this non-reference pattern matches on a reference type `&_`
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:145:9
    |
 LL |     let [&mut [ref a]] = &mut [&mut &[0]];
-   |         ^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference patterns explicit
+   |         ^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     let &mut [&mut &[ref a]] = &mut [&mut &[0]];
    |         ++++       +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:150:10
    |
 LL |     let [&(_)] = &[&0];
-   |          ^ reference pattern not allowed under `ref` default binding mode
+   |          ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:150:9
    |
 LL |     let [&(_)] = &[&0];
-   |         ^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[&(_)] = &[&0];
    |         +
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:157:18
    |
 LL |     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
-   |                  ^^^    ^^^ binding modifier not allowed under `ref` default binding mode
+   |                  ^^^    ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |                  |
-   |                  binding modifier not allowed under `ref` default binding mode
+   |                  explicit `ref` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:157:9
    |
 LL |     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
 help: remove the unnecessary binding modifiers
    |
 LL -     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
 LL +     let Struct { a, b, c } = &Struct { a: 0, b: 0, c: 0 };
    |
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly borrow within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:164:18
    |
 LL |     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
-   |                  ^^^    ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
+   |                  ^^^    ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |                  |
-   |                  binding modifier not allowed under `ref mut` default binding mode
+   |                  explicit `ref` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:164:9
    |
 LL |     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern and variable binding mode explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
+help: match on the reference with a reference pattern and borrow explicitly using a variable binding mode
    |
 LL |     let &mut Struct { ref a, ref mut b, ref mut c } = &mut Struct { a: 0, b: 0, c: 0 };
    |         ++++                            +++++++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:172:21
    |
 LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
-   |                     ^            ^^^^ reference pattern not allowed under `ref` default binding mode
+   |                     ^            ^^^^ reference pattern not allowed when implicitly borrowing
    |                     |
-   |                     reference pattern not allowed under `ref` default binding mode
+   |                     reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:172:9
    |
 LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding modes explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns and borrow explicitly using variable binding modes
    |
 LL |     let &mut &Struct { a: &[ref a], b: &mut [&[ref b]], ref c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
    |         ++++++                               + +++      +++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:180:13
    |
 LL |     let Foo(&ref a) = &Foo(&0);
-   |             ^ reference pattern not allowed under `ref` default binding mode
+   |             ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:180:9
    |
 LL |     let Foo(&ref a) = &Foo(&0);
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &Foo(&ref a) = &Foo(&0);
    |         +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:186:10
    |
 LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
-   |          ^ reference pattern not allowed under `ref` default binding mode
+   |          ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:186:9
    |
 LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding modes explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns and borrow explicitly using variable binding modes
    |
 LL |     let &(&a, ref b, &[ref c], &mut [&mut (ref d, &[ref e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
    |         +     +++    + +++     ++++  ++++  +++    + +++
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:196:19
    |
 LL |     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
-   |                   ^^^ binding modifier not allowed under `ref` default binding mode
+   |                   ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:196:9
    |
 LL |     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
-   |         ^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding modes explicit
+   |         ^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns and borrow explicitly using variable binding modes
    |
 LL |     let &(ref a, &mut [ref b], &[mut c]) = &(0, &mut [0], &[0]);
    |         + +++    ++++  +++     +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:204:10
    |
 LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
-   |          ^       ^ reference pattern not allowed under `ref` default binding mode
+   |          ^       ^ reference pattern not allowed when implicitly borrowing
    |          |
-   |          reference pattern not allowed under `ref` default binding mode
+   |          reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:204:9
    |
 LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
-   |         ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding mode explicit
+   |         ^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns and borrow explicitly using a variable binding mode
    |
 LL |     let &(&a, &mut (ref b, &[ref c])) = &(&0, &mut (0, &[0]));
    |         +     ++++  +++
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:212:10
    |
 LL |     let [mut a @ b] = &[0];
-   |          ^^^ binding modifier not allowed under `ref` default binding mode
+   |          ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:212:9
    |
 LL |     let [mut a @ b] = &[0];
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern and variable binding mode explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern and borrow explicitly using a variable binding mode
    |
 LL |     let &[mut a @ ref b] = &[0];
    |         +         +++
 
-error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
+error: cannot mutably bind by value within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:219:14
    |
 LL |     let [a @ mut b] = &[0];
-   |              ^^^ binding modifier not allowed under `ref` default binding mode
+   |              ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:219:9
    |
 LL |     let [a @ mut b] = &[0];
-   |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern and variable binding mode explicit
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern and borrow explicitly using a variable binding mode
    |
 LL |     let &[ref a @ mut b] = &[0];
    |         + +++
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:226:14
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
-   |              ^                    ^ reference pattern not allowed under `ref` default binding mode
+   |              ^                    ^ reference pattern not allowed when implicitly borrowing
    |              |
-   |              reference pattern not allowed under `ref` default binding mode
+   |              reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:226:31
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
-   |                               ^^^^^^^^^^^^^^^ this matches on type `&_`
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   |                               ^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:226:10
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
-   |          ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+   |          ^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     let [&Foo(&ref a @ ref b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
    |          +                     +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:235:14
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-   |              ^                      ^ reference pattern not allowed under `ref` default binding mode
+   |              ^                      ^ reference pattern not allowed when implicitly borrowing
    |              |
-   |              reference pattern not allowed under `ref` default binding mode
+   |              reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:235:33
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-   |                                 ^^^^^^^^^^^^^^^^^ this matches on type `&_`
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   |                                 ^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:235:10
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-   |          ^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+   |          ^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on these references with reference patterns to avoid implicitly borrowing
    |
 LL |     let [&Foo(&ref a @ [ref b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |          +                       +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/migration_lint.rs:244:10
    |
 LL |     let [migration_lint_macros::bind_ref!(a)] = &[0];
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:244:9
    |
 LL |     let [migration_lint_macros::bind_ref!(a)] = &[0];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
    = note: this error originates in the macro `migration_lint_macros::bind_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: make the implied reference pattern explicit
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
    |         +
 
-error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+error: cannot explicitly dereference within an implicitly-borrowing pattern in Rust 2024
   --> $DIR/migration_lint.rs:249:10
    |
 LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
-   |          ^ reference pattern not allowed under `ref` default binding mode
+   |          ^ reference pattern not allowed when implicitly borrowing
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/migration_lint.rs:249:9
    |
 LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
    |         +
 
-error: aborting due to 31 previous errors
+error: cannot write explicit binding modifiers within an implicitly-borrowing pattern in Rust 2024
+  --> $DIR/migration_lint.rs:255:10
+   |
+LL |     let (mut a, ref b) = &(0, 0);
+   |          ^^^    ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
+   |          |
+   |          `mut` binding modifier not allowed when implicitly borrowing
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
+  --> $DIR/migration_lint.rs:255:9
+   |
+LL |     let (mut a, ref b) = &(0, 0);
+   |         ^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
+   |
+LL |     let &(mut a, ref b) = &(0, 0);
+   |         +
+
+error: cannot mutably bind by value or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+  --> $DIR/migration_lint.rs:261:10
+   |
+LL |     let (mut a, &b) = &(0, &0);
+   |          ^^^    ^ reference pattern not allowed when implicitly borrowing
+   |          |
+   |          `mut` binding modifier not allowed when implicitly borrowing
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
+  --> $DIR/migration_lint.rs:261:9
+   |
+LL |     let (mut a, &b) = &(0, &0);
+   |         ^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
+   |
+LL |     let &(mut a, &b) = &(0, &0);
+   |         +
+
+error: cannot write explicit binding modifiers or explicitly dereference within an implicitly-borrowing pattern in Rust 2024
+  --> $DIR/migration_lint.rs:267:10
+   |
+LL |     let (mut a, ref b, &c) = &(0, 0, &0);
+   |          ^^^    ^^^    ^ reference pattern not allowed when implicitly borrowing
+   |          |      |
+   |          |      explicit `ref` binding modifier not allowed when implicitly borrowing
+   |          `mut` binding modifier not allowed when implicitly borrowing
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
+  --> $DIR/migration_lint.rs:267:9
+   |
+LL |     let (mut a, ref b, &c) = &(0, 0, &0);
+   |         ^^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
+   |
+LL |     let &(mut a, ref b, &c) = &(0, 0, &0);
+   |         +
+
+error: aborting due to 34 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.rs
@@ -21,17 +21,17 @@ macro_rules! test_pat_on_type {
 }
 
 test_pat_on_type![(&x,): &(T,)]; //~ ERROR mismatched types
-test_pat_on_type![(&x,): &(&T,)]; //~ ERROR reference patterns may only be written when the default binding mode is `move`
+test_pat_on_type![(&x,): &(&T,)]; //~ ERROR cannot explicitly dereference within an implicitly-borrowing pattern
 test_pat_on_type![(&x,): &(&mut T,)]; //~ ERROR mismatched types
 test_pat_on_type![(&mut x,): &(&T,)]; //~ ERROR mismatched types
-test_pat_on_type![(&mut x,): &(&mut T,)]; //~ ERROR reference patterns may only be written when the default binding mode is `move`
+test_pat_on_type![(&mut x,): &(&mut T,)]; //~ ERROR cannot explicitly dereference within an implicitly-borrowing pattern
 test_pat_on_type![(&x,): &&mut &(T,)]; //~ ERROR mismatched types
 test_pat_on_type![Foo { f: (&x,) }: Foo]; //~ ERROR mismatched types
 test_pat_on_type![Foo { f: (&x,) }: &mut Foo]; //~ ERROR mismatched types
-test_pat_on_type![Foo { f: &(x,) }: &Foo]; //~ ERROR reference patterns may only be written when the default binding mode is `move`
-test_pat_on_type![(mut x,): &(T,)]; //~ ERROR binding modifiers may only be written when the default binding mode is `move`
-test_pat_on_type![(ref x,): &(T,)]; //~ ERROR binding modifiers may only be written when the default binding mode is `move`
-test_pat_on_type![(ref mut x,): &mut (T,)]; //~ ERROR binding modifiers may only be written when the default binding mode is `move`
+test_pat_on_type![Foo { f: &(x,) }: &Foo]; //~ ERROR cannot explicitly dereference within an implicitly-borrowing pattern
+test_pat_on_type![(mut x,): &(T,)]; //~ ERROR cannot mutably bind by value within an implicitly-borrowing pattern
+test_pat_on_type![(ref x,): &(T,)]; //~ ERROR cannot explicitly borrow within an implicitly-borrowing pattern
+test_pat_on_type![(ref mut x,): &mut (T,)]; //~ ERROR cannot explicitly borrow within an implicitly-borrowing pattern
 
 fn get<X>() -> X {
     unimplemented!()
@@ -40,6 +40,6 @@ fn get<X>() -> X {
 // Make sure this works even when the underlying type is inferred. This test passes on rust stable.
 fn infer<X: Copy>() -> X {
     match &get() {
-        (&x,) => x, //~ ERROR reference patterns may only be written when the default binding mode is `move`
+        (&x,) => x, //~ ERROR cannot explicitly dereference within an implicitly-borrowing pattern
     }
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.stderr
@@ -99,123 +99,123 @@ LL - test_pat_on_type![Foo { f: (&x,) }: &mut Foo];
 LL + test_pat_on_type![Foo { f: (x,) }: &mut Foo];
    |
 
-error: reference patterns may only be written when the default binding mode is `move`
+error: cannot explicitly dereference within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:24:20
    |
 LL | test_pat_on_type![(&x,): &(&T,)];
-   |                    ^ reference pattern not allowed under `ref` default binding mode
+   |                    ^ reference pattern not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:24:19
    |
 LL | test_pat_on_type![(&x,): &(&T,)];
-   |                   ^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |                   ^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL | test_pat_on_type![&(&x,): &(&T,)];
    |                   +
 
-error: reference patterns may only be written when the default binding mode is `move`
+error: cannot explicitly dereference within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:27:20
    |
 LL | test_pat_on_type![(&mut x,): &(&mut T,)];
-   |                    ^^^^ reference pattern not allowed under `ref` default binding mode
+   |                    ^^^^ reference pattern not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:27:19
    |
 LL | test_pat_on_type![(&mut x,): &(&mut T,)];
-   |                   ^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |                   ^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL | test_pat_on_type![&(&mut x,): &(&mut T,)];
    |                   +
 
-error: reference patterns may only be written when the default binding mode is `move`
+error: cannot explicitly dereference within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:31:28
    |
 LL | test_pat_on_type![Foo { f: &(x,) }: &Foo];
-   |                            ^ reference pattern not allowed under `ref` default binding mode
+   |                            ^ reference pattern not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:31:19
    |
 LL | test_pat_on_type![Foo { f: &(x,) }: &Foo];
-   |                   ^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |                   ^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL | test_pat_on_type![&Foo { f: &(x,) }: &Foo];
    |                   +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot mutably bind by value within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:32:20
    |
 LL | test_pat_on_type![(mut x,): &(T,)];
-   |                    ^^^ binding modifier not allowed under `ref` default binding mode
+   |                    ^^^ `mut` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:32:19
    |
 LL | test_pat_on_type![(mut x,): &(T,)];
-   |                   ^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |                   ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL | test_pat_on_type![&(mut x,): &(T,)];
    |                   +
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:33:20
    |
 LL | test_pat_on_type![(ref x,): &(T,)];
-   |                    ^^^ binding modifier not allowed under `ref` default binding mode
+   |                    ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:33:19
    |
 LL | test_pat_on_type![(ref x,): &(T,)];
-   |                   ^^^^^^^^ this matches on type `&_`
+   |                   ^^^^^^^^ this non-reference pattern matches on a reference type `&_`
 help: remove the unnecessary binding modifier
    |
 LL - test_pat_on_type![(ref x,): &(T,)];
 LL + test_pat_on_type![(x,): &(T,)];
    |
 
-error: binding modifiers may only be written when the default binding mode is `move`
+error: cannot explicitly borrow within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:34:20
    |
 LL | test_pat_on_type![(ref mut x,): &mut (T,)];
-   |                    ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
+   |                    ^^^^^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:34:19
    |
 LL | test_pat_on_type![(ref mut x,): &mut (T,)];
-   |                   ^^^^^^^^^^^^ this matches on type `&mut _`
+   |                   ^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&mut _`
 help: remove the unnecessary binding modifier
    |
 LL - test_pat_on_type![(ref mut x,): &mut (T,)];
 LL + test_pat_on_type![(x,): &mut (T,)];
    |
 
-error: reference patterns may only be written when the default binding mode is `move`
+error: cannot explicitly dereference within an implicitly-borrowing pattern
   --> $DIR/min_match_ergonomics_fail.rs:43:10
    |
 LL |         (&x,) => x,
-   |          ^ reference pattern not allowed under `ref` default binding mode
+   |          ^ reference pattern not allowed when implicitly borrowing
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
-note: matching on a reference type with a non-reference pattern changes the default binding mode
+   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
+note: matching on a reference type with a non-reference pattern implicitly borrows the contents
   --> $DIR/min_match_ergonomics_fail.rs:43:9
    |
 LL |         (&x,) => x,
-   |         ^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+   |         ^^^^^ this non-reference pattern matches on a reference type `&_`
+help: match on the reference with a reference pattern to avoid implicitly borrowing
    |
 LL |         &(&x,) => x,
    |         +


### PR DESCRIPTION
Partially addresses rust-lang/rust#143557:
- Uses different wording than the Edition Guide chapter, to hopefully stand alone a bit better. Instead of referring to the "default binding mode", it now talks about what can't be written "within elided reference patterns". I ended up going with "elided" instead of "implicit" in hope that it reads bit less like it should behave the same as an explicit reference pattern, but I'm not totally happy with that wording.
- The explanatory note still points to where the default binding mode was introduced, but only refers to its effect, not what we call it. How that relates to the rest of the diagnostic may still be a bit of a puzzle, but hopefully it isn't too much of one? It also doesn't make sense anymore for the case of `&` written under a by-ref binding mode, so I've left the note out in that case (but kept the label). It's more cramped, but talking about binding modes would feel like a non-sequitur for the error about `&` patterns without further explanation.
- Links to the stable version of the Edition Guide instead of the nightly version. It looks like almost every link to the Edition Guide in diagnostics is to the nightly version, presumably for the same reason as here: the diagnostics were added before the new Edition was stabilized, then never updated. I'll make a separate PR to clean up the others.

This only changes the diagnostic messages, not the code suggestion or the Edition Guide.

r? @Nadrieril or reassign