### PR TITLE
Validate transmute in CTFE

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -150,6 +150,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
 
                 self.copy_op_allow_transmute(src, dest)?;
+
+                // Even if general validation is disabled, transmutes should always check their result.
+                if !M::enforce_validity(self, dest.layout) {
+                    self.validate_operand(
+                        &dest,
+                        M::enforce_validity_recursively(self, dest.layout),
+                        /*reset_provenance_and_padding*/ true,
+                    )?;
+                }
             }
         }
         interp_ok(())

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -146,6 +146,10 @@ pub trait Machine<'tcx>: Sized {
     /// already been checked before.
     const ALL_CONSTS_ARE_PRECHECKED: bool = true;
 
+    /// Whether to validate the result of various operations like transmutes
+    /// irrespective of [Machine::enforce_validity]
+    const VALIDATE_UNSAFE_OUTPUTS: bool = true;
+
     /// Whether memory accesses should be alignment-checked.
     fn enforce_alignment(ecx: &InterpCx<'tcx, Self>) -> bool;
 

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1107,6 +1107,7 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         MonoHashMap<AllocId, (MemoryKind, Allocation<Provenance, Self::AllocExtra, Self::Bytes>)>;
 
     const GLOBAL_KIND: Option<MiriMemoryKind> = Some(MiriMemoryKind::Global);
+    const VALIDATE_UNSAFE_OUTPUTS: bool = false;
 
     const PANIC_ON_ALLOC_FAIL: bool = false;
 

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -1,90 +1,50 @@
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x00000001, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:23:1
+  --> $DIR/raw-bytes.rs:23:33
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               01 00 00 00                                     │ ....
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x00000000, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:31:1
+  --> $DIR/raw-bytes.rs:31:35
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:45:1
+  --> $DIR/raw-bytes.rs:45:62
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               01                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT1` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:47:1
+  --> $DIR/raw-bytes.rs:47:62
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT2` failed here
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/raw-bytes.rs:53:1
+error[E0080]: constructing invalid value: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+  --> $DIR/raw-bytes.rs:53:67
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               78 00 00 00 ff ff ff ff                         │ x.......
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_OPTION_CHAR` failed here
 
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:58:1
+  --> $DIR/raw-bytes.rs:58:40
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_PTR` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:61:1
+  --> $DIR/raw-bytes.rs:61:39
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               00                                              │ .
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_U8` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:63:1
+  --> $DIR/raw-bytes.rs:63:45
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_USIZE` failed here
 
 error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
   --> $DIR/raw-bytes.rs:69:1
@@ -109,92 +69,52 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:78:1
+  --> $DIR/raw-bytes.rs:81:5
    |
-LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               00 00 00 00 ╾ALLOC_ID╼                         │ ....╾──╼
-           }
+LL |     mem::transmute((0_usize, meta))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FAT_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:85:1
+  --> $DIR/raw-bytes.rs:85:34
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED` failed here
 
 error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:88:42
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a null reference
-  --> $DIR/raw-bytes.rs:91:1
+  --> $DIR/raw-bytes.rs:91:29
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL` failed here
 
 error[E0080]: constructing invalid value: encountered a null box
-  --> $DIR/raw-bytes.rs:94:1
+  --> $DIR/raw-bytes.rs:94:37
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:97:1
+  --> $DIR/raw-bytes.rs:97:44
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               39 05 00 00                                     │ 9...
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_REF` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:100:1
+  --> $DIR/raw-bytes.rs:100:40
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               39 05 00 00                                     │ 9...
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_BOX` failed here
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
-  --> $DIR/raw-bytes.rs:103:1
+error[E0080]: constructing invalid value: encountered a null function pointer
+  --> $DIR/raw-bytes.rs:103:36
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FN_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/raw-bytes.rs:105:1
@@ -207,7 +127,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00                                     │ ....
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value: encountered ALLOC0<imm>, but expected a function pointer
   --> $DIR/raw-bytes.rs:107:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -219,48 +139,28 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
-  --> $DIR/raw-bytes.rs:113:1
+  --> $DIR/raw-bytes.rs:113:36
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               01 00 00 00                                     │ ....
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_REF` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:137:1
+  --> $DIR/raw-bytes.rs:137:37
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
-           }
-
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:139:1
-   |
-LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:139:53
+   |
+LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NESTED_STR_MUCH_TOO_LONG` failed here
+
+error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+  --> $DIR/raw-bytes.rs:141:47
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff ff                         │ ╾──╼....
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_MUCH_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:144:1
@@ -298,48 +198,28 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
            }
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:152:1
+  --> $DIR/raw-bytes.rs:152:40
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:154:50
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ff ff ff 7f                         │ ╾──╼....
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_OVERFLOW` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:157:1
+  --> $DIR/raw-bytes.rs:157:48
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ e7 03 00 00                         │ ╾──╼....
-           }
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_BOX` failed here
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:160:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:160:51
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
-           }
+   |                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_CONTENT_INVALID` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:160:40
@@ -347,16 +227,11 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:164:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:164:60
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_PREFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:164:42
@@ -364,16 +239,11 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:167:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:167:67
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾ALLOC_ID╼                                     │ ╾──╼
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_SUFFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:167:42
@@ -381,49 +251,29 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:171:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC13<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:171:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_1` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:174:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC14<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:174:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_2` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:177:1
+  --> $DIR/raw-bytes.rs:177:54
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 04 00 00 00                         │ ╾──╼....
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_INT_VTABLE` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:179:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC15<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:179:66
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
-           }
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR` failed here
 
 error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:182:1
@@ -437,26 +287,16 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:185:1
+  --> $DIR/raw-bytes.rs:185:62
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ 00 00 00 00                         │ ╾──╼....
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:187:1
+error[E0080]: constructing invalid value: encountered ALLOC16<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:187:65
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼                         │ ╾──╼╾──╼
-           }
+   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID` failed here
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
   --> $DIR/raw-bytes.rs:191:1

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -1,90 +1,50 @@
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0000000000000001, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:23:1
+  --> $DIR/raw-bytes.rs:23:33
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               01 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
-  --> $DIR/raw-bytes.rs:31:1
+  --> $DIR/raw-bytes.rs:31:35
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:45:1
+  --> $DIR/raw-bytes.rs:45:62
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               01                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT1` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/raw-bytes.rs:47:1
+  --> $DIR/raw-bytes.rs:47:62
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT2` failed here
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/raw-bytes.rs:53:1
+error[E0080]: constructing invalid value: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+  --> $DIR/raw-bytes.rs:53:67
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               78 00 00 00 ff ff ff ff                         │ x.......
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_OPTION_CHAR` failed here
 
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:58:1
+  --> $DIR/raw-bytes.rs:58:40
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_PTR` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:61:1
+  --> $DIR/raw-bytes.rs:61:39
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               00                                              │ .
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_U8` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:63:1
+  --> $DIR/raw-bytes.rs:63:45
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_USIZE` failed here
 
 error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
   --> $DIR/raw-bytes.rs:69:1
