### PR TITLE
Stabilize const TypeId::of

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -725,7 +725,7 @@ unsafe impl Send for TypeId {}
 unsafe impl Sync for TypeId {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 impl const PartialEq for TypeId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -773,7 +773,7 @@ impl TypeId {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[rustc_const_stable(feature = "const_type_id", since = "CURRENT_RUSTC_VERSION")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         const { intrinsics::type_id::<T>() }
     }

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -1,4 +1,3 @@
-#![feature(const_type_id)]
 #![feature(generic_const_exprs)]
 #![feature(const_trait_impl, const_cmp)]
 #![feature(core_intrinsics)]

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -1,5 +1,5 @@
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:15:8
+  --> $DIR/issue-90318.rs:14:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = note: this operation may be supported in the future
 
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:22:8
+  --> $DIR/issue-90318.rs:21:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-typeid-of-rpass.rs
+++ b/tests/ui/consts/const-typeid-of-rpass.rs
@@ -1,6 +1,4 @@
 //@ run-pass
-#![feature(const_type_id)]
-#![feature(core_intrinsics)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_cmp_type_id.rs
+++ b/tests/ui/consts/const_cmp_type_id.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id.rs
+++ b/tests/ui/consts/const_transmute_type_id.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id2.rs
+++ b/tests/ui/consts/const_transmute_type_id2.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "0x(ff)+" -> "<u128::MAX>"
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature( const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id3.rs
+++ b/tests/ui/consts/const_transmute_type_id3.rs
@@ -1,7 +1,7 @@
 //! Test that all bytes of a TypeId must have the
 //! TypeId marker provenance.
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature( const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id4.rs
+++ b/tests/ui/consts/const_transmute_type_id4.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id5.rs
+++ b/tests/ui/consts/const_transmute_type_id5.rs
@@ -1,7 +1,7 @@
 //! Test that we require an equal TypeId to have an integer part that properly
 //! reflects the type id hash.
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/issue-102117.rs
+++ b/tests/ui/consts/issue-102117.rs
@@ -1,5 +1,3 @@
-#![feature(const_type_id)]
-
 use std::alloc::Layout;
 use std::any::TypeId;
 use std::mem::transmute;

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -1,5 +1,5 @@
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/issue-102117.rs:19:26
+  --> $DIR/issue-102117.rs:17:26
    |
 LL |                 type_id: TypeId::of::<T>(),
    |                          ^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     pub fn new<T: 'static>() -> &'static Self {
    |                 +++++++++
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/issue-102117.rs:19:26
+  --> $DIR/issue-102117.rs:17:26
    |
 LL |                 type_id: TypeId::of::<T>(),
    |                          ^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/issue-73976-monomorphic.rs
+++ b/tests/ui/consts/issue-73976-monomorphic.rs
@@ -5,7 +5,6 @@
 // will be properly rejected. This test will ensure that monomorphic use of these
 // would not be wrongly rejected in patterns.
 
-#![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_trait_impl)]
 #![feature(const_cmp)]

--- a/tests/ui/consts/issue-73976-polymorphic.rs
+++ b/tests/ui/consts/issue-73976-polymorphic.rs
@@ -5,7 +5,6 @@
 // This test case should either run-pass or be rejected at compile time.
 // Currently we just disallow this usage and require pattern is monomorphic.
 
-#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/tests/ui/consts/issue-73976-polymorphic.stderr
+++ b/tests/ui/consts/issue-73976-polymorphic.stderr
@@ -1,5 +1,5 @@
 error[E0158]: constant pattern cannot depend on generic parameters
-  --> $DIR/issue-73976-polymorphic.rs:20:37
+  --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL | impl<T: 'static> GetTypeId<T> {
    | -----------------------------
@@ -12,7 +12,7 @@ LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^ `const` depends on a generic parameter
 
 error[E0158]: constant pattern cannot depend on generic parameters
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:30:42
    |
 LL | impl<T: 'static> GetTypeNameLen<T> {
    | ----------------------------------


### PR DESCRIPTION
fixes rust-lang/rust#77125

# Stabilization report for `const_type_id`

## General design

### What is the RFC for this feature and what changes have occurred to the user-facing design since the RFC was finalized?

N/A the constness was never RFCed

### What behavior are we committing to that has been controversial? Summarize the major arguments pro/con.

`const_type_id` was kept unstable because we are currently unable to stabilize the `PartialEq` impl for it (in const contexts), so we feared people would transmute the type id to an integer and compare that integer.

### Are there extensions to this feature that remain unstable? How do we know that we are not accidentally committing to those?

`TypeId::eq` is not const at this time, and will only become const once const traits are stable.

## Has a Call for Testing period been conducted? If so, what feedback was received?

This feature has been unstable for a long time, and most people just worked around it on stable by storing a pointer to `TypeId::of` and calling that at "runtime" (usually LLVM devirtualized the function pointer and inlined the call so there was no real performance difference). 

A lot of people seem to be using the `const_type_id` feature gate (600 results for the feature gate on github: https://github.com/search?q=%22%23%21%5Bfeature%28const_type_id%29%5D%22&type=code)

We have had very little feedback except desire for stabilization being expressed.

## Implementation quality

Until these three PRs

* https://github.com/rust-lang/rust/pull/142789
* https://github.com/rust-lang/rust/pull/143696
* https://github.com/rust-lang/rust/pull/143736

there was no difference between the const eval feature and the runtime feature except that we prevented you from using `TypeId::of` at compile-time. These three recent PRs have hardened the internals of `TypeId`:

* it now contains an array of pointers instead of integers
* these pointers at compile-time (and in miri) contain provenance that makes them unique and prevents inspection. Both miri and CTFE will in fact error if you mess with the bits or the provenance of the pointers in any way and then try to use the `TypeId` for an equality check. This also guards against creating values of type `TypeId` by any means other than `TypeId::of`

### Summarize the major parts of the implementation and provide links into the code (or to PRs)

N/A see above

### Summarize existing test coverage of this feature

Since we are not stabilizing any operations on `TypeId` except for creating `TypeId`s, the test coverage of the runtime implementation of `TypeId` covers all the interesting use cases not in the list below

#### Hardening against transmutes

* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_transmute_type_id.rs
* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_transmute_type_id2.rs
* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_transmute_type_id3.rs
* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_transmute_type_id4.rs
* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_transmute_type_id5.rs

#### TypeId::eq is still unstable

* https://github.com/rust-lang/rust/blob/master/tests/ui/consts/const_cmp_type_id.rs

### What outstanding bugs in the issue tracker involve this feature? Are they stabilization-blocking?

https://github.com/rust-lang/rust/issues/129014 is still unresolved, but it affects more the runtime version of `TypeId` than the compile-time.

### What FIXMEs are still in the code for that feature and why is it ok to leave them there?

none

### Summarize contributors to the feature by name for recognition and assuredness that people involved in the feature agree with stabilization 

* @eddyb 
* @RalfJung 

### Which tools need to be adjusted to support this feature. Has this work been done?

N/A

## Type system and execution rules

### What compilation-time checks are done that are needed to prevent undefined behavior?

Already covered above. Transmuting types with private fields to expose those fields has always been library UB, but for the specific case of `TypeId` CTFE and Miri will detect it if that is done in any way other than for reconstructing the exact same `TypeId` in another location.

### Does the feature's implementation need checks to prevent UB or is it sound by default and needs opt in in places to perform the dangerous/unsafe operations? If it is not sound by default, what is the rationale?

N/A

### Can users use this feature to introduce undefined behavior, or use this feature to break the abstraction of Rust and expose the underlying assembly-level implementation? (Describe.)

N/A

### What updates are needed to the reference/specification? (link to PRs when they exist)

Nothing more than what needs to exist for `TypeId` already.

## Common interactions

### Does this feature introduce new expressions and can they produce temporaries? What are the lifetimes of those temporaries?

N/A

### What other unstable features may be exposed by this feature?

N/A
