### PR TITLE
Fix false positive double negations with macro invocation

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1584,6 +1584,8 @@ impl EarlyLintPass for DoubleNegations {
         if let ExprKind::Unary(UnOp::Neg, ref inner) = expr.kind
             && let ExprKind::Unary(UnOp::Neg, ref inner2) = inner.kind
             && !matches!(inner2.kind, ExprKind::Unary(UnOp::Neg, _))
+            // Don't lint if this jumps macro expansion boundary (Issue #143980)
+            && expr.span.eq_ctxt(inner.span)
         {
             cx.emit_span_lint(
                 DOUBLE_NEGATIONS,

--- a/tests/ui/lint/lint-double-negations-macro.rs
+++ b/tests/ui/lint/lint-double-negations-macro.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+macro_rules! neg {
+    ($e: expr) => {
+        -$e
+    };
+}
+macro_rules! bad_macro {
+    ($e: expr) => {
+        --$e //~ WARN use of a double negation
+    };
+}
+
+fn main() {
+    neg!(-1);
+    bad_macro!(1);
+}

--- a/tests/ui/lint/lint-double-negations-macro.stderr
+++ b/tests/ui/lint/lint-double-negations-macro.stderr
@@ -1,0 +1,20 @@
+warning: use of a double negation
+  --> $DIR/lint-double-negations-macro.rs:9:9
+   |
+LL |         --$e
+   |         ^^^^
+...
+LL |     bad_macro!(1);
+   |     ------------- in this macro invocation
+   |
+   = note: the prefix `--` could be misinterpreted as a decrement operator which exists in other languages
+   = note: use `-= 1` if you meant to decrement the value
+   = note: `#[warn(double_negations)]` on by default
+   = note: this warning originates in the macro `bad_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add parentheses for clarity
+   |
+LL |         -(-$e)
+   |          +   +
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes false positive double_negations lint when macro expansion has negation and macro caller also has negations.

Fix rust-lang/rust#143980
