### PR TITLE
generate elf symbol version in raw-dylib

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -330,3 +330,6 @@ metadata_wasm_import_form =
 
 metadata_whole_archive_needs_static =
     linking modifier `whole-archive` is only compatible with `static` linking kind
+
+metadata_raw_dylib_malformed =
+    link name must be well-formed if link kind is `raw-dylib`

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -815,3 +815,10 @@ pub struct AsyncDropTypesInDependency {
     pub extern_crate: Symbol,
     pub local_crate: Symbol,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_raw_dylib_malformed)]
+pub struct RawDylibMalformed {
+    #[primary_span]
+    pub span: Span,
+}

--- a/tests/ui/linkage-attr/raw-dylib/elf/empty.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/empty.rs
@@ -1,0 +1,11 @@
+//@ only-x86_64-unknown-linux-gnu
+//@ needs-dynamic-linking
+//@ build-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+
+#[link(name = "hack", kind = "raw-dylib")]
+unsafe extern "C" {}
+
+fn main() {}

--- a/tests/ui/linkage-attr/raw-dylib/elf/glibc-x86_64.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/glibc-x86_64.rs
@@ -1,0 +1,80 @@
+//@ only-x86_64-unknown-linux-gnu
+//@ needs-dynamic-linking
+//@ run-pass
+//@ compile-flags: -Cpanic=abort
+//@ edition: 2024
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+#![no_std]
+#![no_main]
+
+use core::ffi::{c_char, c_int};
+
+extern "C" fn callback(
+    _fpath: *const c_char,
+    _sb: *const (),
+    _tflag: c_int,
+    _ftwbuf: *const (),
+) -> c_int {
+    0
+}
+
+// `libc.so` is a linker script that provides the paths to `libc.so.6` and `libc_nonshared.a`.
+// In earlier versions of glibc, `libc_nonshared.a` provides the symbols `__libc_csu_init` and
+// `__libc_csu_fini` required by `Scrt1.o`.
+#[link(name = "c_nonshared", kind = "static")]
+unsafe extern "C" {}
+
+#[link(name = "libc.so.6", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    #[link_name = "nftw@GLIBC_2.2.5"]
+    unsafe fn nftw_2_2_5(
+        dirpath: *const c_char,
+        f: extern "C" fn(*const c_char, *const (), c_int, *const ()) -> c_int,
+        nopenfd: c_int,
+        flags: c_int,
+    ) -> c_int;
+    #[link_name = "nftw@GLIBC_2.3.3"]
+    unsafe fn nftw_2_3_3(
+        dirpath: *const c_char,
+        f: extern "C" fn(*const c_char, *const (), c_int, *const ()) -> c_int,
+        nopenfd: c_int,
+        flags: c_int,
+    ) -> c_int;
+    #[link_name = "exit@GLIBC_2.2.5"]
+    safe fn exit(status: i32) -> !;
+    unsafe fn __libc_start_main() -> c_int;
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn main() -> ! {
+    unsafe {
+        // The old `nftw` does not check whether unknown flags are set.
+        let res = nftw_2_2_5(c".".as_ptr(), callback, 20, 1 << 30);
+        assert_eq!(res, 0);
+    }
+    unsafe {
+        // The new `nftw` does.
+        let res = nftw_2_3_3(c".".as_ptr(), callback, 20, 1 << 30);
+        assert_eq!(res, -1);
+    }
+    exit(0);
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo<'_>) -> ! {
+    exit(1);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    exit(1);
+}

--- a/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.rs
@@ -1,0 +1,20 @@
+//@ only-elf
+//@ needs-dynamic-linking
+//@ check-fail
+
+#![feature(raw_dylib_elf)]
+#![allow(incomplete_features)]
+
+#[link(name = "libc.so.6", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    #[link_name = "exit@"]
+    pub safe fn exit_0(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "@GLIBC_2.2.5"]
+    pub safe fn exit_1(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "ex\0it@GLIBC_2.2.5"]
+    pub safe fn exit_2(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "exit@@GLIBC_2.2.5"]
+    pub safe fn exit_3(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+}
+
+fn main() {}

--- a/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.stderr
@@ -1,0 +1,26 @@
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:11:5
+   |
+LL |     pub safe fn exit_0(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:13:5
+   |
+LL |     pub safe fn exit_1(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:15:5
+   |
+LL |     pub safe fn exit_2(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:17:5
+   |
+LL |     pub safe fn exit_3(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
For link names like `aaa@bbb`, it generates a symbol named `aaa` and a version named `bbb`.

For link names like `aaa\0bbb`, `aaa@@bbb` or `aa@bb@cc`, it emits errors.

It adds a test that the executable is linked with glibc using raw-dylib.

cc rust-lang/rust#135694