### PR TITLE
Parser: Recover from attributes applied to types and generic args

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -71,6 +71,17 @@ parse_attr_without_generics = attribute without generic parameters
 parse_attribute_on_param_type = attributes cannot be applied to a function parameter's type
     .label = attributes are not allowed here
 
+parse_attribute_on_type = attributes cannot be applied to types
+    .label = attributes are not allowed here
+    .suggestion = remove attribute from here
+
+parse_attribute_on_generic_arg = attributes cannot be applied to generic arguments
+    .label = attributes are not allowed here
+    .suggestion = remove attribute from here
+
+parse_attribute_on_empty_type = attributes cannot be applied here
+    .label = attributes are not allowed here
+
 parse_bad_assoc_type_bounds = bounds on associated types do not belong here
     .label = belongs in `where` clause
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1490,6 +1490,34 @@ pub(crate) struct AttributeOnParamType {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_attribute_on_type)]
+pub(crate) struct AttributeOnType {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
+    pub fix_span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_attribute_on_generic_arg)]
+pub(crate) struct AttributeOnGenericArg {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
+    pub fix_span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_attribute_on_empty_type)]
+pub(crate) struct AttributeOnEmptyType {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_pattern_method_param_without_body, code = E0642)]
 pub(crate) struct PatternMethodParamWithoutBody {
     #[primary_span]

--- a/tests/ui/parser/attribute-on-empty.rs
+++ b/tests/ui/parser/attribute-on-empty.rs
@@ -1,0 +1,29 @@
+//! Regression test for: <https://github.com/rust-lang/rust/issues/144132>
+//!                      <https://github.com/rust-lang/rust/issues/135017>
+
+struct Baz<const N: usize>(i32);
+
+fn main() {
+    let _: Baz<#[cfg(any())]> = todo!();
+    //~^ ERROR attributes cannot be applied here
+}
+
+fn f(_param: #[attr]) {}
+//~^ ERROR attributes cannot be applied to a function parameter's type
+//~| ERROR expected type, found `)`
+
+fn g() -> #[attr] { 0 }
+//~^ ERROR attributes cannot be applied here
+
+struct S {
+    field: #[attr],
+    //~^ ERROR attributes cannot be applied here
+    field1: (#[attr], i32),
+    //~^ ERROR attributes cannot be applied here
+}
+
+type Tuple = (#[attr], String);
+//~^ ERROR attributes cannot be applied here
+
+impl #[attr] {}
+//~^ ERROR attributes cannot be applied here

--- a/tests/ui/parser/attribute-on-empty.stderr
+++ b/tests/ui/parser/attribute-on-empty.stderr
@@ -1,0 +1,52 @@
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:7:16
+   |
+LL |     let _: Baz<#[cfg(any())]> = todo!();
+   |          -     ^^^^^^^^^^^^^ attributes are not allowed here
+   |          |
+   |          while parsing the type for `_`
+
+error: attributes cannot be applied to a function parameter's type
+  --> $DIR/attribute-on-empty.rs:11:14
+   |
+LL | fn f(_param: #[attr]) {}
+   |              ^^^^^^^ attributes are not allowed here
+
+error: expected type, found `)`
+  --> $DIR/attribute-on-empty.rs:11:21
+   |
+LL | fn f(_param: #[attr]) {}
+   |                     ^ expected type
+
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:15:11
+   |
+LL | fn g() -> #[attr] { 0 }
+   |           ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:19:12
+   |
+LL |     field: #[attr],
+   |            ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:21:14
+   |
+LL |     field1: (#[attr], i32),
+   |              ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:25:15
+   |
+LL | type Tuple = (#[attr], String);
+   |               ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied here
+  --> $DIR/attribute-on-empty.rs:28:6
+   |
+LL | impl #[attr] {}
+   |      ^^^^^^^ attributes are not allowed here
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/parser/attribute-on-type.fixed
+++ b/tests/ui/parser/attribute-on-type.fixed
@@ -1,0 +1,58 @@
+//! Regression test for: <https://github.com/rust-lang/rust/issues/144132>
+//!                      <https://github.com/rust-lang/rust/issues/135017>
+
+//@ run-rustfix
+
+#![allow(dead_code, unused_variables)]
+
+struct Foo<T>(T);
+struct Bar<'a>(&'a i32);
+struct Baz<const N: usize>(i32);
+
+fn main() {
+    let foo: Foo<i32> = Foo(2i32);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: &'static str = "123";
+    //~^ ERROR attributes cannot be applied to types
+
+    let _: Bar<'static> = Bar(&123);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Baz<42> = Baz(42);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Foo<String> = Foo(String::new());
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Bar<'static> = Bar(&456);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _generic: Box<i32> = Box::new(1);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _assignment: i32 = *Box::new(1);
+    //~^ ERROR attributes cannot be applied to types
+
+    let _complex: Vec<String> = vec![];
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _nested: Box<Vec<u64>> = Box::new(vec![]);
+    //~^ ERROR attributes cannot be applied to generic arguments
+}
+
+fn g() -> i32 { 0 }
+//~^ ERROR attributes cannot be applied to types
+
+struct S {
+    field: i32,
+    //~^ ERROR attributes cannot be applied to types
+    field1: (i32, i32),
+    //~^ ERROR attributes cannot be applied to types
+}
+
+type Tuple = (i32, String);
+//~^ ERROR attributes cannot be applied to types
+
+impl S {}
+//~^ ERROR attributes cannot be applied to types

--- a/tests/ui/parser/attribute-on-type.rs
+++ b/tests/ui/parser/attribute-on-type.rs
@@ -1,0 +1,58 @@
+//! Regression test for: <https://github.com/rust-lang/rust/issues/144132>
+//!                      <https://github.com/rust-lang/rust/issues/135017>
+
+//@ run-rustfix
+
+#![allow(dead_code, unused_variables)]
+
+struct Foo<T>(T);
+struct Bar<'a>(&'a i32);
+struct Baz<const N: usize>(i32);
+
+fn main() {
+    let foo: Foo<#[cfg(not(wrong))] i32> = Foo(2i32);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: #[attr] &'static str = "123";
+    //~^ ERROR attributes cannot be applied to types
+
+    let _: Bar<#[cfg(any())] 'static> = Bar(&123);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Baz<#[cfg(any())] 42> = Baz(42);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Foo<#[cfg(not(wrong))]String> = Foo(String::new());
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _: Bar<#[cfg(any())]       'static> = Bar(&456);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _generic: Box<#[attr] i32> = Box::new(1);
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _assignment: #[attr] i32 = *Box::new(1);
+    //~^ ERROR attributes cannot be applied to types
+
+    let _complex: Vec<#[derive(Debug)] String> = vec![];
+    //~^ ERROR attributes cannot be applied to generic arguments
+
+    let _nested: Box<Vec<#[cfg(feature = "test")] u64>> = Box::new(vec![]);
+    //~^ ERROR attributes cannot be applied to generic arguments
+}
+
+fn g() -> #[attr] i32 { 0 }
+//~^ ERROR attributes cannot be applied to types
+
+struct S {
+    field: #[attr] i32,
+    //~^ ERROR attributes cannot be applied to types
+    field1: (#[attr] i32, i32),
+    //~^ ERROR attributes cannot be applied to types
+}
+
+type Tuple = (#[attr] i32, String);
+//~^ ERROR attributes cannot be applied to types
+
+impl #[attr] S {}
+//~^ ERROR attributes cannot be applied to types

--- a/tests/ui/parser/attribute-on-type.stderr
+++ b/tests/ui/parser/attribute-on-type.stderr
@@ -1,0 +1,92 @@
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:13:18
+   |
+LL |     let foo: Foo<#[cfg(not(wrong))] i32> = Foo(2i32);
+   |                  ^^^^^^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:16:12
+   |
+LL |     let _: #[attr] &'static str = "123";
+   |            ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:19:16
+   |
+LL |     let _: Bar<#[cfg(any())] 'static> = Bar(&123);
+   |                ^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:22:16
+   |
+LL |     let _: Baz<#[cfg(any())] 42> = Baz(42);
+   |                ^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:25:16
+   |
+LL |     let _: Foo<#[cfg(not(wrong))]String> = Foo(String::new());
+   |                ^^^^^^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:28:16
+   |
+LL |     let _: Bar<#[cfg(any())]       'static> = Bar(&456);
+   |                ^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:31:23
+   |
+LL |     let _generic: Box<#[attr] i32> = Box::new(1);
+   |                       ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:34:22
+   |
+LL |     let _assignment: #[attr] i32 = *Box::new(1);
+   |                      ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:37:23
+   |
+LL |     let _complex: Vec<#[derive(Debug)] String> = vec![];
+   |                       ^^^^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to generic arguments
+  --> $DIR/attribute-on-type.rs:40:26
+   |
+LL |     let _nested: Box<Vec<#[cfg(feature = "test")] u64>> = Box::new(vec![]);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:44:11
+   |
+LL | fn g() -> #[attr] i32 { 0 }
+   |           ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:48:12
+   |
+LL |     field: #[attr] i32,
+   |            ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:50:14
+   |
+LL |     field1: (#[attr] i32, i32),
+   |              ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:54:15
+   |
+LL | type Tuple = (#[attr] i32, String);
+   |               ^^^^^^^ attributes are not allowed here
+
+error: attributes cannot be applied to types
+  --> $DIR/attribute-on-type.rs:57:6
+   |
+LL | impl #[attr] S {}
+   |      ^^^^^^^ attributes are not allowed here
+
+error: aborting due to 15 previous errors
+

--- a/tests/ui/parser/issues/issue-103143.rs
+++ b/tests/ui/parser/issues/issue-103143.rs
@@ -1,5 +1,5 @@
 fn main() {
     x::<#[a]y::<z>>
-    //~^ ERROR invalid const generic expression
+    //~^ ERROR attributes cannot be applied to generic arguments
     //~| ERROR cannot find value `x` in this scope
 }

--- a/tests/ui/parser/issues/issue-103143.stderr
+++ b/tests/ui/parser/issues/issue-103143.stderr
@@ -1,13 +1,8 @@
-error: invalid const generic expression
-  --> $DIR/issue-103143.rs:2:13
+error: attributes cannot be applied to generic arguments
+  --> $DIR/issue-103143.rs:2:9
    |
 LL |     x::<#[a]y::<z>>
-   |             ^^^^^^
-   |
-help: expressions must be enclosed in braces to be used as const generic arguments
-   |
-LL |     x::<#[a]{ y::<z> }>
-   |             +        +
+   |         ^^^^ attributes are not allowed here
 
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-103143.rs:2:5

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
@@ -1,7 +1,9 @@
 // Regression test for issues #100790 and #106439.
 //@ run-rustfix
 
-pub struct Example(#[allow(dead_code)] usize)
+#![allow(dead_code)]
+
+pub struct Example(usize)
 where
     (): Sized;
 //~^^^ ERROR where clauses are not allowed before tuple struct bodies

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
@@ -1,10 +1,12 @@
 // Regression test for issues #100790 and #106439.
 //@ run-rustfix
 
+#![allow(dead_code)]
+
 pub struct Example
 where
     (): Sized,
-(#[allow(dead_code)] usize);
+(usize);
 //~^^^ ERROR where clauses are not allowed before tuple struct bodies
 
 struct _Demo

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
@@ -1,23 +1,23 @@
 error: where clauses are not allowed before tuple struct bodies
-  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:5:1
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:7:1
    |
 LL |   pub struct Example
    |              ------- while parsing this tuple struct
 LL | / where
 LL | |     (): Sized,
    | |______________^ unexpected where clause
-LL |   (#[allow(dead_code)] usize);
-   |   --------------------------- the struct body
+LL |   (usize);
+   |   ------- the struct body
    |
 help: move the body before the where clause
    |
-LL ~ pub struct Example(#[allow(dead_code)] usize)
+LL ~ pub struct Example(usize)
 LL | where
 LL ~     (): Sized;
    |
 
 error: where clauses are not allowed before tuple struct bodies
-  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:11:1
+  --> $DIR/recover-where-clause-before-tuple-struct-body-0.rs:13:1
    |
 LL |   struct _Demo
    |          ----- while parsing this tuple struct


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? compiler

Add clearer error messages for invalid attribute usage in types or generic types

fixes rust-lang/rust#135017
fixes rust-lang/rust#144132
