### PR TITLE
Ignore tests/run-make/link-eh-frame-terminator/rmake.rs when cross-compiling

### DIFF
--- a/tests/assembly/dwarf-mixed-versions-lto.rs
+++ b/tests/assembly/dwarf-mixed-versions-lto.rs
@@ -15,6 +15,6 @@ fn main() {
 }
 
 // CHECK: .section .debug_info
-// CHECK-NOT: {{\.(short|hword|2byte)}} 2
-// CHECK-NOT: {{\.(short|hword|2byte)}} 4
-// CHECK: {{\.(short|hword|2byte)}} 5
+// CHECK-NOT: {{\.(short|hword|2byte|half)}} 2
+// CHECK-NOT: {{\.(short|hword|2byte|half)}} 4
+// CHECK: {{\.(short|hword|2byte|half)}} 5

--- a/tests/codegen/const-vector.rs
+++ b/tests/codegen/const-vector.rs
@@ -15,6 +15,7 @@
 #![feature(arm_target_feature)]
 #![feature(mips_target_feature)]
 #![allow(non_camel_case_types)]
+#![feature(riscv_target_feature)]
 
 // Setting up structs that can be used as const vectors
 #[repr(simd)]
@@ -51,6 +52,7 @@ extern "unadjusted" {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 pub fn do_call() {
     unsafe {
         // CHECK: call void @test_i8x2(<2 x i8> <i8 32, i8 64>

--- a/tests/codegen/enum/enum-aggregate.rs
+++ b/tests/codegen/enum/enum-aggregate.rs
@@ -27,7 +27,7 @@ fn make_none_bool() -> Option<bool> {
 
 #[no_mangle]
 fn make_some_ordering(x: Ordering) -> Option<Ordering> {
-    // CHECK-LABEL: i8 @make_some_ordering(i8 %x)
+    // CHECK-LABEL: i8 @make_some_ordering(i8 {{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i8 %x
     Some(x)
@@ -35,7 +35,7 @@ fn make_some_ordering(x: Ordering) -> Option<Ordering> {
 
 #[no_mangle]
 fn make_some_u16(x: u16) -> Option<u16> {
-    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16 %x)
+    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16 {{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: %0 = insertvalue { i16, i16 } { i16 1, i16 poison }, i16 %x, 1
     // CHECK-NEXT: ret { i16, i16 } %0
@@ -52,7 +52,7 @@ fn make_none_u16() -> Option<u16> {
 
 #[no_mangle]
 fn make_some_nzu32(x: NonZero<u32>) -> Option<NonZero<u32>> {
-    // CHECK-LABEL: i32 @make_some_nzu32(i32 %x)
+    // CHECK-LABEL: i32 @make_some_nzu32(i32 {{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i32 %x
     Some(x)
@@ -114,7 +114,7 @@ fn make_uninhabited_err_indirectly(n: Never) -> Result<u32, Never> {
 fn make_fully_uninhabited_result(v: u32, n: Never) -> Result<(u32, Never), (Never, u32)> {
     // Actually reaching this would be UB, so we don't actually build a result.
 
-    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32 %v)
+    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32 {{.*}}%v)
     // CHECK-NEXT: start:
     // CHECK-NEXT: call void @llvm.trap()
     // CHECK-NEXT: call void @llvm.trap()

--- a/tests/codegen/simd/extract-insert-dyn.rs
+++ b/tests/codegen/simd/extract-insert-dyn.rs
@@ -5,7 +5,8 @@
     repr_simd,
     arm_target_feature,
     mips_target_feature,
-    s390x_target_feature
+    s390x_target_feature,
+    riscv_target_feature
 )]
 #![no_std]
 #![crate_type = "lib"]
@@ -25,97 +26,105 @@ pub struct u32x16([u32; 16]);
 pub struct i8x16([i8; 16]);
 
 // CHECK-LABEL: dyn_simd_extract
-// CHECK: extractelement <16 x i8> %x, i32 %idx
+// CHECK: extractelement <16 x i8> %[[TEMP:.+]], i32 %idx
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn dyn_simd_extract(x: i8x16, idx: u32) -> i8 {
     simd_extract_dyn(x, idx)
 }
 
 // CHECK-LABEL: literal_dyn_simd_extract
-// CHECK: extractelement <16 x i8> %x, i32 7
+// CHECK: extractelement <16 x i8> %[[TEMP:.+]], i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn literal_dyn_simd_extract(x: i8x16) -> i8 {
     simd_extract_dyn(x, 7)
 }
 
 // CHECK-LABEL: const_dyn_simd_extract
-// CHECK: extractelement <16 x i8> %x, i32 7
+// CHECK: extractelement <16 x i8> %[[TEMP:.+]], i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn const_dyn_simd_extract(x: i8x16) -> i8 {
     simd_extract_dyn(x, const { 3 + 4 })
 }
 
 // CHECK-LABEL: const_simd_extract
-// CHECK: extractelement <16 x i8> %x, i32 7
+// CHECK: extractelement <16 x i8> %[[TEMP:.+]], i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn const_simd_extract(x: i8x16) -> i8 {
     simd_extract(x, const { 3 + 4 })
 }
 
 // CHECK-LABEL: dyn_simd_insert
-// CHECK: insertelement <16 x i8> %x, i8 %e, i32 %idx
+// CHECK: insertelement <16 x i8> %[[TEMP:.+]], i8 %e, i32 %idx
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn dyn_simd_insert(x: i8x16, e: i8, idx: u32) -> i8x16 {
     simd_insert_dyn(x, idx, e)
 }
 
 // CHECK-LABEL: literal_dyn_simd_insert
-// CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
+// CHECK: insertelement <16 x i8> %[[TEMP:.+]], i8 %e, i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn literal_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert_dyn(x, 7, e)
 }
 
 // CHECK-LABEL: const_dyn_simd_insert
-// CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
+// CHECK: insertelement <16 x i8> %[[TEMP:.+]], i8 %e, i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn const_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert_dyn(x, const { 3 + 4 }, e)
 }
 
 // CHECK-LABEL: const_simd_insert
-// CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
+// CHECK: insertelement <16 x i8> %[[TEMP:.+]], i8 %e, i32 7
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 unsafe extern "C" fn const_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert(x, const { 3 + 4 }, e)
 }

--- a/tests/codegen/transmute-scalar.rs
+++ b/tests/codegen/transmute-scalar.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: -C opt-level=0 -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-#![feature(no_core, repr_simd, arm_target_feature, mips_target_feature, s390x_target_feature)]
+#![feature(no_core, repr_simd, arm_target_feature, mips_target_feature, s390x_target_feature, riscv_target_feature)]
 #![no_core]
 extern crate minicore;
 
@@ -79,7 +79,7 @@ pub fn bool_to_fake_bool_signed(b: bool) -> FakeBoolSigned {
     unsafe { mem::transmute(b) }
 }
 
-// CHECK-LABEL: define{{.*}}i1 @fake_bool_signed_to_bool(i8 %b)
+// CHECK-LABEL: define{{.*}}i1 @fake_bool_signed_to_bool(i8 {{.*}}%b)
 // CHECK: %_0 = trunc nuw i8 %b to i1
 // CHECK-NEXT: ret i1 %_0
 #[no_mangle]
@@ -110,34 +110,36 @@ pub fn fake_bool_unsigned_to_bool(b: FakeBoolUnsigned) -> bool {
 #[repr(simd)]
 struct S([i64; 1]);
 
-// CHECK-LABEL: define{{.*}}i64 @single_element_simd_to_scalar(<1 x i64> %b)
+// CHECK-LABEL: define{{.*}}i64 @single_element_simd_to_scalar({{.*}}i64 %{{.*}})
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[RET:.+]] = alloca [8 x i8]
-// CHECK-NEXT: store <1 x i64> %b, ptr %[[RET]]
-// CHECK-NEXT: %[[TEMP:.+]] = load i64, ptr %[[RET]]
-// CHECK-NEXT: ret i64 %[[TEMP]]
+// CHECK: store <1 x i64> %[[TEMP:.+]], ptr %[[RET]]
+// CHECK: %[[TEMP:.+]] = load i64, ptr %[[RET]]
+// CHECK: ret i64 %[[TEMP]]
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 pub extern "C" fn single_element_simd_to_scalar(b: S) -> i64 {
     unsafe { mem::transmute(b) }
 }
 
-// CHECK-LABEL: define{{.*}}<1 x i64> @scalar_to_single_element_simd(i64 %b)
+// CHECK-LABEL: define{{.*}}i64{{.*}} @scalar_to_single_element_simd(i64 %b)
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[RET:.+]] = alloca [8 x i8]
 // CHECK-NEXT: store i64 %b, ptr %[[RET]]
-// CHECK-NEXT: %[[TEMP:.+]] = load <1 x i64>, ptr %[[RET]]
-// CHECK-NEXT: ret <1 x i64> %[[TEMP]]
+// CHECK-NEXT: %[[TEMP:.+]] = load{{.*}}i64{{.*}}, ptr %[[RET]]
+// CHECK-NEXT: ret {{.*}}i64{{.*}}%[[TEMP]]
 #[no_mangle]
 #[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
 #[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 pub extern "C" fn scalar_to_single_element_simd(b: i64) -> S {
     unsafe { mem::transmute(b) }
 }

