### PR TITLE
Make `IoSlice` and `IoSliceMut` methods unstably const

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1378,8 +1378,9 @@ impl<'a> IoSliceMut<'a> {
     ///
     /// Panics on Windows if the slice is larger than 4GB.
     #[stable(feature = "iovec", since = "1.36.0")]
+    #[rustc_const_unstable(feature = "io_slice_const", issue = "146459")]
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+    pub const fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut(sys::io::IoSliceMut::new(buf))
     }
 
@@ -1406,8 +1407,9 @@ impl<'a> IoSliceMut<'a> {
     /// assert_eq!(buf.deref(), [1; 5].as_ref());
     /// ```
     #[stable(feature = "io_slice_advance", since = "1.81.0")]
+    #[rustc_const_unstable(feature = "io_slice_const", issue = "146459")]
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         self.0.advance(n)
     }
 
@@ -1536,9 +1538,10 @@ impl<'a> IoSlice<'a> {
     ///
     /// Panics on Windows if the slice is larger than 4GB.
     #[stable(feature = "iovec", since = "1.36.0")]
+    #[rustc_const_unstable(feature = "io_slice_const", issue = "146459")]
     #[must_use]
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+    pub const fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice(sys::io::IoSlice::new(buf))
     }
 
@@ -1565,8 +1568,9 @@ impl<'a> IoSlice<'a> {
     /// assert_eq!(buf.deref(), [1; 5].as_ref());
     /// ```
     #[stable(feature = "io_slice_advance", since = "1.81.0")]
+    #[rustc_const_unstable(feature = "io_slice_const", issue = "146459")]
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         self.0.advance(n)
     }
 

--- a/library/std/src/sys/io/io_slice/iovec.rs
+++ b/library/std/src/sys/io/io_slice/iovec.rs
@@ -18,7 +18,7 @@ pub struct IoSlice<'a> {
 
 impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+    pub const fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice {
             vec: iovec { iov_base: buf.as_ptr() as *mut u8 as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
@@ -26,7 +26,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         if self.vec.iov_len < n {
             panic!("advancing IoSlice beyond its length");
         }
@@ -51,7 +51,7 @@ pub struct IoSliceMut<'a> {
 
 impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+    pub const fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut {
             vec: iovec { iov_base: buf.as_mut_ptr() as *mut c_void, iov_len: buf.len() },
             _p: PhantomData,
@@ -59,7 +59,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         if self.vec.iov_len < n {
             panic!("advancing IoSliceMut beyond its length");
         }
@@ -71,7 +71,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 
@@ -81,7 +81,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub const fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.vec.iov_base as *mut u8, self.vec.iov_len) }
     }
 }

--- a/library/std/src/sys/io/io_slice/unsupported.rs
+++ b/library/std/src/sys/io/io_slice/unsupported.rs
@@ -5,13 +5,14 @@ pub struct IoSlice<'a>(&'a [u8]);
 
 impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+    pub const fn new(buf: &'a [u8]) -> IoSlice<'a> {
         IoSlice(buf)
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
-        self.0 = &self.0[n..]
+    pub const fn advance(&mut self, n: usize) {
+        let (_, remaining) = self.0.split_at(n);
+        self.0 = remaining;
     }
 
     #[inline]
@@ -24,19 +25,19 @@ pub struct IoSliceMut<'a>(&'a mut [u8]);
 
 impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+    pub const fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         IoSliceMut(buf)
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
-        let slice = mem::take(&mut self.0);
+    pub const fn advance(&mut self, n: usize) {
+        let slice = mem::replace(&mut self.0, &mut []);
         let (_, remaining) = slice.split_at_mut(n);
         self.0 = remaining;
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         self.0
     }
 
@@ -46,7 +47,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub const fn as_mut_slice(&mut self) -> &mut [u8] {
         self.0
     }
 }

--- a/library/std/src/sys/io/io_slice/windows.rs
+++ b/library/std/src/sys/io/io_slice/windows.rs
@@ -11,7 +11,7 @@ pub struct IoSlice<'a> {
 
 impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+    pub const fn new(buf: &'a [u8]) -> IoSlice<'a> {
         assert!(buf.len() <= u32::MAX as usize);
         IoSlice {
             vec: c::WSABUF { len: buf.len() as u32, buf: buf.as_ptr() as *mut u8 },
@@ -20,7 +20,7 @@ impl<'a> IoSlice<'a> {
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         if (self.vec.len as usize) < n {
             panic!("advancing IoSlice beyond its length");
         }
@@ -45,7 +45,7 @@ pub struct IoSliceMut<'a> {
 
 impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+    pub const fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         assert!(buf.len() <= u32::MAX as usize);
         IoSliceMut {
             vec: c::WSABUF { len: buf.len() as u32, buf: buf.as_mut_ptr() },
@@ -54,7 +54,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn advance(&mut self, n: usize) {
+    pub const fn advance(&mut self, n: usize) {
         if (self.vec.len as usize) < n {
             panic!("advancing IoSliceMut beyond its length");
         }
@@ -66,7 +66,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub const fn as_slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.vec.buf, self.vec.len as usize) }
     }
 
@@ -76,7 +76,7 @@ impl<'a> IoSliceMut<'a> {
     }
 
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    pub const fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.vec.buf, self.vec.len as usize) }
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144090)*
<!-- homu-ignore:end -->

This enables constructing `IoSlice` and `IoSliceMut` in const contexts without users needing to break the platform abstraction by doing the cast themselves. This is useful for statics.

Since all current and plausible future platforms use simple slice-like structs, this should not impose a burden when adding a new platform with a different struct.