@@ -109,92 +69,52 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/raw-bytes.rs:78:1
+  --> $DIR/raw-bytes.rs:81:5
    |
-LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               00 00 00 00 00 00 00 00 ╾ALLOC_ID╼ │ ........╾──────╼
-           }
+LL |     mem::transmute((0_usize, meta))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FAT_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:85:1
+  --> $DIR/raw-bytes.rs:85:34
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED` failed here
 
 error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:88:42
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a null reference
-  --> $DIR/raw-bytes.rs:91:1
+  --> $DIR/raw-bytes.rs:91:29
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL` failed here
 
 error[E0080]: constructing invalid value: encountered a null box
-  --> $DIR/raw-bytes.rs:94:1
+  --> $DIR/raw-bytes.rs:94:37
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:97:1
+  --> $DIR/raw-bytes.rs:97:44
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               39 05 00 00 00 00 00 00                         │ 9.......
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_REF` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/raw-bytes.rs:100:1
+  --> $DIR/raw-bytes.rs:100:40
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               39 05 00 00 00 00 00 00                         │ 9.......
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_BOX` failed here
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
-  --> $DIR/raw-bytes.rs:103:1
+error[E0080]: constructing invalid value: encountered a null function pointer
+  --> $DIR/raw-bytes.rs:103:36
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FN_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
   --> $DIR/raw-bytes.rs:105:1
@@ -207,7 +127,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                0d 00 00 00 00 00 00 00                         │ ........
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value: encountered ALLOC0<imm>, but expected a function pointer
   --> $DIR/raw-bytes.rs:107:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -219,48 +139,28 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
-  --> $DIR/raw-bytes.rs:113:1
+  --> $DIR/raw-bytes.rs:113:36
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               01 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_REF` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:137:1
+  --> $DIR/raw-bytes.rs:137:37
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
-
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:139:1
-   |
-LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:139:53
+   |
+LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NESTED_STR_MUCH_TOO_LONG` failed here
+
+error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+  --> $DIR/raw-bytes.rs:141:47
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_MUCH_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
   --> $DIR/raw-bytes.rs:144:1
@@ -298,48 +198,28 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
            }
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:152:1
+  --> $DIR/raw-bytes.rs:152:40
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:154:50
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ff ff ff ff ff ff ff 7f │ ╾──────╼........
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_OVERFLOW` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/raw-bytes.rs:157:1
+  --> $DIR/raw-bytes.rs:157:48
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_BOX` failed here
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:160:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:160:51
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
-           }
+   |                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_CONTENT_INVALID` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:160:40
@@ -347,16 +227,11 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:164:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:164:60
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_PREFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:164:42
@@ -364,16 +239,11 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
-  --> $DIR/raw-bytes.rs:167:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/raw-bytes.rs:167:67
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC_ID╼                         │ ╾──────╼
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_SUFFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/raw-bytes.rs:167:42
@@ -381,49 +251,29 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:171:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC13<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:171:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_1` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:174:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC14<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:174:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_2` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:177:1
+  --> $DIR/raw-bytes.rs:177:54
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_INT_VTABLE` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:179:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC15<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:179:66
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
-           }
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR` failed here
 
 error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
   --> $DIR/raw-bytes.rs:182:1
@@ -437,26 +287,16 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:185:1
+  --> $DIR/raw-bytes.rs:185:62
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
-  --> $DIR/raw-bytes.rs:187:1
+error[E0080]: constructing invalid value: encountered ALLOC16<imm>, but expected a vtable pointer
+  --> $DIR/raw-bytes.rs:187:65
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC_ID╼ ╾ALLOC_ID╼ │ ╾──────╼╾──────╼
-           }
+   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID` failed here
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
   --> $DIR/raw-bytes.rs:191:1

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -76,10 +76,10 @@ const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
 //~^ ERROR constructing invalid value
 
 const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-    //~^ ERROR constructing invalid value
     let x: &dyn Send = &42;
     let meta = std::ptr::metadata(x);
     mem::transmute((0_usize, meta))
+    //~^ ERROR constructing invalid value
 };
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };

--- a/tests/ui/consts/const-eval/transmute-const.stderr
+++ b/tests/ui/consts/const-eval/transmute-const.stderr
@@ -1,13 +1,8 @@
 error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
-  --> $DIR/transmute-const.rs:4:1
+  --> $DIR/transmute-const.rs:4:29
    |
 LL | static FOO: bool = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^ evaluation of `FOO` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -31,10 +31,10 @@ const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
 //~^ ERROR expected a valid enum tag
 
 const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 // # simple enum with discriminant 2
 
