### PR TITLE
Add implicit sized bound to trait ascription types

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2489,6 +2489,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     ty::List::empty(),
                     PredicateFilter::All,
                 );
+                self.add_sizedness_bounds(
+                    &mut bounds,
+                    self_ty,
+                    hir_bounds,
+                    None,
+                    None,
+                    hir_ty.span,
+                );
                 self.register_trait_ascription_bounds(bounds, hir_ty.hir_id, hir_ty.span);
                 self_ty
             }

--- a/tests/ui/impl-trait/in-bindings/implicit-sized.rs
+++ b/tests/ui/impl-trait/in-bindings/implicit-sized.rs
@@ -1,0 +1,19 @@
+#![feature(impl_trait_in_bindings)]
+
+trait Trait {}
+impl<T: ?Sized> Trait for T {}
+
+fn doesnt_work() {
+    let x: &impl Trait = "hi";
+    //~^ ERROR the size for values of type `str` cannot be known at compilation time
+}
+
+fn works() {
+    let x: &(impl Trait + ?Sized) = "hi";
+    // No implicit sized.
+
+    let x: &impl Trait = &();
+    // Is actually sized.
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-bindings/implicit-sized.stderr
+++ b/tests/ui/impl-trait/in-bindings/implicit-sized.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/implicit-sized.rs:7:13
+   |
+LL |     let x: &impl Trait = "hi";
+   |             ^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
r? @fmease or reassign

Thanks for catching this :)

Fixes rust-lang/rust#144135