### PR TITLE
minimally implement `is` (RFC 3573), sans parsing

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1562,6 +1562,9 @@ impl Expr {
             // need parens sometimes. E.g. we can print `(let _ = a) && b` as `let _ = a && b`
             // but we need to print `(let _ = a) < b` as-is with parens.
             | ExprKind::Let(..)
+            // FIXME(is): `expr is pat` should be binop-like, but until it can be parsed as such,
+            // it's using prefix placeholder syntax.
+            | ExprKind::Is(..)
             | ExprKind::Unary(..) => ExprPrecedence::Prefix,
 
             // Need parens if and only if there are prefix attributes.
@@ -1739,6 +1742,11 @@ pub enum ExprKind {
     ///
     /// `Span` represents the whole `let pat = expr` statement.
     Let(P<Pat>, P<Expr>, Span, Recovered),
+    /// An `expr is pat` expression. Currently, there's no `is` keyword, so as a placeholder it's
+    /// parsed as `builtin # is(expr is pat)`.
+    ///
+    /// This is desugared to `if` and `let` expressions.
+    Is(P<Expr>, P<Pat>),
     /// An `if` block, with an optional `else` block.
     ///
     /// `if expr { block } else { expr }`

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1621,6 +1621,19 @@ impl Expr {
         )
     }
 
+    /// Is this an `is` expression or a chain of `&&` operators containing an `is` expression?
+    /// This determines the scope of the `is` expression's bindings. E.g., since
+    /// `(expr is x) && f()` is broken up by parentheses, `x` is dropped before evaluating `f()`.
+    pub fn has_expr_is(&self) -> bool {
+        match &self.kind {
+            ExprKind::Is(..) => true,
+            ExprKind::Binary(BinOp { node: BinOpKind::And, .. }, lhs, rhs) => {
+                lhs.has_expr_is() || rhs.has_expr_is()
+            }
+            _ => false,
+        }
+    }
+
     /// Creates a dummy `Expr`.
     ///
     /// Should only be used when it will be replaced afterwards or as a return value when an error was encountered.

--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -99,6 +99,7 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
 /// }
 /// ```
 pub fn leading_labeled_expr(mut expr: &ast::Expr) -> bool {
+    // FIXME(is): This will need tests for `is` once it can be parsed.
     loop {
         match &expr.kind {
             Block(_, label) | ForLoop { label, .. } | Loop(_, label, _) | While(_, _, label) => {
@@ -110,6 +111,7 @@ pub fn leading_labeled_expr(mut expr: &ast::Expr) -> bool {
             | Await(e, _)
             | Use(e, _)
             | Binary(_, e, _)
+            | Is(e, _)
             | Call(e, _)
             | Cast(e, _)
             | Field(e, _)
@@ -171,6 +173,7 @@ pub enum TrailingBrace<'a> {
 
 /// If an expression ends with `}`, returns the innermost expression ending in the `}`
 pub fn expr_trailing_brace(mut expr: &ast::Expr) -> Option<TrailingBrace<'_>> {
+    // FIXME(is): We should have a test for `let b = expr is Variant {} else { return }`.
     loop {
         match &expr.kind {
             AddrOf(_, _, e)
@@ -237,6 +240,7 @@ pub fn expr_trailing_brace(mut expr: &ast::Expr) -> Option<TrailingBrace<'_>> {
             | Paren(_)
             | Try(_)
             | Yeet(None)
+            | Is(..)
             | UnsafeBinderCast(..)
             | Err(_)
             | Dummy => {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -972,6 +972,8 @@ macro_rules! common_visitor_and_walkers {
                     visit_visitable!($($mut)? vis, subexpression, typ),
                 ExprKind::Let(pat, expr, span, _recovered) =>
                     visit_visitable!($($mut)? vis, pat, expr, span),
+                ExprKind::Is(expr, pat) =>
+                    visit_visitable!($($mut)? vis, expr, pat),
                 ExprKind::If(head_expression, if_block, optional_else) =>
                     visit_visitable!($($mut)? vis, head_expression, if_block, optional_else),
                 ExprKind::While(subexpression, block, opt_label) =>

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -176,6 +176,16 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         recovered: *recovered,
                     }))
                 }
+                ExprKind::Is(scrutinee, pat) => {
+                    // TODO: properly desugar `is` outside of `if`/`while`
+                    hir::ExprKind::Let(self.arena.alloc(hir::LetExpr {
+                        span: self.lower_span(e.span),
+                        pat: self.lower_pat(pat),
+                        ty: None,
+                        init: self.lower_expr(scrutinee),
+                        recovered: Recovered::No,
+                    }))
+                }
                 ExprKind::If(cond, then, else_opt) => {
                     self.lower_expr_if(cond, then, else_opt.as_deref())
                 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -94,6 +94,17 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 ExprKind::ForLoop { pat, iter, body, label, kind } => {
                     return self.lower_expr_for(e, pat, iter, body, *label, *kind);
                 }
+                // Desugar `expr is pat` expressions. This likewise needs special handling as `is`
+                // expressions outside of `if`/`while` conditions are wrapped in an `if` expression.
+                ExprKind::Is(..) => return self.lower_wrapped_cond_for_expr_is(e),
+                ExprKind::Binary(BinOp { node: BinOpKind::And, .. }, ..) => {
+                    if e.has_expr_is() {
+                        return self.lower_wrapped_cond_for_expr_is(e);
+                    } else {
+                        // `has_expr_is` will be false for this `&&`'s operands; don't check again.
+                        return self.lower_cond_mut(e);
+                    }
+                }
                 _ => (),
             }
 
@@ -174,16 +185,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         ty: None,
                         init: self.lower_expr(scrutinee),
                         recovered: *recovered,
-                    }))
-                }
-                ExprKind::Is(scrutinee, pat) => {
-                    // TODO: properly desugar `is` outside of `if`/`while`
-                    hir::ExprKind::Let(self.arena.alloc(hir::LetExpr {
-                        span: self.lower_span(e.span),
-                        pat: self.lower_pat(pat),
-                        ty: None,
-                        init: self.lower_expr(scrutinee),
-                        recovered: Recovered::No,
                     }))
                 }
                 ExprKind::If(cond, then, else_opt) => {
@@ -379,7 +380,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                 ExprKind::Try(sub_expr) => self.lower_expr_try(e.span, sub_expr),
 
-                ExprKind::Paren(_) | ExprKind::ForLoop { .. } => {
+                ExprKind::Paren(_) | ExprKind::ForLoop { .. } | ExprKind::Is(..) => {
                     unreachable!("already handled")
                 }
 
@@ -532,13 +533,86 @@ impl<'hir> LoweringContext<'_, 'hir> {
         hir::ExprKind::Call(f, self.lower_exprs(&real_args))
     }
 
+    /// Lower an expression in a context where `let` expressions are permitted, such as the
+    /// condition of an `if` or `while` expression. This allows `is` expressions to be lowered
+    /// directly to `let` expressions without needing to be wrapped in an `if`'s condition.
+    fn lower_cond(&mut self, e: &Expr) -> &'hir hir::Expr<'hir> {
+        self.arena.alloc(self.lower_cond_mut(e))
+    }
+
+    fn lower_cond_mut(&mut self, e: &Expr) -> hir::Expr<'hir> {
+        self.lower_cond_inner(e, None)
+    }
+
+    fn lower_cond_inner(&mut self, e: &Expr, wrapper: Option<(HirId, Span)>) -> hir::Expr<'hir> {
+        let lower_id_and_attrs = |this: &mut LoweringContext<'_, 'hir>| {
+            let expr_hir_id = this.lower_node_id(e.id);
+            // If the condition is wrapped in an `if` expression for `is` desugaring, attach
+            // attributes to the `if` expression instead of `e`.
+            let (attr_hir_id, attr_span) = wrapper.unwrap_or((expr_hir_id, e.span));
+            this.lower_attrs(attr_hir_id, &e.attrs, attr_span);
+            expr_hir_id
+        };
+        match &e.kind {
+            ExprKind::Is(scrutinee, pat) => {
+                // At the top level of a condition, `is` expressions lower directly to `let`.
+                let hir_id = lower_id_and_attrs(self);
+                let span = self.mark_span_with_reason(
+                    DesugaringKind::IsExpr,
+                    self.lower_span(e.span),
+                    None,
+                );
+                let kind = hir::ExprKind::Let(self.arena.alloc(hir::LetExpr {
+                    span,
+                    pat: self.lower_pat(pat),
+                    ty: None,
+                    init: self.lower_expr(scrutinee),
+                    recovered: Recovered::No,
+                }));
+                hir::Expr { hir_id, kind, span }
+            }
+            ExprKind::Binary(binop @ BinOp { node: BinOpKind::And, .. }, lhs, rhs) => {
+                // `is` expressions in chains of `&&` operators can lower to `let`, so we lower the
+                // operands using `self.lower_cond` rather than `self.lower_expr`.
+                ensure_sufficient_stack(|| {
+                    let hir_id = lower_id_and_attrs(self);
+                    let binop = self.lower_binop(*binop);
+                    let lhs = self.lower_cond(lhs);
+                    let rhs = self.lower_cond(rhs);
+                    let kind = hir::ExprKind::Binary(binop, lhs, rhs);
+                    hir::Expr { hir_id, kind, span: self.lower_span(e.span) }
+                })
+            }
+            _ => return self.lower_expr_mut(e),
+        }
+    }
+
+    /// Lower `cond`, wrapped in an `if` expression's condition: `if cond { true } else { false }`.
+    /// This allows `is` expressions in `cond` to lower to `let` expressions.
+    fn lower_wrapped_cond_for_expr_is(&mut self, cond: &Expr) -> hir::Expr<'hir> {
+        let span =
+            self.mark_span_with_reason(DesugaringKind::IsExpr, self.lower_span(cond.span), None);
+        let hir_id = self.next_id();
+        let lowered_cond = self.arena.alloc(self.lower_cond_inner(cond, Some((hir_id, span))));
+        let mut bool_block = |b| {
+            let lit = hir::Lit { span, node: ast::LitKind::Bool(b) };
+            let expr_lit = self.arena.alloc(self.expr(span, hir::ExprKind::Lit(lit)));
+            let block = self.block_expr(expr_lit);
+            self.arena.alloc(self.expr_block(block))
+        };
+        let expr_true = bool_block(true);
+        let expr_false = bool_block(false);
+        let kind = hir::ExprKind::If(lowered_cond, expr_true, Some(expr_false));
+        hir::Expr { span, kind, hir_id }
+    }
+
     fn lower_expr_if(
         &mut self,
         cond: &Expr,
         then: &Block,
         else_opt: Option<&Expr>,
     ) -> hir::ExprKind<'hir> {
