### PR TITLE
Stabilize as_array_of_cells

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -698,14 +698,14 @@ impl<T, const N: usize> Cell<[T; N]> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(as_array_of_cells)]
     /// use std::cell::Cell;
     ///
     /// let mut array: [i32; 3] = [1, 2, 3];
     /// let cell_array: &Cell<[i32; 3]> = Cell::from_mut(&mut array);
     /// let array_cell: &[Cell<i32>; 3] = cell_array.as_array_of_cells();
     /// ```
-    #[unstable(feature = "as_array_of_cells", issue = "88248")]
+    #[stable(feature = "as_array_of_cells", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "as_array_of_cells", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_array_of_cells(&self) -> &[Cell<T>; N] {
         // SAFETY: `Cell<T>` has the same memory layout as `T`.
         unsafe { &*(self as *const Cell<[T; N]> as *const [Cell<T>; N]) }

--- a/tests/ui/rfcs/rfc-1789-as-cell/from-mut.rs
+++ b/tests/ui/rfcs/rfc-1789-as-cell/from-mut.rs
@@ -1,7 +1,5 @@
 //@ run-pass
 
-#![feature(as_array_of_cells)]
-
 use std::cell::Cell;
 
 fn main() {


### PR DESCRIPTION
This PR stabilizes

```rust
impl<T, const N: usize> Cell<[T; N]> {
    pub const fn as_array_of_cells(&self) -> &[Cell<T>; N];
}
```

Stabilization report: https://github.com/rust-lang/rust/issues/88248#issuecomment-3082986863
Closes: https://github.com/rust-lang/rust/issues/88248