### PR TITLE
don't link to the nightly version of the Edition Guide in stable lints

### DIFF
--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -1047,7 +1047,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             }
                         }
                     }
-                    lint.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
+                    lint.note("for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
 
                     let diagnostic_msg = format!(
                         "add a dummy let to cause {migrated_variables_concat} to be fully captured"

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -569,7 +569,7 @@ lint_non_camel_case_type = {$sort} `{$name}` should have an upper camel case nam
 
 lint_non_fmt_panic = panic message is not a string literal
     .note = this usage of `{$name}!()` is deprecated; it will be a hard error in Rust 2021
-    .more_info_note = for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+    .more_info_note = for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
     .supports_fmt_note = the `{$name}!()` macro supports formatting, so there's no need for the `format!()` macro here
     .supports_fmt_suggestion = remove the `format!(..)` macro call
     .display_suggestion = add a "{"{"}{"}"}" format string to `Display` the message

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1651,7 +1651,7 @@ declare_lint! {
     "`...` range patterns are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>",
     };
 }
 
@@ -1832,7 +1832,7 @@ declare_lint! {
     "detects edition keywords being used as an identifier",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -87,7 +87,7 @@ declare_lint! {
     rewriting in `match` is an option to preserve the semantics up to Edition 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -71,7 +71,7 @@ declare_lint! {
     "`impl Trait` will capture more lifetimes than possibly intended in edition 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
+++ b/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
@@ -65,7 +65,7 @@ declare_lint! {
     /// to ensure the macros implement the desired behavior.
     ///
     /// [editions]: https://doc.rust-lang.org/edition-guide/
-    /// [macro matcher fragment specifiers]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html
+    /// [macro matcher fragment specifiers]: https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html
     /// [`cargo fix`]: https://doc.rust-lang.org/cargo/commands/cargo-fix.html
     pub EDITION_2024_EXPR_FRAGMENT_SPECIFIER,
     Allow,
@@ -73,7 +73,7 @@ declare_lint! {
     To keep the existing behavior, use the `expr_2021` fragment specifier.",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>",
+        reference: "Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/shadowed_into_iter.rs
+++ b/compiler/rustc_lint/src/shadowed_into_iter.rs
@@ -32,7 +32,7 @@ declare_lint! {
     "detects calling `into_iter` on arrays in Rust 2015 and 2018",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>",
     };
 }
 
@@ -61,7 +61,7 @@ declare_lint! {
     "detects calling `into_iter` on boxed slices in Rust 2015, 2018, and 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>"
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>"
     };
 }
 

--- a/compiler/rustc_lint/src/static_mut_refs.rs
+++ b/compiler/rustc_lint/src/static_mut_refs.rs
@@ -54,7 +54,7 @@ declare_lint! {
     "creating a shared reference to mutable static",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>",
         explain_reason: false,
     };
     @edition Edition2024 => Deny;

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1814,7 +1814,7 @@ declare_lint! {
     "suggest using `dyn Trait` for trait objects",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>",
     };
 }
 
@@ -2472,7 +2472,7 @@ declare_lint! {
     "unsafe operations in unsafe functions without an explicit unsafe block are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>",
         explain_reason: false
     };
     @edition Edition2024 => Warn;
@@ -3445,7 +3445,7 @@ declare_lint! {
     "detects usage of old versions of or-patterns",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>",
     };
 }
 
@@ -3494,7 +3494,7 @@ declare_lint! {
         prelude in future editions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>",
     };
 }
 
@@ -3534,7 +3534,7 @@ declare_lint! {
         prelude in future editions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>",
     };
 }
 
@@ -3571,7 +3571,7 @@ declare_lint! {
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>",
     };
     crate_level_only
 }
@@ -4100,7 +4100,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>",
         report_in_deps: true,
     };
     @edition Edition2024 => Deny;
@@ -4155,7 +4155,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>",
         report_in_deps: true,
     };
     report_in_external_macro
@@ -4740,7 +4740,7 @@ declare_lint! {
     "detects unsafe functions being used as safe functions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>",
     };
 }
 
@@ -4776,7 +4776,7 @@ declare_lint! {
     "detects missing unsafe keyword on extern declarations",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html>",
     };
 }
 
@@ -4817,7 +4817,7 @@ declare_lint! {
     "detects unsafe attributes outside of unsafe",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>",
     };
 }
 
@@ -5014,7 +5014,7 @@ declare_lint! {
     "Detect and warn on significant change in drop order in tail expression location",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>",
     };
 }
 
