### PR TITLE
Remove the `CoroutineWitness` type

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1801,7 +1801,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
                     | ty::Closure(_, _)
                     | ty::CoroutineClosure(_, _)
                     | ty::Coroutine(_, _)
-                    | ty::CoroutineWitness(..)
                     | ty::Never
                     | ty::Tuple(_)
                     | ty::UnsafeBinder(_)
@@ -1844,7 +1843,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
                     | ty::FnDef(_, _)
                     | ty::FnPtr(..)
                     | ty::Dynamic(_, _, _)
-                    | ty::CoroutineWitness(..)
                     | ty::Never
                     | ty::UnsafeBinder(_)
                     | ty::Alias(_, _)

--- a/compiler/rustc_borrowck/src/type_check/input_output.rs
+++ b/compiler/rustc_borrowck/src/type_check/input_output.rs
@@ -86,7 +86,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                         // them with fresh ty vars.
                         resume_ty: next_ty_var(),
                         yield_ty: next_ty_var(),
-                        witness: next_ty_var(),
                     },
                 )
                 .args,

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -973,19 +973,6 @@ pub(crate) fn assert_assignable<'tcx>(
                 }
             }
         }
-        (&ty::CoroutineWitness(def_id_a, args_a), &ty::CoroutineWitness(def_id_b, args_b))
-            if def_id_a == def_id_b =>
-        {
-            let mut types_a = args_a.types();
-            let mut types_b = args_b.types();
-            loop {
-                match (types_a.next(), types_b.next()) {
-                    (Some(a), Some(b)) => assert_assignable(fx, a, b, limit - 1),
-                    (None, None) => return,
-                    (Some(_), None) | (None, Some(_)) => panic!("{:#?}/{:#?}", from_ty, to_ty),
-                }
-            }
-        }
         _ => {
             assert_eq!(
                 from_ty,

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -344,7 +344,6 @@ fn exported_generic_symbols_provider_local<'tcx>(
                 ty::FnDef(def_id, _) => *def_id,
                 ty::Coroutine(def_id, _) => *def_id,
                 ty::CoroutineClosure(def_id, _) => *def_id,
-                ty::CoroutineWitness(def_id, _) => *def_id,
                 _ => return false,
             };
             let Some(root_def_id) = root_def_id.as_local() else {

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -437,8 +437,7 @@ fn push_debuginfo_type_name<'tcx>(
         | ty::Infer(_)
         | ty::Placeholder(..)
         | ty::Alias(..)
-        | ty::Bound(..)
-        | ty::CoroutineWitness(..) => {
+        | ty::Bound(..) => {
             bug!(
                 "debuginfo: Trying to create type name for \
                   unexpected type: {:?}",

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -176,7 +176,6 @@ fn const_to_valtree_inner<'tcx>(
         | ty::Closure(..)
         | ty::CoroutineClosure(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..)
         | ty::UnsafeBinder(_) => Err(ValTreeCreationError::NonSupportedType(ty)),
     }
 }
@@ -336,7 +335,6 @@ pub fn valtree_to_const_value<'tcx>(
         | ty::Closure(..)
         | ty::CoroutineClosure(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..)
         | ty::FnPtr(..)
         | ty::Str
         | ty::Slice(_)

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -184,7 +184,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     | ty::Closure(_, _)
                     | ty::CoroutineClosure(_, _)
                     | ty::Coroutine(_, _)
-                    | ty::CoroutineWitness(..)
                     | ty::UnsafeBinder(_)
                     | ty::Never
                     | ty::Tuple(_)

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -499,7 +499,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 | ty::Char
                 | ty::Ref(..)
                 | ty::Coroutine(..)
-                | ty::CoroutineWitness(..)
                 | ty::Array(..)
                 | ty::Closure(..)
                 | ty::CoroutineClosure(..)

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -795,8 +795,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             | ty::Placeholder(..)
             | ty::Bound(..)
             | ty::Param(..)
-            | ty::Alias(..)
-            | ty::CoroutineWitness(..) => bug!("Encountered invalid type {:?}", ty),
+            | ty::Alias(..) => bug!("Encountered invalid type {:?}", ty),
         }
     }
 

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -58,7 +58,6 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
             ty::Alias(ty::Free, _) => bug!("type_name: unexpected free alias"),
             ty::Alias(ty::Inherent, _) => bug!("type_name: unexpected inherent projection"),
-            ty::CoroutineWitness(..) => bug!("type_name: unexpected `CoroutineWitness`"),
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -194,7 +194,6 @@ impl<'tcx> InherentCollect<'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Alias(ty::Free, _)
             | ty::Bound(..)
             | ty::Placeholder(_)

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -230,7 +230,6 @@ pub(crate) fn orphan_check_impl(
             ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Bound(..)
             | ty::Placeholder(..)
             | ty::Infer(..) => {

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -379,20 +379,14 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
         // for info on the usage of each of these fields.
         let dummy_args = match kind {
             ClosureKind::Closure => &["<closure_kind>", "<closure_signature>", "<upvars>"][..],
-            ClosureKind::Coroutine(_) => &[
-                "<coroutine_kind>",
-                "<resume_ty>",
-                "<yield_ty>",
-                "<return_ty>",
-                "<witness>",
-                "<upvars>",
-            ][..],
+            ClosureKind::Coroutine(_) => {
+                &["<coroutine_kind>", "<resume_ty>", "<yield_ty>", "<return_ty>", "<upvars>"][..]
+            }
             ClosureKind::CoroutineClosure(_) => &[
                 "<closure_kind>",
                 "<closure_signature_parts>",
                 "<upvars>",
                 "<bound_captures_by_ref>",
-                "<witness>",
             ][..],
         };
 

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -323,7 +323,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 // types, where we use Error as the Self type
             }
 
-            ty::Placeholder(..) | ty::CoroutineWitness(..) | ty::Bound(..) | ty::Infer(..) => {
+            ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) => {
                 bug!("unexpected type encountered in variance inference: {}", ty);
             }
         }

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -132,7 +132,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ty::Uint(..)
             | ty::Float(_)
             | ty::Array(..)
-            | ty::CoroutineWitness(..)
             | ty::RawPtr(_, _)
             | ty::Ref(..)
             | ty::Pat(..)

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -161,8 +161,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Resume type defaults to `()` if the coroutine has no argument.
                 let resume_ty = liberated_sig.inputs().get(0).copied().unwrap_or(tcx.types.unit);
 
-                let interior = Ty::new_coroutine_witness(tcx, expr_def_id.to_def_id(), parent_args);
-
                 // Coroutines that come from coroutine closures have not yet determined
                 // their kind ty, so make a fresh infer var which will be constrained
                 // later during upvar analysis. Regular coroutines always have the kind
@@ -182,7 +180,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         resume_ty,
                         yield_ty,
                         return_ty: liberated_sig.output(),
-                        witness: interior,
                         tupled_upvars_ty,
                     },
                 );
@@ -210,7 +207,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
                 // Compute all of the variables that will be used to populate the coroutine.
                 let resume_ty = self.next_ty_var(expr_span);
-                let interior = self.next_ty_var(expr_span);
 
                 let closure_kind_ty = match expected_kind {
                     Some(kind) => Ty::from_closure_kind(tcx, kind),
@@ -243,7 +239,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                         tupled_upvars_ty,
                         coroutine_captures_by_ref_ty,
-                        coroutine_witness_ty: interior,
                     },
                 );
 

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -562,7 +562,6 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             | ty::Closure(_, _)
             | ty::CoroutineClosure(_, _)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(_, _)
             | ty::Never
             | ty::Tuple(_) => return Err(TypeError::Mismatch),
             _ => {}

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -408,7 +408,6 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Bool
             | ty::Char
             | ty::Int(..)

--- a/compiler/rustc_lint/src/foreign_modules.rs
+++ b/compiler/rustc_lint/src/foreign_modules.rs
@@ -368,7 +368,6 @@ fn structurally_same_type_impl<'tcx>(
                 | (ty::Error(..), ty::Error(..))
                 | (ty::Closure(..), ty::Closure(..))
                 | (ty::Coroutine(..), ty::Coroutine(..))
-                | (ty::CoroutineWitness(..), ty::CoroutineWitness(..))
                 | (ty::Alias(ty::Projection, ..), ty::Alias(ty::Projection, ..))
                 | (ty::Alias(ty::Inherent, ..), ty::Alias(ty::Inherent, ..))
                 | (ty::Alias(ty::Opaque, ..), ty::Alias(ty::Opaque, ..)) => false,

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1407,7 +1407,6 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Placeholder(..)
             | ty::FnDef(..) => bug!("unexpected type in foreign function: {:?}", ty),
         }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -607,11 +607,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
             // `assemble_candidates_after_normalizing_self_ty`.
             ty::Alias(_, _) | ty::Placeholder(..) | ty::Error(_) => (),
 
-            // FIXME: These should ideally not exist as a self type. It would be nice for
-            // the builtin auto trait impls of coroutines to instead directly recurse
-            // into the witness.
-            ty::CoroutineWitness(..) => (),
-
             // These variants should not exist as a self type.
             ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
             | ty::Param(_)
