### PR TITLE
Fix encoding of link_section and no_mangle cross crate

### DIFF
--- a/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_data_structures/src/encode_cross_crate.rs
@@ -40,9 +40,9 @@ impl AttributeKind {
             Fundamental { .. } => Yes,
             Ignore { .. } => No,
             Inline(..) => No,
-            LinkName { .. } => Yes,
+            LinkName { .. } => Yes, // Needed for rustdoc
             LinkOrdinal { .. } => No,
-            LinkSection { .. } => No,
+            LinkSection { .. } => Yes, // Needed for rustdoc
             LoopMatch(..) => No,
             MacroTransparency(..) => Yes,
             Marker(..) => No,
@@ -50,8 +50,8 @@ impl AttributeKind {
             MustUse { .. } => Yes,
             Naked(..) => No,
             NoImplicitPrelude(..) => No,
-            NoMangle(..) => No,
-            NonExhaustive(..) => Yes,
+            NoMangle(..) => Yes,      // Needed for rustdoc
+            NonExhaustive(..) => Yes, // Needed for rustdoc
             OmitGdbPrettyPrinterSection => No,
             Optimize(..) => No,
             ParenSugar(..) => No,

--- a/tests/rustdoc/reexport/auxiliary/reexports-attrs.rs
+++ b/tests/rustdoc/reexport/auxiliary/reexports-attrs.rs
@@ -1,0 +1,14 @@
+#[unsafe(no_mangle)]
+pub fn f0() {}
+
+#[unsafe(link_section = ".here")]
+pub fn f1() {}
+
+#[unsafe(export_name = "f2export")]
+pub fn f2() {}
+
+#[repr(u8)]
+pub enum T0 { V1 }
+
+#[non_exhaustive]
+pub enum T1 {}

--- a/tests/rustdoc/reexport/reexport-attrs.rs
+++ b/tests/rustdoc/reexport/reexport-attrs.rs
@@ -1,0 +1,20 @@
+//@ aux-build: reexports-attrs.rs
+
+#![crate_name = "foo"]
+
+extern crate reexports_attrs;
+
+//@ has 'foo/fn.f0.html' '//pre[@class="rust item-decl"]' '#[no_mangle]'
+pub use reexports_attrs::f0;
+
+//@ has 'foo/fn.f1.html' '//pre[@class="rust item-decl"]' '#[link_section = ".here"]'
+pub use reexports_attrs::f1;
+
+//@ has 'foo/fn.f2.html' '//pre[@class="rust item-decl"]' '#[export_name = "f2export"]'
+pub use reexports_attrs::f2;
+
+//@ has 'foo/enum.T0.html' '//pre[@class="rust item-decl"]' '#[repr(u8)]'
+pub use reexports_attrs::T0;
+
+//@ has 'foo/enum.T1.html' '//pre[@class="rust item-decl"]' '#[non_exhaustive]'
+pub use reexports_attrs::T1;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/144004

@bjorn3 suggested using the `codegen_fn_attrs` query but given that these attributes are not that common it's probably fine to just always encode them. I can also go for that solution if it is preferred but that would require more changes.

r? @jdonszelmann @fmease (whoever feels like it)