@@ -5053,7 +5053,7 @@ declare_lint! {
     "will be parsed as a guarded string in Rust 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>",
     };
     crate_level_only
 }

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -328,7 +328,7 @@ error: creating a shared reference to mutable static
 LL |         if X.is_some() {
    |            ^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[deny(static_mut_refs)]` on by default
 

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |         let sfoo: *mut Foo = &mut SFOO;
    |                              ^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/closures/2229_closure_analysis/issue-90465.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-90465.stderr
@@ -10,7 +10,7 @@ LL |         let _ = f0;
 LL | }
    | - in Rust 2018, `f0` is dropped here along with the closure, but in Rust 2021 `f0` is not part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/issue-90465.rs:3:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -7,7 +7,7 @@ LL |     thread::spawn(move || unsafe {
 LL |         *fptr.0 = 20;
    |         ------- in Rust 2018, this closure captures all of `fptr`, but in Rust 2021, it will only capture `fptr.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/auto_traits.rs:2:9
    |
@@ -34,7 +34,7 @@ LL |     thread::spawn(move || unsafe {
 LL |         *fptr.0.0 = 20;
    |         --------- in Rust 2018, this closure captures all of `fptr`, but in Rust 2021, it will only capture `fptr.0.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
@@ -56,7 +56,7 @@ LL |         let f_1 = f.1;
 LL | }
    | - in Rust 2018, `f` is dropped here, but in Rust 2021, only `f.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
 LL ~     let c = || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
@@ -15,7 +15,7 @@ LL | |         println!("{:?}", x);
 LL | |     });
    | |______- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/closure-body-macro-fragment.rs:4:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/insignificant_drop_attr_migrations.rs:3:9
    |
@@ -34,7 +34,7 @@ LL |         let _t = t.1;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = move || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/macro.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/macro.stderr
@@ -7,7 +7,7 @@ LL |     let _ = || dbg!(a.0);
 LL | }
    | - in Rust 2018, `a` is dropped here, but in Rust 2021, only `a.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/macro.rs:5:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/migrations_rustfix.rs:2:9
    |
@@ -31,7 +31,7 @@ LL |     let c = || t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; t.0 };

--- a/tests/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -10,7 +10,7 @@ LL |     let result = panic::catch_unwind(move || {
 LL |         f.0()
    |         --- in Rust 2018, this closure captures all of `f`, but in Rust 2021, it will only capture `f.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/mir_calls_to_shims.rs:4:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -13,7 +13,7 @@ LL |         let _f_2 = f2.1;
 LL | }
    | - in Rust 2018, `f2` is dropped here, but in Rust 2021, only `f2.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/multi_diagnostics.rs:2:9
    |
@@ -34,7 +34,7 @@ LL |     let c = || {
 LL |         let _f_1 = f1.0;
    |                    ---- in Rust 2018, this closure captures all of `f1`, but in Rust 2021, it will only capture `f1.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -56,7 +56,7 @@ LL |
 LL |         let _f_2 = f1.2;
    |                    ---- in Rust 2018, this closure captures all of `f1`, but in Rust 2021, it will only capture `f1.2`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -81,7 +81,7 @@ LL | }
    | in Rust 2018, `f1` is dropped here, but in Rust 2021, only `f1.0` will be dropped here as part of the closure
    | in Rust 2018, `f1` is dropped here, but in Rust 2021, only `f1.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -104,7 +104,7 @@ LL |
 LL |         *fptr2.0 = 20;
    |         -------- in Rust 2018, this closure captures all of `fptr2`, but in Rust 2021, it will only capture `fptr2.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {

--- a/tests/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/precise.rs:3:9
    |
@@ -44,7 +44,7 @@ LL | }
    | in Rust 2018, `u` is dropped here, but in Rust 2021, only `u.0.1` will be dropped here as part of the closure
    | in Rust 2018, `u` is dropped here, but in Rust 2021, only `u.1.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured
    |
 LL ~     let c = || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -20,7 +20,7 @@ LL | }
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.0` will be dropped here as part of the closure
    | in Rust 2018, `t2` is dropped here, but in Rust 2021, only `t2.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/significant_drop.rs:2:9
    |
@@ -50,7 +50,7 @@ LL | }
    | in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL ~     let c = || {
@@ -69,7 +69,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -88,7 +88,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -107,7 +107,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -126,7 +126,7 @@ LL |         let _t = t.1;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -150,7 +150,7 @@ LL | }
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.1` will be dropped here as part of the closure
    | in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL ~     let c = move || {
@@ -169,7 +169,7 @@ LL |                 tuple.0;
 LL |         }
    |         - in Rust 2018, `tuple` is dropped here, but in Rust 2021, only `tuple.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~             let c = || {
@@ -188,7 +188,7 @@ LL |             tuple.0;
 LL |     };
    |     - in Rust 2018, `tuple` is dropped here, but in Rust 2021, only `tuple.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~         let c = || {
@@ -204,7 +204,7 @@ LL |         let _c = || tup.0;
 LL | }
    | - in Rust 2018, `tup` is dropped here, but in Rust 2021, only `tup.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tup` to be fully captured
    |
 LL |         let _c = || { let _ = &tup; tup.0 };

--- a/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
+++ b/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
@@ -5,7 +5,7 @@ LL |     panic!({ "foo" });
    |            ^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: `#[warn(non_fmt_panics)]` on by default
 help: add a "{}" format string to `Display` the message
    |

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |     let ptr = unsafe { &mut BB };
    |                        ^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -16,7 +16,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -186,7 +186,7 @@ LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -27,7 +27,7 @@ LL | |     }, e.mark(3), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#3` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -75,7 +75,7 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -107,7 +107,7 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -139,7 +139,7 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -171,7 +171,7 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -193,7 +193,7 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -223,7 +223,7 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -252,7 +252,7 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -281,7 +281,7 @@ LL |         if let true = e.err(9).is_ok() {} else {
    |                       this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -310,7 +310,7 @@ LL |         if let Ok(_v) = e.err(8) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -339,7 +339,7 @@ LL |         if let Ok(_) = e.err(7) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -368,7 +368,7 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -397,7 +397,7 @@ LL |         if let Ok(_v) = e.err(5) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -426,7 +426,7 @@ LL |         if let Ok(_) = e.err(4) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -455,7 +455,7 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = Droppy.get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-gated.rs:14:1
    |

--- a/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
@@ -14,7 +14,7 @@ LL | |     };
    | |_____- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-with-macro.rs:22:1
    |

