### PR TITLE
Fix wrong messages from methods with the same name from different traits

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1649,7 +1649,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 }
             }
 
-            let sources = candidates.iter().map(|p| self.candidate_source(p, self_ty)).collect();
+            let sources =
+                applicable_candidates.iter().map(|p| self.candidate_source(p.0, self_ty)).collect();
             return Some(Err(MethodError::Ambiguity(sources)));
         }
 

--- a/tests/ui/impl-trait/call_method_without_import.no_import.stderr
+++ b/tests/ui/impl-trait/call_method_without_import.no_import.stderr
@@ -22,15 +22,10 @@ LL |         x.fmt(f);
    = help: items from traits can only be used if the trait is in scope
 help: the following traits which provide `fmt` are implemented but not in scope; perhaps you want to import one of them
    |
-LL + use std::fmt::Binary;
-   |
 LL + use std::fmt::Debug;
    |
-LL + use std::fmt::Display;
+LL + use std::fmt::Pointer;
    |
-LL + use std::fmt::LowerExp;
-   |
-   = and 5 other candidates
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/tests/ui/impl-trait/no-method-suggested-traits.stderr
@@ -9,11 +9,7 @@ help: the following traits which provide `method` are implemented but not in sco
    |
 LL + use foo::Bar;
    |
-LL + use no_method_suggested_traits::Reexported;
-   |
 LL + use no_method_suggested_traits::foo::PubPub;
-   |
-LL + use no_method_suggested_traits::qux::PrivPub;
    |
 help: there is a method `method2` with a similar name
    |
@@ -31,11 +27,7 @@ help: the following traits which provide `method` are implemented but not in sco
    |
 LL + use foo::Bar;
    |
-LL + use no_method_suggested_traits::Reexported;
-   |
 LL + use no_method_suggested_traits::foo::PubPub;
-   |
-LL + use no_method_suggested_traits::qux::PrivPub;
    |
 help: there is a method `method2` with a similar name
    |

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
@@ -20,17 +20,12 @@ error[E0034]: multiple applicable items in scope
 LL |     let z = x.foo();
    |               ^^^ multiple `foo` found
    |
-note: candidate #1 is defined in the trait `FinalFoo`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:60:5
-   |
-LL |     fn foo(&self) -> u8;
-   |     ^^^^^^^^^^^^^^^^^^^^
-note: candidate #2 is defined in an impl of the trait `NuisanceFoo` for the type `T`
+note: candidate #1 is defined in an impl of the trait `NuisanceFoo` for the type `T`
   --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:73:9
    |
 LL |         fn foo(self) {}
    |         ^^^^^^^^^^^^
-note: candidate #3 is defined in an impl of the trait `X` for the type `T`
+note: candidate #2 is defined in an impl of the trait `X` for the type `T`
   --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:46:9
    |
 LL |         fn foo(self: Smaht<Self, u64>) -> u64 {
@@ -38,14 +33,9 @@ LL |         fn foo(self: Smaht<Self, u64>) -> u64 {
 help: disambiguate the method for candidate #1
    |
 LL -     let z = x.foo();
-LL +     let z = FinalFoo::foo(&x);
-   |
-help: disambiguate the method for candidate #2
-   |
-LL -     let z = x.foo();
 LL +     let z = NuisanceFoo::foo(x);
    |
-help: disambiguate the method for candidate #3
+help: disambiguate the method for candidate #2
    |
 LL -     let z = x.foo();
 LL +     let z = X::foo(x);

--- a/tests/ui/methods/wrong-ambig-message.rs
+++ b/tests/ui/methods/wrong-ambig-message.rs
@@ -1,0 +1,34 @@
+fn main() {
+    trait Hello {
+        fn name(&self) -> String;
+    }
+
+    #[derive(Debug)]
+    struct Container2 {
+        val: String,
+    }
+
+    trait AName2 {
+        fn name(&self) -> String;
+    }
+
+    trait BName2 {
+        fn name(&self, v: bool) -> String;
+    }
+
+    impl AName2 for Container2 {
+        fn name(&self) -> String {
+            "aname2".into()
+        }
+    }
+
+    impl BName2 for Container2 {
+        fn name(&self, _v: bool) -> String {
+            "bname2".into()
+        }
+    }
+
+    let c2 = Container2 { val: "abc".into() };
+    println!("c2 = {:?}", c2.name());
+    //~^ ERROR: multiple applicable items in scope
+}

--- a/tests/ui/methods/wrong-ambig-message.stderr
+++ b/tests/ui/methods/wrong-ambig-message.stderr
@@ -1,0 +1,30 @@
+error[E0034]: multiple applicable items in scope
+  --> $DIR/wrong-ambig-message.rs:32:30
+   |
+LL |     println!("c2 = {:?}", c2.name());
+   |                              ^^^^ multiple `name` found
+   |
+note: candidate #1 is defined in an impl of the trait `AName2` for the type `Container2`
+  --> $DIR/wrong-ambig-message.rs:20:9
+   |
+LL |         fn name(&self) -> String {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl of the trait `BName2` for the type `Container2`
+  --> $DIR/wrong-ambig-message.rs:26:9
+   |
+LL |         fn name(&self, _v: bool) -> String {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: disambiguate the method for candidate #1
+   |
+LL -     println!("c2 = {:?}", c2.name());
+LL +     println!("c2 = {:?}", AName2::name(&c2));
+   |
+help: disambiguate the method for candidate #2
+   |
+LL -     println!("c2 = {:?}", c2.name());
+LL +     println!("c2 = {:?}", BName2::name(&c2));
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0034`.


### PR DESCRIPTION
fix issue https://github.com/rust-lang/rust/issues/143740