@@ -2498,7 +2493,6 @@ impl<'tcx> TyCtxt<'tcx> {
                 UnsafeBinder,
                 Placeholder,
                 Coroutine,
-                CoroutineWitness,
                 Dynamic,
                 Closure,
                 CoroutineClosure,

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -608,7 +608,6 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IsSuggestableVisitor<'tcx> {
             | Closure(..)
             | Infer(..)
             | Coroutine(..)
-            | CoroutineWitness(..)
             | Bound(_, _)
             | Placeholder(_)
             | Error(_) => {
@@ -692,7 +691,6 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for MakeSuggestableFolder<'tcx> {
             | FnDef(..)
             | Infer(..)
             | Coroutine(..)
-            | CoroutineWitness(..)
             | Bound(_, _)
             | Placeholder(_)
             | Error(_) => {

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -138,7 +138,6 @@ impl<'tcx> Ty<'tcx> {
             ty::Coroutine(def_id, ..) => {
                 format!("{:#}", tcx.coroutine_kind(def_id).unwrap()).into()
             }
-            ty::CoroutineWitness(..) => "coroutine witness".into(),
             ty::Infer(ty::TyVar(_)) => "inferred type".into(),
             ty::Infer(ty::IntVar(_)) => "integer".into(),
             ty::Infer(ty::FloatVar(_)) => "floating-point number".into(),
@@ -200,7 +199,6 @@ impl<'tcx> Ty<'tcx> {
             ty::Coroutine(def_id, ..) => {
                 format!("{:#}", tcx.coroutine_kind(def_id).unwrap()).into()
             }
-            ty::CoroutineWitness(..) => "coroutine witness".into(),
             ty::Tuple(..) => "tuple".into(),
             ty::Placeholder(..) => "higher-ranked type".into(),
             ty::Bound(..) => "bound type variable".into(),

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -96,14 +96,12 @@ impl<'tcx> rustc_type_ir::inherent::GenericArgs<TyCtxt<'tcx>> for ty::GenericArg
                 signature_parts_ty,
                 tupled_upvars_ty,
                 coroutine_captures_by_ref_ty,
-                coroutine_witness_ty,
             ] => ty::CoroutineClosureArgsParts {
                 parent_args,
                 closure_kind_ty: closure_kind_ty.expect_ty(),
                 signature_parts_ty: signature_parts_ty.expect_ty(),
                 tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
                 coroutine_captures_by_ref_ty: coroutine_captures_by_ref_ty.expect_ty(),
-                coroutine_witness_ty: coroutine_witness_ty.expect_ty(),
             },
             _ => bug!("closure args missing synthetics"),
         }
@@ -111,23 +109,16 @@ impl<'tcx> rustc_type_ir::inherent::GenericArgs<TyCtxt<'tcx>> for ty::GenericArg
 
     fn split_coroutine_args(self) -> ty::CoroutineArgsParts<TyCtxt<'tcx>> {
         match self[..] {
-            [
-                ref parent_args @ ..,
-                kind_ty,
-                resume_ty,
-                yield_ty,
-                return_ty,
-                witness,
-                tupled_upvars_ty,
-            ] => ty::CoroutineArgsParts {
-                parent_args,
-                kind_ty: kind_ty.expect_ty(),
-                resume_ty: resume_ty.expect_ty(),
-                yield_ty: yield_ty.expect_ty(),
-                return_ty: return_ty.expect_ty(),
-                witness: witness.expect_ty(),
-                tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
-            },
+            [ref parent_args @ .., kind_ty, resume_ty, yield_ty, return_ty, tupled_upvars_ty] => {
+                ty::CoroutineArgsParts {
+                    parent_args,
+                    kind_ty: kind_ty.expect_ty(),
+                    resume_ty: resume_ty.expect_ty(),
+                    yield_ty: yield_ty.expect_ty(),
+                    return_ty: return_ty.expect_ty(),
+                    tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
+                }
+            }
             _ => bug!("coroutine args missing synthetics"),
         }
     }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -806,7 +806,6 @@ where
                 | ty::FnPtr(..)
                 | ty::Never
                 | ty::FnDef(..)
-                | ty::CoroutineWitness(..)
                 | ty::Foreign(..)
                 | ty::Pat(_, _)
                 | ty::Dynamic(_, _, ty::Dyn) => {

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -155,11 +155,6 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
                 Ty::new_coroutine(self.tcx, def_id, args)
             }
 
-            ty::CoroutineWitness(def_id, args) => {
-                let args = self.fold_closure_args(def_id, args);
-                Ty::new_coroutine_witness(self.tcx, def_id, args)
-            }
-
             ty::Param(param) => {
                 // Look it up in the generic parameters list.
                 match self.map.get(&ty.into()).map(|arg| arg.kind()) {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -287,7 +287,6 @@ fn characteristic_def_id_of_type_cached<'a>(
         | ty::Closure(def_id, _)
         | ty::CoroutineClosure(def_id, _)
         | ty::Coroutine(def_id, _)
-        | ty::CoroutineWitness(def_id, _)
         | ty::Foreign(def_id) => Some(def_id),
 
         ty::Bool

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -913,31 +913,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                         " yield_ty=",
                         print(args.as_coroutine().yield_ty()),
                         " return_ty=",
-                        print(args.as_coroutine().return_ty()),
-                        " witness=",
-                        print(args.as_coroutine().witness())
+                        print(args.as_coroutine().return_ty())
                     );
-                }
-
-                p!("}}")
-            }
-            ty::CoroutineWitness(did, args) => {
-                p!(write("{{"));
-                if !self.tcx().sess.verbose_internals() {
-                    p!("coroutine witness");
-                    if let Some(did) = did.as_local() {
-                        let span = self.tcx().def_span(did);
-                        p!(write(
-                            "@{}",
-                            // This may end up in stderr diagnostics but it may also be emitted
-                            // into MIR. Hence we use the remapped path if available
-                            self.tcx().sess.source_map().span_to_embeddable_string(span)
-                        ));
-                    } else {
-                        p!(write("@"), print_def_path(did, args));
-                    }
-                } else {
-                    p!(print_def_path(did, args));
                 }
 
                 p!("}}")
@@ -1035,9 +1012,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                         " upvar_tys=",
                         print(args.as_coroutine_closure().tupled_upvars_ty()),
                         " coroutine_captures_by_ref_ty=",
-                        print(args.as_coroutine_closure().coroutine_captures_by_ref_ty()),
-                        " coroutine_witness_ty=",
-                        print(args.as_coroutine_closure().coroutine_witness_ty())
+                        print(args.as_coroutine_closure().coroutine_captures_by_ref_ty())
                     );
                 }
                 p!("}}");
@@ -2296,7 +2271,6 @@ impl<'tcx> Printer<'tcx> for FmtPrinter<'_, 'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Tuple(_)
             | ty::Alias(..)
             | ty::Param(_)

--- a/compiler/rustc_middle/src/ty/significant_drop_order.rs
+++ b/compiler/rustc_middle/src/ty/significant_drop_order.rs
@@ -150,7 +150,6 @@ pub fn ty_dtor_span<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Span> {
             }
         }
         ty::Coroutine(did, _)
-        | ty::CoroutineWitness(did, _)
         | ty::CoroutineClosure(did, _)
         | ty::Closure(did, _)
         | ty::FnDef(did, _)

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -403,9 +403,6 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
                 ty::Ref(r.try_fold_with(folder)?, ty.try_fold_with(folder)?, mutbl)
             }
             ty::Coroutine(did, args) => ty::Coroutine(did, args.try_fold_with(folder)?),
-            ty::CoroutineWitness(did, args) => {
-                ty::CoroutineWitness(did, args.try_fold_with(folder)?)
-            }
             ty::Closure(did, args) => ty::Closure(did, args.try_fold_with(folder)?),
             ty::CoroutineClosure(did, args) => {
                 ty::CoroutineClosure(did, args.try_fold_with(folder)?)
@@ -446,7 +443,6 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
             ty::UnsafeBinder(f) => ty::UnsafeBinder(f.fold_with(folder)),
             ty::Ref(r, ty, mutbl) => ty::Ref(r.fold_with(folder), ty.fold_with(folder), mutbl),
             ty::Coroutine(did, args) => ty::Coroutine(did, args.fold_with(folder)),
-            ty::CoroutineWitness(did, args) => ty::CoroutineWitness(did, args.fold_with(folder)),
             ty::Closure(did, args) => ty::Closure(did, args.fold_with(folder)),
             ty::CoroutineClosure(did, args) => ty::CoroutineClosure(did, args.fold_with(folder)),
             ty::Alias(kind, data) => ty::Alias(kind, data.fold_with(folder)),
@@ -494,7 +490,6 @@ impl<'tcx> TypeSuperVisitable<TyCtxt<'tcx>> for Ty<'tcx> {
                 ty.visit_with(visitor)
             }
             ty::Coroutine(_did, args) => args.visit_with(visitor),
-            ty::CoroutineWitness(_did, args) => args.visit_with(visitor),
             ty::Closure(_did, args) => args.visit_with(visitor),
             ty::CoroutineClosure(_did, args) => args.visit_with(visitor),
             ty::Alias(_, data) => data.visit_with(visitor),

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -816,15 +816,6 @@ impl<'tcx> Ty<'tcx> {
         Ty::new(tcx, Coroutine(def_id, coroutine_args))
     }
 
-    #[inline]
-    pub fn new_coroutine_witness(
-        tcx: TyCtxt<'tcx>,
-        id: DefId,
-        args: GenericArgsRef<'tcx>,
-    ) -> Ty<'tcx> {
-        Ty::new(tcx, CoroutineWitness(id, args))
-    }
-
     // misc
 
     #[inline]
@@ -973,14 +964,6 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
 
     fn new_closure(interner: TyCtxt<'tcx>, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> Self {
         Ty::new_closure(interner, def_id, args)
-    }
-
-    fn new_coroutine_witness(
-        interner: TyCtxt<'tcx>,
-        def_id: DefId,
-        args: ty::GenericArgsRef<'tcx>,
-    ) -> Self {
-        Ty::new_coroutine_witness(interner, def_id, args)
     }
 
     fn new_ptr(interner: TyCtxt<'tcx>, ty: Self, mutbl: hir::Mutability) -> Self {
@@ -1580,7 +1563,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Dynamic(..)
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
             | ty::UnsafeBinder(_)
@@ -1616,7 +1598,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Char
             | ty::Ref(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Array(..)
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
@@ -1807,7 +1788,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Char
             | ty::Ref(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Array(..)
             | ty::Pat(..)
             | ty::Closure(..)
@@ -1883,7 +1863,7 @@ impl<'tcx> Ty<'tcx> {
             // for all unsized types.
             ty::Ref(_, _, hir::Mutability::Not) | ty::RawPtr(..) => true,
 
-            ty::Coroutine(..) | ty::CoroutineWitness(..) => false,
+            ty::Coroutine(..) => false,
 
             // Might be, but not "trivial" so just giving the safe answer.
             ty::Adt(..) | ty::Closure(..) | ty::CoroutineClosure(..) => false,
@@ -1939,7 +1919,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Alias(..)
             | ty::Error(_) => false,
         }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1178,7 +1178,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Dynamic(..)
             | ty::Foreign(_)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::UnsafeBinder(_)
             | ty::Infer(_)
             | ty::Alias(..)
@@ -1219,7 +1218,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Dynamic(..)
             | ty::Foreign(_)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::UnsafeBinder(_)
             | ty::Infer(_)
             | ty::Alias(..)
@@ -1274,7 +1272,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::Dynamic(..)
             | ty::Foreign(_)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Infer(_)
             | ty::Alias(..)
             | ty::Param(_)
@@ -1443,7 +1440,7 @@ impl<'tcx> Ty<'tcx> {
                 false
             }
 
-            ty::Foreign(_) | ty::CoroutineWitness(..) | ty::Error(_) | ty::UnsafeBinder(_) => false,
+            ty::Foreign(_) | ty::Error(_) | ty::UnsafeBinder(_) => false,
         }
     }
 
@@ -1553,7 +1550,6 @@ pub fn needs_drop_components_with_async<'tcx>(
         | ty::Closure(..)
         | ty::CoroutineClosure(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..)
         | ty::UnsafeBinder(_) => Ok(smallvec![ty]),
     }
 }

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -157,7 +157,6 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                     | ty::Closure(..)
                     | ty::CoroutineClosure(..)
                     | ty::Coroutine(_, _)
-                    | ty::CoroutineWitness(..)
                     | ty::Never
                     | ty::Tuple(_)
                     | ty::UnsafeBinder(_)
@@ -198,7 +197,6 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                     | ty::FnDef(_, _)
                     | ty::FnPtr(..)
                     | ty::Dynamic(_, _, _)
-                    | ty::CoroutineWitness(..)
                     | ty::Never
                     | ty::UnsafeBinder(_)
                     | ty::Alias(_, _)

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -953,7 +953,7 @@ fn try_write_constant<'tcx>(
         | ty::Dynamic(..)
         | ty::UnsafeBinder(_) => throw_machine_stop_str!("unsupported type"),
 
-        ty::Error(_) | ty::Infer(..) | ty::CoroutineWitness(..) => bug!(),
+        ty::Error(_) | ty::Infer(..)  => bug!(),
     }
 
     interp_ok(())

--- a/compiler/rustc_next_trait_solver/src/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonicalizer.rs
@@ -371,7 +371,6 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
             | ty::Alias(_, _)

