### PR TITLE
Fix debuginfo-lto-alloc.rs test

### DIFF
--- a/tests/ui/lto/debuginfo-lto-alloc.rs
+++ b/tests/ui/lto/debuginfo-lto-alloc.rs
@@ -8,8 +8,9 @@
 // This test reproduces the circumstances that caused the error to appear, and checks
 // that compilation is successful.
 
-//@ check-pass
+//@ build-pass
 //@ compile-flags: --test -C debuginfo=2 -C lto=fat
+//@ no-prefer-dynamic
 //@ incremental
 
 extern crate alloc;


### PR DESCRIPTION
This should have used build-pass rather than check-pass.