--- a/tests/codegen/transmute-scalar.rs
+++ b/tests/codegen/transmute-scalar.rs
@@ -2,8 +2,9 @@
 //@ compile-flags: -C opt-level=0 -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-#![feature(no_core, repr_simd, arm_target_feature, mips_target_feature, s390x_target_feature, riscv_target_feature)]
+#![feature(no_core, repr_simd, arm_target_feature, mips_target_feature, s390x_target_feature)]
 #![no_core]
+#![feature(riscv_target_feature)]
 extern crate minicore;
 
 use minicore::*;

--- a/tests/codegen/transmute-scalar.rs
+++ b/tests/codegen/transmute-scalar.rs
@@ -111,7 +111,7 @@ pub fn fake_bool_unsigned_to_bool(b: FakeBoolUnsigned) -> bool {
 #[repr(simd)]
 struct S([i64; 1]);
 
-// CHECK-LABEL: define{{.*}}i64 @single_element_simd_to_scalar({{.*}}i64 %{{.*}})
+// CHECK-LABEL: define{{.*}}i64 @single_element_simd_to_scalar({{.*}}i64{{.*}}%{{.*}})
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[RET:.+]] = alloca [8 x i8]
 // CHECK: store <1 x i64> %[[TEMP:.+]], ptr %[[RET]]