@@ -48,10 +48,10 @@ enum Enum2 {
 const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
 //~^ ERROR expected a valid enum tag
 const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 // something wrapping the enum so that we test layout first, not enum
 const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 // Undef enum discriminant.
 #[repr(C)]
@@ -64,7 +64,7 @@ const BAD_ENUM2_UNDEF: Enum2 = unsafe { MaybeUninit { uninit: () }.init };
 
 // Pointer value in an enum with a niche that is not just 0.
 const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 // # valid discriminant for uninhabited variant
 

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -1,57 +1,47 @@
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x01, but expected a valid enum tag
-  --> $DIR/ub-enum.rs:30:1
+  --> $DIR/ub-enum.rs:30:33
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-enum.rs:33:1
+error[E0080]: constructing invalid value at .<enum-tag>: encountered a pointer, but expected an integer
+  --> $DIR/ub-enum.rs:33:37
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_PTR` failed here
+   |                                     ^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-enum.rs:36:1
+error[E0080]: constructing invalid value at .0.<enum-tag>: encountered a pointer, but expected an integer
+  --> $DIR/ub-enum.rs:36:47
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_WRAPPED` failed here
+   |                                               ^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM_WRAPPED` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered 0x0, but expected a valid enum tag
-  --> $DIR/ub-enum.rs:48:1
+  --> $DIR/ub-enum.rs:48:35
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-enum.rs:50:1
+error[E0080]: constructing invalid value at .<enum-tag>: encountered a pointer, but expected an integer
+  --> $DIR/ub-enum.rs:50:39
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_PTR` failed here
+   |                                       ^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-enum.rs:53:1
+error[E0080]: constructing invalid value at .0.<enum-tag>: encountered a pointer, but expected an integer
+  --> $DIR/ub-enum.rs:53:49
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_WRAPPED` failed here
+   |                                                 ^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_WRAPPED` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -66,47 +56,32 @@ LL | const BAD_ENUM2_UNDEF: Enum2 = unsafe { MaybeUninit { uninit: () }.init };
                HEX_DUMP
            }
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-enum.rs:66:1
+error[E0080]: constructing invalid value at .<enum-tag>: encountered a pointer, but expected an integer
+  --> $DIR/ub-enum.rs:66:54
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_OPTION_PTR` failed here
+   |                                                      ^^^^^^^^^^^^^^^^^^ evaluation of `BAD_ENUM2_OPTION_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/ub-enum.rs:83:1
+  --> $DIR/ub-enum.rs:83:62
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT1` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/ub-enum.rs:85:1
+  --> $DIR/ub-enum.rs:85:62
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINHABITED_VARIANT2` failed here
 
-error[E0080]: constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/ub-enum.rs:93:1
+error[E0080]: constructing invalid value: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+  --> $DIR/ub-enum.rs:93:67
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_OPTION_CHAR` failed here
 
 error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
   --> $DIR/ub-enum.rs:98:77

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,57 +1,32 @@
-error[E0080]: constructing invalid value: encountered ALLOC1<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:18:1
+error[E0080]: constructing invalid value: encountered ALLOC2<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
 
 error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:22:1
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
-LL | const INVALID_VTABLE_SIZE: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
+
+error[E0080]: constructing invalid value at .0: encountered ALLOC4<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:32:14
    |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT_UB` failed here
 
 error[E0080]: constructing invalid value at .0: encountered ALLOC5<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:31:1
+  --> $DIR/ub-incorrect-vtable.rs:36:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE_UB` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC7<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:35:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC6<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:41:14
    |
-LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼                         │ ╾──╼╾──╼
-           }
-
-error[E0080]: constructing invalid value at .0: encountered ALLOC9<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:40:1
-   |
-LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_UB` failed here
 
 error[E0080]: constructing invalid value at .1: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-incorrect-vtable.rs:86:1
@@ -61,7 +36,7 @@ LL | const G: Wide = unsafe { Transmute { t: FOO }.u };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC10<imm>╼ ╾ALLOC11╼                         │ ╾──╼╾──╼
+               ╾ALLOC0<imm>╼ ╾ALLOC1╼                         │ ╾──╼╾──╼
            }
 
 error: aborting due to 6 previous errors

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,57 +1,32 @@
-error[E0080]: constructing invalid value: encountered ALLOC1<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:18:1
+error[E0080]: constructing invalid value: encountered ALLOC2<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1<imm>╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
 
 error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:22:1
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
-LL | const INVALID_VTABLE_SIZE: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
+
+error[E0080]: constructing invalid value at .0: encountered ALLOC4<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:32:14
    |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC2<imm>╼ ╾ALLOC3<imm>╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT_UB` failed here
 
 error[E0080]: constructing invalid value at .0: encountered ALLOC5<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:31:1
+  --> $DIR/ub-incorrect-vtable.rs:36:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC4<imm>╼ ╾ALLOC5<imm>╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE_UB` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC7<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:35:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC6<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:41:14
    |