--- a/tests/ui/drop/lint-if-let-rescope.stderr
+++ b/tests/ui/drop/lint-if-let-rescope.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = droppy().get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -47,7 +47,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  -------- this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -89,7 +89,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -120,7 +120,7 @@ LL |     if let Some(1) = { if let Some(_value) = Droppy.get() { Some(1) } else 
    |                                              this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -146,7 +146,7 @@ LL |     if (if let Some(_value) = droppy().get() { true } else { false }) {
    |                               this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -172,7 +172,7 @@ LL |     } else if (((if let Some(_value) = droppy().get() { true } else { false
    |                                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -198,7 +198,7 @@ LL |     while (if let Some(_value) = droppy().get() { false } else { true }) {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -224,7 +224,7 @@ LL |     if let Some(_value) = Some((droppy(), ()).1) {} else {}
    |                                this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:97:51
    |

--- a/tests/ui/drop/lint-tail-expr-drop-order-borrowck.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order-borrowck.stderr
@@ -7,7 +7,7 @@ LL |     let _ = { String::new().as_str() }.len();
    |               this temporary value will be dropped at the end of the block
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: the lint level is defined here
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:6:9
    |
@@ -23,7 +23,7 @@ LL |     f(unsafe { String::new().as_str() }.len());
    |                this temporary value will be dropped at the end of the block
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: relative drop order changing in Rust 2024
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:31:9
@@ -35,7 +35,7 @@ LL |         &mut || 0
    |         borrow later used here
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: relative drop order changing in Rust 2024
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:43:9
@@ -46,7 +46,7 @@ LL |     g({ &f() });
    |     borrow later used by call
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -17,7 +17,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -54,7 +54,7 @@ LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -86,7 +86,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -118,7 +118,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -145,7 +145,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -167,7 +167,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -199,7 +199,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:193:5
    |
@@ -231,7 +231,7 @@ LL |     ));
    |       - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -23,7 +23,7 @@ LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
@@ -5,7 +5,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
@@ -5,7 +5,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                         ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: A) -> dyn A; }
@@ -32,7 +32,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: dyn B) -> B; }
@@ -45,7 +45,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                         ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: B) -> dyn B; }
@@ -58,7 +58,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -100,7 +100,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
@@ -23,7 +23,7 @@ LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
@@ -5,7 +5,7 @@ LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/bare-trait-dont-suggest-dyn.rs:5:9
    |

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -5,7 +5,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |                 ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/dyn-2018-edition-lint.rs:2:8
    |
@@ -23,7 +23,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |                                   ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
@@ -36,7 +36,7 @@ LL |     let _x: &SomeTrait = todo!();
    |              ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _x: &dyn SomeTrait = todo!();

