### PR TITLE
tests: Skip supported-crate-types test on musl hosts

### DIFF
--- a/tests/ui/print-request/supported-crate-types.rs
+++ b/tests/ui/print-request/supported-crate-types.rs
@@ -8,6 +8,11 @@
 
 //@ check-pass
 
+// FIXME: musl targets are currently statically linked, but running on a musl host
+// requires dynamic linkage, which in turn changes the supported crate types for
+// x86_64-unknown-linux-musl.
+//@ ignore-musl
+
 //@ revisions: wasm musl linux
 
 //@[wasm] compile-flags: --target=wasm32-unknown-unknown --print=supported-crate-types -Zunstable-options


### PR DESCRIPTION
This test depends on the target-specific default of crt-static for musl targets. However, running the testsuite on a musl host requires setting `crt-static` to `false`, as it wouldn't otherwise be possible to build rustc. This in turn will enable `-Ctarget-feature=-crt-static` for all tests, mismatching the expected `+crt-static` for the musl target tested in this testcase.

Since this test specifically tests the default value of `crt-static` for the musl target, ignoring it entirely makes more sense than manually setting `-Ctarget-feature=+crt-static` here, but both would be valid approaches.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