-LL | const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC6<imm>╼ ╾ALLOC7<imm>╼ │ ╾──────╼╾──────╼
-           }
-
-error[E0080]: constructing invalid value at .0: encountered ALLOC9<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:40:1
-   |
-LL | const INVALID_VTABLE_UB: W<&dyn Trait> =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC8<imm>╼ ╾ALLOC9<imm>╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_UB` failed here
 
 error[E0080]: constructing invalid value at .1: encountered a dangling reference (going beyond the bounds of its allocation)
   --> $DIR/ub-incorrect-vtable.rs:86:1
@@ -61,7 +36,7 @@ LL | const G: Wide = unsafe { Transmute { t: FOO }.u };
    |
    = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC10<imm>╼ ╾ALLOC11╼ │ ╾──────╼╾──────╼
+               ╾ALLOC0<imm>╼ ╾ALLOC1╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 6 previous errors

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -17,11 +17,11 @@ trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-//~^^ ERROR vtable
+//~^ ERROR vtable
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-//~^^ ERROR vtable
+//~^ ERROR vtable
 
 #[repr(transparent)]
 struct W<T>(T);
@@ -30,16 +30,16 @@ fn drop_me(_: *mut usize) {}
 
 const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
-//~^^ ERROR expected a vtable pointer
+//~^ ERROR expected a vtable pointer
 
 const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
-//~^^ ERROR expected a vtable pointer
+//~^ ERROR expected a vtable pointer
 
 // Even if the vtable has a fn ptr and a reasonable size+align, it still does not work.
 const INVALID_VTABLE_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1usize))) };
-//~^^ ERROR expected a vtable pointer
+//~^ ERROR expected a vtable pointer
 
 // Trying to access the data in a vtable does not work, either.
 

--- a/tests/ui/consts/const-eval/ub-int-array.rs
+++ b/tests/ui/consts/const-eval/ub-int-array.rs
@@ -18,8 +18,8 @@ impl<T: Copy> MaybeUninit<T> {
 }
 
 const UNINIT_INT_0: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [0]
     mem::transmute([
+    //~^ ERROR invalid value at [0]
         MaybeUninit { uninit: () },
         // Constants chosen to achieve endianness-independent hex dump.
         MaybeUninit::new(0x11111111),
@@ -27,8 +27,8 @@ const UNINIT_INT_0: [u32; 3] = unsafe {
     ])
 };
 const UNINIT_INT_1: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [1]
     mem::transmute([
+    //~^ ERROR invalid value at [1]
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),
@@ -44,8 +44,8 @@ const UNINIT_INT_1: [u32; 3] = unsafe {
     ])
 };
 const UNINIT_INT_2: [u32; 3] = unsafe {
-    //~^ ERROR invalid value at [2]
     mem::transmute([
+    //~^ ERROR invalid value at [2]
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),

--- a/tests/ui/consts/const-eval/ub-int-array.stderr
+++ b/tests/ui/consts/const-eval/ub-int-array.stderr
@@ -1,35 +1,37 @@
 error[E0080]: constructing invalid value at [0]: encountered uninitialized memory, but expected an integer
-  --> $DIR/ub-int-array.rs:20:1
+  --> $DIR/ub-int-array.rs:21:5
    |
-LL | const UNINIT_INT_0: [u32; 3] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               __ __ __ __ 11 11 11 11 22 22 22 22             │ ░░░░....""""
-           }
+LL | /     mem::transmute([
+LL | |
+LL | |         MaybeUninit { uninit: () },
+...  |
+LL | |         MaybeUninit::new(0x22222222),
+LL | |     ])
+   | |______^ evaluation of `UNINIT_INT_0` failed here
 
 error[E0080]: constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
-  --> $DIR/ub-int-array.rs:29:1
+  --> $DIR/ub-int-array.rs:30:5
    |
-LL | const UNINIT_INT_1: [u32; 3] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 __ 01 01 02 02 __ 02             │ .....░....░.
-           }
+LL | /     mem::transmute([
+LL | |
+LL | |         MaybeUninit::new(0u8),
+LL | |         MaybeUninit::new(0u8),
+...  |
+LL | |         MaybeUninit::new(2u8),
+LL | |     ])
+   | |______^ evaluation of `UNINIT_INT_1` failed here
 
 error[E0080]: constructing invalid value at [2]: encountered uninitialized memory, but expected an integer
-  --> $DIR/ub-int-array.rs:46:1
+  --> $DIR/ub-int-array.rs:47:5
    |
-LL | const UNINIT_INT_2: [u32; 3] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 01 01 01 02 02 02 __             │ ...........░
-           }
+LL | /     mem::transmute([
+LL | |
+LL | |         MaybeUninit::new(0u8),
+LL | |         MaybeUninit::new(0u8),
+...  |
+LL | |         MaybeUninit { uninit: () },
+LL | |     ])
+   | |______^ evaluation of `UNINIT_INT_2` failed here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -18,8 +18,9 @@ const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
 
 const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+    //~^ ERROR going beyond the bounds of its allocation
     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-    let out_of_bounds_ptr = &ptr[255]; //~ ERROR in-bounds pointer arithmetic failed
+    let out_of_bounds_ptr = &ptr[255];
     mem::transmute(out_of_bounds_ptr)
 } };
 
@@ -51,10 +52,10 @@ const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
 //~^ ERROR invalid value
 
 const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-//~^ ERROR invalid value
     let x: &dyn Send = &42;
     let meta = std::ptr::metadata(x);
     mem::transmute((0_usize, meta))
+//~^ ERROR invalid value
 };
 
 static S: u32 = 0; // just a static to construct a maybe-null pointer off of

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -1,44 +1,29 @@
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:16:1
+  --> $DIR/ub-nonnull.rs:16:40
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_PTR` failed here
 
-error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 255 bytes, but got ALLOC2 which is only 1 byte from the end of the allocation
-  --> $DIR/ub-nonnull.rs:22:29
+error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
+  --> $DIR/ub-nonnull.rs:20:27
    |
-LL |     let out_of_bounds_ptr = &ptr[255];
-   |                             ^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
+LL |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+   |                           ^^^^^^^^^^^^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:26:1
+  --> $DIR/ub-nonnull.rs:27:39
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_U8` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:28:1
+  --> $DIR/ub-nonnull.rs:29:45
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_USIZE` failed here
 
