### PR TITLE
Impls and impl items inherit `dead_code` lint level of the corresponding traits and trait items

### DIFF
--- a/tests/ui/lint/dead-code/allow-trait-or-impl.rs
+++ b/tests/ui/lint/dead-code/allow-trait-or-impl.rs
@@ -1,0 +1,38 @@
+#![deny(dead_code)]
+
+pub mod a {
+    pub trait Foo { }
+    impl Foo for u32 { }
+
+    struct PrivateType; //~ ERROR struct `PrivateType` is never constructed
+    impl Foo for PrivateType { } // <-- warns as dead, even though Foo is public
+
+    struct AnotherPrivateType; //~ ERROR struct `AnotherPrivateType` is never constructed
+    impl Foo for AnotherPrivateType { } // <-- warns as dead, even though Foo is public
+}
+
+pub mod b {
+    #[allow(dead_code)]
+    pub trait Foo { }
+    impl Foo for u32 { }
+
+    struct PrivateType;
+    impl Foo for PrivateType { } // <-- no warning, trait is "allowed"
+
+    struct AnotherPrivateType;
+    impl Foo for AnotherPrivateType { } // <-- no warning, trait is "allowed"
+}
+
+pub mod c {
+    pub trait Foo { }
+    impl Foo for u32 { }
+
+    struct PrivateType;
+    #[allow(dead_code)]
+    impl Foo for PrivateType { } // <-- no warning, impl is allowed
+
+    struct AnotherPrivateType; //~ ERROR struct `AnotherPrivateType` is never constructed
+    impl Foo for AnotherPrivateType { } // <-- warns as dead, even though Foo is public
+}
+
+fn main() {}

--- a/tests/ui/lint/dead-code/allow-trait-or-impl.stderr
+++ b/tests/ui/lint/dead-code/allow-trait-or-impl.stderr
@@ -1,0 +1,26 @@
+error: struct `PrivateType` is never constructed
+  --> $DIR/allow-trait-or-impl.rs:7:12
+   |
+LL |     struct PrivateType;
+   |            ^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/allow-trait-or-impl.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: struct `AnotherPrivateType` is never constructed
+  --> $DIR/allow-trait-or-impl.rs:10:12
+   |
+LL |     struct AnotherPrivateType;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: struct `AnotherPrivateType` is never constructed
+  --> $DIR/allow-trait-or-impl.rs:34:12
+   |
+LL |     struct AnotherPrivateType;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/dead-code/allow-unused-trait.rs
+++ b/tests/ui/lint/dead-code/allow-unused-trait.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+
+#![deny(dead_code)]
+
+#[allow(dead_code)]
+trait Foo {
+    const FOO: u32;
+    type Baz;
+    fn foobar();
+}
+
+const fn bar(x: u32) -> u32 {
+    x
+}
+
+struct Qux;
+
+struct FooBar;
+
+impl Foo for u32 {
+    const FOO: u32 = bar(0);
+    type Baz = Qux;
+
+    fn foobar() {
+        let _ = FooBar;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/master/compiler/rustc_passes/src/dead.rs#L360-L361 won't insert assoc items into the live set, so that impl items cannot be marked live.

This PR lets impls and impl items can inherit lint levels of the corresponding traits and trait items.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#144060

r? @petrochenkov