### PR TITLE
tests: Test line number in debuginfo for diverging function calls

### DIFF
--- a/tests/codegen-llvm/diverging-function-call-debuginfo.rs
+++ b/tests/codegen-llvm/diverging-function-call-debuginfo.rs
@@ -1,0 +1,38 @@
+/// Make sure that line debuginfo is correct for diverging calls under certain
+/// conditions. In particular we want to ensure that the line number is never
+/// 0, but we check the absence of 0 by looking for the expected exact line
+/// numbers. Regression test for <https://github.com/rust-lang/rust/issues/59558>.
+
+//@ compile-flags: -g -Clto -Copt-level=0
+//@ no-prefer-dynamic
+
+// First find the scope of both diverge() calls, namely this main() function.
+// CHECK-DAG: [[MAIN_SCOPE:![0-9]+]] = distinct !DISubprogram(name: "main", linkageName: {{.*}}diverging_function_call_debuginfo{{.*}}main{{.*}}
+fn main() {
+    if True == False {
+        // unreachable
+        // Then find the DILocation with the correct line number for this call ...
+        // CHECK-DAG: [[UNREACHABLE_CALL_DBG:![0-9]+]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: [[MAIN_SCOPE]]
+        diverge();
+    }
+
+    // ... and this call.
+    // CHECK-DAG: [[LAST_CALL_DBG:![0-9]+]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: [[MAIN_SCOPE]]
+    diverge();
+}
+
+#[derive(PartialEq)]
+pub enum MyBool {
+    True,
+    False,
+}
+
+use MyBool::*;
+
+fn diverge() -> ! {
+    panic!();
+}
+
+// Finally make sure both DILocations belong to each the respective diverge() call.
+// CHECK-DAG: call void {{.*}}diverging_function_call_debuginfo{{.*}}diverge{{.*}} !dbg [[LAST_CALL_DBG]]
+// CHECK-DAG: call void {{.*}}diverging_function_call_debuginfo{{.*}}diverge{{.*}} !dbg [[UNREACHABLE_CALL_DBG]]


### PR DESCRIPTION
Closes rust-lang/rust#59558 which just [E-needs-test](https://github.com/rust-lang/rust/issues/59558#issuecomment-1322236891).

The bug seems to have been fixed in **nightly-2021-05-10**:

```sh
for toolchain in nightly-2021-05-09 \
                 nightly-2021-05-10 \
                 1.88; do
    echo -e "\nWith $toolchain:"
    rustc +$toolchain tests/codegen/diverging-function-call-debuginfo.rs --emit llvm-ir -o /tmp/out.ll -g -Clto -Copt-level=0
    build/x86_64-unknown-linux-gnu/ci-llvm/bin/FileCheck --input-file /tmp/out.ll tests/codegen/diverging-function-call-debuginfo.rs --check-prefix=CHECK --dump-input-context 10 2>/dev/null && echo OK || echo FAIL
done
```

```
With nightly-2021-05-09:
FAIL

With nightly-2021-05-10:
OK

With 1.88:
OK
```

which gives the following list of candidate commits. Not clear which one it is exactly but it doesn't matter much since we can confirm that the test works. I have confirmed locally that with **nightly-2021-05-09** we get `line: 0` for the last call.

<details>
<summary>click to expand</summary>

```
$ git log ^881c1ac408d93bb7adaa3a51dabab9266e82eee8 ca82264ec7556a6011b9d3f1b2fd4c7cd0bc8ae2 --no-merges --oneline
```
f25aa5767f0 Remove unused `opt_span_warn` function
ebbc9495755 Note why `Handler::fatal` is different from `Sesssion::fatal`
96509b48358 Make `Diagnostic::span_fatal` unconditionally raise an error
e49f4471aae Remove some unnecessary uses of `struct_span_fatal`
955fdaea4a1 Rename `Parser::span_fatal_err` -> `Parser::span_err`
4b7c8b0b53c Add `#[track_caller]` to `FakeDefId::expect_real()`
ba13225ba1e Remove `FakeDefId::expect_local()`
020d83d9f5f Enable `-W semicolon_in_expressions_from_macros` in bootstrap
1b928ff8f8b Update LLVM submodule
c2b15a6b641 Support -C passes in NewPM
5519cbfe334 Don't force -O1 with ThinLTO
7c4989ab707 Drop -opt-bisect-limit=0 flag from test
db140de8f29 Explicitly register GCOV profiling pass as well
5ecbe7fcf8b Explicitly register instrprof pass
0318883cd62 Make -Z new-llvm-pass-manager an Option<bool>
0367e24f944 Avoid predecessors having Drop impls

</details>

