### PR TITLE
Add powerpc64-unknown-linux-gnuelfv2 target

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -201,6 +201,14 @@ pub(crate) unsafe fn create_module<'ll>(
         if sess.target.arch == Arch::PowerPC64 {
             // LLVM 22 updated the ABI alignment for double on AIX: https://github.com/llvm/llvm-project/pull/144673
             target_data_layout = target_data_layout.replace("-f64:32:64", "");
+
+            // LLVM 22 fixed the data layout calculation for targets that default to ELFv1
+            // when the ABI is set to ELFv2. With LLVM 21, the ELFv1 datalayout must be used,
+            // which will overalign function entries.
+            // https://github.com/llvm/llvm-project/pull/149725
+            if sess.target.llvm_target == "powerpc64-unknown-linux-gnu" {
+                target_data_layout = target_data_layout.replace("-Fn32", "-Fi64");
+            }
         }
         if sess.target.arch == Arch::AmdGpu {
             // LLVM 22 specified ELF mangling in the amdgpu data layout:

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1465,6 +1465,7 @@ supported_targets! {
     ("powerpc-unknown-linux-muslspe", powerpc_unknown_linux_muslspe),
     ("powerpc64-ibm-aix", powerpc64_ibm_aix),
     ("powerpc64-unknown-linux-gnu", powerpc64_unknown_linux_gnu),
+    ("powerpc64-unknown-linux-gnuelfv2", powerpc64_unknown_linux_gnuelfv2),
     ("powerpc64-unknown-linux-musl", powerpc64_unknown_linux_musl),
     ("powerpc64le-unknown-linux-gnu", powerpc64le_unknown_linux_gnu),
     ("powerpc64le-unknown-linux-musl", powerpc64le_unknown_linux_musl),

--- a/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnuelfv2.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_unknown_linux_gnuelfv2.rs
@@ -1,0 +1,30 @@
+use rustc_abi::Endian;
+
+use crate::spec::{
+    Arch, Cc, CfgAbi, LinkerFlavor, Lld, LlvmAbi, StackProbeType, Target, TargetMetadata,
+    TargetOptions, base,
+};
+
+pub(crate) fn target() -> Target {
+    let mut base = base::linux_gnu::opts();
+    base.cpu = "ppc64".into();
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
+    base.max_atomic_width = Some(64);
+    base.stack_probes = StackProbeType::Inline;
+    base.cfg_abi = CfgAbi::ElfV2;
+    base.llvm_abiname = LlvmAbi::ElfV2;
+
+    Target {
+        llvm_target: "powerpc64-unknown-linux-gnu".into(),
+        metadata: TargetMetadata {
+            description: Some("PPC64 Linux (ELFv2 ABI, kernel 3.2, glibc 2.17)".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(true),
+        },
+        pointer_width: 64,
+        data_layout: "E-m:e-Fn32-i64:64-i128:128-n32:64-S128-v256:256:256-v512:512:512".into(),
+        arch: Arch::PowerPC64,
+        options: TargetOptions { endian: Endian::Big, mcount: "_mcount".into(), ..base },
+    }
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -37,6 +37,7 @@ pub struct Finder {
 /// when the newly-bumped stage 0 compiler now knows about the formerly-missing targets.
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
+    "powerpc64-unknown-linux-gnuelfv2",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -107,6 +107,7 @@
     - [powerpc-unknown-linux-gnuspe](platform-support/powerpc-unknown-linux-gnuspe.md)
     - [powerpc-unknown-linux-muslspe](platform-support/powerpc-unknown-linux-muslspe.md)
     - [powerpc64-ibm-aix](platform-support/aix.md)
+    - [powerpc64-unknown-linux-gnuelfv2](platform-support/powerpc64-unknown-linux-gnuelfv2.md)
     - [powerpc64-unknown-linux-musl](platform-support/powerpc64-unknown-linux-musl.md)
     - [powerpc64le-unknown-linux-gnu](platform-support/powerpc64le-unknown-linux-gnu.md)
     - [powerpc64le-unknown-linux-musl](platform-support/powerpc64le-unknown-linux-musl.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -385,6 +385,7 @@ target | std | host | notes
 [`powerpc-wrs-vxworks-spe`](platform-support/vxworks.md) | ✓ |  |
 [`powerpc64-ibm-aix`](platform-support/aix.md) | ? |  | 64-bit AIX (7.2 and newer)
 [`powerpc64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64 FreeBSD (ELFv2)
+[`powerpc64-unknown-linux-gnuelfv2`](platform-support/powerpc64-unknown-linux-gnuelfv2.md) | ✓ | ✓ | PPC64 Linux (ELFv2 ABI, kernel 3.2, glibc 2.17)
 [`powerpc64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/powerpc64
 [`powerpc64-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 [`powerpc64le-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64LE FreeBSD

--- a/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-gnuelfv2.md
+++ b/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-gnuelfv2.md
@@ -1,0 +1,50 @@
+# powerpc64-unknown-linux-gnuelfv2
+
+**Tier: 3**
+
+Target for 64-bit big endian PowerPC Linux programs using the ELFv2 ABI and
+the GNU C library.
+
+## Target maintainers
+
+[@Gelbpunkt](https://github.com/Gelbpunkt)
+
+## Requirements
+
+Building the target itself requires a 64-bit big endian PowerPC compiler that
+uses the ELFv2 ABI and is supported by `cc-rs`.
+
+## Building the target
+
+The target can be built by enabling it for a `rustc` build.
+
+```toml
+[build]
+target = ["powerpc64-unknown-linux-gnuelfv2"]
+```
+
+Make sure your C compiler is included in `$PATH`, then add it to the
+`bootstrap.toml`:
+
+```toml
+[target.powerpc64-unknown-linux-gnuelfv2]
+cc = "powerpc64-linux-gnu-gcc"
+cxx = "powerpc64-linux-gnu-g++"
+ar = "powerpc64-linux-gnu-ar"
+linker = "powerpc64-linux-gnu-gcc"
+```
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will first need to build Rust with the target enabled (see
+"Building the target" above).
+
+## Cross-compilation
+
+This target can be cross-compiled from any host.
+
+## Testing
+
+This target can be tested as normal with `x.py` on a 64-bit big endian PowerPC
+host or via QEMU emulation.

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -394,6 +394,9 @@
 //@ revisions: powerpc64_unknown_linux_gnu
 //@ [powerpc64_unknown_linux_gnu] compile-flags: --target powerpc64-unknown-linux-gnu
 //@ [powerpc64_unknown_linux_gnu] needs-llvm-components: powerpc
+//@ revisions: powerpc64_unknown_linux_gnuelfv2
+//@ [powerpc64_unknown_linux_gnuelfv2] compile-flags: --target powerpc64-unknown-linux-gnuelfv2
+//@ [powerpc64_unknown_linux_gnuelfv2] needs-llvm-components: powerpc
 //@ revisions: powerpc64_unknown_linux_musl
 //@ [powerpc64_unknown_linux_musl] compile-flags: --target powerpc64-unknown-linux-musl
 //@ [powerpc64_unknown_linux_musl] needs-llvm-components: powerpc


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144220)*
<!-- homu-ignore:end -->

This is virtually the same target as the existing -gnu target, but using the ELFv2 ABI instead of the ELFv1 ABI and made possible now that we expose target_abi = "elfv1" or "elfv2" on the 64-bit PowerPC targets.

The ELFv2 ABI is the preferred ABI for powerpc64 when compatibility with ELFv1 is not required and therefore used by e.g. distributions that were bootstrapped after the introduction of ELFv2.

Copying the [target tier policy](https://doc.rust-lang.org/rustc/target-tier-policy.html#tier-3-target-policy):

> A tier 3 target must have a designated developer or developers (the "target maintainers") on record to be CCed when issues arise regarding the target. (The mechanism to track and CC such developers may evolve over time.)

That would be me.

> Targets must use naming consistent with any existing targets; for instance, a target for the same CPU or OS as an existing Rust target should use the same name for that CPU or OS. Targets should normally use the same names and naming conventions as used elsewhere in the broader ecosystem beyond Rust (such as in other toolchains), unless they have a very good reason to diverge. Changing the name of a target can be highly disruptive, especially once the target reaches a higher tier, so getting the name right is important even for a tier 3 target. 

This is an interesting one, because I'm not aware of any toolchain that has a target triple for ppc64 + glibc + ELFv2, even though it is a totally valid combination and actively in used by some distributions. Clang and GCC both simply use `-target powerpc64-unknown-linux-gnu -mabi=elfv2` to my knowledge (and cross-toolchains should be using `--with-abi=elfv2` when configuring GCC). However, the chosen name should be somewhat in line with the other existing targets with special ABIs. Renaming `powerpc64-unknown-linux-gnu` to `powerpc64-unknown-linux-gnuelfv1` at the same time to avoid ambiguity would've been an interesting idea, but it'd be a breaking change to a tier 2 target.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users.

This target isn't any different than the ELFv1 target in this regard.

> Neither this policy nor any decisions made regarding targets shall create any binding agreement or estoppel by any party. If any member of an approving Rust team serves as one of the maintainers of a target, or has any legal or employment requirement (explicit or implicit) that might affect their decisions regarding a target, they must recuse themselves from any approval decisions regarding the target's tier status, though they may otherwise participate in discussions.

Nothing to comment on here on my end.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate (core for most targets, alloc for targets that can support dynamic memory allocation, std for targets with an operating system or equivalent layer of system-provided functionality), but may leave some code unimplemented (either unavailable or stubbed out as appropriate), whether because the target makes it impossible to implement or challenging to implement. The authors of pull requests are not obligated to avoid calling any portions of the standard library on the basis of a tier 3 target not implementing those portions.

This target implements the entire standard library.

> The target must provide documentation for the Rust community explaining how to build for the target, using cross-compilation if possible. If the target supports running binaries, or running tests (even if they do not pass), the documentation must explain how to run such binaries or tests for the target, using emulation if possible or dedicated hardware if necessary.

Documentation can be found in the markdown document added by this PR.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target. In particular, do not post comments (automated or manual) on a PR that derail or suggest a block on the PR based on a tier 3 target. Do not send automated messages or notifications (via any medium, including via @) to a PR author or others involved with a PR regarding a tier 3 target, unless they have opted into such messages. 

Roger that :)

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target. 

This PR doesn't touch any other targets.

> Tier 3 targets must be able to produce assembly using at least one of rustc's supported backends from any host target. (Having support in a fork of the backend is not sufficient, it must be upstream.)

The LLVM backend works.

r? compiler