### PR TITLE
tests: debuginfo: Work around or disable broken tests on powerpc

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -854,6 +854,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-openbsd",
     "ignore-pass",
     "ignore-powerpc",
+    "ignore-powerpc64",
     "ignore-remote",
     "ignore-riscv64",
     "ignore-rustc-debug-assertions",

--- a/tests/debuginfo/basic-types-globals-metadata.rs
+++ b/tests/debuginfo/basic-types-globals-metadata.rs
@@ -60,8 +60,10 @@ fn main() {
     _zzz(); // #break
 
     let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
-    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
-    // not exist on some targets like PowerPC
+    // FIXME: Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which
+    // does not exist on some targets like PowerPC.
+    // See https://github.com/llvm/llvm-project/issues/97981 and
+    // https://github.com/rust-lang/compiler-builtins/issues/655
     let b = unsafe { F16 };
 }
 

--- a/tests/debuginfo/basic-types-globals-metadata.rs
+++ b/tests/debuginfo/basic-types-globals-metadata.rs
@@ -59,7 +59,10 @@ static mut F64: f64 = 3.5;
 fn main() {
     _zzz(); // #break
 
-    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F16, F32, F64) };
+    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
+    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
+    // not exist on some targets like PowerPC
+    let b = unsafe { F16 };
 }
 
 fn _zzz() {()}

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -64,8 +64,10 @@ fn main() {
     _zzz(); // #break
 
     let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
-    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
-    // not exist on some targets like PowerPC
+    // FIXME: Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which
+    // does not exist on some targets like PowerPC.
+    // See https://github.com/llvm/llvm-project/issues/97981 and
+    // https://github.com/rust-lang/compiler-builtins/issues/655
     let b = unsafe { F16 };
 }
 

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -63,7 +63,10 @@ static mut F64: f64 = 3.5;
 fn main() {
     _zzz(); // #break
 
-    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F16, F32, F64) };
+    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
+    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
+    // not exist on some targets like PowerPC
+    let b = unsafe { F16 };
 }
 
 fn _zzz() {()}

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -3,6 +3,7 @@
 //@ compile-flags:-g
 //@ ignore-windows-gnu: #128973
 //@ ignore-aarch64-unknown-linux-gnu (gdb tries to read from 0x0; FIXME: #128973)
+//@ ignore-powerpc64: #128973 on both -gnu and -musl
 
 // === GDB TESTS ===================================================================================
 


### PR DESCRIPTION
f16 support for PowerPC has issues in LLVM, therefore we need a small workaround to prevent LLVM from emitting symbols that don't exist for PowerPC yet.

It also appears that rust-lang/rust#128973 applies to PowerPC targets as well, though I've only tested 64-bit Linux targets.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
