### PR TITLE
Add non-regression test for #144168

### DIFF
--- a/tests/ui/resolve/underscore-bindings-disambiguators.rs
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.rs
@@ -1,0 +1,27 @@
+// Regression test for issue #144168 where some `_` bindings were incorrectly only allowed once per
+// module, failing with "error[E0428]: the name `_` is defined multiple times".
+
+// This weird/complex setup is reduced from `zerocopy-0.8.25` where the issue was encountered.
+
+#![crate_type = "lib"]
+
+macro_rules! impl_for_transmute_from {
+    () => {
+        const _: () = {};
+    };
+}
+
+mod impls {
+    use super::*;
+    impl_for_transmute_from!();
+    impl_for_transmute_from!();
+    const _: () = todo!(); //~ ERROR: evaluation panicked
+    const _: () = todo!(); //~ ERROR: evaluation panicked
+    const _: () = todo!(); //~ ERROR: evaluation panicked
+    const _: () = todo!(); //~ ERROR: evaluation panicked
+    const _: () = todo!(); //~ ERROR: evaluation panicked
+}
+use X as Y; //~ ERROR: unresolved import
+use Z as W; //~ ERROR: unresolved import
+
+const _: () = todo!(); //~ ERROR: evaluation panicked

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -1,0 +1,70 @@
+error[E0432]: unresolved import `X`
+  --> $DIR/underscore-bindings-disambiguators.rs:24:5
+   |
+LL | use X as Y;
+   |     -^^^^^
+   |     |
+   |     no `X` in the root
+   |     help: a similar name exists in the module: `_`
+
+error[E0432]: unresolved import `Z`
+  --> $DIR/underscore-bindings-disambiguators.rs:25:5
+   |
+LL | use Z as W;
+   |     -^^^^^
+   |     |
+   |     no `Z` in the root
+   |     help: a similar name exists in the module: `_`
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:18:19
+   |
+LL |     const _: () = todo!();
+   |                   ^^^^^^^ evaluation of `impls::_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:19:19
+   |
+LL |     const _: () = todo!();
+   |                   ^^^^^^^ evaluation of `impls::_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:20:19
+   |
+LL |     const _: () = todo!();
+   |                   ^^^^^^^ evaluation of `impls::_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:21:19
+   |
+LL |     const _: () = todo!();
+   |                   ^^^^^^^ evaluation of `impls::_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:22:19
+   |
+LL |     const _: () = todo!();
+   |                   ^^^^^^^ evaluation of `impls::_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation panicked: not yet implemented
+  --> $DIR/underscore-bindings-disambiguators.rs:27:15
+   |
+LL | const _: () = todo!();
+   |               ^^^^^^^ evaluation of `_` failed here
+   |
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0080, E0432.
+For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
This is a non-regression test for issue rust-lang/rust#144168, reduced from `zerocopy`, to go with https://github.com/rust-lang/rust/pull/144172 since it had no test yet, and we didn't want to delay it from landing.

Closes rust-lang/rust#144168

I've checked that the test does fail without rust-lang/rust#144172.