### PR TITLE
Rename bool::ok_or[_else] to bool::then_ok_or[_else] to avoid confusion with Option::ok_or[_else]

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -65,19 +65,19 @@ impl bool {
     /// Returns `Ok(())` if the `bool` is [`true`](../std/keyword.true.html),
     /// or `Err(err)` otherwise.
     ///
-    /// Arguments passed to `ok_or` are eagerly evaluated; if you are
+    /// Arguments passed to `then_ok_or` are eagerly evaluated; if you are
     /// passing the result of a function call, it is recommended to use
-    /// [`ok_or_else`], which is lazily evaluated.
+    /// [`then_ok_or_else`], which is lazily evaluated.
     ///
-    /// [`ok_or_else`]: bool::ok_or_else
+    /// [`then_ok_or_else`]: bool::then_ok_or_else
     ///
     /// # Examples
     ///
     /// ```
     /// #![feature(bool_to_result)]
     ///
-    /// assert_eq!(false.ok_or(0), Err(0));
-    /// assert_eq!(true.ok_or(0), Ok(()));
+    /// assert_eq!(false.then_ok_or(0), Err(0));
+    /// assert_eq!(true.then_ok_or(0), Ok(()));
     /// ```
     ///
     /// ```
@@ -86,16 +86,16 @@ impl bool {
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
     ///
-    /// assert!(true.ok_or(function_with_side_effects()).is_ok());
-    /// assert!(false.ok_or(function_with_side_effects()).is_err());
+    /// assert!(true.then_ok_or(function_with_side_effects()).is_ok());
+    /// assert!(false.then_ok_or(function_with_side_effects()).is_err());
     ///
-    /// // `a` is incremented twice because the value passed to `ok_or` is
+    /// // `a` is incremented twice because the value passed to `then_ok_or` is
     /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
     #[unstable(feature = "bool_to_result", issue = "142748")]
     #[inline]
-    pub fn ok_or<E>(self, err: E) -> Result<(), E> {
+    pub fn then_ok_or<E>(self, err: E) -> Result<(), E> {
         if self { Ok(()) } else { Err(err) }
     }
 
@@ -107,8 +107,8 @@ impl bool {
     /// ```
     /// #![feature(bool_to_result)]
     ///
-    /// assert_eq!(false.ok_or_else(|| 0), Err(0));
-    /// assert_eq!(true.ok_or_else(|| 0), Ok(()));
+    /// assert_eq!(false.then_ok_or_else(|| 0), Err(0));
+    /// assert_eq!(true.then_ok_or_else(|| 0), Ok(()));
     /// ```
     ///
     /// ```
@@ -116,16 +116,16 @@ impl bool {
     ///
     /// let mut a = 0;
     ///
-    /// assert!(true.ok_or_else(|| { a += 1; }).is_ok());
-    /// assert!(false.ok_or_else(|| { a += 1; }).is_err());
+    /// assert!(true.then_ok_or_else(|| { a += 1; }).is_ok());
+    /// assert!(false.then_ok_or_else(|| { a += 1; }).is_err());
     ///
     /// // `a` is incremented once because the closure is evaluated lazily by
-    /// // `ok_or_else`.
+    /// // `then_ok_or_else`.
     /// assert_eq!(a, 1);
     /// ```
     #[unstable(feature = "bool_to_result", issue = "142748")]
     #[inline]
-    pub fn ok_or_else<E, F: FnOnce() -> E>(self, f: F) -> Result<(), E> {
+    pub fn then_ok_or_else<E, F: FnOnce() -> E>(self, f: F) -> Result<(), E> {
         if self { Ok(()) } else { Err(f()) }
     }
 }

--- a/library/coretests/tests/bool.rs
+++ b/library/coretests/tests/bool.rs
@@ -108,8 +108,8 @@ fn test_bool_to_option() {
 
 #[test]
 fn test_bool_to_result() {
-    assert_eq!(false.ok_or(0), Err(0));
-    assert_eq!(true.ok_or(0), Ok(()));
-    assert_eq!(false.ok_or_else(|| 0), Err(0));
-    assert_eq!(true.ok_or_else(|| 0), Ok(()));
+    assert_eq!(false.then_ok_or(0), Err(0));
+    assert_eq!(true.then_ok_or(0), Ok(()));
+    assert_eq!(false.then_ok_or_else(|| 0), Err(0));
+    assert_eq!(true.then_ok_or_else(|| 0), Ok(()));
 }


### PR DESCRIPTION
Relevant tracking issue: https://github.com/rust-lang/rust/issues/142748#issuecomment-3059216049

