### PR TITLE
[WIP] Check coroutine upvars and resume ty in dtorck constraint, this time based off of `TypingMode`

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1267,9 +1267,11 @@ impl<'tcx> InferCtxt<'tcx> {
             // to handle them without proper canonicalization. This means we may cause cycle
             // errors and fail to reveal opaques while inside of bodies. We should rename this
             // function and require explicit comments on all use-sites in the future.
-            ty::TypingMode::Analysis { defining_opaque_types_and_generators: _ }
-            | ty::TypingMode::Borrowck { defining_opaque_types: _ } => {
+            ty::TypingMode::Analysis { defining_opaque_types_and_generators: _ } => {
                 TypingMode::non_body_analysis()
+            }
+            ty::TypingMode::Borrowck { defining_opaque_types: _ } => {
+                TypingMode::Borrowck { defining_opaque_types: ty::List::empty() }
             }
             mode @ (ty::TypingMode::Coherence
             | ty::TypingMode::PostBorrowckAnalysis { .. }

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -344,9 +344,14 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
             let args = args.as_coroutine();
 
             // While we conservatively assume that all coroutines require drop
-            // to avoid query cycles during MIR building, we can check the actual
-            // witness during borrowck to avoid unnecessary liveness constraints.
-            if args.witness().needs_drop(tcx, tcx.erase_regions(typing_env)) {
+            // to avoid query cycles during MIR building, we can be more precise
+            // here and check the specific components of the coroutines. This
+            // includes the witness types, upvars, *and* the resume ty.
+            let typing_env = tcx.erase_regions(typing_env);
+            let needs_drop = args.witness().needs_drop(tcx, typing_env)
+                || args.upvar_tys().iter().any(|ty| ty.needs_drop(tcx, typing_env))
+                || args.resume_ty().needs_drop(tcx, typing_env);
+            if needs_drop {
                 constraints.outlives.extend(args.upvar_tys().iter().map(ty::GenericArg::from));
                 constraints.outlives.push(args.resume_ty().into());
             }

--- a/compiler/rustc_traits/src/dropck_outlives.rs
+++ b/compiler/rustc_traits/src/dropck_outlives.rs
@@ -23,7 +23,6 @@ fn dropck_outlives<'tcx>(
     canonical_goal: CanonicalDropckOutlivesGoal<'tcx>,
 ) -> Result<&'tcx Canonical<'tcx, QueryResponse<'tcx, DropckOutlivesResult<'tcx>>>, NoSolution> {
     debug!("dropck_outlives(goal={:#?})", canonical_goal);
-
     tcx.infer_ctxt().enter_canonical_trait_query(&canonical_goal, |ocx, goal| {
         compute_dropck_outlives_inner(ocx, goal, DUMMY_SP)
     })

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -117,11 +117,11 @@ impl<I: Interner> TypingMode<I> {
     }
 
     pub fn borrowck(cx: I, body_def_id: I::LocalDefId) -> TypingMode<I> {
-        let defining_opaque_types = cx.opaque_types_defined_by(body_def_id);
-        if defining_opaque_types.is_empty() {
+        // N.B. we can only use an analysis env if there are no coroutines defined.
+        if cx.opaque_types_and_coroutines_defined_by(body_def_id).is_empty() {
             TypingMode::non_body_analysis()
         } else {
-            TypingMode::Borrowck { defining_opaque_types }
+            TypingMode::Borrowck { defining_opaque_types: cx.opaque_types_defined_by(body_def_id) }
         }
     }
 

--- a/tests/ui/async-await/drop-live-upvar.rs
+++ b/tests/ui/async-await/drop-live-upvar.rs
@@ -1,0 +1,23 @@
+//@ edition: 2018
+// Regression test for <https://github.com/rust-lang/rust/issues/144155>.
+
+struct NeedsDrop<'a>(&'a Vec<i32>);
+
+async fn await_point() {}
+
+impl Drop for NeedsDrop<'_> {
+    fn drop(&mut self) {}
+}
+
+fn foo() {
+    let v = vec![1, 2, 3];
+    let x = NeedsDrop(&v);
+    let c = async {
+        std::future::ready(()).await;
+        drop(x);
+    };
+    drop(v);
+    //~^ ERROR cannot move out of `v` because it is borrowed
+}
+
+fn main() {}

--- a/tests/ui/async-await/drop-live-upvar.stderr
+++ b/tests/ui/async-await/drop-live-upvar.stderr
@@ -1,0 +1,22 @@
+error[E0505]: cannot move out of `v` because it is borrowed
+  --> $DIR/drop-live-upvar.rs:19:10
+   |
+LL |     let v = vec![1, 2, 3];
+   |         - binding `v` declared here
+LL |     let x = NeedsDrop(&v);
+   |                       -- borrow of `v` occurs here
+...
+LL |     drop(v);
+   |          ^ move out of `v` occurs here
+LL |
+LL | }
+   | - borrow might be used here, when `c` is dropped and runs the destructor for coroutine
+   |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     let x = NeedsDrop(&v.clone());
+   |                         ++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0505`.


### PR DESCRIPTION
cc rust-lang/rust#144156, see the paragraph about a better approach.

This is broken until we start using `TypingMode::Borrowck` unconditionally. This also has some perf implications, since there were a few places we were collapsing `TypingMode::Borrowck { defining_opaque_types: [] }` into a non-body analysis typing mode, which means we may have to go back to splitting the caching between these modes.