### PR TITLE
Update dist-x86_64-linux host toolchain to LLVM 21

### DIFF
--- a/src/ci/docker/scripts/build-clang.sh
+++ b/src/ci/docker/scripts/build-clang.sh
@@ -5,7 +5,7 @@ set -ex
 source shared.sh
 
 # Try to keep the LLVM version here in sync with src/ci/scripts/install-clang.sh
-LLVM=llvmorg-20.1.0-rc2
+LLVM=llvmorg-21.1.0-rc1
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
This updates the host clang used to build LLVM, as well as llvm-bolt. This avoids the bolt miscompile encountered in https://github.com/rust-lang/rust/pull/143684.

r? @ghost