### PR TITLE
[EXPERIMENTAL] Try using Windows Server 2025 images

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -31,7 +31,8 @@ runners:
     <<: *base-job
 
   - &job-windows
-    os: windows-2022
+    # EXPERIMENTAL
+    os: windows-2025
     <<: *base-job
 
   - &job-windows-25
@@ -39,7 +40,8 @@ runners:
     <<: *base-job
 
   - &job-windows-8c
-    os: windows-2022-8core-32gb
+    # EXPERIMENTAL
+    os: windows-2025-8core-32gb
     <<: *base-job
 
   - &job-windows-25-8c


### PR DESCRIPTION
I've noticed that the Windows Server 2025 images might still be having storage capacity problems, taking a look.

try-job: `x86_64-msvc-*`
try-job: `i686-msvc-*`