### PR TITLE
Ignore tests/run-make/link-eh-frame-terminator/rmake.rs when cross-compiling

### DIFF
--- a/tests/run-make/link-eh-frame-terminator/rmake.rs
+++ b/tests/run-make/link-eh-frame-terminator/rmake.rs
@@ -9,6 +9,7 @@
 //@ ignore-32bit
 // Reason: the usage of a large array in the test causes an out-of-memory
 // error on 32 bit systems.
+//@ ignore-cross-compile
 
 use run_make_support::{bin_name, llvm_objdump, run, rustc};
 


### PR DESCRIPTION
The test tests/run-make/link-eh-frame-terminator/rmake.rs fails to link when cross-compiling. Therefore, it should be ignored in cross-compilation environments.
See [commit a27bdea](https://github.com/rust-lang/rust/commit/a27bdea4b7b5107ea912659813418445d9e46ba4) and [commit 2beccc4](https://github.com/rust-lang/rust/commit/2beccc4d8e5066a42e6623d91e7991870d36feb2) for reference.