-        let lowered_cond = self.lower_expr(cond);
+        let lowered_cond = self.lower_cond(cond);
         let then_expr = self.lower_block_expr(then);
         if let Some(rslt) = else_opt {
             hir::ExprKind::If(
@@ -574,7 +648,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         body: &Block,
         opt_label: Option<Label>,
     ) -> hir::ExprKind<'hir> {
-        let lowered_cond = self.with_loop_condition_scope(|t| t.lower_expr(cond));
+        let lowered_cond = self.with_loop_condition_scope(|t| t.lower_cond(cond));
         let then = self.lower_block_expr(body);
         let expr_break = self.expr_break(span);
         let stmt_break = self.stmt_expr(span, expr_break);
@@ -643,7 +717,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_arm(&mut self, arm: &Arm) -> hir::Arm<'hir> {
         let pat = self.lower_pat(&arm.pat);
-        let guard = arm.guard.as_ref().map(|cond| self.lower_expr(cond));
+        let guard = arm.guard.as_ref().map(|cond| self.lower_cond(cond));
         let hir_id = self.next_id();
         let span = self.lower_span(arm.span);
         self.lower_attrs(hir_id, &arm.attrs, arm.span);

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -134,6 +134,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         );
                     }
                     PatKind::Guard(inner, cond) => {
+                        // FIXME(is, guard_patterns): use `self.lower_cond` to support `is` bindings
                         break hir::PatKind::Guard(self.lower_pat(inner), self.lower_expr(cond));
                     }
                     PatKind::Slice(pats) => break self.lower_pat_slice(pats),

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -503,6 +503,13 @@ impl<'a> State<'a> {
             ast::ExprKind::Let(pat, scrutinee, _, _) => {
                 self.print_let(pat, scrutinee, fixup);
             }
+            ast::ExprKind::Is(scrutinee, pat) => {
+                // FIXME(is): This is a placeholder. Pretty-print properly once `is` can be parsed.
+                self.print_expr(scrutinee, fixup);
+                self.space();
+                self.word_space("is");
+                self.print_pat(pat);
+            }
             ast::ExprKind::If(test, blk, elseopt) => self.print_if(test, blk, elseopt.as_deref()),
             ast::ExprKind::While(test, blk, opt_label) => {
                 if let Some(label) = opt_label {

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -243,6 +243,9 @@ impl<'cx, 'a> Context<'cx, 'a> {
             ExprKind::Let(_, local_expr, _, _) => {
                 self.manage_cond_expr(local_expr);
             }
+            ExprKind::Is(local_expr, _) => {
+                self.manage_cond_expr(local_expr);
+            }
             ExprKind::Match(local_expr, ..) => {
                 self.manage_cond_expr(local_expr);
             }

--- a/compiler/rustc_passes/src/input_stats.rs
+++ b/compiler/rustc_passes/src/input_stats.rs
@@ -655,7 +655,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
         record_variants!(
             (self, e, e.kind, None, ast, Expr, ExprKind),
             [
-                Array, ConstBlock, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type, Let,
+                Array, ConstBlock, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type, Let, Is,
                 If, While, ForLoop, Loop, Match, Closure, Block, Await, Use, TryBlock, Assign,
                 AssignOp, Field, Index, Range, Underscore, Path, AddrOf, Break, Continue, Ret,
                 InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -61,6 +61,7 @@ struct BindingInfo {
 pub(crate) enum PatternSource {
     Match,
     Let,
+    Is,
     For,
     FnParam,
 }
@@ -88,6 +89,7 @@ impl PatternSource {
         match self {
             PatternSource::Match => "match binding",
             PatternSource::Let => "let binding",
+            PatternSource::Is => "is binding",
             PatternSource::For => "for binding",
             PatternSource::FnParam => "function parameter",
         }
@@ -4842,6 +4844,13 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     }
                 }
                 self.apply_pattern_bindings(bindings);
+            }
+
+            ExprKind::Is(ref scrutinee, ref pat) => {
+                // TODO: handle `is` outside of `if`/`while`: we'll need to introduce a new rib for
+                // the `is`'s `&&`-chain.
+                self.visit_expr(scrutinee);
+                self.resolve_pattern_top(pat, PatternSource::Is);
             }
 
             ExprKind::If(ref cond, ref then, ref opt_else) => {

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1219,6 +1219,8 @@ pub enum DesugaringKind {
         /// rewriting it.
         source: bool,
     },
+    /// Desugaring of an `expr is pat` expression
+    IsExpr,
 }
 
 impl DesugaringKind {
@@ -1240,6 +1242,7 @@ impl DesugaringKind {
             DesugaringKind::FormatLiteral { source: false } => {
                 "expression that expanded into a format string literal"
             }
+            DesugaringKind::IsExpr => "`is` expression",
         }
     }
 
@@ -1259,6 +1262,7 @@ impl DesugaringKind {
             DesugaringKind::Contract => value == "Contract",
             DesugaringKind::PatTyRange => value == "PatTyRange",
             DesugaringKind::FormatLiteral { .. } => value == "FormatLiteral",
+            DesugaringKind::IsExpr => value == "IsExpr",
         }
     }
 }

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -184,6 +184,8 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Closure { .. }
             | ast::ExprKind::If(..)
             | ast::ExprKind::Let(..)
+            // FIXME(is): Once `is` can be parsed, it should provide `BinOp` suggestions.
+            | ast::ExprKind::Is(..)
             | ast::ExprKind::Unary(..)
             | ast::ExprKind::Match(..) => match snippet_with_context(cx, expr.span, ctxt, default, app) {
                 (snip, false) => Sugg::MaybeParen(snip),

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -426,6 +426,10 @@ pub(crate) fn format_expr(
             // Also, rustfmt might get passed the output from `-Zunpretty=expanded`.
             Err(RewriteError::Unknown)
         }
+        ast::ExprKind::Is(..) => {
+            // FIXME(is): add formatting for `expr is pat` expressions.
+            Err(RewriteError::Unknown)
+        }
         ast::ExprKind::Err(_) | ast::ExprKind::Dummy => Err(RewriteError::Unknown),
     };
 

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -505,6 +505,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Field(..)
         | ast::ExprKind::IncludedBytes(..)
         | ast::ExprKind::InlineAsm(..)
+        | ast::ExprKind::Is(..)
         | ast::ExprKind::OffsetOf(..)
         | ast::ExprKind::UnsafeBinderCast(..)
         | ast::ExprKind::Let(..)

--- a/tests/ui/rfcs/rfc-3573-is/auxiliary/is-macro.rs
+++ b/tests/ui/rfcs/rfc-3573-is/auxiliary/is-macro.rs
@@ -1,0 +1,7 @@
+// FIXME(is): This syntax is a placeholder.
+#[macro_export]
+macro_rules! is {
+    ($($args:tt)*) => {
+        builtin # is($($args)*)
+    }
+}

--- a/tests/ui/rfcs/rfc-3573-is/desugaring.rs
+++ b/tests/ui/rfcs/rfc-3573-is/desugaring.rs
@@ -1,0 +1,21 @@
+//! Test desugaring of `is` expressions to `let` and `if`.
+//@ check-pass
+//@ compile-flags: -Z unpretty=hir
+//@ edition: 2024
+#![feature(builtin_syntax)]
+
+fn main() {
+    // At the top level of an `if` or `while` condition, `is` desugars directly to `let`.
+    if true && builtin # is(0 is 0) && true {}
+    while true && builtin # is(0 is 0) && true {}
+
+    // Otherwise, an `&&`-chain with `is` in it is wrapped in an `if` expression.
+    builtin # is(0 is 0);
+    true && builtin # is(0 is 0) && true;
+
+    // `let` isn't allowed under parentheses or other operators.
+    // `is` anywhere other than the top level `&&`-chain of a condition is wrapped in an `if`.
+    if (builtin # is(0 is 0)) {}
+    if (true && builtin # is(0 is 0) && true) {}
+    if builtin # is(0 is 0) || true && builtin # is(0 is 0) && true {}
+}

--- a/tests/ui/rfcs/rfc-3573-is/desugaring.stdout
+++ b/tests/ui/rfcs/rfc-3573-is/desugaring.stdout
@@ -1,0 +1,27 @@
+//! Test desugaring of `is` expressions to `let` and `if`.
+//@ check-pass
+//@ compile-flags: -Z unpretty=hir
+//@ edition: 2024
+#![feature(builtin_syntax)]
+#[prelude_import]
+use std::prelude::rust_2024::*;
+#[attr = MacroUse {arguments: UseAll}]
+extern crate std;
+
+fn main() {
+    // At the top level of an `if` or `while` condition, `is` desugars directly to `let`.
+    if true && let 0 = 0 && true { }
+    loop { if true && let 0 = 0 && true { } else { break; } }
+
+    // Otherwise, an `&&`-chain with `is` in it is wrapped in an `if` expression.
+    if let 0 = 0 { true } else { false };
+    if true && let 0 = 0 && true { true } else { false };
+
+    // `let` isn't allowed under parentheses or other operators.
+    // `is` anywhere other than the top level `&&`-chain of a condition is wrapped in an `if`.
+    if if let 0 = 0 { true } else { false } { }
+    if if true && let 0 = 0 && true { true } else { false } { }
+    if if let 0 = 0 { true } else { false } ||
+            if true && let 0 = 0 && true { true } else { false } {
+    }
+}

--- a/tests/ui/rfcs/rfc-3573-is/drop-scopes.rs
+++ b/tests/ui/rfcs/rfc-3573-is/drop-scopes.rs
@@ -1,0 +1,76 @@
+//! Demonstrates where temporaries and bindings for `is` expressions are dropped.
+//@ edition: 2024
+//@ run-pass
+//@ aux-crate: is_macro=is-macro.rs
+#![feature(builtin_syntax)]
+use is_macro::is;
+
+use core::{cell::RefCell, ops::Drop};
+
+#[expect(irrefutable_let_patterns)]
+fn main() {
+    // `is` used where a `let` expression is allowed desugars directly to `let`, using the scope of
+    // the enclosing condition. As such, its temporaries and bindings behave the same as `let`'s.
+    assert_drop_order(1..=6, |o| {
+        if is!(o.log(5).ignore_temp().log(4) is _v)
+            && is!(o.log(3).ignore_temp().log(2) is _v)
+        {
+            // The bindings and temporaries are all dropped after locals declared within the block.
+            let _v = o.log(1);
+        }
+        // Everything is dropped before leaving the success block.
+        o.log(6);
+    });
+
+    // `is` used elsewhere introduces a new scope.
+    assert_drop_order(1..=9, |o| {
+        // `let` isn't allowed through parentheses; the `is`'s bindings and temporaries only live to
+        // the end of the `&&`-chain they're in.
+        if (
+            is!(o.log(4).ignore_temp().log(3) is _v)
+                && is!(o.log(2).ignore_temp().log(1) is _v)
+        ) && (
+            is!(o.log(8).ignore_temp().log(7) is _v)
+                && is!(o.log(6).ignore_temp().log(5) is _v)
+        ) {
+            o.log(9);
+        }
+    });
+}
+
+// # Test scaffolding...
+
+struct DropOrder(RefCell<Vec<u64>>);
+struct LogDrop<'o>(&'o DropOrder, u64);
+
+impl DropOrder {
+    fn log(&self, n: u64) -> LogDrop<'_> {
+        LogDrop(self, n)
+    }
+    fn push(&self, n: u64) {
+        self.0.borrow_mut().push(n);
+    }
+}
+
+impl<'o> Drop for LogDrop<'o> {
+    fn drop(&mut self) {
+        self.0.push(self.1);
+    }
+}
+impl<'o> LogDrop<'o> {
+    fn ignore_temp(&self) -> &'o DropOrder {
+        self.0
+    }
+}
+
+#[track_caller]
+fn assert_drop_order(
+    ex: impl IntoIterator<Item = u64>,
+    f: impl Fn(&DropOrder),
+) {
+    let order = DropOrder(RefCell::new(Vec::new()));
+    f(&order);
+    let order = order.0.into_inner();
+    let expected: Vec<u64> = ex.into_iter().collect();
+    assert_eq!(order, expected);
+}

--- a/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.rs
+++ b/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.rs
@@ -11,17 +11,63 @@ fn main() {
         && x
     {
         x;
+    } else {
+        x; //~ ERROR cannot find value `x` in this scope
     }
     x; //~ ERROR cannot find value `x` in this scope
 
     // Elsewhere, `is`'s bindings only extend to the end of its `&&`-chain.
     if x //~ ERROR cannot find value `x` in this scope
-        && (is!(true is x) && x)
+        && (is!(true is x) && x && { x })
         && x //~ ERROR cannot find value `x` in this scope
         && (is!(true is x) || x) //~ ERROR cannot find value `x` in this scope
+        && (!is!(true is x) || x) //~ ERROR cannot find value `x` in this scope
+        && (is!(true is x) & x) //~ ERROR cannot find value `x` in this scope
     {
         x; //~ ERROR cannot find value `x` in this scope
     }
+
+    match is!(true is x) {
+        _ => { x; } //~ ERROR cannot find value `x` in this scope
+    }
+
+    match () {
+        () if is!(true is x) && x => { x; }
+        () if x => {} //~ ERROR cannot find value `x` in this scope
+    }
+
+    match () {
+        () if is!(true is x) && x => { x; }
+        () => { x; } //~ ERROR cannot find value `x` in this scope
+    }
+
+    fn f(_a: bool, _b: bool) {}
+    f(is!(true is x) && x, true);
+    f(is!(true is x), x); //~ ERROR cannot find value `x` in this scope
+    f(is!(true is x) && x, x); //~ ERROR cannot find value `x` in this scope
+
+    if !is!(true is x) {
+        x; //~ ERROR cannot find value `x` in this scope
+    } else {
+        x; //~ ERROR cannot find value `x` in this scope
+    }
+
+    if true
+        && if is!(true is x) && x { x } else { false }
+        && x //~ ERROR cannot find value `x` in this scope
+    {
+        x; //~ ERROR cannot find value `x` in this scope
+    }
+
+    while is!(true is x) {
+        x;
+        break;
+    }
+    x; //~ ERROR cannot find value `x` in this scope
+
+    is!(true is x);
+    x; //~ ERROR cannot find value `x` in this scope
+
     is!(true is x);
     x; //~ ERROR cannot find value `x` in this scope
 }

--- a/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.rs
+++ b/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.rs
@@ -1,0 +1,27 @@
+//! Test that the lexical scope for `is`'s bindings doesn't extend farther than it should.
+//@ edition: 2024
+//@ aux-crate: is_macro=is-macro.rs
+#![feature(builtin_syntax)]
+use is_macro::is;
+
+fn main() {
+    // `is` used where `let` expressions can be used behaves like a `let` expression.
+    if x //~ ERROR cannot find value `x` in this scope
+        && is!(true is x)
+        && x
+    {
+        x;
+    }
+    x; //~ ERROR cannot find value `x` in this scope
+
+    // Elsewhere, `is`'s bindings only extend to the end of its `&&`-chain.
+    if x //~ ERROR cannot find value `x` in this scope
+        && (is!(true is x) && x)
+        && x //~ ERROR cannot find value `x` in this scope
+        && (is!(true is x) || x) //~ ERROR cannot find value `x` in this scope
+    {
+        x; //~ ERROR cannot find value `x` in this scope
+    }
+    is!(true is x);
+    x; //~ ERROR cannot find value `x` in this scope
+}

--- a/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.stderr
+++ b/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.stderr
@@ -2,44 +2,191 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution-errors.rs:9:8
    |
 LL |     if x
-   |        ^ not found in this scope
+   |        ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:15:5
-   |
-LL |     x;
-   |     ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:18:8
-   |
-LL |     if x
-   |        ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:20:12
-   |
-LL |         && x
-   |            ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:21:31
-   |
-LL |         && (is!(true is x) || x)
-   |                               ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:23:9
+  --> $DIR/name-resolution-errors.rs:15:9
    |
 LL |         x;
-   |         ^ not found in this scope
+   |         ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/name-resolution-errors.rs:26:5
+  --> $DIR/name-resolution-errors.rs:17:5
    |
 LL |     x;
-   |     ^ not found in this scope
+   |     ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
 
-error: aborting due to 7 previous errors
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:20:8
+   |
+LL |     if x
+   |        ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:22:12
+   |
+LL |         && x
+   |            ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:23:31
+   |
+LL |         && (is!(true is x) || x)
+   |                               ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:24:32
+   |
+LL |         && (!is!(true is x) || x)
+   |                                ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:25:30
+   |
+LL |         && (is!(true is x) & x)
+   |                              ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:27:9
+   |
+LL |         x;
+   |         ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:31:16
+   |
+LL |         _ => { x; }
+   |                ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:36:15
+   |
+LL |         () if x => {}
+   |               ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:41:17
+   |
+LL |         () => { x; }
+   |                 ^ help: a function with a similar name exists: `f`
+...
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:46:23
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+LL |     f(is!(true is x) && x, true);
+LL |     f(is!(true is x), x);
+   |                       ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:47:28
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |     f(is!(true is x) && x, x);
+   |                            ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:50:9
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |         x;
+   |         ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:52:9
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |         x;
+   |         ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:57:12
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |         && x
+   |            ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:59:9
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |         x;
+   |         ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:66:5
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |     x;
+   |     ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:69:5
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |     x;
+   |     ^ help: a function with a similar name exists: `f`
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:72:5
+   |
+LL |     fn f(_a: bool, _b: bool) {}
+   |     ------------------------ similarly named function `f` defined here
+...
+LL |     x;
+   |     ^ help: a function with a similar name exists: `f`
+
+error: aborting due to 21 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.stderr
+++ b/tests/ui/rfcs/rfc-3573-is/name-resolution-errors.stderr
@@ -1,0 +1,45 @@
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:9:8
+   |
+LL |     if x
+   |        ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:15:5
+   |
+LL |     x;
+   |     ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:18:8
+   |
+LL |     if x
+   |        ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:20:12
+   |
+LL |         && x
+   |            ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:21:31
+   |
+LL |         && (is!(true is x) || x)
+   |                               ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:23:9
+   |
+LL |         x;
+   |         ^ not found in this scope
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/name-resolution-errors.rs:26:5
+   |
+LL |     x;
+   |     ^ not found in this scope
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/rfcs/rfc-3573-is/run-pass-simple.rs
+++ b/tests/ui/rfcs/rfc-3573-is/run-pass-simple.rs
@@ -43,9 +43,18 @@ fn test_while() {
     assert_eq!(count, 4);
 }
 
-// TODO: test `is` not directly in conditions
+// Test `is` not directly in an `if` or `while` condition.
+fn test_elsewhere() {
+    for test_in in [None, Some(None), Some(Some(3)), Some(Some(4))] {
+        let test_is = is!(test_in is Some(x)) && is!(x is Some(y)) && y > 3;
+        let test_expected =
+            if let Some(x) = test_in && let Some(y) = x && y > 3 { true } else { false };
+        assert_eq!(test_is, test_expected);
+    }
+}
 
 fn main() {
     test_if();
     test_while();
+    test_elsewhere();
 }

--- a/tests/ui/rfcs/rfc-3573-is/run-pass-simple.rs
+++ b/tests/ui/rfcs/rfc-3573-is/run-pass-simple.rs
@@ -1,0 +1,51 @@
+//! Simple tests for matching and binding with `is` expressions.
+//@ run-pass
+//@ edition: 2024
+//@ aux-crate: is_macro=is-macro.rs
+#![feature(builtin_syntax)]
+use is_macro::is;
+
+// Test `is` used as `let` in `if` conditions.
+fn test_if() {
+    for test_in in [None, Some(3), Some(4)] {
+        let test_if_expr = if is!(test_in is Some(x)) && x > 3 {
+            // `x` is bound in the success block
+            x
+        } else {
+            0
+        };
+        let test_guard = match test_in {
+            x if is!(x is Some(y)) && y > 3 => {
+                // `y` is bound in the arm body
+                y
+            }
+            _ => 0,
+        };
+        let test_expected = if let Some(x) = test_in && x > 3 {
+            x
+        } else {
+            0
+        };
+        assert_eq!(test_if_expr, test_expected);
+        assert_eq!(test_guard, test_expected);
+    }
+}
+
+// Test `is` used as `let` in `while` conditions.
+fn test_while() {
+    let mut count = 0;
+    let mut opt = Some(3u8);
+    while is!(opt is Some(x)) {
+        // `x` is bound in the loop body
+        count += 1;
+        opt = x.checked_sub(1);
+    }
+    assert_eq!(count, 4);
+}
+
+// TODO: test `is` not directly in conditions
+
+fn main() {
+    test_if();
+    test_while();
+}


### PR DESCRIPTION
This PR partially implements rust-lang/rfcs#3573 for experimentation. It's not yet suitable for general use and may not yet reflect the intended design, but this should hopefully make it easier to explore its design space. r? @joshtriplett for design concerns

### Placeholder syntax

Since `is` isn't parsed as an infix operator, I'm using permanently-unstable [`builtin#` syntax](https://github.com/rust-lang/compiler-team/issues/580) as a placeholder. Instead of `expr is pat`, write `builtin # is(expr is pat)` or define a macro expanding to that. One possible improvement if raw keywords ([RFC 3098](https://github.com/rust-lang/rfcs/pull/3098)) were implemented would be to use `k#is` as an infix operator. My understanding is that this syntax is already reserved by [RFC 3101](https://github.com/rust-lang/rfcs/pull/3101).

### Scoping

I've opted for a simple and restrictive interpretation of the scoping rules in the RFC, based on the rules for `let`-chains:
```rust
// For `is` in an `&&` operator chain at the top-level of an `if` or `while`'s
// condition, such that a `let` expression would be permitted, `is`'s bindings
// and temporaries are in-scope for the success branch of the condition, as if
// `let pat = expr` were written instead of `expr is pat`.
if mutex.lock().unwrap().test() is true {
    // Like with `if let`, the mutex guard isn't dropped, so it remains locked.
}

// Otherwise, an `is` expression's bindings and temporaries are in scope for the
// remainder of the `&&` operator chain it's in.
if (mutex.lock().unwrap().test() is true) {
    // `let` isn't allowed in parentheses. For this PR's interpretation of `is`,
    // that means it introduced a new scope. The mutex is unlocked here.
}
```

I don't think this is necessarily the intended scope for `is` (or the ideal scope for `let` expressions in that first case, honestly), but my hope is that it will be easier to refine given a concrete implementation[^1]. Lints or errors to prevent shadowing mistakes are left for future work.

### Desugaring

`builtin # is(expr is pat)` is desugared as follows when lowering to HIR:
- In a condition where a `let` expression would be permitted, `expr is pat` desugars to `let pat = expr`. 
- Anywhere else, the `&&`-chain containing the `is` is wrapped in an `if` condition, then `is` is desugared to `let`: `... && expr is pat &&...` becomes `if ... && let pat = expr && ... { true } else { false }`.

This results in non-ideal MIR in some cases, but jump-threading optimizations should hopefully clean it up. I haven't included any tests for that, since this implementation isn't meant for production use. This also doesn't currently enforce Rust 2024 scoping rules for `if`s in its desugaring; how to handle older editions is left as an open question.

### Behavior in macro expansions

I couldn't find discussion of macros on the RFC, so I've taken the simplest approach: it doesn't really work yet. Similar to `let` statements but unlike `let` expressions, you can put `builtin # is($e is $p)` in a macro and it will introduce its pattern's bindings into scope as if it were inlined into its expansion site. This doesn't work for `let` expressions because of how macros are parsed: whether `let` is allowed is determined when parsing, and the macro doesn't have the context of its expansion site to work with, so it doesn't know if it's being expanded into a condition or not. There's one catch though: because of this, most parts of the compiler that work with `let` expressions assume `&&` operators associate to the left. Since macro expansions sites aren't re-parsed (cc https://github.com/rust-lang/rust/issues/61733#issuecomment-509626449), macros expanding to `&&`-chains containing `is` operators will break that assumption: putting one of those expansions on the right-hand-side of an `&&` will cause this implementation to panic in `check_match` (and also likely make some incorrect assumptions in `region_scope_tree`).

I've also tried to handle attributes on `is` correctly. There's no tests since it would be impossible to put an attribute directly on an `is` operator expression currently without parentheses (cc rust-lang/rust#127436), but it may eventually be possible if attributes can apply to macro expansions (cc rust-lang/rust#63221).

### Feature gate and tracking issue

None yet. I can add those if there's interest in merging these changes. Since the current `builtin # is(expr is pat)` syntax is permanently unstable, this PR does not stabilize anything.

[^1]: Since `let`-chains already exist, I'd be curious if it'd make sense to restrict the scope of `is` further, to avoid its scope depending on whether it appears in a condition. Possibly some of the questions around shadowing would be easier to resolve too. But it raises some questions around temporary lifetimes and how mixing `is` and `let` in `&&`-chains should work. Alternatively, I'd be happy with shortening the lifetime of `let` expressions' temporaries by default and keeping `is` consistent with `let`. I've been running into some trouble with `let` temporary lifetimes in designing `if let` guard patterns too.