--- a/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -5,7 +5,7 @@ LL |         <fmt::Debug>::fmt(self, f)
    |          ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/dyn-angle-brackets.rs:4:9
    |

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -5,7 +5,7 @@ LL | fn m() {
    | ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:22:17
@@ -25,7 +25,7 @@ LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:37:5
@@ -44,7 +44,7 @@ LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
   --> $DIR/never-type-fallback-breaking.rs:50:5
@@ -63,7 +63,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:62:19
@@ -82,7 +82,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:76:17
@@ -104,7 +104,7 @@ LL | fn m() {
    | ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:22:17
@@ -125,7 +125,7 @@ LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:37:5
@@ -146,7 +146,7 @@ LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
   --> $DIR/never-type-fallback-breaking.rs:50:5
@@ -167,7 +167,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:62:19
@@ -188,7 +188,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:76:17

--- a/tests/ui/ergonomic-clones/closure/rfc2229-migration.stderr
+++ b/tests/ui/ergonomic-clones/closure/rfc2229-migration.stderr
@@ -10,7 +10,7 @@ LL |         let x = a.0;
 LL | }
    | - in Rust 2018, `a` is dropped here, but in Rust 2021, only `a.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/rfc2229-migration.rs:5:9
    |

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -5,7 +5,7 @@ LL |     let _ = MyIterator::next;
    |             ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -5,7 +5,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |                        ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |                        ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
@@ -5,7 +5,7 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024-machine-applicable.rs:9:10
    |

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
@@ -5,7 +5,7 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:7:10
    |
@@ -29,7 +29,7 @@ LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                         ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:11:16
    |
@@ -48,7 +48,7 @@ LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                                 ^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:17:24
    |
@@ -67,7 +67,7 @@ LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                                               ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:29:23
    |
@@ -86,7 +86,7 @@ LL | fn apit(_: &impl Sized) -> impl Sized {}
    |                            ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:33:12
    |
@@ -111,7 +111,7 @@ LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    |                                      ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:37:16
    |
@@ -136,7 +136,7 @@ LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
    |                                     ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:41:19
    |
@@ -155,7 +155,7 @@ LL | pub fn parens(x: &i32) -> &impl Clone { x }
    |                            ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:45:18
    |

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -5,7 +5,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                 ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -25,7 +25,7 @@ LL |     let g = BitXor::bitor;
    |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let g = <dyn BitXor>::bitor;

--- a/tests/ui/issues/issue-39367.stderr
+++ b/tests/ui/issues/issue-39367.stderr
@@ -9,7 +9,7 @@ LL | |                     (Box::new(__static_ref_initialize()));
 LL | |             });
    | |______________^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -5,7 +5,7 @@ LL |     Trait::nonexistent(());
    |     ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -19,7 +19,7 @@ LL |     eq::<dyn, Foo>
    |               ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/iterators/into-iter-on-arrays-2018.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-2018.stderr
@@ -5,7 +5,7 @@ LL |     let _: Iter<'_, i32> = array.into_iter();
    |                                  ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
    = note: `#[warn(array_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     let _: Iter<'_, i32> = Box::new(array).into_iter();
    |                                            ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:22:43
@@ -34,7 +34,7 @@ LL |     let _: Iter<'_, i32> = Rc::new(array).into_iter();
    |                                           ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:25:41
@@ -43,7 +43,7 @@ LL |     let _: Iter<'_, i32> = Array(array).into_iter();
    |                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:32:24
@@ -52,7 +52,7 @@ LL |     for _ in [1, 2, 3].into_iter() {}
    |                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     for _ in [1, 2, 3].into_iter() {}

--- a/tests/ui/iterators/into-iter-on-arrays-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-lint.stderr
@@ -5,7 +5,7 @@ LL |     small.into_iter();
    |           ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
    = note: `#[warn(array_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     [1, 2].into_iter();
    |            ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     [1, 2].into_iter();
@@ -44,7 +44,7 @@ LL |     big.into_iter();
    |         ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     big.into_iter();
@@ -63,7 +63,7 @@ LL |     [0u8; 33].into_iter();
    |               ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     [0u8; 33].into_iter();
@@ -82,7 +82,7 @@ LL |     Box::new(small).into_iter();
    |                     ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:27:22
@@ -91,7 +91,7 @@ LL |     Box::new([1, 2]).into_iter();
    |                      ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:30:19
@@ -100,7 +100,7 @@ LL |     Box::new(big).into_iter();
    |                   ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:33:25
@@ -109,7 +109,7 @@ LL |     Box::new([0u8; 33]).into_iter();
    |                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:37:31
@@ -118,7 +118,7 @@ LL |     Box::new(Box::new(small)).into_iter();
    |                               ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:40:32
@@ -127,7 +127,7 @@ LL |     Box::new(Box::new([1, 2])).into_iter();
    |                                ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:43:29
@@ -136,7 +136,7 @@ LL |     Box::new(Box::new(big)).into_iter();
    |                             ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:46:35
@@ -145,7 +145,7 @@ LL |     Box::new(Box::new([0u8; 33])).into_iter();
    |                                   ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: 12 warnings emitted
 

--- a/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
@@ -5,7 +5,7 @@ LL |     let _: Iter<'_, i32> = boxed_slice.into_iter();
    |                                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     let _: Iter<'_, i32> = Box::new(boxed_slice.clone()).into_iter();
    |                                                          ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:22:57
@@ -34,7 +34,7 @@ LL |     let _: Iter<'_, i32> = Rc::new(boxed_slice.clone()).into_iter();
    |                                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:25:55
@@ -43,7 +43,7 @@ LL |     let _: Iter<'_, i32> = Array(boxed_slice.clone()).into_iter();
    |                                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:32:48
@@ -52,7 +52,7 @@ LL |     for _ in (Box::new([1, 2, 3]) as Box<[_]>).into_iter() {}
    |                                                ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     for _ in (Box::new([1, 2, 3]) as Box<[_]>).into_iter() {}

--- a/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
@@ -5,7 +5,7 @@ LL |     boxed.into_iter();
    |           ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     Box::new(boxed.clone()).into_iter();
    |                             ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-lint.rs:16:39
@@ -34,7 +34,7 @@ LL |     Box::new(Box::new(boxed.clone())).into_iter();
    |                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: 3 warnings emitted
 

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -5,7 +5,7 @@ LL |     Dyn::func();
    |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL |     ::Dyn::func();
    |     ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn (::Dyn)>::func();
@@ -32,7 +32,7 @@ LL |     Dyn::CONST;
    |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Dyn>::CONST;
@@ -45,7 +45,7 @@ LL |     let _: Dyn::Ty;
    |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: <dyn Dyn>::Ty;

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-allow.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL |         0...100 => true,
    |          ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn ellipsis-inclusive-range-patterns` implied by `--force-warn rust-2021-compatibility`
 
 warning: 1 warning emitted

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/inclusive-range-pattern-syntax.stderr
+++ b/tests/ui/lint/inclusive-range-pattern-syntax.stderr
@@ -5,7 +5,7 @@ LL |         1...2 => {}
    |          ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/inclusive-range-pattern-syntax.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |         &1...2 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(1..=2)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/lint/lint-attr-everywhere-early.stderr
+++ b/tests/ui/lint/lint-attr-everywhere-early.stderr
@@ -391,7 +391,7 @@ LL |         Match{f1: 0...100} => {}
    |                    ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/lint-attr-everywhere-early.rs:138:16
    |
@@ -489,7 +489,7 @@ LL |             f1: 0...100,
    |                  ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/lint-attr-everywhere-early.rs:174:20
    |

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a mutable reference to mutable static
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
@@ -31,7 +31,7 @@ warning: creating a shared reference to mutable static
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -40,7 +40,7 @@ warning: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -53,7 +53,7 @@ warning: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -66,7 +66,7 @@ warning: creating a shared reference to mutable static
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -79,7 +79,7 @@ warning: creating a shared reference to mutable static
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -88,7 +88,7 @@ warning: creating a shared reference to mutable static
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -97,7 +97,7 @@ warning: creating a shared reference to mutable static
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -110,7 +110,7 @@ warning: creating a shared reference to mutable static
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -123,7 +123,7 @@ warning: creating a shared reference to mutable static
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a mutable reference to mutable static
@@ -135,7 +135,7 @@ LL |         &mut ($x.0)
 LL |         let _x = bar!(FOO);
    |                  --------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: this warning originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -4,7 +4,7 @@ error: creating a shared reference to mutable static
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[deny(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ error: creating a mutable reference to mutable static
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
@@ -31,7 +31,7 @@ error: creating a shared reference to mutable static
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -40,7 +40,7 @@ error: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -53,7 +53,7 @@ error: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -66,7 +66,7 @@ error: creating a shared reference to mutable static
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -79,7 +79,7 @@ error: creating a shared reference to mutable static
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -88,7 +88,7 @@ error: creating a shared reference to mutable static
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -97,7 +97,7 @@ error: creating a shared reference to mutable static
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -110,7 +110,7 @@ error: creating a shared reference to mutable static
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -123,7 +123,7 @@ error: creating a shared reference to mutable static
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a mutable reference to mutable static
@@ -135,7 +135,7 @@ LL |         &mut ($x.0)
 LL |         let _x = bar!(FOO);
    |                  --------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
@@ -5,7 +5,7 @@ LL |     ($e:expr) => {
    |         ^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>
 note: the lint level is defined here
   --> $DIR/expr_2021_cargo_fix_edition.rs:4:9
    |
@@ -23,7 +23,7 @@ LL |     ($($i:expr)*) => { };
    |           ^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
 LL |     ($($i:expr_2021)*) => { };

--- a/tests/ui/macros/macro-or-patterns-back-compat.stderr
+++ b/tests/ui/macros/macro-or-patterns-back-compat.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! foo { ($x:pat | $y:pat) => {} }
    |                     ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 note: the lint level is defined here
   --> $DIR/macro-or-patterns-back-compat.rs:4:9
    |
@@ -19,7 +19,7 @@ LL | macro_rules! bar { ($($x:pat)+ | $($y:pat)+) => {} }
    |                       ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:19:21
@@ -28,7 +28,7 @@ LL | macro_rules! ogg { ($x:pat | $y:pat_param) => {} }
    |                     ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:23:26
@@ -37,7 +37,7 @@ LL |     ( $expr:expr , $( $( $pat:pat )|+ => $expr_arm:expr ),+ ) => {
    |                          ^^^^^^^^ help: use pat_param to preserve semantics: `$pat:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/non-fmt-panic.stderr
+++ b/tests/ui/macros/non-fmt-panic.stderr
@@ -74,7 +74,7 @@ LL |     assert!(false, S);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", S);
@@ -87,7 +87,7 @@ LL |     assert!(false, 123);
    |                    ^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", 123);
@@ -100,7 +100,7 @@ LL |     assert!(false, Some(123));
    |                    ^^^^^^^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `Option<i32>`
    |
 LL |     assert!(false, "{:?}", Some(123));
@@ -125,7 +125,7 @@ LL |     panic!(C);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", C);
@@ -138,7 +138,7 @@ LL |     panic!(S);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", S);
@@ -151,7 +151,7 @@ LL |     unreachable!(S);
    |                  ^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", S);
@@ -164,7 +164,7 @@ LL |     unreachable!(S);
    |                  ^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", S);
@@ -177,7 +177,7 @@ LL |     std::panic!(123);
    |                 ^^^
    |
    = note: this usage of `std::panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     std::panic!("{}", 123);
@@ -195,7 +195,7 @@ LL |     core::panic!(&*"abc");
    |                  ^^^^^^^
    |
    = note: this usage of `core::panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     core::panic!("{}", &*"abc");
@@ -208,7 +208,7 @@ LL |     panic!(Some(123));
    |            ^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `Option<i32>`
    |
 LL |     panic!("{:?}", Some(123));
@@ -262,7 +262,7 @@ LL |     panic!(a!());
    |            ^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", a!());
@@ -280,7 +280,7 @@ LL |     unreachable!(a!());
    |                  ^^^^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", a!());
@@ -293,7 +293,7 @@ LL |     panic!(format!("{}", 1));
    |            ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -308,7 +308,7 @@ LL |     unreachable!(format!("{}", 1));
    |                  ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `unreachable!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -323,7 +323,7 @@ LL |     assert!(false, format!("{}", 1));
    |                    ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `assert!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -338,7 +338,7 @@ LL |     debug_assert!(false, format!("{}", 1));
    |                          ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `debug_assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `debug_assert!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -353,7 +353,7 @@ LL |     panic![123];
    |            ^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!["{}", 123];
@@ -371,7 +371,7 @@ LL |     panic!{123};
    |            ^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!{"{}", 123};
@@ -391,7 +391,7 @@ LL |     panic!(v);
    |     help: use std::panic::panic_any instead: `std::panic::panic_any`
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:79:20
@@ -400,7 +400,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:83:12
@@ -409,7 +409,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `T`
    |
 LL |     panic!("{:?}", v);
@@ -427,7 +427,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `T`
    |
 LL |     assert!(false, "{:?}", v);
@@ -440,7 +440,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", v);
@@ -458,7 +458,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", v);
@@ -471,7 +471,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", v);
@@ -489,7 +489,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", v);

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn smeg() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
   --> $DIR/defaulted-never-note.rs:32:9
@@ -28,7 +28,7 @@ LL | fn smeg() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
   --> $DIR/defaulted-never-note.rs:32:9

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -5,7 +5,7 @@ LL | fn def() {
    | ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:12:19
@@ -26,7 +26,7 @@ LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:22:5
@@ -48,7 +48,7 @@ LL | fn def() {
    | ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:12:19
@@ -70,7 +70,7 @@ LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:22:5

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
@@ -25,7 +25,7 @@ LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:50:13
@@ -47,7 +47,7 @@ LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
@@ -68,7 +68,7 @@ LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:50:13

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
   --> $DIR/diverging-fallback-no-leak.rs:20:23
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
   --> $DIR/diverging-fallback-no-leak.rs:20:23

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail
   --> $DIR/diverging-fallback-unconstrained-return.rs:39:23
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail
   --> $DIR/diverging-fallback-unconstrained-return.rs:39:23

--- a/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
+++ b/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
@@ -5,7 +5,7 @@ LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23
@@ -32,7 +32,7 @@ LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
   --> $DIR/fallback-closure-ret.rs:24:5
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
   --> $DIR/fallback-closure-ret.rs:24:5

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -5,7 +5,7 @@ LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
   --> $DIR/impl_trait_fallback.rs:8:25
@@ -24,7 +24,7 @@ LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
   --> $DIR/impl_trait_fallback.rs:8:25

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
@@ -5,7 +5,7 @@ LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9
@@ -32,7 +32,7 @@ LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -141,7 +141,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -157,7 +157,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -173,7 +173,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -185,7 +185,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -201,7 +201,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -217,7 +217,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -233,7 +233,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -249,7 +249,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -265,7 +265,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -280,7 +280,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -150,7 +150,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -166,7 +166,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -182,7 +182,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -194,7 +194,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -210,7 +210,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -226,7 +226,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -242,7 +242,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -258,7 +258,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -274,7 +274,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -289,7 +289,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |         S1 { a: unsafe { &mut X1 } }
    |                          ^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/parser/recover/recover-pat-ranges.stderr
+++ b/tests/ui/parser/recover/recover-pat-ranges.stderr
@@ -191,7 +191,7 @@ LL |         (1 + 4)...1 * 2 => (),
    |                ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default
 
 error: aborting due to 13 previous errors; 1 warning emitted

--- a/tests/ui/parser/recover/recover-range-pats.stderr
+++ b/tests/ui/parser/recover/recover-range-pats.stderr
@@ -339,7 +339,7 @@ LL |     if let 0...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/recover-range-pats.rs:6:9
    |
@@ -353,7 +353,7 @@ LL |     if let 0...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:46:13
@@ -362,7 +362,7 @@ LL |     if let X...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:49:13
@@ -371,7 +371,7 @@ LL |     if let X...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:52:16
@@ -380,7 +380,7 @@ LL |     if let true...Y = 0 {}
    |                ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:55:13
@@ -389,7 +389,7 @@ LL |     if let X...true = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:58:14
@@ -398,7 +398,7 @@ LL |     if let .0...Y = 0 {}
    |              ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:62:13
@@ -407,7 +407,7 @@ LL |     if let X... .0 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:137:20
@@ -419,7 +419,7 @@ LL |     mac2!(0, 1);
    |     ----------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0029]: only `char` and numeric types are allowed in range patterns

--- a/tests/ui/parser/trait-object-trait-parens.stderr
+++ b/tests/ui/parser/trait-object-trait-parens.stderr
@@ -32,7 +32,7 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -57,7 +57,7 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
@@ -81,7 +81,7 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;

--- a/tests/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence.stderr
@@ -16,7 +16,7 @@ LL |         &0...9 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(0..=9)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/range-inclusive-pattern-precedence.rs:7:9
    |

--- a/tests/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -16,7 +16,7 @@ LL |         box 0...9 => {}
    |              ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/range-inclusive-pattern-precedence2.rs:5:9
    |

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -79,7 +79,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = help: in order for the call to be safe, the context requires the following additional target feature: sse2
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 note: an unsafe function restricts its caller, but its body is safe by default

--- a/tests/ui/rust-2021/array-into-iter-ambiguous.stderr
+++ b/tests/ui/rust-2021/array-into-iter-ambiguous.stderr
@@ -5,7 +5,7 @@ LL |     let y = points.into_iter();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyIntoIter::into_iter(points)`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 note: the lint level is defined here
   --> $DIR/array-into-iter-ambiguous.rs:5:9
    |

--- a/tests/ui/rust-2021/future-prelude-collision-generic-trait.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-generic-trait.stderr
@@ -5,7 +5,7 @@ LL |         U::try_from(self)
    |         ^^^^^^^^^^^ help: disambiguate the associated function: `<U as PyTryFrom<'_, _>>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-generic-trait.rs:5:9
    |

--- a/tests/ui/rust-2021/future-prelude-collision-generic.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-generic.stderr
@@ -5,7 +5,7 @@ LL |     Generic::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic<'_, _> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-generic.rs:5:9
    |
@@ -19,7 +19,7 @@ LL |     Generic::<'static, i32>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<'static, i32> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-generic.rs:34:5
@@ -28,7 +28,7 @@ LL |     Generic::<'_, _>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<'_, _> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 3 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -5,7 +5,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-imported.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `crate::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:53:22
@@ -28,7 +28,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `super::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:64:22
@@ -37,7 +37,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 4 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-macros.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-macros.stderr
@@ -5,7 +5,7 @@ LL |     foo!().try_into(todo!());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyTry::try_into(foo!(), todo!())`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-macros.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |     <bar!()>::try_from(0);
    |     ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<bar!() as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-turbofish.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-turbofish.stderr
@@ -5,7 +5,7 @@ LL |     x.try_into::<usize>().or(Err("foo"))?.checked_sub(1);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-turbofish.rs:6:9
    |
@@ -19,7 +19,7 @@ LL |     x.try_into::<usize>().or(Err("foo"))?;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision.stderr
@@ -5,7 +5,7 @@ LL |     let _: u32 = 3u8.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |     let _ = u32::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^ help: disambiguate the associated function: `<u32 as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:66:13
@@ -28,7 +28,7 @@ LL |     let _ = <Vec<u8>>::from_iter(vec![1u8, 2, 3, 4, 5, 6].into_iter());
    |             ^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<u8> as FromByteIterator>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:74:18
@@ -37,7 +37,7 @@ LL |     let _: u32 = <_>::try_from(3u8).unwrap();
    |                  ^^^^^^^^^^^^^ help: disambiguate the associated function: `<_ as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:79:18
@@ -46,7 +46,7 @@ LL |     let _: u32 = (&3u8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(*(&3u8))`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:84:18
@@ -55,7 +55,7 @@ LL |     let _: u32 = 3.0.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(&3.0)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:90:18
@@ -64,7 +64,7 @@ LL |     let _: u32 = mut_ptr.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(mut_ptr as *const _)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:95:13
@@ -73,7 +73,7 @@ LL |     let _ = U32Alias::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<U32Alias as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 8 warnings emitted
 

--- a/tests/ui/rust-2021/generic-type-collision.stderr
+++ b/tests/ui/rust-2021/generic-type-collision.stderr
@@ -5,7 +5,7 @@ LL |     <Vec<i32>>::from_iter(None);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<i32> as MyTrait<_>>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/generic-type-collision.rs:4:9
    |

--- a/tests/ui/rust-2021/inherent-dyn-collision.stderr
+++ b/tests/ui/rust-2021/inherent-dyn-collision.stderr
@@ -5,7 +5,7 @@ LL |         get_dyn_trait().try_into().unwrap()
    |         ^^^^^^^^^^^^^^^ help: disambiguate the method call: `(&*get_dyn_trait())`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/inherent-dyn-collision.rs:8:9
    |

--- a/tests/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/tests/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -5,7 +5,7 @@ LL |     m2!(z"hey");
    |         ^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-prefixes-migration.rs:5:9
    |
@@ -23,7 +23,7 @@ LL |     m2!(prefix"hey");
    |         ^^^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(prefix "hey");
@@ -36,7 +36,7 @@ LL |     m3!(hey#123);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #123);
@@ -49,7 +49,7 @@ LL |     m3!(hey#hey);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #hey);
@@ -62,7 +62,7 @@ LL |     #name = #kind#value
    |              ^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     #name = #kind #value

--- a/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
+++ b/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
@@ -5,7 +5,7 @@ LL |     let y = points.into_iter();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyIntoIter::into_iter(points)`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 note: the lint level is defined here
   --> $DIR/box-slice-into-iter-ambiguous.rs:5:9
    |

--- a/tests/ui/rust-2024/gen-kw.e2015.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2015.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2018.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2018.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(async {}).poll(&mut context());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-poll-async-block.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(()).poll();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(()))`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-poll-not-future-pinned.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(async {}).poll(&mut context());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/in_2024_compatibility.rs:3:9
    |

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
@@ -5,7 +5,7 @@ LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/into-future-adt.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
@@ -5,7 +5,7 @@ LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/into-future-not-into-future.rs:7:9
    |

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -35,7 +35,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-lexing.rs:4:9
    |
@@ -53,7 +53,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -66,7 +66,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -79,7 +79,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -92,7 +92,7 @@ LL |     demo7!(### "foo"###);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(# ## "foo"###);
@@ -105,7 +105,7 @@ LL |     demo7!(### "foo"###);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(## # "foo"###);
@@ -118,7 +118,7 @@ LL |     demo7!(### "foo"###);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"# ##);
@@ -131,7 +131,7 @@ LL |     demo7!(### "foo"###);
    |                      ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"## #);
@@ -144,7 +144,7 @@ LL |     demo5!(###"foo"#);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# ##"foo"#);
@@ -157,7 +157,7 @@ LL |     demo5!(###"foo"#);
    |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## #"foo"#);
@@ -170,7 +170,7 @@ LL |     demo5!(###"foo"#);
    |              ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(### "foo"#);
@@ -183,7 +183,7 @@ LL |     demo5!(#"foo"###);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# "foo"###);
@@ -196,7 +196,7 @@ LL |     demo5!(#"foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"# ##);
@@ -209,7 +209,7 @@ LL |     demo5!(#"foo"###);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"## #);
@@ -222,7 +222,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -235,7 +235,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -248,7 +248,7 @@ LL |     demo4!(Ñ#""#);
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(Ñ# ""#);
@@ -261,7 +261,7 @@ LL |     demo3!(🙃#"");
    |              ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(🙃# "");

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -5,7 +5,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-migration.rs:5:9
    |
@@ -23,7 +23,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -36,7 +36,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -49,7 +49,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -62,7 +62,7 @@ LL |     demo6!(### "foo"##);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(# ## "foo"##);
@@ -75,7 +75,7 @@ LL |     demo6!(### "foo"##);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(## # "foo"##);
@@ -88,7 +88,7 @@ LL |     demo6!(### "foo"##);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(### "foo"# #);
@@ -101,7 +101,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -114,7 +114,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -127,7 +127,7 @@ LL |     demo2!(#"");
    |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "");
@@ -140,7 +140,7 @@ LL |     demo3!(#""#);
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# ""#);
@@ -153,7 +153,7 @@ LL |     demo3!(##"");
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"");
@@ -166,7 +166,7 @@ LL |     demo3!(##"");
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "");
@@ -179,7 +179,7 @@ LL |     demo2!(#"foo");
    |            ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "foo");
@@ -192,7 +192,7 @@ LL |     demo3!(##"foo");
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"foo");
@@ -205,7 +205,7 @@ LL |     demo3!(##"foo");
    |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "foo");
@@ -218,7 +218,7 @@ LL |     demo3!(#"foo"#);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# "foo"#);
@@ -231,7 +231,7 @@ LL |     demo4!(##"foo"#);
    |            ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(# #"foo"#);
@@ -244,7 +244,7 @@ LL |     demo4!(##"foo"#);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(## "foo"#);
@@ -257,7 +257,7 @@ LL |     demo5!(##"foo"##);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# #"foo"##);
@@ -270,7 +270,7 @@ LL |     demo5!(##"foo"##);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## "foo"##);
@@ -283,7 +283,7 @@ LL |     demo5!(##"foo"##);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(##"foo"# #);

--- a/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
@@ -5,7 +5,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/in_2024_compatibility.rs:1:9
    |

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
@@ -5,7 +5,7 @@ LL | tt!([no_mangle]);
    |      ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/unsafe-attributes-fix.rs:2:9
    |
@@ -26,7 +26,7 @@ LL | ident!(no_mangle);
    | ----------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -40,7 +40,7 @@ LL | meta!(no_mangle);
    |       ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta!(unsafe(no_mangle));
@@ -53,7 +53,7 @@ LL | meta2!(export_name = "baw");
    |        ^^^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta2!(unsafe(export_name = "baw"));
@@ -69,7 +69,7 @@ LL | ident2!(export_name, "bars");
    | ---------------------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident2` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -86,7 +86,7 @@ LL | with_cfg_attr!();
    | ---------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `with_cfg_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -100,7 +100,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | #[unsafe(no_mangle)]

--- a/tests/ui/rust-2024/unsafe-env-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>
 note: the lint level is defined here
   --> $DIR/unsafe-env-suggestion.rs:3:9
    |
@@ -24,7 +24,7 @@ LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>
 help: you can wrap the call in an `unsafe` block if you can guarantee that the environment access only happens in single-threaded code
    |
 LL +     // TODO: Audit that the environment access only happens in single-threaded code.

--- a/tests/ui/rust-2024/unsafe-env.e2021.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2021.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1

--- a/tests/ui/rust-2024/unsafe-env.e2024.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2024.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `std::env::set_var` is unsafe and requires
 LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `std::env::remove_var` is unsafe and requi
 LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `set_var` is unsafe and requires unsafe block

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
@@ -14,7 +14,7 @@ LL | | }
    | |_^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html>
 note: the lint level is defined here
   --> $DIR/unsafe-extern-suggestion.rs:3:9
    |

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL | static n: &'static usize = unsafe { &n_mut };
    |                                     ^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |     let _ = unsafe { (&TEST) as *const usize };
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a mutable reference to mutable static
 LL |     let _ = unsafe { (&mut TEST) as *const usize };
    |                      ^^^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 3);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 
@@ -14,7 +14,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 4);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -23,7 +23,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 5);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -32,7 +32,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 15);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -41,7 +41,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, -3);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -50,7 +50,7 @@ warning: creating a shared reference to mutable static
 LL |     static_bound(&static_mut_xc::a);
    |                  ^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -63,7 +63,7 @@ warning: creating a mutable reference to mutable static
 LL |     static_bound_set(&mut static_mut_xc::a);
    |                      ^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
    |                                    ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a shared reference to mutable static
 LL |         assert_eq!(S, *(S as *const *const u8));
    |                    ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: 2 warnings emitted

--- a/tests/ui/suggestions/issue-116434-2015.stderr
+++ b/tests/ui/suggestions/issue-116434-2015.stderr
@@ -5,7 +5,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -52,7 +52,7 @@ LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn handle() -> dyn DbHandle;
@@ -65,7 +65,7 @@ LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/suggestions/issue-61963.stderr
+++ b/tests/ui/suggestions/issue-61963.stderr
@@ -5,7 +5,7 @@ LL |     bar: Box<Bar>,
    |              ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/issue-61963.rs:4:9
    |
@@ -23,7 +23,7 @@ LL | pub struct Foo {
    | ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | dyn pub struct Foo {

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -68,7 +68,7 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |                           ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -82,7 +82,7 @@ LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |                         ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
@@ -95,7 +95,7 @@ LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |                          ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -5,7 +5,7 @@ LL | fn foo(_x: Foo + Send) {
    |            ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
@@ -5,7 +5,7 @@ LL | impl Foo<i64> {
    |      ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -23,7 +23,7 @@ LL | impl Foo<i64> {
    |      ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/traits/unspecified-self-in-trait-ref.stderr
+++ b/tests/ui/traits/unspecified-self-in-trait-ref.stderr
@@ -5,7 +5,7 @@ LL |     let a = Foo::lol();
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -25,7 +25,7 @@ LL |     let b = Foo::<_>::lol();
    |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let b = <dyn Foo::<_>>::lol();
@@ -44,7 +44,7 @@ LL |     let c = Bar::lol();
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let c = <dyn Bar>::lol();
@@ -63,7 +63,7 @@ LL |     let d = Bar::<usize, _>::lol();
    |             ^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let d = <dyn Bar::<usize, _>>::lol();
@@ -82,7 +82,7 @@ LL |     let e = Bar::<usize>::lol();
    |             ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let e = <dyn Bar::<usize>>::lol();

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:8:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition_2024_default.rs:11:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/in_2024_compatibility.rs:6:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
@@ -53,7 +53,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:23:1
@@ -73,7 +73,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -82,7 +82,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:11:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     let y = *x;
    |             ^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:23:1
@@ -46,7 +46,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     y + *x
    |         ^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -55,7 +55,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     let y = BAZ;
    |             ^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:36:1
@@ -69,7 +69,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     y + BAZ
    |         ^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
@@ -81,7 +81,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:58:1
@@ -99,7 +99,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
    = note: this error originates in the macro `unsafe_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -5,7 +5,7 @@ LL | trait Foo<const N: Bar<2>> {
    |                    ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Bar<const M: dyn Foo<2>> {}


### PR DESCRIPTION
As reported in rust-lang/rust#143557 for `rust_2024_incompatible_pat`, most future-Edition-incompatibility lints link to the nightly version of the Edition Guide; the lints were written before their respective Editions (and their guides) stabilized. But now that Rusts 2021 and 2024 are stable, these lints are emitted on stable versions of the compiler, where it makes more sense to present users with links that don't say "nightly" in them.

This does not change the link for `rust_2024_incompatible_pat`. That's handled in rust-lang/rust#144006.