-error[E0080]: reading memory at ALLOC3[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
-  --> $DIR/ub-nonnull.rs:36:38
+error[E0080]: reading memory at ALLOC0[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
+  --> $DIR/ub-nonnull.rs:37:38
    |
 LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINIT` failed here
@@ -48,7 +33,7 @@ LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: constructing invalid value: encountered 42, but expected something in the range 10..=30
-  --> $DIR/ub-nonnull.rs:44:1
+  --> $DIR/ub-nonnull.rs:45:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -59,7 +44,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
-  --> $DIR/ub-nonnull.rs:50:1
+  --> $DIR/ub-nonnull.rs:51:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
@@ -70,26 +55,16 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/ub-nonnull.rs:53:1
+  --> $DIR/ub-nonnull.rs:57:5
    |
-LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |     mem::transmute((0_usize, meta))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FAT_PTR` failed here
 
 error[E0080]: constructing invalid value: encountered a maybe-null pointer, but expected something that is definitely non-zero
-  --> $DIR/ub-nonnull.rs:61:1
+  --> $DIR/ub-nonnull.rs:62:46
    |
 LL | const MAYBE_NULL_PTR: NonNull<()> = unsafe { mem::transmute((&raw const S).wrapping_add(4)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MAYBE_NULL_PTR` failed here
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -37,13 +37,13 @@ const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
 // but that would fail to compile; so we ended up breaking user code that would
 // have worked fine had we not promoted.
 const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected an integer
 
 const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
 //~^ ERROR invalid value

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -1,72 +1,52 @@
 error[E0080]: constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/ub-ref-ptr.rs:18:1
+  --> $DIR/ub-ref-ptr.rs:18:34
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED` failed here
 
 error[E0080]: constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
-  --> $DIR/ub-ref-ptr.rs:21:1
+  --> $DIR/ub-ref-ptr.rs:21:42
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNALIGNED_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a null reference
-  --> $DIR/ub-ref-ptr.rs:24:1
+  --> $DIR/ub-ref-ptr.rs:24:29
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL` failed here
 
 error[E0080]: constructing invalid value: encountered a null box
-  --> $DIR/ub-ref-ptr.rs:27:1
+  --> $DIR/ub-ref-ptr.rs:27:37
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_BOX` failed here
 
 error[E0080]: constructing invalid value: encountered a maybe-null box
-  --> $DIR/ub-ref-ptr.rs:30:1
+  --> $DIR/ub-ref-ptr.rs:30:42
    |
-LL | const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |   const MAYBE_NULL_BOX: Box<()> = unsafe { mem::transmute({
+   |  __________________________________________^
+LL | |
+LL | |     let ref_ = &0u8;
+LL | |     (ref_ as *const u8).wrapping_add(10)
+LL | | }) };
+   | |__^ evaluation of `MAYBE_NULL_BOX` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:39:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/ub-ref-ptr.rs:39:38
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE` failed here
+   |                                      ^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:42:39
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/ub-ref-ptr.rs:42:49
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_SLICE` failed here
+   |                                                 ^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_SLICE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -77,11 +57,11 @@ note: erroneous constant encountered
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-ref-ptr.rs:45:86
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/ub-ref-ptr.rs:45:87
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   |                                                                                      ^^^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_BOX_SLICE` failed here
+   |                                                                                       ^^^^^^^^^^^^^^^^^^ evaluation of `REF_AS_USIZE_BOX_SLICE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
@@ -93,28 +73,18 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
    |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
-  --> $DIR/ub-ref-ptr.rs:48:1
+  --> $DIR/ub-ref-ptr.rs:48:44
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_REF` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
-  --> $DIR/ub-ref-ptr.rs:51:1
+  --> $DIR/ub-ref-ptr.rs:51:40
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `USIZE_AS_BOX` failed here
 
-error[E0080]: reading memory at ALLOC6[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC1[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-ref-ptr.rs:54:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
@@ -124,18 +94,13 @@ LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered null pointer, but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:57:1
+error[E0080]: constructing invalid value: encountered a null function pointer
+  --> $DIR/ub-ref-ptr.rs:57:36
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NULL_FN_PTR` failed here
 
-error[E0080]: reading memory at ALLOC7[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
+error[E0080]: reading memory at ALLOC2[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
   --> $DIR/ub-ref-ptr.rs:59:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
@@ -156,7 +121,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
+error[E0080]: constructing invalid value: encountered ALLOC0<imm>, but expected a function pointer
   --> $DIR/ub-ref-ptr.rs:63:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
@@ -167,16 +132,17 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value: encountered ALLOC4+0xa, but expected a function pointer
-  --> $DIR/ub-ref-ptr.rs:65:1
+error[E0080]: constructing invalid value: encountered a maybe-null function pointer
+  --> $DIR/ub-ref-ptr.rs:65:42
    |
-LL | const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |   const MAYBE_NULL_FN_PTR: fn() = unsafe { mem::transmute({
+   |  __________________________________________^
+LL | |
+LL | |     fn fun() {}
+LL | |     let ptr = fun as fn();
+LL | |     (ptr as *const u8).wrapping_add(10)
+LL | | }) };
+   | |__^ evaluation of `MAYBE_NULL_FN_PTR` failed here
 
 error[E0080]: accessing memory based on pointer with alignment 1, but alignment 4 is required
   --> $DIR/ub-ref-ptr.rs:75:5
@@ -185,15 +151,10 @@ LL |     ptr.read();
    |     ^^^^^^^^^^ evaluation of `UNALIGNED_READ` failed here
 
 error[E0080]: constructing invalid value: encountered a pointer with unknown absolute address, but expected something that is definitely greater or equal to 1000
-  --> $DIR/ub-ref-ptr.rs:84:1
+  --> $DIR/ub-ref-ptr.rs:84:42
    |
 LL | const INVALID_VALUE_PTR: High = unsafe { mem::transmute(&S) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VALUE_PTR` failed here
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -5,15 +5,10 @@ LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_BAD` failed here
 
 error[E0080]: constructing invalid value: encountered a reference pointing to uninhabited type Bar
-  --> $DIR/ub-uninhabit.rs:23:1
+  --> $DIR/ub-uninhabit.rs:23:36
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_BAD_REF` failed here
 
 error[E0080]: constructing invalid value at [0]: encountered a value of uninhabited type `Bar`
   --> $DIR/ub-uninhabit.rs:26:42

--- a/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.32bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
-  --> $DIR/ub-upvars.rs:7:1
+error[E0080]: constructing invalid value: encountered a null reference
+  --> $DIR/ub-upvars.rs:8:42
    |
-LL | const BAD_UPVAR: &dyn FnOnce() = &{
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1╼                         │ ╾──╼╾──╼
-           }
+LL |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UPVAR` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-upvars.64bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
-  --> $DIR/ub-upvars.rs:7:1
+error[E0080]: constructing invalid value: encountered a null reference
+  --> $DIR/ub-upvars.rs:8:42
    |
-LL | const BAD_UPVAR: &dyn FnOnce() = &{
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC0<imm>╼ ╾ALLOC1╼ │ ╾──────╼╾──────╼
-           }
+LL |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UPVAR` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-upvars.rs
+++ b/tests/ui/consts/const-eval/ub-upvars.rs
@@ -4,10 +4,13 @@
 
 use std::mem;
 
-const BAD_UPVAR: &dyn FnOnce() = &{ //~ ERROR null reference
-    let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+const BAD_UPVAR: &dyn FnOnce() = &{
+    let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) }; //~ ERROR null reference
     let another_var = 13;
-    move || { let _ = bad_ref; let _ = another_var; }
+    move || {
+        let _ = bad_ref;
+        let _ = another_var;
+    }
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -43,10 +43,10 @@ const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::
 //~^ ERROR slice is bigger than largest supported object
 // bad str
 const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected a reference
 // bad str in user-defined unsized type
 const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected a reference
 const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
 //~^ ERROR slice is bigger than largest supported object
 
@@ -62,9 +62,9 @@ const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::
 const SLICE_VALID: &[u8] = unsafe { mem::transmute((&42u8, 1usize)) };
 // bad slice: length uninit
 const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-    //~^ ERROR uninitialized
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
+//~^ ERROR uninitialized
 };
 // bad slice: length too big
 const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
@@ -74,13 +74,13 @@ const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::
 //~^ ERROR slice is bigger than largest supported object
 // bad slice: length not an int
 const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected a reference
 // bad slice box: length too big
 const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
 //~^ ERROR dangling box (going beyond the bounds of its allocation)
 // bad slice box: length not an int
 const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR unable to turn pointer into integer
+//~^ ERROR encountered a pointer, but expected a box
 
 // bad data *inside* the slice
 const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
@@ -100,9 +100,9 @@ const RAW_SLICE_VALID: *const [u8] = unsafe { mem::transmute((&42u8, 1usize)) };
 const RAW_SLICE_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, 999usize)) }; // ok because raw
 const RAW_SLICE_MUCH_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, usize::MAX)) }; // ok because raw
 const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-    //~^ ERROR uninitialized
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
+//~^ ERROR uninitialized
 };
 
 // # trait object
@@ -140,11 +140,11 @@ const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::
 
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-    //~^^ ERROR null pointer
+    //~^ ERROR null pointer
 };
 static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-    //~^^ ERROR vtable
+    //~^ ERROR vtable
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -1,53 +1,38 @@
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:40:1
+  --> $DIR/ub-wide-ptr.rs:40:37
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_TOO_LONG` failed here
 
-error[E0080]: constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:42:1
+error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
+  --> $DIR/ub-wide-ptr.rs:42:53
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NESTED_STR_MUCH_TOO_LONG` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:45:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected a reference
+  --> $DIR/ub-wide-ptr.rs:45:39
    |
 LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_LENGTH_PTR` failed here
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `STR_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:48:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected a reference
+  --> $DIR/ub-wide-ptr.rs:48:44
    |
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_LENGTH_PTR` failed here
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:50:1
+  --> $DIR/ub-wide-ptr.rs:50:47
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `MY_STR_MUCH_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
   --> $DIR/ub-wide-ptr.rs:54:1
@@ -71,77 +56,53 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
                HEX_DUMP
            }
 
-error[E0080]: reading memory at ALLOC32[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-wide-ptr.rs:64:1
+error[E0080]: constructing invalid value: encountered uninitialized memory, but expected a reference
+  --> $DIR/ub-wide-ptr.rs:66:5
    |
-LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_UNINIT` failed here
-   |
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_UNINIT` failed here
 
 error[E0080]: constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:70:1
+  --> $DIR/ub-wide-ptr.rs:70:40
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG` failed here
 
 error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/ub-wide-ptr.rs:73:1
+  --> $DIR/ub-wide-ptr.rs:73:50
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_OVERFLOW` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:76:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected a reference
+  --> $DIR/ub-wide-ptr.rs:76:42
    |
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR` failed here
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
-  --> $DIR/ub-wide-ptr.rs:79:1
+  --> $DIR/ub-wide-ptr.rs:79:48
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_TOO_LONG_BOX` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ub-wide-ptr.rs:82:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected a box
+  --> $DIR/ub-wide-ptr.rs:82:50
    |
 LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR_BOX` failed here
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_LENGTH_PTR_BOX` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:86:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/ub-wide-ptr.rs:86:51
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `SLICE_CONTENT_INVALID` failed here
 
 note: erroneous constant encountered
   --> $DIR/ub-wide-ptr.rs:86:40
@@ -149,16 +110,11 @@ note: erroneous constant encountered
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:92:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/ub-wide-ptr.rs:92:60
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_PREFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/ub-wide-ptr.rs:92:42
@@ -166,16 +122,11 @@ note: erroneous constant encountered
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
-  --> $DIR/ub-wide-ptr.rs:95:1
+error[E0080]: constructing invalid value: encountered 0x03, but expected a boolean
+  --> $DIR/ub-wide-ptr.rs:95:67
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^ evaluation of `MYSLICE_SUFFIX_BAD` failed here
 
 note: erroneous constant encountered
   --> $DIR/ub-wide-ptr.rs:95:42
@@ -183,92 +134,53 @@ note: erroneous constant encountered
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: reading memory at ALLOC33[0x%..0x%], but memory is uninitialized at [0x%..0x%], and this operation requires initialized memory
-  --> $DIR/ub-wide-ptr.rs:102:1
+error[E0080]: constructing invalid value: encountered uninitialized memory, but expected a raw pointer
+  --> $DIR/ub-wide-ptr.rs:104:5
    |
-LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_SLICE_LENGTH_UNINIT` failed here
-   |
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_SLICE_LENGTH_UNINIT` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC12<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:110:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC4<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:110:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_1` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC14<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:113:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC5<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:113:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_SHORT_VTABLE_2` failed here
 
 error[E0080]: constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:116:1
+  --> $DIR/ub-wide-ptr.rs:116:54
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_INT_VTABLE` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC17<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:118:1
+error[E0080]: constructing invalid value: encountered ALLOC6<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:118:57
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_UNALIGNED_VTABLE` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC19<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:120:1
+error[E0080]: constructing invalid value: encountered ALLOC7<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:120:57
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NULL` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC21<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:122:1
+error[E0080]: constructing invalid value: encountered ALLOC8<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:122:56
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_INT` failed here
 
-error[E0080]: constructing invalid value at .0: encountered ALLOC23<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:124:1
+error[E0080]: constructing invalid value at .0: encountered ALLOC9<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:124:66
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR` failed here
 
 error[E0080]: constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
   --> $DIR/ub-wide-ptr.rs:128:1
@@ -282,48 +194,28 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:132:1
+  --> $DIR/ub-wide-ptr.rs:132:62
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC28<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:134:1
+error[E0080]: constructing invalid value: encountered ALLOC10<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:134:65
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID` failed here
 
 error[E0080]: constructing invalid value: encountered null pointer, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:141:1
+  --> $DIR/ub-wide-ptr.rs:142:5
    |
-LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF` failed here
 
-error[E0080]: constructing invalid value: encountered ALLOC31<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:145:1
+error[E0080]: constructing invalid value: encountered ALLOC11<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:146:5
    |
-LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF` failed here
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/consts/const_transmute_type_id7.stderr
+++ b/tests/ui/consts/const_transmute_type_id7.stderr
@@ -1,13 +1,8 @@
 error[E0080]: constructing invalid value at [0]: encountered a maybe-null reference
-  --> $DIR/const_transmute_type_id7.rs:13:1
+  --> $DIR/const_transmute_type_id7.rs:13:56
    |
 LL | const A: [&(); 16 / size_of::<*const ()>()] = unsafe { transmute(TypeId::of::<i32>()) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `A` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.no_flag.stderr
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.no_flag.stderr
@@ -49,27 +49,6 @@ LL | |         (ptr as *const u8).wrapping_add(10)
 LL | |     });
    | |______^ evaluation of `MAYBE_NULL_FN_PTR` failed here
 
-error[E0080]: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
-  --> $DIR/detect-extra-ub.rs:67:13
-   |
-LL |     let v = *addr_of!(data).cast::<UninhDiscriminant>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `UNINHABITED_VARIANT` failed here
-
-error[E0080]: constructing invalid value at [0]: encountered a partial pointer or a mix of pointers
-  --> $DIR/detect-extra-ub.rs:86:16
-   |
-LL |     let _val = *(&mem as *const Align as *const [*const u8; 2]);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PARTIAL_POINTER` failed here
-   |
-   = help: this code performed an operation that depends on the underlying bytes representing a pointer
-   = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
-
-error[E0080]: constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
-  --> $DIR/detect-extra-ub.rs:100:16
-   |
-LL |     let _val = &*slice;
-   |                ^^^^^^^ evaluation of `OVERSIZED_REF` failed here
-
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
@@ -1,5 +1,4 @@
 //@ revisions: no_flag with_flag
-//@ [no_flag] check-pass
 //@ [with_flag] compile-flags: -Zextra-const-ub-checks
 #![feature(never_type)]
 #![allow(unnecessary_transmutes)]
@@ -28,34 +27,34 @@ enum UninhDiscriminant {
 
 const INVALID_BOOL: () = unsafe {
     let _x: bool = transmute(3u8);
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
 };
 
 const INVALID_PTR_IN_INT: () = unsafe {
     let _x: usize = transmute(&3u8);
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
 };
 
 const INVALID_PTR_IN_ENUM: () = unsafe {
     let _x: PtrSizedEnum = transmute(&3u8);
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
 };
 
 const INVALID_SLICE_TO_USIZE_TRANSMUTE: () = unsafe {
     let x: &[u8] = &[0; 32];
     let _x: (usize, usize) = transmute(x);
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
 };
 
 const UNALIGNED_PTR: () = unsafe {
     let _x: &u32 = transmute(&[0u8; 4]);
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
 };
 
 // A function pointer offset to be maybe-null.
 const MAYBE_NULL_FN_PTR: () = unsafe {
     let _x: fn() = transmute({
-    //[with_flag]~^ ERROR: invalid value
+    //~^ ERROR: invalid value
         fn fun() {}
         let ptr = fun as fn();
         (ptr as *const u8).wrapping_add(10)

--- a/tests/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/tests/ui/consts/miri_unleashed/ptr_arith.rs
@@ -11,8 +11,8 @@ static PTR_INT_CAST: () = {
 
 static PTR_INT_TRANSMUTE: () = unsafe {
     let x: usize = std::mem::transmute(&0);
+    //~^ ERROR: constructing invalid value: encountered a pointer, but expected an integer
     let _v = x + 0;
-    //~^ ERROR unable to turn pointer into integer
 };
 
 // I'd love to test pointer comparison, but that is not possible since

--- a/tests/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/tests/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -4,11 +4,11 @@ error[E0080]: exposing pointers is not possible at compile-time
 LL |     let x = &0 as *const _ as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PTR_INT_CAST` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/ptr_arith.rs:14:14
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/ptr_arith.rs:13:20
    |
-LL |     let _v = x + 0;
-   |              ^ evaluation of `PTR_INT_TRANSMUTE` failed here
+LL |     let x: usize = std::mem::transmute(&0);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PTR_INT_TRANSMUTE` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/promotion-in-const-validation.rs
+++ b/tests/ui/consts/promotion-in-const-validation.rs
@@ -1,9 +1,9 @@
 fn foo() {}
 
 const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
-//~^ ERROR: constructing invalid value at .<deref>: encountered a pointer, but expected an integer
+//~^ ERROR: encountered a pointer, but expected an integer
 
 const _: usize = unsafe { std::mem::transmute(foo as fn()) };
-//~^ ERROR: unable to turn pointer into integer
+//~^ ERROR: encountered a pointer, but expected an integer
 
 fn main() {}

--- a/tests/ui/consts/promotion-in-const-validation.rs
+++ b/tests/ui/consts/promotion-in-const-validation.rs
@@ -1,0 +1,9 @@
+fn foo() {}
+
+const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
+//~^ ERROR: constructing invalid value at .<deref>: encountered a pointer, but expected an integer
+
+const _: usize = unsafe { std::mem::transmute(foo as fn()) };
+//~^ ERROR: unable to turn pointer into integer
+
+fn main() {}

--- a/tests/ui/consts/promotion-in-const-validation.stderr
+++ b/tests/ui/consts/promotion-in-const-validation.stderr
@@ -1,15 +1,11 @@
-error[E0080]: constructing invalid value at .<deref>: encountered a pointer, but expected an integer
-  --> $DIR/promotion-in-const-validation.rs:3:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/promotion-in-const-validation.rs:3:29
    |
 LL | const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
-   | ^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾ALLOC0<imm>╼                         │ ╾──────╼
-           }
 
 note: erroneous constant encountered
   --> $DIR/promotion-in-const-validation.rs:3:28
@@ -17,11 +13,11 @@ note: erroneous constant encountered
 LL | const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/promotion-in-const-validation.rs:6:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/promotion-in-const-validation.rs:6:27
    |
 LL | const _: usize = unsafe { std::mem::transmute(foo as fn()) };
-   | ^^^^^^^^^^^^^^ evaluation of `_` failed here
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported

--- a/tests/ui/consts/promotion-in-const-validation.stderr
+++ b/tests/ui/consts/promotion-in-const-validation.stderr
@@ -1,0 +1,31 @@
+error[E0080]: constructing invalid value at .<deref>: encountered a pointer, but expected an integer
+  --> $DIR/promotion-in-const-validation.rs:3:1
+   |
+LL | const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
+   | ^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = help: this code performed an operation that depends on the underlying bytes representing a pointer
+   = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾ALLOC0<imm>╼                         │ ╾──────╼
+           }
+
+note: erroneous constant encountered
+  --> $DIR/promotion-in-const-validation.rs:3:28
+   |
+LL | const _: &usize = unsafe { &std::mem::transmute(foo as fn()) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0080]: unable to turn pointer into integer
+  --> $DIR/promotion-in-const-validation.rs:6:1
+   |
+LL | const _: usize = unsafe { std::mem::transmute(foo as fn()) };
+   | ^^^^^^^^^^^^^^ evaluation of `_` failed here
+   |
+   = help: this code performed an operation that depends on the underlying bytes representing a pointer
+   = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/type/pattern_types/validity.rs
+++ b/tests/ui/type/pattern_types/validity.rs
@@ -11,24 +11,24 @@ const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
 //~^ ERROR: constructing invalid value: encountered 0
 
 const BAD_UNINIT: pattern_type!(u32 is 1..) =
-    //~^ ERROR: this operation requires initialized memory
     unsafe { std::mem::transmute(std::mem::MaybeUninit::<u32>::uninit()) };
+//~^ ERROR: encountered uninitialized memory, but expected an integer
 
 const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&42) };
-//~^ ERROR: unable to turn pointer into integer
+//~^ ERROR: encountered a pointer, but expected an integer
 
 const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem::transmute(0) }, 0);
-//~^ ERROR: constructing invalid value at .0: encountered 0
+//~^ ERROR: encountered 0, but expected something greater or equal to 1
 
 struct Foo(Bar);
 struct Bar(pattern_type!(u32 is 1..));
 
 const BAD_FOO: Foo = Foo(Bar(unsafe { std::mem::transmute(0) }));
-//~^ ERROR: constructing invalid value at .0.0: encountered 0
+//~^ ERROR: encountered 0, but expected something greater or equal to 1
 
 const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
-    //~^ ERROR: this operation requires initialized memory
     unsafe { std::mem::transmute(std::mem::MaybeUninit::<u32>::uninit()) };
+//~^ ERROR: encountered uninitialized memory, but expected a unicode scalar value
 
 const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute('a') };
 //~^ ERROR: constructing invalid value: encountered 97, but expected something in the range 65..=89

--- a/tests/ui/type/pattern_types/validity.stderr
+++ b/tests/ui/type/pattern_types/validity.stderr
@@ -1,86 +1,53 @@
 error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
-  --> $DIR/validity.rs:10:1
+  --> $DIR/validity.rs:10:49
    |
 LL | const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               HEX_DUMP
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD` failed here
 
-error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
-  --> $DIR/validity.rs:13:1
+error[E0080]: constructing invalid value: encountered uninitialized memory, but expected an integer
+  --> $DIR/validity.rs:14:14
    |
-LL | const BAD_UNINIT: pattern_type!(u32 is 1..) =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINIT` failed here
-   |
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+LL |     unsafe { std::mem::transmute(std::mem::MaybeUninit::<u32>::uninit()) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_UNINIT` failed here
 
-error[E0080]: unable to turn pointer into integer
-  --> $DIR/validity.rs:17:1
+error[E0080]: constructing invalid value: encountered a pointer, but expected an integer
+  --> $DIR/validity.rs:17:55
    |
 LL | const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&42) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_PTR` failed here
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_PTR` failed here
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/validity.rs:20:1
+error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+  --> $DIR/validity.rs:20:67
    |
 LL | const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem::transmute(0) }, 0);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               HEX_DUMP
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_AGGREGATE` failed here
 
-error[E0080]: constructing invalid value at .0.0: encountered 0, but expected something greater or equal to 1
-  --> $DIR/validity.rs:26:1
+error[E0080]: constructing invalid value: encountered 0, but expected something greater or equal to 1
+  --> $DIR/validity.rs:26:39
    |
 LL | const BAD_FOO: Foo = Foo(Bar(unsafe { std::mem::transmute(0) }));
-   | ^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               HEX_DUMP
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `BAD_FOO` failed here
 
-error[E0080]: reading memory at ALLOC1[0x0..0x4], but memory is uninitialized at [0x0..0x4], and this operation requires initialized memory
-  --> $DIR/validity.rs:29:1
+error[E0080]: constructing invalid value: encountered uninitialized memory, but expected a unicode scalar value
+  --> $DIR/validity.rs:30:14
    |
-LL | const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CHAR_UNINIT` failed here
-   |
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+LL |     unsafe { std::mem::transmute(std::mem::MaybeUninit::<u32>::uninit()) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CHAR_UNINIT` failed here
 
 error[E0080]: constructing invalid value: encountered 97, but expected something in the range 65..=89
-  --> $DIR/validity.rs:33:1
+  --> $DIR/validity.rs:33:64
    |
 LL | const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute('a') };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               HEX_DUMP
-           }
+   |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CHAR_OOB_PAT` failed here
 
 error[E0080]: constructing invalid value: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-  --> $DIR/validity.rs:36:1
+  --> $DIR/validity.rs:36:60
    |
 LL | const CHAR_OOB: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute(u32::MAX) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               HEX_DUMP
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `CHAR_OOB` failed here
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust#142230

let's see what perf says, maybe we need to restrict it to literal transmutes, and not all the implicit ones happening in mir interpreter internal situations

r? @ghost