### PR TITLE
Add approval blocking labels for new bors

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -1,2 +1,19 @@
 # 6 hours timeout for CI builds
 timeout = 21600
+
+# Do not allow approving PRs with certain labels
+labels_blocking_approval = [
+    # Waiting for an FCP to finish
+    "final-comment-period",
+    "proposed-final-comment-period",
+    # PRs that were closed or postponed by an FCP
+    "disposition-close",
+    "disposition-postpone",
+    # Waiting for library ACP
+    "S-waiting-on-ACP",
+    "S-waiting-on-concerns",
+    "S-waiting-on-crater",
+    "S-waiting-on-fcp",
+    "S-waiting-on-MCP",
+    "S-waiting-on-team"
+]


### PR DESCRIPTION
If a PR contains these labels, new bors won't let anyone approve it. We don't merge PRs using new bors yet, ofc, but I wanted to prepare this so that I don't forget about it.

This was proposed here: [#t-lang/meetings > Triage meeting 2025-07-23 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/410673-t-lang.2Fmeetings/topic/Triage.20meeting.202025-07-23/near/529407150) and implemented [here](https://github.com/rust-lang/bors/pull/367).

CC @RalfJung

r? @oli-obk