### PR TITLE
Rename `optional-mingw-check-1` to `optional-pr-check-1`

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -172,9 +172,9 @@ try:
 optional:
   # This job is used just to test optional jobs.
   # It will be replaced by tier 2 and tier 3 jobs in the future.
-  - name: optional-mingw-check-1
+  - name: optional-pr-check-1
     env:
-      IMAGE: mingw-check-1
+      IMAGE: pr-check-1
     <<: *job-linux-4c
 
 # Main CI jobs that have to be green to merge a commit into master


### PR DESCRIPTION
I noticed this when doing a `bors2 try` for `mingw`.

I also changed it to use the `pr-check-1` image as `mingw-check-1` no longer exists.