--- a/tests/codegen/uninhabited-transparent-return-abi.rs
+++ b/tests/codegen/uninhabited-transparent-return-abi.rs
@@ -36,7 +36,7 @@ pub fn test_uninhabited_ret_by_ref() {
 pub fn test_uninhabited_ret_by_ref_with_arg(rsi: u32) {
     // CHECK: %_2 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_2)
-    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef %rsi) #2
+    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef{{.*}}%rsi) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque_with_arg(rsi);

--- a/tests/run-make/link-eh-frame-terminator/rmake.rs
+++ b/tests/run-make/link-eh-frame-terminator/rmake.rs
@@ -9,6 +9,7 @@
 //@ ignore-32bit
 // Reason: the usage of a large array in the test causes an out-of-memory
 // error on 32 bit systems.
+//@ ignore-cross-compile
 
 use run_make_support::{bin_name, llvm_objdump, run, rustc};
 

--- a/tests/run-make/link-eh-frame-terminator/rmake.rs
+++ b/tests/run-make/link-eh-frame-terminator/rmake.rs
@@ -9,7 +9,6 @@
 //@ ignore-32bit
 // Reason: the usage of a large array in the test causes an out-of-memory
 // error on 32 bit systems.
-//@ ignore-cross-compile
 
 use run_make_support::{bin_name, llvm_objdump, run, rustc};
 


### PR DESCRIPTION
The test tests/run-make/link-eh-frame-terminator/rmake.rs fails to link when cross-compiling. Therefore, it should be ignored in cross-compilation environments.
See [commit a27bdea](https://github.com/rust-lang/rust/commit/a27bdea4b7b5107ea912659813418445d9e46ba4) and [commit 2beccc4](https://github.com/rust-lang/rust/commit/2beccc4d8e5066a42e6623d91e7991870d36feb2) for reference.