### PR TITLE
Suggest adding `Fn` bound when calling a generic parameter

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -25,6 +25,7 @@ use tracing::{debug, instrument};
 use super::method::MethodCallee;
 use super::method::probe::ProbeScope;
 use super::{Expectation, FnCtxt, TupleArgumentsFlag};
+use crate::expr_use_visitor::TypeInformationCtxt;
 use crate::{errors, fluent_generated};
 
 /// Checks that it is legal to call methods of the trait corresponding
@@ -122,7 +123,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     );
                 }
 
-                let guar = self.report_invalid_callee(call_expr, callee_expr, expr_ty, arg_exprs);
+                let guar = self.report_invalid_callee(
+                    call_expr,
+                    callee_expr,
+                    expr_ty,
+                    arg_exprs,
+                    expected,
+                );
                 Ty::new_error(self.tcx, guar)
             }
 
@@ -677,6 +684,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         callee_expr: &'tcx hir::Expr<'tcx>,
         callee_ty: Ty<'tcx>,
         arg_exprs: &'tcx [hir::Expr<'tcx>],
+        expected: Expectation<'tcx>,
     ) -> ErrorGuaranteed {
         // Callee probe fails when APIT references errors, so suppress those
         // errors here.
@@ -806,6 +814,33 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_label(def_span, "the callable type is defined here");
                 }
             } else {
+                // Suggest adding <Param>: Fn(...) [-> RetType]
+                if callee_ty.has_non_region_param() {
+                    let arg_types: Vec<Ty<'tcx>> = arg_exprs
+                        .iter()
+                        .map(|arg| self.typeck_results.borrow().expr_ty(arg))
+                        .collect();
+                    let args_tuple = Ty::new_tup(self.tcx(), &arg_types);
+
+                    let fn_def_id = self.tcx().require_lang_item(LangItem::Fn, callee_expr.span);
+                    let trait_ref =
+                        ty::TraitRef::new(self.tcx(), fn_def_id, [callee_ty, args_tuple]);
+
+                    let trait_pred =
+                        ty::TraitPredicate { trait_ref, polarity: ty::PredicatePolarity::Positive };
+
+                    let associated_ty = expected
+                        .to_option(self)
+                        // We do not want to suggest e.g. `-> _`
+                        .filter(|ty| !ty.has_infer())
+                        .map(|ty| ("Output", ty));
+                    self.err_ctxt().suggest_restricting_param_bound(
+                        &mut err,
+                        ty::Binder::dummy(trait_pred),
+                        associated_ty,
+                        self.body_id,
+                    );
+                }
                 err.span_label(call_expr.span, "call expression requires function");
             }
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -388,12 +388,16 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
 
                     if let Some((name, term)) = associated_ty {
-                        // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.
-                        // That should be extracted into a helper function.
-                        if let Some(stripped) = constraint.strip_suffix('>') {
-                            constraint = format!("{stripped}, {name} = {term}>");
+                        if self.tcx.is_fn_trait(trait_pred.skip_binder().trait_ref.def_id) {
+                            constraint.push_str(&format!(" -> {term}"));
                         } else {
-                            constraint.push_str(&format!("<{name} = {term}>"));
+                            // FIXME: this case overlaps with code in TyCtxt::note_and_explain_type_err.
+                            // That should be extracted into a helper function.
+                            if let Some(stripped) = constraint.strip_suffix('>') {
+                                constraint = format!("{stripped}, {name} = {term}>");
+                            } else {
+                                constraint.push_str(&format!("<{name} = {term}>"));
+                            }
                         }
                     }
 

--- a/tests/ui/issues/issue-21701.stderr
+++ b/tests/ui/issues/issue-21701.stderr
@@ -7,6 +7,11 @@ LL |     let y = t();
    |             ^--
    |             |
    |             call expression requires function
+   |
+help: consider restricting type parameter `U` with trait `Fn`
+   |
+LL | fn foo<U: Fn()>(t: U) {
+   |         ++++++
 
 error[E0618]: expected function, found struct `Bar`
   --> $DIR/issue-21701.rs:9:13

--- a/tests/ui/suggestions/suggest-call-on-generic-param.rs
+++ b/tests/ui/suggestions/suggest-call-on-generic-param.rs
@@ -1,0 +1,26 @@
+fn return_type<T>(t: T) {
+    let x: u32 = t(1);
+    //~^ ERROR: expected function, found `T` [E0618]
+}
+
+fn unknown_return_type<T>(t: T) {
+    let x = t();
+    //~^ ERROR: expected function, found `T` [E0618]
+}
+
+fn nested_return_type<T>(t: Vec<T>) {
+    t();
+    //~^ ERROR: expected function, found `Vec<T>` [E0618]
+}
+
+fn no_return_type<T>(t: T) {
+    t(1, 2, true);
+    //~^ ERROR: expected function, found `T` [E0618]
+}
+
+fn existing_bound<T: Copy>(t: T) {
+    t(false);
+    //~^ ERROR: expected function, found `T` [E0618]
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-call-on-generic-param.stderr
+++ b/tests/ui/suggestions/suggest-call-on-generic-param.stderr
@@ -1,0 +1,78 @@
+error[E0618]: expected function, found `T`
+  --> $DIR/suggest-call-on-generic-param.rs:2:18
+   |
+LL | fn return_type<T>(t: T) {
+   |                   - `t` has type `T`
+LL |     let x: u32 = t(1);
+   |                  ^---
+   |                  |
+   |                  call expression requires function
+   |
+help: consider restricting type parameter `T` with trait `Fn`
+   |
+LL | fn return_type<T: Fn(i32) -> u32>(t: T) {
+   |                 ++++++++++++++++
+
+error[E0618]: expected function, found `T`
+  --> $DIR/suggest-call-on-generic-param.rs:7:13
+   |
+LL | fn unknown_return_type<T>(t: T) {
+   |                           - `t` has type `T`
+LL |     let x = t();
+   |             ^--
+   |             |
+   |             call expression requires function
+   |
+help: consider restricting type parameter `T` with trait `Fn`
+   |
+LL | fn unknown_return_type<T: Fn()>(t: T) {
+   |                         ++++++
+
+error[E0618]: expected function, found `Vec<T>`
+  --> $DIR/suggest-call-on-generic-param.rs:12:5
+   |
+LL | fn nested_return_type<T>(t: Vec<T>) {
+   |                          - `t` has type `Vec<T>`
+LL |     t();
+   |     ^--
+   |     |
+   |     call expression requires function
+   |
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn nested_return_type<T>(t: Vec<T>) where Vec<T>: Fn() {
+   |                                     ++++++++++++++++++
+
+error[E0618]: expected function, found `T`
+  --> $DIR/suggest-call-on-generic-param.rs:17:5
+   |
+LL | fn no_return_type<T>(t: T) {
+   |                      - `t` has type `T`
+LL |     t(1, 2, true);
+   |     ^------------
+   |     |
+   |     call expression requires function
+   |
+help: consider restricting type parameter `T` with trait `Fn`
+   |
+LL | fn no_return_type<T: Fn(i32, i32, bool)>(t: T) {
+   |                    ++++++++++++++++++++
+
+error[E0618]: expected function, found `T`
+  --> $DIR/suggest-call-on-generic-param.rs:22:5
+   |
+LL | fn existing_bound<T: Copy>(t: T) {
+   |                            - `t` has type `T`
+LL |     t(false);
+   |     ^-------
+   |     |
+   |     call expression requires function
+   |
+help: consider further restricting type parameter `T` with trait `Fn`
+   |
+LL | fn existing_bound<T: Copy + Fn(bool)>(t: T) {
+   |                           ++++++++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
The goal of the PR is to provide this diagnostic hint:
```rust
fn foo<T>(t: T) {
    let x: u32 = t(1);
}
//vvv
fn foo<T: Fn(i32) -> u32>(t: T) {
    let x: u32 = t(1);
}
```

I had to provide some input for `suggest_restricting_param_bound`, but I wasn't sure where to get the corresponding `Fn` trait for, because here it didn't seem like the code was already checking for trait impl matches, unlike e.g. in `check_overloaded_binop`, where the suggest function is also used. With the help of Claude, I managed to create the trait ref *somehow*, but I'm not at all sure if it's the right way to do (in particular around `Binder::dummy`).

The `suggest_restricting_param_bound` change is also super hacky - maybe there's a way to "attach" the associated `Output` type to the `Fn` trait ref, so that we don't have to manually render the output type?