### PR TITLE
tests: assembly: cstring-merging: Disable GlobalMerge pass

### DIFF
--- a/tests/assembly/cstring-merging.rs
+++ b/tests/assembly/cstring-merging.rs
@@ -2,7 +2,7 @@
 // other architectures (including ARM and x86-64) use the prefix `.Lanon.`
 //@ only-linux
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -Copt-level=3
+//@ compile-flags: --crate-type=lib -Copt-level=3 -Cllvm-args=-enable-global-merge=0
 //@ edition: 2024
 
 use std::ffi::CStr;


### PR DESCRIPTION
The test relies on LLVM not merging all the globals into one and would currently otherwise fail on powerpc64le.

See https://github.com/llvm/llvm-project/blob/release/20.x/llvm/lib/CodeGen/GlobalMerge.cpp and here's the assembly generated prior to disabling the pass:

<details>

<summary>Expand me</summary>

```asm
	.abiversion 2
	.file	"cstring_merging.5aa81ea7b99b31fe-cgu.0"
	.section	.text.cstr,"ax",@progbits
	.globl	cstr
	.p2align	4
	.type	cstr,@function
cstr:
.Lfunc_begin0:
	.cfi_startproc
.Lfunc_gep0:
	addis 2, 12, .TOC.-.Lfunc_gep0@ha
	addi 2, 2, .TOC.-.Lfunc_gep0@l
.Lfunc_lep0:
	.localentry	cstr, .Lfunc_lep0-.Lfunc_gep0
	addis 3, 2, .L_MergedGlobals@toc@ha
	li 4, 4
	addi 3, 3, .L_MergedGlobals@toc@l
	addi 3, 3, 4
	blr
	.long	0
	.quad	0
.Lfunc_end0:
	.size	cstr, .Lfunc_end0-.Lfunc_begin0
	.cfi_endproc

	.section	.text.manual_cstr,"ax",@progbits
	.globl	manual_cstr
	.p2align	4
	.type	manual_cstr,@function
manual_cstr:
.Lfunc_begin1:
	.cfi_startproc
.Lfunc_gep1:
	addis 2, 12, .TOC.-.Lfunc_gep1@ha
	addi 2, 2, .TOC.-.Lfunc_gep1@l
.Lfunc_lep1:
	.localentry	manual_cstr, .Lfunc_lep1-.Lfunc_gep1
	addis 3, 2, .L_MergedGlobals@toc@ha
	li 4, 4
	addi 3, 3, .L_MergedGlobals@toc@l
	addi 3, 3, 8
	blr
	.long	0
	.quad	0
.Lfunc_end1:
	.size	manual_cstr, .Lfunc_end1-.Lfunc_begin1
	.cfi_endproc

	.type	CSTR,@object
	.section	.data.rel.ro.CSTR,"aw",@progbits
	.globl	CSTR
	.p2align	3, 0x0
CSTR:
	.quad	.L_MergedGlobals
	.size	CSTR, 8

	.type	.L_MergedGlobals,@object
	.section	.rodata..L_MergedGlobals,"a",@progbits
.L_MergedGlobals:
	.asciz	"foo"
	.asciz	"bar"
	.asciz	"baz"
	.size	.L_MergedGlobals, 12

.set .Lanon.a643e9a6bba67b7953be2b5f96e0e802.0, .L_MergedGlobals
	.size	.Lanon.a643e9a6bba67b7953be2b5f96e0e802.0, 4
.set .Lanon.a643e9a6bba67b7953be2b5f96e0e802.1, .L_MergedGlobals+4
	.size	.Lanon.a643e9a6bba67b7953be2b5f96e0e802.1, 4
.set .Lanon.a643e9a6bba67b7953be2b5f96e0e802.2, .L_MergedGlobals+8
	.size	.Lanon.a643e9a6bba67b7953be2b5f96e0e802.2, 4
	.ident	"rustc version 1.90.0-dev"
	.section	".note.GNU-stack","",@progbits
```

</details>

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
