### PR TITLE
Don't test panic=unwind in panic_main.rs on Fuchsia

### DIFF
--- a/tests/ui/panics/panic-main.rs
+++ b/tests/ui/panics/panic-main.rs
@@ -14,12 +14,15 @@
 
 //@[unwind-zero] compile-flags: -Cpanic=unwind
 //@[unwind-zero] exec-env:RUST_BACKTRACE=0
+//@[unwind-zero] needs-unwind
 
 //@[unwind-one] compile-flags: -Cpanic=unwind
 //@[unwind-one] exec-env:RUST_BACKTRACE=1
+//@[unwind-one] needs-unwind
 
 //@[unwind-full] compile-flags: -Cpanic=unwind
 //@[unwind-full] exec-env:RUST_BACKTRACE=full
+//@[unwind-full] needs-unwind
 
 //@ run-fail
 //@ error-pattern:moop


### PR DESCRIPTION
@Enselic added a few new test conditions to tests/ui/panics/panic-main.rs in rust-lang/rust#142304, but it is unfortunately causing the test to fail for Fuchsia with the `panic=unwind` modes since we compile Rust for Fuchsia with `panic=abort`. This patch just ignores the test for Fuchsia.

Note that this test might also need to filter out a few other platforms, since another panicking test we exclude from Fuchsia https://github.com/rust-lang/rust/blob/master/tests/ui/panics/runtime-switch.rs also excludes running on msvc, android, openbsd, and wasm, but I'm not familiar with those platforms so I didn't want to add them here.

cc @compile-errors, who reviewed the initial PR