### PR TITLE
Add myself to the `infra-ci` reviewer group and adjust some infra auto-labels

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -471,6 +471,7 @@ trigger_files = [
 
 [autolabel."T-infra"]
 trigger_files = [
+    ".github/workflows",
     "src/ci",
     "src/tools/bump-stage0",
     "src/tools/cargotest",
@@ -596,6 +597,12 @@ trigger_files = [
 [autolabel."T-clippy"]
 trigger_files = [
     "src/tools/clippy",
+]
+
+[autolabel."A-CI"]
+trigger_files = [
+    ".github/workflows",
+    "src/ci",
 ]
 
 # ------------------------------------------------------------------------------

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1323,6 +1323,7 @@ infra-ci = [
     "@Kobzol",
     "@marcoieni",
     "@jdno",
+    "@jieyouxu",
 ]
 rustdoc = [
     "@GuillaumeGomez",


### PR DESCRIPTION
- Commit 1 is a drive-by adjustment. Auto-label `src/ci` and `.github/workflows` with https://github.com/rust-lang/rust/labels/A-CI, and include `.github/workflows` for https://github.com/rust-lang/rust/labels/T-infra trigger files.
- Commit 2 adds myself to the `infra-ci` reviewer adhoc group.

r? @Kobzol