--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -442,10 +442,6 @@ where
                     self.found_non_local_ty(ty)
                 }
             }
-            // This should only be created when checking whether we have to check whether some
-            // auto trait impl applies. There will never be multiple impls, so we can just
-            // act as if it were a local type here.
-            ty::CoroutineWitness(..) => ControlFlow::Break(OrphanCheckEarlyExit::LocalTy(ty)),
         };
         // A bit of a hack, the `OrphanChecker` is only used to visit a `TraitRef`, so
         // the first type we visit is always the self type.

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -621,7 +621,6 @@ where
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
             | ty::Param(_)
@@ -735,7 +734,6 @@ where
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
             | ty::Param(_)

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -75,16 +75,17 @@ where
             Ok(ty::Binder::dummy(vec![args.as_coroutine_closure().tupled_upvars_ty()]))
         }
 
-        ty::Coroutine(_, args) => {
-            let coroutine_args = args.as_coroutine();
-            Ok(ty::Binder::dummy(vec![coroutine_args.tupled_upvars_ty(), coroutine_args.witness()]))
+        ty::Coroutine(def_id, args) => {
+            let coroutine = args.as_coroutine();
+            Ok(ecx.cx().coroutine_hidden_types(def_id).instantiate(ecx.cx(), args).map_bound(
+                |bound_tys| {
+                    [coroutine.tupled_upvars_ty()]
+                        .into_iter()
+                        .chain(bound_tys.types.iter())
+                        .collect()
+                },
+            ))
         }
-
-        ty::CoroutineWitness(def_id, args) => Ok(ecx
-            .cx()
-            .coroutine_hidden_types(def_id)
-            .instantiate(cx, args)
-            .map_bound(|bound| bound.types.to_vec())),
 
         ty::UnsafeBinder(bound_ty) => Ok(bound_ty.map_bound(|ty| vec![ty])),
 
@@ -116,7 +117,7 @@ where
 {
     match ty.kind() {
         // impl {Meta,}Sized for u*, i*, bool, f*, FnDef, FnPtr, *(const/mut) T, char
-        // impl {Meta,}Sized for &mut? T, [T; N], dyn* Trait, !, Coroutine, CoroutineWitness
+        // impl {Meta,}Sized for &mut? T, [T; N], dyn* Trait, !, Coroutine
         // impl {Meta,}Sized for Closure, CoroutineClosure
         ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
         | ty::Uint(_)
@@ -129,7 +130,6 @@ where
         | ty::Char
         | ty::Ref(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..)
         | ty::Array(..)
         | ty::Pat(..)
         | ty::Closure(..)
@@ -245,7 +245,16 @@ where
             Movability::Movable => {
                 if ecx.cx().features().coroutine_clone() {
                     let coroutine = args.as_coroutine();
-                    Ok(ty::Binder::dummy(vec![coroutine.tupled_upvars_ty(), coroutine.witness()]))
+                    Ok(ecx
+                        .cx()
+                        .coroutine_hidden_types(def_id)
+                        .instantiate(ecx.cx(), args)
+                        .map_bound(|bound_tys| {
+                            [coroutine.tupled_upvars_ty()]
+                                .into_iter()
+                                .chain(bound_tys.types.iter())
+                                .collect()
+                        }))
                 } else {
                     Err(NoSolution)
                 }
@@ -253,13 +262,6 @@ where
         },
 
         ty::UnsafeBinder(_) => Err(NoSolution),
-
-        // impl Copy/Clone for CoroutineWitness where T: Copy/Clone forall T in coroutine_hidden_types
-        ty::CoroutineWitness(def_id, args) => Ok(ecx
-            .cx()
-            .coroutine_hidden_types(def_id)
-            .instantiate(ecx.cx(), args)
-            .map_bound(|bound| bound.types.to_vec())),
     }
 }
 
@@ -383,7 +385,6 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<I: Intern
         | ty::Ref(_, _, _)
         | ty::Dynamic(_, _, _)
         | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(..)
         | ty::Never
         | ty::Tuple(_)
         | ty::Pat(_, _)
@@ -557,7 +558,6 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: 
         | ty::Ref(_, _, _)
         | ty::Dynamic(_, _, _)
         | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(..)
         | ty::Never
         | ty::UnsafeBinder(_)
         | ty::Tuple(_)
@@ -706,7 +706,6 @@ pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
         | ty::Ref(_, _, _)
         | ty::Dynamic(_, _, _)
         | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(..)
         | ty::Never
         | ty::Tuple(_)
         | ty::Pat(_, _)
@@ -785,10 +784,7 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
 
         // Coroutines and closures could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => Err(NoSolution),
+        ty::Closure(_, _) | ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) => Err(NoSolution),
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -655,7 +655,6 @@ where
             | ty::CoroutineClosure(..)
             | ty::Infer(ty::IntVar(..) | ty::FloatVar(..))
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Foreign(..) => Ty::new_unit(cx),
 
@@ -909,7 +908,6 @@ where
             | ty::CoroutineClosure(..)
             | ty::Infer(ty::IntVar(..) | ty::FloatVar(..))
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Foreign(..)
             | ty::Adt(_, _)

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -229,7 +229,7 @@ where
         }
 
         // We need to make sure to stall any coroutines we are inferring to avoid query cycles.
-        if let Some(cand) = ecx.try_stall_coroutine_witness(goal.predicate.self_ty()) {
+        if let Some(cand) = ecx.try_stall_coroutine(goal.predicate.self_ty()) {
             return cand;
         }
 
@@ -294,7 +294,7 @@ where
         }
 
         // We need to make sure to stall any coroutines we are inferring to avoid query cycles.
-        if let Some(cand) = ecx.try_stall_coroutine_witness(goal.predicate.self_ty()) {
+        if let Some(cand) = ecx.try_stall_coroutine(goal.predicate.self_ty()) {
             return cand;
         }
 
@@ -1432,11 +1432,8 @@ where
         self.merge_trait_candidates(candidates)
     }
 
