### PR TITLE
Introduce Scope::NonGlobModule and Scope::GlobModule

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1055,6 +1055,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 Scope::NonGlobModule(module, _) | Scope::GlobModule(module, _) => {
                     this.add_module_candidates(module, suggestions, filter_fn, None);
                 }
+                Scope::GlobModule(..) => {
+                    // already inserted in `Scope::NonGlobModule` arm
+                }
                 Scope::MacroUsePrelude => {
                     suggestions.extend(this.macro_use_prelude.iter().filter_map(
                         |(name, binding)| {
@@ -1476,9 +1479,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             &parent_scope,
             ident.span.ctxt(),
             |this, scope, _use_prelude, _ctxt| {
-                let m = match scope {
-                    Scope::NonGlobModule(module, _) | Scope::GlobModule(module, _) => module,
-                    _ => return None,
+                let (Scope::NonGlobModule(m, _) | Scope::GlobModule(m, _)) = scope else {
+                    return None;
                 };
 
                 for (_, resolution) in this.resolutions(m).borrow().iter() {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1052,7 +1052,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
                     }
                 }
-                Scope::Module(module, _) => {
+                Scope::NonGlobModule(module, _) | Scope::GlobModule(module, _) => {
                     this.add_module_candidates(module, suggestions, filter_fn, None);
                 }
                 Scope::MacroUsePrelude => {
@@ -1476,9 +1476,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             &parent_scope,
             ident.span.ctxt(),
             |this, scope, _use_prelude, _ctxt| {
-                let Scope::Module(m, _) = scope else {
-                    return None;
+                let m = match scope {
+                    Scope::NonGlobModule(module, _) | Scope::GlobModule(module, _) => module,
+                    _ => return None,
                 };
+
                 for (_, resolution) in this.resolutions(m).borrow().iter() {
                     let Some(binding) = resolution.borrow().best_binding() else {
                         continue;

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1052,7 +1052,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
                     }
                 }
-                Scope::NonGlobModule(module, _) | Scope::GlobModule(module, _) => {
+                Scope::NonGlobModule(module, _) => {
                     this.add_module_candidates(module, suggestions, filter_fn, None);
                 }
                 Scope::GlobModule(..) => {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -196,15 +196,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                     MacroRulesScope::Empty => Scope::NonGlobModule(module, None),
                 },
-                Scope::NonGlobModule(..) | Scope::GlobModule(..) if module_and_extern_prelude => {
-                    match ns {
-                        TypeNS => {
-                            ctxt.adjust(ExpnId::root());
-                            Scope::ExternPreludeItems
-                        }
-                        ValueNS | MacroNS => break,
+                Scope::GlobModule(..) if module_and_extern_prelude => match ns {
+                    TypeNS => {
+                        ctxt.adjust(ExpnId::root());
+                        Scope::ExternPreludeItems
                     }
-                }
+                    ValueNS | MacroNS => break,
+                },
                 Scope::NonGlobModule(module, prev_lint_id) => {
                     use_prelude = !module.no_implicit_prelude;
                     Scope::GlobModule(module, prev_lint_id)
@@ -739,7 +737,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     )
                                     || flags.contains(Flags::MACRO_RULES)
                                         && (innermost_flags.contains(Flags::NON_GLOB_MODULE)
-                                            || flags.contains(Flags::GLOB_MODULE))
+                                            || innermost_flags.contains(Flags::GLOB_MODULE))
                                         && !this.disambiguate_macro_rules_vs_modularized(
                                             binding,
                                             innermost_binding,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -725,12 +725,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             // Found another solution, if the first one was "weak", report an error.
                             let (res, innermost_res) = (binding.res(), innermost_binding.res());
 
-                            // don't report ambiguity errors when we have a glob resolution with a
-                            // non-glob innermost resolution.
-                            let ignore_innermost_result = flags.contains(Flags::GLOB_MODULE)
-                                && innermost_flags.contains(Flags::NON_GLOB_MODULE);
-
-                            if res != innermost_res && !ignore_innermost_result {
+                            if res != innermost_res {
                                 let is_builtin = |res| {
                                     matches!(res, Res::NonMacroAttr(NonMacroAttrKind::Builtin(..)))
                                 };

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -40,6 +40,18 @@ enum Shadowing {
     Unrestricted,
 }
 
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    struct Flags: u8 {
+        const MACRO_RULES          = 1 << 0;
+        const NON_GLOB_MODULE      = 1 << 1;
+        const GLOB_MODULE          = 1 << 2;
+        const MISC_SUGGEST_CRATE   = 1 << 3;
+        const MISC_SUGGEST_SELF    = 1 << 4;
+        const MISC_FROM_PRELUDE    = 1 << 5;
+    }
+}
+
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// A generic scope visitor.
     /// Visits scopes in order to resolve some identifier in them or perform other actions.
@@ -114,9 +126,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let module_and_extern_prelude = matches!(scope_set, ScopeSet::ModuleAndExternPrelude(..));
         let extern_prelude = matches!(scope_set, ScopeSet::ExternPrelude);
         let mut scope = match ns {
-            _ if module_and_extern_prelude => Scope::Module(module, None),
+            _ if module_and_extern_prelude => Scope::NonGlobModule(module, None),
             _ if extern_prelude => Scope::ExternPreludeItems,
-            TypeNS | ValueNS => Scope::Module(module, None),
+            TypeNS | ValueNS => Scope::NonGlobModule(module, None),
             MacroNS => Scope::DeriveHelpers(parent_scope.expansion),
         };
         let mut ctxt = ctxt.normalize_to_macros_2_0();
@@ -143,7 +155,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                     true
                 }
-                Scope::Module(..) => true,
+                Scope::NonGlobModule(..) | Scope::GlobModule(..) => true,
                 Scope::MacroUsePrelude => use_prelude || rust_2015,
                 Scope::BuiltinAttrs => true,
                 Scope::ExternPreludeItems | Scope::ExternPreludeFlags => {
@@ -182,16 +194,22 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     MacroRulesScope::Invocation(invoc_id) => {
                         Scope::MacroRules(self.invocation_parent_scopes[&invoc_id].macro_rules)
                     }
-                    MacroRulesScope::Empty => Scope::Module(module, None),
+                    MacroRulesScope::Empty => Scope::NonGlobModule(module, None),
                 },
-                Scope::Module(..) if module_and_extern_prelude => match ns {
-                    TypeNS => {
-                        ctxt.adjust(ExpnId::root());
-                        Scope::ExternPreludeItems
+                Scope::NonGlobModule(..) | Scope::GlobModule(..) if module_and_extern_prelude => {
+                    match ns {
+                        TypeNS => {
+                            ctxt.adjust(ExpnId::root());
+                            Scope::ExternPreludeItems
+                        }
+                        ValueNS | MacroNS => break,
                     }
-                    ValueNS | MacroNS => break,
-                },
-                Scope::Module(module, prev_lint_id) => {
+                }
+                Scope::NonGlobModule(module, prev_lint_id) => {
+                    use_prelude = !module.no_implicit_prelude;
+                    Scope::GlobModule(module, prev_lint_id)
+                }
+                Scope::GlobModule(module, prev_lint_id) => {
                     use_prelude = !module.no_implicit_prelude;
                     let derive_fallback_lint_id = match scope_set {
                         ScopeSet::Late(.., lint_id) => lint_id,
@@ -199,7 +217,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     };
                     match self.hygienic_lexical_parent(module, &mut ctxt, derive_fallback_lint_id) {
                         Some((parent_module, lint_id)) => {
-                            Scope::Module(parent_module, lint_id.or(prev_lint_id))
+                            Scope::NonGlobModule(parent_module, lint_id.or(prev_lint_id))
                         }
                         None => {
                             ctxt.adjust(ExpnId::root());
@@ -392,17 +410,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ignore_binding: Option<NameBinding<'ra>>,
         ignore_import: Option<Import<'ra>>,
     ) -> Result<NameBinding<'ra>, Determinacy> {
-        bitflags::bitflags! {
-            #[derive(Clone, Copy)]
-            struct Flags: u8 {
-                const MACRO_RULES          = 1 << 0;
-                const MODULE               = 1 << 1;
-                const MISC_SUGGEST_CRATE   = 1 << 2;
-                const MISC_SUGGEST_SELF    = 1 << 3;
-                const MISC_FROM_PRELUDE    = 1 << 4;
-            }
-        }
-
         assert!(force || finalize.is_none()); // `finalize` implies `force`
 
         // Make sure `self`, `super` etc produce an error when passed to here.
@@ -494,7 +501,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         MacroRulesScope::Invocation(_) => Err(Determinacy::Undetermined),
                         _ => Err(Determinacy::Determined),
                     },
-                    Scope::Module(module, derive_fallback_lint_id) => {
+                    Scope::NonGlobModule(module, derive_fallback_lint_id) => {
                         // FIXME: use `finalize_scope` here.
                         let (adjusted_parent_scope, adjusted_finalize) =
                             if matches!(scope_set, ScopeSet::ModuleAndExternPrelude(..)) {
@@ -505,8 +512,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     finalize.map(|f| Finalize { used: Used::Scope, ..f }),
                                 )
                             };
-                        let binding = this.reborrow().resolve_ident_in_module_unadjusted(
-                            ModuleOrUniformRoot::Module(module),
+
+                        let binding = this.reborrow().resolve_ident_in_non_glob_module_unadjusted(
+                            module,
                             ident,
                             ns,
                             adjusted_parent_scope,
@@ -519,6 +527,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             ignore_binding,
                             ignore_import,
                         );
+
                         match binding {
                             Ok(binding) => {
                                 if let Some(lint_id) = derive_fallback_lint_id {
@@ -533,14 +542,62 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                         },
                                     );
                                 }
-                                let misc_flags = if module == this.graph_root {
-                                    Flags::MISC_SUGGEST_CRATE
-                                } else if module.is_normal() {
-                                    Flags::MISC_SUGGEST_SELF
-                                } else {
-                                    Flags::empty()
-                                };
-                                Ok((binding, Flags::MODULE | misc_flags))
+
+                                let misc_flags = this.create_module_misc_flags(module);
+                                Ok((binding, Flags::NON_GLOB_MODULE | misc_flags))
+                            }
+                            Err((Determinacy::Undetermined, Weak::No)) => {
+                                return Some(Err(Determinacy::determined(force)));
+                            }
+                            Err((Determinacy::Undetermined, Weak::Yes)) => {
+                                Err(Determinacy::Undetermined)
+                            }
+                            Err((Determinacy::Determined, _)) => Err(Determinacy::Determined),
+                        }
+                    }
+                    Scope::GlobModule(module, derive_fallback_lint_id) => {
+                        let (adjusted_parent_scope, finalize) =
+                            if matches!(scope_set, ScopeSet::ModuleAndExternPrelude(..)) {
+                                (parent_scope, finalize)
+                            } else {
+                                (
+                                    &ParentScope { module, ..*parent_scope },
+                                    finalize.map(|f| Finalize { used: Used::Scope, ..f }),
+                                )
+                            };
+
+                        let binding = this.reborrow().resolve_ident_in_glob_module_unadjusted(
+                            module,
+                            ident,
+                            ns,
+                            adjusted_parent_scope,
+                            if matches!(scope_set, ScopeSet::Late(..)) {
+                                Shadowing::Unrestricted
+                            } else {
+                                Shadowing::Restricted
+                            },
+                            finalize.map(|finalize| Finalize { used: Used::Scope, ..finalize }),
+                            ignore_binding,
+                            ignore_import,
+                        );
+
+                        match binding {
+                            Ok(binding) => {
+                                if let Some(lint_id) = derive_fallback_lint_id {
+                                    this.get_mut().lint_buffer.buffer_lint(
+                                        PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
+                                        lint_id,
+                                        orig_ident.span,
+                                        BuiltinLintDiag::ProcMacroDeriveResolutionFallback {
+                                            span: orig_ident.span,
+                                            ns,
+                                            ident,
+                                        },
+                                    );
+                                }
+
+                                let misc_flags = this.create_module_misc_flags(module);
+                                Ok((binding, Flags::GLOB_MODULE | misc_flags))
                             }
                             Err((Determinacy::Undetermined, Weak::No)) => {
                                 return Some(Err(Determinacy::determined(force)));
@@ -650,7 +707,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         if let Some((innermost_binding, innermost_flags)) = innermost_result {
                             // Found another solution, if the first one was "weak", report an error.
                             let (res, innermost_res) = (binding.res(), innermost_binding.res());
-                            if res != innermost_res {
+
+                            // don't report ambiguity errors when we have a glob resolution with a
+                            // non-glob innermost resolution.
+                            let ignore_innermost_result = flags.contains(Flags::GLOB_MODULE)
+                                && innermost_flags.contains(Flags::NON_GLOB_MODULE);
+
+                            if res != innermost_res && !ignore_innermost_result {
                                 let is_builtin = |res| {
                                     matches!(res, Res::NonMacroAttr(NonMacroAttrKind::Builtin(..)))
                                 };
@@ -668,13 +731,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 {
                                     Some(AmbiguityKind::DeriveHelper)
                                 } else if innermost_flags.contains(Flags::MACRO_RULES)
-                                    && flags.contains(Flags::MODULE)
+                                    && (flags.contains(Flags::NON_GLOB_MODULE)
+                                        || flags.contains(Flags::GLOB_MODULE))
                                     && !this.disambiguate_macro_rules_vs_modularized(
                                         innermost_binding,
                                         binding,
                                     )
                                     || flags.contains(Flags::MACRO_RULES)
-                                        && innermost_flags.contains(Flags::MODULE)
+                                        && (innermost_flags.contains(Flags::NON_GLOB_MODULE)
+                                            || flags.contains(Flags::GLOB_MODULE))
                                         && !this.disambiguate_macro_rules_vs_modularized(
                                             binding,
                                             innermost_binding,
@@ -720,7 +785,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
                     }
                     Err(Determinacy::Determined) => {}
-                    Err(Determinacy::Undetermined) => determinacy = Determinacy::Undetermined,
+                    Err(Determinacy::Undetermined) => {
+                        if let Scope::NonGlobModule(..) = scope {
+                            // we wait for Scope::GlobModule to determine `determinacy`
+                        } else {
+                            determinacy = Determinacy::Undetermined;
+                        }
+                    }
                 }
 
                 None
@@ -737,6 +808,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         Err(Determinacy::determined(determinacy == Determinacy::Determined || force))
+    }
+
+    fn create_module_misc_flags(&self, module: Module<'ra>) -> Flags {
+        if module == self.graph_root {
+            Flags::MISC_SUGGEST_CRATE
+        } else if module.is_normal() {
+            Flags::MISC_SUGGEST_SELF
+        } else {
+            Flags::empty()
+        }
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -865,6 +946,49 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
         };
 
+        match self.reborrow().resolve_ident_in_non_glob_module_unadjusted(
+            module,
+            ident,
+            ns,
+            parent_scope,
+            shadowing,
+            finalize,
+            ignore_binding,
+            ignore_import,
+        ) {
+            Ok(binding) => return Ok(binding),
+            Err((_, Weak::No)) => {
+                return Err((Determined, Weak::No));
+            }
+            // no non-glob binding was found, check for glob binding
+            Err((_, Weak::Yes)) => {}
+        }
+
+        self.reborrow().resolve_ident_in_glob_module_unadjusted(
+            module,
+            ident,
+            ns,
+            parent_scope,
+            shadowing,
+            finalize,
+            ignore_binding,
+            ignore_import,
+        )
+    }
+
+    fn resolve_ident_in_non_glob_module_unadjusted<'r>(
+        mut self: CmResolver<'r, 'ra, 'tcx>,
+        module: Module<'ra>,
+        ident: Ident,
+        ns: Namespace,
+        parent_scope: &ParentScope<'ra>,
+        shadowing: Shadowing,
+        finalize: Option<Finalize>,
+        // This binding should be ignored during in-module resolution, so that we don't get
+        // "self-confirming" import resolutions during import validation and checking.
+        ignore_binding: Option<NameBinding<'ra>>,
+        _ignore_import: Option<Import<'ra>>, // not used, but kept for signature consistency
+    ) -> Result<NameBinding<'ra>, (Determinacy, Weak)> {
         let key = BindingKey::new(ident, ns);
         // `try_borrow_mut` is required to ensure exclusive access, even if the resulting binding
         // doesn't need to be mutable. It will fail when there is a cycle of imports, and without
@@ -874,74 +998,134 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             .try_borrow_mut()
             .map_err(|_| (Determined, Weak::No))?;
 
-        // If the primary binding is unusable, search further and return the shadowed glob
-        // binding if it exists. What we really want here is having two separate scopes in
-        // a module - one for non-globs and one for globs, but until that's done use this
-        // hack to avoid inconsistent resolution ICEs during import validation.
-        let binding = [resolution.non_glob_binding, resolution.glob_binding]
-            .into_iter()
-            .find_map(|binding| if binding == ignore_binding { None } else { binding });
+        let check_usable = |this: CmResolver<'r, 'ra, 'tcx>, binding: NameBinding<'ra>| {
+            let usable = this.is_accessible_from(binding.vis, parent_scope.module);
+            if usable { Ok(binding) } else { Err((Determined, Weak::No)) }
+        };
 
-        if let Some(finalize) = finalize {
-            return self.get_mut().finalize_module_binding(
-                ident,
-                binding,
-                if resolution.non_glob_binding.is_some() { resolution.glob_binding } else { None },
-                parent_scope,
-                finalize,
-                shadowing,
-            );
+        if let Some(binding) = resolution.non_glob_binding
+            && ignore_binding.map_or(true, |b| binding != b)
+        {
+            if let Some(finalize) = finalize {
+                return self.get_mut().finalize_non_glob_module_binding(
+                    ident,
+                    binding,
+                    resolution.glob_binding,
+                    parent_scope,
+                    finalize,
+                    shadowing,
+                );
+            } else {
+                return check_usable(self, binding);
+            }
         }
+
+        Err((Determinacy::determined(finalize.is_some()), Weak::Yes))
+    }
+
+    fn resolve_ident_in_glob_module_unadjusted<'r>(
+        mut self: CmResolver<'r, 'ra, 'tcx>,
+        module: Module<'ra>,
+        ident: Ident,
+        ns: Namespace,
+        parent_scope: &ParentScope<'ra>,
+        shadowing: Shadowing,
+        finalize: Option<Finalize>,
+        // This binding should be ignored during in-module resolution, so that we don't get
+        // "self-confirming" import resolutions during import validation and checking.
+        ignore_binding: Option<NameBinding<'ra>>,
+        ignore_import: Option<Import<'ra>>,
+    ) -> Result<NameBinding<'ra>, (Determinacy, Weak)> {
+        let key = BindingKey::new(ident, ns);
+        let resolution = self
+            .resolution_or_default(module, key)
+            .try_borrow_mut()
+            .map_err(|_| (Determined, Weak::No))?; // This happens when there is a cycle of imports.
 
         let check_usable = |this: CmResolver<'r, 'ra, 'tcx>, binding: NameBinding<'ra>| {
             let usable = this.is_accessible_from(binding.vis, parent_scope.module);
             if usable { Ok(binding) } else { Err((Determined, Weak::No)) }
         };
 
-        // Items and single imports are not shadowable, if we have one, then it's determined.
-        if let Some(binding) = binding
-            && !binding.is_glob_import()
+        if let Some(binding) = resolution.glob_binding
+            && ignore_binding.map_or(true, |b| binding != b)
         {
-            return check_usable(self, binding);
-        }
+            if let Some(finalize) = finalize {
+                return self.get_mut().finalize_glob_module_binding(
+                    ident,
+                    binding,
+                    parent_scope,
+                    finalize,
+                    shadowing,
+                );
+            }
 
-        // --- From now on we either have a glob resolution or no resolution. ---
+            // Check if a single import can still define the name,
+            // if it can then our result is not determined and can be invalidated.
+            if self.reborrow().single_import_can_define_name(
+                &resolution,
+                Some(binding),
+                ns,
+                ignore_import,
+                ignore_binding,
+                parent_scope,
+            ) {
+                return Err((Undetermined, Weak::No));
+            }
 
-        // Check if one of single imports can still define the name,
-        // if it can then our result is not determined and can be invalidated.
-        if self.reborrow().single_import_can_define_name(
-            &resolution,
-            binding,
-            ns,
-            ignore_import,
-            ignore_binding,
-            parent_scope,
-        ) {
-            return Err((Undetermined, Weak::No));
-        }
-
-        // So we have a resolution that's from a glob import. This resolution is determined
-        // if it cannot be shadowed by some new item/import expanded from a macro.
-        // This happens either if there are no unexpanded macros, or expanded names cannot
-        // shadow globs (that happens in macro namespace or with restricted shadowing).
-        //
-        // Additionally, any macro in any module can plant names in the root module if it creates
-        // `macro_export` macros, so the root module effectively has unresolved invocations if any
-        // module has unresolved invocations.
-        // However, it causes resolution/expansion to stuck too often (#53144), so, to make
-        // progress, we have to ignore those potential unresolved invocations from other modules
-        // and prohibit access to macro-expanded `macro_export` macros instead (unless restricted
-        // shadowing is enabled, see `macro_expanded_macro_export_errors`).
-        if let Some(binding) = binding {
+            // So we have a resolution that's from a glob import. This resolution is determined
+            // if it cannot be shadowed by some new item/import expanded from a macro.
+            // This happens either if there are no unexpanded macros, or expanded names cannot
+            // shadow globs (that happens in macro namespace or with restricted shadowing).
+            //
+            // Additionally, any macro in any module can plant names in the root module if it creates
+            // `macro_export` macros, so the root module effectively has unresolved invocations if any
+            // module has unresolved invocations.
+            // However, it causes resolution/expansion to stuck too often (#53144), so, to make
+            // progress, we have to ignore those potential unresolved invocations from other modules
+            // and prohibit access to macro-expanded `macro_export` macros instead (unless restricted
+            // shadowing is enabled, see `macro_expanded_macro_export_errors`).
             if binding.determined() || ns == MacroNS || shadowing == Shadowing::Restricted {
                 return check_usable(self, binding);
             } else {
                 return Err((Undetermined, Weak::No));
             }
+        } else if finalize.is_some() {
+            return Err((Determined, Weak::No));
+        } else {
+            // Check if a single import can still define the name,
+            // if it can then our result is not determined and can be invalidated.
+            if self.reborrow().single_import_can_define_name(
+                &resolution,
+                None,
+                ns,
+                ignore_import,
+                ignore_binding,
+                parent_scope,
+            ) {
+                return Err((Undetermined, Weak::No));
+            }
+
+            return Err(self.create_resolution_in_module_error(
+                module,
+                ident,
+                ns,
+                parent_scope,
+                ignore_binding,
+                ignore_import,
+            ));
         }
+    }
 
-        // --- From now on we have no resolution. ---
-
+    fn create_resolution_in_module_error<'r>(
+        mut self: CmResolver<'r, 'ra, 'tcx>,
+        module: Module<'ra>,
+        ident: Ident,
+        ns: Namespace,
+        parent_scope: &ParentScope<'ra>,
+        ignore_binding: Option<NameBinding<'ra>>,
+        ignore_import: Option<Import<'ra>>,
+    ) -> (Determinacy, Weak) {
         // Now we are in situation when new item/import can appear only from a glob or a macro
         // expansion. With restricted shadowing names from globs and macro expansions cannot
         // shadow names from outer scopes, so we can freely fallback from module search to search
@@ -951,7 +1135,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Check if one of unexpanded macros can still define the name,
         // if it can then our "no resolution" result is not determined and can be invalidated.
         if !module.unexpanded_invocations.borrow().is_empty() {
-            return Err((Undetermined, Weak::Yes));
+            return (Undetermined, Weak::Yes);
         }
 
         // Check if one of glob imports can still define the name,
@@ -966,8 +1150,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             let module = match glob_import.imported_module.get() {
                 Some(ModuleOrUniformRoot::Module(module)) => module,
                 Some(_) => continue,
-                None => return Err((Undetermined, Weak::Yes)),
+                None => return (Undetermined, Weak::Yes),
             };
+
             let tmp_parent_scope;
             let (mut adjusted_parent_scope, mut ident) =
                 (parent_scope, ident.normalize_to_macros_2_0());
@@ -998,28 +1183,24 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 {
                     continue;
                 }
-                Ok(_) | Err((Undetermined, _)) => return Err((Undetermined, Weak::Yes)),
+                Ok(_) | Err((Undetermined, _)) => return (Undetermined, Weak::Yes),
             }
         }
 
         // No resolution and no one else can define the name - determinate error.
-        Err((Determined, Weak::No))
+        (Determined, Weak::No)
     }
 
-    fn finalize_module_binding(
+    fn finalize_non_glob_module_binding(
         &mut self,
         ident: Ident,
-        binding: Option<NameBinding<'ra>>,
-        shadowed_glob: Option<NameBinding<'ra>>,
+        binding: NameBinding<'ra>,
+        glob_binding: Option<NameBinding<'ra>>,
         parent_scope: &ParentScope<'ra>,
         finalize: Finalize,
         shadowing: Shadowing,
     ) -> Result<NameBinding<'ra>, (Determinacy, Weak)> {
         let Finalize { path_span, report_private, used, root_span, .. } = finalize;
-
-        let Some(binding) = binding else {
-            return Err((Determined, Weak::No));
-        };
 
         if !self.is_accessible_from(binding.vis, parent_scope.module) {
             if report_private {
@@ -1038,7 +1219,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         // Forbid expanded shadowing to avoid time travel.
-        if let Some(shadowed_glob) = shadowed_glob
+        // FIXME it should be possible to output a MoreExpandedVsOuter ambiguity error
+        // instead of GlobVsExpanded, but that presumably has to be done in a different location.
+        if let Some(shadowed_glob) = glob_binding
             && shadowing == Shadowing::Restricted
             && binding.expansion != LocalExpnId::ROOT
             && binding.res() != shadowed_glob.res()
@@ -1052,6 +1235,44 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 misc1: AmbiguityErrorMisc::None,
                 misc2: AmbiguityErrorMisc::None,
             });
+        }
+
+        if shadowing == Shadowing::Unrestricted
+            && binding.expansion != LocalExpnId::ROOT
+            && let NameBindingKind::Import { import, .. } = binding.kind
+            && matches!(import.kind, ImportKind::MacroExport)
+        {
+            self.macro_expanded_macro_export_errors.insert((path_span, binding.span));
+        }
+
+        self.record_use(ident, binding, used);
+        return Ok(binding);
+    }
+
+    fn finalize_glob_module_binding(
+        &mut self,
+        ident: Ident,
+        binding: NameBinding<'ra>,
+        parent_scope: &ParentScope<'ra>,
+        finalize: Finalize,
+        shadowing: Shadowing,
+    ) -> Result<NameBinding<'ra>, (Determinacy, Weak)> {
+        let Finalize { path_span, report_private, used, root_span, .. } = finalize;
+
+        if !self.is_accessible_from(binding.vis, parent_scope.module) {
+            if report_private {
+                self.privacy_errors.push(PrivacyError {
+                    ident,
+                    binding,
+                    dedup_span: path_span,
+                    outermost_res: None,
+                    source: None,
+                    parent_scope: *parent_scope,
+                    single_nested: path_span != root_span,
+                });
+            } else {
+                return Err((Determined, Weak::No));
+            }
         }
 
         if shadowing == Shadowing::Unrestricted

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -549,12 +549,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     );
                                 }
 
-                                // Don't visit Scope::GlobModule after successful resolution in
-                                // Scope::NonGlobModule with ScopeSet::Module.
-                                if matches!(scope_set, ScopeSet::Module(..)) {
-                                    return Some(Ok(binding));
-                                }
-
                                 let misc_flags = this.create_module_misc_flags(module);
                                 Ok((binding, Flags::NON_GLOB_MODULE | misc_flags))
                             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1882,17 +1882,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
         }
 
-        let mut non_glob_module_inserted = false;
         self.cm().visit_scopes(ScopeSet::All(TypeNS), parent_scope, ctxt, |this, scope, _, _| {
             match scope {
                 Scope::NonGlobModule(module, _) => {
                     this.get_mut().traits_in_module(module, assoc_item, &mut found_traits);
-                    non_glob_module_inserted = true;
                 }
-                Scope::GlobModule(module, _) => {
-                    if !non_glob_module_inserted {
-                        this.get_mut().traits_in_module(module, assoc_item, &mut found_traits);
-                    }
+                Scope::GlobModule(..) => {
+                    // already inserted in `Scope::NonGlobModule` arm
                 }
                 Scope::StdLibPrelude => {
                     if let Some(module) = this.prelude {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -147,12 +147,6 @@ enum Scope<'ra> {
     BuiltinTypes,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-enum Shadowing {
-    Restricted,
-    Unrestricted,
-}
-
 /// Names from different contexts may want to visit different subsets of all specific scopes
 /// with different restrictions when looking up the resolution.
 #[derive(Clone, Copy, Debug)]
@@ -169,7 +163,7 @@ enum ScopeSet<'ra> {
     /// The node id enables lints and is used for reporting them.
     Late(Namespace, Module<'ra>, Option<NodeId>),
     /// Scope::NonGlobModule and Scope::GlobModule.
-    Module(Module<'ra>, Namespace, Shadowing),
+    Module(Namespace, Module<'ra>),
 }
 
 /// Everything you need to know about a name's location to resolve it.

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -147,6 +147,12 @@ enum Scope<'ra> {
     BuiltinTypes,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Shadowing {
+    Restricted,
+    Unrestricted,
+}
+
 /// Names from different contexts may want to visit different subsets of all specific scopes
 /// with different restrictions when looking up the resolution.
 #[derive(Clone, Copy, Debug)]
@@ -162,6 +168,8 @@ enum ScopeSet<'ra> {
     /// All scopes with the given namespace, used for partially performing late resolution.
     /// The node id enables lints and is used for reporting them.
     Late(Namespace, Module<'ra>, Option<NodeId>),
+    /// Scope::NonGlobModule and Scope::GlobModule.
+    Module(Module<'ra>, Namespace, Shadowing),
 }
 
 /// Everything you need to know about a name's location to resolve it.

--- a/tests/ui/imports/import-after-macro-expand-10.rs
+++ b/tests/ui/imports/import-after-macro-expand-10.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 mod b {
     pub mod http {
         pub struct HeaderMap;
@@ -14,4 +12,5 @@ use crate::b::*;
 
 fn main() {
     let h: crate::b::HeaderMap = HeaderMap;
+    //~^ ERROR ambiguous
 }

--- a/tests/ui/imports/import-after-macro-expand-10.stderr
+++ b/tests/ui/imports/import-after-macro-expand-10.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `HeaderMap` is ambiguous
+  --> $DIR/import-after-macro-expand-10.rs:14:22
+   |
+LL |     let h: crate::b::HeaderMap = HeaderMap;
+   |                      ^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `HeaderMap` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-10.rs:8:5
+   |
+LL |     pub struct HeaderMap;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+note: `HeaderMap` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-10.rs:6:13
+   |
+LL |     pub use self::http::*;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-11.rs
+++ b/tests/ui/imports/import-after-macro-expand-11.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 #[derive(Debug)]
 struct H;
 
@@ -14,6 +12,7 @@ mod p {
 
         fn f() {
            let h: crate::p::H = H;
+           //~^ ERROR ambiguous
         }
     }
 }

--- a/tests/ui/imports/import-after-macro-expand-11.stderr
+++ b/tests/ui/imports/import-after-macro-expand-11.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `H` is ambiguous
+  --> $DIR/import-after-macro-expand-11.rs:14:29
+   |
+LL |            let h: crate::p::H = H;
+   |                             ^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `H` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-11.rs:8:5
+   |
+LL |     struct H;
+   |     ^^^^^^^^^
+   = help: use `self::H` to refer to this struct unambiguously
+note: `H` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-11.rs:5:9
+   |
+LL |     use super::*;
+   |         ^^^^^^^^
+   = help: use `self::H` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-13.rs
+++ b/tests/ui/imports/import-after-macro-expand-13.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // similar as `import-after-macro-expand-6.rs`
 
 use crate::a::HeaderMap;
@@ -19,4 +18,5 @@ mod a {
 
 fn main() {
     let h: crate::b::HeaderMap = HeaderMap;
+    //~^ ERROR ambiguous
 }

--- a/tests/ui/imports/import-after-macro-expand-13.stderr
+++ b/tests/ui/imports/import-after-macro-expand-13.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `HeaderMap` is ambiguous
+  --> $DIR/import-after-macro-expand-13.rs:20:22
+   |
+LL |     let h: crate::b::HeaderMap = HeaderMap;
+   |                      ^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `HeaderMap` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-13.rs:12:5
+   |
+LL |     pub struct HeaderMap;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+note: `HeaderMap` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-13.rs:10:13
+   |
+LL |     pub use self::http::*;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-14.rs
+++ b/tests/ui/imports/import-after-macro-expand-14.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 use crate::a::HeaderMap;
 
 mod b {
@@ -19,4 +17,5 @@ mod a {
 
 fn main() {
     let h: crate::b::HeaderMap = HeaderMap;
+    //~^ ERROR ambiguous
 }

--- a/tests/ui/imports/import-after-macro-expand-14.stderr
+++ b/tests/ui/imports/import-after-macro-expand-14.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `HeaderMap` is ambiguous
+  --> $DIR/import-after-macro-expand-14.rs:19:22
+   |
+LL |     let h: crate::b::HeaderMap = HeaderMap;
+   |                      ^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `HeaderMap` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-14.rs:11:5
+   |
+LL |     pub struct HeaderMap;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+note: `HeaderMap` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-14.rs:9:13
+   |
+LL |     pub use self::http::*;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-2.rs
+++ b/tests/ui/imports/import-after-macro-expand-2.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/issues/56593#issuecomment-1133174514
 
 use thing::*;
@@ -13,6 +12,7 @@ mod tests {
 
     fn test_thing() {
         let thing: crate::Thing = Thing::Foo;
+        //~^ ERROR ambiguous
     }
 }
 

--- a/tests/ui/imports/import-after-macro-expand-2.stderr
+++ b/tests/ui/imports/import-after-macro-expand-2.stderr
@@ -1,0 +1,25 @@
+error[E0659]: `Thing` is ambiguous
+  --> $DIR/import-after-macro-expand-2.rs:14:27
+   |
+LL |         let thing: crate::Thing = Thing::Foo;
+   |                           ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `Thing` could refer to the enum defined here
+  --> $DIR/import-after-macro-expand-2.rs:6:1
+   |
+LL | / pub enum Thing {
+LL | |     Foo
+LL | | }
+   | |_^
+   = help: use `crate::Thing` to refer to this enum unambiguously
+note: `Thing` could also refer to the enum imported here
+  --> $DIR/import-after-macro-expand-2.rs:3:5
+   |
+LL | use thing::*;
+   |     ^^^^^^^^
+   = help: use `crate::Thing` to refer to this enum unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-6.rs
+++ b/tests/ui/imports/import-after-macro-expand-6.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 // https://github.com/rust-lang/rust/pull/113099#issuecomment-1633574396
 
 pub mod a {
@@ -19,4 +18,5 @@ use crate::a::HeaderMap;
 
 fn main() {
     let h: crate::b::HeaderMap = HeaderMap;
+    //~^ ERROR ambiguous
 }

--- a/tests/ui/imports/import-after-macro-expand-6.stderr
+++ b/tests/ui/imports/import-after-macro-expand-6.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `HeaderMap` is ambiguous
+  --> $DIR/import-after-macro-expand-6.rs:20:22
+   |
+LL |     let h: crate::b::HeaderMap = HeaderMap;
+   |                      ^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `HeaderMap` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-6.rs:14:5
+   |
+LL |     pub struct HeaderMap;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+note: `HeaderMap` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-6.rs:12:13
+   |
+LL |     pub use self::http::*;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/import-after-macro-expand-9.rs
+++ b/tests/ui/imports/import-after-macro-expand-9.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 use crate::b::*;
 
 mod b {
@@ -14,4 +12,5 @@ mod b {
 
 fn main() {
     let h: crate::b::HeaderMap = HeaderMap;
+    //~^ ERROR ambiguous
 }

--- a/tests/ui/imports/import-after-macro-expand-9.stderr
+++ b/tests/ui/imports/import-after-macro-expand-9.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `HeaderMap` is ambiguous
+  --> $DIR/import-after-macro-expand-9.rs:14:22
+   |
+LL |     let h: crate::b::HeaderMap = HeaderMap;
+   |                      ^^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `HeaderMap` could refer to the struct defined here
+  --> $DIR/import-after-macro-expand-9.rs:10:5
+   |
+LL |     pub struct HeaderMap;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+note: `HeaderMap` could also refer to the struct imported here
+  --> $DIR/import-after-macro-expand-9.rs:8:13
+   |
+LL |     pub use self::http::*;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::HeaderMap` to refer to this struct unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/imports.rs
+++ b/tests/ui/imports/imports.rs
@@ -1,4 +1,3 @@
-//@ run-pass
 #![allow(unused)]
 
 // Like other items, private imports can be imported and used non-lexically in paths.
@@ -22,6 +21,7 @@ fn g() {
     use crate::bar::*;
     fn f() -> bool { true }
     let _: bool = f();
+    //~^ ERROR `f` is ambiguous
 }
 
 fn h() {
@@ -29,6 +29,7 @@ fn h() {
     use crate::bar::*;
     use crate::f;
     let _: bool = f();
+    //~^ ERROR `f` is ambiguous
 }
 
 // Here, there appears to be shadowing but isn't because of namespaces.

--- a/tests/ui/imports/imports.stderr
+++ b/tests/ui/imports/imports.stderr
@@ -1,0 +1,43 @@
+error[E0659]: `f` is ambiguous
+  --> $DIR/imports.rs:23:19
+   |
+LL |     let _: bool = f();
+   |                   ^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function imported here
+  --> $DIR/imports.rs:20:9
+   |
+LL |     use crate::foo::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `f` to disambiguate
+note: `f` could also refer to the function imported here
+  --> $DIR/imports.rs:21:9
+   |
+LL |     use crate::bar::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `f` to disambiguate
+
+error[E0659]: `f` is ambiguous
+  --> $DIR/imports.rs:31:19
+   |
+LL |     let _: bool = f();
+   |                   ^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `f` could refer to the function imported here
+  --> $DIR/imports.rs:28:9
+   |
+LL |     use crate::foo::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `f` to disambiguate
+note: `f` could also refer to the function imported here
+  --> $DIR/imports.rs:29:9
+   |
+LL |     use crate::bar::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `f` to disambiguate
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/issue-114682-1.rs
+++ b/tests/ui/imports/issue-114682-1.rs
@@ -22,4 +22,5 @@ mac!();
 fn main() {
     A!();
     //~^ ERROR `A` is ambiguous
+    //~^^ ERROR `A` is ambiguous
 }

--- a/tests/ui/imports/issue-114682-1.stderr
+++ b/tests/ui/imports/issue-114682-1.stderr
@@ -23,6 +23,32 @@ LL | pub use m::*;
    = help: consider adding an explicit import of `A` to disambiguate
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0659]: `A` is ambiguous
+  --> $DIR/issue-114682-1.rs:23:5
+   |
+LL |     A!();
+   |     ^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `A` could refer to the macro defined here
+  --> $DIR/issue-114682-1.rs:7:9
+   |
+LL | /         pub macro A() {
+LL | |             println!("non import")
+LL | |         }
+   | |_________^
+...
+LL |   mac!();
+   |   ------ in this macro invocation
+   = help: use `crate::A` to refer to this macro unambiguously
+note: `A` could also refer to the macro imported here
+  --> $DIR/issue-114682-1.rs:19:9
+   |
+LL | pub use m::*;
+   |         ^^^^
+   = help: use `crate::A` to refer to this macro unambiguously
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/local-modularized-tricky-fail-1.rs
+++ b/tests/ui/imports/local-modularized-tricky-fail-1.rs
@@ -27,6 +27,7 @@ mod inner1 {
 }
 
 exported!(); //~ ERROR `exported` is ambiguous
+//~^ ERROR `exported` is ambiguous
 
 mod inner2 {
     define_exported!();

--- a/tests/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -23,8 +23,34 @@ LL | use inner1::*;
    = help: consider adding an explicit import of `exported` to disambiguate
    = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0659]: `exported` is ambiguous
+  --> $DIR/local-modularized-tricky-fail-1.rs:29:1
+   |
+LL | exported!();
+   | ^^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `exported` could refer to the macro defined here
+  --> $DIR/local-modularized-tricky-fail-1.rs:6:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |       define_exported!();
+   |       ------------------ in this macro invocation
+   = help: use `crate::exported` to refer to this macro unambiguously
+note: `exported` could also refer to the macro imported here
+  --> $DIR/local-modularized-tricky-fail-1.rs:23:5
+   |
+LL | use inner1::*;
+   |     ^^^^^^^^^
+   = help: use `crate::exported` to refer to this macro unambiguously
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0659]: `panic` is ambiguous
-  --> $DIR/local-modularized-tricky-fail-1.rs:36:5
+  --> $DIR/local-modularized-tricky-fail-1.rs:37:5
    |
 LL |     panic!();
    |     ^^^^^ ambiguous name
@@ -45,7 +71,7 @@ LL |       define_panic!();
    = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `include` is ambiguous
-  --> $DIR/local-modularized-tricky-fail-1.rs:47:1
+  --> $DIR/local-modularized-tricky-fail-1.rs:48:1
    |
 LL | include!();
    | ^^^^^^^ ambiguous name
@@ -65,6 +91,6 @@ LL |       define_include!();
    = help: use `crate::include` to refer to this macro unambiguously
    = note: this error originates in the macro `define_include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/macro-paths.rs
+++ b/tests/ui/imports/macro-paths.rs
@@ -11,6 +11,7 @@ mod foo {
 fn f() {
     use foo::*;
     bar::m! { //~ ERROR ambiguous
+    //~^ ERROR ambiguous
         mod bar { pub use two_macros::m; }
     }
 }

--- a/tests/ui/imports/macro-paths.stderr
+++ b/tests/ui/imports/macro-paths.stderr
@@ -6,7 +6,7 @@ LL |     bar::m! {
    |
    = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `bar` could refer to the module defined here
-  --> $DIR/macro-paths.rs:14:9
+  --> $DIR/macro-paths.rs:15:9
    |
 LL |         mod bar { pub use two_macros::m; }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,20 +17,38 @@ LL |     use foo::*;
    |         ^^^^^^
    = help: consider adding an explicit import of `bar` to disambiguate
 
+error[E0659]: `bar` is ambiguous
+  --> $DIR/macro-paths.rs:13:5
+   |
+LL |     bar::m! {
+   |     ^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `bar` could refer to the module defined here
+  --> $DIR/macro-paths.rs:15:9
+   |
+LL |         mod bar { pub use two_macros::m; }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `bar` could also refer to the module imported here
+  --> $DIR/macro-paths.rs:12:9
+   |
+LL |     use foo::*;
+   |         ^^^^^^
+
 error[E0659]: `baz` is ambiguous
-  --> $DIR/macro-paths.rs:23:5
+  --> $DIR/macro-paths.rs:24:5
    |
 LL |     baz::m! {
    |     ^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `baz` could refer to the module defined here
-  --> $DIR/macro-paths.rs:24:9
+  --> $DIR/macro-paths.rs:25:9
    |
 LL |         mod baz { pub use two_macros::m; }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `baz` could also refer to the module defined here
-  --> $DIR/macro-paths.rs:18:1
+  --> $DIR/macro-paths.rs:19:1
    |
 LL | / pub mod baz {
 LL | |     pub use two_macros::m;
@@ -38,6 +56,6 @@ LL | | }
    | |_^
    = help: use `crate::baz` to refer to this module unambiguously
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/macros.rs
+++ b/tests/ui/imports/macros.rs
@@ -14,6 +14,7 @@ mod m1 {
 mod m2 {
     use two_macros::*;
     m! { //~ ERROR ambiguous
+    //~^ ERROR ambiguous
         use crate::foo::m;
     }
 }

--- a/tests/ui/imports/macros.stderr
+++ b/tests/ui/imports/macros.stderr
@@ -6,7 +6,7 @@ LL |     m! {
    |
    = note: ambiguous because of a conflict between a name from a glob import and a macro-expanded name in the same module during import or macro resolution
 note: `m` could refer to the macro imported here
-  --> $DIR/macros.rs:17:13
+  --> $DIR/macros.rs:18:13
    |
 LL |         use crate::foo::m;
    |             ^^^^^^^^^^^^^
@@ -18,24 +18,44 @@ LL |     use two_macros::*;
    = help: consider adding an explicit import of `m` to disambiguate
 
 error[E0659]: `m` is ambiguous
-  --> $DIR/macros.rs:29:9
+  --> $DIR/macros.rs:16:5
+   |
+LL |     m! {
+   |     ^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `m` could refer to the macro imported here
+  --> $DIR/macros.rs:18:13
+   |
+LL |         use crate::foo::m;
+   |             ^^^^^^^^^^^^^
+   = help: use `self::m` to refer to this macro unambiguously
+note: `m` could also refer to the macro imported here
+  --> $DIR/macros.rs:15:9
+   |
+LL |     use two_macros::*;
+   |         ^^^^^^^^^^^^^
+   = help: use `self::m` to refer to this macro unambiguously
+
+error[E0659]: `m` is ambiguous
+  --> $DIR/macros.rs:30:9
    |
 LL |         m! {
    |         ^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
 note: `m` could refer to the macro imported here
-  --> $DIR/macros.rs:30:17
+  --> $DIR/macros.rs:31:17
    |
 LL |             use two_macros::n as m;
    |                 ^^^^^^^^^^^^^^^^^^
 note: `m` could also refer to the macro imported here
-  --> $DIR/macros.rs:22:9
+  --> $DIR/macros.rs:23:9
    |
 LL |     use two_macros::m;
    |         ^^^^^^^^^^^^^
    = help: use `self::m` to refer to this macro unambiguously
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/resolve/issue-109153.rs
+++ b/tests/ui/resolve/issue-109153.rs
@@ -10,5 +10,6 @@ mod foo {
 
 use bar::bar; //~ ERROR `bar` is ambiguous
 use bar::*;
+//~^ ERROR `bar` is ambiguous
 
 fn main() { }

--- a/tests/ui/resolve/issue-109153.stderr
+++ b/tests/ui/resolve/issue-109153.stderr
@@ -18,6 +18,26 @@ LL | use bar::*;
    |     ^^^^^^
    = help: consider adding an explicit import of `bar` to disambiguate
 
-error: aborting due to 1 previous error
+error[E0659]: `bar` is ambiguous
+  --> $DIR/issue-109153.rs:12:5
+   |
+LL | use bar::*;
+   |     ^^^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `bar` could refer to the module imported here
+  --> $DIR/issue-109153.rs:1:5
+   |
+LL | use foo::*;
+   |     ^^^^^^
+   = help: consider adding an explicit import of `bar` to disambiguate
+note: `bar` could also refer to the module imported here
+  --> $DIR/issue-109153.rs:12:5
+   |
+LL | use bar::*;
+   |     ^^^^^^
+   = help: consider adding an explicit import of `bar` to disambiguate
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/underscore-imports/shadow.rs
+++ b/tests/ui/underscore-imports/shadow.rs
@@ -14,9 +14,10 @@ mod b {
 
 mod c {
     use crate::b::Shadow as _; // Only imports the struct
+    //~^ ERROR `Shadow` is ambiguous
 
     fn f(x: &()) {
-        x.deref(); //~ ERROR no method named `deref` found
+        x.deref() //~ ERROR no method named `deref` found
     }
 }
 

--- a/tests/ui/underscore-imports/shadow.stderr
+++ b/tests/ui/underscore-imports/shadow.stderr
@@ -1,7 +1,31 @@
-error[E0599]: no method named `deref` found for reference `&()` in the current scope
-  --> $DIR/shadow.rs:19:11
+error[E0659]: `Shadow` is ambiguous
+  --> $DIR/shadow.rs:16:19
    |
-LL |         x.deref();
+LL |     use crate::b::Shadow as _; // Only imports the struct
+   |                   ^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+note: `Shadow` could refer to the struct defined here
+  --> $DIR/shadow.rs:10:25
+   |
+LL |         ($i:ident) => { pub struct $i; }
+   |                         ^^^^^^^^^^^^^^
+LL |     }
+LL |     m!(Shadow);
+   |     ---------- in this macro invocation
+   = help: use `self::Shadow` to refer to this struct unambiguously
+note: `Shadow` could also refer to the trait imported here
+  --> $DIR/shadow.rs:8:13
+   |
+LL |     pub use crate::a::*;
+   |             ^^^^^^^^^^^
+   = help: use `self::Shadow` to refer to this trait unambiguously
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `deref` found for reference `&()` in the current scope
+  --> $DIR/shadow.rs:20:11
+   |
+LL |         x.deref()
    |           ^^^^^ method not found in `&()`
    |
    = help: items from traits can only be used if the trait is in scope
@@ -10,6 +34,7 @@ help: trait `Deref` which provides `deref` is implemented but not in scope; perh
 LL +     use std::ops::Deref;
    |
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0599`.
+Some errors have detailed explanations: E0599, E0659.
+For more information about an error, try `rustc --explain E0599`.


### PR DESCRIPTION
Splits `Scope::Module` into `Scope::NonGlobModule` and `Scope::GlobModule`. This makes it easier to implement [the open namespaces](https://rust-lang.github.io/rust-project-goals/2025h1/open-namespaces.html) project, where we have to introduce a third scope. Introducing two separate scopes for a module was also a change requested by @petrochenkov, and should make it easier to output better diagnostics.

r? @petrochenkov 
