### PR TITLE
Fix empty target_config in apply_rust_config bootstrap

### DIFF
--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1646,22 +1646,15 @@ mod snapshot {
 
     #[test]
     fn test_lld_opt_in() {
-        let target: &'static str = Box::leak(Box::new(host_target()));
-        let slice: &'static [&'static str] = Box::leak(Box::new([target]));
-
-        with_lld_opt_in_targets(slice, || {
+        with_lld_opt_in_targets(vec![host_target()], || {
             let ctx = TestCtx::new();
-
             insta::assert_snapshot!(
-                ctx.config("doc")
-                    .path("core")
-                    .override_target_no_std(&host_target())
+                ctx.config("build")
+                    .path("compiler")
                     .render_steps(), @r"
             [build] llvm <host>
             [build] rustc 0 <host> -> rustc 1 <host>
             [build] rustc 0 <host> -> LldWrapper 1 <host>
-            [build] rustdoc 0 <host>
-            [doc] std 1 <host> crates=[core]
             ");
         });
     }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1638,6 +1638,7 @@ mod snapshot {
                 .render_steps(), @r"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 0 <host> -> LldWrapper 1 <host>
         [build] rustdoc 0 <host>
         [doc] std 1 <host> crates=[core]
         ");
@@ -1653,6 +1654,7 @@ mod snapshot {
                 .render_steps(), @r"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 0 <host> -> LldWrapper 1 <host>
         [build] rustdoc 0 <host>
         [doc] std 1 <host> crates=[alloc,core]
         ");

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -942,6 +942,7 @@ impl Config {
         config.rust_profile_use = flags_rust_profile_use;
         config.rust_profile_generate = flags_rust_profile_generate;
 
+        config.apply_target_config(toml.target);
         config.apply_rust_config(toml.rust, flags_warnings);
 
         config.reproducible_artifacts = flags_reproducible_artifact;
@@ -966,8 +967,6 @@ impl Config {
         config.apply_llvm_config(toml.llvm);
 
         config.apply_gcc_config(toml.gcc);
-
-        config.apply_target_config(toml.target);
 
         match ccache {
             Some(StringOrBool::String(ref s)) => config.ccache = Some(s.to_string()),

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -410,6 +410,31 @@ pub(crate) fn validate_codegen_backends(backends: Vec<String>, section: &str) ->
     backends
 }
 
+#[cfg(not(test))]
+fn default_lld_opt_in_targets() -> Vec<String> {
+    vec!["x86_64-unknown-linux-gnu".to_string()]
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_LLD_OPT_IN_TARGETS: std::cell::RefCell<Option<Vec<String>>> = std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn default_lld_opt_in_targets() -> Vec<String> {
+    TEST_LLD_OPT_IN_TARGETS.with(|cell| cell.borrow().clone()).unwrap_or_default()
+}
+
+#[cfg(test)]
+pub fn with_lld_opt_in_targets<R>(targets: Vec<String>, f: impl FnOnce() -> R) -> R {
+    TEST_LLD_OPT_IN_TARGETS.with(|cell| {
+        let prev = cell.replace(Some(targets));
+        let result = f();
+        cell.replace(prev);
+        result
+    })
+}
+
 impl Config {
     pub fn apply_rust_config(&mut self, toml_rust: Option<Rust>, warnings: Warnings) {
         let mut debug = None;
@@ -609,12 +634,13 @@ impl Config {
         //   thus, disabled
         // - similarly, lld will not be built nor used by default when explicitly asked not to, e.g.
         //   when the config sets `rust.lld = false`
-        if self.host_target.triple == "x86_64-unknown-linux-gnu" && self.hosts == [self.host_target]
+        if default_lld_opt_in_targets().contains(&self.host_target.triple.to_string())
+            && self.hosts == [self.host_target]
         {
             let no_llvm_config = self
                 .target_config
                 .get(&self.host_target)
-                .is_some_and(|target_config| target_config.llvm_config.is_none());
+                .is_none_or(|target_config| target_config.llvm_config.is_none());
             let enable_lld = self.llvm_from_ci || no_llvm_config;
             // Prefer the config setting in case an explicit opt-out is needed.
             self.lld_enabled = lld_enabled.unwrap_or(enable_lld);


### PR DESCRIPTION
This PR fixes the issue of an empty target_config in apply_rust_config, which was caused by the ordering of TOML config parsing. This was inadvertently introduced during the last config refactor. The test and the corresponding configuration order have been corrected in this PR.

r? @Kobzol 