### PR TITLE
flt2dec: replace for loop by iter_mut

### DIFF
--- a/library/core/src/num/flt2dec/mod.rs
+++ b/library/core/src/num/flt2dec/mod.rs
@@ -150,22 +150,18 @@ pub fn round_up(d: &mut [u8]) -> Option<u8> {
         Some(i) => {
             // d[i+1..n] is all nines
             d[i] += 1;
-            for j in i + 1..d.len() {
-                d[j] = b'0';
-            }
+            d[i + 1..].fill(b'0');
             None
         }
-        None if d.len() > 0 => {
-            // 999..999 rounds to 1000..000 with an increased exponent
-            d[0] = b'1';
-            for j in 1..d.len() {
-                d[j] = b'0';
-            }
-            Some(b'0')
-        }
-        None => {
+        None if d.is_empty() => {
             // an empty buffer rounds up (a bit strange but reasonable)
             Some(b'1')
+        }
+        None => {
+            // 999..999 rounds to 1000..000 with an increased exponent
+            d[0] = b'1';
+            d[1..].fill(b'0');
+            Some(b'0')
         }
     }
 }


### PR DESCRIPTION
Perf is explored in https://github.com/rust-lang/rust/issues/144118, which initially showed small losses, but then also showed significant gains. Both are real, but given the smallness of the losses, this seems a good change.