### PR TITLE
tests: cover more `exported_private_dependencies` cases

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/auxiliary/priv_dep.rs
+++ b/tests/ui/privacy/pub-priv-dep/auxiliary/priv_dep.rs
@@ -10,3 +10,9 @@ macro_rules! m {
 pub enum E {
     V1
 }
+
+struct PrivType;
+
+pub type Unit = ();
+pub type PubPub = OtherType;
+pub type PubPriv = PrivType;

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -32,6 +32,33 @@ pub struct PublicType {
     pub other_field: PubType, // Type from public dependency - this is fine
 }
 
+pub struct PublicTuple(
+    pub OtherType,
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface [exported_private_dependencies]
+    OtherType,
+    pub PubType,
+);
+
+pub enum PublicEnum {
+    OtherType,
+    ActualOtherType(OtherType, PubType),
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface [exported_private_dependencies]
+    ActualOtherTypeStruct {
+        field: OtherType,
+        //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface [exported_private_dependencies]
+        other_field: PubType,
+    },
+}
+
+pub struct PublicGenericType<T, U>(pub T, U);
+pub type ReexportedPublicGeneric = PublicGenericType<OtherType, ()>;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+pub type ReexportedPrivateGeneric = PublicGenericType<(), OtherType>;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub struct PublicGenericBoundedType<T: OtherTrait>(T);
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+
 impl PublicType {
     pub fn pub_fn_param(param: OtherType) {}
     //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
@@ -46,9 +73,15 @@ pub trait MyPubTrait {
     type Foo: OtherTrait;
     //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
-    fn required() -> impl OtherTrait;
+    fn required_impl_trait() -> impl OtherTrait;
 
-    fn provided() -> impl OtherTrait { OtherType }
+    fn provided_impl_trait() -> impl OtherTrait { OtherType }
+
+    fn required_concrete() -> OtherType;
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+    fn provided_concrete() -> OtherType { OtherType }
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 }
 
 pub trait WithSuperTrait: OtherTrait {}
@@ -67,6 +100,12 @@ impl PubLocalTraitWithAssoc for PrivateAssoc {
 pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
 //~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
+pub fn private_return_impl_trait() -> impl OtherTrait { OtherType }
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
+
+pub fn private_return() -> OtherType { OtherType }
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
 pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
 //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 
@@ -79,6 +118,9 @@ pub const CONST: OtherType = OtherType;
 pub type Alias = OtherType;
 //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 
+pub type AliasOfAlias = priv_dep::PubPub;
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
 pub struct PublicWithPrivateImpl;
 
 impl OtherTrait for PublicWithPrivateImpl {}
@@ -89,6 +131,22 @@ pub trait PubTraitOnPrivate {}
 impl PubTraitOnPrivate for OtherType {}
 //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 //~| ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+
+pub struct PublicWithStdImpl;
+
+impl From<OtherType> for PublicWithStdImpl {
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+    fn from(val: OtherType) -> Self { Self }
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+}
+
+impl From<PublicWithStdImpl> for OtherType {
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+    //~| ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+    fn from(val: PublicWithStdImpl) -> Self { Self }
+    //~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+    //~| ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+}
 
 pub struct AllowedPrivType {
     #[allow(exported_private_dependencies)]
@@ -106,5 +164,14 @@ pub use pm::pm_attr;
 
 pub use priv_dep::E::V1;
 //~^ ERROR variant `V1` from private dependency 'priv_dep' is re-exported
+
+pub use priv_dep::Unit;
+//~^ ERROR type alias `Unit` from private dependency 'priv_dep' is re-exported
+pub use priv_dep::PubPub;
+//~^ ERROR type alias `PubPub` from private dependency 'priv_dep' is re-exported
+pub use priv_dep::PubPriv;
+//~^ ERROR type alias `PubPriv` from private dependency 'priv_dep' is re-exported
+pub use priv_dep::OtherType as Renamed;
+//~^ ERROR struct `Renamed` from private dependency 'priv_dep' is re-exported
 
 fn main() {}

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -11,34 +11,58 @@ LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: macro `m` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:98:9
+  --> $DIR/pub-priv1.rs:156:9
    |
 LL | pub use priv_dep::m;
    |         ^^^^^^^^^^^
 
 error: macro `fn_like` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:100:9
+  --> $DIR/pub-priv1.rs:158:9
    |
 LL | pub use pm::fn_like;
    |         ^^^^^^^^^^^
 
 error: derive macro `PmDerive` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:102:9
+  --> $DIR/pub-priv1.rs:160:9
    |
 LL | pub use pm::PmDerive;
    |         ^^^^^^^^^^^^
 
 error: attribute macro `pm_attr` from private dependency 'pm' is re-exported
-  --> $DIR/pub-priv1.rs:104:9
+  --> $DIR/pub-priv1.rs:162:9
    |
 LL | pub use pm::pm_attr;
    |         ^^^^^^^^^^^
 
 error: variant `V1` from private dependency 'priv_dep' is re-exported
-  --> $DIR/pub-priv1.rs:107:9
+  --> $DIR/pub-priv1.rs:165:9
    |
 LL | pub use priv_dep::E::V1;
    |         ^^^^^^^^^^^^^^^
+
+error: type alias `Unit` from private dependency 'priv_dep' is re-exported
+  --> $DIR/pub-priv1.rs:168:9
+   |
+LL | pub use priv_dep::Unit;
+   |         ^^^^^^^^^^^^^^
+
+error: type alias `PubPub` from private dependency 'priv_dep' is re-exported
+  --> $DIR/pub-priv1.rs:170:9
+   |
+LL | pub use priv_dep::PubPub;
+   |         ^^^^^^^^^^^^^^^^
+
+error: type alias `PubPriv` from private dependency 'priv_dep' is re-exported
+  --> $DIR/pub-priv1.rs:172:9
+   |
+LL | pub use priv_dep::PubPriv;
+   |         ^^^^^^^^^^^^^^^^^
+
+error: struct `Renamed` from private dependency 'priv_dep' is re-exported
+  --> $DIR/pub-priv1.rs:174:9
+   |
+LL | pub use priv_dep::OtherType as Renamed;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
   --> $DIR/pub-priv1.rs:29:5
@@ -49,82 +73,188 @@ LL |     pub field: OtherType,
 error: type `OtherType` from private dependency 'priv_dep' in public interface
   --> $DIR/pub-priv1.rs:36:5
    |
+LL |     pub OtherType,
+   |     ^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:44:21
+   |
+LL |     ActualOtherType(OtherType, PubType),
+   |                     ^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:47:9
+   |
+LL |         field: OtherType,
+   |         ^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:54:1
+   |
+LL | pub type ReexportedPublicGeneric = PublicGenericType<OtherType, ()>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:56:1
+   |
+LL | pub type ReexportedPrivateGeneric = PublicGenericType<(), OtherType>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:59:1
+   |
+LL | pub struct PublicGenericBoundedType<T: OtherTrait>(T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:63:5
+   |
 LL |     pub fn pub_fn_param(param: OtherType) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:39:5
+  --> $DIR/pub-priv1.rs:66:5
    |
 LL |     pub fn pub_fn_return() -> OtherType { OtherType }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:46:5
+  --> $DIR/pub-priv1.rs:73:5
    |
 LL |     type Foo: OtherTrait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:80:5
+   |
+LL |     fn required_concrete() -> OtherType;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:83:5
+   |
+LL |     fn provided_concrete() -> OtherType { OtherType }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:54:1
+  --> $DIR/pub-priv1.rs:87:1
    |
 LL | pub trait WithSuperTrait: OtherTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:63:5
+  --> $DIR/pub-priv1.rs:96:5
    |
 LL |     type X = OtherType;
    |     ^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:67:1
+  --> $DIR/pub-priv1.rs:100:1
    |
 LL | pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:103:1
+   |
+LL | pub fn private_return_impl_trait() -> impl OtherTrait { OtherType }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:70:1
+  --> $DIR/pub-priv1.rs:106:1
+   |
+LL | pub fn private_return() -> OtherType { OtherType }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:109:1
    |
 LL | pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:73:1
+  --> $DIR/pub-priv1.rs:112:1
    |
 LL | pub static STATIC: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:76:1
+  --> $DIR/pub-priv1.rs:115:1
    |
 LL | pub const CONST: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:79:1
+  --> $DIR/pub-priv1.rs:118:1
    |
 LL | pub type Alias = OtherType;
    | ^^^^^^^^^^^^^^
 
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:121:1
+   |
+LL | pub type AliasOfAlias = priv_dep::PubPub;
+   | ^^^^^^^^^^^^^^^^^^^^^
+
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:84:1
+  --> $DIR/pub-priv1.rs:126:1
    |
 LL | impl OtherTrait for PublicWithPrivateImpl {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:89:1
+  --> $DIR/pub-priv1.rs:131:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:89:1
+  --> $DIR/pub-priv1.rs:131:1
    |
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 20 previous errors
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:137:1
+   |
+LL | impl From<OtherType> for PublicWithStdImpl {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:139:5
+   |
+LL |     fn from(val: OtherType) -> Self { Self }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:143:1
+   |
+LL | impl From<PublicWithStdImpl> for OtherType {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:143:1
+   |
+LL | impl From<PublicWithStdImpl> for OtherType {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:146:5
+   |
+LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:146:5
+   |
+LL |     fn from(val: PublicWithStdImpl) -> Self { Self }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds tests for all missing cases from rust-lang/rust#71043 and some on top of that. I believe with this, that issue can be closed.

Some of the lints can be improved, e.g. `provided_impl_trait` and `impl From<PublicWithStdImpl> for OtherType` lint twice.

cc @epage in case you want to double check I didn't miss anything.