-    fn try_stall_coroutine_witness(
-        &mut self,
-        self_ty: I::Ty,
-    ) -> Option<Result<Candidate<I>, NoSolution>> {
-        if let ty::CoroutineWitness(def_id, _) = self_ty.kind() {
+    fn try_stall_coroutine(&mut self, self_ty: I::Ty) -> Option<Result<Candidate<I>, NoSolution>> {
+        if let ty::Coroutine(def_id, _) = self_ty.kind() {
             match self.typing_mode() {
                 TypingMode::Analysis {
                     defining_opaque_types_and_generators: stalled_generators,

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -738,8 +738,7 @@ where
                 | ty::Closure(..)
                 | ty::CoroutineClosure(..)
                 | ty::Coroutine(..)
-                | ty::UnsafeBinder(_)
-                | ty::CoroutineWitness(..) => {
+                | ty::UnsafeBinder(_) => {
                     ecx.add_goal(
                         GoalSource::ImplWhereBound,
                         goal.with(
@@ -1237,7 +1236,6 @@ where
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
             | ty::Adt(_, _)

--- a/compiler/rustc_passes/src/check_export.rs
+++ b/compiler/rustc_passes/src/check_export.rs
@@ -305,7 +305,6 @@ impl<'tcx, 'a> TypeVisitor<TyCtxt<'tcx>> for ExportableItemsChecker<'tcx, 'a> {
             | ty::FnDef(_, _)
             | ty::FnPtr(_, _)
             | ty::CoroutineClosure(_, _)
-            | ty::CoroutineWitness(_, _)
             | ty::Never
             | ty::UnsafeBinder(_)
             | ty::Alias(ty::AliasTyKind::Opaque, _) => {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -416,7 +416,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
             | ty::Alias(_, _)
             | ty::Param(_)
             | ty::Error(_) => ConstructorSet::Unlistable,
-            ty::CoroutineWitness(_, _) | ty::Bound(_, _) | ty::Placeholder(_) | ty::Infer(_) => {
+            ty::Bound(_, _) | ty::Placeholder(_) | ty::Infer(_) => {
                 bug!("Encountered unexpected type in `ConstructorSet::for_ty`: {ty:?}")
             }
         })

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -290,8 +290,7 @@ where
             | ty::UnsafeBinder(_)
             | ty::Param(..)
             | ty::Bound(..)
-            | ty::Error(_)
-            | ty::CoroutineWitness(..) => {}
+            | ty::Error(_) => {}
             ty::Placeholder(..) | ty::Infer(..) => {
                 bug!("unexpected type: {:?}", ty)
             }

--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -57,7 +57,6 @@ impl Bridge for BridgeTys {
     type ConstDef = crate::ty::ConstDef;
     type ImplDef = crate::ty::ImplDef;
     type RegionDef = crate::ty::RegionDef;
-    type CoroutineWitnessDef = crate::ty::CoroutineWitnessDef;
     type AssocDef = crate::ty::AssocDef;
     type OpaqueDef = crate::ty::OpaqueDef;
     type Prov = crate::ty::Prov;

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -268,7 +268,6 @@ bridge_impl!(GenericDef, crate::ty::GenericDef);
 bridge_impl!(ConstDef, crate::ty::ConstDef);
 bridge_impl!(ImplDef, crate::ty::ImplDef);
 bridge_impl!(RegionDef, crate::ty::RegionDef);
-bridge_impl!(CoroutineWitnessDef, crate::ty::CoroutineWitnessDef);
 bridge_impl!(AssocDef, crate::ty::AssocDef);
 bridge_impl!(OpaqueDef, crate::ty::OpaqueDef);
 bridge_impl!(StaticDef, crate::mir::mono::StaticDef);

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -566,7 +566,6 @@ pub enum RigidTy {
     Dynamic(Vec<Binder<ExistentialPredicate>>, Region, DynKind),
     Never,
     Tuple(Vec<Ty>),
-    CoroutineWitness(CoroutineWitnessDef, GenericArgs),
 }
 
 impl RigidTy {
@@ -990,11 +989,6 @@ impl ImplDef {
 crate_def! {
     #[derive(Serialize)]
     pub RegionDef;
-}
-
-crate_def! {
-    #[derive(Serialize)]
-    pub CoroutineWitnessDef;
 }
 
 /// A list of generic arguments.

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -184,10 +184,6 @@ impl RustcInternal for RigidTy {
                 def.0.internal(tables, tcx),
                 args.internal(tables, tcx),
             ),
-            RigidTy::CoroutineWitness(def, args) => rustc_ty::TyKind::CoroutineWitness(
-                def.0.internal(tables, tcx),
-                args.internal(tables, tcx),
-            ),
             RigidTy::Dynamic(predicate, region, dyn_kind) => rustc_ty::TyKind::Dynamic(
                 tcx.mk_poly_existential_predicates(&predicate.internal(tables, tcx)),
                 region.internal(tables, tcx),

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -470,10 +470,6 @@ impl<'tcx> Stable<'tcx> for ty::TyKind<'tcx> {
             ty::Bound(debruijn_idx, bound_ty) => {
                 TyKind::Bound(debruijn_idx.as_usize(), bound_ty.stable(tables, cx))
             }
-            ty::CoroutineWitness(def_id, args) => TyKind::RigidTy(RigidTy::CoroutineWitness(
-                tables.coroutine_witness_def(*def_id),
-                args.stable(tables, cx),
-            )),
             ty::Placeholder(..) | ty::Infer(_) | ty::Error(_) => {
                 unreachable!();
             }

--- a/compiler/rustc_public/src/visitor.rs
+++ b/compiler/rustc_public/src/visitor.rs
@@ -167,7 +167,6 @@ impl Visitable for RigidTy {
             RigidTy::Adt(_, args)
             | RigidTy::Closure(_, args)
             | RigidTy::Coroutine(_, args, _)
-            | RigidTy::CoroutineWitness(_, args)
             | RigidTy::CoroutineClosure(_, args)
             | RigidTy::FnDef(_, args) => args.visit(visitor),
             RigidTy::FnPtr(sig) => sig.visit(visitor),

--- a/compiler/rustc_public_bridge/src/bridge.rs
+++ b/compiler/rustc_public_bridge/src/bridge.rs
@@ -53,7 +53,6 @@ make_bridge_trait!(GenericDef);
 make_bridge_trait!(ConstDef);
 make_bridge_trait!(ImplDef);
 make_bridge_trait!(RegionDef);
-make_bridge_trait!(CoroutineWitnessDef);
 make_bridge_trait!(AssocDef);
 make_bridge_trait!(OpaqueDef);
 make_bridge_trait!(StaticDef);

--- a/compiler/rustc_public_bridge/src/lib.rs
+++ b/compiler/rustc_public_bridge/src/lib.rs
@@ -186,13 +186,6 @@ impl<'tcx, B: Bridge> Tables<'tcx, B> {
         B::RegionDef::new(self.create_def_id(did))
     }
 
-    pub fn coroutine_witness_def(
-        &mut self,
-        did: rustc_span::def_id::DefId,
-    ) -> B::CoroutineWitnessDef {
-        B::CoroutineWitnessDef::new(self.create_def_id(did))
-    }
-
     pub fn assoc_def(&mut self, did: rustc_span::def_id::DefId) -> B::AssocDef {
         B::AssocDef::new(self.create_def_id(did))
     }
@@ -239,7 +232,6 @@ pub trait Bridge: Sized {
     type ConstDef: ConstDef<Self>;
     type ImplDef: ImplDef<Self>;
     type RegionDef: RegionDef<Self>;
-    type CoroutineWitnessDef: CoroutineWitnessDef<Self>;
     type AssocDef: AssocDef<Self>;
     type OpaqueDef: OpaqueDef<Self>;
     type Prov: Prov<Self>;

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
@@ -648,12 +648,7 @@ pub(crate) fn encode_ty<'tcx>(
         }
 
         // Unexpected types
-        ty::Alias(..)
-        | ty::Bound(..)
-        | ty::Error(..)
-        | ty::CoroutineWitness(..)
-        | ty::Infer(..)
-        | ty::Placeholder(..) => {
+        ty::Alias(..) | ty::Bound(..) | ty::Error(..) | ty::Infer(..) | ty::Placeholder(..) => {
             bug!("encode_ty: unexpected `{:?}`", ty.kind());
         }
     };

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -53,7 +53,6 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for TransformTy<'tcx> {
             ty::Closure(..)
             | ty::Coroutine(..)
             | ty::CoroutineClosure(..)
-            | ty::CoroutineWitness(..)
             | ty::Dynamic(..)
             | ty::Float(..)
             | ty::FnDef(..)

--- a/compiler/rustc_symbol_mangling/src/export.rs
+++ b/compiler/rustc_symbol_mangling/src/export.rs
@@ -121,7 +121,6 @@ impl<'tcx> AbiHashStable<'tcx> for Ty<'tcx> {
             | ty::Closure(_, _)
             | ty::CoroutineClosure(_, _)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(_, _)
             | ty::Never
             | ty::Tuple(_)
             | ty::Alias(_, _)

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -582,7 +582,6 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
             }
 
             ty::Alias(..) => bug!("symbol_names: unexpected alias"),
-            ty::CoroutineWitness(..) => bug!("symbol_names: unexpected `CoroutineWitness`"),
         }
 
         // Only cache types that do not refer to an enclosing

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1678,10 +1678,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 ty::Adt(..) => Some(17),
                 ty::Coroutine(..) => Some(18),
                 ty::Foreign(..) => Some(19),
-                ty::CoroutineWitness(..) => Some(20),
-                ty::CoroutineClosure(..) => Some(21),
-                ty::Pat(..) => Some(22),
-                ty::UnsafeBinder(..) => Some(23),
+                ty::CoroutineClosure(..) => Some(20),
+                ty::Pat(..) => Some(21),
+                ty::UnsafeBinder(..) => Some(22),
                 ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) | ty::Error(_) => None,
             }
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2332,7 +2332,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
 
                     match *ty.kind() {
-                        ty::Coroutine(did, ..) | ty::CoroutineWitness(did, _) => {
+                        ty::Coroutine(did, ..) => {
                             coroutine = coroutine.or(Some(did));
                             outer_coroutine = Some(did);
                         }
@@ -2361,7 +2361,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
 
                     match *ty.kind() {
-                        ty::Coroutine(did, ..) | ty::CoroutineWitness(did, ..) => {
+                        ty::Coroutine(did, ..) => {
                             coroutine = coroutine.or(Some(did));
                             outer_coroutine = Some(did);
                         }
@@ -3377,10 +3377,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                     "required because it's used within this {kind:#}",
                                 )),
                             );
-                        }
-                        ty::CoroutineWitness(..) => {
-                            // Skip printing coroutine-witnesses, since we'll drill into
-                            // the bad field in another derived obligation cause.
                         }
                         ty::Closure(def_id, _) | ty::CoroutineClosure(def_id, _) => {
                             err.span_note(

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -330,7 +330,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for StalledOnCoroutines<'tcx> {
             return ControlFlow::Continue(());
         }
 
-        if let ty::CoroutineWitness(def_id, _) = *ty.kind()
+        if let ty::Coroutine(def_id, _) = *ty.kind()
             && def_id.as_local().is_some_and(|def_id| self.stalled_coroutines.contains(&def_id))
         {
             ControlFlow::Break(())

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -371,10 +371,9 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
 
         // Coroutines and closures could implement `[const] Drop`,
         // but they don't really need to right now.
-        ty::Closure(_, _)
-        | ty::CoroutineClosure(_, _)
-        | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _) => return Err(EvaluationFailure::NoSolution),
+        ty::Closure(_, _) | ty::CoroutineClosure(_, _) | ty::Coroutine(_, _) => {
+            return Err(EvaluationFailure::NoSolution);
+        }
 
         // FIXME(unsafe_binders): Unsafe binders could implement `[const] Drop`
         // if their inner type implements it.

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1036,7 +1036,6 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::Closure(..)
                         | ty::CoroutineClosure(..)
                         | ty::Coroutine(..)
-                        | ty::CoroutineWitness(..)
                         | ty::Never
                         | ty::Tuple(..)
                         // Integers and floats always have `u8` as their discriminant.
@@ -1090,7 +1089,6 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                             | ty::Closure(..)
                             | ty::CoroutineClosure(..)
                             | ty::Coroutine(..)
-                            | ty::CoroutineWitness(..)
                             | ty::Never
                             // Extern types have unit metadata, according to RFC 2850
                             | ty::Foreign(_)

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -38,7 +38,6 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::FnDef(..)
         | ty::FnPtr(..)
         | ty::Char
-        | ty::CoroutineWitness(..)
         | ty::RawPtr(_, _)
         | ty::Ref(..)
         | ty::Str
@@ -279,8 +278,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
         | ty::RawPtr(..)
         | ty::Ref(..)
         | ty::FnDef(..)
-        | ty::FnPtr(..)
-        | ty::CoroutineWitness(..) => {
+        | ty::FnPtr(..) => {
             // these types never have a destructor
         }
 

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -318,7 +318,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
             })
         }
 
-        ty::Coroutine(_, args) => {
+        ty::Coroutine(def_id, args) => {
             // rust-lang/rust#49918: types can be constructed, stored
             // in the interior, and sit idle when coroutine yields
             // (and is subsequently dropped).
@@ -346,7 +346,9 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
             // While we conservatively assume that all coroutines require drop
             // to avoid query cycles during MIR building, we can check the actual
             // witness during borrowck to avoid unnecessary liveness constraints.
-            if args.witness().needs_drop(tcx, tcx.erase_regions(typing_env)) {
+            if tcx.mir_coroutine_witnesses(def_id).is_some_and(|witness| {
+                witness.field_tys.iter().any(|field| field.ty.needs_drop(tcx, typing_env))
+            }) {
                 constraints.outlives.extend(args.upvar_tys().iter().map(ty::GenericArg::from));
                 constraints.outlives.push(args.resume_ty().into());
             }

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -794,18 +794,25 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     // The auto impl might apply; we don't know.
                     candidates.ambiguous = true;
                 }
-                ty::Coroutine(coroutine_def_id, _)
-                    if self.tcx().is_lang_item(def_id, LangItem::Unpin) =>
-                {
-                    match self.tcx().coroutine_movability(coroutine_def_id) {
-                        hir::Movability::Static => {
-                            // Immovable coroutines are never `Unpin`, so
-                            // suppress the normal auto-impl candidate for it.
+                ty::Coroutine(coroutine_def_id, _) => {
+                    if self.tcx().is_lang_item(def_id, LangItem::Unpin) {
+                        match self.tcx().coroutine_movability(coroutine_def_id) {
+                            hir::Movability::Static => {
+                                // Immovable coroutines are never `Unpin`, so
+                                // suppress the normal auto-impl candidate for it.
+                            }
+                            hir::Movability::Movable => {
+                                // Movable coroutines are always `Unpin`, so add an
+                                // unconditional builtin candidate with no sub-obligations.
+                                candidates.vec.push(BuiltinCandidate);
+                            }
                         }
-                        hir::Movability::Movable => {
-                            // Movable coroutines are always `Unpin`, so add an
-                            // unconditional builtin candidate.
-                            candidates.vec.push(BuiltinCandidate);
+                    } else {
+                        if self.should_stall_coroutine(coroutine_def_id) {
+                            candidates.ambiguous = true;
+                        } else {
+                            // Coroutines implement all other auto traits normally.
+                            candidates.vec.push(AutoImplCandidate);
                         }
                     }
                 }
@@ -842,12 +849,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
                 }
 
-                ty::CoroutineWitness(def_id, _) => {
-                    if self.should_stall_coroutine_witness(def_id) {
-                        candidates.ambiguous = true;
-                    } else {
-                        candidates.vec.push(AutoImplCandidate);
-                    }
+                ty::CoroutineWitness(..) => {
+                    candidates.vec.push(AutoImplCandidate);
                 }
 
                 ty::Bool
@@ -866,7 +869,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 | ty::FnPtr(..)
                 | ty::Closure(..)
                 | ty::CoroutineClosure(..)
-                | ty::Coroutine(..)
                 | ty::Never
                 | ty::Tuple(_)
                 | ty::UnsafeBinder(_) => {
@@ -1153,6 +1155,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Ref(_, _, hir::Mutability::Mut) => {}
 
             ty::Coroutine(coroutine_def_id, args) => {
+                if self.should_stall_coroutine(coroutine_def_id) {
+                    candidates.ambiguous = true;
+                    return;
+                }
+
                 match self.tcx().coroutine_movability(coroutine_def_id) {
                     hir::Movability::Static => {}
                     hir::Movability::Movable => {
@@ -1194,12 +1201,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
             }
 
-            ty::CoroutineWitness(coroutine_def_id, _) => {
-                if self.should_stall_coroutine_witness(coroutine_def_id) {
-                    candidates.ambiguous = true;
-                } else {
-                    candidates.vec.push(SizedCandidate);
-                }
+            ty::CoroutineWitness(..) => {
+                candidates.vec.push(SizedCandidate);
             }
 
             // Fallback to whatever user-defined impls or param-env clauses exist in this case.
@@ -1238,7 +1241,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::RawPtr(..)
             | ty::Char
             | ty::Ref(..)
-            | ty::Coroutine(..)
             | ty::Array(..)
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
@@ -1247,12 +1249,16 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 candidates.vec.push(SizedCandidate);
             }
 
-            ty::CoroutineWitness(coroutine_def_id, _) => {
-                if self.should_stall_coroutine_witness(coroutine_def_id) {
+            ty::Coroutine(coroutine_def_id, _) => {
+                if self.should_stall_coroutine(coroutine_def_id) {
                     candidates.ambiguous = true;
                 } else {
                     candidates.vec.push(SizedCandidate);
                 }
+            }
+
+            ty::CoroutineWitness(..) => {
+                candidates.vec.push(SizedCandidate);
             }
 
             // Conditionally `Sized`.

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -693,7 +693,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 | ty::Closure(..)
                 | ty::CoroutineClosure(..)
                 | ty::Coroutine(_, _)
-                | ty::CoroutineWitness(..)
                 | ty::UnsafeBinder(_)
                 | ty::Never
                 | ty::Tuple(_)
@@ -847,10 +846,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     } else {
                         candidates.vec.push(AutoImplCandidate)
                     }
-                }
-
-                ty::CoroutineWitness(..) => {
-                    candidates.vec.push(AutoImplCandidate);
                 }
 
                 ty::Bool
@@ -1166,9 +1161,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         if self.tcx().features().coroutine_clone() {
                             let resolved_upvars =
                                 self.infcx.shallow_resolve(args.as_coroutine().tupled_upvars_ty());
-                            let resolved_witness =
-                                self.infcx.shallow_resolve(args.as_coroutine().witness());
-                            if resolved_upvars.is_ty_var() || resolved_witness.is_ty_var() {
+                            if resolved_upvars.is_ty_var() {
                                 // Not yet resolved.
                                 candidates.ambiguous = true;
                             } else {
@@ -1199,10 +1192,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 } else {
                     candidates.vec.push(BuiltinCandidate);
                 }
-            }
-
-            ty::CoroutineWitness(..) => {
-                candidates.vec.push(SizedCandidate);
             }
 
             // Fallback to whatever user-defined impls or param-env clauses exist in this case.
@@ -1255,10 +1244,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 } else {
                     candidates.vec.push(SizedCandidate);
                 }
-            }
-
-            ty::CoroutineWitness(..) => {
-                candidates.vec.push(SizedCandidate);
             }
 
             // Conditionally `Sized`.
@@ -1333,7 +1318,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Alias(..)
             | ty::Param(_)
@@ -1372,7 +1356,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::UnsafeBinder(_)
             | ty::Never
             | ty::Tuple(..)
@@ -1425,7 +1408,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
             | ty::UnsafeBinder(_)
-            | ty::CoroutineWitness(..)
             | ty::Bound(..) => {
                 candidates.vec.push(BikeshedGuaranteedNoDropCandidate);
             }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1307,7 +1307,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
             | ty::UnsafeBinder(_)
-            | ty::CoroutineWitness(..)
             | ty::Bound(..) => {
                 obligations.push(obligation.with(
                     tcx,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2844,7 +2844,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         obligations
     }
 
-    fn should_stall_coroutine_witness(&self, def_id: DefId) -> bool {
+    fn should_stall_coroutine(&self, def_id: DefId) -> bool {
         match self.infcx.typing_mode() {
             TypingMode::Analysis { defining_opaque_types_and_generators: stalled_generators } => {
                 def_id.as_local().is_some_and(|def_id| stalled_generators.contains(&def_id))

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -728,7 +728,6 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
             | ty::Float(..)
             | ty::Error(_)
             | ty::Str
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Param(_)
             | ty::Bound(..)

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -264,7 +264,6 @@ fn resolve_associated_item<'tcx>(
                     match self_ty.kind() {
                         ty::FnDef(..) | ty::FnPtr(..) => (),
                         ty::Coroutine(..)
-                        | ty::CoroutineWitness(..)
                         | ty::Closure(..)
                         | ty::CoroutineClosure(..)
                         | ty::Tuple(..) => {}

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -707,7 +707,7 @@ fn layout_of_uncached<'tcx>(
             return Err(error(cx, err));
         }
 
-        ty::Bound(..) | ty::CoroutineWitness(..) | ty::Infer(_) | ty::Error(_) => {
+        ty::Bound(..) | ty::Infer(_) | ty::Error(_) => {
             // `ty::Error` is handled at the top of this function.
             bug!("layout_of: unexpected type `{ty}`")
         }

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -112,6 +112,12 @@ struct NeedsDropTypes<'tcx, F> {
     adt_components: F,
     /// Set this to true if an exhaustive list of types involved in
     /// drop obligation is requested.
+    // FIXME: `exhaustive` is misleading here, since it both changes the behavior
+    // of how the coroutine's drop is computed, but ALSO changes the way that the
+    // iterator iterates over types that are unconditionally dropped. This should
+    // probably be replaced with a proper enum, or "get all types that may affect
+    // whether a type is drop for the purpose of diagnostics" should be split out
+    // into a totally different helper.
     exhaustive: bool,
 }
 
@@ -209,10 +215,6 @@ where
                             return Some(self.always_drop_component(ty));
                         }
                     }
-                    ty::CoroutineWitness(..) => {
-                        unreachable!("witness should be handled in parent");
-                    }
-
                     ty::UnsafeBinder(bound_ty) => {
                         let ty = self.tcx.instantiate_bound_regions_with_erased(bound_ty.into());
                         queue_type(self, ty);

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -101,9 +101,6 @@ fn has_significant_drop_raw<'tcx>(
 struct NeedsDropTypes<'tcx, F> {
     tcx: TyCtxt<'tcx>,
     typing_env: ty::TypingEnv<'tcx>,
-    /// Whether to reveal coroutine witnesses, this is set
-    /// to `false` unless we compute `needs_drop` for a coroutine witness.
-    reveal_coroutine_witnesses: bool,
     query_ty: Ty<'tcx>,
     seen_tys: FxHashSet<Ty<'tcx>>,
     /// A stack of types left to process, and the recursion depth when we
@@ -131,7 +128,6 @@ impl<'tcx, F> NeedsDropTypes<'tcx, F> {
         Self {
             tcx,
             typing_env,
-            reveal_coroutine_witnesses: exhaustive,
             seen_tys,
             query_ty: ty,
             unchecked_tys: vec![(ty, 0)],
@@ -195,23 +191,26 @@ where
                     // for the coroutine witness and check whether any of the contained types
                     // need to be dropped, and only require the captured types to be live
                     // if they do.
-                    ty::Coroutine(_, args) => {
-                        if self.reveal_coroutine_witnesses {
-                            queue_type(self, args.as_coroutine().witness());
+                    ty::Coroutine(def_id, args) => {
+                        if self.exhaustive {
+                            for upvar in args.as_coroutine().upvar_tys() {
+                                queue_type(self, upvar);
+                            }
+                            queue_type(self, args.as_coroutine().resume_ty());
+                            if let Some(witness) = tcx.mir_coroutine_witnesses(def_id) {
+                                for field_ty in &witness.field_tys {
+                                    queue_type(
+                                        self,
+                                        EarlyBinder::bind(field_ty.ty).instantiate(tcx, args),
+                                    );
+                                }
+                            }
                         } else {
                             return Some(self.always_drop_component(ty));
                         }
                     }
-                    ty::CoroutineWitness(def_id, args) => {
-                        if let Some(witness) = tcx.mir_coroutine_witnesses(def_id) {
-                            self.reveal_coroutine_witnesses = true;
-                            for field_ty in &witness.field_tys {
-                                queue_type(
-                                    self,
-                                    EarlyBinder::bind(field_ty.ty).instantiate(tcx, args),
-                                );
-                            }
-                        }
+                    ty::CoroutineWitness(..) => {
+                        unreachable!("witness should be handled in parent");
                     }
 
                     ty::UnsafeBinder(bound_ty) => {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -37,7 +37,6 @@ fn sizedness_constraint_for_ty<'tcx>(
         | ty::Closure(..)
         | ty::CoroutineClosure(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..)
         | ty::Never => None,
 
         ty::Str | ty::Slice(..) | ty::Dynamic(_, _, ty::Dyn) => match sizedness {
@@ -374,7 +373,6 @@ fn impl_self_is_guaranteed_unsized<'tcx>(tcx: TyCtxt<'tcx>, impl_def_id: DefId) 
         | ty::Closure(_, _)
         | ty::CoroutineClosure(_, _)
         | ty::Coroutine(_, _)
-        | ty::CoroutineWitness(_, _)
         | ty::Never
         | ty::Tuple(_)
         | ty::Alias(_, _)

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -42,7 +42,6 @@ pub enum SimplifiedType<DefId> {
     Trait(DefId),
     Closure(DefId),
     Coroutine(DefId),
-    CoroutineWitness(DefId),
     Function(usize),
     UnsafeBinder,
     Placeholder,
@@ -139,7 +138,6 @@ pub fn simplify_type<I: Interner>(
             Some(SimplifiedType::Closure(def_id))
         }
         ty::Coroutine(def_id, _) => Some(SimplifiedType::Coroutine(def_id)),
-        ty::CoroutineWitness(def_id, _) => Some(SimplifiedType::CoroutineWitness(def_id)),
         ty::Never => Some(SimplifiedType::Never),
         ty::Tuple(tys) => Some(SimplifiedType::Tuple(tys.len())),
         ty::FnPtr(sig_tys, _hdr) => {
@@ -174,8 +172,7 @@ impl<DefId> SimplifiedType<DefId> {
             | SimplifiedType::Foreign(d)
             | SimplifiedType::Trait(d)
             | SimplifiedType::Closure(d)
-            | SimplifiedType::Coroutine(d)
-            | SimplifiedType::CoroutineWitness(d) => Some(d),
+            | SimplifiedType::Coroutine(d) => Some(d),
             _ => None,
         }
     }
@@ -306,7 +303,6 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Foreign(_)
             | ty::Placeholder(_)
             | ty::UnsafeBinder(_) => {}
@@ -449,13 +445,6 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
 
             ty::Coroutine(lhs_def_id, lhs_args) => match rhs.kind() {
                 ty::Coroutine(rhs_def_id, rhs_args) => {
-                    lhs_def_id == rhs_def_id && self.args_may_unify_inner(lhs_args, rhs_args, depth)
-                }
-                _ => false,
-            },
-
-            ty::CoroutineWitness(lhs_def_id, lhs_args) => match rhs.kind() {
-                ty::CoroutineWitness(rhs_def_id, rhs_args) => {
                     lhs_def_id == rhs_def_id && self.args_may_unify_inner(lhs_args, rhs_args, depth)
                 }
                 _ => false,

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -131,10 +131,7 @@ bitflags::bitflags! {
         /// Does this have any binders with bound vars (e.g. that need to be anonymized)?
         const HAS_BINDER_VARS             = 1 << 23;
 
-        /// Does this type have any coroutine witnesses in it?
-        // FIXME: This should probably be changed to track whether the type has any
-        // *coroutines* in it, though this will happen if we remove coroutine witnesses
-        // altogether.
+        /// Does this type have any coroutines in it?
         const HAS_TY_CORO                 = 1 << 24;
     }
 }
@@ -246,11 +243,13 @@ impl<I: Interner> FlagComputation<I> {
                 self.add_flags(TypeFlags::HAS_TY_PARAM);
             }
 
-            ty::Closure(_, args) | ty::Coroutine(_, args) | ty::CoroutineClosure(_, args) => {
+            ty::Closure(_, args)
+            | ty::CoroutineClosure(_, args)
+            | ty::CoroutineWitness(_, args) => {
                 self.add_args(args.as_slice());
             }
 
-            ty::CoroutineWitness(_, args) => {
+            ty::Coroutine(_, args) => {
                 self.add_flags(TypeFlags::HAS_TY_CORO);
                 self.add_args(args.as_slice());
             }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -243,9 +243,7 @@ impl<I: Interner> FlagComputation<I> {
                 self.add_flags(TypeFlags::HAS_TY_PARAM);
             }
 
-            ty::Closure(_, args)
-            | ty::CoroutineClosure(_, args)
-            | ty::CoroutineWitness(_, args) => {
+            ty::Closure(_, args) | ty::CoroutineClosure(_, args) => {
                 self.add_args(args.as_slice());
             }
 

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -89,8 +89,6 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_closure(interner: I, def_id: I::DefId, args: I::GenericArgs) -> Self;
 
-    fn new_coroutine_witness(interner: I, def_id: I::DefId, args: I::GenericArgs) -> Self;
-
     fn new_ptr(interner: I, ty: Self, mutbl: Mutability) -> Self;
 
     fn new_ref(interner: I, region: I::Region, ty: Self, mutbl: Mutability) -> Self;
@@ -175,7 +173,6 @@ pub trait Ty<I: Interner<Ty = Self>>:
             | ty::Closure(_, _)
             | ty::CoroutineClosure(_, _)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(_, _)
             | ty::Never
             | ty::Tuple(_)
             | ty::Alias(_, _)

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -126,10 +126,6 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
                 // want these to affect region inference
             }
 
-            // All regions are bound inside a witness, and we don't emit
-            // higher-ranked outlives components currently.
-            ty::CoroutineWitness(..) => {}
-
             // OutlivesTypeParameterEnv -- the actual checking that `X:'a`
             // is implied by the environment is done in regionck.
             ty::Param(p) => {

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -425,16 +425,6 @@ pub fn structurally_relate_tys<I: Interner, R: TypeRelation<I>>(
             Ok(Ty::new_coroutine(cx, a_id, args))
         }
 
-        (ty::CoroutineWitness(a_id, a_args), ty::CoroutineWitness(b_id, b_args))
-            if a_id == b_id =>
-        {
-            // All CoroutineWitness types with the same id represent
-            // the (anonymous) type of the same coroutine expression. So
-            // all of their regions should be equated.
-            let args = relate_args_invariantly(relation, a_args, b_args)?;
-            Ok(Ty::new_coroutine_witness(cx, a_id, args))
-        }
-
         (ty::Closure(a_id, a_args), ty::Closure(b_id, b_args)) if a_id == b_id => {
             // All Closure types with the same id represent
             // the (anonymous) type of the same closure expression. So

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -188,31 +188,6 @@ pub enum TyKind<I: Interner> {
     /// `CoroutineArgs`.
     Coroutine(I::DefId, I::GenericArgs),
 
-    /// A type representing the types stored inside a coroutine.
-    /// This should only appear as part of the `CoroutineArgs`.
-    ///
-    /// Unlike upvars, the witness can reference lifetimes from
-    /// inside of the coroutine itself. To deal with them in
-    /// the type of the coroutine, we convert them to higher ranked
-    /// lifetimes bound by the witness itself.
-    ///
-    /// This contains the `DefId` and the `GenericArgsRef` of the coroutine.
-    /// The actual witness types are computed on MIR by the `mir_coroutine_witnesses` query.
-    ///
-    /// Looking at the following example, the witness for this coroutine
-    /// may end up as something like `for<'a> [Vec<i32>, &'a Vec<i32>]`:
-    ///
-    /// ```
-    /// #![feature(coroutines)]
-    /// #[coroutine] static |a| {
-    ///     let x = &vec![3];
-    ///     yield a;
-    ///     yield x[0];
-    /// }
-    /// # ;
-    /// ```
-    CoroutineWitness(I::DefId, I::GenericArgs),
-
     /// The never type `!`.
     Never,
 
@@ -316,7 +291,6 @@ impl<I: Interner> TyKind<I> {
             | ty::Closure(_, _)
             | ty::CoroutineClosure(_, _)
             | ty::Coroutine(_, _)
-            | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_) => true,
 
@@ -371,7 +345,6 @@ impl<I: Interner> fmt::Debug for TyKind<I> {
             Closure(d, s) => f.debug_tuple("Closure").field(d).field(&s).finish(),
             CoroutineClosure(d, s) => f.debug_tuple("CoroutineClosure").field(d).field(&s).finish(),
             Coroutine(d, s) => f.debug_tuple("Coroutine").field(d).field(&s).finish(),
-            CoroutineWitness(d, s) => f.debug_tuple("CoroutineWitness").field(d).field(&s).finish(),
             Never => write!(f, "!"),
             Tuple(t) => {
                 write!(f, "(")?;

--- a/compiler/rustc_type_ir/src/ty_kind/closure.rs
+++ b/compiler/rustc_type_ir/src/ty_kind/closure.rs
@@ -101,7 +101,6 @@ use crate::{self as ty, Interner};
 ///   `yield` inside the coroutine.
 /// * `GR`: The "return type", which is the type of value returned upon
 ///   completion of the coroutine.
-/// * `GW`: The "coroutine witness".
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
 pub struct ClosureArgs<I: Interner> {
@@ -239,8 +238,6 @@ pub struct CoroutineClosureArgsParts<I: Interner> {
     /// while the `tupled_upvars_ty`, representing the by-move version of the same
     /// captures, will be `(String,)`.
     pub coroutine_captures_by_ref_ty: I::Ty,
-    /// Witness type returned by the generator produced by this coroutine-closure.
-    pub coroutine_witness_ty: I::Ty,
 }
 
 impl<I: Interner> CoroutineClosureArgs<I> {
@@ -251,7 +248,6 @@ impl<I: Interner> CoroutineClosureArgs<I> {
                 parts.signature_parts_ty.into(),
                 parts.tupled_upvars_ty.into(),
                 parts.coroutine_captures_by_ref_ty.into(),
-                parts.coroutine_witness_ty.into(),
             ])),
         }
     }
@@ -292,7 +288,6 @@ impl<I: Interner> CoroutineClosureArgs<I> {
     }
 
     pub fn coroutine_closure_sig(self) -> ty::Binder<I, CoroutineClosureSignature<I>> {
-        let interior = self.coroutine_witness_ty();
         let ty::FnPtr(sig_tys, hdr) = self.signature_parts_ty().kind() else { panic!() };
         sig_tys.map_bound(|sig_tys| {
             let [resume_ty, tupled_inputs_ty] = *sig_tys.inputs().as_slice() else {
@@ -302,7 +297,6 @@ impl<I: Interner> CoroutineClosureArgs<I> {
                 panic!()
             };
             CoroutineClosureSignature {
-                interior,
                 tupled_inputs_ty,
                 resume_ty,
                 yield_ty,
@@ -316,10 +310,6 @@ impl<I: Interner> CoroutineClosureArgs<I> {
 
     pub fn coroutine_captures_by_ref_ty(self) -> I::Ty {
         self.split().coroutine_captures_by_ref_ty
-    }
-
-    pub fn coroutine_witness_ty(self) -> I::Ty {
-        self.split().coroutine_witness_ty
     }
 
     pub fn has_self_borrows(&self) -> bool {
@@ -361,7 +351,6 @@ impl<I: Interner> TypeVisitor<I> for HasRegionsBoundAt {
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
 pub struct CoroutineClosureSignature<I: Interner> {
-    pub interior: I::Ty,
     pub tupled_inputs_ty: I::Ty,
     pub resume_ty: I::Ty,
     pub yield_ty: I::Ty,
@@ -407,7 +396,6 @@ impl<I: Interner> CoroutineClosureSignature<I> {
                 resume_ty: self.resume_ty,
                 yield_ty: self.yield_ty,
                 return_ty: self.return_ty,
-                witness: self.interior,
                 tupled_upvars_ty,
             },
         );
@@ -587,11 +575,6 @@ pub struct CoroutineArgsParts<I: Interner> {
     pub yield_ty: I::Ty,
     pub return_ty: I::Ty,
 
-    /// The interior type of the coroutine.
-    /// Represents all types that are stored in locals
-    /// in the coroutine's body.
-    pub witness: I::Ty,
-
     /// The upvars captured by the closure. Remains an inference variable
     /// until the upvar analysis, which happens late in HIR typeck.
     pub tupled_upvars_ty: I::Ty,
@@ -607,7 +590,6 @@ impl<I: Interner> CoroutineArgs<I> {
                 parts.resume_ty.into(),
                 parts.yield_ty.into(),
                 parts.return_ty.into(),
-                parts.witness.into(),
                 parts.tupled_upvars_ty.into(),
             ])),
         }
@@ -627,15 +609,6 @@ impl<I: Interner> CoroutineArgs<I> {
     // Returns the kind of the coroutine. See docs on the `kind_ty` field.
     pub fn kind_ty(self) -> I::Ty {
         self.split().kind_ty
-    }
-
-    /// This describes the types that can be contained in a coroutine.
-    /// It will be a type variable initially and unified in the last stages of typeck of a body.
-    /// It contains a tuple of all the types that could end up on a coroutine frame.
-    /// The state transformation MIR pass may only produce layouts which mention types
-    /// in this tuple. Upvars are not counted here.
-    pub fn witness(self) -> I::Ty {
-        self.split().witness
     }
 
     /// Returns an iterator over the list of types of captured paths by the coroutine.

--- a/compiler/rustc_type_ir/src/walk.rs
+++ b/compiler/rustc_type_ir/src/walk.rs
@@ -135,7 +135,6 @@ fn push_inner<I: Interner>(stack: &mut TypeWalkerStack<I>, parent: I::GenericArg
             | ty::Closure(_, args)
             | ty::CoroutineClosure(_, args)
             | ty::Coroutine(_, args)
-            | ty::CoroutineWitness(_, args)
             | ty::FnDef(_, args) => {
                 stack.extend(args.iter().rev());
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2259,7 +2259,6 @@ pub(crate) fn clean_middle_ty<'tcx>(
         ty::CoroutineClosure(..) => panic!("CoroutineClosure"),
         ty::Coroutine(..) => panic!("Coroutine"),
         ty::Placeholder(..) => panic!("Placeholder"),
-        ty::CoroutineWitness(..) => panic!("CoroutineWitness"),
         ty::Infer(..) => panic!("Infer"),
 
         ty::Error(_) => FatalError.raise(),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -567,7 +567,6 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
             | ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Dynamic(..)
             | ty::UnsafeBinder(_)
             | ty::Param(_)

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -888,7 +888,6 @@ impl TyCoercionStability {
                 | ty::Foreign(_)
                 | ty::FnDef(..)
                 | ty::Coroutine(..)
-                | ty::CoroutineWitness(..)
                 | ty::Closure(..)
                 | ty::CoroutineClosure(..)
                 | ty::Never

--- a/tests/debuginfo/function-names.rs
+++ b/tests/debuginfo/function-names.rs
@@ -37,7 +37,7 @@
 // Const generic parameter
 // gdb-command:info functions -q function_names::const_generic_fn.*
 // gdb-check:[...]static fn function_names::const_generic_fn_bool<false>();
-// gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#ffa3db4ca1d52dce}>();
+// gdb-check:[...]static fn function_names::const_generic_fn_non_int<{CONST#a70c39591cb5f53d}>();
 // gdb-check:[...]static fn function_names::const_generic_fn_signed_int<-7>();
 // gdb-check:[...]static fn function_names::const_generic_fn_unsigned_int<14>();
 

--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -9,10 +9,6 @@
                     std::future::ResumeTy,
                     (),
                     (),
-                    CoroutineWitness(
-                        DefId(0:5 ~ async_await[ccf8]::a::{closure#0}),
-                        [],
-                    ),
                     (),
                 ],
             ),
@@ -30,10 +26,6 @@
                     std::future::ResumeTy,
                     (),
                     (),
-                    CoroutineWitness(
-                        DefId(0:5 ~ async_await[ccf8]::a::{closure#0}),
-                        [],
-                    ),
                     (),
                 ],
             ),

--- a/tests/ui/async-await/async-closures/def-path.stderr
+++ b/tests/ui/async-await/async-closures/def-path.stderr
@@ -5,11 +5,11 @@ LL |     let x = async || {};
    |                      -- the expected `async` closure body
 LL |
 LL |     let () = x();
-   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure#0}::{closure#0}}}`
+   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=ResumeTy yield_ty=() return_ty=()}`
    |         |
    |         expected `async` closure body, found `()`
    |
-   = note: expected `async` closure body `{static main::{closure#0}::{closure#0}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure#0}::{closure#0}}}`
+   = note: expected `async` closure body `{static main::{closure#0}::{closure#0}<?15t> upvar_tys=?14t resume_ty=ResumeTy yield_ty=() return_ty=()}`
                          found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/async-await/higher-ranked-auto-trait-6.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-6.no_assumptions.stderr
@@ -21,30 +21,6 @@ LL |     Box::new(async { new(|| async { f().await }).await })
    = help: consider pinning your async block and casting it to a trait object
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-auto-trait-6.rs:16:5
-   |
-LL |     Box::new(async { new(|| async { f().await }).await })
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-              found `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-   = note: no two async blocks, even if identical, have the same type
-   = help: consider pinning your async block and casting it to a trait object
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0308]: mismatched types
-  --> $DIR/higher-ranked-auto-trait-6.rs:16:5
-   |
-LL |     Box::new(async { new(|| async { f().await }).await })
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-              found `async` block `{async block@$DIR/higher-ranked-auto-trait-6.rs:16:29: 16:34}`
-   = note: no two async blocks, even if identical, have the same type
-   = help: consider pinning your async block and casting it to a trait object
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/issue-70818.rs
+++ b/tests/ui/async-await/issue-70818.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
     //~^ ERROR future cannot be sent between threads safely
     async { (ty, ty1) }
+    //~^ ERROR future cannot be sent between threads safely
 }
 
 fn main() {}

--- a/tests/ui/async-await/issue-70818.stderr
+++ b/tests/ui/async-await/issue-70818.stderr
@@ -1,4 +1,25 @@
 error: future cannot be sent between threads safely
+  --> $DIR/issue-70818.rs:6:5
+   |
+LL |     async { (ty, ty1) }
+   |     ^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+   |
+note: captured value is not `Send`
+  --> $DIR/issue-70818.rs:6:18
+   |
+LL |     async { (ty, ty1) }
+   |                  ^^^ has type `U` which is not `Send`
+note: required by a bound in an opaque type
+  --> $DIR/issue-70818.rs:4:69
+   |
+LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                                                                     ^^^^
+help: consider restricting type parameter `U` with trait `Send`
+   |
+LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                  +++++++++++++++++++
+
+error: future cannot be sent between threads safely
   --> $DIR/issue-70818.rs:4:38
    |
 LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
@@ -14,5 +35,5 @@ help: consider restricting type parameter `U` with trait `Send`
 LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                  +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -13,7 +13,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
    |
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
-   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
 help: consider further restricting type parameter `T` with trait `Sync`
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)

--- a/tests/ui/async-await/partial-drop-partial-reinit.rs
+++ b/tests/ui/async-await/partial-drop-partial-reinit.rs
@@ -7,7 +7,6 @@ fn main() {
     //~^ ERROR cannot be sent between threads safely
     //~| NOTE cannot be sent
     //~| NOTE bound introduced by
-    //~| NOTE appears within the type
 }
 
 fn gimme_send<T: Send>(t: T) {

--- a/tests/ui/async-await/partial-drop-partial-reinit.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.stderr
@@ -10,9 +10,8 @@ LL | async fn foo() {
    | -------------- within this `impl Future<Output = ()>`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
-   = note: required because it appears within the type `(NotSend,)`
 note: required because it's used within this `async` fn body
-  --> $DIR/partial-drop-partial-reinit.rs:27:16
+  --> $DIR/partial-drop-partial-reinit.rs:26:16
    |
 LL |   async fn foo() {
    |  ________________^
@@ -24,7 +23,7 @@ LL | |     bar().await;
 LL | | }
    | |_^
 note: required by a bound in `gimme_send`
-  --> $DIR/partial-drop-partial-reinit.rs:13:18
+  --> $DIR/partial-drop-partial-reinit.rs:12:18
    |
 LL | fn gimme_send<T: Send>(t: T) {
    |                  ^^^^ required by this bound in `gimme_send`

--- a/tests/ui/coroutine/clone-impl-async.rs
+++ b/tests/ui/coroutine/clone-impl-async.rs
@@ -9,7 +9,7 @@ use std::future::ready;
 
 struct NonClone;
 
-fn main() {
+fn local() {
     let inner_non_clone = async {
         let non_clone = NonClone;
         let () = ready(()).await;
@@ -34,7 +34,9 @@ fn main() {
     //~^ ERROR : Copy` is not satisfied
     check_clone(&maybe_copy_clone);
     //~^ ERROR : Clone` is not satisfied
+}
 
+fn non_local() {
     let inner_non_clone_fn = the_inner_non_clone_fn();
     check_copy(&inner_non_clone_fn);
     //~^ ERROR : Copy` is not satisfied
@@ -69,3 +71,5 @@ async fn the_maybe_copy_clone_fn() {}
 
 fn check_copy<T: Copy>(_x: &T) {}
 fn check_clone<T: Clone>(_x: &T) {}
+
+fn main() {}

--- a/tests/ui/coroutine/clone-impl-async.stderr
+++ b/tests/ui/coroutine/clone-impl-async.stderr
@@ -1,89 +1,5 @@
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:18:16
-   |
-LL |     check_copy(&inner_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
-   |
-LL | fn check_copy<T: Copy>(_x: &T) {}
-   |                  ^^^^ required by this bound in `check_copy`
-
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:20:17
-   |
-LL |     check_clone(&inner_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
-   |
-LL | fn check_clone<T: Clone>(_x: &T) {}
-   |                   ^^^^^ required by this bound in `check_clone`
-
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:27:16
-   |
-LL |     check_copy(&outer_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
-   |
-LL | fn check_copy<T: Copy>(_x: &T) {}
-   |                  ^^^^ required by this bound in `check_copy`
-
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:29:17
-   |
-LL |     check_clone(&outer_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
-   |
-LL | fn check_clone<T: Clone>(_x: &T) {}
-   |                   ^^^^^ required by this bound in `check_clone`
-
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:33:16
-   |
-LL |     check_copy(&maybe_copy_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
-   |
-LL | fn check_copy<T: Copy>(_x: &T) {}
-   |                  ^^^^ required by this bound in `check_copy`
-
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:35:17
-   |
-LL |     check_clone(&maybe_copy_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
-   |
-LL | fn check_clone<T: Clone>(_x: &T) {}
-   |                   ^^^^^ required by this bound in `check_clone`
-
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:39:16
+  --> $DIR/clone-impl-async.rs:41:16
    |
 LL |     check_copy(&inner_non_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -91,13 +7,13 @@ LL |     check_copy(&inner_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
+  --> $DIR/clone-impl-async.rs:72:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:41:17
+  --> $DIR/clone-impl-async.rs:43:17
    |
 LL |     check_clone(&inner_non_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -105,13 +21,13 @@ LL |     check_clone(&inner_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
+  --> $DIR/clone-impl-async.rs:73:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:45:16
+  --> $DIR/clone-impl-async.rs:47:16
    |
 LL |     check_copy(&outer_non_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -119,13 +35,13 @@ LL |     check_copy(&outer_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
+  --> $DIR/clone-impl-async.rs:72:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:47:17
+  --> $DIR/clone-impl-async.rs:49:17
    |
 LL |     check_clone(&outer_non_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -133,13 +49,13 @@ LL |     check_clone(&outer_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
+  --> $DIR/clone-impl-async.rs:73:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:51:16
+  --> $DIR/clone-impl-async.rs:53:16
    |
 LL |     check_copy(&maybe_copy_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -147,13 +63,13 @@ LL |     check_copy(&maybe_copy_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:70:18
+  --> $DIR/clone-impl-async.rs:72:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:53:17
+  --> $DIR/clone-impl-async.rs:55:17
    |
 LL |     check_clone(&maybe_copy_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -161,7 +77,79 @@ LL |     check_clone(&maybe_copy_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:71:19
+  --> $DIR/clone-impl-async.rs:73:19
+   |
+LL | fn check_clone<T: Clone>(_x: &T) {}
+   |                   ^^^^^ required by this bound in `check_clone`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:18:5
+   |
+LL |     check_copy(&inner_non_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
+   |
+note: required by a bound in `check_copy`
+  --> $DIR/clone-impl-async.rs:72:18
+   |
+LL | fn check_copy<T: Copy>(_x: &T) {}
+   |                  ^^^^ required by this bound in `check_copy`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:20:5
+   |
+LL |     check_clone(&inner_non_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
+   |
+note: required by a bound in `check_clone`
+  --> $DIR/clone-impl-async.rs:73:19
+   |
+LL | fn check_clone<T: Clone>(_x: &T) {}
+   |                   ^^^^^ required by this bound in `check_clone`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:27:5
+   |
+LL |     check_copy(&outer_non_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
+   |
+note: required by a bound in `check_copy`
+  --> $DIR/clone-impl-async.rs:72:18
+   |
+LL | fn check_copy<T: Copy>(_x: &T) {}
+   |                  ^^^^ required by this bound in `check_copy`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:29:5
+   |
+LL |     check_clone(&outer_non_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
+   |
+note: required by a bound in `check_clone`
+  --> $DIR/clone-impl-async.rs:73:19
+   |
+LL | fn check_clone<T: Clone>(_x: &T) {}
+   |                   ^^^^^ required by this bound in `check_clone`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:33:5
+   |
+LL |     check_copy(&maybe_copy_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
+   |
+note: required by a bound in `check_copy`
+  --> $DIR/clone-impl-async.rs:72:18
+   |
+LL | fn check_copy<T: Copy>(_x: &T) {}
+   |                  ^^^^ required by this bound in `check_copy`
+
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:35:5
+   |
+LL |     check_clone(&maybe_copy_clone);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
+   |
+note: required by a bound in `check_clone`
+  --> $DIR/clone-impl-async.rs:73:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/clone-impl-static.stderr
+++ b/tests/ui/coroutine/clone-impl-static.stderr
@@ -1,10 +1,8 @@
 error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}: Copy` is not satisfied
-  --> $DIR/clone-impl-static.rs:14:16
+  --> $DIR/clone-impl-static.rs:14:5
    |
 LL |     check_copy(&generator);
-   |     ---------- ^^^^^^^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
-   |     |
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
    |
 note: required by a bound in `check_copy`
   --> $DIR/clone-impl-static.rs:20:18
@@ -13,12 +11,10 @@ LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}: Clone` is not satisfied
-  --> $DIR/clone-impl-static.rs:16:17
+  --> $DIR/clone-impl-static.rs:16:5
    |
 LL |     check_clone(&generator);
-   |     ----------- ^^^^^^^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
-   |     |
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:11:5: 11:19}`
    |
 note: required by a bound in `check_clone`
   --> $DIR/clone-impl-static.rs:21:19

--- a/tests/ui/coroutine/clone-impl.rs
+++ b/tests/ui/coroutine/clone-impl.rs
@@ -42,6 +42,7 @@ fn test3_upvars() {
     let clonable_0: Vec<u32> = Vec::new();
     let gen_clone_0 = #[coroutine]
     move || {
+        yield;
         drop(clonable_0);
     };
     check_copy(&gen_clone_0);

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -1,59 +1,81 @@
 error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
-  --> $DIR/clone-impl.rs:47:16
+  --> $DIR/clone-impl.rs:48:5
    |
 LL |     move || {
    |     ------- within this `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |                ^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:45:14
+  --> $DIR/clone-impl.rs:46:14
    |
 LL |         drop(clonable_0);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:91:18
+  --> $DIR/clone-impl.rs:92:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:67:5: 67:12}`
-  --> $DIR/clone-impl.rs:73:16
+error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:55:5: 55:12}`
+  --> $DIR/clone-impl.rs:60:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:67:5: 67:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:55:5: 55:12}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |                ^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:67:5: 67:12}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:55:5: 55:12}`, the trait `Copy` is not implemented for `Vec<char>`
+   |
+note: coroutine does not implement `Copy` as this value is used across a yield
+  --> $DIR/clone-impl.rs:57:9
+   |
+LL |         let v = vec!['a'];
+   |             - has type `Vec<char>` which does not implement `Copy`
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `v` maybe used later
+note: required by a bound in `check_copy`
+  --> $DIR/clone-impl.rs:92:18
+   |
+LL | fn check_copy<T: Copy>(_x: &T) {}
+   |                  ^^^^ required by this bound in `check_copy`
+
+error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:68:5: 68:12}`
+  --> $DIR/clone-impl.rs:74:5
+   |
+LL |     move || {
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:68:5: 68:12}`
+...
+LL |     check_copy(&gen_clone_1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:68:5: 68:12}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:71:14
+  --> $DIR/clone-impl.rs:72:14
    |
 LL |         drop(clonable_1);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:91:18
+  --> $DIR/clone-impl.rs:92:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`
-  --> $DIR/clone-impl.rs:85:16
+error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`
+  --> $DIR/clone-impl.rs:86:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`
 ...
 LL |     check_copy(&gen_non_clone);
-   |                ^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`, the trait `Copy` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`, the trait `Copy` is not implemented for `NonClone`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:83:14
+  --> $DIR/clone-impl.rs:84:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:91:18
+  --> $DIR/clone-impl.rs:92:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
@@ -63,22 +85,22 @@ LL + #[derive(Copy)]
 LL | struct NonClone;
    |
 
-error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`
-  --> $DIR/clone-impl.rs:87:17
+error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`
+  --> $DIR/clone-impl.rs:88:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`
 ...
 LL |     check_clone(&gen_non_clone);
-   |                 ^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:81:5: 81:12}`, the trait `Clone` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:82:5: 82:12}`, the trait `Clone` is not implemented for `NonClone`
    |
 note: captured value does not implement `Clone`
-  --> $DIR/clone-impl.rs:83:14
+  --> $DIR/clone-impl.rs:84:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Clone`
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl.rs:92:19
+  --> $DIR/clone-impl.rs:93:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
@@ -87,28 +109,6 @@ help: consider annotating `NonClone` with `#[derive(Clone)]`
 LL + #[derive(Clone)]
 LL | struct NonClone;
    |
-
-error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:54:5: 54:12}`
-  --> $DIR/clone-impl.rs:59:5
-   |
-LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:54:5: 54:12}`
-...
-LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:54:5: 54:12}`, the trait `Copy` is not implemented for `Vec<char>`
-   |
-note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/clone-impl.rs:56:9
-   |
-LL |         let v = vec!['a'];
-   |             - has type `Vec<char>` which does not implement `Copy`
-LL |         yield;
-   |         ^^^^^ yield occurs here, with `v` maybe used later
-note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:91:18
-   |
-LL | fn check_copy<T: Copy>(_x: &T) {}
-   |                  ^^^^ required by this bound in `check_copy`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{main::{closure#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{main::{closure#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{main::{closure#1} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{main::{closure#1} upvar_tys=() resume_ty=() yield_ty=() return_ty=()}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{main::{closure#0} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str witness={main::{closure#0}}}`
+              found coroutine `{main::{closure#0} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/ref-upvar-not-send.stderr
+++ b/tests/ui/coroutine/ref-upvar-not-send.stderr
@@ -1,14 +1,13 @@
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:15:30
+  --> $DIR/ref-upvar-not-send.rs:15:5
    |
-LL |       assert_send(#[coroutine] move || {
-   |  ______________________________^
+LL | /     assert_send(#[coroutine] move || {
 LL | |
 LL | |
 LL | |         yield;
 LL | |         let _x = x;
 LL | |     });
-   | |_____^ coroutine is not `Send`
+   | |______^ coroutine is not `Send`
    |
    = help: the trait `Sync` is not implemented for `*mut ()`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
@@ -23,16 +22,15 @@ LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:23:30
+  --> $DIR/ref-upvar-not-send.rs:23:5
    |
-LL |       assert_send(#[coroutine] move || {
-   |  ______________________________^
+LL | /     assert_send(#[coroutine] move || {
 LL | |
 LL | |
 LL | |         yield;
 LL | |         let _y = y;
 LL | |     });
-   | |_____^ coroutine is not `Send`
+   | |______^ coroutine is not `Send`
    |
    = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:30: 23:37}`, the trait `Send` is not implemented for `*mut ()`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`

--- a/tests/ui/impl-trait/issues/issue-55872-2.rs
+++ b/tests/ui/impl-trait/issues/issue-55872-2.rs
@@ -12,7 +12,6 @@ impl<S> Bar for S {
     type E = impl std::marker::Send;
     fn foo<T>() -> Self::E {
         //~^ ERROR type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-        //~| ERROR type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
         async {}
     }
 }

--- a/tests/ui/impl-trait/issues/issue-55872-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-55872-2.stderr
@@ -4,13 +4,5 @@ error: type parameter `T` is part of concrete type but not used in parameter lis
 LL |     fn foo<T>() -> Self::E {
    |                    ^^^^^^^
 
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-  --> $DIR/issue-55872-2.rs:13:20
-   |
-LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/issues/issue-55872-3.rs
+++ b/tests/ui/impl-trait/issues/issue-55872-3.rs
@@ -14,7 +14,6 @@ impl<S> Bar for S {
     fn foo<T>() -> Self::E {
         //~^ ERROR : Copy` is not satisfied [E0277]
         //~| ERROR type parameter `T` is part of concrete type
-        //~| ERROR type parameter `T` is part of concrete type
         async {}
     }
 }

--- a/tests/ui/impl-trait/issues/issue-55872-3.stderr
+++ b/tests/ui/impl-trait/issues/issue-55872-3.stderr
@@ -1,12 +1,3 @@
-error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}: Copy` is not satisfied
-  --> $DIR/issue-55872-3.rs:14:20
-   |
-LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}`
-...
-LL |         async {}
-   |         -------- return type was inferred to be `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}` here
-
 error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
   --> $DIR/issue-55872-3.rs:14:20
    |
@@ -20,6 +11,12 @@ LL |     fn foo<T>() -> Self::E {
    |                    ^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}: Copy` is not satisfied
+  --> $DIR/issue-55872-3.rs:14:20
+   |
+LL |     fn foo<T>() -> Self::E {
+   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-55872-3.stderr
+++ b/tests/ui/impl-trait/issues/issue-55872-3.stderr
@@ -4,20 +4,12 @@ error: type parameter `T` is part of concrete type but not used in parameter lis
 LL |     fn foo<T>() -> Self::E {
    |                    ^^^^^^^
 
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:17:9: 17:14}: Copy` is not satisfied
   --> $DIR/issue-55872-3.rs:14:20
    |
 LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:17:9: 17:14}`
 
-error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}: Copy` is not satisfied
-  --> $DIR/issue-55872-3.rs:14:20
-   |
-LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:18:9: 18:14}`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/symbol-names/basic.legacy.stderr
+++ b/tests/ui/symbol-names/basic.legacy.stderr
@@ -1,10 +1,10 @@
-error: symbol-name(_ZN5basic4main17h1dddcfd03744167fE)
+error: symbol-name(_ZN5basic4main17h450e807e9148568eE)
   --> $DIR/basic.rs:8:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(basic::main::h1dddcfd03744167f)
+error: demangling(basic::main::h450e807e9148568e)
   --> $DIR/basic.rs:8:1
    |
 LL | #[rustc_symbol_name]

--- a/tests/ui/symbol-names/issue-60925.legacy.stderr
+++ b/tests/ui/symbol-names/issue-60925.legacy.stderr
@@ -1,10 +1,10 @@
-error: symbol-name(_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$3foo17h4b3099ec5dc5d306E)
+error: symbol-name(_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$3foo17h878706bd4ff1829aE)
   --> $DIR/issue-60925.rs:21:9
    |
 LL |         #[rustc_symbol_name]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo::h4b3099ec5dc5d306)
+error: demangling(issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo::h878706bd4ff1829a)
   --> $DIR/issue-60925.rs:21:9
    |
 LL |         #[rustc_symbol_name]


### PR DESCRIPTION
It's no longer needed, since it always just matches the def id and substs of the `Coroutine` that it's contained within.

This PR reworks a bit of obligation stalling logic and dtorck constraint behavior, but otherwise it's pretty straightforward.

This luckily was very easy to do because of the setup work in:
* https://github.com/rust-lang/rust/pull/141762

r? @lcnr or reassign (e.g. to oli, who probably would also be down to review)