### PR TITLE
ci: use windows 22 for all free runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -34,6 +34,8 @@ runners:
     os: windows-2022
     <<: *base-job
 
+  # NOTE: windows-2025 has less disk space available than windows-2022,
+  # because the D drive is missing.
   - &job-windows-25
     os: windows-2025
     <<: *base-job
@@ -542,13 +544,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-sanitizers --enable-profiler
       SCRIPT: make ci-msvc-py
-    <<: *job-windows-25
+    <<: *job-windows
 
   - name: x86_64-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-sanitizers --enable-profiler
       SCRIPT: make ci-msvc-ps1
-    <<: *job-windows-25
+    <<: *job-windows
 
   # i686-msvc is split into two jobs to run tests in parallel.
   - name: i686-msvc-1


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
As discussed in [#t-infra > windows-2025 image](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/windows-2025.20image/with/529269980), the windows 25 image has fewer disk space than the windows 22 image. So we are moving CI to use windows 22, at least for the free runners.
<!-- homu-ignore:end -->
try-job: `x86_64-msvc-*`