### PR TITLE
Change memcmp and bcmp return type to c_int

### DIFF
--- a/library/compiler-builtins/compiler-builtins/src/mem/impls.rs
+++ b/library/compiler-builtins/compiler-builtins/src/mem/impls.rs
@@ -384,13 +384,13 @@ pub unsafe fn set_bytes(mut s: *mut u8, c: u8, mut n: usize) {
 }
 
 #[inline(always)]
-pub unsafe fn compare_bytes(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+pub unsafe fn compare_bytes(s1: *const u8, s2: *const u8, n: usize) -> crate::mem::c_int {
     let mut i = 0;
     while i < n {
         let a = *s1.wrapping_add(i);
         let b = *s2.wrapping_add(i);
         if a != b {
-            return a as i32 - b as i32;
+            return a as crate::mem::c_int - b as crate::mem::c_int;
         }
         i += 1;
     }

--- a/library/compiler-builtins/compiler-builtins/src/mem/mod.rs
+++ b/library/compiler-builtins/compiler-builtins/src/mem/mod.rs
@@ -44,12 +44,12 @@ intrinsics! {
     }
 
     #[mem_builtin]
-    pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> crate::mem::c_int {
         impls::compare_bytes(s1, s2, n)
     }
 
     #[mem_builtin]
-    pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> crate::mem::c_int {
         memcmp(s1, s2, n)
     }
 


### PR DESCRIPTION
This PR fix the return type of memcmp builtin function on target with a `pointer_width` equals to 16.
Linked issue: rust-lang/rust#144076 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
