### PR TITLE
 opt-dist: add an option for setting path to stage0 root

### DIFF
--- a/src/tools/opt-dist/src/environment.rs
+++ b/src/tools/opt-dist/src/environment.rs
@@ -28,6 +28,8 @@ pub struct Environment {
     run_tests: bool,
     fast_try_build: bool,
     build_llvm: bool,
+    #[builder(default)]
+    stage0_root: Option<Utf8PathBuf>,
 }
 
 impl Environment {
@@ -56,17 +58,11 @@ impl Environment {
     }
 
     pub fn cargo_stage_0(&self) -> Utf8PathBuf {
-        self.build_artifacts()
-            .join("stage0")
-            .join("bin")
-            .join(format!("cargo{}", executable_extension()))
+        self.stage0().join("bin").join(format!("cargo{}", executable_extension()))
     }
 
     pub fn rustc_stage_0(&self) -> Utf8PathBuf {
-        self.build_artifacts()
-            .join("stage0")
-            .join("bin")
-            .join(format!("rustc{}", executable_extension()))
+        self.stage0().join("bin").join(format!("rustc{}", executable_extension()))
     }
 
     pub fn rustc_stage_2(&self) -> Utf8PathBuf {
@@ -115,6 +111,10 @@ impl Environment {
 
     pub fn build_llvm(&self) -> bool {
         self.build_llvm
+    }
+
+    pub fn stage0(&self) -> Utf8PathBuf {
+        self.stage0_root.clone().unwrap_or_else(|| self.build_artifacts().join("stage0"))
     }
 }
 

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -107,6 +107,10 @@ enum EnvironmentCmd {
         /// in bootstrap.toml via `build.build-dir` option
         #[arg(long, default_value = "build")]
         build_dir: Utf8PathBuf,
+
+        /// Path to custom stage0 root
+        #[arg(long)]
+        stage0_root: Option<Utf8PathBuf>,
     },
     /// Perform an optimized build on Linux CI, from inside Docker.
     LinuxCi {
@@ -144,6 +148,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
             run_tests,
             build_llvm,
             build_dir,
+            stage0_root,
         } => {
             let env = EnvironmentBuilder::default()
                 .host_tuple(target_triple)
@@ -160,6 +165,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 .run_tests(run_tests)
                 .fast_try_build(is_fast_try_build)
                 .build_llvm(build_llvm)
+                .stage0_root(stage0_root)
                 .build()?;
 
             (env, shared.build_args)


### PR DESCRIPTION
in MSYS2 we have problems with stage0 for *-gnullvm hosts because prebuilt dist tarballs will be
available starting from 1.90.0-beta. also this change helps to match bootstrap.toml config

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? Kobzol

try-job: dist-x86_64-msvc
try-job: dist-x86_64-linux