### PR TITLE
Write .cargo/config.toml in x vendor

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1206,17 +1206,13 @@ impl Step for Src {
         );
 
         // Vendor all Cargo dependencies
-        let vendor = builder.ensure(Vendor {
+        builder.ensure(Vendor {
             sync_args: vec![],
             versioned_dirs: true,
             root_dir: dst_src.clone(),
             output_dir: None,
             only_library_workspace: true,
         });
-
-        let library_cargo_config_dir = dst_src.join("library").join(".cargo");
-        builder.create_dir(&library_cargo_config_dir);
-        builder.create(&library_cargo_config_dir.join("config.toml"), &vendor.config_library);
 
         tarball.generate()
     }
@@ -1379,21 +1375,13 @@ fn prepare_source_tarball<'a>(
             });
 
         // Vendor all Cargo dependencies
-        let vendor = builder.ensure(Vendor {
+        builder.ensure(Vendor {
             sync_args: pkgs_for_pgo_training.collect(),
             versioned_dirs: true,
             root_dir: plain_dst_src.into(),
             output_dir: None,
             only_library_workspace: false,
         });
-
-        let cargo_config_dir = plain_dst_src.join(".cargo");
-        builder.create_dir(&cargo_config_dir);
-        builder.create(&cargo_config_dir.join("config.toml"), &vendor.config);
-
-        let library_cargo_config_dir = plain_dst_src.join("library").join(".cargo");
-        builder.create_dir(&library_cargo_config_dir);
-        builder.create(&library_cargo_config_dir.join("config.toml"), &vendor.config_library);
     }
 
     // Delete extraneous directories

--- a/src/bootstrap/src/core/build_steps/vendor.rs
+++ b/src/bootstrap/src/core/build_steps/vendor.rs
@@ -59,7 +59,7 @@ pub(crate) struct Vendor {
 }
 
 impl Step for Vendor {
-    type Output = VendorOutput;
+    type Output = ();
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -84,7 +84,7 @@ impl Step for Vendor {
     ///
     /// This function runs `cargo vendor` and ensures all required submodules
     /// are initialized before vendoring begins.
-    fn run(self, builder: &Builder<'_>) -> Self::Output {
+    fn run(self, builder: &Builder<'_>) {
         let _guard = builder.group(&format!("Vendoring sources to {:?}", self.root_dir));
 
         let config = if self.only_library_workspace {
@@ -163,13 +163,15 @@ impl Step for Vendor {
 
         let config_library = cmd.run_capture_stdout(builder).stdout();
 
-        VendorOutput { config, config_library }
-    }
-}
+        // Write .cargo/config.toml
+        let cargo_config_dir = self.output_dir.as_ref().unwrap_or(&self.root_dir).join(".cargo");
+        builder.create_dir(&cargo_config_dir);
+        builder.create(&cargo_config_dir.join("config.toml"), &config);
 
-/// Stores the result of the vendoring step.
-#[derive(Debug, Clone)]
-pub(crate) struct VendorOutput {
-    pub(crate) config: String,
-    pub(crate) config_library: String,
+        // Write library/.cargo/config.toml
+        let library_cargo_config_dir =
+            self.output_dir.unwrap_or(self.root_dir).join("library").join(".cargo");
+        builder.create_dir(&library_cargo_config_dir);
+        builder.create(&library_cargo_config_dir.join("config.toml"), &config_library);
+    }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144124)*
<!-- homu-ignore:end -->

x vendor hides the cargo vendor telling you what to write to `.cargo/config.toml`. to use the vendored sources, so without this PR it isn't obvious how to use the vendored sources.