### PR TITLE
stdarch subtree update

### DIFF
--- a/library/stdarch/.github/workflows/main.yml
+++ b/library/stdarch/.github/workflows/main.yml
@@ -255,6 +255,28 @@ jobs:
       env:
         TARGET: ${{ matrix.target.tuple }}
 
+  # Check that the generated files agree with the checked-in versions.
+  check-stdarch-gen:
+    needs: [style]
+    name: Check stdarch-gen-{arm, loongarch} output 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup update nightly && rustup default nightly && rustup component add rustfmt
+    - name: Check arm spec
+      run: |
+        cargo run --bin=stdarch-gen-arm --release -- crates/stdarch-gen-arm/spec
+        git diff --exit-code
+    - name: Check lsx.spec
+      run: |
+        cargo run --bin=stdarch-gen-loongarch --release -- crates/stdarch-gen-loongarch/lsx.spec
+        git diff --exit-code
+    - name: Check lasx.spec
+      run: |
+        cargo run --bin=stdarch-gen-loongarch --release -- crates/stdarch-gen-loongarch/lasx.spec
+        git diff --exit-code
+
   build-std-detect:
     needs: [style]
     name: Build std_detect
@@ -271,6 +293,7 @@ jobs:
       - verify
       - test
       - build-std-detect
+      - check-stdarch-gen
     runs-on: ubuntu-latest
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to

--- a/library/stdarch/.github/workflows/rustc-pull.yml
+++ b/library/stdarch/.github/workflows/rustc-pull.yml
@@ -1,0 +1,22 @@
+# Perform a subtree sync (pull) using the josh-sync tool once every few days (or on demand).
+name: rustc-pull
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 04:00 UTC every Monday and Thursday
+    - cron: '0 4 * * 1,4'
+
+jobs:
+  pull:
+    if: github.repository == 'rust-lang/stdarch'
+    uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@main
+    with:
+      # https://rust-lang.zulipchat.com/#narrow/channel/208962-t-libs.2Fstdarch/topic/Subtree.20sync.20automation/with/528461782
+      zulip-stream-id: 208962
+      zulip-bot-email:  "stdarch-ci-bot@rust-lang.zulipchat.com"
+      pr-base-branch: master
+      branch-name: rustc-pull
+    secrets:
+      zulip-api-token: ${{ secrets.ZULIP_API_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -73,20 +73,20 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -128,7 +128,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -403,9 +403,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linked-hash-map"
@@ -624,7 +624,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,7 +838,7 @@ version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "semver",
 ]
 
@@ -945,20 +945,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -726,7 +726,6 @@ dependencies = [
  "assert-instr-macro",
  "cc",
  "cfg-if",
- "lazy_static",
  "rustc-demangle",
  "simd-test-macro",
  "wasmprinter",

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -703,7 +703,6 @@ name = "stdarch-gen-arm"
 version = "0.1.0"
 dependencies = [
  "itertools",
- "lazy_static",
  "proc-macro2",
  "quote",
  "regex",

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]

--- a/library/stdarch/Cargo.lock
+++ b/library/stdarch/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "cc"
 version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,9 +105,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -109,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -121,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -833,21 +839,23 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasmparser"
-version = "0.113.3"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286049849b5a5bd09a8773171be96824afabffc7cc3df6caaf33a38db6cd07ae"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
+ "bitflags",
  "indexmap 2.10.0",
  "semver",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.67"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6615a5587149e753bf4b93f90fa3c3f41c88597a7a2da72879afcabeda9648f"
+checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
 dependencies = [
  "anyhow",
+ "termcolor",
  "wasmparser",
 ]
 

--- a/library/stdarch/Cargo.toml
+++ b/library/stdarch/Cargo.toml
@@ -5,7 +5,8 @@ members = [
   "examples",
 ]
 exclude = [
-  "crates/wasm-assert-instr-tests"
+  "crates/wasm-assert-instr-tests",
+  "rust_programs",
 ]
 
 [profile.release]

--- a/library/stdarch/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qemu-user \
   make \
   file \
-  clang-19 \
+  clang \
   lld
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \

--- a/library/stdarch/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   g++ \

--- a/library/stdarch/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \

--- a/library/stdarch/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile
@@ -9,15 +9,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qemu-user \
   make \
   file \
-  clang-19 \
+  clang \
   curl \
   xz-utils \
   lld
 
-ENV TOOLCHAIN="arm-gnu-toolchain-14.2.rel1-x86_64-aarch64_be-none-linux-gnu"
+ENV TOOLCHAIN="arm-gnu-toolchain-14.3.rel1-x86_64-aarch64_be-none-linux-gnu"
 
 # Download the aarch64_be gcc toolchain
-RUN curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/${TOOLCHAIN}.tar.xz" -o "${TOOLCHAIN}.tar.xz"
+RUN curl -L "https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/${TOOLCHAIN}.tar.xz" -o "${TOOLCHAIN}.tar.xz"
 RUN tar -xvf "${TOOLCHAIN}.tar.xz"
 RUN mkdir /toolchains && mv "./${TOOLCHAIN}" /toolchains
 

--- a/library/stdarch/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/library/stdarch/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   ca-certificates \

--- a/library/stdarch/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/library/stdarch/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   qemu-user \
   make \
   file \
-  clang-19 \
+  clang \
   lld
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER="qemu-arm -cpu max -L /usr/arm-linux-gnueabihf" \

--- a/library/stdarch/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc-multilib \
   libc6-dev \

--- a/library/stdarch/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc-multilib \
   libc6-dev \

--- a/library/stdarch/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/library/stdarch/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:25.10
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     gcc libc6-dev qemu-user-static ca-certificates \
-    gcc-14-loongarch64-linux-gnu libc6-dev-loong64-cross
+    gcc-loongarch64-linux-gnu libc6-dev-loong64-cross
 
 
 ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-14 \

--- a/library/stdarch/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/library/stdarch/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/library/stdarch/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/library/stdarch/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/library/stdarch/ci/docker/nvptx64-nvidia-cuda/Dockerfile
+++ b/library/stdarch/ci/docker/nvptx64-nvidia-cuda/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \

--- a/library/stdarch/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/riscv32gc-unknown-linux-gnu/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \
         wget xz-utils make file llvm
 
-ENV VERSION=2025.01.20
+ENV VERSION=2025.07.03
 
 RUN wget "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${VERSION}/riscv32-glibc-ubuntu-24.04-gcc-nightly-${VERSION}-nightly.tar.xz" \
     -O riscv-toolchain.tar.xz

--- a/library/stdarch/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc libc6-dev qemu-user ca-certificates \

--- a/library/stdarch/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \

--- a/library/stdarch/ci/docker/wasm32-wasip1/Dockerfile
+++ b/library/stdarch/ci/docker/wasm32-wasip1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends \

--- a/library/stdarch/ci/docker/wasm32-wasip1/Dockerfile
+++ b/library/stdarch/ci/docker/wasm32-wasip1/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   clang
 
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v18.0.2/wasmtime-v18.0.2-x86_64-linux.tar.xz | tar xJf -
-ENV PATH=$PATH:/wasmtime-v18.0.2-x86_64-linux
+ENV VERSION=v34.0.1
+
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz | tar xJf -
+ENV PATH=$PATH:/wasmtime-${VERSION}-x86_64-linux
 
 ENV CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime --dir /checkout/target/wasm32-wasip1/release/deps::."

--- a/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \

--- a/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   xz-utils
 
-RUN wget http://ci-mirrors.rust-lang.org/stdarch/sde-external-9.53.0-2025-03-16-lin.tar.xz -O sde.tar.xz
+RUN wget http://ci-mirrors.rust-lang.org/stdarch/sde-external-9.58.0-2025-06-16-lin.tar.xz -O sde.tar.xz
 RUN mkdir intel-sde
 RUN tar -xJf sde.tar.xz --strip-components=1 -C intel-sde
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/intel-sde/sde64 \

--- a/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/cpuid.def
+++ b/library/stdarch/ci/docker/x86_64-unknown-linux-gnu/cpuid.def
@@ -1,41 +1,35 @@
-# Copyright (C) 2024-2024 Intel Corporation.
-#
+# Copyright (C) 2017-2025 Intel Corporation.
+# 
 # This software and the related documents are Intel copyrighted materials, and your
 # use of them is governed by the express license under which they were provided to
 # you ("License"). Unless the License provides otherwise, you may not use, modify,
 # copy, publish, distribute, disclose or transmit this software or the related
 # documents without Intel's prior written permission.
-#
+# 
 # This software and the related documents are provided as is, with no express or
 # implied warranties, other than those that are expressly stated in the License.
-#
-# The CPUID information in this file is for software enabling purposes only and
-# it is not a full and accurate representation of the CPU under development which
-# it represents.
-# The CPUID information in this file is not a guarantee of the availability of
-# features or characteristics in the final released CPU.
 #
 # CPUID_VERSION = 1.0
 #      Input      =>               Output
 # EAX      ECX    =>   EAX      EBX      ECX      EDX
 00000000 ******** => 00000024 68747541 444d4163 69746e65
-00000001 ******** => 000d06f0 00100800 7ffaf3ff bfebfbff
+00000001 ******** => 00400f10 00100800 7ffaf3ff bfebfbff
 00000002 ******** => 76035a01 00f0b6ff 00000000 00c10000
 00000003 ******** => 00000000 00000000 00000000 00000000
-00000004 00000000 => 7c004121 02c0003f 0000003f 00000000 #Deterministic Cache
+00000004 00000000 => 7c004121 01c0003f 0000003f 00000000 #Deterministic Cache
 00000004 00000001 => 7c004122 01c0003f 0000003f 00000000
-00000004 00000002 => 7c004143 03c0003f 000007ff 00000000
-00000004 00000003 => 7c0fc163 04c0003f 0005ffff 00000004
+00000004 00000002 => 7c004143 03c0003f 000003ff 00000000
+00000004 00000003 => 7c0fc163 0280003f 0000dfff 00000004
 00000004 00000004 => 00000000 00000000 00000000 00000000
 00000005 ******** => 00000040 00000040 00000003 00042120 #MONITOR/MWAIT
 00000006 ******** => 00000077 00000002 00000001 00000000 #Thermal and Power
-00000007 00000000 => 00000001 f3bfbfbf bbc05ffe 03d55130 #Extended Features
-00000007 00000001 => 88ee00bf 00000002 00000000 1d29cd3e
+00000007 00000000 => 00000001 f3bfbfbf bac05ffe 03d54130 #Extended Features
+00000007 00000001 => 98ee00bf 00000002 00000020 1d29cd3e
 00000008 ******** => 00000000 00000000 00000000 00000000
 00000009 ******** => 00000000 00000000 00000000 00000000 #Direct Cache
 0000000a ******** => 07300403 00000000 00000000 00000603
-0000000b 00000000 => 00000001 00000002 00000100 0000001e #Extended Topology
-0000000b 00000001 => 00000004 00000002 00000201 0000001e
+0000000b 00000000 => 00000001 00000002 00000100 00000000 #Extended Topology
+0000000b 00000001 => 00000004 00000002 00000201 00000000
 0000000c ******** => 00000000 00000000 00000000 00000000
 0000000d 00000000 => 000e02e7 00002b00 00002b00 00000000 #xcr0
 0000000d 00000001 => 0000001f 00000240 00000100 00000000
@@ -52,10 +46,8 @@
 0000001d 00000001 => 04002000 00080040 00000010 00000000 #AMX Palette1
 0000001e 00000000 => 00000001 00004010 00000000 00000000 #AMX Tmul
 0000001e 00000001 => 000001ff 00000000 00000000 00000000
-0000001f 00000000 => 00000001 00000002 00000100 0000001e
-0000001f 00000001 => 00000007 00000070 00000201 0000001e
-0000001f 00000002 => 00000000 00000000 00000002 0000001e
-00000024 00000000 => 00000000 00070002 00000000 00000000 #AVX10
+00000024 00000000 => 00000001 00070002 00000000 00000000 #AVX10
+00000024 00000001 => 00000000 00000000 00000004 00000000
 80000000 ******** => 80000008 00000000 00000000 00000000
 80000001 ******** => 00000000 00000000 00200961 2c100000
 80000002 ******** => 00000000 00000000 00000000 00000000
@@ -66,6 +58,6 @@
 80000007 ******** => 00000000 00000000 00000000 00000100
 80000008 ******** => 00003028 00000200 00000200 00000000
 
-# This file was copied from intel-sde/misc/cpuid/dmr/cpuid.def, and modified to
+# This file was copied from intel-sde/misc/cpuid/future/cpuid.def, and modified to
 # use "AuthenticAMD" as the vendor and the support for `XOP`, `SSE4a`, `TBM`,
 # `AVX512_VP2INTERSECT` and the VEX variants of AVX512 was added in the CPUID.

--- a/library/stdarch/ci/run.sh
+++ b/library/stdarch/ci/run.sh
@@ -144,21 +144,21 @@ case ${TARGET} in
     aarch64-unknown-linux-gnu*)
         TEST_CPPFLAGS="-fuse-ld=lld -I/usr/aarch64-linux-gnu/include/ -I/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu/"
         TEST_SKIP_INTRINSICS=crates/intrinsic-test/missing_aarch64.txt
-        TEST_CXX_COMPILER="clang++-19"
+        TEST_CXX_COMPILER="clang++"
         TEST_RUNNER="${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER}"
         ;;
 
     aarch64_be-unknown-linux-gnu*)
         TEST_CPPFLAGS="-fuse-ld=lld"
         TEST_SKIP_INTRINSICS=crates/intrinsic-test/missing_aarch64.txt
-        TEST_CXX_COMPILER="clang++-19"
+        TEST_CXX_COMPILER="clang++"
         TEST_RUNNER="${CARGO_TARGET_AARCH64_BE_UNKNOWN_LINUX_GNU_RUNNER}"
         ;;
 
     armv7-unknown-linux-gnueabihf*)
         TEST_CPPFLAGS="-fuse-ld=lld -I/usr/arm-linux-gnueabihf/include/ -I/usr/arm-linux-gnueabihf/include/c++/9/arm-linux-gnueabihf/"
         TEST_SKIP_INTRINSICS=crates/intrinsic-test/missing_arm.txt
-        TEST_CXX_COMPILER="clang++-19"
+        TEST_CXX_COMPILER="clang++"
         TEST_RUNNER="${CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER}"
         ;;
     *)

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -13381,14 +13381,7 @@ pub fn vmaxvq_f64(a: float64x2_t) -> f64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxv))]
 pub fn vmaxv_s8(a: int8x8_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i8.v8i8"
-        )]
-        fn _vmaxv_s8(a: int8x8_t) -> i8;
-    }
-    unsafe { _vmaxv_s8(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_s8)"]
@@ -13397,14 +13390,7 @@ pub fn vmaxv_s8(a: int8x8_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxv))]
 pub fn vmaxvq_s8(a: int8x16_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i8.v16i8"
-        )]
-        fn _vmaxvq_s8(a: int8x16_t) -> i8;
-    }
-    unsafe { _vmaxvq_s8(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_s16)"]
@@ -13413,14 +13399,7 @@ pub fn vmaxvq_s8(a: int8x16_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxv))]
 pub fn vmaxv_s16(a: int16x4_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i16.v4i16"
-        )]
-        fn _vmaxv_s16(a: int16x4_t) -> i16;
-    }
-    unsafe { _vmaxv_s16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_s16)"]
@@ -13429,14 +13408,7 @@ pub fn vmaxv_s16(a: int16x4_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxv))]
 pub fn vmaxvq_s16(a: int16x8_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i16.v8i16"
-        )]
-        fn _vmaxvq_s16(a: int16x8_t) -> i16;
-    }
-    unsafe { _vmaxvq_s16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_s32)"]
@@ -13445,14 +13417,7 @@ pub fn vmaxvq_s16(a: int16x8_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxp))]
 pub fn vmaxv_s32(a: int32x2_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i32.v2i32"
-        )]
-        fn _vmaxv_s32(a: int32x2_t) -> i32;
-    }
-    unsafe { _vmaxv_s32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_s32)"]
@@ -13461,14 +13426,7 @@ pub fn vmaxv_s32(a: int32x2_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(smaxv))]
 pub fn vmaxvq_s32(a: int32x4_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smaxv.i32.v4i32"
-        )]
-        fn _vmaxvq_s32(a: int32x4_t) -> i32;
-    }
-    unsafe { _vmaxvq_s32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_u8)"]
@@ -13477,14 +13435,7 @@ pub fn vmaxvq_s32(a: int32x4_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxv))]
 pub fn vmaxv_u8(a: uint8x8_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i8.v8i8"
-        )]
-        fn _vmaxv_u8(a: uint8x8_t) -> u8;
-    }
-    unsafe { _vmaxv_u8(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_u8)"]
@@ -13493,14 +13444,7 @@ pub fn vmaxv_u8(a: uint8x8_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxv))]
 pub fn vmaxvq_u8(a: uint8x16_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i8.v16i8"
-        )]
-        fn _vmaxvq_u8(a: uint8x16_t) -> u8;
-    }
-    unsafe { _vmaxvq_u8(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_u16)"]
@@ -13509,14 +13453,7 @@ pub fn vmaxvq_u8(a: uint8x16_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxv))]
 pub fn vmaxv_u16(a: uint16x4_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i16.v4i16"
-        )]
-        fn _vmaxv_u16(a: uint16x4_t) -> u16;
-    }
-    unsafe { _vmaxv_u16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_u16)"]
@@ -13525,14 +13462,7 @@ pub fn vmaxv_u16(a: uint16x4_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxv))]
 pub fn vmaxvq_u16(a: uint16x8_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i16.v8i16"
-        )]
-        fn _vmaxvq_u16(a: uint16x8_t) -> u16;
-    }
-    unsafe { _vmaxvq_u16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_u32)"]
@@ -13541,14 +13471,7 @@ pub fn vmaxvq_u16(a: uint16x8_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxp))]
 pub fn vmaxv_u32(a: uint32x2_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i32.v2i32"
-        )]
-        fn _vmaxv_u32(a: uint32x2_t) -> u32;
-    }
-    unsafe { _vmaxv_u32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Horizontal vector max."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxvq_u32)"]
@@ -13557,14 +13480,7 @@ pub fn vmaxv_u32(a: uint32x2_t) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(umaxv))]
 pub fn vmaxvq_u32(a: uint32x4_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umaxv.i32.v4i32"
-        )]
-        fn _vmaxvq_u32(a: uint32x4_t) -> u32;
-    }
-    unsafe { _vmaxvq_u32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_f64)"]
@@ -13773,14 +13689,7 @@ pub fn vminvq_f64(a: float64x2_t) -> f64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminv))]
 pub fn vminv_s8(a: int8x8_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i8.v8i8"
-        )]
-        fn _vminv_s8(a: int8x8_t) -> i8;
-    }
-    unsafe { _vminv_s8(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_s8)"]
@@ -13789,14 +13698,7 @@ pub fn vminv_s8(a: int8x8_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminv))]
 pub fn vminvq_s8(a: int8x16_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i8.v16i8"
-        )]
-        fn _vminvq_s8(a: int8x16_t) -> i8;
-    }
-    unsafe { _vminvq_s8(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_s16)"]
@@ -13805,14 +13707,7 @@ pub fn vminvq_s8(a: int8x16_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminv))]
 pub fn vminv_s16(a: int16x4_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i16.v4i16"
-        )]
-        fn _vminv_s16(a: int16x4_t) -> i16;
-    }
-    unsafe { _vminv_s16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_s16)"]
@@ -13821,14 +13716,7 @@ pub fn vminv_s16(a: int16x4_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminv))]
 pub fn vminvq_s16(a: int16x8_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i16.v8i16"
-        )]
-        fn _vminvq_s16(a: int16x8_t) -> i16;
-    }
-    unsafe { _vminvq_s16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_s32)"]
@@ -13837,14 +13725,7 @@ pub fn vminvq_s16(a: int16x8_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminp))]
 pub fn vminv_s32(a: int32x2_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i32.v2i32"
-        )]
-        fn _vminv_s32(a: int32x2_t) -> i32;
-    }
-    unsafe { _vminv_s32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_s32)"]
@@ -13853,14 +13734,7 @@ pub fn vminv_s32(a: int32x2_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(sminv))]
 pub fn vminvq_s32(a: int32x4_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.sminv.i32.v4i32"
-        )]
-        fn _vminvq_s32(a: int32x4_t) -> i32;
-    }
-    unsafe { _vminvq_s32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_u8)"]
@@ -13869,14 +13743,7 @@ pub fn vminvq_s32(a: int32x4_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminv))]
 pub fn vminv_u8(a: uint8x8_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i8.v8i8"
-        )]
-        fn _vminv_u8(a: uint8x8_t) -> u8;
-    }
-    unsafe { _vminv_u8(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_u8)"]
@@ -13885,14 +13752,7 @@ pub fn vminv_u8(a: uint8x8_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminv))]
 pub fn vminvq_u8(a: uint8x16_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i8.v16i8"
-        )]
-        fn _vminvq_u8(a: uint8x16_t) -> u8;
-    }
-    unsafe { _vminvq_u8(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_u16)"]
@@ -13901,14 +13761,7 @@ pub fn vminvq_u8(a: uint8x16_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminv))]
 pub fn vminv_u16(a: uint16x4_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i16.v4i16"
-        )]
-        fn _vminv_u16(a: uint16x4_t) -> u16;
-    }
-    unsafe { _vminv_u16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_u16)"]
@@ -13917,14 +13770,7 @@ pub fn vminv_u16(a: uint16x4_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminv))]
 pub fn vminvq_u16(a: uint16x8_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i16.v8i16"
-        )]
-        fn _vminvq_u16(a: uint16x8_t) -> u16;
-    }
-    unsafe { _vminvq_u16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_u32)"]
@@ -13933,14 +13779,7 @@ pub fn vminvq_u16(a: uint16x8_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminp))]
 pub fn vminv_u32(a: uint32x2_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i32.v2i32"
-        )]
-        fn _vminv_u32(a: uint32x2_t) -> u32;
-    }
-    unsafe { _vminv_u32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Horizontal vector min."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminvq_u32)"]
@@ -13949,14 +13788,7 @@ pub fn vminv_u32(a: uint32x2_t) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(uminv))]
 pub fn vminvq_u32(a: uint32x4_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uminv.i32.v4i32"
-        )]
-        fn _vminvq_u32(a: uint32x4_t) -> u32;
-    }
-    unsafe { _vminvq_u32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point multiply-add to accumulator"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmla_f64)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -13256,14 +13256,7 @@ pub fn vmaxnmh_f16(a: f16, b: f16) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fmaxnmv))]
 pub fn vmaxnmv_f16(a: float16x4_t) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnmv.f16.v4f16"
-        )]
-        fn _vmaxnmv_f16(a: float16x4_t) -> f16;
-    }
-    unsafe { _vmaxnmv_f16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmvq_f16)"]
@@ -13272,14 +13265,7 @@ pub fn vmaxnmv_f16(a: float16x4_t) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fmaxnmv))]
 pub fn vmaxnmvq_f16(a: float16x8_t) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnmv.f16.v8f16"
-        )]
-        fn _vmaxnmvq_f16(a: float16x8_t) -> f16;
-    }
-    unsafe { _vmaxnmvq_f16(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmv_f32)"]
@@ -13288,14 +13274,7 @@ pub fn vmaxnmvq_f16(a: float16x8_t) -> f16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmaxnmp))]
 pub fn vmaxnmv_f32(a: float32x2_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnmv.f32.v2f32"
-        )]
-        fn _vmaxnmv_f32(a: float32x2_t) -> f32;
-    }
-    unsafe { _vmaxnmv_f32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmvq_f64)"]
@@ -13304,14 +13283,7 @@ pub fn vmaxnmv_f32(a: float32x2_t) -> f32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmaxnmp))]
 pub fn vmaxnmvq_f64(a: float64x2_t) -> f64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnmv.f64.v2f64"
-        )]
-        fn _vmaxnmvq_f64(a: float64x2_t) -> f64;
-    }
-    unsafe { _vmaxnmvq_f64(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmvq_f32)"]
@@ -13320,14 +13292,7 @@ pub fn vmaxnmvq_f64(a: float64x2_t) -> f64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmaxnmv))]
 pub fn vmaxnmvq_f32(a: float32x4_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnmv.f32.v4f32"
-        )]
-        fn _vmaxnmvq_f32(a: float32x4_t) -> f32;
-    }
-    unsafe { _vmaxnmvq_f32(a) }
+    unsafe { simd_reduce_max(a) }
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxv_f16)"]
@@ -13683,14 +13648,7 @@ pub fn vminnmh_f16(a: f16, b: f16) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fminnmv))]
 pub fn vminnmv_f16(a: float16x4_t) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnmv.f16.v4f16"
-        )]
-        fn _vminnmv_f16(a: float16x4_t) -> f16;
-    }
-    unsafe { _vminnmv_f16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmvq_f16)"]
@@ -13699,14 +13657,7 @@ pub fn vminnmv_f16(a: float16x4_t) -> f16 {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fminnmv))]
 pub fn vminnmvq_f16(a: float16x8_t) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnmv.f16.v8f16"
-        )]
-        fn _vminnmvq_f16(a: float16x8_t) -> f16;
-    }
-    unsafe { _vminnmvq_f16(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmv_f32)"]
@@ -13715,14 +13666,7 @@ pub fn vminnmvq_f16(a: float16x8_t) -> f16 {
 #[cfg_attr(test, assert_instr(fminnmp))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vminnmv_f32(a: float32x2_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnmv.f32.v2f32"
-        )]
-        fn _vminnmv_f32(a: float32x2_t) -> f32;
-    }
-    unsafe { _vminnmv_f32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmvq_f64)"]
@@ -13731,14 +13675,7 @@ pub fn vminnmv_f32(a: float32x2_t) -> f32 {
 #[cfg_attr(test, assert_instr(fminnmp))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vminnmvq_f64(a: float64x2_t) -> f64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnmv.f64.v2f64"
-        )]
-        fn _vminnmvq_f64(a: float64x2_t) -> f64;
-    }
-    unsafe { _vminnmvq_f64(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmvq_f32)"]
@@ -13747,14 +13684,7 @@ pub fn vminnmvq_f64(a: float64x2_t) -> f64 {
 #[cfg_attr(test, assert_instr(fminnmv))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vminnmvq_f32(a: float32x4_t) -> f32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnmv.f32.v4f32"
-        )]
-        fn _vminnmvq_f32(a: float32x4_t) -> f32;
-    }
-    unsafe { _vminnmvq_f32(a) }
+    unsafe { simd_reduce_min(a) }
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminv_f16)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -13229,14 +13229,7 @@ pub fn vmaxh_f16(a: f16, b: f16) -> f16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmaxnm))]
 pub fn vmaxnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v1f64"
-        )]
-        fn _vmaxnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vmaxnm_f64(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Floating-point Maximum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmq_f64)"]
@@ -13245,14 +13238,7 @@ pub fn vmaxnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fmaxnm))]
 pub fn vmaxnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v2f64"
-        )]
-        fn _vmaxnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vmaxnmq_f64(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Floating-point Maximum Number"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmh_f16)"]
@@ -13670,14 +13656,7 @@ pub fn vminh_f16(a: f16, b: f16) -> f16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fminnm))]
 pub fn vminnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v1f64"
-        )]
-        fn _vminnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t;
-    }
-    unsafe { _vminnm_f64(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point Minimum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmq_f64)"]
@@ -13686,14 +13665,7 @@ pub fn vminnm_f64(a: float64x1_t, b: float64x1_t) -> float64x1_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(fminnm))]
 pub fn vminnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v2f64"
-        )]
-        fn _vminnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t;
-    }
-    unsafe { _vminnmq_f64(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point Minimum Number"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmh_f16)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -13261,14 +13261,7 @@ pub fn vmaxnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fmaxnm))]
 pub fn vmaxnmh_f16(a: f16, b: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.f16"
-        )]
-        fn _vmaxnmh_f16(a: f16, b: f16) -> f16;
-    }
-    unsafe { _vmaxnmh_f16(a, b) }
+    f16::max(a, b)
 }
 #[doc = "Floating-point maximum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmv_f16)"]
@@ -13709,14 +13702,7 @@ pub fn vminnmq_f64(a: float64x2_t, b: float64x2_t) -> float64x2_t {
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 #[cfg_attr(test, assert_instr(fminnm))]
 pub fn vminnmh_f16(a: f16, b: f16) -> f16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.f16"
-        )]
-        fn _vminnmh_f16(a: f16, b: f16) -> f16;
-    }
-    unsafe { _vminnmh_f16(a, b) }
+    f16::min(a, b)
 }
 #[doc = "Floating-point minimum number across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmv_f16)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -604,14 +604,7 @@ pub fn vaddvq_f64(a: float64x2_t) -> f64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vaddv_s32(a: int32x2_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v2i32"
-        )]
-        fn _vaddv_s32(a: int32x2_t) -> i32;
-    }
-    unsafe { _vaddv_s32(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddv_s8)"]
@@ -620,14 +613,7 @@ pub fn vaddv_s32(a: int32x2_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddv_s8(a: int8x8_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i8.v8i8"
-        )]
-        fn _vaddv_s8(a: int8x8_t) -> i8;
-    }
-    unsafe { _vaddv_s8(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_s8)"]
@@ -636,14 +622,7 @@ pub fn vaddv_s8(a: int8x8_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_s8(a: int8x16_t) -> i8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i8.v16i8"
-        )]
-        fn _vaddvq_s8(a: int8x16_t) -> i8;
-    }
-    unsafe { _vaddvq_s8(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddv_s16)"]
@@ -652,14 +631,7 @@ pub fn vaddvq_s8(a: int8x16_t) -> i8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddv_s16(a: int16x4_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i16.v4i16"
-        )]
-        fn _vaddv_s16(a: int16x4_t) -> i16;
-    }
-    unsafe { _vaddv_s16(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_s16)"]
@@ -668,14 +640,7 @@ pub fn vaddv_s16(a: int16x4_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_s16(a: int16x8_t) -> i16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i16.v8i16"
-        )]
-        fn _vaddvq_s16(a: int16x8_t) -> i16;
-    }
-    unsafe { _vaddvq_s16(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_s32)"]
@@ -684,14 +649,7 @@ pub fn vaddvq_s16(a: int16x8_t) -> i16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_s32(a: int32x4_t) -> i32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i32.v4i32"
-        )]
-        fn _vaddvq_s32(a: int32x4_t) -> i32;
-    }
-    unsafe { _vaddvq_s32(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddv_u32)"]
@@ -700,14 +658,7 @@ pub fn vaddvq_s32(a: int32x4_t) -> i32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vaddv_u32(a: uint32x2_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v2i32"
-        )]
-        fn _vaddv_u32(a: uint32x2_t) -> u32;
-    }
-    unsafe { _vaddv_u32(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddv_u8)"]
@@ -716,14 +667,7 @@ pub fn vaddv_u32(a: uint32x2_t) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddv_u8(a: uint8x8_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i8.v8i8"
-        )]
-        fn _vaddv_u8(a: uint8x8_t) -> u8;
-    }
-    unsafe { _vaddv_u8(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_u8)"]
@@ -732,14 +676,7 @@ pub fn vaddv_u8(a: uint8x8_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_u8(a: uint8x16_t) -> u8 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i8.v16i8"
-        )]
-        fn _vaddvq_u8(a: uint8x16_t) -> u8;
-    }
-    unsafe { _vaddvq_u8(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddv_u16)"]
@@ -748,14 +685,7 @@ pub fn vaddvq_u8(a: uint8x16_t) -> u8 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddv_u16(a: uint16x4_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i16.v4i16"
-        )]
-        fn _vaddv_u16(a: uint16x4_t) -> u16;
-    }
-    unsafe { _vaddv_u16(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_u16)"]
@@ -764,14 +694,7 @@ pub fn vaddv_u16(a: uint16x4_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_u16(a: uint16x8_t) -> u16 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i16.v8i16"
-        )]
-        fn _vaddvq_u16(a: uint16x8_t) -> u16;
-    }
-    unsafe { _vaddvq_u16(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_u32)"]
@@ -780,14 +703,7 @@ pub fn vaddvq_u16(a: uint16x8_t) -> u16 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addv))]
 pub fn vaddvq_u32(a: uint32x4_t) -> u32 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i32.v4i32"
-        )]
-        fn _vaddvq_u32(a: uint32x4_t) -> u32;
-    }
-    unsafe { _vaddvq_u32(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_s64)"]
@@ -796,14 +712,7 @@ pub fn vaddvq_u32(a: uint32x4_t) -> u32 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vaddvq_s64(a: int64x2_t) -> i64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.saddv.i64.v2i64"
-        )]
-        fn _vaddvq_s64(a: int64x2_t) -> i64;
-    }
-    unsafe { _vaddvq_s64(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add across vector"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddvq_u64)"]
@@ -812,14 +721,7 @@ pub fn vaddvq_s64(a: int64x2_t) -> i64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vaddvq_u64(a: uint64x2_t) -> u64 {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.uaddv.i64.v2i64"
-        )]
-        fn _vaddvq_u64(a: uint64x2_t) -> u64;
-    }
-    unsafe { _vaddvq_u64(a) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Multi-vector floating-point absolute maximum"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vamax_f32)"]
@@ -15951,23 +15853,11 @@ pub fn vpadds_f32(a: float32x2_t) -> f32 {
 #[doc = "Add pairwise"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpaddd_s64)"]
 #[inline]
-#[cfg(target_endian = "little")]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vpaddd_s64(a: int64x2_t) -> i64 {
-    unsafe { transmute(vaddvq_u64(transmute(a))) }
-}
-#[doc = "Add pairwise"]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpaddd_s64)"]
-#[inline]
-#[cfg(target_endian = "big")]
-#[target_feature(enable = "neon")]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(addp))]
-pub fn vpaddd_s64(a: int64x2_t) -> i64 {
-    let a: int64x2_t = unsafe { simd_shuffle!(a, a, [1, 0]) };
-    unsafe { transmute(vaddvq_u64(transmute(a))) }
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Add pairwise"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpaddd_u64)"]
@@ -15976,7 +15866,7 @@ pub fn vpaddd_s64(a: int64x2_t) -> i64 {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(addp))]
 pub fn vpaddd_u64(a: uint64x2_t) -> u64 {
-    vaddvq_u64(a)
+    unsafe { simd_reduce_add_unordered(a) }
 }
 #[doc = "Floating-point add pairwise"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vpaddq_f16)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -298,14 +298,24 @@ pub fn vabsq_f64(a: float64x2_t) -> float64x2_t {
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 #[cfg_attr(test, assert_instr(abs))]
 pub fn vabs_s64(a: int64x1_t) -> int64x1_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v1i64"
-        )]
-        fn _vabs_s64(a: int64x1_t) -> int64x1_t;
+    unsafe {
+        let neg: int64x1_t = simd_neg(a);
+        let mask: int64x1_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabs_s64(a) }
+}
+#[doc = "Absolute Value (wrapping)."]
+#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsq_s64)"]
+#[inline]
+#[target_feature(enable = "neon")]
+#[stable(feature = "neon_intrinsics", since = "1.59.0")]
+#[cfg_attr(test, assert_instr(abs))]
+pub fn vabsq_s64(a: int64x2_t) -> int64x2_t {
+    unsafe {
+        let neg: int64x2_t = simd_neg(a);
+        let mask: int64x2_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
+    }
 }
 #[doc = "Absolute Value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsd_s64)"]
@@ -322,22 +332,6 @@ pub fn vabsd_s64(a: i64) -> i64 {
         fn _vabsd_s64(a: i64) -> i64;
     }
     unsafe { _vabsd_s64(a) }
-}
-#[doc = "Absolute Value (wrapping)."]
-#[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsq_s64)"]
-#[inline]
-#[target_feature(enable = "neon")]
-#[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(abs))]
-pub fn vabsq_s64(a: int64x2_t) -> int64x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v2i64"
-        )]
-        fn _vabsq_s64(a: int64x2_t) -> int64x2_t;
-    }
-    unsafe { _vabsq_s64(a) }
 }
 #[doc = "Add"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vaddd_s64)"]

--- a/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs
@@ -51,7 +51,7 @@ pub fn __crc32d(crc: u32, data: u64) -> u32 {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal2))]
 pub fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
     unsafe {
         let d: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -66,7 +66,7 @@ pub fn vabal_high_s8(a: int16x8_t, b: int8x16_t, c: int8x16_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal2))]
 pub fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
     unsafe {
         let d: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
@@ -81,7 +81,7 @@ pub fn vabal_high_s16(a: int32x4_t, b: int16x8_t, c: int16x8_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(sabal2))]
 pub fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
     unsafe {
         let d: int32x2_t = simd_shuffle!(b, b, [2, 3]);
@@ -96,7 +96,7 @@ pub fn vabal_high_s32(a: int64x2_t, b: int32x4_t, c: int32x4_t) -> int64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal2))]
 pub fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t {
     unsafe {
         let d: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -110,7 +110,7 @@ pub fn vabal_high_u8(a: uint16x8_t, b: uint8x16_t, c: uint8x16_t) -> uint16x8_t 
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal2))]
 pub fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t {
     unsafe {
         let d: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
@@ -124,7 +124,7 @@ pub fn vabal_high_u16(a: uint32x4_t, b: uint16x8_t, c: uint16x8_t) -> uint32x4_t
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal))]
+#[cfg_attr(all(test, not(target_env = "msvc")), assert_instr(uabal2))]
 pub fn vabal_high_u32(a: uint64x2_t, b: uint32x4_t, c: uint32x4_t) -> uint64x2_t {
     unsafe {
         let d: uint32x2_t = simd_shuffle!(b, b, [2, 3]);
@@ -197,7 +197,7 @@ pub fn vabdh_f16(a: f16, b: f16) -> f16 {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(sabdl))]
+#[cfg_attr(test, assert_instr(sabdl2))]
 pub fn vabdl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
     unsafe {
         let c: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
@@ -211,7 +211,7 @@ pub fn vabdl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(sabdl))]
+#[cfg_attr(test, assert_instr(sabdl2))]
 pub fn vabdl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
     unsafe {
         let c: int32x2_t = simd_shuffle!(a, a, [2, 3]);
@@ -225,7 +225,7 @@ pub fn vabdl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(sabdl))]
+#[cfg_attr(test, assert_instr(sabdl2))]
 pub fn vabdl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
     unsafe {
         let c: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -238,7 +238,7 @@ pub fn vabdl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabdl_high_u8)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabdl))]
+#[cfg_attr(test, assert_instr(uabdl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vabdl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
     unsafe {
@@ -251,7 +251,7 @@ pub fn vabdl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabdl_high_u16)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabdl))]
+#[cfg_attr(test, assert_instr(uabdl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vabdl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
     unsafe {
@@ -264,7 +264,7 @@ pub fn vabdl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabdl_high_u32)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(uabdl))]
+#[cfg_attr(test, assert_instr(uabdl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vabdl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
     unsafe {
@@ -7177,7 +7177,7 @@ pub fn vcvt_high_f32_f16(a: float16x8_t) -> float32x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcvt_high_f32_f64)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(fcvtn))]
+#[cfg_attr(test, assert_instr(fcvtn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vcvt_high_f32_f64(a: float32x2_t, b: float64x2_t) -> float32x4_t {
     unsafe { simd_shuffle!(a, simd_cast(b), [0, 1, 2, 3]) }
@@ -7186,7 +7186,7 @@ pub fn vcvt_high_f32_f64(a: float32x2_t, b: float64x2_t) -> float32x4_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcvt_high_f64_f32)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(fcvtl))]
+#[cfg_attr(test, assert_instr(fcvtl2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vcvt_high_f64_f32(a: float32x4_t) -> float64x2_t {
     unsafe {
@@ -9286,7 +9286,7 @@ pub fn vcvtx_f32_f64(a: float64x2_t) -> float32x2_t {
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vcvtx_high_f32_f64)"]
 #[inline]
 #[target_feature(enable = "neon")]
-#[cfg_attr(test, assert_instr(fcvtxn))]
+#[cfg_attr(test, assert_instr(fcvtxn2))]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
 pub fn vcvtx_high_f32_f64(a: float32x2_t, b: float64x2_t) -> float32x4_t {
     unsafe { simd_shuffle!(a, vcvtx_f32_f64(b), [0, 1, 2, 3]) }
@@ -14893,7 +14893,7 @@ pub fn vmull_high_n_u32(a: uint32x4_t, b: u32) -> uint64x2_t {
 #[inline]
 #[target_feature(enable = "neon,aes")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(pmull))]
+#[cfg_attr(test, assert_instr(pmull2))]
 pub fn vmull_high_p64(a: poly64x2_t, b: poly64x2_t) -> p128 {
     unsafe { vmull_p64(simd_extract!(a, 1), simd_extract!(b, 1)) }
 }
@@ -14902,7 +14902,7 @@ pub fn vmull_high_p64(a: poly64x2_t, b: poly64x2_t) -> p128 {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(pmull))]
+#[cfg_attr(test, assert_instr(pmull2))]
 pub fn vmull_high_p8(a: poly8x16_t, b: poly8x16_t) -> poly16x8_t {
     unsafe {
         let a: poly8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -26497,7 +26497,7 @@ pub fn vsubh_f16(a: f16, b: f16) -> f16 {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubl))]
+#[cfg_attr(test, assert_instr(ssubl2))]
 pub fn vsubl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
     unsafe {
         let c: int8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -26512,7 +26512,7 @@ pub fn vsubl_high_s8(a: int8x16_t, b: int8x16_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubl))]
+#[cfg_attr(test, assert_instr(ssubl2))]
 pub fn vsubl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
     unsafe {
         let c: int16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
@@ -26527,7 +26527,7 @@ pub fn vsubl_high_s16(a: int16x8_t, b: int16x8_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubl))]
+#[cfg_attr(test, assert_instr(ssubl2))]
 pub fn vsubl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
     unsafe {
         let c: int32x2_t = simd_shuffle!(a, a, [2, 3]);
@@ -26542,7 +26542,7 @@ pub fn vsubl_high_s32(a: int32x4_t, b: int32x4_t) -> int64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubl))]
+#[cfg_attr(test, assert_instr(usubl2))]
 pub fn vsubl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
     unsafe {
         let c: uint8x8_t = simd_shuffle!(a, a, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -26557,7 +26557,7 @@ pub fn vsubl_high_u8(a: uint8x16_t, b: uint8x16_t) -> uint16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubl))]
+#[cfg_attr(test, assert_instr(usubl2))]
 pub fn vsubl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
     unsafe {
         let c: uint16x4_t = simd_shuffle!(a, a, [4, 5, 6, 7]);
@@ -26572,7 +26572,7 @@ pub fn vsubl_high_u16(a: uint16x8_t, b: uint16x8_t) -> uint32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubl))]
+#[cfg_attr(test, assert_instr(usubl2))]
 pub fn vsubl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
     unsafe {
         let c: uint32x2_t = simd_shuffle!(a, a, [2, 3]);
@@ -26587,7 +26587,7 @@ pub fn vsubl_high_u32(a: uint32x4_t, b: uint32x4_t) -> uint64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubw))]
+#[cfg_attr(test, assert_instr(ssubw2))]
 pub fn vsubw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
     unsafe {
         let c: int8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -26599,7 +26599,7 @@ pub fn vsubw_high_s8(a: int16x8_t, b: int8x16_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubw))]
+#[cfg_attr(test, assert_instr(ssubw2))]
 pub fn vsubw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
     unsafe {
         let c: int16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
@@ -26611,7 +26611,7 @@ pub fn vsubw_high_s16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(ssubw))]
+#[cfg_attr(test, assert_instr(ssubw2))]
 pub fn vsubw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
     unsafe {
         let c: int32x2_t = simd_shuffle!(b, b, [2, 3]);
@@ -26623,7 +26623,7 @@ pub fn vsubw_high_s32(a: int64x2_t, b: int32x4_t) -> int64x2_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubw))]
+#[cfg_attr(test, assert_instr(usubw2))]
 pub fn vsubw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
     unsafe {
         let c: uint8x8_t = simd_shuffle!(b, b, [8, 9, 10, 11, 12, 13, 14, 15]);
@@ -26635,7 +26635,7 @@ pub fn vsubw_high_u8(a: uint16x8_t, b: uint8x16_t) -> uint16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubw))]
+#[cfg_attr(test, assert_instr(usubw2))]
 pub fn vsubw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
     unsafe {
         let c: uint16x4_t = simd_shuffle!(b, b, [4, 5, 6, 7]);
@@ -26647,7 +26647,7 @@ pub fn vsubw_high_u16(a: uint32x4_t, b: uint16x8_t) -> uint32x4_t {
 #[inline]
 #[target_feature(enable = "neon")]
 #[stable(feature = "neon_intrinsics", since = "1.59.0")]
-#[cfg_attr(test, assert_instr(usubw))]
+#[cfg_attr(test, assert_instr(usubw2))]
 pub fn vsubw_high_u32(a: uint64x2_t, b: uint32x4_t) -> uint64x2_t {
     unsafe {
         let c: uint32x2_t = simd_shuffle!(b, b, [2, 3]);

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -14322,8 +14322,7 @@ pub unsafe fn vld1q_dup_f16(ptr: *const f16) -> float16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
-    let x = vld1_lane_f32::<0>(ptr, transmute(f32x2::splat(0.0)));
-    simd_shuffle!(x, x, [0, 0])
+    transmute(f32x2::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_p16)"]
@@ -14346,8 +14345,7 @@ pub unsafe fn vld1_dup_f32(ptr: *const f32) -> float32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
-    let x = vld1_lane_p16::<0>(ptr, transmute(u16x4::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(u16x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_p8)"]
@@ -14370,8 +14368,7 @@ pub unsafe fn vld1_dup_p16(ptr: *const p16) -> poly16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
-    let x = vld1_lane_p8::<0>(ptr, transmute(u8x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u8x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_s16)"]
@@ -14394,8 +14391,7 @@ pub unsafe fn vld1_dup_p8(ptr: *const p8) -> poly8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
-    let x = vld1_lane_s16::<0>(ptr, transmute(i16x4::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(i16x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_s32)"]
@@ -14418,8 +14414,7 @@ pub unsafe fn vld1_dup_s16(ptr: *const i16) -> int16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
-    let x = vld1_lane_s32::<0>(ptr, transmute(i32x2::splat(0)));
-    simd_shuffle!(x, x, [0, 0])
+    transmute(i32x2::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_s8)"]
@@ -14442,8 +14437,7 @@ pub unsafe fn vld1_dup_s32(ptr: *const i32) -> int32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
-    let x = vld1_lane_s8::<0>(ptr, transmute(i8x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(i8x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_u16)"]
@@ -14466,8 +14460,7 @@ pub unsafe fn vld1_dup_s8(ptr: *const i8) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
-    let x = vld1_lane_u16::<0>(ptr, transmute(u16x4::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(u16x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_u32)"]
@@ -14490,8 +14483,7 @@ pub unsafe fn vld1_dup_u16(ptr: *const u16) -> uint16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
-    let x = vld1_lane_u32::<0>(ptr, transmute(u32x2::splat(0)));
-    simd_shuffle!(x, x, [0, 0])
+    transmute(u32x2::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_u8)"]
@@ -14514,8 +14506,7 @@ pub unsafe fn vld1_dup_u32(ptr: *const u32) -> uint32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
-    let x = vld1_lane_u8::<0>(ptr, transmute(u8x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u8x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_f32)"]
@@ -14538,8 +14529,7 @@ pub unsafe fn vld1_dup_u8(ptr: *const u8) -> uint8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_f32(ptr: *const f32) -> float32x4_t {
-    let x = vld1q_lane_f32::<0>(ptr, transmute(f32x4::splat(0.0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(f32x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_p16)"]
@@ -14562,8 +14552,7 @@ pub unsafe fn vld1q_dup_f32(ptr: *const f32) -> float32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
-    let x = vld1q_lane_p16::<0>(ptr, transmute(u16x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u16x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_p8)"]
@@ -14586,8 +14575,7 @@ pub unsafe fn vld1q_dup_p16(ptr: *const p16) -> poly16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
-    let x = vld1q_lane_p8::<0>(ptr, transmute(u8x16::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u8x16::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_s16)"]
@@ -14610,8 +14598,7 @@ pub unsafe fn vld1q_dup_p8(ptr: *const p8) -> poly8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
-    let x = vld1q_lane_s16::<0>(ptr, transmute(i16x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(i16x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_s32)"]
@@ -14634,8 +14621,7 @@ pub unsafe fn vld1q_dup_s16(ptr: *const i16) -> int16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
-    let x = vld1q_lane_s32::<0>(ptr, transmute(i32x4::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(i32x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_s64)"]
@@ -14658,8 +14644,7 @@ pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
-    let x = vld1q_lane_s64::<0>(ptr, transmute(i64x2::splat(0)));
-    simd_shuffle!(x, x, [0, 0])
+    transmute(i64x2::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_s8)"]
@@ -14682,8 +14667,7 @@ pub unsafe fn vld1q_dup_s64(ptr: *const i64) -> int64x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
-    let x = vld1q_lane_s8::<0>(ptr, transmute(i8x16::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(i8x16::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_u16)"]
@@ -14706,8 +14690,7 @@ pub unsafe fn vld1q_dup_s8(ptr: *const i8) -> int8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
-    let x = vld1q_lane_u16::<0>(ptr, transmute(u16x8::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u16x8::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_u32)"]
@@ -14730,8 +14713,7 @@ pub unsafe fn vld1q_dup_u16(ptr: *const u16) -> uint16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
-    let x = vld1q_lane_u32::<0>(ptr, transmute(u32x4::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0])
+    transmute(u32x4::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_u64)"]
@@ -14754,8 +14736,7 @@ pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
-    let x = vld1q_lane_u64::<0>(ptr, transmute(u64x2::splat(0)));
-    simd_shuffle!(x, x, [0, 0])
+    transmute(u64x2::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1q_dup_u8)"]
@@ -14778,8 +14759,7 @@ pub unsafe fn vld1q_dup_u64(ptr: *const u64) -> uint64x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub unsafe fn vld1q_dup_u8(ptr: *const u8) -> uint8x16_t {
-    let x = vld1q_lane_u8::<0>(ptr, transmute(u8x16::splat(0)));
-    simd_shuffle!(x, x, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    transmute(u8x16::splat(*ptr))
 }
 #[doc = "Load one single-element structure and Replicate to all lanes (of one register)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vld1_dup_p64)"]

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -27681,15 +27681,10 @@ pub fn vmaxq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v8i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v8i8"
-        )]
-        fn _vmax_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t;
+    unsafe {
+        let mask: int8x8_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_s8(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_s8)"]
@@ -27710,15 +27705,10 @@ pub fn vmax_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v16i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v16i8"
-        )]
-        fn _vmaxq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t;
+    unsafe {
+        let mask: int8x16_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_s8(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmax_s16)"]
@@ -27739,15 +27729,10 @@ pub fn vmaxq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v4i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v4i16"
-        )]
-        fn _vmax_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t;
+    unsafe {
+        let mask: int16x4_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_s16(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_s16)"]
@@ -27768,15 +27753,10 @@ pub fn vmax_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v8i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v8i16"
-        )]
-        fn _vmaxq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t;
+    unsafe {
+        let mask: int16x8_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_s16(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmax_s32)"]
@@ -27797,15 +27777,10 @@ pub fn vmaxq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v2i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v2i32"
-        )]
-        fn _vmax_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t;
+    unsafe {
+        let mask: int32x2_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_s32(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_s32)"]
@@ -27826,15 +27801,10 @@ pub fn vmax_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxs.v4i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smax.v4i32"
-        )]
-        fn _vmaxq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t;
+    unsafe {
+        let mask: int32x4_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_s32(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmax_u8)"]
@@ -27855,15 +27825,10 @@ pub fn vmaxq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v8i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v8i8"
-        )]
-        fn _vmax_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t;
+    unsafe {
+        let mask: uint8x8_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_u8(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_u8)"]
@@ -27884,15 +27849,10 @@ pub fn vmax_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v16i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v16i8"
-        )]
-        fn _vmaxq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t;
+    unsafe {
+        let mask: uint8x16_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_u8(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmax_u16)"]
@@ -27913,15 +27873,10 @@ pub fn vmaxq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v4i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v4i16"
-        )]
-        fn _vmax_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t;
+    unsafe {
+        let mask: uint16x4_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_u16(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_u16)"]
@@ -27942,15 +27897,10 @@ pub fn vmax_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v8i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v8i16"
-        )]
-        fn _vmaxq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t;
+    unsafe {
+        let mask: uint16x8_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_u16(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmax_u32)"]
@@ -27971,15 +27921,10 @@ pub fn vmaxq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmax_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v2i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v2i32"
-        )]
-        fn _vmax_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t;
+    unsafe {
+        let mask: uint32x2_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmax_u32(a, b) }
 }
 #[doc = "Maximum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxq_u32)"]
@@ -28000,15 +27945,10 @@ pub fn vmax_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxu.v4i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umax.v4i32"
-        )]
-        fn _vmaxq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t;
+    unsafe {
+        let mask: uint32x4_t = simd_ge(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmaxq_u32(a, b) }
 }
 #[doc = "Floating-point Maximum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnm_f16)"]
@@ -28233,15 +28173,10 @@ pub fn vminq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v8i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v8i8"
-        )]
-        fn _vmin_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t;
+    unsafe {
+        let mask: int8x8_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_s8(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_s8)"]
@@ -28262,15 +28197,10 @@ pub fn vmin_s8(a: int8x8_t, b: int8x8_t) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v16i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v16i8"
-        )]
-        fn _vminq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t;
+    unsafe {
+        let mask: int8x16_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_s8(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_s16)"]
@@ -28291,15 +28221,10 @@ pub fn vminq_s8(a: int8x16_t, b: int8x16_t) -> int8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v4i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v4i16"
-        )]
-        fn _vmin_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t;
+    unsafe {
+        let mask: int16x4_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_s16(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_s16)"]
@@ -28320,15 +28245,10 @@ pub fn vmin_s16(a: int16x4_t, b: int16x4_t) -> int16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v8i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v8i16"
-        )]
-        fn _vminq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t;
+    unsafe {
+        let mask: int16x8_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_s16(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_s32)"]
@@ -28349,15 +28269,10 @@ pub fn vminq_s16(a: int16x8_t, b: int16x8_t) -> int16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v2i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v2i32"
-        )]
-        fn _vmin_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t;
+    unsafe {
+        let mask: int32x2_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_s32(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_s32)"]
@@ -28378,15 +28293,10 @@ pub fn vmin_s32(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmins.v4i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.smin.v4i32"
-        )]
-        fn _vminq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t;
+    unsafe {
+        let mask: int32x4_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_s32(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_u8)"]
@@ -28407,15 +28317,10 @@ pub fn vminq_s32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v8i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v8i8"
-        )]
-        fn _vmin_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t;
+    unsafe {
+        let mask: uint8x8_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_u8(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_u8)"]
@@ -28436,15 +28341,10 @@ pub fn vmin_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v16i8")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v16i8"
-        )]
-        fn _vminq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t;
+    unsafe {
+        let mask: uint8x16_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_u8(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_u16)"]
@@ -28465,15 +28365,10 @@ pub fn vminq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v4i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v4i16"
-        )]
-        fn _vmin_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t;
+    unsafe {
+        let mask: uint16x4_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_u16(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_u16)"]
@@ -28494,15 +28389,10 @@ pub fn vmin_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v8i16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v8i16"
-        )]
-        fn _vminq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t;
+    unsafe {
+        let mask: uint16x8_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_u16(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_u32)"]
@@ -28523,15 +28413,10 @@ pub fn vminq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmin_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v2i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v2i32"
-        )]
-        fn _vmin_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t;
+    unsafe {
+        let mask: uint32x2_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vmin_u32(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminq_u32)"]
@@ -28552,15 +28437,10 @@ pub fn vmin_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminu.v4i32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.umin.v4i32"
-        )]
-        fn _vminq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t;
+    unsafe {
+        let mask: uint32x4_t = simd_le(a, b);
+        simd_select(mask, a, b)
     }
-    unsafe { _vminq_u32(a, b) }
 }
 #[doc = "Floating-point Minimum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnm_f16)"]

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -39546,17 +39546,7 @@ pub fn vqrshrn_n_s16<const N: i32>(a: int16x8_t) -> int8x8_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftns.v8i8")]
         fn _vqrshrn_n_s16(a: int16x8_t, n: int16x8_t) -> int8x8_t;
     }
-    unsafe {
-        _vqrshrn_n_s16(
-            a,
-            const {
-                int16x8_t([
-                    -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16,
-                    -N as i16,
-                ])
-            },
-        )
-    }
+    unsafe { _vqrshrn_n_s16(a, const { int16x8_t([-N as i16; 8]) }) }
 }
 #[doc = "Signed saturating rounded shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrn_n_s32)"]
@@ -39572,12 +39562,7 @@ pub fn vqrshrn_n_s32<const N: i32>(a: int32x4_t) -> int16x4_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftns.v4i16")]
         fn _vqrshrn_n_s32(a: int32x4_t, n: int32x4_t) -> int16x4_t;
     }
-    unsafe {
-        _vqrshrn_n_s32(
-            a,
-            const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) },
-        )
-    }
+    unsafe { _vqrshrn_n_s32(a, const { int32x4_t([-N; 4]) }) }
 }
 #[doc = "Signed saturating rounded shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrn_n_s64)"]
@@ -39593,7 +39578,7 @@ pub fn vqrshrn_n_s64<const N: i32>(a: int64x2_t) -> int32x2_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftns.v2i32")]
         fn _vqrshrn_n_s64(a: int64x2_t, n: int64x2_t) -> int32x2_t;
     }
-    unsafe { _vqrshrn_n_s64(a, const { int64x2_t([-N as i64, -N as i64]) }) }
+    unsafe { _vqrshrn_n_s64(a, const { int64x2_t([-N as i64; 2]) }) }
 }
 #[doc = "Signed saturating rounded shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrn_n_s16)"]
@@ -39786,17 +39771,7 @@ pub fn vqrshrun_n_s16<const N: i32>(a: int16x8_t) -> uint8x8_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftnsu.v8i8")]
         fn _vqrshrun_n_s16(a: int16x8_t, n: int16x8_t) -> uint8x8_t;
     }
-    unsafe {
-        _vqrshrun_n_s16(
-            a,
-            const {
-                int16x8_t([
-                    -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16,
-                    -N as i16,
-                ])
-            },
-        )
-    }
+    unsafe { _vqrshrun_n_s16(a, const { int16x8_t([-N as i16; 8]) }) }
 }
 #[doc = "Signed saturating rounded shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrun_n_s32)"]
@@ -39812,12 +39787,7 @@ pub fn vqrshrun_n_s32<const N: i32>(a: int32x4_t) -> uint16x4_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftnsu.v4i16")]
         fn _vqrshrun_n_s32(a: int32x4_t, n: int32x4_t) -> uint16x4_t;
     }
-    unsafe {
-        _vqrshrun_n_s32(
-            a,
-            const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) },
-        )
-    }
+    unsafe { _vqrshrun_n_s32(a, const { int32x4_t([-N; 4]) }) }
 }
 #[doc = "Signed saturating rounded shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrun_n_s64)"]
@@ -39833,7 +39803,7 @@ pub fn vqrshrun_n_s64<const N: i32>(a: int64x2_t) -> uint32x2_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqrshiftnsu.v2i32")]
         fn _vqrshrun_n_s64(a: int64x2_t, n: int64x2_t) -> uint32x2_t;
     }
-    unsafe { _vqrshrun_n_s64(a, const { int64x2_t([-N as i64, -N as i64]) }) }
+    unsafe { _vqrshrun_n_s64(a, const { int64x2_t([-N as i64; 2]) }) }
 }
 #[doc = "Signed saturating rounded shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqrshrun_n_s16)"]
@@ -41018,17 +40988,7 @@ pub fn vqshrn_n_s16<const N: i32>(a: int16x8_t) -> int8x8_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftns.v8i8")]
         fn _vqshrn_n_s16(a: int16x8_t, n: int16x8_t) -> int8x8_t;
     }
-    unsafe {
-        _vqshrn_n_s16(
-            a,
-            const {
-                int16x8_t([
-                    -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16,
-                    -N as i16,
-                ])
-            },
-        )
-    }
+    unsafe { _vqshrn_n_s16(a, const { int16x8_t([-N as i16; 8]) }) }
 }
 #[doc = "Signed saturating shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrn_n_s32)"]
@@ -41044,12 +41004,7 @@ pub fn vqshrn_n_s32<const N: i32>(a: int32x4_t) -> int16x4_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftns.v4i16")]
         fn _vqshrn_n_s32(a: int32x4_t, n: int32x4_t) -> int16x4_t;
     }
-    unsafe {
-        _vqshrn_n_s32(
-            a,
-            const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) },
-        )
-    }
+    unsafe { _vqshrn_n_s32(a, const { int32x4_t([-N; 4]) }) }
 }
 #[doc = "Signed saturating shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrn_n_s64)"]
@@ -41065,7 +41020,7 @@ pub fn vqshrn_n_s64<const N: i32>(a: int64x2_t) -> int32x2_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftns.v2i32")]
         fn _vqshrn_n_s64(a: int64x2_t, n: int64x2_t) -> int32x2_t;
     }
-    unsafe { _vqshrn_n_s64(a, const { int64x2_t([-N as i64, -N as i64]) }) }
+    unsafe { _vqshrn_n_s64(a, const { int64x2_t([-N as i64; 2]) }) }
 }
 #[doc = "Signed saturating shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrn_n_s16)"]
@@ -41258,17 +41213,7 @@ pub fn vqshrun_n_s16<const N: i32>(a: int16x8_t) -> uint8x8_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftnsu.v8i8")]
         fn _vqshrun_n_s16(a: int16x8_t, n: int16x8_t) -> uint8x8_t;
     }
-    unsafe {
-        _vqshrun_n_s16(
-            a,
-            const {
-                int16x8_t([
-                    -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16,
-                    -N as i16,
-                ])
-            },
-        )
-    }
+    unsafe { _vqshrun_n_s16(a, const { int16x8_t([-N as i16; 8]) }) }
 }
 #[doc = "Signed saturating shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrun_n_s32)"]
@@ -41284,12 +41229,7 @@ pub fn vqshrun_n_s32<const N: i32>(a: int32x4_t) -> uint16x4_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftnsu.v4i16")]
         fn _vqshrun_n_s32(a: int32x4_t, n: int32x4_t) -> uint16x4_t;
     }
-    unsafe {
-        _vqshrun_n_s32(
-            a,
-            const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) },
-        )
-    }
+    unsafe { _vqshrun_n_s32(a, const { int32x4_t([-N; 4]) }) }
 }
 #[doc = "Signed saturating shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrun_n_s64)"]
@@ -41305,7 +41245,7 @@ pub fn vqshrun_n_s64<const N: i32>(a: int64x2_t) -> uint32x2_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vqshiftnsu.v2i32")]
         fn _vqshrun_n_s64(a: int64x2_t, n: int64x2_t) -> uint32x2_t;
     }
-    unsafe { _vqshrun_n_s64(a, const { int64x2_t([-N as i64, -N as i64]) }) }
+    unsafe { _vqshrun_n_s64(a, const { int64x2_t([-N as i64; 2]) }) }
 }
 #[doc = "Signed saturating shift right unsigned narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vqshrun_n_s16)"]
@@ -59463,17 +59403,7 @@ pub fn vrshrn_n_s16<const N: i32>(a: int16x8_t) -> int8x8_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrshiftn.v8i8")]
         fn _vrshrn_n_s16(a: int16x8_t, n: int16x8_t) -> int8x8_t;
     }
-    unsafe {
-        _vrshrn_n_s16(
-            a,
-            const {
-                int16x8_t([
-                    -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16,
-                    -N as i16,
-                ])
-            },
-        )
-    }
+    unsafe { _vrshrn_n_s16(a, const { int16x8_t([-N as i16; 8]) }) }
 }
 #[doc = "Rounding shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrshrn_n_s32)"]
@@ -59489,12 +59419,7 @@ pub fn vrshrn_n_s32<const N: i32>(a: int32x4_t) -> int16x4_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrshiftn.v4i16")]
         fn _vrshrn_n_s32(a: int32x4_t, n: int32x4_t) -> int16x4_t;
     }
-    unsafe {
-        _vrshrn_n_s32(
-            a,
-            const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) },
-        )
-    }
+    unsafe { _vrshrn_n_s32(a, const { int32x4_t([-N; 4]) }) }
 }
 #[doc = "Rounding shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrshrn_n_s64)"]
@@ -59510,7 +59435,7 @@ pub fn vrshrn_n_s64<const N: i32>(a: int64x2_t) -> int32x2_t {
         #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vrshiftn.v2i32")]
         fn _vrshrn_n_s64(a: int64x2_t, n: int64x2_t) -> int32x2_t;
     }
-    unsafe { _vrshrn_n_s64(a, const { int64x2_t([-N as i64, -N as i64]) }) }
+    unsafe { _vrshrn_n_s64(a, const { int64x2_t([-N as i64; 2]) }) }
 }
 #[doc = "Rounding shift right narrow"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vrshrn_n_s16)"]
@@ -63163,7 +63088,7 @@ pub fn vsli_n_u32<const N: i32>(a: uint32x2_t, b: uint32x2_t) -> uint32x2_t {
         transmute(vshiftins_v2i32(
             transmute(a),
             transmute(b),
-            int32x2_t::splat(N as i32),
+            int32x2_t::splat(N),
         ))
     }
 }
@@ -63181,7 +63106,7 @@ pub fn vsliq_n_u32<const N: i32>(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
         transmute(vshiftins_v4i32(
             transmute(a),
             transmute(b),
-            int32x4_t::splat(N as i32),
+            int32x4_t::splat(N),
         ))
     }
 }
@@ -63719,7 +63644,7 @@ pub fn vsriq_n_s16<const N: i32>(a: int16x8_t, b: int16x8_t) -> int16x8_t {
 #[rustc_legacy_const_generics(2)]
 pub fn vsri_n_s32<const N: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
     static_assert!(1 <= N && N <= 32);
-    vshiftins_v2i32(a, b, int32x2_t::splat(-N as i32))
+    vshiftins_v2i32(a, b, int32x2_t::splat(-N))
 }
 #[doc = "Shift Right and Insert (immediate)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsriq_n_s32)"]
@@ -63731,7 +63656,7 @@ pub fn vsri_n_s32<const N: i32>(a: int32x2_t, b: int32x2_t) -> int32x2_t {
 #[rustc_legacy_const_generics(2)]
 pub fn vsriq_n_s32<const N: i32>(a: int32x4_t, b: int32x4_t) -> int32x4_t {
     static_assert!(1 <= N && N <= 32);
-    vshiftins_v4i32(a, b, int32x4_t::splat(-N as i32))
+    vshiftins_v4i32(a, b, int32x4_t::splat(-N))
 }
 #[doc = "Shift Right and Insert (immediate)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsri_n_s64)"]

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -27942,15 +27942,7 @@ pub fn vmaxq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxnm.v4f16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v4f16"
-        )]
-        fn _vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vmaxnm_f16(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Floating-point Maximum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmq_f16)"]
@@ -27964,15 +27956,7 @@ pub fn vmaxnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxnm.v8f16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v8f16"
-        )]
-        fn _vmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vmaxnmq_f16(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Floating-point Maximum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnm_f32)"]
@@ -27993,15 +27977,7 @@ pub fn vmaxnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxnm.v2f32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v2f32"
-        )]
-        fn _vmaxnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vmaxnm_f32(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Floating-point Maximum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmaxnmq_f32)"]
@@ -28022,15 +27998,7 @@ pub fn vmaxnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vmaxnmq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vmaxnm.v4f32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fmaxnm.v4f32"
-        )]
-        fn _vmaxnmq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vmaxnmq_f32(a, b) }
+    unsafe { simd_fmax(a, b) }
 }
 #[doc = "Minimum (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmin_f16)"]
@@ -28434,15 +28402,7 @@ pub fn vminq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminnm.v4f16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v4f16"
-        )]
-        fn _vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t;
-    }
-    unsafe { _vminnm_f16(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point Minimum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmq_f16)"]
@@ -28456,15 +28416,7 @@ pub fn vminnm_f16(a: float16x4_t, b: float16x4_t) -> float16x4_t {
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
 pub fn vminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminnm.v8f16")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v8f16"
-        )]
-        fn _vminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t;
-    }
-    unsafe { _vminnmq_f16(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point Minimum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnm_f32)"]
@@ -28485,15 +28437,7 @@ pub fn vminnmq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminnm.v2f32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v2f32"
-        )]
-        fn _vminnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t;
-    }
-    unsafe { _vminnm_f32(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point Minimum Number (vector)"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vminnmq_f32)"]
@@ -28514,15 +28458,7 @@ pub fn vminnm_f32(a: float32x2_t, b: float32x2_t) -> float32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vminnmq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vminnm.v4f32")]
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.fminnm.v4f32"
-        )]
-        fn _vminnmq_f32(a: float32x4_t, b: float32x4_t) -> float32x4_t;
-    }
-    unsafe { _vminnmq_f32(a, b) }
+    unsafe { simd_fmin(a, b) }
 }
 #[doc = "Floating-point multiply-add to accumulator"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vmla_f32)"]

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -1483,15 +1483,11 @@ pub fn vabsq_f32(a: float32x4_t) -> float32x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabs_s8(a: int8x8_t) -> int8x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v8i8"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v8i8")]
-        fn _vabs_s8(a: int8x8_t) -> int8x8_t;
+    unsafe {
+        let neg: int8x8_t = simd_neg(a);
+        let mask: int8x8_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabs_s8(a) }
 }
 #[doc = "Absolute value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsq_s8)"]
@@ -1512,15 +1508,11 @@ pub fn vabs_s8(a: int8x8_t) -> int8x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabsq_s8(a: int8x16_t) -> int8x16_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v16i8"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v16i8")]
-        fn _vabsq_s8(a: int8x16_t) -> int8x16_t;
+    unsafe {
+        let neg: int8x16_t = simd_neg(a);
+        let mask: int8x16_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabsq_s8(a) }
 }
 #[doc = "Absolute value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabs_s16)"]
@@ -1541,15 +1533,11 @@ pub fn vabsq_s8(a: int8x16_t) -> int8x16_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabs_s16(a: int16x4_t) -> int16x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v4i16"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v4i16")]
-        fn _vabs_s16(a: int16x4_t) -> int16x4_t;
+    unsafe {
+        let neg: int16x4_t = simd_neg(a);
+        let mask: int16x4_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabs_s16(a) }
 }
 #[doc = "Absolute value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsq_s16)"]
@@ -1570,15 +1558,11 @@ pub fn vabs_s16(a: int16x4_t) -> int16x4_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabsq_s16(a: int16x8_t) -> int16x8_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v8i16"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v8i16")]
-        fn _vabsq_s16(a: int16x8_t) -> int16x8_t;
+    unsafe {
+        let neg: int16x8_t = simd_neg(a);
+        let mask: int16x8_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabsq_s16(a) }
 }
 #[doc = "Absolute value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabs_s32)"]
@@ -1599,15 +1583,11 @@ pub fn vabsq_s16(a: int16x8_t) -> int16x8_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabs_s32(a: int32x2_t) -> int32x2_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v2i32"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v2i32")]
-        fn _vabs_s32(a: int32x2_t) -> int32x2_t;
+    unsafe {
+        let neg: int32x2_t = simd_neg(a);
+        let mask: int32x2_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabs_s32(a) }
 }
 #[doc = "Absolute value (wrapping)."]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsq_s32)"]
@@ -1628,15 +1608,11 @@ pub fn vabs_s32(a: int32x2_t) -> int32x2_t {
     unstable(feature = "stdarch_arm_neon_intrinsics", issue = "111800")
 )]
 pub fn vabsq_s32(a: int32x4_t) -> int32x4_t {
-    unsafe extern "unadjusted" {
-        #[cfg_attr(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            link_name = "llvm.aarch64.neon.abs.v4i32"
-        )]
-        #[cfg_attr(target_arch = "arm", link_name = "llvm.arm.neon.vabs.v4i32")]
-        fn _vabsq_s32(a: int32x4_t) -> int32x4_t;
+    unsafe {
+        let neg: int32x4_t = simd_neg(a);
+        let mask: int32x4_t = simd_ge(a, neg);
+        simd_select(mask, a, neg)
     }
-    unsafe { _vabsq_s32(a) }
 }
 #[doc = "Floating-point absolute value"]
 #[doc = "[Arm's documentation](https://developer.arm.com/architectures/instruction-sets/intrinsics/vabsh_f16)"]

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -74058,7 +74058,11 @@ pub fn vusmmlaq_s32(a: int32x4_t, b: uint8x16_t, c: int8x16_t) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -74076,7 +74080,11 @@ pub fn vuzp_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -74182,7 +74190,11 @@ pub fn vuzp_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74207,7 +74219,11 @@ pub fn vuzpq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74232,7 +74248,11 @@ pub fn vuzp_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74265,7 +74285,11 @@ pub fn vuzpq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74290,7 +74314,11 @@ pub fn vuzp_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74315,7 +74343,11 @@ pub fn vuzpq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74340,7 +74372,11 @@ pub fn vuzpq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74365,7 +74401,11 @@ pub fn vuzp_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74398,7 +74438,11 @@ pub fn vuzpq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74423,7 +74467,11 @@ pub fn vuzp_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74448,7 +74496,11 @@ pub fn vuzpq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74473,7 +74525,11 @@ pub fn vuzpq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74498,7 +74554,11 @@ pub fn vuzp_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74531,7 +74591,11 @@ pub fn vuzpq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74556,7 +74620,11 @@ pub fn vuzp_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vuzp))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(uzp)
+    assert_instr(uzp1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(uzp2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -14609,7 +14609,7 @@ pub unsafe fn vld1q_dup_s32(ptr: *const i32) -> int32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(ld1)
+    assert_instr(ld1r)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -14701,7 +14701,7 @@ pub unsafe fn vld1q_dup_u32(ptr: *const u32) -> uint32x4_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vldr"))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(ld1)
+    assert_instr(ld1r)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73031,7 +73031,11 @@ pub fn vtrnq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73056,7 +73060,11 @@ pub fn vtrn_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73081,7 +73089,11 @@ pub fn vtrn_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74083,7 +74095,11 @@ pub fn vuzpq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74108,7 +74124,11 @@ pub fn vuzp_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74133,7 +74153,11 @@ pub fn vuzp_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74556,7 +74580,11 @@ pub fn vuzpq_p16(a: poly16x8_t, b: poly16x8_t) -> poly16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vzip.16"))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -74574,7 +74602,11 @@ pub fn vzip_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr("vzip.16"))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -74593,7 +74625,11 @@ pub fn vzipq_f16(a: float16x8_t, b: float16x8_t) -> float16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74618,7 +74654,11 @@ pub fn vzip_f32(a: float32x2_t, b: float32x2_t) -> float32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74643,7 +74683,11 @@ pub fn vzip_s32(a: int32x2_t, b: int32x2_t) -> int32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74668,7 +74712,11 @@ pub fn vzip_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74693,7 +74741,11 @@ pub fn vzip_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74718,7 +74770,11 @@ pub fn vzip_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74743,7 +74799,11 @@ pub fn vzip_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74768,7 +74828,11 @@ pub fn vzip_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74793,7 +74857,11 @@ pub fn vzip_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vzip))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74818,7 +74886,11 @@ pub fn vzip_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74843,7 +74915,11 @@ pub fn vzipq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74876,7 +74952,11 @@ pub fn vzipq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74901,7 +74981,11 @@ pub fn vzipq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74926,7 +75010,11 @@ pub fn vzipq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74959,7 +75047,11 @@ pub fn vzipq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -74984,7 +75076,11 @@ pub fn vzipq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -75009,7 +75105,11 @@ pub fn vzipq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -75042,7 +75142,11 @@ pub fn vzipq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vorr))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(zip)
+    assert_instr(zip1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(zip2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),

--- a/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/neon/generated.rs
@@ -72994,7 +72994,11 @@ pub fn vtbx4_p8(a: poly8x8_t, b: poly8x8x4_t, c: uint8x8_t) -> poly8x8_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -73012,7 +73016,11 @@ pub fn vtrn_f16(a: float16x4_t, b: float16x4_t) -> float16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[target_feature(enable = "neon,fp16")]
 #[unstable(feature = "stdarch_neon_f16", issue = "136306")]
@@ -73118,7 +73126,11 @@ pub fn vtrn_u32(a: uint32x2_t, b: uint32x2_t) -> uint32x2x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73143,7 +73155,11 @@ pub fn vtrnq_f32(a: float32x4_t, b: float32x4_t) -> float32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73168,7 +73184,11 @@ pub fn vtrn_s8(a: int8x8_t, b: int8x8_t) -> int8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73201,7 +73221,11 @@ pub fn vtrnq_s8(a: int8x16_t, b: int8x16_t) -> int8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73226,7 +73250,11 @@ pub fn vtrn_s16(a: int16x4_t, b: int16x4_t) -> int16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73251,7 +73279,11 @@ pub fn vtrnq_s16(a: int16x8_t, b: int16x8_t) -> int16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73276,7 +73308,11 @@ pub fn vtrnq_s32(a: int32x4_t, b: int32x4_t) -> int32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73301,7 +73337,11 @@ pub fn vtrn_u8(a: uint8x8_t, b: uint8x8_t) -> uint8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73334,7 +73374,11 @@ pub fn vtrnq_u8(a: uint8x16_t, b: uint8x16_t) -> uint8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73359,7 +73403,11 @@ pub fn vtrn_u16(a: uint16x4_t, b: uint16x4_t) -> uint16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73384,7 +73432,11 @@ pub fn vtrnq_u16(a: uint16x8_t, b: uint16x8_t) -> uint16x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73409,7 +73461,11 @@ pub fn vtrnq_u32(a: uint32x4_t, b: uint32x4_t) -> uint32x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73434,7 +73490,11 @@ pub fn vtrn_p8(a: poly8x8_t, b: poly8x8_t) -> poly8x8x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73467,7 +73527,11 @@ pub fn vtrnq_p8(a: poly8x16_t, b: poly8x16_t) -> poly8x16x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),
@@ -73492,7 +73556,11 @@ pub fn vtrn_p16(a: poly16x4_t, b: poly16x4_t) -> poly16x4x2_t {
 #[cfg_attr(all(test, target_arch = "arm"), assert_instr(vtrn))]
 #[cfg_attr(
     all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
-    assert_instr(trn)
+    assert_instr(trn1)
+)]
+#[cfg_attr(
+    all(test, any(target_arch = "aarch64", target_arch = "arm64ec")),
+    assert_instr(trn2)
 )]
 #[cfg_attr(
     not(target_arch = "arm"),

--- a/library/stdarch/crates/core_arch/src/core_arch_docs.md
+++ b/library/stdarch/crates/core_arch/src/core_arch_docs.md
@@ -193,6 +193,7 @@ others at:
 * [`powerpc64`]
 * [`nvptx`]
 * [`wasm32`]
+* [`loongarch32`]
 * [`loongarch64`]
 * [`s390x`]
 
@@ -208,6 +209,7 @@ others at:
 [`powerpc64`]: ../../core/arch/powerpc64/index.html
 [`nvptx`]: ../../core/arch/nvptx/index.html
 [`wasm32`]: ../../core/arch/wasm32/index.html
+[`loongarch32`]: ../../core/arch/loongarch32/index.html
 [`loongarch64`]: ../../core/arch/loongarch64/index.html
 [`s390x`]: ../../core/arch/s390x/index.html
 

--- a/library/stdarch/crates/core_arch/src/loongarch32/mod.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch32/mod.rs
@@ -1,0 +1,47 @@
+//! `LoongArch32` intrinsics
+
+use crate::arch::asm;
+
+#[allow(improper_ctypes)]
+unsafe extern "unadjusted" {
+    #[link_name = "llvm.loongarch.cacop.w"]
+    fn __cacop(a: i32, b: i32, c: i32);
+    #[link_name = "llvm.loongarch.csrrd.w"]
+    fn __csrrd(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.csrwr.w"]
+    fn __csrwr(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.csrxchg.w"]
+    fn __csrxchg(a: i32, b: i32, c: i32) -> i32;
+}
+
+/// Generates the cache operation instruction
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn cacop<const IMM12: i32>(a: i32, b: i32) {
+    static_assert_simm_bits!(IMM12, 12);
+    __cacop(a, b, IMM12);
+}
+
+/// Reads the CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn csrrd<const IMM14: i32>() -> i32 {
+    static_assert_uimm_bits!(IMM14, 14);
+    __csrrd(IMM14)
+}
+
+/// Writes the CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn csrwr<const IMM14: i32>(a: i32) -> i32 {
+    static_assert_uimm_bits!(IMM14, 14);
+    __csrwr(a, IMM14)
+}
+
+/// Exchanges the CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn csrxchg<const IMM14: i32>(a: i32, b: i32) -> i32 {
+    static_assert_uimm_bits!(IMM14, 14);
+    __csrxchg(a, b, IMM14)
+}

--- a/library/stdarch/crates/core_arch/src/loongarch64/lasx/generated.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch64/lasx/generated.rs
@@ -1495,3501 +1495,3501 @@ unsafe extern "unadjusted" {
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsll_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsll_b(a, b)
+pub fn lasx_xvsll_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsll_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsll_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsll_h(a, b)
+pub fn lasx_xvsll_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsll_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsll_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsll_w(a, b)
+pub fn lasx_xvsll_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsll_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsll_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsll_d(a, b)
+pub fn lasx_xvsll_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsll_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslli_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvslli_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvslli_b(a, IMM3)
+    unsafe { __lasx_xvslli_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslli_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvslli_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvslli_h(a, IMM4)
+    unsafe { __lasx_xvslli_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslli_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvslli_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslli_w(a, IMM5)
+    unsafe { __lasx_xvslli_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslli_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvslli_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvslli_d(a, IMM6)
+    unsafe { __lasx_xvslli_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsra_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsra_b(a, b)
+pub fn lasx_xvsra_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsra_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsra_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsra_h(a, b)
+pub fn lasx_xvsra_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsra_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsra_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsra_w(a, b)
+pub fn lasx_xvsra_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsra_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsra_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsra_d(a, b)
+pub fn lasx_xvsra_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsra_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrai_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsrai_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsrai_b(a, IMM3)
+    unsafe { __lasx_xvsrai_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrai_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsrai_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrai_h(a, IMM4)
+    unsafe { __lasx_xvsrai_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrai_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsrai_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrai_w(a, IMM5)
+    unsafe { __lasx_xvsrai_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrai_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsrai_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrai_d(a, IMM6)
+    unsafe { __lasx_xvsrai_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrar_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsrar_b(a, b)
+pub fn lasx_xvsrar_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsrar_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrar_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsrar_h(a, b)
+pub fn lasx_xvsrar_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsrar_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrar_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsrar_w(a, b)
+pub fn lasx_xvsrar_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsrar_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrar_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsrar_d(a, b)
+pub fn lasx_xvsrar_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsrar_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrari_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsrari_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsrari_b(a, IMM3)
+    unsafe { __lasx_xvsrari_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrari_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsrari_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrari_h(a, IMM4)
+    unsafe { __lasx_xvsrari_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrari_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsrari_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrari_w(a, IMM5)
+    unsafe { __lasx_xvsrari_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrari_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsrari_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrari_d(a, IMM6)
+    unsafe { __lasx_xvsrari_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrl_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsrl_b(a, b)
+pub fn lasx_xvsrl_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsrl_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrl_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsrl_h(a, b)
+pub fn lasx_xvsrl_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsrl_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrl_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsrl_w(a, b)
+pub fn lasx_xvsrl_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsrl_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrl_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsrl_d(a, b)
+pub fn lasx_xvsrl_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsrl_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrli_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsrli_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsrli_b(a, IMM3)
+    unsafe { __lasx_xvsrli_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrli_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsrli_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrli_h(a, IMM4)
+    unsafe { __lasx_xvsrli_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrli_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsrli_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrli_w(a, IMM5)
+    unsafe { __lasx_xvsrli_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrli_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsrli_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrli_d(a, IMM6)
+    unsafe { __lasx_xvsrli_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlr_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsrlr_b(a, b)
+pub fn lasx_xvsrlr_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsrlr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlr_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsrlr_h(a, b)
+pub fn lasx_xvsrlr_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsrlr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlr_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsrlr_w(a, b)
+pub fn lasx_xvsrlr_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsrlr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlr_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsrlr_d(a, b)
+pub fn lasx_xvsrlr_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsrlr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlri_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsrlri_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsrlri_b(a, IMM3)
+    unsafe { __lasx_xvsrlri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlri_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsrlri_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrlri_h(a, IMM4)
+    unsafe { __lasx_xvsrlri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlri_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsrlri_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrlri_w(a, IMM5)
+    unsafe { __lasx_xvsrlri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlri_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsrlri_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrlri_d(a, IMM6)
+    unsafe { __lasx_xvsrlri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclr_b(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvbitclr_b(a, b)
+pub fn lasx_xvbitclr_b(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvbitclr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclr_h(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvbitclr_h(a, b)
+pub fn lasx_xvbitclr_h(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvbitclr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclr_w(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvbitclr_w(a, b)
+pub fn lasx_xvbitclr_w(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvbitclr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclr_d(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvbitclr_d(a, b)
+pub fn lasx_xvbitclr_d(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvbitclr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclri_b<const IMM3: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvbitclri_b<const IMM3: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvbitclri_b(a, IMM3)
+    unsafe { __lasx_xvbitclri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclri_h<const IMM4: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvbitclri_h<const IMM4: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvbitclri_h(a, IMM4)
+    unsafe { __lasx_xvbitclri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclri_w<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvbitclri_w<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvbitclri_w(a, IMM5)
+    unsafe { __lasx_xvbitclri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitclri_d<const IMM6: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvbitclri_d<const IMM6: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvbitclri_d(a, IMM6)
+    unsafe { __lasx_xvbitclri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitset_b(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvbitset_b(a, b)
+pub fn lasx_xvbitset_b(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvbitset_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitset_h(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvbitset_h(a, b)
+pub fn lasx_xvbitset_h(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvbitset_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitset_w(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvbitset_w(a, b)
+pub fn lasx_xvbitset_w(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvbitset_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitset_d(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvbitset_d(a, b)
+pub fn lasx_xvbitset_d(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvbitset_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitseti_b<const IMM3: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvbitseti_b<const IMM3: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvbitseti_b(a, IMM3)
+    unsafe { __lasx_xvbitseti_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitseti_h<const IMM4: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvbitseti_h<const IMM4: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvbitseti_h(a, IMM4)
+    unsafe { __lasx_xvbitseti_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitseti_w<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvbitseti_w<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvbitseti_w(a, IMM5)
+    unsafe { __lasx_xvbitseti_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitseti_d<const IMM6: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvbitseti_d<const IMM6: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvbitseti_d(a, IMM6)
+    unsafe { __lasx_xvbitseti_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrev_b(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvbitrev_b(a, b)
+pub fn lasx_xvbitrev_b(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvbitrev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrev_h(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvbitrev_h(a, b)
+pub fn lasx_xvbitrev_h(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvbitrev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrev_w(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvbitrev_w(a, b)
+pub fn lasx_xvbitrev_w(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvbitrev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrev_d(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvbitrev_d(a, b)
+pub fn lasx_xvbitrev_d(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvbitrev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrevi_b<const IMM3: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvbitrevi_b<const IMM3: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvbitrevi_b(a, IMM3)
+    unsafe { __lasx_xvbitrevi_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrevi_h<const IMM4: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvbitrevi_h<const IMM4: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvbitrevi_h(a, IMM4)
+    unsafe { __lasx_xvbitrevi_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrevi_w<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvbitrevi_w<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvbitrevi_w(a, IMM5)
+    unsafe { __lasx_xvbitrevi_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitrevi_d<const IMM6: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvbitrevi_d<const IMM6: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvbitrevi_d(a, IMM6)
+    unsafe { __lasx_xvbitrevi_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadd_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvadd_b(a, b)
+pub fn lasx_xvadd_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvadd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadd_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvadd_h(a, b)
+pub fn lasx_xvadd_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvadd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadd_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvadd_w(a, b)
+pub fn lasx_xvadd_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvadd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadd_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvadd_d(a, b)
+pub fn lasx_xvadd_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddi_bu<const IMM5: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvaddi_bu<const IMM5: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvaddi_bu(a, IMM5)
+    unsafe { __lasx_xvaddi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddi_hu<const IMM5: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvaddi_hu<const IMM5: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvaddi_hu(a, IMM5)
+    unsafe { __lasx_xvaddi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddi_wu<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvaddi_wu<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvaddi_wu(a, IMM5)
+    unsafe { __lasx_xvaddi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddi_du<const IMM5: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvaddi_du<const IMM5: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvaddi_du(a, IMM5)
+    unsafe { __lasx_xvaddi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsub_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsub_b(a, b)
+pub fn lasx_xvsub_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsub_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsub_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsub_h(a, b)
+pub fn lasx_xvsub_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsub_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsub_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsub_w(a, b)
+pub fn lasx_xvsub_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsub_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsub_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsub_d(a, b)
+pub fn lasx_xvsub_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubi_bu<const IMM5: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsubi_bu<const IMM5: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsubi_bu(a, IMM5)
+    unsafe { __lasx_xvsubi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubi_hu<const IMM5: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsubi_hu<const IMM5: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsubi_hu(a, IMM5)
+    unsafe { __lasx_xvsubi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubi_wu<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsubi_wu<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsubi_wu(a, IMM5)
+    unsafe { __lasx_xvsubi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubi_du<const IMM5: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsubi_du<const IMM5: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsubi_du(a, IMM5)
+    unsafe { __lasx_xvsubi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvmax_b(a, b)
+pub fn lasx_xvmax_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmax_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvmax_h(a, b)
+pub fn lasx_xvmax_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmax_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvmax_w(a, b)
+pub fn lasx_xvmax_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmax_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmax_d(a, b)
+pub fn lasx_xvmax_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmax_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvmaxi_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmaxi_b(a, IMM_S5)
+    unsafe { __lasx_xvmaxi_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvmaxi_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmaxi_h(a, IMM_S5)
+    unsafe { __lasx_xvmaxi_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvmaxi_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmaxi_w(a, IMM_S5)
+    unsafe { __lasx_xvmaxi_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvmaxi_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmaxi_d(a, IMM_S5)
+    unsafe { __lasx_xvmaxi_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvmax_bu(a, b)
+pub fn lasx_xvmax_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvmax_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvmax_hu(a, b)
+pub fn lasx_xvmax_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvmax_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvmax_wu(a, b)
+pub fn lasx_xvmax_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvmax_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmax_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvmax_du(a, b)
+pub fn lasx_xvmax_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmax_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_bu<const IMM5: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvmaxi_bu<const IMM5: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmaxi_bu(a, IMM5)
+    unsafe { __lasx_xvmaxi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_hu<const IMM5: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvmaxi_hu<const IMM5: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmaxi_hu(a, IMM5)
+    unsafe { __lasx_xvmaxi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvmaxi_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmaxi_wu(a, IMM5)
+    unsafe { __lasx_xvmaxi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaxi_du<const IMM5: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvmaxi_du<const IMM5: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmaxi_du(a, IMM5)
+    unsafe { __lasx_xvmaxi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvmin_b(a, b)
+pub fn lasx_xvmin_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmin_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvmin_h(a, b)
+pub fn lasx_xvmin_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmin_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvmin_w(a, b)
+pub fn lasx_xvmin_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmin_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmin_d(a, b)
+pub fn lasx_xvmin_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmin_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvmini_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmini_b(a, IMM_S5)
+    unsafe { __lasx_xvmini_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvmini_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmini_h(a, IMM_S5)
+    unsafe { __lasx_xvmini_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvmini_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmini_w(a, IMM_S5)
+    unsafe { __lasx_xvmini_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvmini_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvmini_d(a, IMM_S5)
+    unsafe { __lasx_xvmini_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvmin_bu(a, b)
+pub fn lasx_xvmin_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvmin_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvmin_hu(a, b)
+pub fn lasx_xvmin_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvmin_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvmin_wu(a, b)
+pub fn lasx_xvmin_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvmin_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmin_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvmin_du(a, b)
+pub fn lasx_xvmin_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmin_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_bu<const IMM5: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvmini_bu<const IMM5: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmini_bu(a, IMM5)
+    unsafe { __lasx_xvmini_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_hu<const IMM5: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvmini_hu<const IMM5: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmini_hu(a, IMM5)
+    unsafe { __lasx_xvmini_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvmini_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmini_wu(a, IMM5)
+    unsafe { __lasx_xvmini_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmini_du<const IMM5: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvmini_du<const IMM5: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvmini_du(a, IMM5)
+    unsafe { __lasx_xvmini_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseq_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvseq_b(a, b)
+pub fn lasx_xvseq_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvseq_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseq_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvseq_h(a, b)
+pub fn lasx_xvseq_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvseq_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseq_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvseq_w(a, b)
+pub fn lasx_xvseq_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvseq_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseq_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvseq_d(a, b)
+pub fn lasx_xvseq_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvseq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseqi_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvseqi_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvseqi_b(a, IMM_S5)
+    unsafe { __lasx_xvseqi_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseqi_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvseqi_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvseqi_h(a, IMM_S5)
+    unsafe { __lasx_xvseqi_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseqi_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvseqi_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvseqi_w(a, IMM_S5)
+    unsafe { __lasx_xvseqi_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvseqi_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvseqi_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvseqi_d(a, IMM_S5)
+    unsafe { __lasx_xvseqi_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvslt_b(a, b)
+pub fn lasx_xvslt_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvslt_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvslt_h(a, b)
+pub fn lasx_xvslt_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvslt_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvslt_w(a, b)
+pub fn lasx_xvslt_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvslt_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvslt_d(a, b)
+pub fn lasx_xvslt_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvslt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvslti_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslti_b(a, IMM_S5)
+    unsafe { __lasx_xvslti_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvslti_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslti_h(a, IMM_S5)
+    unsafe { __lasx_xvslti_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvslti_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslti_w(a, IMM_S5)
+    unsafe { __lasx_xvslti_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvslti_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslti_d(a, IMM_S5)
+    unsafe { __lasx_xvslti_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_bu(a: v32u8, b: v32u8) -> v32i8 {
-    __lasx_xvslt_bu(a, b)
+pub fn lasx_xvslt_bu(a: v32u8, b: v32u8) -> v32i8 {
+    unsafe { __lasx_xvslt_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_hu(a: v16u16, b: v16u16) -> v16i16 {
-    __lasx_xvslt_hu(a, b)
+pub fn lasx_xvslt_hu(a: v16u16, b: v16u16) -> v16i16 {
+    unsafe { __lasx_xvslt_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_wu(a: v8u32, b: v8u32) -> v8i32 {
-    __lasx_xvslt_wu(a, b)
+pub fn lasx_xvslt_wu(a: v8u32, b: v8u32) -> v8i32 {
+    unsafe { __lasx_xvslt_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslt_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvslt_du(a, b)
+pub fn lasx_xvslt_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvslt_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_bu<const IMM5: u32>(a: v32u8) -> v32i8 {
+pub fn lasx_xvslti_bu<const IMM5: u32>(a: v32u8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslti_bu(a, IMM5)
+    unsafe { __lasx_xvslti_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_hu<const IMM5: u32>(a: v16u16) -> v16i16 {
+pub fn lasx_xvslti_hu<const IMM5: u32>(a: v16u16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslti_hu(a, IMM5)
+    unsafe { __lasx_xvslti_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_wu<const IMM5: u32>(a: v8u32) -> v8i32 {
+pub fn lasx_xvslti_wu<const IMM5: u32>(a: v8u32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslti_wu(a, IMM5)
+    unsafe { __lasx_xvslti_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslti_du<const IMM5: u32>(a: v4u64) -> v4i64 {
+pub fn lasx_xvslti_du<const IMM5: u32>(a: v4u64) -> v4i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslti_du(a, IMM5)
+    unsafe { __lasx_xvslti_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsle_b(a, b)
+pub fn lasx_xvsle_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsle_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsle_h(a, b)
+pub fn lasx_xvsle_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsle_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsle_w(a, b)
+pub fn lasx_xvsle_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsle_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsle_d(a, b)
+pub fn lasx_xvsle_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvslei_b<const IMM_S5: i32>(a: v32i8) -> v32i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslei_b(a, IMM_S5)
+    unsafe { __lasx_xvslei_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvslei_h<const IMM_S5: i32>(a: v16i16) -> v16i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslei_h(a, IMM_S5)
+    unsafe { __lasx_xvslei_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvslei_w<const IMM_S5: i32>(a: v8i32) -> v8i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslei_w(a, IMM_S5)
+    unsafe { __lasx_xvslei_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvslei_d<const IMM_S5: i32>(a: v4i64) -> v4i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lasx_xvslei_d(a, IMM_S5)
+    unsafe { __lasx_xvslei_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_bu(a: v32u8, b: v32u8) -> v32i8 {
-    __lasx_xvsle_bu(a, b)
+pub fn lasx_xvsle_bu(a: v32u8, b: v32u8) -> v32i8 {
+    unsafe { __lasx_xvsle_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_hu(a: v16u16, b: v16u16) -> v16i16 {
-    __lasx_xvsle_hu(a, b)
+pub fn lasx_xvsle_hu(a: v16u16, b: v16u16) -> v16i16 {
+    unsafe { __lasx_xvsle_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_wu(a: v8u32, b: v8u32) -> v8i32 {
-    __lasx_xvsle_wu(a, b)
+pub fn lasx_xvsle_wu(a: v8u32, b: v8u32) -> v8i32 {
+    unsafe { __lasx_xvsle_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsle_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvsle_du(a, b)
+pub fn lasx_xvsle_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvsle_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_bu<const IMM5: u32>(a: v32u8) -> v32i8 {
+pub fn lasx_xvslei_bu<const IMM5: u32>(a: v32u8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslei_bu(a, IMM5)
+    unsafe { __lasx_xvslei_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_hu<const IMM5: u32>(a: v16u16) -> v16i16 {
+pub fn lasx_xvslei_hu<const IMM5: u32>(a: v16u16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslei_hu(a, IMM5)
+    unsafe { __lasx_xvslei_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_wu<const IMM5: u32>(a: v8u32) -> v8i32 {
+pub fn lasx_xvslei_wu<const IMM5: u32>(a: v8u32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslei_wu(a, IMM5)
+    unsafe { __lasx_xvslei_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvslei_du<const IMM5: u32>(a: v4u64) -> v4i64 {
+pub fn lasx_xvslei_du<const IMM5: u32>(a: v4u64) -> v4i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvslei_du(a, IMM5)
+    unsafe { __lasx_xvslei_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvsat_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsat_b(a, IMM3)
+    unsafe { __lasx_xvsat_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvsat_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsat_h(a, IMM4)
+    unsafe { __lasx_xvsat_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvsat_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsat_w(a, IMM5)
+    unsafe { __lasx_xvsat_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvsat_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsat_d(a, IMM6)
+    unsafe { __lasx_xvsat_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_bu<const IMM3: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvsat_bu<const IMM3: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsat_bu(a, IMM3)
+    unsafe { __lasx_xvsat_bu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_hu<const IMM4: u32>(a: v16u16) -> v16u16 {
+pub fn lasx_xvsat_hu<const IMM4: u32>(a: v16u16) -> v16u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsat_hu(a, IMM4)
+    unsafe { __lasx_xvsat_hu(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
+pub fn lasx_xvsat_wu<const IMM5: u32>(a: v8u32) -> v8u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsat_wu(a, IMM5)
+    unsafe { __lasx_xvsat_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsat_du<const IMM6: u32>(a: v4u64) -> v4u64 {
+pub fn lasx_xvsat_du<const IMM6: u32>(a: v4u64) -> v4u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsat_du(a, IMM6)
+    unsafe { __lasx_xvsat_du(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadda_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvadda_b(a, b)
+pub fn lasx_xvadda_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvadda_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadda_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvadda_h(a, b)
+pub fn lasx_xvadda_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvadda_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadda_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvadda_w(a, b)
+pub fn lasx_xvadda_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvadda_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadda_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvadda_d(a, b)
+pub fn lasx_xvadda_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvadda_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsadd_b(a, b)
+pub fn lasx_xvsadd_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsadd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsadd_h(a, b)
+pub fn lasx_xvsadd_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsadd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsadd_w(a, b)
+pub fn lasx_xvsadd_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsadd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsadd_d(a, b)
+pub fn lasx_xvsadd_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvsadd_bu(a, b)
+pub fn lasx_xvsadd_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvsadd_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvsadd_hu(a, b)
+pub fn lasx_xvsadd_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvsadd_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvsadd_wu(a, b)
+pub fn lasx_xvsadd_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvsadd_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsadd_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvsadd_du(a, b)
+pub fn lasx_xvsadd_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvsadd_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvavg_b(a, b)
+pub fn lasx_xvavg_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvavg_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvavg_h(a, b)
+pub fn lasx_xvavg_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvavg_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvavg_w(a, b)
+pub fn lasx_xvavg_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvavg_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvavg_d(a, b)
+pub fn lasx_xvavg_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvavg_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvavg_bu(a, b)
+pub fn lasx_xvavg_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvavg_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvavg_hu(a, b)
+pub fn lasx_xvavg_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvavg_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvavg_wu(a, b)
+pub fn lasx_xvavg_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvavg_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavg_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvavg_du(a, b)
+pub fn lasx_xvavg_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvavg_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvavgr_b(a, b)
+pub fn lasx_xvavgr_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvavgr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvavgr_h(a, b)
+pub fn lasx_xvavgr_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvavgr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvavgr_w(a, b)
+pub fn lasx_xvavgr_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvavgr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvavgr_d(a, b)
+pub fn lasx_xvavgr_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvavgr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvavgr_bu(a, b)
+pub fn lasx_xvavgr_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvavgr_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvavgr_hu(a, b)
+pub fn lasx_xvavgr_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvavgr_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvavgr_wu(a, b)
+pub fn lasx_xvavgr_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvavgr_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvavgr_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvavgr_du(a, b)
+pub fn lasx_xvavgr_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvavgr_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvssub_b(a, b)
+pub fn lasx_xvssub_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvssub_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvssub_h(a, b)
+pub fn lasx_xvssub_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvssub_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvssub_w(a, b)
+pub fn lasx_xvssub_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvssub_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvssub_d(a, b)
+pub fn lasx_xvssub_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvssub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvssub_bu(a, b)
+pub fn lasx_xvssub_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvssub_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvssub_hu(a, b)
+pub fn lasx_xvssub_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvssub_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvssub_wu(a, b)
+pub fn lasx_xvssub_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvssub_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssub_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvssub_du(a, b)
+pub fn lasx_xvssub_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvssub_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvabsd_b(a, b)
+pub fn lasx_xvabsd_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvabsd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvabsd_h(a, b)
+pub fn lasx_xvabsd_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvabsd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvabsd_w(a, b)
+pub fn lasx_xvabsd_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvabsd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvabsd_d(a, b)
+pub fn lasx_xvabsd_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvabsd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvabsd_bu(a, b)
+pub fn lasx_xvabsd_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvabsd_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvabsd_hu(a, b)
+pub fn lasx_xvabsd_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvabsd_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvabsd_wu(a, b)
+pub fn lasx_xvabsd_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvabsd_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvabsd_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvabsd_du(a, b)
+pub fn lasx_xvabsd_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvabsd_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmul_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvmul_b(a, b)
+pub fn lasx_xvmul_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmul_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmul_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvmul_h(a, b)
+pub fn lasx_xvmul_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmul_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmul_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvmul_w(a, b)
+pub fn lasx_xvmul_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmul_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmul_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmul_d(a, b)
+pub fn lasx_xvmul_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmul_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmadd_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
-    __lasx_xvmadd_b(a, b, c)
+pub fn lasx_xvmadd_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmadd_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmadd_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
-    __lasx_xvmadd_h(a, b, c)
+pub fn lasx_xvmadd_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmadd_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmadd_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
-    __lasx_xvmadd_w(a, b, c)
+pub fn lasx_xvmadd_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmadd_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmadd_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
-    __lasx_xvmadd_d(a, b, c)
+pub fn lasx_xvmadd_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmsub_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
-    __lasx_xvmsub_b(a, b, c)
+pub fn lasx_xvmsub_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmsub_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmsub_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
-    __lasx_xvmsub_h(a, b, c)
+pub fn lasx_xvmsub_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmsub_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmsub_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
-    __lasx_xvmsub_w(a, b, c)
+pub fn lasx_xvmsub_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmsub_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmsub_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
-    __lasx_xvmsub_d(a, b, c)
+pub fn lasx_xvmsub_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvdiv_b(a, b)
+pub fn lasx_xvdiv_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvdiv_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvdiv_h(a, b)
+pub fn lasx_xvdiv_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvdiv_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvdiv_w(a, b)
+pub fn lasx_xvdiv_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvdiv_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvdiv_d(a, b)
+pub fn lasx_xvdiv_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvdiv_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvdiv_bu(a, b)
+pub fn lasx_xvdiv_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvdiv_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvdiv_hu(a, b)
+pub fn lasx_xvdiv_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvdiv_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvdiv_wu(a, b)
+pub fn lasx_xvdiv_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvdiv_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvdiv_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvdiv_du(a, b)
+pub fn lasx_xvdiv_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvdiv_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvhaddw_h_b(a, b)
+pub fn lasx_xvhaddw_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvhaddw_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvhaddw_w_h(a, b)
+pub fn lasx_xvhaddw_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvhaddw_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvhaddw_d_w(a, b)
+pub fn lasx_xvhaddw_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvhaddw_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_hu_bu(a: v32u8, b: v32u8) -> v16u16 {
-    __lasx_xvhaddw_hu_bu(a, b)
+pub fn lasx_xvhaddw_hu_bu(a: v32u8, b: v32u8) -> v16u16 {
+    unsafe { __lasx_xvhaddw_hu_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_wu_hu(a: v16u16, b: v16u16) -> v8u32 {
-    __lasx_xvhaddw_wu_hu(a, b)
+pub fn lasx_xvhaddw_wu_hu(a: v16u16, b: v16u16) -> v8u32 {
+    unsafe { __lasx_xvhaddw_wu_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_du_wu(a: v8u32, b: v8u32) -> v4u64 {
-    __lasx_xvhaddw_du_wu(a, b)
+pub fn lasx_xvhaddw_du_wu(a: v8u32, b: v8u32) -> v4u64 {
+    unsafe { __lasx_xvhaddw_du_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvhsubw_h_b(a, b)
+pub fn lasx_xvhsubw_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvhsubw_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvhsubw_w_h(a, b)
+pub fn lasx_xvhsubw_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvhsubw_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvhsubw_d_w(a, b)
+pub fn lasx_xvhsubw_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvhsubw_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_hu_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvhsubw_hu_bu(a, b)
+pub fn lasx_xvhsubw_hu_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvhsubw_hu_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_wu_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvhsubw_wu_hu(a, b)
+pub fn lasx_xvhsubw_wu_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvhsubw_wu_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_du_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvhsubw_du_wu(a, b)
+pub fn lasx_xvhsubw_du_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvhsubw_du_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvmod_b(a, b)
+pub fn lasx_xvmod_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvmod_h(a, b)
+pub fn lasx_xvmod_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvmod_w(a, b)
+pub fn lasx_xvmod_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmod_d(a, b)
+pub fn lasx_xvmod_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvmod_bu(a, b)
+pub fn lasx_xvmod_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvmod_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvmod_hu(a, b)
+pub fn lasx_xvmod_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvmod_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvmod_wu(a, b)
+pub fn lasx_xvmod_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvmod_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmod_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvmod_du(a, b)
+pub fn lasx_xvmod_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmod_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepl128vei_b<const IMM4: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvrepl128vei_b<const IMM4: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvrepl128vei_b(a, IMM4)
+    unsafe { __lasx_xvrepl128vei_b(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepl128vei_h<const IMM3: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvrepl128vei_h<const IMM3: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvrepl128vei_h(a, IMM3)
+    unsafe { __lasx_xvrepl128vei_h(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepl128vei_w<const IMM2: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvrepl128vei_w<const IMM2: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvrepl128vei_w(a, IMM2)
+    unsafe { __lasx_xvrepl128vei_w(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepl128vei_d<const IMM1: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvrepl128vei_d<const IMM1: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM1, 1);
-    __lasx_xvrepl128vei_d(a, IMM1)
+    unsafe { __lasx_xvrepl128vei_d(a, IMM1) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickev_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvpickev_b(a, b)
+pub fn lasx_xvpickev_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvpickev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickev_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvpickev_h(a, b)
+pub fn lasx_xvpickev_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvpickev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickev_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvpickev_w(a, b)
+pub fn lasx_xvpickev_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvpickev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickev_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvpickev_d(a, b)
+pub fn lasx_xvpickev_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvpickev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickod_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvpickod_b(a, b)
+pub fn lasx_xvpickod_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvpickod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickod_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvpickod_h(a, b)
+pub fn lasx_xvpickod_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvpickod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickod_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvpickod_w(a, b)
+pub fn lasx_xvpickod_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvpickod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickod_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvpickod_d(a, b)
+pub fn lasx_xvpickod_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvpickod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvh_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvilvh_b(a, b)
+pub fn lasx_xvilvh_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvilvh_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvh_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvilvh_h(a, b)
+pub fn lasx_xvilvh_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvilvh_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvh_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvilvh_w(a, b)
+pub fn lasx_xvilvh_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvilvh_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvh_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvilvh_d(a, b)
+pub fn lasx_xvilvh_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvilvh_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvl_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvilvl_b(a, b)
+pub fn lasx_xvilvl_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvilvl_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvl_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvilvl_h(a, b)
+pub fn lasx_xvilvl_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvilvl_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvl_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvilvl_w(a, b)
+pub fn lasx_xvilvl_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvilvl_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvilvl_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvilvl_d(a, b)
+pub fn lasx_xvilvl_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvilvl_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackev_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvpackev_b(a, b)
+pub fn lasx_xvpackev_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvpackev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackev_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvpackev_h(a, b)
+pub fn lasx_xvpackev_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvpackev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackev_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvpackev_w(a, b)
+pub fn lasx_xvpackev_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvpackev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackev_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvpackev_d(a, b)
+pub fn lasx_xvpackev_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvpackev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackod_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvpackod_b(a, b)
+pub fn lasx_xvpackod_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvpackod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackod_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvpackod_h(a, b)
+pub fn lasx_xvpackod_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvpackod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackod_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvpackod_w(a, b)
+pub fn lasx_xvpackod_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvpackod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpackod_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvpackod_d(a, b)
+pub fn lasx_xvpackod_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvpackod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
-    __lasx_xvshuf_b(a, b, c)
+pub fn lasx_xvshuf_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
+    unsafe { __lasx_xvshuf_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
-    __lasx_xvshuf_h(a, b, c)
+pub fn lasx_xvshuf_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
+    unsafe { __lasx_xvshuf_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
-    __lasx_xvshuf_w(a, b, c)
+pub fn lasx_xvshuf_w(a: v8i32, b: v8i32, c: v8i32) -> v8i32 {
+    unsafe { __lasx_xvshuf_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
-    __lasx_xvshuf_d(a, b, c)
+pub fn lasx_xvshuf_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvshuf_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvand_v(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvand_v(a, b)
-}
-
-#[inline]
-#[target_feature(enable = "lasx")]
-#[rustc_legacy_const_generics(1)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvandi_b<const IMM8: u32>(a: v32u8) -> v32u8 {
-    static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvandi_b(a, IMM8)
-}
-
-#[inline]
-#[target_feature(enable = "lasx")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvor_v(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvor_v(a, b)
+pub fn lasx_xvand_v(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvand_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvandi_b<const IMM8: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvori_b(a, IMM8)
+    unsafe { __lasx_xvandi_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvnor_v(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvnor_v(a, b)
+pub fn lasx_xvor_v(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvor_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvnori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvnori_b(a, IMM8)
+    unsafe { __lasx_xvori_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvxor_v(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvxor_v(a, b)
+pub fn lasx_xvnor_v(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvnor_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvxori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
+pub fn lasx_xvnori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvxori_b(a, IMM8)
+    unsafe { __lasx_xvnori_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitsel_v(a: v32u8, b: v32u8, c: v32u8) -> v32u8 {
-    __lasx_xvbitsel_v(a, b, c)
+pub fn lasx_xvxor_v(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvxor_v(a, b) }
+}
+
+#[inline]
+#[target_feature(enable = "lasx")]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lasx_xvxori_b<const IMM8: u32>(a: v32u8) -> v32u8 {
+    static_assert_uimm_bits!(IMM8, 8);
+    unsafe { __lasx_xvxori_b(a, IMM8) }
+}
+
+#[inline]
+#[target_feature(enable = "lasx")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lasx_xvbitsel_v(a: v32u8, b: v32u8, c: v32u8) -> v32u8 {
+    unsafe { __lasx_xvbitsel_v(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbitseli_b<const IMM8: u32>(a: v32u8, b: v32u8) -> v32u8 {
+pub fn lasx_xvbitseli_b<const IMM8: u32>(a: v32u8, b: v32u8) -> v32u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvbitseli_b(a, b, IMM8)
+    unsafe { __lasx_xvbitseli_b(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf4i_b<const IMM8: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvshuf4i_b<const IMM8: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvshuf4i_b(a, IMM8)
+    unsafe { __lasx_xvshuf4i_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf4i_h<const IMM8: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvshuf4i_h<const IMM8: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvshuf4i_h(a, IMM8)
+    unsafe { __lasx_xvshuf4i_h(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf4i_w<const IMM8: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvshuf4i_w<const IMM8: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvshuf4i_w(a, IMM8)
+    unsafe { __lasx_xvshuf4i_w(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplgr2vr_b(a: i32) -> v32i8 {
-    __lasx_xvreplgr2vr_b(a)
+pub fn lasx_xvreplgr2vr_b(a: i32) -> v32i8 {
+    unsafe { __lasx_xvreplgr2vr_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplgr2vr_h(a: i32) -> v16i16 {
-    __lasx_xvreplgr2vr_h(a)
+pub fn lasx_xvreplgr2vr_h(a: i32) -> v16i16 {
+    unsafe { __lasx_xvreplgr2vr_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplgr2vr_w(a: i32) -> v8i32 {
-    __lasx_xvreplgr2vr_w(a)
+pub fn lasx_xvreplgr2vr_w(a: i32) -> v8i32 {
+    unsafe { __lasx_xvreplgr2vr_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplgr2vr_d(a: i64) -> v4i64 {
-    __lasx_xvreplgr2vr_d(a)
+pub fn lasx_xvreplgr2vr_d(a: i64) -> v4i64 {
+    unsafe { __lasx_xvreplgr2vr_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpcnt_b(a: v32i8) -> v32i8 {
-    __lasx_xvpcnt_b(a)
+pub fn lasx_xvpcnt_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvpcnt_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpcnt_h(a: v16i16) -> v16i16 {
-    __lasx_xvpcnt_h(a)
+pub fn lasx_xvpcnt_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvpcnt_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpcnt_w(a: v8i32) -> v8i32 {
-    __lasx_xvpcnt_w(a)
+pub fn lasx_xvpcnt_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvpcnt_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpcnt_d(a: v4i64) -> v4i64 {
-    __lasx_xvpcnt_d(a)
+pub fn lasx_xvpcnt_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvpcnt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclo_b(a: v32i8) -> v32i8 {
-    __lasx_xvclo_b(a)
+pub fn lasx_xvclo_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvclo_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclo_h(a: v16i16) -> v16i16 {
-    __lasx_xvclo_h(a)
+pub fn lasx_xvclo_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvclo_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclo_w(a: v8i32) -> v8i32 {
-    __lasx_xvclo_w(a)
+pub fn lasx_xvclo_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvclo_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclo_d(a: v4i64) -> v4i64 {
-    __lasx_xvclo_d(a)
+pub fn lasx_xvclo_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvclo_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclz_b(a: v32i8) -> v32i8 {
-    __lasx_xvclz_b(a)
+pub fn lasx_xvclz_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvclz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclz_h(a: v16i16) -> v16i16 {
-    __lasx_xvclz_h(a)
+pub fn lasx_xvclz_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvclz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclz_w(a: v8i32) -> v8i32 {
-    __lasx_xvclz_w(a)
+pub fn lasx_xvclz_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvclz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvclz_d(a: v4i64) -> v4i64 {
-    __lasx_xvclz_d(a)
+pub fn lasx_xvclz_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvclz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfadd_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfadd_s(a, b)
+pub fn lasx_xvfadd_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfadd_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfadd_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfadd_d(a, b)
+pub fn lasx_xvfadd_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfsub_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfsub_s(a, b)
+pub fn lasx_xvfsub_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfsub_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfsub_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfsub_d(a, b)
+pub fn lasx_xvfsub_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfsub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmul_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfmul_s(a, b)
+pub fn lasx_xvfmul_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmul_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmul_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfmul_d(a, b)
+pub fn lasx_xvfmul_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmul_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfdiv_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfdiv_s(a, b)
+pub fn lasx_xvfdiv_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfdiv_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfdiv_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfdiv_d(a, b)
+pub fn lasx_xvfdiv_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfdiv_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvt_h_s(a: v8f32, b: v8f32) -> v16i16 {
-    __lasx_xvfcvt_h_s(a, b)
+pub fn lasx_xvfcvt_h_s(a: v8f32, b: v8f32) -> v16i16 {
+    unsafe { __lasx_xvfcvt_h_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvt_s_d(a: v4f64, b: v4f64) -> v8f32 {
-    __lasx_xvfcvt_s_d(a, b)
+pub fn lasx_xvfcvt_s_d(a: v4f64, b: v4f64) -> v8f32 {
+    unsafe { __lasx_xvfcvt_s_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmin_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfmin_s(a, b)
+pub fn lasx_xvfmin_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmin_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmin_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfmin_d(a, b)
+pub fn lasx_xvfmin_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmin_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmina_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfmina_s(a, b)
+pub fn lasx_xvfmina_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmina_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmina_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfmina_d(a, b)
+pub fn lasx_xvfmina_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmina_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmax_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfmax_s(a, b)
+pub fn lasx_xvfmax_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmax_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmax_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfmax_d(a, b)
+pub fn lasx_xvfmax_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmax_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmaxa_s(a: v8f32, b: v8f32) -> v8f32 {
-    __lasx_xvfmaxa_s(a, b)
+pub fn lasx_xvfmaxa_s(a: v8f32, b: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmaxa_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmaxa_d(a: v4f64, b: v4f64) -> v4f64 {
-    __lasx_xvfmaxa_d(a, b)
+pub fn lasx_xvfmaxa_d(a: v4f64, b: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmaxa_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfclass_s(a: v8f32) -> v8i32 {
-    __lasx_xvfclass_s(a)
+pub fn lasx_xvfclass_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfclass_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfclass_d(a: v4f64) -> v4i64 {
-    __lasx_xvfclass_d(a)
+pub fn lasx_xvfclass_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfclass_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfsqrt_s(a: v8f32) -> v8f32 {
-    __lasx_xvfsqrt_s(a)
+pub fn lasx_xvfsqrt_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfsqrt_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfsqrt_d(a: v4f64) -> v4f64 {
-    __lasx_xvfsqrt_d(a)
+pub fn lasx_xvfsqrt_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfsqrt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrecip_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrecip_s(a)
+pub fn lasx_xvfrecip_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrecip_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrecip_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrecip_d(a)
-}
-
-#[inline]
-#[target_feature(enable = "lasx,frecipe")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrecipe_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrecipe_s(a)
+pub fn lasx_xvfrecip_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrecip_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrecipe_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrecipe_d(a)
+pub fn lasx_xvfrecipe_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrecipe_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrsqrte_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrsqrte_s(a)
+pub fn lasx_xvfrecipe_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrecipe_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrsqrte_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrsqrte_d(a)
+pub fn lasx_xvfrsqrte_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrsqrte_s(a) }
+}
+
+#[inline]
+#[target_feature(enable = "lasx,frecipe")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lasx_xvfrsqrte_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrsqrte_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrint_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrint_s(a)
+pub fn lasx_xvfrint_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrint_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrint_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrint_d(a)
+pub fn lasx_xvfrint_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrint_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrsqrt_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrsqrt_s(a)
+pub fn lasx_xvfrsqrt_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrsqrt_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrsqrt_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrsqrt_d(a)
+pub fn lasx_xvfrsqrt_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrsqrt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvflogb_s(a: v8f32) -> v8f32 {
-    __lasx_xvflogb_s(a)
+pub fn lasx_xvflogb_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvflogb_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvflogb_d(a: v4f64) -> v4f64 {
-    __lasx_xvflogb_d(a)
+pub fn lasx_xvflogb_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvflogb_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvth_s_h(a: v16i16) -> v8f32 {
-    __lasx_xvfcvth_s_h(a)
+pub fn lasx_xvfcvth_s_h(a: v16i16) -> v8f32 {
+    unsafe { __lasx_xvfcvth_s_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvth_d_s(a: v8f32) -> v4f64 {
-    __lasx_xvfcvth_d_s(a)
+pub fn lasx_xvfcvth_d_s(a: v8f32) -> v4f64 {
+    unsafe { __lasx_xvfcvth_d_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvtl_s_h(a: v16i16) -> v8f32 {
-    __lasx_xvfcvtl_s_h(a)
+pub fn lasx_xvfcvtl_s_h(a: v16i16) -> v8f32 {
+    unsafe { __lasx_xvfcvtl_s_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcvtl_d_s(a: v8f32) -> v4f64 {
-    __lasx_xvfcvtl_d_s(a)
+pub fn lasx_xvfcvtl_d_s(a: v8f32) -> v4f64 {
+    unsafe { __lasx_xvfcvtl_d_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftint_w_s(a: v8f32) -> v8i32 {
-    __lasx_xvftint_w_s(a)
+pub fn lasx_xvftint_w_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvftint_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftint_l_d(a: v4f64) -> v4i64 {
-    __lasx_xvftint_l_d(a)
+pub fn lasx_xvftint_l_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvftint_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftint_wu_s(a: v8f32) -> v8u32 {
-    __lasx_xvftint_wu_s(a)
+pub fn lasx_xvftint_wu_s(a: v8f32) -> v8u32 {
+    unsafe { __lasx_xvftint_wu_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftint_lu_d(a: v4f64) -> v4u64 {
-    __lasx_xvftint_lu_d(a)
+pub fn lasx_xvftint_lu_d(a: v4f64) -> v4u64 {
+    unsafe { __lasx_xvftint_lu_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrz_w_s(a: v8f32) -> v8i32 {
-    __lasx_xvftintrz_w_s(a)
+pub fn lasx_xvftintrz_w_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvftintrz_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrz_l_d(a: v4f64) -> v4i64 {
-    __lasx_xvftintrz_l_d(a)
+pub fn lasx_xvftintrz_l_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvftintrz_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrz_wu_s(a: v8f32) -> v8u32 {
-    __lasx_xvftintrz_wu_s(a)
+pub fn lasx_xvftintrz_wu_s(a: v8f32) -> v8u32 {
+    unsafe { __lasx_xvftintrz_wu_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrz_lu_d(a: v4f64) -> v4u64 {
-    __lasx_xvftintrz_lu_d(a)
+pub fn lasx_xvftintrz_lu_d(a: v4f64) -> v4u64 {
+    unsafe { __lasx_xvftintrz_lu_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffint_s_w(a: v8i32) -> v8f32 {
-    __lasx_xvffint_s_w(a)
+pub fn lasx_xvffint_s_w(a: v8i32) -> v8f32 {
+    unsafe { __lasx_xvffint_s_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffint_d_l(a: v4i64) -> v4f64 {
-    __lasx_xvffint_d_l(a)
+pub fn lasx_xvffint_d_l(a: v4i64) -> v4f64 {
+    unsafe { __lasx_xvffint_d_l(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffint_s_wu(a: v8u32) -> v8f32 {
-    __lasx_xvffint_s_wu(a)
+pub fn lasx_xvffint_s_wu(a: v8u32) -> v8f32 {
+    unsafe { __lasx_xvffint_s_wu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffint_d_lu(a: v4u64) -> v4f64 {
-    __lasx_xvffint_d_lu(a)
+pub fn lasx_xvffint_d_lu(a: v4u64) -> v4f64 {
+    unsafe { __lasx_xvffint_d_lu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve_b(a: v32i8, b: i32) -> v32i8 {
-    __lasx_xvreplve_b(a, b)
+pub fn lasx_xvreplve_b(a: v32i8, b: i32) -> v32i8 {
+    unsafe { __lasx_xvreplve_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve_h(a: v16i16, b: i32) -> v16i16 {
-    __lasx_xvreplve_h(a, b)
+pub fn lasx_xvreplve_h(a: v16i16, b: i32) -> v16i16 {
+    unsafe { __lasx_xvreplve_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve_w(a: v8i32, b: i32) -> v8i32 {
-    __lasx_xvreplve_w(a, b)
+pub fn lasx_xvreplve_w(a: v8i32, b: i32) -> v8i32 {
+    unsafe { __lasx_xvreplve_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve_d(a: v4i64, b: i32) -> v4i64 {
-    __lasx_xvreplve_d(a, b)
+pub fn lasx_xvreplve_d(a: v4i64, b: i32) -> v4i64 {
+    unsafe { __lasx_xvreplve_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpermi_w<const IMM8: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvpermi_w<const IMM8: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvpermi_w(a, b, IMM8)
+    unsafe { __lasx_xvpermi_w(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvandn_v(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvandn_v(a, b)
+pub fn lasx_xvandn_v(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvandn_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvneg_b(a: v32i8) -> v32i8 {
-    __lasx_xvneg_b(a)
+pub fn lasx_xvneg_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvneg_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvneg_h(a: v16i16) -> v16i16 {
-    __lasx_xvneg_h(a)
+pub fn lasx_xvneg_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvneg_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvneg_w(a: v8i32) -> v8i32 {
-    __lasx_xvneg_w(a)
+pub fn lasx_xvneg_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvneg_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvneg_d(a: v4i64) -> v4i64 {
-    __lasx_xvneg_d(a)
+pub fn lasx_xvneg_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvneg_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvmuh_b(a, b)
+pub fn lasx_xvmuh_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmuh_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvmuh_h(a, b)
+pub fn lasx_xvmuh_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmuh_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvmuh_w(a, b)
+pub fn lasx_xvmuh_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmuh_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmuh_d(a, b)
+pub fn lasx_xvmuh_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmuh_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_bu(a: v32u8, b: v32u8) -> v32u8 {
-    __lasx_xvmuh_bu(a, b)
+pub fn lasx_xvmuh_bu(a: v32u8, b: v32u8) -> v32u8 {
+    unsafe { __lasx_xvmuh_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_hu(a: v16u16, b: v16u16) -> v16u16 {
-    __lasx_xvmuh_hu(a, b)
+pub fn lasx_xvmuh_hu(a: v16u16, b: v16u16) -> v16u16 {
+    unsafe { __lasx_xvmuh_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_wu(a: v8u32, b: v8u32) -> v8u32 {
-    __lasx_xvmuh_wu(a, b)
+pub fn lasx_xvmuh_wu(a: v8u32, b: v8u32) -> v8u32 {
+    unsafe { __lasx_xvmuh_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmuh_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvmuh_du(a, b)
+pub fn lasx_xvmuh_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmuh_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_h_b<const IMM3: u32>(a: v32i8) -> v16i16 {
+pub fn lasx_xvsllwil_h_b<const IMM3: u32>(a: v32i8) -> v16i16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsllwil_h_b(a, IMM3)
+    unsafe { __lasx_xvsllwil_h_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_w_h<const IMM4: u32>(a: v16i16) -> v8i32 {
+pub fn lasx_xvsllwil_w_h<const IMM4: u32>(a: v16i16) -> v8i32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsllwil_w_h(a, IMM4)
+    unsafe { __lasx_xvsllwil_w_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_d_w<const IMM5: u32>(a: v8i32) -> v4i64 {
+pub fn lasx_xvsllwil_d_w<const IMM5: u32>(a: v8i32) -> v4i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsllwil_d_w(a, IMM5)
+    unsafe { __lasx_xvsllwil_d_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_hu_bu<const IMM3: u32>(a: v32u8) -> v16u16 {
+pub fn lasx_xvsllwil_hu_bu<const IMM3: u32>(a: v32u8) -> v16u16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvsllwil_hu_bu(a, IMM3)
+    unsafe { __lasx_xvsllwil_hu_bu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_wu_hu<const IMM4: u32>(a: v16u16) -> v8u32 {
+pub fn lasx_xvsllwil_wu_hu<const IMM4: u32>(a: v16u16) -> v8u32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsllwil_wu_hu(a, IMM4)
+    unsafe { __lasx_xvsllwil_wu_hu(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsllwil_du_wu<const IMM5: u32>(a: v8u32) -> v4u64 {
+pub fn lasx_xvsllwil_du_wu<const IMM5: u32>(a: v8u32) -> v4u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsllwil_du_wu(a, IMM5)
+    unsafe { __lasx_xvsllwil_du_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsran_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvsran_b_h(a, b)
+pub fn lasx_xvsran_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvsran_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsran_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvsran_h_w(a, b)
+pub fn lasx_xvsran_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvsran_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsran_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvsran_w_d(a, b)
+pub fn lasx_xvsran_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvsran_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvssran_b_h(a, b)
+pub fn lasx_xvssran_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvssran_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvssran_h_w(a, b)
+pub fn lasx_xvssran_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvssran_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvssran_w_d(a, b)
+pub fn lasx_xvssran_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvssran_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_bu_h(a: v16u16, b: v16u16) -> v32u8 {
-    __lasx_xvssran_bu_h(a, b)
+pub fn lasx_xvssran_bu_h(a: v16u16, b: v16u16) -> v32u8 {
+    unsafe { __lasx_xvssran_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_hu_w(a: v8u32, b: v8u32) -> v16u16 {
-    __lasx_xvssran_hu_w(a, b)
+pub fn lasx_xvssran_hu_w(a: v8u32, b: v8u32) -> v16u16 {
+    unsafe { __lasx_xvssran_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssran_wu_d(a: v4u64, b: v4u64) -> v8u32 {
-    __lasx_xvssran_wu_d(a, b)
+pub fn lasx_xvssran_wu_d(a: v4u64, b: v4u64) -> v8u32 {
+    unsafe { __lasx_xvssran_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarn_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvsrarn_b_h(a, b)
+pub fn lasx_xvsrarn_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvsrarn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarn_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvsrarn_h_w(a, b)
+pub fn lasx_xvsrarn_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvsrarn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarn_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvsrarn_w_d(a, b)
+pub fn lasx_xvsrarn_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvsrarn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvssrarn_b_h(a, b)
+pub fn lasx_xvssrarn_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvssrarn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvssrarn_h_w(a, b)
+pub fn lasx_xvssrarn_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvssrarn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvssrarn_w_d(a, b)
+pub fn lasx_xvssrarn_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvssrarn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_bu_h(a: v16u16, b: v16u16) -> v32u8 {
-    __lasx_xvssrarn_bu_h(a, b)
+pub fn lasx_xvssrarn_bu_h(a: v16u16, b: v16u16) -> v32u8 {
+    unsafe { __lasx_xvssrarn_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_hu_w(a: v8u32, b: v8u32) -> v16u16 {
-    __lasx_xvssrarn_hu_w(a, b)
+pub fn lasx_xvssrarn_hu_w(a: v8u32, b: v8u32) -> v16u16 {
+    unsafe { __lasx_xvssrarn_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarn_wu_d(a: v4u64, b: v4u64) -> v8u32 {
-    __lasx_xvssrarn_wu_d(a, b)
+pub fn lasx_xvssrarn_wu_d(a: v4u64, b: v4u64) -> v8u32 {
+    unsafe { __lasx_xvssrarn_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrln_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvsrln_b_h(a, b)
+pub fn lasx_xvsrln_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvsrln_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrln_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvsrln_h_w(a, b)
+pub fn lasx_xvsrln_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvsrln_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrln_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvsrln_w_d(a, b)
+pub fn lasx_xvsrln_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvsrln_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_bu_h(a: v16u16, b: v16u16) -> v32u8 {
-    __lasx_xvssrln_bu_h(a, b)
+pub fn lasx_xvssrln_bu_h(a: v16u16, b: v16u16) -> v32u8 {
+    unsafe { __lasx_xvssrln_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_hu_w(a: v8u32, b: v8u32) -> v16u16 {
-    __lasx_xvssrln_hu_w(a, b)
+pub fn lasx_xvssrln_hu_w(a: v8u32, b: v8u32) -> v16u16 {
+    unsafe { __lasx_xvssrln_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_wu_d(a: v4u64, b: v4u64) -> v8u32 {
-    __lasx_xvssrln_wu_d(a, b)
+pub fn lasx_xvssrln_wu_d(a: v4u64, b: v4u64) -> v8u32 {
+    unsafe { __lasx_xvssrln_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrn_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvsrlrn_b_h(a, b)
+pub fn lasx_xvsrlrn_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvsrlrn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrn_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvsrlrn_h_w(a, b)
+pub fn lasx_xvsrlrn_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvsrlrn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrn_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvsrlrn_w_d(a, b)
+pub fn lasx_xvsrlrn_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvsrlrn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_bu_h(a: v16u16, b: v16u16) -> v32u8 {
-    __lasx_xvssrlrn_bu_h(a, b)
+pub fn lasx_xvssrlrn_bu_h(a: v16u16, b: v16u16) -> v32u8 {
+    unsafe { __lasx_xvssrlrn_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_hu_w(a: v8u32, b: v8u32) -> v16u16 {
-    __lasx_xvssrlrn_hu_w(a, b)
+pub fn lasx_xvssrlrn_hu_w(a: v8u32, b: v8u32) -> v16u16 {
+    unsafe { __lasx_xvssrlrn_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_wu_d(a: v4u64, b: v4u64) -> v8u32 {
-    __lasx_xvssrlrn_wu_d(a, b)
+pub fn lasx_xvssrlrn_wu_d(a: v4u64, b: v4u64) -> v8u32 {
+    unsafe { __lasx_xvssrlrn_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrstpi_b<const IMM5: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvfrstpi_b<const IMM5: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvfrstpi_b(a, b, IMM5)
+    unsafe { __lasx_xvfrstpi_b(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrstpi_h<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvfrstpi_h<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvfrstpi_h(a, b, IMM5)
+    unsafe { __lasx_xvfrstpi_h(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrstp_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
-    __lasx_xvfrstp_b(a, b, c)
+pub fn lasx_xvfrstp_b(a: v32i8, b: v32i8, c: v32i8) -> v32i8 {
+    unsafe { __lasx_xvfrstp_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrstp_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
-    __lasx_xvfrstp_h(a, b, c)
+pub fn lasx_xvfrstp_h(a: v16i16, b: v16i16, c: v16i16) -> v16i16 {
+    unsafe { __lasx_xvfrstp_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvshuf4i_d<const IMM8: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvshuf4i_d<const IMM8: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvshuf4i_d(a, b, IMM8)
+    unsafe { __lasx_xvshuf4i_d(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbsrl_v<const IMM5: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvbsrl_v<const IMM5: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvbsrl_v(a, IMM5)
+    unsafe { __lasx_xvbsrl_v(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvbsll_v<const IMM5: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvbsll_v<const IMM5: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvbsll_v(a, IMM5)
+    unsafe { __lasx_xvbsll_v(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextrins_b<const IMM8: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvextrins_b<const IMM8: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvextrins_b(a, b, IMM8)
+    unsafe { __lasx_xvextrins_b(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextrins_h<const IMM8: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvextrins_h<const IMM8: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvextrins_h(a, b, IMM8)
+    unsafe { __lasx_xvextrins_h(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextrins_w<const IMM8: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvextrins_w<const IMM8: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvextrins_w(a, b, IMM8)
+    unsafe { __lasx_xvextrins_w(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextrins_d<const IMM8: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvextrins_d<const IMM8: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvextrins_d(a, b, IMM8)
+    unsafe { __lasx_xvextrins_d(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmskltz_b(a: v32i8) -> v32i8 {
-    __lasx_xvmskltz_b(a)
+pub fn lasx_xvmskltz_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmskltz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmskltz_h(a: v16i16) -> v16i16 {
-    __lasx_xvmskltz_h(a)
+pub fn lasx_xvmskltz_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvmskltz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmskltz_w(a: v8i32) -> v8i32 {
-    __lasx_xvmskltz_w(a)
+pub fn lasx_xvmskltz_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvmskltz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmskltz_d(a: v4i64) -> v4i64 {
-    __lasx_xvmskltz_d(a)
+pub fn lasx_xvmskltz_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmskltz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsigncov_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvsigncov_b(a, b)
+pub fn lasx_xvsigncov_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvsigncov_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsigncov_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvsigncov_h(a, b)
+pub fn lasx_xvsigncov_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvsigncov_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsigncov_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvsigncov_w(a, b)
+pub fn lasx_xvsigncov_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvsigncov_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsigncov_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsigncov_d(a, b)
+pub fn lasx_xvsigncov_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsigncov_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmadd_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
-    __lasx_xvfmadd_s(a, b, c)
+pub fn lasx_xvfmadd_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmadd_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmadd_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
-    __lasx_xvfmadd_d(a, b, c)
+pub fn lasx_xvfmadd_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmsub_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
-    __lasx_xvfmsub_s(a, b, c)
+pub fn lasx_xvfmsub_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfmsub_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfmsub_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
-    __lasx_xvfmsub_d(a, b, c)
+pub fn lasx_xvfmsub_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfnmadd_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
-    __lasx_xvfnmadd_s(a, b, c)
+pub fn lasx_xvfnmadd_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfnmadd_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfnmadd_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
-    __lasx_xvfnmadd_d(a, b, c)
+pub fn lasx_xvfnmadd_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfnmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfnmsub_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
-    __lasx_xvfnmsub_s(a, b, c)
+pub fn lasx_xvfnmsub_s(a: v8f32, b: v8f32, c: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfnmsub_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfnmsub_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
-    __lasx_xvfnmsub_d(a, b, c)
+pub fn lasx_xvfnmsub_d(a: v4f64, b: v4f64, c: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfnmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrne_w_s(a: v8f32) -> v8i32 {
-    __lasx_xvftintrne_w_s(a)
+pub fn lasx_xvftintrne_w_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvftintrne_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrne_l_d(a: v4f64) -> v4i64 {
-    __lasx_xvftintrne_l_d(a)
+pub fn lasx_xvftintrne_l_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvftintrne_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrp_w_s(a: v8f32) -> v8i32 {
-    __lasx_xvftintrp_w_s(a)
+pub fn lasx_xvftintrp_w_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvftintrp_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrp_l_d(a: v4f64) -> v4i64 {
-    __lasx_xvftintrp_l_d(a)
+pub fn lasx_xvftintrp_l_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvftintrp_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrm_w_s(a: v8f32) -> v8i32 {
-    __lasx_xvftintrm_w_s(a)
+pub fn lasx_xvftintrm_w_s(a: v8f32) -> v8i32 {
+    unsafe { __lasx_xvftintrm_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrm_l_d(a: v4f64) -> v4i64 {
-    __lasx_xvftintrm_l_d(a)
+pub fn lasx_xvftintrm_l_d(a: v4f64) -> v4i64 {
+    unsafe { __lasx_xvftintrm_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftint_w_d(a: v4f64, b: v4f64) -> v8i32 {
-    __lasx_xvftint_w_d(a, b)
+pub fn lasx_xvftint_w_d(a: v4f64, b: v4f64) -> v8i32 {
+    unsafe { __lasx_xvftint_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffint_s_l(a: v4i64, b: v4i64) -> v8f32 {
-    __lasx_xvffint_s_l(a, b)
+pub fn lasx_xvffint_s_l(a: v4i64, b: v4i64) -> v8f32 {
+    unsafe { __lasx_xvffint_s_l(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrz_w_d(a: v4f64, b: v4f64) -> v8i32 {
-    __lasx_xvftintrz_w_d(a, b)
+pub fn lasx_xvftintrz_w_d(a: v4f64, b: v4f64) -> v8i32 {
+    unsafe { __lasx_xvftintrz_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrp_w_d(a: v4f64, b: v4f64) -> v8i32 {
-    __lasx_xvftintrp_w_d(a, b)
+pub fn lasx_xvftintrp_w_d(a: v4f64, b: v4f64) -> v8i32 {
+    unsafe { __lasx_xvftintrp_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrm_w_d(a: v4f64, b: v4f64) -> v8i32 {
-    __lasx_xvftintrm_w_d(a, b)
+pub fn lasx_xvftintrm_w_d(a: v4f64, b: v4f64) -> v8i32 {
+    unsafe { __lasx_xvftintrm_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrne_w_d(a: v4f64, b: v4f64) -> v8i32 {
-    __lasx_xvftintrne_w_d(a, b)
+pub fn lasx_xvftintrne_w_d(a: v4f64, b: v4f64) -> v8i32 {
+    unsafe { __lasx_xvftintrne_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftinth_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftinth_l_s(a)
+pub fn lasx_xvftinth_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftinth_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintl_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintl_l_s(a)
+pub fn lasx_xvftintl_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffinth_d_w(a: v8i32) -> v4f64 {
-    __lasx_xvffinth_d_w(a)
+pub fn lasx_xvffinth_d_w(a: v8i32) -> v4f64 {
+    unsafe { __lasx_xvffinth_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvffintl_d_w(a: v8i32) -> v4f64 {
-    __lasx_xvffintl_d_w(a)
+pub fn lasx_xvffintl_d_w(a: v8i32) -> v4f64 {
+    unsafe { __lasx_xvffintl_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrzh_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrzh_l_s(a)
+pub fn lasx_xvftintrzh_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrzh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrzl_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrzl_l_s(a)
+pub fn lasx_xvftintrzl_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrzl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrph_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrph_l_s(a)
+pub fn lasx_xvftintrph_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrph_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrpl_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrpl_l_s(a)
+pub fn lasx_xvftintrpl_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrpl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrmh_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrmh_l_s(a)
+pub fn lasx_xvftintrmh_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrmh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrml_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrml_l_s(a)
+pub fn lasx_xvftintrml_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrml_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrneh_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrneh_l_s(a)
+pub fn lasx_xvftintrneh_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrneh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvftintrnel_l_s(a: v8f32) -> v4i64 {
-    __lasx_xvftintrnel_l_s(a)
+pub fn lasx_xvftintrnel_l_s(a: v8f32) -> v4i64 {
+    unsafe { __lasx_xvftintrnel_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrne_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrintrne_s(a)
+pub fn lasx_xvfrintrne_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrintrne_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrne_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrintrne_d(a)
+pub fn lasx_xvfrintrne_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrintrne_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrz_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrintrz_s(a)
+pub fn lasx_xvfrintrz_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrintrz_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrz_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrintrz_d(a)
+pub fn lasx_xvfrintrz_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrintrz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrp_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrintrp_s(a)
+pub fn lasx_xvfrintrp_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrintrp_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrp_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrintrp_d(a)
+pub fn lasx_xvfrintrp_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrintrp_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrm_s(a: v8f32) -> v8f32 {
-    __lasx_xvfrintrm_s(a)
+pub fn lasx_xvfrintrm_s(a: v8f32) -> v8f32 {
+    unsafe { __lasx_xvfrintrm_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfrintrm_d(a: v4f64) -> v4f64 {
-    __lasx_xvfrintrm_d(a)
+pub fn lasx_xvfrintrm_d(a: v4f64) -> v4f64 {
+    unsafe { __lasx_xvfrintrm_d(a) }
 }
 
 #[inline]
@@ -5054,94 +5054,94 @@ pub unsafe fn lasx_xvstelm_d<const IMM_S8: i32, const IMM1: u32>(a: v4i64, mem_a
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvinsve0_w<const IMM3: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvinsve0_w<const IMM3: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvinsve0_w(a, b, IMM3)
+    unsafe { __lasx_xvinsve0_w(a, b, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvinsve0_d<const IMM2: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvinsve0_d<const IMM2: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvinsve0_d(a, b, IMM2)
+    unsafe { __lasx_xvinsve0_d(a, b, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve_w<const IMM3: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvpickve_w<const IMM3: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvpickve_w(a, IMM3)
+    unsafe { __lasx_xvpickve_w(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve_d<const IMM2: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvpickve_d<const IMM2: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvpickve_d(a, IMM2)
+    unsafe { __lasx_xvpickve_d(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvssrlrn_b_h(a, b)
+pub fn lasx_xvssrlrn_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvssrlrn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvssrlrn_h_w(a, b)
+pub fn lasx_xvssrlrn_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvssrlrn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrn_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvssrlrn_w_d(a, b)
+pub fn lasx_xvssrlrn_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvssrlrn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_b_h(a: v16i16, b: v16i16) -> v32i8 {
-    __lasx_xvssrln_b_h(a, b)
+pub fn lasx_xvssrln_b_h(a: v16i16, b: v16i16) -> v32i8 {
+    unsafe { __lasx_xvssrln_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_h_w(a: v8i32, b: v8i32) -> v16i16 {
-    __lasx_xvssrln_h_w(a, b)
+pub fn lasx_xvssrln_h_w(a: v8i32, b: v8i32) -> v16i16 {
+    unsafe { __lasx_xvssrln_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrln_w_d(a: v4i64, b: v4i64) -> v8i32 {
-    __lasx_xvssrln_w_d(a, b)
+pub fn lasx_xvssrln_w_d(a: v4i64, b: v4i64) -> v8i32 {
+    unsafe { __lasx_xvssrln_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvorn_v(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvorn_v(a, b)
+pub fn lasx_xvorn_v(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvorn_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvldi<const IMM_S13: i32>() -> v4i64 {
+pub fn lasx_xvldi<const IMM_S13: i32>() -> v4i64 {
     static_assert_simm_bits!(IMM_S13, 13);
-    __lasx_xvldi(IMM_S13)
+    unsafe { __lasx_xvldi(IMM_S13) }
 }
 
 #[inline]
@@ -5161,170 +5161,170 @@ pub unsafe fn lasx_xvstx(a: v32i8, mem_addr: *mut i8, b: i64) {
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextl_qu_du(a: v4u64) -> v4u64 {
-    __lasx_xvextl_qu_du(a)
+pub fn lasx_xvextl_qu_du(a: v4u64) -> v4u64 {
+    unsafe { __lasx_xvextl_qu_du(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvinsgr2vr_w<const IMM3: u32>(a: v8i32, b: i32) -> v8i32 {
+pub fn lasx_xvinsgr2vr_w<const IMM3: u32>(a: v8i32, b: i32) -> v8i32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvinsgr2vr_w(a, b, IMM3)
+    unsafe { __lasx_xvinsgr2vr_w(a, b, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvinsgr2vr_d<const IMM2: u32>(a: v4i64, b: i64) -> v4i64 {
+pub fn lasx_xvinsgr2vr_d<const IMM2: u32>(a: v4i64, b: i64) -> v4i64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvinsgr2vr_d(a, b, IMM2)
+    unsafe { __lasx_xvinsgr2vr_d(a, b, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve0_b(a: v32i8) -> v32i8 {
-    __lasx_xvreplve0_b(a)
+pub fn lasx_xvreplve0_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvreplve0_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve0_h(a: v16i16) -> v16i16 {
-    __lasx_xvreplve0_h(a)
+pub fn lasx_xvreplve0_h(a: v16i16) -> v16i16 {
+    unsafe { __lasx_xvreplve0_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve0_w(a: v8i32) -> v8i32 {
-    __lasx_xvreplve0_w(a)
+pub fn lasx_xvreplve0_w(a: v8i32) -> v8i32 {
+    unsafe { __lasx_xvreplve0_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve0_d(a: v4i64) -> v4i64 {
-    __lasx_xvreplve0_d(a)
+pub fn lasx_xvreplve0_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvreplve0_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvreplve0_q(a: v32i8) -> v32i8 {
-    __lasx_xvreplve0_q(a)
+pub fn lasx_xvreplve0_q(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvreplve0_q(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_h_b(a: v32i8) -> v16i16 {
-    __lasx_vext2xv_h_b(a)
+pub fn lasx_vext2xv_h_b(a: v32i8) -> v16i16 {
+    unsafe { __lasx_vext2xv_h_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_w_h(a: v16i16) -> v8i32 {
-    __lasx_vext2xv_w_h(a)
+pub fn lasx_vext2xv_w_h(a: v16i16) -> v8i32 {
+    unsafe { __lasx_vext2xv_w_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_d_w(a: v8i32) -> v4i64 {
-    __lasx_vext2xv_d_w(a)
+pub fn lasx_vext2xv_d_w(a: v8i32) -> v4i64 {
+    unsafe { __lasx_vext2xv_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_w_b(a: v32i8) -> v8i32 {
-    __lasx_vext2xv_w_b(a)
+pub fn lasx_vext2xv_w_b(a: v32i8) -> v8i32 {
+    unsafe { __lasx_vext2xv_w_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_d_h(a: v16i16) -> v4i64 {
-    __lasx_vext2xv_d_h(a)
+pub fn lasx_vext2xv_d_h(a: v16i16) -> v4i64 {
+    unsafe { __lasx_vext2xv_d_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_d_b(a: v32i8) -> v4i64 {
-    __lasx_vext2xv_d_b(a)
+pub fn lasx_vext2xv_d_b(a: v32i8) -> v4i64 {
+    unsafe { __lasx_vext2xv_d_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_hu_bu(a: v32i8) -> v16i16 {
-    __lasx_vext2xv_hu_bu(a)
+pub fn lasx_vext2xv_hu_bu(a: v32i8) -> v16i16 {
+    unsafe { __lasx_vext2xv_hu_bu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_wu_hu(a: v16i16) -> v8i32 {
-    __lasx_vext2xv_wu_hu(a)
+pub fn lasx_vext2xv_wu_hu(a: v16i16) -> v8i32 {
+    unsafe { __lasx_vext2xv_wu_hu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_du_wu(a: v8i32) -> v4i64 {
-    __lasx_vext2xv_du_wu(a)
+pub fn lasx_vext2xv_du_wu(a: v8i32) -> v4i64 {
+    unsafe { __lasx_vext2xv_du_wu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_wu_bu(a: v32i8) -> v8i32 {
-    __lasx_vext2xv_wu_bu(a)
+pub fn lasx_vext2xv_wu_bu(a: v32i8) -> v8i32 {
+    unsafe { __lasx_vext2xv_wu_bu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_du_hu(a: v16i16) -> v4i64 {
-    __lasx_vext2xv_du_hu(a)
+pub fn lasx_vext2xv_du_hu(a: v16i16) -> v4i64 {
+    unsafe { __lasx_vext2xv_du_hu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_vext2xv_du_bu(a: v32i8) -> v4i64 {
-    __lasx_vext2xv_du_bu(a)
+pub fn lasx_vext2xv_du_bu(a: v32i8) -> v4i64 {
+    unsafe { __lasx_vext2xv_du_bu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpermi_q<const IMM8: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvpermi_q<const IMM8: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvpermi_q(a, b, IMM8)
+    unsafe { __lasx_xvpermi_q(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpermi_d<const IMM8: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvpermi_d<const IMM8: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lasx_xvpermi_d(a, IMM8)
+    unsafe { __lasx_xvpermi_d(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvperm_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvperm_w(a, b)
+pub fn lasx_xvperm_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvperm_w(a, b) }
 }
 
 #[inline]
@@ -5367,1697 +5367,1697 @@ pub unsafe fn lasx_xvldrepl_d<const IMM_S9: i32>(mem_addr: *const i8) -> v4i64 {
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve2gr_w<const IMM3: u32>(a: v8i32) -> i32 {
+pub fn lasx_xvpickve2gr_w<const IMM3: u32>(a: v8i32) -> i32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvpickve2gr_w(a, IMM3)
+    unsafe { __lasx_xvpickve2gr_w(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve2gr_wu<const IMM3: u32>(a: v8i32) -> u32 {
+pub fn lasx_xvpickve2gr_wu<const IMM3: u32>(a: v8i32) -> u32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvpickve2gr_wu(a, IMM3)
+    unsafe { __lasx_xvpickve2gr_wu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve2gr_d<const IMM2: u32>(a: v4i64) -> i64 {
+pub fn lasx_xvpickve2gr_d<const IMM2: u32>(a: v4i64) -> i64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvpickve2gr_d(a, IMM2)
+    unsafe { __lasx_xvpickve2gr_d(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve2gr_du<const IMM2: u32>(a: v4i64) -> u64 {
+pub fn lasx_xvpickve2gr_du<const IMM2: u32>(a: v4i64) -> u64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvpickve2gr_du(a, IMM2)
+    unsafe { __lasx_xvpickve2gr_du(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvaddwev_q_d(a, b)
+pub fn lasx_xvaddwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvaddwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvaddwev_d_w(a, b)
+pub fn lasx_xvaddwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvaddwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvaddwev_w_h(a, b)
+pub fn lasx_xvaddwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvaddwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvaddwev_h_b(a, b)
+pub fn lasx_xvaddwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvaddwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvaddwev_q_du(a, b)
+pub fn lasx_xvaddwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvaddwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvaddwev_d_wu(a, b)
+pub fn lasx_xvaddwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvaddwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvaddwev_w_hu(a, b)
+pub fn lasx_xvaddwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvaddwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvaddwev_h_bu(a, b)
+pub fn lasx_xvaddwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvaddwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsubwev_q_d(a, b)
+pub fn lasx_xvsubwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsubwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvsubwev_d_w(a, b)
+pub fn lasx_xvsubwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvsubwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvsubwev_w_h(a, b)
+pub fn lasx_xvsubwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvsubwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvsubwev_h_b(a, b)
+pub fn lasx_xvsubwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvsubwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvsubwev_q_du(a, b)
+pub fn lasx_xvsubwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvsubwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvsubwev_d_wu(a, b)
+pub fn lasx_xvsubwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvsubwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvsubwev_w_hu(a, b)
+pub fn lasx_xvsubwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvsubwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvsubwev_h_bu(a, b)
+pub fn lasx_xvsubwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvsubwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmulwev_q_d(a, b)
+pub fn lasx_xvmulwev_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmulwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvmulwev_d_w(a, b)
+pub fn lasx_xvmulwev_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmulwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvmulwev_w_h(a, b)
+pub fn lasx_xvmulwev_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmulwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvmulwev_h_b(a, b)
+pub fn lasx_xvmulwev_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmulwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvmulwev_q_du(a, b)
+pub fn lasx_xvmulwev_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvmulwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvmulwev_d_wu(a, b)
+pub fn lasx_xvmulwev_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvmulwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvmulwev_w_hu(a, b)
+pub fn lasx_xvmulwev_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvmulwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvmulwev_h_bu(a, b)
+pub fn lasx_xvmulwev_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvmulwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvaddwod_q_d(a, b)
+pub fn lasx_xvaddwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvaddwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvaddwod_d_w(a, b)
+pub fn lasx_xvaddwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvaddwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvaddwod_w_h(a, b)
+pub fn lasx_xvaddwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvaddwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvaddwod_h_b(a, b)
+pub fn lasx_xvaddwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvaddwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvaddwod_q_du(a, b)
+pub fn lasx_xvaddwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvaddwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvaddwod_d_wu(a, b)
+pub fn lasx_xvaddwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvaddwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvaddwod_w_hu(a, b)
+pub fn lasx_xvaddwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvaddwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvaddwod_h_bu(a, b)
+pub fn lasx_xvaddwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvaddwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsubwod_q_d(a, b)
+pub fn lasx_xvsubwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsubwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvsubwod_d_w(a, b)
+pub fn lasx_xvsubwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvsubwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvsubwod_w_h(a, b)
+pub fn lasx_xvsubwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvsubwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvsubwod_h_b(a, b)
+pub fn lasx_xvsubwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvsubwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvsubwod_q_du(a, b)
+pub fn lasx_xvsubwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvsubwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvsubwod_d_wu(a, b)
+pub fn lasx_xvsubwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvsubwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvsubwod_w_hu(a, b)
+pub fn lasx_xvsubwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvsubwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsubwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvsubwod_h_bu(a, b)
+pub fn lasx_xvsubwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvsubwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvmulwod_q_d(a, b)
+pub fn lasx_xvmulwod_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmulwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
-    __lasx_xvmulwod_d_w(a, b)
+pub fn lasx_xvmulwod_d_w(a: v8i32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmulwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
-    __lasx_xvmulwod_w_h(a, b)
+pub fn lasx_xvmulwod_w_h(a: v16i16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmulwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
-    __lasx_xvmulwod_h_b(a, b)
+pub fn lasx_xvmulwod_h_b(a: v32i8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmulwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
-    __lasx_xvmulwod_q_du(a, b)
+pub fn lasx_xvmulwod_q_du(a: v4u64, b: v4u64) -> v4i64 {
+    unsafe { __lasx_xvmulwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
-    __lasx_xvmulwod_d_wu(a, b)
+pub fn lasx_xvmulwod_d_wu(a: v8u32, b: v8u32) -> v4i64 {
+    unsafe { __lasx_xvmulwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
-    __lasx_xvmulwod_w_hu(a, b)
+pub fn lasx_xvmulwod_w_hu(a: v16u16, b: v16u16) -> v8i32 {
+    unsafe { __lasx_xvmulwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
-    __lasx_xvmulwod_h_bu(a, b)
+pub fn lasx_xvmulwod_h_bu(a: v32u8, b: v32u8) -> v16i16 {
+    unsafe { __lasx_xvmulwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
-    __lasx_xvaddwev_d_wu_w(a, b)
+pub fn lasx_xvaddwev_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvaddwev_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
-    __lasx_xvaddwev_w_hu_h(a, b)
+pub fn lasx_xvaddwev_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvaddwev_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
-    __lasx_xvaddwev_h_bu_b(a, b)
+pub fn lasx_xvaddwev_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvaddwev_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
-    __lasx_xvmulwev_d_wu_w(a, b)
+pub fn lasx_xvmulwev_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmulwev_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
-    __lasx_xvmulwev_w_hu_h(a, b)
+pub fn lasx_xvmulwev_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmulwev_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
-    __lasx_xvmulwev_h_bu_b(a, b)
+pub fn lasx_xvmulwev_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmulwev_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
-    __lasx_xvaddwod_d_wu_w(a, b)
+pub fn lasx_xvaddwod_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvaddwod_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
-    __lasx_xvaddwod_w_hu_h(a, b)
+pub fn lasx_xvaddwod_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvaddwod_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
-    __lasx_xvaddwod_h_bu_b(a, b)
+pub fn lasx_xvaddwod_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvaddwod_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
-    __lasx_xvmulwod_d_wu_w(a, b)
+pub fn lasx_xvmulwod_d_wu_w(a: v8u32, b: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmulwod_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
-    __lasx_xvmulwod_w_hu_h(a, b)
+pub fn lasx_xvmulwod_w_hu_h(a: v16u16, b: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmulwod_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
-    __lasx_xvmulwod_h_bu_b(a, b)
+pub fn lasx_xvmulwod_h_bu_b(a: v32u8, b: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmulwod_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvhaddw_q_d(a, b)
+pub fn lasx_xvhaddw_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvhaddw_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhaddw_qu_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvhaddw_qu_du(a, b)
+pub fn lasx_xvhaddw_qu_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvhaddw_qu_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_q_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvhsubw_q_d(a, b)
+pub fn lasx_xvhsubw_q_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvhsubw_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvhsubw_qu_du(a: v4u64, b: v4u64) -> v4u64 {
-    __lasx_xvhsubw_qu_du(a, b)
+pub fn lasx_xvhsubw_qu_du(a: v4u64, b: v4u64) -> v4u64 {
+    unsafe { __lasx_xvhsubw_qu_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_q_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
-    __lasx_xvmaddwev_q_d(a, b, c)
+pub fn lasx_xvmaddwev_q_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmaddwev_q_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_d_w(a: v4i64, b: v8i32, c: v8i32) -> v4i64 {
-    __lasx_xvmaddwev_d_w(a, b, c)
+pub fn lasx_xvmaddwev_d_w(a: v4i64, b: v8i32, c: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmaddwev_d_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_w_h(a: v8i32, b: v16i16, c: v16i16) -> v8i32 {
-    __lasx_xvmaddwev_w_h(a, b, c)
+pub fn lasx_xvmaddwev_w_h(a: v8i32, b: v16i16, c: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmaddwev_w_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_h_b(a: v16i16, b: v32i8, c: v32i8) -> v16i16 {
-    __lasx_xvmaddwev_h_b(a, b, c)
+pub fn lasx_xvmaddwev_h_b(a: v16i16, b: v32i8, c: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmaddwev_h_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_q_du(a: v4u64, b: v4u64, c: v4u64) -> v4u64 {
-    __lasx_xvmaddwev_q_du(a, b, c)
+pub fn lasx_xvmaddwev_q_du(a: v4u64, b: v4u64, c: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmaddwev_q_du(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_d_wu(a: v4u64, b: v8u32, c: v8u32) -> v4u64 {
-    __lasx_xvmaddwev_d_wu(a, b, c)
+pub fn lasx_xvmaddwev_d_wu(a: v4u64, b: v8u32, c: v8u32) -> v4u64 {
+    unsafe { __lasx_xvmaddwev_d_wu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_w_hu(a: v8u32, b: v16u16, c: v16u16) -> v8u32 {
-    __lasx_xvmaddwev_w_hu(a, b, c)
+pub fn lasx_xvmaddwev_w_hu(a: v8u32, b: v16u16, c: v16u16) -> v8u32 {
+    unsafe { __lasx_xvmaddwev_w_hu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_h_bu(a: v16u16, b: v32u8, c: v32u8) -> v16u16 {
-    __lasx_xvmaddwev_h_bu(a, b, c)
+pub fn lasx_xvmaddwev_h_bu(a: v16u16, b: v32u8, c: v32u8) -> v16u16 {
+    unsafe { __lasx_xvmaddwev_h_bu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_q_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
-    __lasx_xvmaddwod_q_d(a, b, c)
+pub fn lasx_xvmaddwod_q_d(a: v4i64, b: v4i64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmaddwod_q_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_d_w(a: v4i64, b: v8i32, c: v8i32) -> v4i64 {
-    __lasx_xvmaddwod_d_w(a, b, c)
+pub fn lasx_xvmaddwod_d_w(a: v4i64, b: v8i32, c: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmaddwod_d_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_w_h(a: v8i32, b: v16i16, c: v16i16) -> v8i32 {
-    __lasx_xvmaddwod_w_h(a, b, c)
+pub fn lasx_xvmaddwod_w_h(a: v8i32, b: v16i16, c: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmaddwod_w_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_h_b(a: v16i16, b: v32i8, c: v32i8) -> v16i16 {
-    __lasx_xvmaddwod_h_b(a, b, c)
+pub fn lasx_xvmaddwod_h_b(a: v16i16, b: v32i8, c: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmaddwod_h_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_q_du(a: v4u64, b: v4u64, c: v4u64) -> v4u64 {
-    __lasx_xvmaddwod_q_du(a, b, c)
+pub fn lasx_xvmaddwod_q_du(a: v4u64, b: v4u64, c: v4u64) -> v4u64 {
+    unsafe { __lasx_xvmaddwod_q_du(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_d_wu(a: v4u64, b: v8u32, c: v8u32) -> v4u64 {
-    __lasx_xvmaddwod_d_wu(a, b, c)
+pub fn lasx_xvmaddwod_d_wu(a: v4u64, b: v8u32, c: v8u32) -> v4u64 {
+    unsafe { __lasx_xvmaddwod_d_wu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_w_hu(a: v8u32, b: v16u16, c: v16u16) -> v8u32 {
-    __lasx_xvmaddwod_w_hu(a, b, c)
+pub fn lasx_xvmaddwod_w_hu(a: v8u32, b: v16u16, c: v16u16) -> v8u32 {
+    unsafe { __lasx_xvmaddwod_w_hu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_h_bu(a: v16u16, b: v32u8, c: v32u8) -> v16u16 {
-    __lasx_xvmaddwod_h_bu(a, b, c)
+pub fn lasx_xvmaddwod_h_bu(a: v16u16, b: v32u8, c: v32u8) -> v16u16 {
+    unsafe { __lasx_xvmaddwod_h_bu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_q_du_d(a: v4i64, b: v4u64, c: v4i64) -> v4i64 {
-    __lasx_xvmaddwev_q_du_d(a, b, c)
+pub fn lasx_xvmaddwev_q_du_d(a: v4i64, b: v4u64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmaddwev_q_du_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_d_wu_w(a: v4i64, b: v8u32, c: v8i32) -> v4i64 {
-    __lasx_xvmaddwev_d_wu_w(a, b, c)
+pub fn lasx_xvmaddwev_d_wu_w(a: v4i64, b: v8u32, c: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmaddwev_d_wu_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_w_hu_h(a: v8i32, b: v16u16, c: v16i16) -> v8i32 {
-    __lasx_xvmaddwev_w_hu_h(a, b, c)
+pub fn lasx_xvmaddwev_w_hu_h(a: v8i32, b: v16u16, c: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmaddwev_w_hu_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwev_h_bu_b(a: v16i16, b: v32u8, c: v32i8) -> v16i16 {
-    __lasx_xvmaddwev_h_bu_b(a, b, c)
+pub fn lasx_xvmaddwev_h_bu_b(a: v16i16, b: v32u8, c: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmaddwev_h_bu_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_q_du_d(a: v4i64, b: v4u64, c: v4i64) -> v4i64 {
-    __lasx_xvmaddwod_q_du_d(a, b, c)
+pub fn lasx_xvmaddwod_q_du_d(a: v4i64, b: v4u64, c: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmaddwod_q_du_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_d_wu_w(a: v4i64, b: v8u32, c: v8i32) -> v4i64 {
-    __lasx_xvmaddwod_d_wu_w(a, b, c)
+pub fn lasx_xvmaddwod_d_wu_w(a: v4i64, b: v8u32, c: v8i32) -> v4i64 {
+    unsafe { __lasx_xvmaddwod_d_wu_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_w_hu_h(a: v8i32, b: v16u16, c: v16i16) -> v8i32 {
-    __lasx_xvmaddwod_w_hu_h(a, b, c)
+pub fn lasx_xvmaddwod_w_hu_h(a: v8i32, b: v16u16, c: v16i16) -> v8i32 {
+    unsafe { __lasx_xvmaddwod_w_hu_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmaddwod_h_bu_b(a: v16i16, b: v32u8, c: v32i8) -> v16i16 {
-    __lasx_xvmaddwod_h_bu_b(a, b, c)
+pub fn lasx_xvmaddwod_h_bu_b(a: v16i16, b: v32u8, c: v32i8) -> v16i16 {
+    unsafe { __lasx_xvmaddwod_h_bu_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotr_b(a: v32i8, b: v32i8) -> v32i8 {
-    __lasx_xvrotr_b(a, b)
+pub fn lasx_xvrotr_b(a: v32i8, b: v32i8) -> v32i8 {
+    unsafe { __lasx_xvrotr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotr_h(a: v16i16, b: v16i16) -> v16i16 {
-    __lasx_xvrotr_h(a, b)
+pub fn lasx_xvrotr_h(a: v16i16, b: v16i16) -> v16i16 {
+    unsafe { __lasx_xvrotr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotr_w(a: v8i32, b: v8i32) -> v8i32 {
-    __lasx_xvrotr_w(a, b)
+pub fn lasx_xvrotr_w(a: v8i32, b: v8i32) -> v8i32 {
+    unsafe { __lasx_xvrotr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotr_d(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvrotr_d(a, b)
+pub fn lasx_xvrotr_d(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvrotr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvadd_q(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvadd_q(a, b)
+pub fn lasx_xvadd_q(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvadd_q(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsub_q(a: v4i64, b: v4i64) -> v4i64 {
-    __lasx_xvsub_q(a, b)
+pub fn lasx_xvsub_q(a: v4i64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvsub_q(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwev_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
-    __lasx_xvaddwev_q_du_d(a, b)
+pub fn lasx_xvaddwev_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvaddwev_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvaddwod_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
-    __lasx_xvaddwod_q_du_d(a, b)
+pub fn lasx_xvaddwod_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvaddwod_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwev_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
-    __lasx_xvmulwev_q_du_d(a, b)
+pub fn lasx_xvmulwev_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmulwev_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmulwod_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
-    __lasx_xvmulwod_q_du_d(a, b)
+pub fn lasx_xvmulwod_q_du_d(a: v4u64, b: v4i64) -> v4i64 {
+    unsafe { __lasx_xvmulwod_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmskgez_b(a: v32i8) -> v32i8 {
-    __lasx_xvmskgez_b(a)
+pub fn lasx_xvmskgez_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmskgez_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvmsknz_b(a: v32i8) -> v32i8 {
-    __lasx_xvmsknz_b(a)
+pub fn lasx_xvmsknz_b(a: v32i8) -> v32i8 {
+    unsafe { __lasx_xvmsknz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_h_b(a: v32i8) -> v16i16 {
-    __lasx_xvexth_h_b(a)
+pub fn lasx_xvexth_h_b(a: v32i8) -> v16i16 {
+    unsafe { __lasx_xvexth_h_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_w_h(a: v16i16) -> v8i32 {
-    __lasx_xvexth_w_h(a)
+pub fn lasx_xvexth_w_h(a: v16i16) -> v8i32 {
+    unsafe { __lasx_xvexth_w_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_d_w(a: v8i32) -> v4i64 {
-    __lasx_xvexth_d_w(a)
+pub fn lasx_xvexth_d_w(a: v8i32) -> v4i64 {
+    unsafe { __lasx_xvexth_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_q_d(a: v4i64) -> v4i64 {
-    __lasx_xvexth_q_d(a)
+pub fn lasx_xvexth_q_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvexth_q_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_hu_bu(a: v32u8) -> v16u16 {
-    __lasx_xvexth_hu_bu(a)
+pub fn lasx_xvexth_hu_bu(a: v32u8) -> v16u16 {
+    unsafe { __lasx_xvexth_hu_bu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_wu_hu(a: v16u16) -> v8u32 {
-    __lasx_xvexth_wu_hu(a)
+pub fn lasx_xvexth_wu_hu(a: v16u16) -> v8u32 {
+    unsafe { __lasx_xvexth_wu_hu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_du_wu(a: v8u32) -> v4u64 {
-    __lasx_xvexth_du_wu(a)
+pub fn lasx_xvexth_du_wu(a: v8u32) -> v4u64 {
+    unsafe { __lasx_xvexth_du_wu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvexth_qu_du(a: v4u64) -> v4u64 {
-    __lasx_xvexth_qu_du(a)
+pub fn lasx_xvexth_qu_du(a: v4u64) -> v4u64 {
+    unsafe { __lasx_xvexth_qu_du(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotri_b<const IMM3: u32>(a: v32i8) -> v32i8 {
+pub fn lasx_xvrotri_b<const IMM3: u32>(a: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvrotri_b(a, IMM3)
+    unsafe { __lasx_xvrotri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotri_h<const IMM4: u32>(a: v16i16) -> v16i16 {
+pub fn lasx_xvrotri_h<const IMM4: u32>(a: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvrotri_h(a, IMM4)
+    unsafe { __lasx_xvrotri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotri_w<const IMM5: u32>(a: v8i32) -> v8i32 {
+pub fn lasx_xvrotri_w<const IMM5: u32>(a: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvrotri_w(a, IMM5)
+    unsafe { __lasx_xvrotri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrotri_d<const IMM6: u32>(a: v4i64) -> v4i64 {
+pub fn lasx_xvrotri_d<const IMM6: u32>(a: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvrotri_d(a, IMM6)
+    unsafe { __lasx_xvrotri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvextl_q_d(a: v4i64) -> v4i64 {
-    __lasx_xvextl_q_d(a)
+pub fn lasx_xvextl_q_d(a: v4i64) -> v4i64 {
+    unsafe { __lasx_xvextl_q_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvsrlni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrlni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvsrlni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvsrlni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrlni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvsrlni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvsrlni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrlni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvsrlni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvsrlni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvsrlni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvsrlni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvsrlrni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrlrni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvsrlrni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvsrlrni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrlrni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvsrlrni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvsrlrni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrlrni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvsrlrni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrlrni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvsrlrni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvsrlrni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvsrlrni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvssrlni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrlni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvssrlni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvssrlni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrlni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvssrlni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvssrlni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrlni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvssrlni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvssrlni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrlni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvssrlni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
+pub fn lasx_xvssrlni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrlni_bu_h(a, b, IMM4)
+    unsafe { __lasx_xvssrlni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
+pub fn lasx_xvssrlni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrlni_hu_w(a, b, IMM5)
+    unsafe { __lasx_xvssrlni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
+pub fn lasx_xvssrlni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrlni_wu_d(a, b, IMM6)
+    unsafe { __lasx_xvssrlni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
+pub fn lasx_xvssrlni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrlni_du_q(a, b, IMM7)
+    unsafe { __lasx_xvssrlni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvssrlrni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrlrni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvssrlrni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvssrlrni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrlrni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvssrlrni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvssrlrni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrlrni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvssrlrni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvssrlrni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrlrni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvssrlrni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
+pub fn lasx_xvssrlrni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrlrni_bu_h(a, b, IMM4)
+    unsafe { __lasx_xvssrlrni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
+pub fn lasx_xvssrlrni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrlrni_hu_w(a, b, IMM5)
+    unsafe { __lasx_xvssrlrni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
+pub fn lasx_xvssrlrni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrlrni_wu_d(a, b, IMM6)
+    unsafe { __lasx_xvssrlrni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrlrni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
+pub fn lasx_xvssrlrni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrlrni_du_q(a, b, IMM7)
+    unsafe { __lasx_xvssrlrni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrani_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvsrani_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrani_b_h(a, b, IMM4)
+    unsafe { __lasx_xvsrani_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrani_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvsrani_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrani_h_w(a, b, IMM5)
+    unsafe { __lasx_xvsrani_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrani_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvsrani_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrani_w_d(a, b, IMM6)
+    unsafe { __lasx_xvsrani_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrani_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvsrani_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvsrani_d_q(a, b, IMM7)
+    unsafe { __lasx_xvsrani_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvsrarni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvsrarni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvsrarni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvsrarni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvsrarni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvsrarni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvsrarni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvsrarni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvsrarni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvsrarni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvsrarni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvsrarni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvsrarni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvssrani_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrani_b_h(a, b, IMM4)
+    unsafe { __lasx_xvssrani_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvssrani_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrani_h_w(a, b, IMM5)
+    unsafe { __lasx_xvssrani_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvssrani_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrani_w_d(a, b, IMM6)
+    unsafe { __lasx_xvssrani_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvssrani_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrani_d_q(a, b, IMM7)
+    unsafe { __lasx_xvssrani_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
+pub fn lasx_xvssrani_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrani_bu_h(a, b, IMM4)
+    unsafe { __lasx_xvssrani_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
+pub fn lasx_xvssrani_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrani_hu_w(a, b, IMM5)
+    unsafe { __lasx_xvssrani_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
+pub fn lasx_xvssrani_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrani_wu_d(a, b, IMM6)
+    unsafe { __lasx_xvssrani_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrani_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
+pub fn lasx_xvssrani_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrani_du_q(a, b, IMM7)
+    unsafe { __lasx_xvssrani_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
+pub fn lasx_xvssrarni_b_h<const IMM4: u32>(a: v32i8, b: v32i8) -> v32i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrarni_b_h(a, b, IMM4)
+    unsafe { __lasx_xvssrarni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
+pub fn lasx_xvssrarni_h_w<const IMM5: u32>(a: v16i16, b: v16i16) -> v16i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrarni_h_w(a, b, IMM5)
+    unsafe { __lasx_xvssrarni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
+pub fn lasx_xvssrarni_w_d<const IMM6: u32>(a: v8i32, b: v8i32) -> v8i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrarni_w_d(a, b, IMM6)
+    unsafe { __lasx_xvssrarni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
+pub fn lasx_xvssrarni_d_q<const IMM7: u32>(a: v4i64, b: v4i64) -> v4i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrarni_d_q(a, b, IMM7)
+    unsafe { __lasx_xvssrarni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
+pub fn lasx_xvssrarni_bu_h<const IMM4: u32>(a: v32u8, b: v32i8) -> v32u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lasx_xvssrarni_bu_h(a, b, IMM4)
+    unsafe { __lasx_xvssrarni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
+pub fn lasx_xvssrarni_hu_w<const IMM5: u32>(a: v16u16, b: v16i16) -> v16u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lasx_xvssrarni_hu_w(a, b, IMM5)
+    unsafe { __lasx_xvssrarni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
+pub fn lasx_xvssrarni_wu_d<const IMM6: u32>(a: v8u32, b: v8i32) -> v8u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lasx_xvssrarni_wu_d(a, b, IMM6)
+    unsafe { __lasx_xvssrarni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvssrarni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
+pub fn lasx_xvssrarni_du_q<const IMM7: u32>(a: v4u64, b: v4i64) -> v4u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lasx_xvssrarni_du_q(a, b, IMM7)
+    unsafe { __lasx_xvssrarni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbnz_b(a: v32u8) -> i32 {
-    __lasx_xbnz_b(a)
+pub fn lasx_xbnz_b(a: v32u8) -> i32 {
+    unsafe { __lasx_xbnz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbnz_d(a: v4u64) -> i32 {
-    __lasx_xbnz_d(a)
+pub fn lasx_xbnz_d(a: v4u64) -> i32 {
+    unsafe { __lasx_xbnz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbnz_h(a: v16u16) -> i32 {
-    __lasx_xbnz_h(a)
+pub fn lasx_xbnz_h(a: v16u16) -> i32 {
+    unsafe { __lasx_xbnz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbnz_v(a: v32u8) -> i32 {
-    __lasx_xbnz_v(a)
+pub fn lasx_xbnz_v(a: v32u8) -> i32 {
+    unsafe { __lasx_xbnz_v(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbnz_w(a: v8u32) -> i32 {
-    __lasx_xbnz_w(a)
+pub fn lasx_xbnz_w(a: v8u32) -> i32 {
+    unsafe { __lasx_xbnz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbz_b(a: v32u8) -> i32 {
-    __lasx_xbz_b(a)
+pub fn lasx_xbz_b(a: v32u8) -> i32 {
+    unsafe { __lasx_xbz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbz_d(a: v4u64) -> i32 {
-    __lasx_xbz_d(a)
+pub fn lasx_xbz_d(a: v4u64) -> i32 {
+    unsafe { __lasx_xbz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbz_h(a: v16u16) -> i32 {
-    __lasx_xbz_h(a)
+pub fn lasx_xbz_h(a: v16u16) -> i32 {
+    unsafe { __lasx_xbz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbz_v(a: v32u8) -> i32 {
-    __lasx_xbz_v(a)
+pub fn lasx_xbz_v(a: v32u8) -> i32 {
+    unsafe { __lasx_xbz_v(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xbz_w(a: v8u32) -> i32 {
-    __lasx_xbz_w(a)
+pub fn lasx_xbz_w(a: v8u32) -> i32 {
+    unsafe { __lasx_xbz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_caf_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_caf_d(a, b)
+pub fn lasx_xvfcmp_caf_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_caf_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_caf_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_caf_s(a, b)
+pub fn lasx_xvfcmp_caf_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_caf_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_ceq_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_ceq_d(a, b)
+pub fn lasx_xvfcmp_ceq_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_ceq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_ceq_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_ceq_s(a, b)
+pub fn lasx_xvfcmp_ceq_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_ceq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cle_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cle_d(a, b)
+pub fn lasx_xvfcmp_cle_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cle_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cle_s(a, b)
+pub fn lasx_xvfcmp_cle_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cle_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_clt_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_clt_d(a, b)
+pub fn lasx_xvfcmp_clt_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_clt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_clt_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_clt_s(a, b)
+pub fn lasx_xvfcmp_clt_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_clt_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cne_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cne_d(a, b)
+pub fn lasx_xvfcmp_cne_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cne_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cne_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cne_s(a, b)
+pub fn lasx_xvfcmp_cne_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cne_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cor_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cor_d(a, b)
+pub fn lasx_xvfcmp_cor_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cor_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cor_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cor_s(a, b)
+pub fn lasx_xvfcmp_cor_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cor_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cueq_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cueq_d(a, b)
+pub fn lasx_xvfcmp_cueq_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cueq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cueq_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cueq_s(a, b)
+pub fn lasx_xvfcmp_cueq_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cueq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cule_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cule_d(a, b)
+pub fn lasx_xvfcmp_cule_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cule_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cule_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cule_s(a, b)
+pub fn lasx_xvfcmp_cule_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cule_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cult_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cult_d(a, b)
+pub fn lasx_xvfcmp_cult_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cult_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cult_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cult_s(a, b)
+pub fn lasx_xvfcmp_cult_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cult_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cun_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cun_d(a, b)
+pub fn lasx_xvfcmp_cun_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cun_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cune_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_cune_d(a, b)
+pub fn lasx_xvfcmp_cune_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_cune_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cune_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cune_s(a, b)
+pub fn lasx_xvfcmp_cune_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cune_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_cun_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_cun_s(a, b)
+pub fn lasx_xvfcmp_cun_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_cun_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_saf_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_saf_d(a, b)
+pub fn lasx_xvfcmp_saf_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_saf_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_saf_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_saf_s(a, b)
+pub fn lasx_xvfcmp_saf_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_saf_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_seq_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_seq_d(a, b)
+pub fn lasx_xvfcmp_seq_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_seq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_seq_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_seq_s(a, b)
+pub fn lasx_xvfcmp_seq_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_seq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sle_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sle_d(a, b)
+pub fn lasx_xvfcmp_sle_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sle_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sle_s(a, b)
+pub fn lasx_xvfcmp_sle_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sle_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_slt_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_slt_d(a, b)
+pub fn lasx_xvfcmp_slt_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_slt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_slt_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_slt_s(a, b)
+pub fn lasx_xvfcmp_slt_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_slt_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sne_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sne_d(a, b)
+pub fn lasx_xvfcmp_sne_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sne_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sne_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sne_s(a, b)
+pub fn lasx_xvfcmp_sne_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sne_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sor_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sor_d(a, b)
+pub fn lasx_xvfcmp_sor_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sor_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sor_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sor_s(a, b)
+pub fn lasx_xvfcmp_sor_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sor_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sueq_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sueq_d(a, b)
+pub fn lasx_xvfcmp_sueq_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sueq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sueq_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sueq_s(a, b)
+pub fn lasx_xvfcmp_sueq_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sueq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sule_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sule_d(a, b)
+pub fn lasx_xvfcmp_sule_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sule_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sule_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sule_s(a, b)
+pub fn lasx_xvfcmp_sule_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sule_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sult_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sult_d(a, b)
+pub fn lasx_xvfcmp_sult_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sult_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sult_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sult_s(a, b)
+pub fn lasx_xvfcmp_sult_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sult_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sun_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sun_d(a, b)
+pub fn lasx_xvfcmp_sun_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sun_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sune_d(a: v4f64, b: v4f64) -> v4i64 {
-    __lasx_xvfcmp_sune_d(a, b)
+pub fn lasx_xvfcmp_sune_d(a: v4f64, b: v4f64) -> v4i64 {
+    unsafe { __lasx_xvfcmp_sune_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sune_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sune_s(a, b)
+pub fn lasx_xvfcmp_sune_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sune_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvfcmp_sun_s(a: v8f32, b: v8f32) -> v8i32 {
-    __lasx_xvfcmp_sun_s(a, b)
+pub fn lasx_xvfcmp_sun_s(a: v8f32, b: v8f32) -> v8i32 {
+    unsafe { __lasx_xvfcmp_sun_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve_d_f<const IMM2: u32>(a: v4f64) -> v4f64 {
+pub fn lasx_xvpickve_d_f<const IMM2: u32>(a: v4f64) -> v4f64 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lasx_xvpickve_d_f(a, IMM2)
+    unsafe { __lasx_xvpickve_d_f(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvpickve_w_f<const IMM3: u32>(a: v8f32) -> v8f32 {
+pub fn lasx_xvpickve_w_f<const IMM3: u32>(a: v8f32) -> v8f32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lasx_xvpickve_w_f(a, IMM3)
+    unsafe { __lasx_xvpickve_w_f(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepli_b<const IMM_S10: i32>() -> v32i8 {
+pub fn lasx_xvrepli_b<const IMM_S10: i32>() -> v32i8 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lasx_xvrepli_b(IMM_S10)
+    unsafe { __lasx_xvrepli_b(IMM_S10) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepli_d<const IMM_S10: i32>() -> v4i64 {
+pub fn lasx_xvrepli_d<const IMM_S10: i32>() -> v4i64 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lasx_xvrepli_d(IMM_S10)
+    unsafe { __lasx_xvrepli_d(IMM_S10) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepli_h<const IMM_S10: i32>() -> v16i16 {
+pub fn lasx_xvrepli_h<const IMM_S10: i32>() -> v16i16 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lasx_xvrepli_h(IMM_S10)
+    unsafe { __lasx_xvrepli_h(IMM_S10) }
 }
 
 #[inline]
 #[target_feature(enable = "lasx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lasx_xvrepli_w<const IMM_S10: i32>() -> v8i32 {
+pub fn lasx_xvrepli_w<const IMM_S10: i32>() -> v8i32 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lasx_xvrepli_w(IMM_S10)
+    unsafe { __lasx_xvrepli_w(IMM_S10) }
 }

--- a/library/stdarch/crates/core_arch/src/loongarch64/lsx/generated.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch64/lsx/generated.rs
@@ -1455,3593 +1455,3593 @@ unsafe extern "unadjusted" {
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsll_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsll_b(a, b)
+pub fn lsx_vsll_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsll_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsll_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsll_h(a, b)
+pub fn lsx_vsll_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsll_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsll_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsll_w(a, b)
+pub fn lsx_vsll_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsll_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsll_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsll_d(a, b)
+pub fn lsx_vsll_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsll_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslli_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vslli_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vslli_b(a, IMM3)
+    unsafe { __lsx_vslli_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslli_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vslli_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vslli_h(a, IMM4)
+    unsafe { __lsx_vslli_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslli_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vslli_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslli_w(a, IMM5)
+    unsafe { __lsx_vslli_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslli_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vslli_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vslli_d(a, IMM6)
+    unsafe { __lsx_vslli_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsra_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsra_b(a, b)
+pub fn lsx_vsra_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsra_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsra_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsra_h(a, b)
+pub fn lsx_vsra_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsra_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsra_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsra_w(a, b)
+pub fn lsx_vsra_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsra_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsra_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsra_d(a, b)
+pub fn lsx_vsra_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsra_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrai_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsrai_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsrai_b(a, IMM3)
+    unsafe { __lsx_vsrai_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrai_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsrai_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrai_h(a, IMM4)
+    unsafe { __lsx_vsrai_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrai_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsrai_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrai_w(a, IMM5)
+    unsafe { __lsx_vsrai_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrai_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsrai_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrai_d(a, IMM6)
+    unsafe { __lsx_vsrai_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrar_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsrar_b(a, b)
+pub fn lsx_vsrar_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsrar_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrar_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsrar_h(a, b)
+pub fn lsx_vsrar_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsrar_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrar_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsrar_w(a, b)
+pub fn lsx_vsrar_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsrar_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrar_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsrar_d(a, b)
+pub fn lsx_vsrar_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsrar_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrari_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsrari_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsrari_b(a, IMM3)
+    unsafe { __lsx_vsrari_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrari_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsrari_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrari_h(a, IMM4)
+    unsafe { __lsx_vsrari_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrari_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsrari_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrari_w(a, IMM5)
+    unsafe { __lsx_vsrari_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrari_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsrari_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrari_d(a, IMM6)
+    unsafe { __lsx_vsrari_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrl_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsrl_b(a, b)
+pub fn lsx_vsrl_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsrl_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrl_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsrl_h(a, b)
+pub fn lsx_vsrl_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsrl_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrl_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsrl_w(a, b)
+pub fn lsx_vsrl_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsrl_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrl_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsrl_d(a, b)
+pub fn lsx_vsrl_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsrl_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrli_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsrli_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsrli_b(a, IMM3)
+    unsafe { __lsx_vsrli_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrli_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsrli_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrli_h(a, IMM4)
+    unsafe { __lsx_vsrli_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrli_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsrli_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrli_w(a, IMM5)
+    unsafe { __lsx_vsrli_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrli_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsrli_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrli_d(a, IMM6)
+    unsafe { __lsx_vsrli_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlr_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsrlr_b(a, b)
+pub fn lsx_vsrlr_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsrlr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlr_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsrlr_h(a, b)
+pub fn lsx_vsrlr_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsrlr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlr_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsrlr_w(a, b)
+pub fn lsx_vsrlr_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsrlr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlr_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsrlr_d(a, b)
+pub fn lsx_vsrlr_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsrlr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlri_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsrlri_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsrlri_b(a, IMM3)
+    unsafe { __lsx_vsrlri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlri_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsrlri_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrlri_h(a, IMM4)
+    unsafe { __lsx_vsrlri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlri_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsrlri_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrlri_w(a, IMM5)
+    unsafe { __lsx_vsrlri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlri_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsrlri_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrlri_d(a, IMM6)
+    unsafe { __lsx_vsrlri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclr_b(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vbitclr_b(a, b)
+pub fn lsx_vbitclr_b(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vbitclr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclr_h(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vbitclr_h(a, b)
+pub fn lsx_vbitclr_h(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vbitclr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclr_w(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vbitclr_w(a, b)
+pub fn lsx_vbitclr_w(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vbitclr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclr_d(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vbitclr_d(a, b)
+pub fn lsx_vbitclr_d(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vbitclr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclri_b<const IMM3: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vbitclri_b<const IMM3: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vbitclri_b(a, IMM3)
+    unsafe { __lsx_vbitclri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclri_h<const IMM4: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vbitclri_h<const IMM4: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vbitclri_h(a, IMM4)
+    unsafe { __lsx_vbitclri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclri_w<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vbitclri_w<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vbitclri_w(a, IMM5)
+    unsafe { __lsx_vbitclri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitclri_d<const IMM6: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vbitclri_d<const IMM6: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vbitclri_d(a, IMM6)
+    unsafe { __lsx_vbitclri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitset_b(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vbitset_b(a, b)
+pub fn lsx_vbitset_b(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vbitset_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitset_h(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vbitset_h(a, b)
+pub fn lsx_vbitset_h(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vbitset_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitset_w(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vbitset_w(a, b)
+pub fn lsx_vbitset_w(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vbitset_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitset_d(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vbitset_d(a, b)
+pub fn lsx_vbitset_d(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vbitset_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitseti_b<const IMM3: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vbitseti_b<const IMM3: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vbitseti_b(a, IMM3)
+    unsafe { __lsx_vbitseti_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitseti_h<const IMM4: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vbitseti_h<const IMM4: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vbitseti_h(a, IMM4)
+    unsafe { __lsx_vbitseti_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitseti_w<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vbitseti_w<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vbitseti_w(a, IMM5)
+    unsafe { __lsx_vbitseti_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitseti_d<const IMM6: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vbitseti_d<const IMM6: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vbitseti_d(a, IMM6)
+    unsafe { __lsx_vbitseti_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrev_b(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vbitrev_b(a, b)
+pub fn lsx_vbitrev_b(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vbitrev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrev_h(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vbitrev_h(a, b)
+pub fn lsx_vbitrev_h(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vbitrev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrev_w(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vbitrev_w(a, b)
+pub fn lsx_vbitrev_w(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vbitrev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrev_d(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vbitrev_d(a, b)
+pub fn lsx_vbitrev_d(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vbitrev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrevi_b<const IMM3: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vbitrevi_b<const IMM3: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vbitrevi_b(a, IMM3)
+    unsafe { __lsx_vbitrevi_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrevi_h<const IMM4: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vbitrevi_h<const IMM4: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vbitrevi_h(a, IMM4)
+    unsafe { __lsx_vbitrevi_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrevi_w<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vbitrevi_w<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vbitrevi_w(a, IMM5)
+    unsafe { __lsx_vbitrevi_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitrevi_d<const IMM6: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vbitrevi_d<const IMM6: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vbitrevi_d(a, IMM6)
+    unsafe { __lsx_vbitrevi_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadd_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vadd_b(a, b)
+pub fn lsx_vadd_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vadd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadd_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vadd_h(a, b)
+pub fn lsx_vadd_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vadd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadd_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vadd_w(a, b)
+pub fn lsx_vadd_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vadd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadd_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vadd_d(a, b)
+pub fn lsx_vadd_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddi_bu<const IMM5: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vaddi_bu<const IMM5: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vaddi_bu(a, IMM5)
+    unsafe { __lsx_vaddi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddi_hu<const IMM5: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vaddi_hu<const IMM5: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vaddi_hu(a, IMM5)
+    unsafe { __lsx_vaddi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddi_wu<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vaddi_wu<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vaddi_wu(a, IMM5)
+    unsafe { __lsx_vaddi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddi_du<const IMM5: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vaddi_du<const IMM5: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vaddi_du(a, IMM5)
+    unsafe { __lsx_vaddi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsub_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsub_b(a, b)
+pub fn lsx_vsub_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsub_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsub_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsub_h(a, b)
+pub fn lsx_vsub_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsub_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsub_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsub_w(a, b)
+pub fn lsx_vsub_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsub_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsub_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsub_d(a, b)
+pub fn lsx_vsub_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubi_bu<const IMM5: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsubi_bu<const IMM5: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsubi_bu(a, IMM5)
+    unsafe { __lsx_vsubi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubi_hu<const IMM5: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsubi_hu<const IMM5: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsubi_hu(a, IMM5)
+    unsafe { __lsx_vsubi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubi_wu<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsubi_wu<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsubi_wu(a, IMM5)
+    unsafe { __lsx_vsubi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubi_du<const IMM5: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsubi_du<const IMM5: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsubi_du(a, IMM5)
+    unsafe { __lsx_vsubi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vmax_b(a, b)
+pub fn lsx_vmax_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vmax_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vmax_h(a, b)
+pub fn lsx_vmax_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vmax_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vmax_w(a, b)
+pub fn lsx_vmax_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vmax_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmax_d(a, b)
+pub fn lsx_vmax_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmax_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
+pub fn lsx_vmaxi_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmaxi_b(a, IMM_S5)
+    unsafe { __lsx_vmaxi_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
+pub fn lsx_vmaxi_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmaxi_h(a, IMM_S5)
+    unsafe { __lsx_vmaxi_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
+pub fn lsx_vmaxi_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmaxi_w(a, IMM_S5)
+    unsafe { __lsx_vmaxi_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
+pub fn lsx_vmaxi_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmaxi_d(a, IMM_S5)
+    unsafe { __lsx_vmaxi_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vmax_bu(a, b)
+pub fn lsx_vmax_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vmax_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vmax_hu(a, b)
+pub fn lsx_vmax_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vmax_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vmax_wu(a, b)
+pub fn lsx_vmax_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vmax_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmax_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vmax_du(a, b)
+pub fn lsx_vmax_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vmax_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_bu<const IMM5: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vmaxi_bu<const IMM5: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmaxi_bu(a, IMM5)
+    unsafe { __lsx_vmaxi_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_hu<const IMM5: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vmaxi_hu<const IMM5: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmaxi_hu(a, IMM5)
+    unsafe { __lsx_vmaxi_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vmaxi_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmaxi_wu(a, IMM5)
+    unsafe { __lsx_vmaxi_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaxi_du<const IMM5: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vmaxi_du<const IMM5: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmaxi_du(a, IMM5)
+    unsafe { __lsx_vmaxi_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vmin_b(a, b)
+pub fn lsx_vmin_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vmin_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vmin_h(a, b)
+pub fn lsx_vmin_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vmin_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vmin_w(a, b)
+pub fn lsx_vmin_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vmin_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmin_d(a, b)
+pub fn lsx_vmin_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmin_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
+pub fn lsx_vmini_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmini_b(a, IMM_S5)
+    unsafe { __lsx_vmini_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
+pub fn lsx_vmini_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmini_h(a, IMM_S5)
+    unsafe { __lsx_vmini_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
+pub fn lsx_vmini_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmini_w(a, IMM_S5)
+    unsafe { __lsx_vmini_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
+pub fn lsx_vmini_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vmini_d(a, IMM_S5)
+    unsafe { __lsx_vmini_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vmin_bu(a, b)
+pub fn lsx_vmin_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vmin_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vmin_hu(a, b)
+pub fn lsx_vmin_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vmin_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vmin_wu(a, b)
+pub fn lsx_vmin_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vmin_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmin_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vmin_du(a, b)
+pub fn lsx_vmin_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vmin_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_bu<const IMM5: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vmini_bu<const IMM5: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmini_bu(a, IMM5)
+    unsafe { __lsx_vmini_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_hu<const IMM5: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vmini_hu<const IMM5: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmini_hu(a, IMM5)
+    unsafe { __lsx_vmini_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vmini_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmini_wu(a, IMM5)
+    unsafe { __lsx_vmini_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmini_du<const IMM5: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vmini_du<const IMM5: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vmini_du(a, IMM5)
+    unsafe { __lsx_vmini_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseq_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vseq_b(a, b)
+pub fn lsx_vseq_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vseq_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseq_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vseq_h(a, b)
+pub fn lsx_vseq_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vseq_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseq_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vseq_w(a, b)
+pub fn lsx_vseq_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vseq_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseq_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vseq_d(a, b)
+pub fn lsx_vseq_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vseq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseqi_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
+pub fn lsx_vseqi_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vseqi_b(a, IMM_S5)
+    unsafe { __lsx_vseqi_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseqi_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
+pub fn lsx_vseqi_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vseqi_h(a, IMM_S5)
+    unsafe { __lsx_vseqi_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseqi_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
+pub fn lsx_vseqi_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vseqi_w(a, IMM_S5)
+    unsafe { __lsx_vseqi_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vseqi_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
+pub fn lsx_vseqi_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vseqi_d(a, IMM_S5)
+    unsafe { __lsx_vseqi_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
+pub fn lsx_vslti_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslti_b(a, IMM_S5)
+    unsafe { __lsx_vslti_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vslt_b(a, b)
+pub fn lsx_vslt_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vslt_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vslt_h(a, b)
+pub fn lsx_vslt_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vslt_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vslt_w(a, b)
+pub fn lsx_vslt_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vslt_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vslt_d(a, b)
+pub fn lsx_vslt_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vslt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
+pub fn lsx_vslti_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslti_h(a, IMM_S5)
+    unsafe { __lsx_vslti_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
+pub fn lsx_vslti_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslti_w(a, IMM_S5)
+    unsafe { __lsx_vslti_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
+pub fn lsx_vslti_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslti_d(a, IMM_S5)
+    unsafe { __lsx_vslti_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_bu(a: v16u8, b: v16u8) -> v16i8 {
-    __lsx_vslt_bu(a, b)
+pub fn lsx_vslt_bu(a: v16u8, b: v16u8) -> v16i8 {
+    unsafe { __lsx_vslt_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_hu(a: v8u16, b: v8u16) -> v8i16 {
-    __lsx_vslt_hu(a, b)
+pub fn lsx_vslt_hu(a: v8u16, b: v8u16) -> v8i16 {
+    unsafe { __lsx_vslt_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_wu(a: v4u32, b: v4u32) -> v4i32 {
-    __lsx_vslt_wu(a, b)
+pub fn lsx_vslt_wu(a: v4u32, b: v4u32) -> v4i32 {
+    unsafe { __lsx_vslt_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslt_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vslt_du(a, b)
+pub fn lsx_vslt_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vslt_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_bu<const IMM5: u32>(a: v16u8) -> v16i8 {
+pub fn lsx_vslti_bu<const IMM5: u32>(a: v16u8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslti_bu(a, IMM5)
+    unsafe { __lsx_vslti_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_hu<const IMM5: u32>(a: v8u16) -> v8i16 {
+pub fn lsx_vslti_hu<const IMM5: u32>(a: v8u16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslti_hu(a, IMM5)
+    unsafe { __lsx_vslti_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_wu<const IMM5: u32>(a: v4u32) -> v4i32 {
+pub fn lsx_vslti_wu<const IMM5: u32>(a: v4u32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslti_wu(a, IMM5)
+    unsafe { __lsx_vslti_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslti_du<const IMM5: u32>(a: v2u64) -> v2i64 {
+pub fn lsx_vslti_du<const IMM5: u32>(a: v2u64) -> v2i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslti_du(a, IMM5)
+    unsafe { __lsx_vslti_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsle_b(a, b)
+pub fn lsx_vsle_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsle_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsle_h(a, b)
+pub fn lsx_vsle_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsle_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsle_w(a, b)
+pub fn lsx_vsle_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsle_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsle_d(a, b)
+pub fn lsx_vsle_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
+pub fn lsx_vslei_b<const IMM_S5: i32>(a: v16i8) -> v16i8 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslei_b(a, IMM_S5)
+    unsafe { __lsx_vslei_b(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
+pub fn lsx_vslei_h<const IMM_S5: i32>(a: v8i16) -> v8i16 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslei_h(a, IMM_S5)
+    unsafe { __lsx_vslei_h(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
+pub fn lsx_vslei_w<const IMM_S5: i32>(a: v4i32) -> v4i32 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslei_w(a, IMM_S5)
+    unsafe { __lsx_vslei_w(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
+pub fn lsx_vslei_d<const IMM_S5: i32>(a: v2i64) -> v2i64 {
     static_assert_simm_bits!(IMM_S5, 5);
-    __lsx_vslei_d(a, IMM_S5)
+    unsafe { __lsx_vslei_d(a, IMM_S5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_bu(a: v16u8, b: v16u8) -> v16i8 {
-    __lsx_vsle_bu(a, b)
+pub fn lsx_vsle_bu(a: v16u8, b: v16u8) -> v16i8 {
+    unsafe { __lsx_vsle_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_hu(a: v8u16, b: v8u16) -> v8i16 {
-    __lsx_vsle_hu(a, b)
+pub fn lsx_vsle_hu(a: v8u16, b: v8u16) -> v8i16 {
+    unsafe { __lsx_vsle_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_wu(a: v4u32, b: v4u32) -> v4i32 {
-    __lsx_vsle_wu(a, b)
+pub fn lsx_vsle_wu(a: v4u32, b: v4u32) -> v4i32 {
+    unsafe { __lsx_vsle_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsle_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vsle_du(a, b)
+pub fn lsx_vsle_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vsle_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_bu<const IMM5: u32>(a: v16u8) -> v16i8 {
+pub fn lsx_vslei_bu<const IMM5: u32>(a: v16u8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslei_bu(a, IMM5)
+    unsafe { __lsx_vslei_bu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_hu<const IMM5: u32>(a: v8u16) -> v8i16 {
+pub fn lsx_vslei_hu<const IMM5: u32>(a: v8u16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslei_hu(a, IMM5)
+    unsafe { __lsx_vslei_hu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_wu<const IMM5: u32>(a: v4u32) -> v4i32 {
+pub fn lsx_vslei_wu<const IMM5: u32>(a: v4u32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslei_wu(a, IMM5)
+    unsafe { __lsx_vslei_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vslei_du<const IMM5: u32>(a: v2u64) -> v2i64 {
+pub fn lsx_vslei_du<const IMM5: u32>(a: v2u64) -> v2i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vslei_du(a, IMM5)
+    unsafe { __lsx_vslei_du(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vsat_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsat_b(a, IMM3)
+    unsafe { __lsx_vsat_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vsat_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsat_h(a, IMM4)
+    unsafe { __lsx_vsat_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vsat_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsat_w(a, IMM5)
+    unsafe { __lsx_vsat_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vsat_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsat_d(a, IMM6)
+    unsafe { __lsx_vsat_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_bu<const IMM3: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vsat_bu<const IMM3: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsat_bu(a, IMM3)
+    unsafe { __lsx_vsat_bu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_hu<const IMM4: u32>(a: v8u16) -> v8u16 {
+pub fn lsx_vsat_hu<const IMM4: u32>(a: v8u16) -> v8u16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsat_hu(a, IMM4)
+    unsafe { __lsx_vsat_hu(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
+pub fn lsx_vsat_wu<const IMM5: u32>(a: v4u32) -> v4u32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsat_wu(a, IMM5)
+    unsafe { __lsx_vsat_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsat_du<const IMM6: u32>(a: v2u64) -> v2u64 {
+pub fn lsx_vsat_du<const IMM6: u32>(a: v2u64) -> v2u64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsat_du(a, IMM6)
+    unsafe { __lsx_vsat_du(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadda_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vadda_b(a, b)
+pub fn lsx_vadda_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vadda_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadda_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vadda_h(a, b)
+pub fn lsx_vadda_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vadda_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadda_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vadda_w(a, b)
+pub fn lsx_vadda_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vadda_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadda_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vadda_d(a, b)
+pub fn lsx_vadda_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vadda_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsadd_b(a, b)
+pub fn lsx_vsadd_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsadd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsadd_h(a, b)
+pub fn lsx_vsadd_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsadd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsadd_w(a, b)
+pub fn lsx_vsadd_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsadd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsadd_d(a, b)
+pub fn lsx_vsadd_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vsadd_bu(a, b)
+pub fn lsx_vsadd_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vsadd_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vsadd_hu(a, b)
+pub fn lsx_vsadd_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vsadd_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vsadd_wu(a, b)
+pub fn lsx_vsadd_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vsadd_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsadd_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vsadd_du(a, b)
+pub fn lsx_vsadd_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vsadd_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vavg_b(a, b)
+pub fn lsx_vavg_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vavg_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vavg_h(a, b)
+pub fn lsx_vavg_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vavg_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vavg_w(a, b)
+pub fn lsx_vavg_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vavg_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vavg_d(a, b)
+pub fn lsx_vavg_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vavg_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vavg_bu(a, b)
+pub fn lsx_vavg_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vavg_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vavg_hu(a, b)
+pub fn lsx_vavg_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vavg_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vavg_wu(a, b)
+pub fn lsx_vavg_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vavg_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavg_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vavg_du(a, b)
+pub fn lsx_vavg_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vavg_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vavgr_b(a, b)
+pub fn lsx_vavgr_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vavgr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vavgr_h(a, b)
+pub fn lsx_vavgr_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vavgr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vavgr_w(a, b)
+pub fn lsx_vavgr_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vavgr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vavgr_d(a, b)
+pub fn lsx_vavgr_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vavgr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vavgr_bu(a, b)
+pub fn lsx_vavgr_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vavgr_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vavgr_hu(a, b)
+pub fn lsx_vavgr_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vavgr_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vavgr_wu(a, b)
+pub fn lsx_vavgr_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vavgr_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vavgr_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vavgr_du(a, b)
+pub fn lsx_vavgr_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vavgr_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vssub_b(a, b)
+pub fn lsx_vssub_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vssub_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vssub_h(a, b)
+pub fn lsx_vssub_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vssub_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vssub_w(a, b)
+pub fn lsx_vssub_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vssub_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vssub_d(a, b)
+pub fn lsx_vssub_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vssub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vssub_bu(a, b)
+pub fn lsx_vssub_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vssub_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vssub_hu(a, b)
+pub fn lsx_vssub_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vssub_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vssub_wu(a, b)
+pub fn lsx_vssub_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vssub_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssub_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vssub_du(a, b)
+pub fn lsx_vssub_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vssub_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vabsd_b(a, b)
+pub fn lsx_vabsd_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vabsd_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vabsd_h(a, b)
+pub fn lsx_vabsd_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vabsd_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vabsd_w(a, b)
+pub fn lsx_vabsd_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vabsd_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vabsd_d(a, b)
+pub fn lsx_vabsd_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vabsd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vabsd_bu(a, b)
+pub fn lsx_vabsd_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vabsd_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vabsd_hu(a, b)
+pub fn lsx_vabsd_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vabsd_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vabsd_wu(a, b)
+pub fn lsx_vabsd_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vabsd_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vabsd_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vabsd_du(a, b)
+pub fn lsx_vabsd_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vabsd_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmul_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vmul_b(a, b)
+pub fn lsx_vmul_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vmul_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmul_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vmul_h(a, b)
+pub fn lsx_vmul_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vmul_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmul_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vmul_w(a, b)
+pub fn lsx_vmul_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vmul_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmul_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmul_d(a, b)
+pub fn lsx_vmul_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmul_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmadd_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
-    __lsx_vmadd_b(a, b, c)
+pub fn lsx_vmadd_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
+    unsafe { __lsx_vmadd_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmadd_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
-    __lsx_vmadd_h(a, b, c)
+pub fn lsx_vmadd_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
+    unsafe { __lsx_vmadd_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmadd_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
-    __lsx_vmadd_w(a, b, c)
+pub fn lsx_vmadd_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
+    unsafe { __lsx_vmadd_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmadd_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
-    __lsx_vmadd_d(a, b, c)
+pub fn lsx_vmadd_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmsub_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
-    __lsx_vmsub_b(a, b, c)
+pub fn lsx_vmsub_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
+    unsafe { __lsx_vmsub_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmsub_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
-    __lsx_vmsub_h(a, b, c)
+pub fn lsx_vmsub_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
+    unsafe { __lsx_vmsub_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmsub_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
-    __lsx_vmsub_w(a, b, c)
+pub fn lsx_vmsub_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
+    unsafe { __lsx_vmsub_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmsub_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
-    __lsx_vmsub_d(a, b, c)
+pub fn lsx_vmsub_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vdiv_b(a, b)
+pub fn lsx_vdiv_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vdiv_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vdiv_h(a, b)
+pub fn lsx_vdiv_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vdiv_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vdiv_w(a, b)
+pub fn lsx_vdiv_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vdiv_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vdiv_d(a, b)
+pub fn lsx_vdiv_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vdiv_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vdiv_bu(a, b)
+pub fn lsx_vdiv_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vdiv_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vdiv_hu(a, b)
+pub fn lsx_vdiv_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vdiv_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vdiv_wu(a, b)
+pub fn lsx_vdiv_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vdiv_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vdiv_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vdiv_du(a, b)
+pub fn lsx_vdiv_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vdiv_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vhaddw_h_b(a, b)
+pub fn lsx_vhaddw_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vhaddw_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vhaddw_w_h(a, b)
+pub fn lsx_vhaddw_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vhaddw_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vhaddw_d_w(a, b)
+pub fn lsx_vhaddw_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vhaddw_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_hu_bu(a: v16u8, b: v16u8) -> v8u16 {
-    __lsx_vhaddw_hu_bu(a, b)
+pub fn lsx_vhaddw_hu_bu(a: v16u8, b: v16u8) -> v8u16 {
+    unsafe { __lsx_vhaddw_hu_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_wu_hu(a: v8u16, b: v8u16) -> v4u32 {
-    __lsx_vhaddw_wu_hu(a, b)
+pub fn lsx_vhaddw_wu_hu(a: v8u16, b: v8u16) -> v4u32 {
+    unsafe { __lsx_vhaddw_wu_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_du_wu(a: v4u32, b: v4u32) -> v2u64 {
-    __lsx_vhaddw_du_wu(a, b)
+pub fn lsx_vhaddw_du_wu(a: v4u32, b: v4u32) -> v2u64 {
+    unsafe { __lsx_vhaddw_du_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vhsubw_h_b(a, b)
+pub fn lsx_vhsubw_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vhsubw_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vhsubw_w_h(a, b)
+pub fn lsx_vhsubw_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vhsubw_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vhsubw_d_w(a, b)
+pub fn lsx_vhsubw_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vhsubw_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_hu_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vhsubw_hu_bu(a, b)
+pub fn lsx_vhsubw_hu_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vhsubw_hu_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_wu_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vhsubw_wu_hu(a, b)
+pub fn lsx_vhsubw_wu_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vhsubw_wu_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_du_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vhsubw_du_wu(a, b)
+pub fn lsx_vhsubw_du_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vhsubw_du_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vmod_b(a, b)
+pub fn lsx_vmod_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vmod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vmod_h(a, b)
+pub fn lsx_vmod_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vmod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vmod_w(a, b)
+pub fn lsx_vmod_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vmod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmod_d(a, b)
+pub fn lsx_vmod_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vmod_bu(a, b)
+pub fn lsx_vmod_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vmod_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vmod_hu(a, b)
+pub fn lsx_vmod_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vmod_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vmod_wu(a, b)
+pub fn lsx_vmod_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vmod_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmod_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vmod_du(a, b)
+pub fn lsx_vmod_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vmod_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplve_b(a: v16i8, b: i32) -> v16i8 {
-    __lsx_vreplve_b(a, b)
+pub fn lsx_vreplve_b(a: v16i8, b: i32) -> v16i8 {
+    unsafe { __lsx_vreplve_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplve_h(a: v8i16, b: i32) -> v8i16 {
-    __lsx_vreplve_h(a, b)
+pub fn lsx_vreplve_h(a: v8i16, b: i32) -> v8i16 {
+    unsafe { __lsx_vreplve_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplve_w(a: v4i32, b: i32) -> v4i32 {
-    __lsx_vreplve_w(a, b)
+pub fn lsx_vreplve_w(a: v4i32, b: i32) -> v4i32 {
+    unsafe { __lsx_vreplve_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplve_d(a: v2i64, b: i32) -> v2i64 {
-    __lsx_vreplve_d(a, b)
+pub fn lsx_vreplve_d(a: v2i64, b: i32) -> v2i64 {
+    unsafe { __lsx_vreplve_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplvei_b<const IMM4: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vreplvei_b<const IMM4: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vreplvei_b(a, IMM4)
+    unsafe { __lsx_vreplvei_b(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplvei_h<const IMM3: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vreplvei_h<const IMM3: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vreplvei_h(a, IMM3)
+    unsafe { __lsx_vreplvei_h(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplvei_w<const IMM2: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vreplvei_w<const IMM2: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lsx_vreplvei_w(a, IMM2)
+    unsafe { __lsx_vreplvei_w(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplvei_d<const IMM1: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vreplvei_d<const IMM1: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM1, 1);
-    __lsx_vreplvei_d(a, IMM1)
+    unsafe { __lsx_vreplvei_d(a, IMM1) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickev_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vpickev_b(a, b)
+pub fn lsx_vpickev_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vpickev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickev_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vpickev_h(a, b)
+pub fn lsx_vpickev_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vpickev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickev_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vpickev_w(a, b)
+pub fn lsx_vpickev_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vpickev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickev_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vpickev_d(a, b)
+pub fn lsx_vpickev_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vpickev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickod_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vpickod_b(a, b)
+pub fn lsx_vpickod_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vpickod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickod_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vpickod_h(a, b)
+pub fn lsx_vpickod_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vpickod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickod_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vpickod_w(a, b)
+pub fn lsx_vpickod_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vpickod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickod_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vpickod_d(a, b)
+pub fn lsx_vpickod_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vpickod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvh_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vilvh_b(a, b)
+pub fn lsx_vilvh_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vilvh_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvh_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vilvh_h(a, b)
+pub fn lsx_vilvh_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vilvh_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvh_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vilvh_w(a, b)
+pub fn lsx_vilvh_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vilvh_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvh_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vilvh_d(a, b)
+pub fn lsx_vilvh_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vilvh_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvl_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vilvl_b(a, b)
+pub fn lsx_vilvl_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vilvl_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvl_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vilvl_h(a, b)
+pub fn lsx_vilvl_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vilvl_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvl_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vilvl_w(a, b)
+pub fn lsx_vilvl_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vilvl_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vilvl_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vilvl_d(a, b)
+pub fn lsx_vilvl_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vilvl_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackev_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vpackev_b(a, b)
+pub fn lsx_vpackev_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vpackev_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackev_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vpackev_h(a, b)
+pub fn lsx_vpackev_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vpackev_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackev_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vpackev_w(a, b)
+pub fn lsx_vpackev_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vpackev_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackev_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vpackev_d(a, b)
+pub fn lsx_vpackev_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vpackev_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackod_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vpackod_b(a, b)
+pub fn lsx_vpackod_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vpackod_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackod_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vpackod_h(a, b)
+pub fn lsx_vpackod_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vpackod_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackod_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vpackod_w(a, b)
+pub fn lsx_vpackod_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vpackod_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpackod_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vpackod_d(a, b)
+pub fn lsx_vpackod_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vpackod_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
-    __lsx_vshuf_h(a, b, c)
+pub fn lsx_vshuf_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
+    unsafe { __lsx_vshuf_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
-    __lsx_vshuf_w(a, b, c)
+pub fn lsx_vshuf_w(a: v4i32, b: v4i32, c: v4i32) -> v4i32 {
+    unsafe { __lsx_vshuf_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
-    __lsx_vshuf_d(a, b, c)
+pub fn lsx_vshuf_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vshuf_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vand_v(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vand_v(a, b)
-}
-
-#[inline]
-#[target_feature(enable = "lsx")]
-#[rustc_legacy_const_generics(1)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vandi_b<const IMM8: u32>(a: v16u8) -> v16u8 {
-    static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vandi_b(a, IMM8)
-}
-
-#[inline]
-#[target_feature(enable = "lsx")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vor_v(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vor_v(a, b)
+pub fn lsx_vand_v(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vand_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vandi_b<const IMM8: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vori_b(a, IMM8)
+    unsafe { __lsx_vandi_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vnor_v(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vnor_v(a, b)
+pub fn lsx_vor_v(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vor_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vnori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vnori_b(a, IMM8)
+    unsafe { __lsx_vori_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vxor_v(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vxor_v(a, b)
+pub fn lsx_vnor_v(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vnor_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vxori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
+pub fn lsx_vnori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vxori_b(a, IMM8)
+    unsafe { __lsx_vnori_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitsel_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
-    __lsx_vbitsel_v(a, b, c)
+pub fn lsx_vxor_v(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vxor_v(a, b) }
+}
+
+#[inline]
+#[target_feature(enable = "lsx")]
+#[rustc_legacy_const_generics(1)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lsx_vxori_b<const IMM8: u32>(a: v16u8) -> v16u8 {
+    static_assert_uimm_bits!(IMM8, 8);
+    unsafe { __lsx_vxori_b(a, IMM8) }
+}
+
+#[inline]
+#[target_feature(enable = "lsx")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lsx_vbitsel_v(a: v16u8, b: v16u8, c: v16u8) -> v16u8 {
+    unsafe { __lsx_vbitsel_v(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbitseli_b<const IMM8: u32>(a: v16u8, b: v16u8) -> v16u8 {
+pub fn lsx_vbitseli_b<const IMM8: u32>(a: v16u8, b: v16u8) -> v16u8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vbitseli_b(a, b, IMM8)
+    unsafe { __lsx_vbitseli_b(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf4i_b<const IMM8: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vshuf4i_b<const IMM8: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vshuf4i_b(a, IMM8)
+    unsafe { __lsx_vshuf4i_b(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf4i_h<const IMM8: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vshuf4i_h<const IMM8: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vshuf4i_h(a, IMM8)
+    unsafe { __lsx_vshuf4i_h(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf4i_w<const IMM8: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vshuf4i_w<const IMM8: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vshuf4i_w(a, IMM8)
+    unsafe { __lsx_vshuf4i_w(a, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplgr2vr_b(a: i32) -> v16i8 {
-    __lsx_vreplgr2vr_b(a)
+pub fn lsx_vreplgr2vr_b(a: i32) -> v16i8 {
+    unsafe { __lsx_vreplgr2vr_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplgr2vr_h(a: i32) -> v8i16 {
-    __lsx_vreplgr2vr_h(a)
+pub fn lsx_vreplgr2vr_h(a: i32) -> v8i16 {
+    unsafe { __lsx_vreplgr2vr_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplgr2vr_w(a: i32) -> v4i32 {
-    __lsx_vreplgr2vr_w(a)
+pub fn lsx_vreplgr2vr_w(a: i32) -> v4i32 {
+    unsafe { __lsx_vreplgr2vr_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vreplgr2vr_d(a: i64) -> v2i64 {
-    __lsx_vreplgr2vr_d(a)
+pub fn lsx_vreplgr2vr_d(a: i64) -> v2i64 {
+    unsafe { __lsx_vreplgr2vr_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpcnt_b(a: v16i8) -> v16i8 {
-    __lsx_vpcnt_b(a)
+pub fn lsx_vpcnt_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vpcnt_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpcnt_h(a: v8i16) -> v8i16 {
-    __lsx_vpcnt_h(a)
+pub fn lsx_vpcnt_h(a: v8i16) -> v8i16 {
+    unsafe { __lsx_vpcnt_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpcnt_w(a: v4i32) -> v4i32 {
-    __lsx_vpcnt_w(a)
+pub fn lsx_vpcnt_w(a: v4i32) -> v4i32 {
+    unsafe { __lsx_vpcnt_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpcnt_d(a: v2i64) -> v2i64 {
-    __lsx_vpcnt_d(a)
+pub fn lsx_vpcnt_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vpcnt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclo_b(a: v16i8) -> v16i8 {
-    __lsx_vclo_b(a)
+pub fn lsx_vclo_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vclo_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclo_h(a: v8i16) -> v8i16 {
-    __lsx_vclo_h(a)
+pub fn lsx_vclo_h(a: v8i16) -> v8i16 {
+    unsafe { __lsx_vclo_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclo_w(a: v4i32) -> v4i32 {
-    __lsx_vclo_w(a)
+pub fn lsx_vclo_w(a: v4i32) -> v4i32 {
+    unsafe { __lsx_vclo_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclo_d(a: v2i64) -> v2i64 {
-    __lsx_vclo_d(a)
+pub fn lsx_vclo_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vclo_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclz_b(a: v16i8) -> v16i8 {
-    __lsx_vclz_b(a)
+pub fn lsx_vclz_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vclz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclz_h(a: v8i16) -> v8i16 {
-    __lsx_vclz_h(a)
+pub fn lsx_vclz_h(a: v8i16) -> v8i16 {
+    unsafe { __lsx_vclz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclz_w(a: v4i32) -> v4i32 {
-    __lsx_vclz_w(a)
+pub fn lsx_vclz_w(a: v4i32) -> v4i32 {
+    unsafe { __lsx_vclz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vclz_d(a: v2i64) -> v2i64 {
-    __lsx_vclz_d(a)
+pub fn lsx_vclz_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vclz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_b<const IMM4: u32>(a: v16i8) -> i32 {
+pub fn lsx_vpickve2gr_b<const IMM4: u32>(a: v16i8) -> i32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vpickve2gr_b(a, IMM4)
+    unsafe { __lsx_vpickve2gr_b(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_h<const IMM3: u32>(a: v8i16) -> i32 {
+pub fn lsx_vpickve2gr_h<const IMM3: u32>(a: v8i16) -> i32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vpickve2gr_h(a, IMM3)
+    unsafe { __lsx_vpickve2gr_h(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_w<const IMM2: u32>(a: v4i32) -> i32 {
+pub fn lsx_vpickve2gr_w<const IMM2: u32>(a: v4i32) -> i32 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lsx_vpickve2gr_w(a, IMM2)
+    unsafe { __lsx_vpickve2gr_w(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_d<const IMM1: u32>(a: v2i64) -> i64 {
+pub fn lsx_vpickve2gr_d<const IMM1: u32>(a: v2i64) -> i64 {
     static_assert_uimm_bits!(IMM1, 1);
-    __lsx_vpickve2gr_d(a, IMM1)
+    unsafe { __lsx_vpickve2gr_d(a, IMM1) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_bu<const IMM4: u32>(a: v16i8) -> u32 {
+pub fn lsx_vpickve2gr_bu<const IMM4: u32>(a: v16i8) -> u32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vpickve2gr_bu(a, IMM4)
+    unsafe { __lsx_vpickve2gr_bu(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_hu<const IMM3: u32>(a: v8i16) -> u32 {
+pub fn lsx_vpickve2gr_hu<const IMM3: u32>(a: v8i16) -> u32 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vpickve2gr_hu(a, IMM3)
+    unsafe { __lsx_vpickve2gr_hu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_wu<const IMM2: u32>(a: v4i32) -> u32 {
+pub fn lsx_vpickve2gr_wu<const IMM2: u32>(a: v4i32) -> u32 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lsx_vpickve2gr_wu(a, IMM2)
+    unsafe { __lsx_vpickve2gr_wu(a, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpickve2gr_du<const IMM1: u32>(a: v2i64) -> u64 {
+pub fn lsx_vpickve2gr_du<const IMM1: u32>(a: v2i64) -> u64 {
     static_assert_uimm_bits!(IMM1, 1);
-    __lsx_vpickve2gr_du(a, IMM1)
+    unsafe { __lsx_vpickve2gr_du(a, IMM1) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vinsgr2vr_b<const IMM4: u32>(a: v16i8, b: i32) -> v16i8 {
+pub fn lsx_vinsgr2vr_b<const IMM4: u32>(a: v16i8, b: i32) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vinsgr2vr_b(a, b, IMM4)
+    unsafe { __lsx_vinsgr2vr_b(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vinsgr2vr_h<const IMM3: u32>(a: v8i16, b: i32) -> v8i16 {
+pub fn lsx_vinsgr2vr_h<const IMM3: u32>(a: v8i16, b: i32) -> v8i16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vinsgr2vr_h(a, b, IMM3)
+    unsafe { __lsx_vinsgr2vr_h(a, b, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vinsgr2vr_w<const IMM2: u32>(a: v4i32, b: i32) -> v4i32 {
+pub fn lsx_vinsgr2vr_w<const IMM2: u32>(a: v4i32, b: i32) -> v4i32 {
     static_assert_uimm_bits!(IMM2, 2);
-    __lsx_vinsgr2vr_w(a, b, IMM2)
+    unsafe { __lsx_vinsgr2vr_w(a, b, IMM2) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vinsgr2vr_d<const IMM1: u32>(a: v2i64, b: i64) -> v2i64 {
+pub fn lsx_vinsgr2vr_d<const IMM1: u32>(a: v2i64, b: i64) -> v2i64 {
     static_assert_uimm_bits!(IMM1, 1);
-    __lsx_vinsgr2vr_d(a, b, IMM1)
+    unsafe { __lsx_vinsgr2vr_d(a, b, IMM1) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfadd_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfadd_s(a, b)
+pub fn lsx_vfadd_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfadd_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfadd_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfadd_d(a, b)
+pub fn lsx_vfadd_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfadd_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfsub_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfsub_s(a, b)
+pub fn lsx_vfsub_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfsub_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfsub_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfsub_d(a, b)
+pub fn lsx_vfsub_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfsub_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmul_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfmul_s(a, b)
+pub fn lsx_vfmul_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmul_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmul_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfmul_d(a, b)
+pub fn lsx_vfmul_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmul_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfdiv_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfdiv_s(a, b)
+pub fn lsx_vfdiv_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfdiv_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfdiv_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfdiv_d(a, b)
+pub fn lsx_vfdiv_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfdiv_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvt_h_s(a: v4f32, b: v4f32) -> v8i16 {
-    __lsx_vfcvt_h_s(a, b)
+pub fn lsx_vfcvt_h_s(a: v4f32, b: v4f32) -> v8i16 {
+    unsafe { __lsx_vfcvt_h_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvt_s_d(a: v2f64, b: v2f64) -> v4f32 {
-    __lsx_vfcvt_s_d(a, b)
+pub fn lsx_vfcvt_s_d(a: v2f64, b: v2f64) -> v4f32 {
+    unsafe { __lsx_vfcvt_s_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmin_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfmin_s(a, b)
+pub fn lsx_vfmin_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmin_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmin_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfmin_d(a, b)
+pub fn lsx_vfmin_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmin_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmina_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfmina_s(a, b)
+pub fn lsx_vfmina_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmina_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmina_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfmina_d(a, b)
+pub fn lsx_vfmina_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmina_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmax_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfmax_s(a, b)
+pub fn lsx_vfmax_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmax_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmax_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfmax_d(a, b)
+pub fn lsx_vfmax_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmax_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmaxa_s(a: v4f32, b: v4f32) -> v4f32 {
-    __lsx_vfmaxa_s(a, b)
+pub fn lsx_vfmaxa_s(a: v4f32, b: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmaxa_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmaxa_d(a: v2f64, b: v2f64) -> v2f64 {
-    __lsx_vfmaxa_d(a, b)
+pub fn lsx_vfmaxa_d(a: v2f64, b: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmaxa_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfclass_s(a: v4f32) -> v4i32 {
-    __lsx_vfclass_s(a)
+pub fn lsx_vfclass_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vfclass_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfclass_d(a: v2f64) -> v2i64 {
-    __lsx_vfclass_d(a)
+pub fn lsx_vfclass_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vfclass_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfsqrt_s(a: v4f32) -> v4f32 {
-    __lsx_vfsqrt_s(a)
+pub fn lsx_vfsqrt_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfsqrt_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfsqrt_d(a: v2f64) -> v2f64 {
-    __lsx_vfsqrt_d(a)
+pub fn lsx_vfsqrt_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfsqrt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrecip_s(a: v4f32) -> v4f32 {
-    __lsx_vfrecip_s(a)
+pub fn lsx_vfrecip_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrecip_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrecip_d(a: v2f64) -> v2f64 {
-    __lsx_vfrecip_d(a)
+pub fn lsx_vfrecip_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrecip_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrecipe_s(a: v4f32) -> v4f32 {
-    __lsx_vfrecipe_s(a)
+pub fn lsx_vfrecipe_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrecipe_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrecipe_d(a: v2f64) -> v2f64 {
-    __lsx_vfrecipe_d(a)
+pub fn lsx_vfrecipe_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrecipe_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrsqrte_s(a: v4f32) -> v4f32 {
-    __lsx_vfrsqrte_s(a)
+pub fn lsx_vfrsqrte_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrsqrte_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx,frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrsqrte_d(a: v2f64) -> v2f64 {
-    __lsx_vfrsqrte_d(a)
+pub fn lsx_vfrsqrte_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrsqrte_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrint_s(a: v4f32) -> v4f32 {
-    __lsx_vfrint_s(a)
+pub fn lsx_vfrint_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrint_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrint_d(a: v2f64) -> v2f64 {
-    __lsx_vfrint_d(a)
+pub fn lsx_vfrint_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrint_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrsqrt_s(a: v4f32) -> v4f32 {
-    __lsx_vfrsqrt_s(a)
+pub fn lsx_vfrsqrt_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrsqrt_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrsqrt_d(a: v2f64) -> v2f64 {
-    __lsx_vfrsqrt_d(a)
+pub fn lsx_vfrsqrt_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrsqrt_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vflogb_s(a: v4f32) -> v4f32 {
-    __lsx_vflogb_s(a)
+pub fn lsx_vflogb_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vflogb_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vflogb_d(a: v2f64) -> v2f64 {
-    __lsx_vflogb_d(a)
+pub fn lsx_vflogb_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vflogb_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvth_s_h(a: v8i16) -> v4f32 {
-    __lsx_vfcvth_s_h(a)
+pub fn lsx_vfcvth_s_h(a: v8i16) -> v4f32 {
+    unsafe { __lsx_vfcvth_s_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvth_d_s(a: v4f32) -> v2f64 {
-    __lsx_vfcvth_d_s(a)
+pub fn lsx_vfcvth_d_s(a: v4f32) -> v2f64 {
+    unsafe { __lsx_vfcvth_d_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvtl_s_h(a: v8i16) -> v4f32 {
-    __lsx_vfcvtl_s_h(a)
+pub fn lsx_vfcvtl_s_h(a: v8i16) -> v4f32 {
+    unsafe { __lsx_vfcvtl_s_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcvtl_d_s(a: v4f32) -> v2f64 {
-    __lsx_vfcvtl_d_s(a)
+pub fn lsx_vfcvtl_d_s(a: v4f32) -> v2f64 {
+    unsafe { __lsx_vfcvtl_d_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftint_w_s(a: v4f32) -> v4i32 {
-    __lsx_vftint_w_s(a)
+pub fn lsx_vftint_w_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vftint_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftint_l_d(a: v2f64) -> v2i64 {
-    __lsx_vftint_l_d(a)
+pub fn lsx_vftint_l_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vftint_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftint_wu_s(a: v4f32) -> v4u32 {
-    __lsx_vftint_wu_s(a)
+pub fn lsx_vftint_wu_s(a: v4f32) -> v4u32 {
+    unsafe { __lsx_vftint_wu_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftint_lu_d(a: v2f64) -> v2u64 {
-    __lsx_vftint_lu_d(a)
+pub fn lsx_vftint_lu_d(a: v2f64) -> v2u64 {
+    unsafe { __lsx_vftint_lu_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrz_w_s(a: v4f32) -> v4i32 {
-    __lsx_vftintrz_w_s(a)
+pub fn lsx_vftintrz_w_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vftintrz_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrz_l_d(a: v2f64) -> v2i64 {
-    __lsx_vftintrz_l_d(a)
+pub fn lsx_vftintrz_l_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vftintrz_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrz_wu_s(a: v4f32) -> v4u32 {
-    __lsx_vftintrz_wu_s(a)
+pub fn lsx_vftintrz_wu_s(a: v4f32) -> v4u32 {
+    unsafe { __lsx_vftintrz_wu_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrz_lu_d(a: v2f64) -> v2u64 {
-    __lsx_vftintrz_lu_d(a)
+pub fn lsx_vftintrz_lu_d(a: v2f64) -> v2u64 {
+    unsafe { __lsx_vftintrz_lu_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffint_s_w(a: v4i32) -> v4f32 {
-    __lsx_vffint_s_w(a)
+pub fn lsx_vffint_s_w(a: v4i32) -> v4f32 {
+    unsafe { __lsx_vffint_s_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffint_d_l(a: v2i64) -> v2f64 {
-    __lsx_vffint_d_l(a)
+pub fn lsx_vffint_d_l(a: v2i64) -> v2f64 {
+    unsafe { __lsx_vffint_d_l(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffint_s_wu(a: v4u32) -> v4f32 {
-    __lsx_vffint_s_wu(a)
+pub fn lsx_vffint_s_wu(a: v4u32) -> v4f32 {
+    unsafe { __lsx_vffint_s_wu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffint_d_lu(a: v2u64) -> v2f64 {
-    __lsx_vffint_d_lu(a)
+pub fn lsx_vffint_d_lu(a: v2u64) -> v2f64 {
+    unsafe { __lsx_vffint_d_lu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vandn_v(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vandn_v(a, b)
+pub fn lsx_vandn_v(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vandn_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vneg_b(a: v16i8) -> v16i8 {
-    __lsx_vneg_b(a)
+pub fn lsx_vneg_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vneg_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vneg_h(a: v8i16) -> v8i16 {
-    __lsx_vneg_h(a)
+pub fn lsx_vneg_h(a: v8i16) -> v8i16 {
+    unsafe { __lsx_vneg_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vneg_w(a: v4i32) -> v4i32 {
-    __lsx_vneg_w(a)
+pub fn lsx_vneg_w(a: v4i32) -> v4i32 {
+    unsafe { __lsx_vneg_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vneg_d(a: v2i64) -> v2i64 {
-    __lsx_vneg_d(a)
+pub fn lsx_vneg_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vneg_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vmuh_b(a, b)
+pub fn lsx_vmuh_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vmuh_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vmuh_h(a, b)
+pub fn lsx_vmuh_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vmuh_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vmuh_w(a, b)
+pub fn lsx_vmuh_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vmuh_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmuh_d(a, b)
+pub fn lsx_vmuh_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmuh_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_bu(a: v16u8, b: v16u8) -> v16u8 {
-    __lsx_vmuh_bu(a, b)
+pub fn lsx_vmuh_bu(a: v16u8, b: v16u8) -> v16u8 {
+    unsafe { __lsx_vmuh_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_hu(a: v8u16, b: v8u16) -> v8u16 {
-    __lsx_vmuh_hu(a, b)
+pub fn lsx_vmuh_hu(a: v8u16, b: v8u16) -> v8u16 {
+    unsafe { __lsx_vmuh_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_wu(a: v4u32, b: v4u32) -> v4u32 {
-    __lsx_vmuh_wu(a, b)
+pub fn lsx_vmuh_wu(a: v4u32, b: v4u32) -> v4u32 {
+    unsafe { __lsx_vmuh_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmuh_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vmuh_du(a, b)
+pub fn lsx_vmuh_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vmuh_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_h_b<const IMM3: u32>(a: v16i8) -> v8i16 {
+pub fn lsx_vsllwil_h_b<const IMM3: u32>(a: v16i8) -> v8i16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsllwil_h_b(a, IMM3)
+    unsafe { __lsx_vsllwil_h_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_w_h<const IMM4: u32>(a: v8i16) -> v4i32 {
+pub fn lsx_vsllwil_w_h<const IMM4: u32>(a: v8i16) -> v4i32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsllwil_w_h(a, IMM4)
+    unsafe { __lsx_vsllwil_w_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_d_w<const IMM5: u32>(a: v4i32) -> v2i64 {
+pub fn lsx_vsllwil_d_w<const IMM5: u32>(a: v4i32) -> v2i64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsllwil_d_w(a, IMM5)
+    unsafe { __lsx_vsllwil_d_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_hu_bu<const IMM3: u32>(a: v16u8) -> v8u16 {
+pub fn lsx_vsllwil_hu_bu<const IMM3: u32>(a: v16u8) -> v8u16 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vsllwil_hu_bu(a, IMM3)
+    unsafe { __lsx_vsllwil_hu_bu(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_wu_hu<const IMM4: u32>(a: v8u16) -> v4u32 {
+pub fn lsx_vsllwil_wu_hu<const IMM4: u32>(a: v8u16) -> v4u32 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsllwil_wu_hu(a, IMM4)
+    unsafe { __lsx_vsllwil_wu_hu(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsllwil_du_wu<const IMM5: u32>(a: v4u32) -> v2u64 {
+pub fn lsx_vsllwil_du_wu<const IMM5: u32>(a: v4u32) -> v2u64 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsllwil_du_wu(a, IMM5)
+    unsafe { __lsx_vsllwil_du_wu(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsran_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vsran_b_h(a, b)
+pub fn lsx_vsran_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vsran_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsran_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vsran_h_w(a, b)
+pub fn lsx_vsran_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vsran_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsran_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vsran_w_d(a, b)
+pub fn lsx_vsran_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vsran_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vssran_b_h(a, b)
+pub fn lsx_vssran_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vssran_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vssran_h_w(a, b)
+pub fn lsx_vssran_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vssran_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vssran_w_d(a, b)
+pub fn lsx_vssran_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vssran_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_bu_h(a: v8u16, b: v8u16) -> v16u8 {
-    __lsx_vssran_bu_h(a, b)
+pub fn lsx_vssran_bu_h(a: v8u16, b: v8u16) -> v16u8 {
+    unsafe { __lsx_vssran_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_hu_w(a: v4u32, b: v4u32) -> v8u16 {
-    __lsx_vssran_hu_w(a, b)
+pub fn lsx_vssran_hu_w(a: v4u32, b: v4u32) -> v8u16 {
+    unsafe { __lsx_vssran_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssran_wu_d(a: v2u64, b: v2u64) -> v4u32 {
-    __lsx_vssran_wu_d(a, b)
+pub fn lsx_vssran_wu_d(a: v2u64, b: v2u64) -> v4u32 {
+    unsafe { __lsx_vssran_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarn_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vsrarn_b_h(a, b)
+pub fn lsx_vsrarn_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vsrarn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarn_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vsrarn_h_w(a, b)
+pub fn lsx_vsrarn_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vsrarn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarn_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vsrarn_w_d(a, b)
+pub fn lsx_vsrarn_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vsrarn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vssrarn_b_h(a, b)
+pub fn lsx_vssrarn_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vssrarn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vssrarn_h_w(a, b)
+pub fn lsx_vssrarn_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vssrarn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vssrarn_w_d(a, b)
+pub fn lsx_vssrarn_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vssrarn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_bu_h(a: v8u16, b: v8u16) -> v16u8 {
-    __lsx_vssrarn_bu_h(a, b)
+pub fn lsx_vssrarn_bu_h(a: v8u16, b: v8u16) -> v16u8 {
+    unsafe { __lsx_vssrarn_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_hu_w(a: v4u32, b: v4u32) -> v8u16 {
-    __lsx_vssrarn_hu_w(a, b)
+pub fn lsx_vssrarn_hu_w(a: v4u32, b: v4u32) -> v8u16 {
+    unsafe { __lsx_vssrarn_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarn_wu_d(a: v2u64, b: v2u64) -> v4u32 {
-    __lsx_vssrarn_wu_d(a, b)
+pub fn lsx_vssrarn_wu_d(a: v2u64, b: v2u64) -> v4u32 {
+    unsafe { __lsx_vssrarn_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrln_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vsrln_b_h(a, b)
+pub fn lsx_vsrln_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vsrln_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrln_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vsrln_h_w(a, b)
+pub fn lsx_vsrln_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vsrln_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrln_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vsrln_w_d(a, b)
+pub fn lsx_vsrln_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vsrln_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_bu_h(a: v8u16, b: v8u16) -> v16u8 {
-    __lsx_vssrln_bu_h(a, b)
+pub fn lsx_vssrln_bu_h(a: v8u16, b: v8u16) -> v16u8 {
+    unsafe { __lsx_vssrln_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_hu_w(a: v4u32, b: v4u32) -> v8u16 {
-    __lsx_vssrln_hu_w(a, b)
+pub fn lsx_vssrln_hu_w(a: v4u32, b: v4u32) -> v8u16 {
+    unsafe { __lsx_vssrln_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_wu_d(a: v2u64, b: v2u64) -> v4u32 {
-    __lsx_vssrln_wu_d(a, b)
+pub fn lsx_vssrln_wu_d(a: v2u64, b: v2u64) -> v4u32 {
+    unsafe { __lsx_vssrln_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrn_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vsrlrn_b_h(a, b)
+pub fn lsx_vsrlrn_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vsrlrn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrn_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vsrlrn_h_w(a, b)
+pub fn lsx_vsrlrn_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vsrlrn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrn_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vsrlrn_w_d(a, b)
+pub fn lsx_vsrlrn_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vsrlrn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_bu_h(a: v8u16, b: v8u16) -> v16u8 {
-    __lsx_vssrlrn_bu_h(a, b)
+pub fn lsx_vssrlrn_bu_h(a: v8u16, b: v8u16) -> v16u8 {
+    unsafe { __lsx_vssrlrn_bu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_hu_w(a: v4u32, b: v4u32) -> v8u16 {
-    __lsx_vssrlrn_hu_w(a, b)
+pub fn lsx_vssrlrn_hu_w(a: v4u32, b: v4u32) -> v8u16 {
+    unsafe { __lsx_vssrlrn_hu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_wu_d(a: v2u64, b: v2u64) -> v4u32 {
-    __lsx_vssrlrn_wu_d(a, b)
+pub fn lsx_vssrlrn_wu_d(a: v2u64, b: v2u64) -> v4u32 {
+    unsafe { __lsx_vssrlrn_wu_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrstpi_b<const IMM5: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vfrstpi_b<const IMM5: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vfrstpi_b(a, b, IMM5)
+    unsafe { __lsx_vfrstpi_b(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrstpi_h<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vfrstpi_h<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vfrstpi_h(a, b, IMM5)
+    unsafe { __lsx_vfrstpi_h(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrstp_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
-    __lsx_vfrstp_b(a, b, c)
+pub fn lsx_vfrstp_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
+    unsafe { __lsx_vfrstp_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrstp_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
-    __lsx_vfrstp_h(a, b, c)
+pub fn lsx_vfrstp_h(a: v8i16, b: v8i16, c: v8i16) -> v8i16 {
+    unsafe { __lsx_vfrstp_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf4i_d<const IMM8: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vshuf4i_d<const IMM8: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vshuf4i_d(a, b, IMM8)
+    unsafe { __lsx_vshuf4i_d(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbsrl_v<const IMM5: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vbsrl_v<const IMM5: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vbsrl_v(a, IMM5)
+    unsafe { __lsx_vbsrl_v(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vbsll_v<const IMM5: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vbsll_v<const IMM5: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vbsll_v(a, IMM5)
+    unsafe { __lsx_vbsll_v(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextrins_b<const IMM8: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vextrins_b<const IMM8: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vextrins_b(a, b, IMM8)
+    unsafe { __lsx_vextrins_b(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextrins_h<const IMM8: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vextrins_h<const IMM8: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vextrins_h(a, b, IMM8)
+    unsafe { __lsx_vextrins_h(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextrins_w<const IMM8: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vextrins_w<const IMM8: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vextrins_w(a, b, IMM8)
+    unsafe { __lsx_vextrins_w(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextrins_d<const IMM8: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vextrins_d<const IMM8: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vextrins_d(a, b, IMM8)
+    unsafe { __lsx_vextrins_d(a, b, IMM8) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmskltz_b(a: v16i8) -> v16i8 {
-    __lsx_vmskltz_b(a)
+pub fn lsx_vmskltz_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vmskltz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmskltz_h(a: v8i16) -> v8i16 {
-    __lsx_vmskltz_h(a)
+pub fn lsx_vmskltz_h(a: v8i16) -> v8i16 {
+    unsafe { __lsx_vmskltz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmskltz_w(a: v4i32) -> v4i32 {
-    __lsx_vmskltz_w(a)
+pub fn lsx_vmskltz_w(a: v4i32) -> v4i32 {
+    unsafe { __lsx_vmskltz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmskltz_d(a: v2i64) -> v2i64 {
-    __lsx_vmskltz_d(a)
+pub fn lsx_vmskltz_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vmskltz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsigncov_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vsigncov_b(a, b)
+pub fn lsx_vsigncov_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vsigncov_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsigncov_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vsigncov_h(a, b)
+pub fn lsx_vsigncov_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vsigncov_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsigncov_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vsigncov_w(a, b)
+pub fn lsx_vsigncov_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vsigncov_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsigncov_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsigncov_d(a, b)
+pub fn lsx_vsigncov_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsigncov_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmadd_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
-    __lsx_vfmadd_s(a, b, c)
+pub fn lsx_vfmadd_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmadd_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
-    __lsx_vfmadd_d(a, b, c)
+pub fn lsx_vfmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmsub_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
-    __lsx_vfmsub_s(a, b, c)
+pub fn lsx_vfmsub_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
+    unsafe { __lsx_vfmsub_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
-    __lsx_vfmsub_d(a, b, c)
+pub fn lsx_vfmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
+    unsafe { __lsx_vfmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfnmadd_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
-    __lsx_vfnmadd_s(a, b, c)
+pub fn lsx_vfnmadd_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
+    unsafe { __lsx_vfnmadd_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfnmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
-    __lsx_vfnmadd_d(a, b, c)
+pub fn lsx_vfnmadd_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
+    unsafe { __lsx_vfnmadd_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfnmsub_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
-    __lsx_vfnmsub_s(a, b, c)
+pub fn lsx_vfnmsub_s(a: v4f32, b: v4f32, c: v4f32) -> v4f32 {
+    unsafe { __lsx_vfnmsub_s(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfnmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
-    __lsx_vfnmsub_d(a, b, c)
+pub fn lsx_vfnmsub_d(a: v2f64, b: v2f64, c: v2f64) -> v2f64 {
+    unsafe { __lsx_vfnmsub_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrne_w_s(a: v4f32) -> v4i32 {
-    __lsx_vftintrne_w_s(a)
+pub fn lsx_vftintrne_w_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vftintrne_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrne_l_d(a: v2f64) -> v2i64 {
-    __lsx_vftintrne_l_d(a)
+pub fn lsx_vftintrne_l_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vftintrne_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrp_w_s(a: v4f32) -> v4i32 {
-    __lsx_vftintrp_w_s(a)
+pub fn lsx_vftintrp_w_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vftintrp_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrp_l_d(a: v2f64) -> v2i64 {
-    __lsx_vftintrp_l_d(a)
+pub fn lsx_vftintrp_l_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vftintrp_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrm_w_s(a: v4f32) -> v4i32 {
-    __lsx_vftintrm_w_s(a)
+pub fn lsx_vftintrm_w_s(a: v4f32) -> v4i32 {
+    unsafe { __lsx_vftintrm_w_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrm_l_d(a: v2f64) -> v2i64 {
-    __lsx_vftintrm_l_d(a)
+pub fn lsx_vftintrm_l_d(a: v2f64) -> v2i64 {
+    unsafe { __lsx_vftintrm_l_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftint_w_d(a: v2f64, b: v2f64) -> v4i32 {
-    __lsx_vftint_w_d(a, b)
+pub fn lsx_vftint_w_d(a: v2f64, b: v2f64) -> v4i32 {
+    unsafe { __lsx_vftint_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffint_s_l(a: v2i64, b: v2i64) -> v4f32 {
-    __lsx_vffint_s_l(a, b)
+pub fn lsx_vffint_s_l(a: v2i64, b: v2i64) -> v4f32 {
+    unsafe { __lsx_vffint_s_l(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrz_w_d(a: v2f64, b: v2f64) -> v4i32 {
-    __lsx_vftintrz_w_d(a, b)
+pub fn lsx_vftintrz_w_d(a: v2f64, b: v2f64) -> v4i32 {
+    unsafe { __lsx_vftintrz_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrp_w_d(a: v2f64, b: v2f64) -> v4i32 {
-    __lsx_vftintrp_w_d(a, b)
+pub fn lsx_vftintrp_w_d(a: v2f64, b: v2f64) -> v4i32 {
+    unsafe { __lsx_vftintrp_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrm_w_d(a: v2f64, b: v2f64) -> v4i32 {
-    __lsx_vftintrm_w_d(a, b)
+pub fn lsx_vftintrm_w_d(a: v2f64, b: v2f64) -> v4i32 {
+    unsafe { __lsx_vftintrm_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrne_w_d(a: v2f64, b: v2f64) -> v4i32 {
-    __lsx_vftintrne_w_d(a, b)
+pub fn lsx_vftintrne_w_d(a: v2f64, b: v2f64) -> v4i32 {
+    unsafe { __lsx_vftintrne_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintl_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintl_l_s(a)
+pub fn lsx_vftintl_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftinth_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftinth_l_s(a)
+pub fn lsx_vftinth_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftinth_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffinth_d_w(a: v4i32) -> v2f64 {
-    __lsx_vffinth_d_w(a)
+pub fn lsx_vffinth_d_w(a: v4i32) -> v2f64 {
+    unsafe { __lsx_vffinth_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vffintl_d_w(a: v4i32) -> v2f64 {
-    __lsx_vffintl_d_w(a)
+pub fn lsx_vffintl_d_w(a: v4i32) -> v2f64 {
+    unsafe { __lsx_vffintl_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrzl_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrzl_l_s(a)
+pub fn lsx_vftintrzl_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrzl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrzh_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrzh_l_s(a)
+pub fn lsx_vftintrzh_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrzh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrpl_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrpl_l_s(a)
+pub fn lsx_vftintrpl_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrpl_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrph_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrph_l_s(a)
+pub fn lsx_vftintrph_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrph_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrml_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrml_l_s(a)
+pub fn lsx_vftintrml_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrml_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrmh_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrmh_l_s(a)
+pub fn lsx_vftintrmh_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrmh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrnel_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrnel_l_s(a)
+pub fn lsx_vftintrnel_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrnel_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vftintrneh_l_s(a: v4f32) -> v2i64 {
-    __lsx_vftintrneh_l_s(a)
+pub fn lsx_vftintrneh_l_s(a: v4f32) -> v2i64 {
+    unsafe { __lsx_vftintrneh_l_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrne_s(a: v4f32) -> v4f32 {
-    __lsx_vfrintrne_s(a)
+pub fn lsx_vfrintrne_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrintrne_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrne_d(a: v2f64) -> v2f64 {
-    __lsx_vfrintrne_d(a)
+pub fn lsx_vfrintrne_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrintrne_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrz_s(a: v4f32) -> v4f32 {
-    __lsx_vfrintrz_s(a)
+pub fn lsx_vfrintrz_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrintrz_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrz_d(a: v2f64) -> v2f64 {
-    __lsx_vfrintrz_d(a)
+pub fn lsx_vfrintrz_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrintrz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrp_s(a: v4f32) -> v4f32 {
-    __lsx_vfrintrp_s(a)
+pub fn lsx_vfrintrp_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrintrp_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrp_d(a: v2f64) -> v2f64 {
-    __lsx_vfrintrp_d(a)
+pub fn lsx_vfrintrp_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrintrp_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrm_s(a: v4f32) -> v4f32 {
-    __lsx_vfrintrm_s(a)
+pub fn lsx_vfrintrm_s(a: v4f32) -> v4f32 {
+    unsafe { __lsx_vfrintrm_s(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfrintrm_d(a: v2f64) -> v2f64 {
-    __lsx_vfrintrm_d(a)
+pub fn lsx_vfrintrm_d(a: v2f64) -> v2f64 {
+    unsafe { __lsx_vfrintrm_d(a) }
 }
 
 #[inline]
@@ -5087,687 +5087,687 @@ pub unsafe fn lsx_vstelm_d<const IMM_S8: i32, const IMM1: u32>(a: v2i64, mem_add
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vaddwev_d_w(a, b)
+pub fn lsx_vaddwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vaddwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vaddwev_w_h(a, b)
+pub fn lsx_vaddwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vaddwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vaddwev_h_b(a, b)
+pub fn lsx_vaddwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vaddwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vaddwod_d_w(a, b)
+pub fn lsx_vaddwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vaddwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vaddwod_w_h(a, b)
+pub fn lsx_vaddwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vaddwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vaddwod_h_b(a, b)
+pub fn lsx_vaddwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vaddwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vaddwev_d_wu(a, b)
+pub fn lsx_vaddwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vaddwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vaddwev_w_hu(a, b)
+pub fn lsx_vaddwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vaddwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vaddwev_h_bu(a, b)
+pub fn lsx_vaddwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vaddwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vaddwod_d_wu(a, b)
+pub fn lsx_vaddwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vaddwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vaddwod_w_hu(a, b)
+pub fn lsx_vaddwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vaddwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vaddwod_h_bu(a, b)
+pub fn lsx_vaddwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vaddwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
-    __lsx_vaddwev_d_wu_w(a, b)
+pub fn lsx_vaddwev_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vaddwev_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
-    __lsx_vaddwev_w_hu_h(a, b)
+pub fn lsx_vaddwev_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vaddwev_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
-    __lsx_vaddwev_h_bu_b(a, b)
+pub fn lsx_vaddwev_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vaddwev_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
-    __lsx_vaddwod_d_wu_w(a, b)
+pub fn lsx_vaddwod_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vaddwod_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
-    __lsx_vaddwod_w_hu_h(a, b)
+pub fn lsx_vaddwod_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vaddwod_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
-    __lsx_vaddwod_h_bu_b(a, b)
+pub fn lsx_vaddwod_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vaddwod_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vsubwev_d_w(a, b)
+pub fn lsx_vsubwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vsubwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vsubwev_w_h(a, b)
+pub fn lsx_vsubwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vsubwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vsubwev_h_b(a, b)
+pub fn lsx_vsubwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vsubwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vsubwod_d_w(a, b)
+pub fn lsx_vsubwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vsubwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vsubwod_w_h(a, b)
+pub fn lsx_vsubwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vsubwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vsubwod_h_b(a, b)
+pub fn lsx_vsubwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vsubwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vsubwev_d_wu(a, b)
+pub fn lsx_vsubwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vsubwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vsubwev_w_hu(a, b)
+pub fn lsx_vsubwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vsubwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vsubwev_h_bu(a, b)
+pub fn lsx_vsubwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vsubwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vsubwod_d_wu(a, b)
+pub fn lsx_vsubwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vsubwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vsubwod_w_hu(a, b)
+pub fn lsx_vsubwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vsubwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vsubwod_h_bu(a, b)
+pub fn lsx_vsubwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vsubwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vaddwev_q_d(a, b)
+pub fn lsx_vaddwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vaddwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vaddwod_q_d(a, b)
+pub fn lsx_vaddwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vaddwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vaddwev_q_du(a, b)
+pub fn lsx_vaddwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vaddwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vaddwod_q_du(a, b)
+pub fn lsx_vaddwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vaddwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsubwev_q_d(a, b)
+pub fn lsx_vsubwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsubwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsubwod_q_d(a, b)
+pub fn lsx_vsubwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsubwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vsubwev_q_du(a, b)
+pub fn lsx_vsubwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vsubwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsubwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vsubwod_q_du(a, b)
+pub fn lsx_vsubwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vsubwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwev_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
-    __lsx_vaddwev_q_du_d(a, b)
+pub fn lsx_vaddwev_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vaddwev_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vaddwod_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
-    __lsx_vaddwod_q_du_d(a, b)
+pub fn lsx_vaddwod_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vaddwod_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vmulwev_d_w(a, b)
+pub fn lsx_vmulwev_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vmulwev_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vmulwev_w_h(a, b)
+pub fn lsx_vmulwev_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vmulwev_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vmulwev_h_b(a, b)
+pub fn lsx_vmulwev_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vmulwev_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
-    __lsx_vmulwod_d_w(a, b)
+pub fn lsx_vmulwod_d_w(a: v4i32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vmulwod_d_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
-    __lsx_vmulwod_w_h(a, b)
+pub fn lsx_vmulwod_w_h(a: v8i16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vmulwod_w_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
-    __lsx_vmulwod_h_b(a, b)
+pub fn lsx_vmulwod_h_b(a: v16i8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vmulwod_h_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vmulwev_d_wu(a, b)
+pub fn lsx_vmulwev_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vmulwev_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vmulwev_w_hu(a, b)
+pub fn lsx_vmulwev_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vmulwev_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vmulwev_h_bu(a, b)
+pub fn lsx_vmulwev_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vmulwev_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
-    __lsx_vmulwod_d_wu(a, b)
+pub fn lsx_vmulwod_d_wu(a: v4u32, b: v4u32) -> v2i64 {
+    unsafe { __lsx_vmulwod_d_wu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
-    __lsx_vmulwod_w_hu(a, b)
+pub fn lsx_vmulwod_w_hu(a: v8u16, b: v8u16) -> v4i32 {
+    unsafe { __lsx_vmulwod_w_hu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
-    __lsx_vmulwod_h_bu(a, b)
+pub fn lsx_vmulwod_h_bu(a: v16u8, b: v16u8) -> v8i16 {
+    unsafe { __lsx_vmulwod_h_bu(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
-    __lsx_vmulwev_d_wu_w(a, b)
+pub fn lsx_vmulwev_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vmulwev_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
-    __lsx_vmulwev_w_hu_h(a, b)
+pub fn lsx_vmulwev_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vmulwev_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
-    __lsx_vmulwev_h_bu_b(a, b)
+pub fn lsx_vmulwev_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vmulwev_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
-    __lsx_vmulwod_d_wu_w(a, b)
+pub fn lsx_vmulwod_d_wu_w(a: v4u32, b: v4i32) -> v2i64 {
+    unsafe { __lsx_vmulwod_d_wu_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
-    __lsx_vmulwod_w_hu_h(a, b)
+pub fn lsx_vmulwod_w_hu_h(a: v8u16, b: v8i16) -> v4i32 {
+    unsafe { __lsx_vmulwod_w_hu_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
-    __lsx_vmulwod_h_bu_b(a, b)
+pub fn lsx_vmulwod_h_bu_b(a: v16u8, b: v16i8) -> v8i16 {
+    unsafe { __lsx_vmulwod_h_bu_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmulwev_q_d(a, b)
+pub fn lsx_vmulwev_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmulwev_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vmulwod_q_d(a, b)
+pub fn lsx_vmulwod_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmulwod_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vmulwev_q_du(a, b)
+pub fn lsx_vmulwev_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vmulwev_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
-    __lsx_vmulwod_q_du(a, b)
+pub fn lsx_vmulwod_q_du(a: v2u64, b: v2u64) -> v2i64 {
+    unsafe { __lsx_vmulwod_q_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwev_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
-    __lsx_vmulwev_q_du_d(a, b)
+pub fn lsx_vmulwev_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmulwev_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmulwod_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
-    __lsx_vmulwod_q_du_d(a, b)
+pub fn lsx_vmulwod_q_du_d(a: v2u64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vmulwod_q_du_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vhaddw_q_d(a, b)
+pub fn lsx_vhaddw_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vhaddw_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhaddw_qu_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vhaddw_qu_du(a, b)
+pub fn lsx_vhaddw_qu_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vhaddw_qu_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_q_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vhsubw_q_d(a, b)
+pub fn lsx_vhsubw_q_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vhsubw_q_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vhsubw_qu_du(a: v2u64, b: v2u64) -> v2u64 {
-    __lsx_vhsubw_qu_du(a, b)
+pub fn lsx_vhsubw_qu_du(a: v2u64, b: v2u64) -> v2u64 {
+    unsafe { __lsx_vhsubw_qu_du(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_d_w(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
-    __lsx_vmaddwev_d_w(a, b, c)
+pub fn lsx_vmaddwev_d_w(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
+    unsafe { __lsx_vmaddwev_d_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_w_h(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
-    __lsx_vmaddwev_w_h(a, b, c)
+pub fn lsx_vmaddwev_w_h(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
+    unsafe { __lsx_vmaddwev_w_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_h_b(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
-    __lsx_vmaddwev_h_b(a, b, c)
+pub fn lsx_vmaddwev_h_b(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
+    unsafe { __lsx_vmaddwev_h_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_d_wu(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
-    __lsx_vmaddwev_d_wu(a, b, c)
+pub fn lsx_vmaddwev_d_wu(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
+    unsafe { __lsx_vmaddwev_d_wu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_w_hu(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
-    __lsx_vmaddwev_w_hu(a, b, c)
+pub fn lsx_vmaddwev_w_hu(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
+    unsafe { __lsx_vmaddwev_w_hu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_h_bu(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
-    __lsx_vmaddwev_h_bu(a, b, c)
+pub fn lsx_vmaddwev_h_bu(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
+    unsafe { __lsx_vmaddwev_h_bu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_d_w(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
-    __lsx_vmaddwod_d_w(a, b, c)
+pub fn lsx_vmaddwod_d_w(a: v2i64, b: v4i32, c: v4i32) -> v2i64 {
+    unsafe { __lsx_vmaddwod_d_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_w_h(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
-    __lsx_vmaddwod_w_h(a, b, c)
+pub fn lsx_vmaddwod_w_h(a: v4i32, b: v8i16, c: v8i16) -> v4i32 {
+    unsafe { __lsx_vmaddwod_w_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_h_b(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
-    __lsx_vmaddwod_h_b(a, b, c)
+pub fn lsx_vmaddwod_h_b(a: v8i16, b: v16i8, c: v16i8) -> v8i16 {
+    unsafe { __lsx_vmaddwod_h_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_d_wu(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
-    __lsx_vmaddwod_d_wu(a, b, c)
+pub fn lsx_vmaddwod_d_wu(a: v2u64, b: v4u32, c: v4u32) -> v2u64 {
+    unsafe { __lsx_vmaddwod_d_wu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_w_hu(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
-    __lsx_vmaddwod_w_hu(a, b, c)
+pub fn lsx_vmaddwod_w_hu(a: v4u32, b: v8u16, c: v8u16) -> v4u32 {
+    unsafe { __lsx_vmaddwod_w_hu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_h_bu(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
-    __lsx_vmaddwod_h_bu(a, b, c)
+pub fn lsx_vmaddwod_h_bu(a: v8u16, b: v16u8, c: v16u8) -> v8u16 {
+    unsafe { __lsx_vmaddwod_h_bu(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_d_wu_w(a: v2i64, b: v4u32, c: v4i32) -> v2i64 {
-    __lsx_vmaddwev_d_wu_w(a, b, c)
+pub fn lsx_vmaddwev_d_wu_w(a: v2i64, b: v4u32, c: v4i32) -> v2i64 {
+    unsafe { __lsx_vmaddwev_d_wu_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_w_hu_h(a: v4i32, b: v8u16, c: v8i16) -> v4i32 {
-    __lsx_vmaddwev_w_hu_h(a, b, c)
+pub fn lsx_vmaddwev_w_hu_h(a: v4i32, b: v8u16, c: v8i16) -> v4i32 {
+    unsafe { __lsx_vmaddwev_w_hu_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_h_bu_b(a: v8i16, b: v16u8, c: v16i8) -> v8i16 {
-    __lsx_vmaddwev_h_bu_b(a, b, c)
+pub fn lsx_vmaddwev_h_bu_b(a: v8i16, b: v16u8, c: v16i8) -> v8i16 {
+    unsafe { __lsx_vmaddwev_h_bu_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_d_wu_w(a: v2i64, b: v4u32, c: v4i32) -> v2i64 {
-    __lsx_vmaddwod_d_wu_w(a, b, c)
+pub fn lsx_vmaddwod_d_wu_w(a: v2i64, b: v4u32, c: v4i32) -> v2i64 {
+    unsafe { __lsx_vmaddwod_d_wu_w(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_w_hu_h(a: v4i32, b: v8u16, c: v8i16) -> v4i32 {
-    __lsx_vmaddwod_w_hu_h(a, b, c)
+pub fn lsx_vmaddwod_w_hu_h(a: v4i32, b: v8u16, c: v8i16) -> v4i32 {
+    unsafe { __lsx_vmaddwod_w_hu_h(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_h_bu_b(a: v8i16, b: v16u8, c: v16i8) -> v8i16 {
-    __lsx_vmaddwod_h_bu_b(a, b, c)
+pub fn lsx_vmaddwod_h_bu_b(a: v8i16, b: v16u8, c: v16i8) -> v8i16 {
+    unsafe { __lsx_vmaddwod_h_bu_b(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_q_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
-    __lsx_vmaddwev_q_d(a, b, c)
+pub fn lsx_vmaddwev_q_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmaddwev_q_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_q_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
-    __lsx_vmaddwod_q_d(a, b, c)
+pub fn lsx_vmaddwod_q_d(a: v2i64, b: v2i64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmaddwod_q_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_q_du(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
-    __lsx_vmaddwev_q_du(a, b, c)
+pub fn lsx_vmaddwev_q_du(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
+    unsafe { __lsx_vmaddwev_q_du(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_q_du(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
-    __lsx_vmaddwod_q_du(a, b, c)
+pub fn lsx_vmaddwod_q_du(a: v2u64, b: v2u64, c: v2u64) -> v2u64 {
+    unsafe { __lsx_vmaddwod_q_du(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwev_q_du_d(a: v2i64, b: v2u64, c: v2i64) -> v2i64 {
-    __lsx_vmaddwev_q_du_d(a, b, c)
+pub fn lsx_vmaddwev_q_du_d(a: v2i64, b: v2u64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmaddwev_q_du_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmaddwod_q_du_d(a: v2i64, b: v2u64, c: v2i64) -> v2i64 {
-    __lsx_vmaddwod_q_du_d(a, b, c)
+pub fn lsx_vmaddwod_q_du_d(a: v2i64, b: v2u64, c: v2i64) -> v2i64 {
+    unsafe { __lsx_vmaddwod_q_du_d(a, b, c) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotr_b(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vrotr_b(a, b)
+pub fn lsx_vrotr_b(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vrotr_b(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotr_h(a: v8i16, b: v8i16) -> v8i16 {
-    __lsx_vrotr_h(a, b)
+pub fn lsx_vrotr_h(a: v8i16, b: v8i16) -> v8i16 {
+    unsafe { __lsx_vrotr_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotr_w(a: v4i32, b: v4i32) -> v4i32 {
-    __lsx_vrotr_w(a, b)
+pub fn lsx_vrotr_w(a: v4i32, b: v4i32) -> v4i32 {
+    unsafe { __lsx_vrotr_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotr_d(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vrotr_d(a, b)
+pub fn lsx_vrotr_d(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vrotr_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vadd_q(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vadd_q(a, b)
+pub fn lsx_vadd_q(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vadd_q(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsub_q(a: v2i64, b: v2i64) -> v2i64 {
-    __lsx_vsub_q(a, b)
+pub fn lsx_vsub_q(a: v2i64, b: v2i64) -> v2i64 {
+    unsafe { __lsx_vsub_q(a, b) }
 }
 
 #[inline]
@@ -5809,555 +5809,555 @@ pub unsafe fn lsx_vldrepl_d<const IMM_S9: i32>(mem_addr: *const i8) -> v2i64 {
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmskgez_b(a: v16i8) -> v16i8 {
-    __lsx_vmskgez_b(a)
+pub fn lsx_vmskgez_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vmskgez_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vmsknz_b(a: v16i8) -> v16i8 {
-    __lsx_vmsknz_b(a)
+pub fn lsx_vmsknz_b(a: v16i8) -> v16i8 {
+    unsafe { __lsx_vmsknz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_h_b(a: v16i8) -> v8i16 {
-    __lsx_vexth_h_b(a)
+pub fn lsx_vexth_h_b(a: v16i8) -> v8i16 {
+    unsafe { __lsx_vexth_h_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_w_h(a: v8i16) -> v4i32 {
-    __lsx_vexth_w_h(a)
+pub fn lsx_vexth_w_h(a: v8i16) -> v4i32 {
+    unsafe { __lsx_vexth_w_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_d_w(a: v4i32) -> v2i64 {
-    __lsx_vexth_d_w(a)
+pub fn lsx_vexth_d_w(a: v4i32) -> v2i64 {
+    unsafe { __lsx_vexth_d_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_q_d(a: v2i64) -> v2i64 {
-    __lsx_vexth_q_d(a)
+pub fn lsx_vexth_q_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vexth_q_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_hu_bu(a: v16u8) -> v8u16 {
-    __lsx_vexth_hu_bu(a)
+pub fn lsx_vexth_hu_bu(a: v16u8) -> v8u16 {
+    unsafe { __lsx_vexth_hu_bu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_wu_hu(a: v8u16) -> v4u32 {
-    __lsx_vexth_wu_hu(a)
+pub fn lsx_vexth_wu_hu(a: v8u16) -> v4u32 {
+    unsafe { __lsx_vexth_wu_hu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_du_wu(a: v4u32) -> v2u64 {
-    __lsx_vexth_du_wu(a)
+pub fn lsx_vexth_du_wu(a: v4u32) -> v2u64 {
+    unsafe { __lsx_vexth_du_wu(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vexth_qu_du(a: v2u64) -> v2u64 {
-    __lsx_vexth_qu_du(a)
+pub fn lsx_vexth_qu_du(a: v2u64) -> v2u64 {
+    unsafe { __lsx_vexth_qu_du(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotri_b<const IMM3: u32>(a: v16i8) -> v16i8 {
+pub fn lsx_vrotri_b<const IMM3: u32>(a: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM3, 3);
-    __lsx_vrotri_b(a, IMM3)
+    unsafe { __lsx_vrotri_b(a, IMM3) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotri_h<const IMM4: u32>(a: v8i16) -> v8i16 {
+pub fn lsx_vrotri_h<const IMM4: u32>(a: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vrotri_h(a, IMM4)
+    unsafe { __lsx_vrotri_h(a, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotri_w<const IMM5: u32>(a: v4i32) -> v4i32 {
+pub fn lsx_vrotri_w<const IMM5: u32>(a: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vrotri_w(a, IMM5)
+    unsafe { __lsx_vrotri_w(a, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(1)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrotri_d<const IMM6: u32>(a: v2i64) -> v2i64 {
+pub fn lsx_vrotri_d<const IMM6: u32>(a: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vrotri_d(a, IMM6)
+    unsafe { __lsx_vrotri_d(a, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextl_q_d(a: v2i64) -> v2i64 {
-    __lsx_vextl_q_d(a)
+pub fn lsx_vextl_q_d(a: v2i64) -> v2i64 {
+    unsafe { __lsx_vextl_q_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vsrlni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrlni_b_h(a, b, IMM4)
+    unsafe { __lsx_vsrlni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vsrlni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrlni_h_w(a, b, IMM5)
+    unsafe { __lsx_vsrlni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vsrlni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrlni_w_d(a, b, IMM6)
+    unsafe { __lsx_vsrlni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vsrlni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vsrlni_d_q(a, b, IMM7)
+    unsafe { __lsx_vsrlni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vsrlrni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrlrni_b_h(a, b, IMM4)
+    unsafe { __lsx_vsrlrni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vsrlrni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrlrni_h_w(a, b, IMM5)
+    unsafe { __lsx_vsrlrni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vsrlrni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrlrni_w_d(a, b, IMM6)
+    unsafe { __lsx_vsrlrni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrlrni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vsrlrni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vsrlrni_d_q(a, b, IMM7)
+    unsafe { __lsx_vsrlrni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vssrlni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrlni_b_h(a, b, IMM4)
+    unsafe { __lsx_vssrlni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vssrlni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrlni_h_w(a, b, IMM5)
+    unsafe { __lsx_vssrlni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vssrlni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrlni_w_d(a, b, IMM6)
+    unsafe { __lsx_vssrlni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vssrlni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrlni_d_q(a, b, IMM7)
+    unsafe { __lsx_vssrlni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
+pub fn lsx_vssrlni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrlni_bu_h(a, b, IMM4)
+    unsafe { __lsx_vssrlni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
+pub fn lsx_vssrlni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrlni_hu_w(a, b, IMM5)
+    unsafe { __lsx_vssrlni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
+pub fn lsx_vssrlni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrlni_wu_d(a, b, IMM6)
+    unsafe { __lsx_vssrlni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
+pub fn lsx_vssrlni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrlni_du_q(a, b, IMM7)
+    unsafe { __lsx_vssrlni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vssrlrni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrlrni_b_h(a, b, IMM4)
+    unsafe { __lsx_vssrlrni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vssrlrni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrlrni_h_w(a, b, IMM5)
+    unsafe { __lsx_vssrlrni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vssrlrni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrlrni_w_d(a, b, IMM6)
+    unsafe { __lsx_vssrlrni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vssrlrni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrlrni_d_q(a, b, IMM7)
+    unsafe { __lsx_vssrlrni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
+pub fn lsx_vssrlrni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrlrni_bu_h(a, b, IMM4)
+    unsafe { __lsx_vssrlrni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
+pub fn lsx_vssrlrni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrlrni_hu_w(a, b, IMM5)
+    unsafe { __lsx_vssrlrni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
+pub fn lsx_vssrlrni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrlrni_wu_d(a, b, IMM6)
+    unsafe { __lsx_vssrlrni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
+pub fn lsx_vssrlrni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrlrni_du_q(a, b, IMM7)
+    unsafe { __lsx_vssrlrni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrani_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vsrani_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrani_b_h(a, b, IMM4)
+    unsafe { __lsx_vsrani_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrani_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vsrani_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrani_h_w(a, b, IMM5)
+    unsafe { __lsx_vsrani_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrani_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vsrani_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrani_w_d(a, b, IMM6)
+    unsafe { __lsx_vsrani_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrani_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vsrani_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vsrani_d_q(a, b, IMM7)
+    unsafe { __lsx_vsrani_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vsrarni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vsrarni_b_h(a, b, IMM4)
+    unsafe { __lsx_vsrarni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vsrarni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vsrarni_h_w(a, b, IMM5)
+    unsafe { __lsx_vsrarni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vsrarni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vsrarni_w_d(a, b, IMM6)
+    unsafe { __lsx_vsrarni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vsrarni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vsrarni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vsrarni_d_q(a, b, IMM7)
+    unsafe { __lsx_vsrarni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vssrani_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrani_b_h(a, b, IMM4)
+    unsafe { __lsx_vssrani_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vssrani_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrani_h_w(a, b, IMM5)
+    unsafe { __lsx_vssrani_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vssrani_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrani_w_d(a, b, IMM6)
+    unsafe { __lsx_vssrani_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vssrani_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrani_d_q(a, b, IMM7)
+    unsafe { __lsx_vssrani_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
+pub fn lsx_vssrani_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrani_bu_h(a, b, IMM4)
+    unsafe { __lsx_vssrani_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
+pub fn lsx_vssrani_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrani_hu_w(a, b, IMM5)
+    unsafe { __lsx_vssrani_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
+pub fn lsx_vssrani_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrani_wu_d(a, b, IMM6)
+    unsafe { __lsx_vssrani_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrani_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
+pub fn lsx_vssrani_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrani_du_q(a, b, IMM7)
+    unsafe { __lsx_vssrani_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
+pub fn lsx_vssrarni_b_h<const IMM4: u32>(a: v16i8, b: v16i8) -> v16i8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrarni_b_h(a, b, IMM4)
+    unsafe { __lsx_vssrarni_b_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
+pub fn lsx_vssrarni_h_w<const IMM5: u32>(a: v8i16, b: v8i16) -> v8i16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrarni_h_w(a, b, IMM5)
+    unsafe { __lsx_vssrarni_h_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vssrarni_w_d<const IMM6: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrarni_w_d(a, b, IMM6)
+    unsafe { __lsx_vssrarni_w_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
+pub fn lsx_vssrarni_d_q<const IMM7: u32>(a: v2i64, b: v2i64) -> v2i64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrarni_d_q(a, b, IMM7)
+    unsafe { __lsx_vssrarni_d_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
+pub fn lsx_vssrarni_bu_h<const IMM4: u32>(a: v16u8, b: v16i8) -> v16u8 {
     static_assert_uimm_bits!(IMM4, 4);
-    __lsx_vssrarni_bu_h(a, b, IMM4)
+    unsafe { __lsx_vssrarni_bu_h(a, b, IMM4) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
+pub fn lsx_vssrarni_hu_w<const IMM5: u32>(a: v8u16, b: v8i16) -> v8u16 {
     static_assert_uimm_bits!(IMM5, 5);
-    __lsx_vssrarni_hu_w(a, b, IMM5)
+    unsafe { __lsx_vssrarni_hu_w(a, b, IMM5) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
+pub fn lsx_vssrarni_wu_d<const IMM6: u32>(a: v4u32, b: v4i32) -> v4u32 {
     static_assert_uimm_bits!(IMM6, 6);
-    __lsx_vssrarni_wu_d(a, b, IMM6)
+    unsafe { __lsx_vssrarni_wu_d(a, b, IMM6) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrarni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
+pub fn lsx_vssrarni_du_q<const IMM7: u32>(a: v2u64, b: v2i64) -> v2u64 {
     static_assert_uimm_bits!(IMM7, 7);
-    __lsx_vssrarni_du_q(a, b, IMM7)
+    unsafe { __lsx_vssrarni_du_q(a, b, IMM7) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(2)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vpermi_w<const IMM8: u32>(a: v4i32, b: v4i32) -> v4i32 {
+pub fn lsx_vpermi_w<const IMM8: u32>(a: v4i32, b: v4i32) -> v4i32 {
     static_assert_uimm_bits!(IMM8, 8);
-    __lsx_vpermi_w(a, b, IMM8)
+    unsafe { __lsx_vpermi_w(a, b, IMM8) }
 }
 
 #[inline]
@@ -6381,66 +6381,66 @@ pub unsafe fn lsx_vst<const IMM_S12: i32>(a: v16i8, mem_addr: *mut i8) {
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vssrlrn_b_h(a, b)
+pub fn lsx_vssrlrn_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vssrlrn_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vssrlrn_h_w(a, b)
+pub fn lsx_vssrlrn_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vssrlrn_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrlrn_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vssrlrn_w_d(a, b)
+pub fn lsx_vssrlrn_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vssrlrn_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_b_h(a: v8i16, b: v8i16) -> v16i8 {
-    __lsx_vssrln_b_h(a, b)
+pub fn lsx_vssrln_b_h(a: v8i16, b: v8i16) -> v16i8 {
+    unsafe { __lsx_vssrln_b_h(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_h_w(a: v4i32, b: v4i32) -> v8i16 {
-    __lsx_vssrln_h_w(a, b)
+pub fn lsx_vssrln_h_w(a: v4i32, b: v4i32) -> v8i16 {
+    unsafe { __lsx_vssrln_h_w(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vssrln_w_d(a: v2i64, b: v2i64) -> v4i32 {
-    __lsx_vssrln_w_d(a, b)
+pub fn lsx_vssrln_w_d(a: v2i64, b: v2i64) -> v4i32 {
+    unsafe { __lsx_vssrln_w_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vorn_v(a: v16i8, b: v16i8) -> v16i8 {
-    __lsx_vorn_v(a, b)
+pub fn lsx_vorn_v(a: v16i8, b: v16i8) -> v16i8 {
+    unsafe { __lsx_vorn_v(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vldi<const IMM_S13: i32>() -> v2i64 {
+pub fn lsx_vldi<const IMM_S13: i32>() -> v2i64 {
     static_assert_simm_bits!(IMM_S13, 13);
-    __lsx_vldi(IMM_S13)
+    unsafe { __lsx_vldi(IMM_S13) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vshuf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
-    __lsx_vshuf_b(a, b, c)
+pub fn lsx_vshuf_b(a: v16i8, b: v16i8, c: v16i8) -> v16i8 {
+    unsafe { __lsx_vshuf_b(a, b, c) }
 }
 
 #[inline]
@@ -6460,420 +6460,420 @@ pub unsafe fn lsx_vstx(a: v16i8, mem_addr: *mut i8, b: i64) {
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vextl_qu_du(a: v2u64) -> v2u64 {
-    __lsx_vextl_qu_du(a)
+pub fn lsx_vextl_qu_du(a: v2u64) -> v2u64 {
+    unsafe { __lsx_vextl_qu_du(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bnz_b(a: v16u8) -> i32 {
-    __lsx_bnz_b(a)
+pub fn lsx_bnz_b(a: v16u8) -> i32 {
+    unsafe { __lsx_bnz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bnz_d(a: v2u64) -> i32 {
-    __lsx_bnz_d(a)
+pub fn lsx_bnz_d(a: v2u64) -> i32 {
+    unsafe { __lsx_bnz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bnz_h(a: v8u16) -> i32 {
-    __lsx_bnz_h(a)
+pub fn lsx_bnz_h(a: v8u16) -> i32 {
+    unsafe { __lsx_bnz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bnz_v(a: v16u8) -> i32 {
-    __lsx_bnz_v(a)
+pub fn lsx_bnz_v(a: v16u8) -> i32 {
+    unsafe { __lsx_bnz_v(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bnz_w(a: v4u32) -> i32 {
-    __lsx_bnz_w(a)
+pub fn lsx_bnz_w(a: v4u32) -> i32 {
+    unsafe { __lsx_bnz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bz_b(a: v16u8) -> i32 {
-    __lsx_bz_b(a)
+pub fn lsx_bz_b(a: v16u8) -> i32 {
+    unsafe { __lsx_bz_b(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bz_d(a: v2u64) -> i32 {
-    __lsx_bz_d(a)
+pub fn lsx_bz_d(a: v2u64) -> i32 {
+    unsafe { __lsx_bz_d(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bz_h(a: v8u16) -> i32 {
-    __lsx_bz_h(a)
+pub fn lsx_bz_h(a: v8u16) -> i32 {
+    unsafe { __lsx_bz_h(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bz_v(a: v16u8) -> i32 {
-    __lsx_bz_v(a)
+pub fn lsx_bz_v(a: v16u8) -> i32 {
+    unsafe { __lsx_bz_v(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_bz_w(a: v4u32) -> i32 {
-    __lsx_bz_w(a)
+pub fn lsx_bz_w(a: v4u32) -> i32 {
+    unsafe { __lsx_bz_w(a) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_caf_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_caf_d(a, b)
+pub fn lsx_vfcmp_caf_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_caf_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_caf_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_caf_s(a, b)
+pub fn lsx_vfcmp_caf_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_caf_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_ceq_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_ceq_d(a, b)
+pub fn lsx_vfcmp_ceq_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_ceq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_ceq_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_ceq_s(a, b)
+pub fn lsx_vfcmp_ceq_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_ceq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cle_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cle_d(a, b)
+pub fn lsx_vfcmp_cle_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cle_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cle_s(a, b)
+pub fn lsx_vfcmp_cle_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cle_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_clt_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_clt_d(a, b)
+pub fn lsx_vfcmp_clt_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_clt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_clt_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_clt_s(a, b)
+pub fn lsx_vfcmp_clt_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_clt_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cne_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cne_d(a, b)
+pub fn lsx_vfcmp_cne_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cne_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cne_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cne_s(a, b)
+pub fn lsx_vfcmp_cne_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cne_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cor_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cor_d(a, b)
+pub fn lsx_vfcmp_cor_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cor_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cor_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cor_s(a, b)
+pub fn lsx_vfcmp_cor_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cor_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cueq_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cueq_d(a, b)
+pub fn lsx_vfcmp_cueq_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cueq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cueq_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cueq_s(a, b)
+pub fn lsx_vfcmp_cueq_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cueq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cule_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cule_d(a, b)
+pub fn lsx_vfcmp_cule_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cule_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cule_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cule_s(a, b)
+pub fn lsx_vfcmp_cule_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cule_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cult_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cult_d(a, b)
+pub fn lsx_vfcmp_cult_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cult_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cult_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cult_s(a, b)
+pub fn lsx_vfcmp_cult_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cult_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cun_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cun_d(a, b)
+pub fn lsx_vfcmp_cun_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cun_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cune_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_cune_d(a, b)
+pub fn lsx_vfcmp_cune_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_cune_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cune_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cune_s(a, b)
+pub fn lsx_vfcmp_cune_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cune_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_cun_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_cun_s(a, b)
+pub fn lsx_vfcmp_cun_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_cun_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_saf_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_saf_d(a, b)
+pub fn lsx_vfcmp_saf_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_saf_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_saf_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_saf_s(a, b)
+pub fn lsx_vfcmp_saf_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_saf_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_seq_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_seq_d(a, b)
+pub fn lsx_vfcmp_seq_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_seq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_seq_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_seq_s(a, b)
+pub fn lsx_vfcmp_seq_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_seq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sle_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sle_d(a, b)
+pub fn lsx_vfcmp_sle_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sle_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sle_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sle_s(a, b)
+pub fn lsx_vfcmp_sle_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sle_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_slt_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_slt_d(a, b)
+pub fn lsx_vfcmp_slt_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_slt_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_slt_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_slt_s(a, b)
+pub fn lsx_vfcmp_slt_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_slt_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sne_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sne_d(a, b)
+pub fn lsx_vfcmp_sne_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sne_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sne_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sne_s(a, b)
+pub fn lsx_vfcmp_sne_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sne_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sor_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sor_d(a, b)
+pub fn lsx_vfcmp_sor_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sor_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sor_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sor_s(a, b)
+pub fn lsx_vfcmp_sor_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sor_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sueq_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sueq_d(a, b)
+pub fn lsx_vfcmp_sueq_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sueq_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sueq_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sueq_s(a, b)
+pub fn lsx_vfcmp_sueq_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sueq_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sule_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sule_d(a, b)
+pub fn lsx_vfcmp_sule_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sule_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sule_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sule_s(a, b)
+pub fn lsx_vfcmp_sule_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sule_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sult_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sult_d(a, b)
+pub fn lsx_vfcmp_sult_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sult_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sult_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sult_s(a, b)
+pub fn lsx_vfcmp_sult_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sult_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sun_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sun_d(a, b)
+pub fn lsx_vfcmp_sun_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sun_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sune_d(a: v2f64, b: v2f64) -> v2i64 {
-    __lsx_vfcmp_sune_d(a, b)
+pub fn lsx_vfcmp_sune_d(a: v2f64, b: v2f64) -> v2i64 {
+    unsafe { __lsx_vfcmp_sune_d(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sune_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sune_s(a, b)
+pub fn lsx_vfcmp_sune_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sune_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vfcmp_sun_s(a: v4f32, b: v4f32) -> v4i32 {
-    __lsx_vfcmp_sun_s(a, b)
-}
-
-#[inline]
-#[target_feature(enable = "lsx")]
-#[rustc_legacy_const_generics(0)]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrepli_b<const IMM_S10: i32>() -> v16i8 {
-    static_assert_simm_bits!(IMM_S10, 10);
-    __lsx_vrepli_b(IMM_S10)
+pub fn lsx_vfcmp_sun_s(a: v4f32, b: v4f32) -> v4i32 {
+    unsafe { __lsx_vfcmp_sun_s(a, b) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrepli_d<const IMM_S10: i32>() -> v2i64 {
+pub fn lsx_vrepli_b<const IMM_S10: i32>() -> v16i8 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lsx_vrepli_d(IMM_S10)
+    unsafe { __lsx_vrepli_b(IMM_S10) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrepli_h<const IMM_S10: i32>() -> v8i16 {
+pub fn lsx_vrepli_d<const IMM_S10: i32>() -> v2i64 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lsx_vrepli_h(IMM_S10)
+    unsafe { __lsx_vrepli_d(IMM_S10) }
 }
 
 #[inline]
 #[target_feature(enable = "lsx")]
 #[rustc_legacy_const_generics(0)]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn lsx_vrepli_w<const IMM_S10: i32>() -> v4i32 {
+pub fn lsx_vrepli_h<const IMM_S10: i32>() -> v8i16 {
     static_assert_simm_bits!(IMM_S10, 10);
-    __lsx_vrepli_w(IMM_S10)
+    unsafe { __lsx_vrepli_h(IMM_S10) }
+}
+
+#[inline]
+#[target_feature(enable = "lsx")]
+#[rustc_legacy_const_generics(0)]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub fn lsx_vrepli_w<const IMM_S10: i32>() -> v4i32 {
+    static_assert_simm_bits!(IMM_S10, 10);
+    unsafe { __lsx_vrepli_w(IMM_S10) }
 }

--- a/library/stdarch/crates/core_arch/src/loongarch64/mod.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch64/mod.rs
@@ -1,4 +1,4 @@
-//! `LoongArch` intrinsics
+//! `LoongArch64` intrinsics
 
 mod lasx;
 mod lsx;
@@ -20,82 +20,24 @@ pub unsafe fn rdtime_d() -> (i64, isize) {
     (val, tid)
 }
 
-/// Reads the lower 32-bit stable counter value and the counter ID
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn rdtimel_w() -> (i32, isize) {
-    let val: i32;
-    let tid: isize;
-    asm!("rdtimel.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
-    (val, tid)
-}
-
-/// Reads the upper 32-bit stable counter value and the counter ID
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn rdtimeh_w() -> (i32, isize) {
-    let val: i32;
-    let tid: isize;
-    asm!("rdtimeh.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
-    (val, tid)
-}
-
 #[allow(improper_ctypes)]
 unsafe extern "unadjusted" {
-    #[link_name = "llvm.loongarch.crc.w.b.w"]
-    fn __crc_w_b_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crc.w.h.w"]
-    fn __crc_w_h_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crc.w.w.w"]
-    fn __crc_w_w_w(a: i32, b: i32) -> i32;
     #[link_name = "llvm.loongarch.crc.w.d.w"]
     fn __crc_w_d_w(a: i64, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.b.w"]
-    fn __crcc_w_b_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.h.w"]
-    fn __crcc_w_h_w(a: i32, b: i32) -> i32;
-    #[link_name = "llvm.loongarch.crcc.w.w.w"]
-    fn __crcc_w_w_w(a: i32, b: i32) -> i32;
     #[link_name = "llvm.loongarch.crcc.w.d.w"]
     fn __crcc_w_d_w(a: i64, b: i32) -> i32;
     #[link_name = "llvm.loongarch.cacop.d"]
     fn __cacop(a: i64, b: i64, c: i64);
-    #[link_name = "llvm.loongarch.dbar"]
-    fn __dbar(a: i32);
-    #[link_name = "llvm.loongarch.ibar"]
-    fn __ibar(a: i32);
-    #[link_name = "llvm.loongarch.movgr2fcsr"]
-    fn __movgr2fcsr(a: i32, b: i32);
-    #[link_name = "llvm.loongarch.movfcsr2gr"]
-    fn __movfcsr2gr(a: i32) -> i32;
     #[link_name = "llvm.loongarch.csrrd.d"]
     fn __csrrd(a: i32) -> i64;
     #[link_name = "llvm.loongarch.csrwr.d"]
     fn __csrwr(a: i64, b: i32) -> i64;
     #[link_name = "llvm.loongarch.csrxchg.d"]
     fn __csrxchg(a: i64, b: i64, c: i32) -> i64;
-    #[link_name = "llvm.loongarch.iocsrrd.b"]
-    fn __iocsrrd_b(a: i32) -> i32;
-    #[link_name = "llvm.loongarch.iocsrrd.h"]
-    fn __iocsrrd_h(a: i32) -> i32;
-    #[link_name = "llvm.loongarch.iocsrrd.w"]
-    fn __iocsrrd_w(a: i32) -> i32;
     #[link_name = "llvm.loongarch.iocsrrd.d"]
     fn __iocsrrd_d(a: i32) -> i64;
-    #[link_name = "llvm.loongarch.iocsrwr.b"]
-    fn __iocsrwr_b(a: i32, b: i32);
-    #[link_name = "llvm.loongarch.iocsrwr.h"]
-    fn __iocsrwr_h(a: i32, b: i32);
-    #[link_name = "llvm.loongarch.iocsrwr.w"]
-    fn __iocsrwr_w(a: i32, b: i32);
     #[link_name = "llvm.loongarch.iocsrwr.d"]
     fn __iocsrwr_d(a: i64, b: i32);
-    #[link_name = "llvm.loongarch.break"]
-    fn __break(a: i32);
-    #[link_name = "llvm.loongarch.cpucfg"]
-    fn __cpucfg(a: i32) -> i32;
-    #[link_name = "llvm.loongarch.syscall"]
-    fn __syscall(a: i32);
     #[link_name = "llvm.loongarch.asrtle.d"]
     fn __asrtle(a: i64, b: i64);
     #[link_name = "llvm.loongarch.asrtgt.d"]
@@ -104,35 +46,6 @@ unsafe extern "unadjusted" {
     fn __lddir(a: i64, b: i64) -> i64;
     #[link_name = "llvm.loongarch.ldpte.d"]
     fn __ldpte(a: i64, b: i64);
-    #[link_name = "llvm.loongarch.frecipe.s"]
-    fn __frecipe_s(a: f32) -> f32;
-    #[link_name = "llvm.loongarch.frecipe.d"]
-    fn __frecipe_d(a: f64) -> f64;
-    #[link_name = "llvm.loongarch.frsqrte.s"]
-    fn __frsqrte_s(a: f32) -> f32;
-    #[link_name = "llvm.loongarch.frsqrte.d"]
-    fn __frsqrte_d(a: f64) -> f64;
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_b_w(a: i32, b: i32) -> i32 {
-    __crc_w_b_w(a, b)
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_h_w(a: i32, b: i32) -> i32 {
-    __crc_w_h_w(a, b)
-}
-
-/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_w_w(a: i32, b: i32) -> i32 {
-    __crc_w_w_w(a, b)
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
@@ -140,27 +53,6 @@ pub unsafe fn crc_w_w_w(a: i32, b: i32) -> i32 {
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn crc_w_d_w(a: i64, b: i32) -> i32 {
     __crc_w_d_w(a, b)
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_b_w(a: i32, b: i32) -> i32 {
-    __crcc_w_b_w(a, b)
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_h_w(a: i32, b: i32) -> i32 {
-    __crcc_w_h_w(a, b)
-}
-
-/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_w_w(a: i32, b: i32) -> i32 {
-    __crcc_w_w_w(a, b)
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
@@ -176,38 +68,6 @@ pub unsafe fn crcc_w_d_w(a: i64, b: i32) -> i32 {
 pub unsafe fn cacop<const IMM12: i64>(a: i64, b: i64) {
     static_assert_simm_bits!(IMM12, 12);
     __cacop(a, b, IMM12);
-}
-
-/// Generates the memory barrier instruction
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn dbar<const IMM15: i32>() {
-    static_assert_uimm_bits!(IMM15, 15);
-    __dbar(IMM15);
-}
-
-/// Generates the instruction-fetch barrier instruction
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn ibar<const IMM15: i32>() {
-    static_assert_uimm_bits!(IMM15, 15);
-    __ibar(IMM15);
-}
-
-/// Moves data from a GPR to the FCSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn movgr2fcsr<const IMM5: i32>(a: i32) {
-    static_assert_uimm_bits!(IMM5, 5);
-    __movgr2fcsr(IMM5, a);
-}
-
-/// Moves data from a FCSR to the GPR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn movfcsr2gr<const IMM5: i32>() -> i32 {
-    static_assert_uimm_bits!(IMM5, 5);
-    __movfcsr2gr(IMM5)
 }
 
 /// Reads the CSR
@@ -234,27 +94,6 @@ pub unsafe fn csrxchg<const IMM14: i32>(a: i64, b: i64) -> i64 {
     __csrxchg(a, b, IMM14)
 }
 
-/// Reads the 8-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrrd_b(a: i32) -> i32 {
-    __iocsrrd_b(a)
-}
-
-/// Reads the 16-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrrd_h(a: i32) -> i32 {
-    __iocsrrd_h(a)
-}
-
-/// Reads the 32-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrrd_w(a: i32) -> i32 {
-    __iocsrrd_w(a)
-}
-
 /// Reads the 64-bit IO-CSR
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
@@ -262,55 +101,11 @@ pub unsafe fn iocsrrd_d(a: i32) -> i64 {
     __iocsrrd_d(a)
 }
 
-/// Writes the 8-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrwr_b(a: i32, b: i32) {
-    __iocsrwr_b(a, b)
-}
-
-/// Writes the 16-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrwr_h(a: i32, b: i32) {
-    __iocsrwr_h(a, b)
-}
-
-/// Writes the 32-bit IO-CSR
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn iocsrwr_w(a: i32, b: i32) {
-    __iocsrwr_w(a, b)
-}
-
 /// Writes the 64-bit IO-CSR
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn iocsrwr_d(a: i64, b: i32) {
     __iocsrwr_d(a, b)
-}
-
-/// Generates the breakpoint instruction
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn brk<const IMM15: i32>() {
-    static_assert_uimm_bits!(IMM15, 15);
-    __break(IMM15);
-}
-
-/// Reads the CPU configuration register
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn cpucfg(a: i32) -> i32 {
-    __cpucfg(a)
-}
-
-/// Generates the syscall instruction
-#[inline]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn syscall<const IMM15: i32>() {
-    static_assert_uimm_bits!(IMM15, 15);
-    __syscall(IMM15);
 }
 
 /// Generates the less-than-or-equal asseration instruction
@@ -341,36 +136,4 @@ pub unsafe fn lddir<const B: i64>(a: i64) -> i64 {
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
 pub unsafe fn ldpte<const B: i64>(a: i64) {
     __ldpte(a, B)
-}
-
-/// Calculate the approximate single-precision result of 1.0 divided
-#[inline]
-#[target_feature(enable = "frecipe")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frecipe_s(a: f32) -> f32 {
-    __frecipe_s(a)
-}
-
-/// Calculate the approximate double-precision result of 1.0 divided
-#[inline]
-#[target_feature(enable = "frecipe")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frecipe_d(a: f64) -> f64 {
-    __frecipe_d(a)
-}
-
-/// Calculate the approximate single-precision result of dividing 1.0 by the square root
-#[inline]
-#[target_feature(enable = "frecipe")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frsqrte_s(a: f32) -> f32 {
-    __frsqrte_s(a)
-}
-
-/// Calculate the approximate double-precision result of dividing 1.0 by the square root
-#[inline]
-#[target_feature(enable = "frecipe")]
-#[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frsqrte_d(a: f64) -> f64 {
-    __frsqrte_d(a)
 }

--- a/library/stdarch/crates/core_arch/src/loongarch64/mod.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch64/mod.rs
@@ -13,10 +13,9 @@ use crate::arch::asm;
 /// Reads the 64-bit stable counter value and the counter ID
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn rdtime_d() -> (i64, isize) {
-    let val: i64;
-    let tid: isize;
-    asm!("rdtime.d {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
+pub fn rdtime_d() -> (i64, isize) {
+    let (val, tid): (i64, isize);
+    unsafe { asm!("rdtime.d {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack)) };
     (val, tid)
 }
 
@@ -51,15 +50,15 @@ unsafe extern "unadjusted" {
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_d_w(a: i64, b: i32) -> i32 {
-    __crc_w_d_w(a, b)
+pub fn crc_w_d_w(a: i64, b: i32) -> i32 {
+    unsafe { __crc_w_d_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_d_w(a: i64, b: i32) -> i32 {
-    __crcc_w_d_w(a, b)
+pub fn crcc_w_d_w(a: i64, b: i32) -> i32 {
+    unsafe { __crcc_w_d_w(a, b) }
 }
 
 /// Generates the cache operation instruction

--- a/library/stdarch/crates/core_arch/src/loongarch_shared/mod.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch_shared/mod.rs
@@ -1,0 +1,244 @@
+//! `Shared LoongArch` intrinsics
+
+use crate::arch::asm;
+
+/// Reads the lower 32-bit stable counter value and the counter ID
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn rdtimel_w() -> (i32, isize) {
+    let val: i32;
+    let tid: isize;
+    asm!("rdtimel.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
+    (val, tid)
+}
+
+/// Reads the upper 32-bit stable counter value and the counter ID
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn rdtimeh_w() -> (i32, isize) {
+    let val: i32;
+    let tid: isize;
+    asm!("rdtimeh.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
+    (val, tid)
+}
+
+#[allow(improper_ctypes)]
+unsafe extern "unadjusted" {
+    #[link_name = "llvm.loongarch.crc.w.b.w"]
+    fn __crc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crc.w.h.w"]
+    fn __crc_w_h_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crc.w.w.w"]
+    fn __crc_w_w_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.b.w"]
+    fn __crcc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.h.w"]
+    fn __crcc_w_h_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.w.w"]
+    fn __crcc_w_w_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.dbar"]
+    fn __dbar(a: i32);
+    #[link_name = "llvm.loongarch.ibar"]
+    fn __ibar(a: i32);
+    #[link_name = "llvm.loongarch.movgr2fcsr"]
+    fn __movgr2fcsr(a: i32, b: i32);
+    #[link_name = "llvm.loongarch.movfcsr2gr"]
+    fn __movfcsr2gr(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.iocsrrd.b"]
+    fn __iocsrrd_b(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.iocsrrd.h"]
+    fn __iocsrrd_h(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.iocsrrd.w"]
+    fn __iocsrrd_w(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.iocsrwr.b"]
+    fn __iocsrwr_b(a: i32, b: i32);
+    #[link_name = "llvm.loongarch.iocsrwr.h"]
+    fn __iocsrwr_h(a: i32, b: i32);
+    #[link_name = "llvm.loongarch.iocsrwr.w"]
+    fn __iocsrwr_w(a: i32, b: i32);
+    #[link_name = "llvm.loongarch.break"]
+    fn __break(a: i32);
+    #[link_name = "llvm.loongarch.cpucfg"]
+    fn __cpucfg(a: i32) -> i32;
+    #[link_name = "llvm.loongarch.syscall"]
+    fn __syscall(a: i32);
+    #[link_name = "llvm.loongarch.frecipe.s"]
+    fn __frecipe_s(a: f32) -> f32;
+    #[link_name = "llvm.loongarch.frecipe.d"]
+    fn __frecipe_d(a: f64) -> f64;
+    #[link_name = "llvm.loongarch.frsqrte.s"]
+    fn __frsqrte_s(a: f32) -> f32;
+    #[link_name = "llvm.loongarch.frsqrte.d"]
+    fn __frsqrte_d(a: f64) -> f64;
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crc_w_b_w(a: i32, b: i32) -> i32 {
+    __crc_w_b_w(a, b)
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crc_w_h_w(a: i32, b: i32) -> i32 {
+    __crc_w_h_w(a, b)
+}
+
+/// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crc_w_w_w(a: i32, b: i32) -> i32 {
+    __crc_w_w_w(a, b)
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crcc_w_b_w(a: i32, b: i32) -> i32 {
+    __crcc_w_b_w(a, b)
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crcc_w_h_w(a: i32, b: i32) -> i32 {
+    __crcc_w_h_w(a, b)
+}
+
+/// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn crcc_w_w_w(a: i32, b: i32) -> i32 {
+    __crcc_w_w_w(a, b)
+}
+
+/// Generates the memory barrier instruction
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn dbar<const IMM15: i32>() {
+    static_assert_uimm_bits!(IMM15, 15);
+    __dbar(IMM15);
+}
+
+/// Generates the instruction-fetch barrier instruction
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn ibar<const IMM15: i32>() {
+    static_assert_uimm_bits!(IMM15, 15);
+    __ibar(IMM15);
+}
+
+/// Moves data from a GPR to the FCSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn movgr2fcsr<const IMM5: i32>(a: i32) {
+    static_assert_uimm_bits!(IMM5, 5);
+    __movgr2fcsr(IMM5, a);
+}
+
+/// Moves data from a FCSR to the GPR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn movfcsr2gr<const IMM5: i32>() -> i32 {
+    static_assert_uimm_bits!(IMM5, 5);
+    __movfcsr2gr(IMM5)
+}
+
+/// Reads the 8-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrrd_b(a: i32) -> i32 {
+    __iocsrrd_b(a)
+}
+
+/// Reads the 16-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrrd_h(a: i32) -> i32 {
+    __iocsrrd_h(a)
+}
+
+/// Reads the 32-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrrd_w(a: i32) -> i32 {
+    __iocsrrd_w(a)
+}
+
+/// Writes the 8-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrwr_b(a: i32, b: i32) {
+    __iocsrwr_b(a, b)
+}
+
+/// Writes the 16-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrwr_h(a: i32, b: i32) {
+    __iocsrwr_h(a, b)
+}
+
+/// Writes the 32-bit IO-CSR
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn iocsrwr_w(a: i32, b: i32) {
+    __iocsrwr_w(a, b)
+}
+
+/// Generates the breakpoint instruction
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn brk<const IMM15: i32>() {
+    static_assert_uimm_bits!(IMM15, 15);
+    __break(IMM15);
+}
+
+/// Reads the CPU configuration register
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn cpucfg(a: i32) -> i32 {
+    __cpucfg(a)
+}
+
+/// Generates the syscall instruction
+#[inline]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn syscall<const IMM15: i32>() {
+    static_assert_uimm_bits!(IMM15, 15);
+    __syscall(IMM15);
+}
+
+/// Calculate the approximate single-precision result of 1.0 divided
+#[inline]
+#[target_feature(enable = "frecipe")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn frecipe_s(a: f32) -> f32 {
+    __frecipe_s(a)
+}
+
+/// Calculate the approximate double-precision result of 1.0 divided
+#[inline]
+#[target_feature(enable = "frecipe")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn frecipe_d(a: f64) -> f64 {
+    __frecipe_d(a)
+}
+
+/// Calculate the approximate single-precision result of dividing 1.0 by the square root
+#[inline]
+#[target_feature(enable = "frecipe")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn frsqrte_s(a: f32) -> f32 {
+    __frsqrte_s(a)
+}
+
+/// Calculate the approximate double-precision result of dividing 1.0 by the square root
+#[inline]
+#[target_feature(enable = "frecipe")]
+#[unstable(feature = "stdarch_loongarch", issue = "117427")]
+pub unsafe fn frsqrte_d(a: f64) -> f64 {
+    __frsqrte_d(a)
+}

--- a/library/stdarch/crates/core_arch/src/loongarch_shared/mod.rs
+++ b/library/stdarch/crates/core_arch/src/loongarch_shared/mod.rs
@@ -5,20 +5,18 @@ use crate::arch::asm;
 /// Reads the lower 32-bit stable counter value and the counter ID
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn rdtimel_w() -> (i32, isize) {
-    let val: i32;
-    let tid: isize;
-    asm!("rdtimel.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
+pub fn rdtimel_w() -> (i32, isize) {
+    let (val, tid): (i32, isize);
+    unsafe { asm!("rdtimel.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack)) };
     (val, tid)
 }
 
 /// Reads the upper 32-bit stable counter value and the counter ID
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn rdtimeh_w() -> (i32, isize) {
-    let val: i32;
-    let tid: isize;
-    asm!("rdtimeh.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack));
+pub fn rdtimeh_w() -> (i32, isize) {
+    let (val, tid): (i32, isize);
+    unsafe { asm!("rdtimeh.w {}, {}", out(reg) val, out(reg) tid, options(readonly, nostack)) };
     (val, tid)
 }
 
@@ -75,59 +73,59 @@ unsafe extern "unadjusted" {
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_b_w(a: i32, b: i32) -> i32 {
-    __crc_w_b_w(a, b)
+pub fn crc_w_b_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_b_w(a, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_h_w(a: i32, b: i32) -> i32 {
-    __crc_w_h_w(a, b)
+pub fn crc_w_h_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_h_w(a, b) }
 }
 
 /// Calculate the CRC value using the IEEE 802.3 polynomial (0xEDB88320)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crc_w_w_w(a: i32, b: i32) -> i32 {
-    __crc_w_w_w(a, b)
+pub fn crc_w_w_w(a: i32, b: i32) -> i32 {
+    unsafe { __crc_w_w_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_b_w(a: i32, b: i32) -> i32 {
-    __crcc_w_b_w(a, b)
+pub fn crcc_w_b_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_b_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_h_w(a: i32, b: i32) -> i32 {
-    __crcc_w_h_w(a, b)
+pub fn crcc_w_h_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_h_w(a, b) }
 }
 
 /// Calculate the CRC value using the Castagnoli polynomial (0x82F63B78)
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn crcc_w_w_w(a: i32, b: i32) -> i32 {
-    __crcc_w_w_w(a, b)
+pub fn crcc_w_w_w(a: i32, b: i32) -> i32 {
+    unsafe { __crcc_w_w_w(a, b) }
 }
 
 /// Generates the memory barrier instruction
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn dbar<const IMM15: i32>() {
+pub fn dbar<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);
-    __dbar(IMM15);
+    unsafe { __dbar(IMM15) };
 }
 
 /// Generates the instruction-fetch barrier instruction
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn ibar<const IMM15: i32>() {
+pub fn ibar<const IMM15: i32>() {
     static_assert_uimm_bits!(IMM15, 15);
-    __ibar(IMM15);
+    unsafe { __ibar(IMM15) };
 }
 
 /// Moves data from a GPR to the FCSR
@@ -141,9 +139,9 @@ pub unsafe fn movgr2fcsr<const IMM5: i32>(a: i32) {
 /// Moves data from a FCSR to the GPR
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn movfcsr2gr<const IMM5: i32>() -> i32 {
+pub fn movfcsr2gr<const IMM5: i32>() -> i32 {
     static_assert_uimm_bits!(IMM5, 5);
-    __movfcsr2gr(IMM5)
+    unsafe { __movfcsr2gr(IMM5) }
 }
 
 /// Reads the 8-bit IO-CSR
@@ -199,8 +197,8 @@ pub unsafe fn brk<const IMM15: i32>() {
 /// Reads the CPU configuration register
 #[inline]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn cpucfg(a: i32) -> i32 {
-    __cpucfg(a)
+pub fn cpucfg(a: i32) -> i32 {
+    unsafe { __cpucfg(a) }
 }
 
 /// Generates the syscall instruction
@@ -215,30 +213,30 @@ pub unsafe fn syscall<const IMM15: i32>() {
 #[inline]
 #[target_feature(enable = "frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frecipe_s(a: f32) -> f32 {
-    __frecipe_s(a)
+pub fn frecipe_s(a: f32) -> f32 {
+    unsafe { __frecipe_s(a) }
 }
 
 /// Calculate the approximate double-precision result of 1.0 divided
 #[inline]
 #[target_feature(enable = "frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frecipe_d(a: f64) -> f64 {
-    __frecipe_d(a)
+pub fn frecipe_d(a: f64) -> f64 {
+    unsafe { __frecipe_d(a) }
 }
 
 /// Calculate the approximate single-precision result of dividing 1.0 by the square root
 #[inline]
 #[target_feature(enable = "frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frsqrte_s(a: f32) -> f32 {
-    __frsqrte_s(a)
+pub fn frsqrte_s(a: f32) -> f32 {
+    unsafe { __frsqrte_s(a) }
 }
 
 /// Calculate the approximate double-precision result of dividing 1.0 by the square root
 #[inline]
 #[target_feature(enable = "frecipe")]
 #[unstable(feature = "stdarch_loongarch", issue = "117427")]
-pub unsafe fn frsqrte_d(a: f64) -> f64 {
-    __frsqrte_d(a)
+pub fn frsqrte_d(a: f64) -> f64 {
+    unsafe { __frsqrte_d(a) }
 }

--- a/library/stdarch/crates/core_arch/src/mod.rs
+++ b/library/stdarch/crates/core_arch/src/mod.rs
@@ -16,6 +16,9 @@ mod riscv_shared;
 ))]
 mod arm_shared;
 
+#[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64", doc))]
+mod loongarch_shared;
+
 mod simd;
 
 #[doc = include_str!("core_arch_docs.md")]
@@ -271,13 +274,25 @@ pub mod arch {
         pub use crate::core_arch::nvptx::*;
     }
 
-    /// Platform-specific intrinsics for the `loongarch` platform.
+    /// Platform-specific intrinsics for the `loongarch32` platform.
+    ///
+    /// See the [module documentation](../index.html) for more details.
+    #[cfg(any(target_arch = "loongarch32", doc))]
+    #[doc(cfg(target_arch = "loongarch32"))]
+    #[unstable(feature = "stdarch_loongarch", issue = "117427")]
+    pub mod loongarch32 {
+        pub use crate::core_arch::loongarch_shared::*;
+        pub use crate::core_arch::loongarch32::*;
+    }
+
+    /// Platform-specific intrinsics for the `loongarch64` platform.
     ///
     /// See the [module documentation](../index.html) for more details.
     #[cfg(any(target_arch = "loongarch64", doc))]
     #[doc(cfg(target_arch = "loongarch64"))]
     #[unstable(feature = "stdarch_loongarch", issue = "117427")]
     pub mod loongarch64 {
+        pub use crate::core_arch::loongarch_shared::*;
         pub use crate::core_arch::loongarch64::*;
     }
 
@@ -333,6 +348,10 @@ mod powerpc64;
 #[cfg(any(target_arch = "nvptx64", doc))]
 #[doc(cfg(target_arch = "nvptx64"))]
 mod nvptx;
+
+#[cfg(any(target_arch = "loongarch32", doc))]
+#[doc(cfg(target_arch = "loongarch32"))]
+mod loongarch32;
 
 #[cfg(any(target_arch = "loongarch64", doc))]
 #[doc(cfg(target_arch = "loongarch64"))]

--- a/library/stdarch/crates/core_arch/src/s390x/vector.rs
+++ b/library/stdarch/crates/core_arch/src/s390x/vector.rs
@@ -2265,14 +2265,14 @@ mod sealed {
 
     #[inline]
     #[target_feature(enable = "vector")]
-    #[cfg_attr(test, assert_instr("vlbb"))]
+    #[cfg_attr(test, assert_instr(vlbb))]
     unsafe fn test_vec_load_bndry(ptr: *const i32) -> MaybeUninit<vector_signed_int> {
         vector_signed_int::vec_load_bndry::<512>(ptr)
     }
 
     #[inline]
     #[target_feature(enable = "vector")]
-    #[cfg_attr(test, assert_instr(vst))]
+    #[cfg_attr(test, assert_instr(vstl))]
     unsafe fn test_vec_store_len(vector: vector_signed_int, ptr: *mut i32, byte_count: u32) {
         vector.vec_store_len(ptr, byte_count)
     }
@@ -2798,11 +2798,11 @@ mod sealed {
     }
 
     test_impl! { vec_vmal_ib(a: vector_signed_char, b: vector_signed_char, c: vector_signed_char) -> vector_signed_char [simd_mladd, vmalb ] }
-    test_impl! { vec_vmal_ih(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short[simd_mladd, vmalh ] }
+    test_impl! { vec_vmal_ih(a: vector_signed_short, b: vector_signed_short, c: vector_signed_short) -> vector_signed_short[simd_mladd, vmalhw ] }
     test_impl! { vec_vmal_if(a: vector_signed_int, b: vector_signed_int, c: vector_signed_int) -> vector_signed_int [simd_mladd, vmalf ] }
 
     test_impl! { vec_vmal_ub(a: vector_unsigned_char, b: vector_unsigned_char, c: vector_unsigned_char) -> vector_unsigned_char [simd_mladd, vmalb ] }
-    test_impl! { vec_vmal_uh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short[simd_mladd, vmalh ] }
+    test_impl! { vec_vmal_uh(a: vector_unsigned_short, b: vector_unsigned_short, c: vector_unsigned_short) -> vector_unsigned_short[simd_mladd, vmalhw ] }
     test_impl! { vec_vmal_uf(a: vector_unsigned_int, b: vector_unsigned_int, c: vector_unsigned_int) -> vector_unsigned_int [simd_mladd, vmalf ] }
 
     impl_mul!([VectorMladd vec_mladd] vec_vmal_ib (vector_signed_char, vector_signed_char, vector_signed_char) -> vector_signed_char );

--- a/library/stdarch/crates/core_arch/src/s390x/vector.rs
+++ b/library/stdarch/crates/core_arch/src/s390x/vector.rs
@@ -1181,6 +1181,20 @@ mod sealed {
 
     impl_vec_trait! { [VectorOrc vec_orc]+ 2c (orc) }
 
+    // Z vector intrinsic      C23 math.h  LLVM IR         ISO/IEC 60559 operation        inexact  vfidb parameters
+    //
+    // vec_rint                rint        llvm.rint       roundToIntegralExact           yes      0, 0
+    // vec_roundc              nearbyint   llvm.nearbyint  n/a                            no       4, 0
+    // vec_floor / vec_roundm  floor       llvm.floor      roundToIntegralTowardNegative  no       4, 7
+    // vec_ceil / vec_roundp   ceil        llvm.ceil       roundToIntegralTowardPositive  no       4, 6
+    // vec_trunc / vec_roundz  trunc       llvm.trunc      roundToIntegralTowardZero      no       4, 5
+    // vec_round               roundeven   llvm.roundeven  roundToIntegralTiesToEven      no       4, 4
+    // n/a                     round       llvm.round      roundToIntegralTiesAway        no       4, 1
+
+    // `simd_round_ties_even` is implemented as `llvm.rint`.
+    test_impl! { vec_rint_f32 (a: vector_float) -> vector_float [simd_round_ties_even, "vector-enhancements-1" vfisb] }
+    test_impl! { vec_rint_f64 (a: vector_double) -> vector_double [simd_round_ties_even, vfidb] }
+
     test_impl! { vec_roundc_f32 (a: vector_float) -> vector_float [nearbyint_v4f32,  "vector-enhancements-1" vfisb] }
     test_impl! { vec_roundc_f64 (a: vector_double) -> vector_double [nearbyint_v2f64, vfidb] }
 
@@ -1188,9 +1202,6 @@ mod sealed {
     // use https://godbolt.org/z/cWq95fexe to check, and enable the instruction test when it works
     test_impl! { vec_round_f32 (a: vector_float) -> vector_float [roundeven_v4f32, _] }
     test_impl! { vec_round_f64 (a: vector_double) -> vector_double [roundeven_v2f64, _] }
-
-    test_impl! { vec_rint_f32 (a: vector_float) -> vector_float [simd_round_ties_even, "vector-enhancements-1" vfisb] }
-    test_impl! { vec_rint_f64 (a: vector_double) -> vector_double [simd_round_ties_even, vfidb] }
 
     #[unstable(feature = "stdarch_s390x", issue = "135681")]
     pub trait VectorRoundc {

--- a/library/stdarch/crates/intrinsic-test/src/arm/compile.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/compile.rs
@@ -38,9 +38,9 @@ pub fn compile_c_arm(
             .set_include_paths(vec![
                 "/include",
                 "/aarch64_be-none-linux-gnu/include",
-                "/aarch64_be-none-linux-gnu/include/c++/14.2.1",
-                "/aarch64_be-none-linux-gnu/include/c++/14.2.1/aarch64_be-none-linux-gnu",
-                "/aarch64_be-none-linux-gnu/include/c++/14.2.1/backward",
+                "/aarch64_be-none-linux-gnu/include/c++/14.3.1",
+                "/aarch64_be-none-linux-gnu/include/c++/14.3.1/aarch64_be-none-linux-gnu",
+                "/aarch64_be-none-linux-gnu/include/c++/14.3.1/backward",
                 "/aarch64_be-none-linux-gnu/libc/usr/include",
             ]);
     }

--- a/library/stdarch/crates/intrinsic-test/src/arm/config.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/config.rs
@@ -114,7 +114,6 @@ pub const AARCH_CONFIGURATIONS: &str = r#"
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_fcma))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_dotprod))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_i8mm))]
-#![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sha3))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_sm4))]
 #![cfg_attr(any(target_arch = "aarch64", target_arch = "arm64ec"), feature(stdarch_neon_ftts))]
 #![feature(fmt_helpers_for_derive)]

--- a/library/stdarch/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -2,7 +2,7 @@ use crate::common::argument::ArgumentList;
 use crate::common::indentation::Indentation;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
 use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, Sign, TypeKind};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArmIntrinsicType(pub IntrinsicType);
@@ -12,6 +12,12 @@ impl Deref for ArmIntrinsicType {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for ArmIntrinsicType {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/library/stdarch/crates/intrinsic-test/src/arm/intrinsic.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/intrinsic.rs
@@ -1,7 +1,7 @@
 use crate::common::argument::ArgumentList;
 use crate::common::indentation::Indentation;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
-use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, TypeKind};
+use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, Sign, TypeKind};
 use std::ops::Deref;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -73,8 +73,9 @@ impl IntrinsicDefinition<ArmIntrinsicType> for Intrinsic<ArmIntrinsicType> {
                     TypeKind::Float if self.results().inner_size() == 16 => "float16_t".to_string(),
                     TypeKind::Float if self.results().inner_size() == 32 => "float".to_string(),
                     TypeKind::Float if self.results().inner_size() == 64 => "double".to_string(),
-                    TypeKind::Int => format!("int{}_t", self.results().inner_size()),
-                    TypeKind::UInt => format!("uint{}_t", self.results().inner_size()),
+                    TypeKind::Int(Sign::Signed) => format!("int{}_t", self.results().inner_size()),
+                    TypeKind::Int(Sign::Unsigned) =>
+                        format!("uint{}_t", self.results().inner_size()),
                     TypeKind::Poly => format!("poly{}_t", self.results().inner_size()),
                     ty => todo!("print_result_c - Unknown type: {:#?}", ty),
                 },

--- a/library/stdarch/crates/intrinsic-test/src/arm/json_parser.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/json_parser.rs
@@ -110,7 +110,7 @@ fn json_to_intrinsic(
     Ok(Intrinsic {
         name,
         arguments,
-        results: *results,
+        results: results,
         arch_tags: intr.architectures,
     })
 }

--- a/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
@@ -104,7 +104,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
     }
 
     fn compare_outputs(&self) -> bool {
-        if let Some(ref toolchain) = self.cli_options.toolchain {
+        if self.cli_options.toolchain.is_some() {
             let intrinsics_name_list = self
                 .intrinsics
                 .iter()
@@ -113,8 +113,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
 
             compare_outputs(
                 &intrinsics_name_list,
-                toolchain,
-                &self.cli_options.c_runner,
+                &self.cli_options.runner,
                 &self.cli_options.target,
             )
         } else {

--- a/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
@@ -7,6 +7,7 @@ mod types;
 use crate::common::SupportedArchitectureTest;
 use crate::common::cli::ProcessedCli;
 use crate::common::compare::compare_outputs;
+use crate::common::gen_c::compile_c_programs;
 use crate::common::gen_rust::compile_rust_programs;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
 use crate::common::intrinsic_helpers::TypeKind;
@@ -66,7 +67,8 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
             &[POLY128_OSTREAM_DEF],
         );
 
-        compile::compile_c_arm(&self.cli_options, intrinsics_name_list.as_slice())
+        let pipeline = compile::build_cpp_compilation(&self.cli_options).unwrap();
+        compile_c_programs(&pipeline, &intrinsics_name_list)
     }
 
     fn build_rust_file(&self) -> bool {

--- a/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
@@ -11,7 +11,6 @@ use crate::common::gen_rust::compile_rust_programs;
 use crate::common::intrinsic::{Intrinsic, IntrinsicDefinition};
 use crate::common::intrinsic_helpers::TypeKind;
 use crate::common::write_file::{write_c_testfiles, write_rust_testfiles};
-use compile::compile_c_arm;
 use config::{AARCH_CONFIGURATIONS, F16_FORMATTING_DEF, POLY128_OSTREAM_DEF, build_notices};
 use intrinsic::ArmIntrinsicType;
 use json_parser::get_neon_intrinsics;
@@ -51,9 +50,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
     }
 
     fn build_c_file(&self) -> bool {
-        let compiler = self.cli_options.cpp_compiler.as_deref();
         let target = &self.cli_options.target;
-        let cxx_toolchain_dir = self.cli_options.cxx_toolchain_dir.as_deref();
         let c_target = "aarch64";
 
         let intrinsics_name_list = write_c_testfiles(
@@ -69,15 +66,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
             &[POLY128_OSTREAM_DEF],
         );
 
-        match compiler {
-            None => true,
-            Some(compiler) => compile_c_arm(
-                intrinsics_name_list.as_slice(),
-                compiler,
-                target,
-                cxx_toolchain_dir,
-            ),
-        }
+        compile::compile_c_arm(&self.cli_options, intrinsics_name_list.as_slice())
     }
 
     fn build_rust_file(&self) -> bool {

--- a/library/stdarch/crates/intrinsic-test/src/arm/types.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/types.rs
@@ -1,6 +1,6 @@
 use super::intrinsic::ArmIntrinsicType;
 use crate::common::cli::Language;
-use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, TypeKind};
+use crate::common::intrinsic_helpers::{IntrinsicType, IntrinsicTypeDefinition, Sign, TypeKind};
 
 impl IntrinsicTypeDefinition for ArmIntrinsicType {
     /// Gets a string containing the typename for this type in C format.
@@ -73,8 +73,8 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
             format!(
                 "vld{len}{quad}_{type}{size}",
                 type = match k {
-                    TypeKind::UInt => "u",
-                    TypeKind::Int => "s",
+                    TypeKind::Int(Sign::Unsigned) => "u",
+                    TypeKind::Int(Sign::Signed) => "s",
                     TypeKind::Float => "f",
                     // The ACLE doesn't support 64-bit polynomial loads on Armv7
                     // if armv7 and bl == 64, use "s", else "p"
@@ -107,8 +107,8 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
             format!(
                 "vget{quad}_lane_{type}{size}",
                 type = match k {
-                    TypeKind::UInt => "u",
-                    TypeKind::Int => "s",
+                    TypeKind::Int(Sign::Unsigned) => "u",
+                    TypeKind::Int(Sign::Signed) => "s",
                     TypeKind::Float => "f",
                     TypeKind::Poly => "p",
                     x => todo!("get_load_function TypeKind: {:#?}", x),
@@ -176,7 +176,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
             } else {
                 let kind = start.parse::<TypeKind>()?;
                 let bit_len = match kind {
-                    TypeKind::Int => Some(32),
+                    TypeKind::Int(_) => Some(32),
                     _ => None,
                 };
                 Ok(Box::new(ArmIntrinsicType(IntrinsicType {

--- a/library/stdarch/crates/intrinsic-test/src/arm/types.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/types.rs
@@ -121,7 +121,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
         }
     }
 
-    fn from_c(s: &str, target: &str) -> Result<Box<Self>, String> {
+    fn from_c(s: &str, target: &str) -> Result<Self, String> {
         const CONST_STR: &str = "const";
         if let Some(s) = s.strip_suffix('*') {
             let (s, constant) = match s.trim().strip_suffix(CONST_STR) {
@@ -131,9 +131,8 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
             let s = s.trim_end();
             let temp_return = ArmIntrinsicType::from_c(s, target);
             temp_return.map(|mut op| {
-                let edited = op.as_mut();
-                edited.0.ptr = true;
-                edited.0.ptr_constant = constant;
+                op.ptr = true;
+                op.ptr_constant = constant;
                 op
             })
         } else {
@@ -163,7 +162,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     ),
                     None => None,
                 };
-                Ok(Box::new(ArmIntrinsicType(IntrinsicType {
+                Ok(ArmIntrinsicType(IntrinsicType {
                     ptr: false,
                     ptr_constant: false,
                     constant,
@@ -172,14 +171,14 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     simd_len,
                     vec_len,
                     target: target.to_string(),
-                })))
+                }))
             } else {
                 let kind = start.parse::<TypeKind>()?;
                 let bit_len = match kind {
                     TypeKind::Int(_) => Some(32),
                     _ => None,
                 };
-                Ok(Box::new(ArmIntrinsicType(IntrinsicType {
+                Ok(ArmIntrinsicType(IntrinsicType {
                     ptr: false,
                     ptr_constant: false,
                     constant,
@@ -188,7 +187,7 @@ impl IntrinsicTypeDefinition for ArmIntrinsicType {
                     simd_len: None,
                     vec_len: None,
                     target: target.to_string(),
-                })))
+                }))
             }
         }
     }

--- a/library/stdarch/crates/intrinsic-test/src/common/argument.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/argument.rs
@@ -125,19 +125,23 @@ where
     /// Creates a line for each argument that initializes an array for C from which `loads` argument
     /// values can be loaded  as a sliding window.
     /// e.g `const int32x2_t a_vals = {0x3effffff, 0x3effffff, 0x3f7fffff}`, if loads=2.
-    pub fn gen_arglists_c(&self, indentation: Indentation, loads: u32) -> String {
-        self.iter()
-            .filter(|&arg| !arg.has_constraint())
-            .map(|arg| {
-                format!(
-                    "{indentation}const {ty} {name}_vals[] = {values};",
-                    ty = arg.ty.c_scalar_type(),
-                    name = arg.name,
-                    values = arg.ty.populate_random(indentation, loads, &Language::C)
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
+    pub fn gen_arglists_c(
+        &self,
+        w: &mut impl std::io::Write,
+        indentation: Indentation,
+        loads: u32,
+    ) -> std::io::Result<()> {
+        for arg in self.iter().filter(|&arg| !arg.has_constraint()) {
+            writeln!(
+                w,
+                "{indentation}const {ty} {name}_vals[] = {values};",
+                ty = arg.ty.c_scalar_type(),
+                name = arg.name,
+                values = arg.ty.populate_random(indentation, loads, &Language::C)
+            )?
+        }
+
+        Ok(())
     }
 
     /// Creates a line for each argument that initializes an array for Rust from which `loads` argument

--- a/library/stdarch/crates/intrinsic-test/src/common/argument.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/argument.rs
@@ -76,7 +76,7 @@ where
         Argument {
             pos,
             name: String::from(var_name),
-            ty: *ty,
+            ty: ty,
             constraint,
         }
     }

--- a/library/stdarch/crates/intrinsic-test/src/common/cli.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/cli.rs
@@ -60,7 +60,7 @@ pub struct ProcessedCli {
     pub filename: PathBuf,
     pub toolchain: Option<String>,
     pub cpp_compiler: Option<String>,
-    pub c_runner: String,
+    pub runner: String,
     pub target: String,
     pub linker: Option<String>,
     pub cxx_toolchain_dir: Option<String>,
@@ -70,7 +70,7 @@ pub struct ProcessedCli {
 impl ProcessedCli {
     pub fn new(cli_options: Cli) -> Self {
         let filename = cli_options.input;
-        let c_runner = cli_options.runner.unwrap_or_default();
+        let runner = cli_options.runner.unwrap_or_default();
         let target = cli_options.target;
         let linker = cli_options.linker;
         let cxx_toolchain_dir = cli_options.cxx_toolchain_dir;
@@ -102,7 +102,7 @@ impl ProcessedCli {
         Self {
             toolchain,
             cpp_compiler,
-            c_runner,
+            runner,
             target,
             linker,
             cxx_toolchain_dir,

--- a/library/stdarch/crates/intrinsic-test/src/common/compare.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/compare.rs
@@ -2,26 +2,24 @@ use super::cli::FailureReason;
 use rayon::prelude::*;
 use std::process::Command;
 
-pub fn compare_outputs(
-    intrinsic_name_list: &Vec<String>,
-    toolchain: &str,
-    runner: &str,
-    target: &str,
-) -> bool {
+pub fn compare_outputs(intrinsic_name_list: &Vec<String>, runner: &str, target: &str) -> bool {
+    fn runner_command(runner: &str) -> Command {
+        let mut it = runner.split_whitespace();
+        let mut cmd = Command::new(it.next().unwrap());
+        cmd.args(it);
+
+        cmd
+    }
+
     let intrinsics = intrinsic_name_list
         .par_iter()
         .filter_map(|intrinsic_name| {
-            let c = Command::new("sh")
-                .arg("-c")
-                .arg(format!("{runner} ./c_programs/{intrinsic_name}"))
+            let c = runner_command(runner)
+                .arg(format!("./c_programs/{intrinsic_name}"))
                 .output();
 
-            let rust = Command::new("sh")
-                .current_dir("rust_programs")
-                .arg("-c")
-                .arg(format!(
-                    "cargo {toolchain} run --target {target} --bin {intrinsic_name} --release",
-                ))
+            let rust = runner_command(runner)
+                .arg(format!("target/{target}/release/{intrinsic_name}"))
                 .env("RUSTFLAGS", "-Cdebuginfo=0")
                 .output();
 
@@ -42,8 +40,8 @@ pub fn compare_outputs(
             if !rust.status.success() {
                 error!(
                     "Failed to run Rust program for intrinsic {intrinsic_name}\nstdout: {stdout}\nstderr: {stderr}",
-                    stdout = std::str::from_utf8(&rust.stdout).unwrap_or(""),
-                    stderr = std::str::from_utf8(&rust.stderr).unwrap_or(""),
+                    stdout = String::from_utf8_lossy(&rust.stdout),
+                    stderr = String::from_utf8_lossy(&rust.stderr),
                 );
                 return Some(FailureReason::RunRust(intrinsic_name.clone()));
             }

--- a/library/stdarch/crates/intrinsic-test/src/common/compare.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/compare.rs
@@ -15,12 +15,12 @@ pub fn compare_outputs(intrinsic_name_list: &Vec<String>, runner: &str, target: 
         .par_iter()
         .filter_map(|intrinsic_name| {
             let c = runner_command(runner)
-                .arg(format!("./c_programs/{intrinsic_name}"))
+                .arg("./c_programs/intrinsic-test-programs")
+                .arg(intrinsic_name)
                 .output();
 
             let rust = runner_command(runner)
                 .arg(format!("target/{target}/release/{intrinsic_name}"))
-                .env("RUSTFLAGS", "-Cdebuginfo=0")
                 .output();
 
             let (c, rust) = match (c, rust) {

--- a/library/stdarch/crates/intrinsic-test/src/common/compile_c.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/compile_c.rs
@@ -112,11 +112,24 @@ impl CppCompilation {
         &mut self.0
     }
 
-    pub fn run(&self, inputs: &[String], output: &str) -> std::io::Result<std::process::Output> {
+    pub fn compile_object_file(
+        &self,
+        input: &str,
+        output: &str,
+    ) -> std::io::Result<std::process::Output> {
+        let mut cmd = clone_command(&self.0);
+        cmd.args([input, "-c", "-o", output]);
+        cmd.output()
+    }
+
+    pub fn link_executable(
+        &self,
+        inputs: impl Iterator<Item = String>,
+        output: &str,
+    ) -> std::io::Result<std::process::Output> {
         let mut cmd = clone_command(&self.0);
         cmd.args(inputs);
         cmd.args(["-o", output]);
-
         cmd.output()
     }
 }

--- a/library/stdarch/crates/intrinsic-test/src/common/compile_c.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/compile_c.rs
@@ -5,11 +5,7 @@ pub struct CompilationCommandBuilder {
     cxx_toolchain_dir: Option<String>,
     arch_flags: Vec<String>,
     optimization: String,
-    include_paths: Vec<String>,
     project_root: Option<String>,
-    output: String,
-    input: String,
-    linker: Option<String>,
     extra_flags: Vec<String>,
 }
 
@@ -21,11 +17,7 @@ impl CompilationCommandBuilder {
             cxx_toolchain_dir: None,
             arch_flags: Vec::new(),
             optimization: "2".to_string(),
-            include_paths: Vec::new(),
             project_root: None,
-            output: String::new(),
-            input: String::new(),
-            linker: None,
             extra_flags: Vec::new(),
         }
     }
@@ -57,34 +49,9 @@ impl CompilationCommandBuilder {
         self
     }
 
-    /// Sets a list of include paths for compilation.
-    /// The paths that are passed must be relative to the
-    /// "cxx_toolchain_dir" directory path.
-    pub fn set_include_paths(mut self, paths: Vec<&str>) -> Self {
-        self.include_paths = paths.into_iter().map(|path| path.to_string()).collect();
-        self
-    }
-
     /// Sets the root path of all the generated test files.
     pub fn set_project_root(mut self, path: &str) -> Self {
         self.project_root = Some(path.to_string());
-        self
-    }
-
-    /// The name of the output executable, without any suffixes
-    pub fn set_output_name(mut self, path: &str) -> Self {
-        self.output = path.to_string();
-        self
-    }
-
-    /// The name of the input C file, without any suffixes
-    pub fn set_input_name(mut self, path: &str) -> Self {
-        self.input = path.to_string();
-        self
-    }
-
-    pub fn set_linker(mut self, linker: String) -> Self {
-        self.linker = Some(linker);
         self
     }
 
@@ -100,55 +67,56 @@ impl CompilationCommandBuilder {
 }
 
 impl CompilationCommandBuilder {
-    pub fn make_string(self) -> String {
-        let arch_flags = self.arch_flags.join("+");
-        let flags = std::env::var("CPPFLAGS").unwrap_or("".into());
-        let project_root = self.project_root.unwrap_or_default();
-        let project_root_str = project_root.as_str();
-        let mut output = self.output.clone();
-        if self.linker.is_some() {
-            output += ".o"
-        };
-        let mut command = format!(
-            "{} {flags} -march={arch_flags} \
-            -O{} \
-            -o {project_root}/{} \
-            {project_root}/{}.cpp",
-            self.compiler, self.optimization, output, self.input,
-        );
+    pub fn into_cpp_compilation(self) -> CppCompilation {
+        let mut cpp_compiler = std::process::Command::new(self.compiler);
 
-        command = command + " " + self.extra_flags.join(" ").as_str();
+        if let Some(project_root) = self.project_root {
+            cpp_compiler.current_dir(project_root);
+        }
+
+        let flags = std::env::var("CPPFLAGS").unwrap_or("".into());
+        cpp_compiler.args(flags.split_whitespace());
+
+        cpp_compiler.arg(format!("-march={}", self.arch_flags.join("+")));
+
+        cpp_compiler.arg(format!("-O{}", self.optimization));
+
+        cpp_compiler.args(self.extra_flags);
 
         if let Some(target) = &self.target {
-            command = command + " --target=" + target;
+            cpp_compiler.arg(format!("--target={target}"));
         }
 
-        if let (Some(linker), Some(cxx_toolchain_dir)) = (&self.linker, &self.cxx_toolchain_dir) {
-            let include_args = self
-                .include_paths
-                .iter()
-                .map(|path| "--include-directory=".to_string() + cxx_toolchain_dir + path)
-                .collect::<Vec<_>>()
-                .join(" ");
+        CppCompilation(cpp_compiler)
+    }
+}
 
-            command = command
-                + " -c "
-                + include_args.as_str()
-                + " && "
-                + linker
-                + " "
-                + project_root_str
-                + "/"
-                + &output
-                + " -o "
-                + project_root_str
-                + "/"
-                + &self.output
-                + " && rm "
-                + project_root_str
-                + "/"
-                + &output;
-        }
-        command
+pub struct CppCompilation(std::process::Command);
+
+fn clone_command(command: &std::process::Command) -> std::process::Command {
+    let mut cmd = std::process::Command::new(command.get_program());
+    if let Some(current_dir) = command.get_current_dir() {
+        cmd.current_dir(current_dir);
+    }
+    cmd.args(command.get_args());
+
+    for (key, val) in command.get_envs() {
+        cmd.env(key, val.unwrap_or_default());
+    }
+
+    cmd
+}
+
+impl CppCompilation {
+    pub fn command_mut(&mut self) -> &mut std::process::Command {
+        &mut self.0
+    }
+
+    pub fn run(&self, inputs: &[String], output: &str) -> std::io::Result<std::process::Output> {
+        let mut cmd = clone_command(&self.0);
+        cmd.args(inputs);
+        cmd.args(["-o", output]);
+
+        cmd.output()
     }
 }

--- a/library/stdarch/crates/intrinsic-test/src/common/gen_c.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/gen_c.rs
@@ -1,9 +1,3 @@
-use itertools::Itertools;
-use rayon::prelude::*;
-use std::collections::BTreeMap;
-
-use crate::common::compile_c::CppCompilation;
-
 use super::argument::Argument;
 use super::indentation::Indentation;
 use super::intrinsic::IntrinsicDefinition;
@@ -12,105 +6,16 @@ use super::intrinsic_helpers::IntrinsicTypeDefinition;
 // The number of times each intrinsic will be called.
 const PASSES: u32 = 20;
 
-// Formats the main C program template with placeholders
-pub fn format_c_main_template(
-    notices: &str,
-    header_files: &[&str],
-    arch_identifier: &str,
-    arch_specific_definitions: &[&str],
-    arglists: &str,
-    passes: &str,
-) -> String {
-    format!(
-        r#"{notices}{header_files}
-#include <iostream>
-#include <cstring>
-#include <iomanip>
-#include <sstream>
-
-template<typename T1, typename T2> T1 cast(T2 x) {{
-  static_assert(sizeof(T1) == sizeof(T2), "sizeof T1 and T2 must be the same");
-  T1 ret{{}};
-  memcpy(&ret, &x, sizeof(T1));
-  return ret;
-}}
-
-std::ostream& operator<<(std::ostream& os, float16_t value) {{
-    uint16_t temp = 0;
-    memcpy(&temp, &value, sizeof(float16_t));
-    std::stringstream ss;
-    ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << temp;
-    os << ss.str();
-    return os;
-}}
-
-#ifdef __{arch_identifier}__
-{arch_specific_definitions}
-#endif
-
-{arglists}
-
-int main(int argc, char **argv) {{
-{passes}
-    return 0;
-}}"#,
-        header_files = header_files
-            .iter()
-            .map(|header| format!("#include <{header}>"))
-            .collect::<Vec<_>>()
-            .join("\n"),
-        arch_specific_definitions = arch_specific_definitions.join("\n"),
-    )
-}
-
-pub fn compile_c_programs(pipeline: &CppCompilation, intrinsics: &[String]) -> bool {
-    intrinsics
-        .par_iter()
-        .map(
-            |intrinsic| match pipeline.run(&[format!("{intrinsic}.cpp")], intrinsic) {
-                Ok(output) if output.status.success() => Ok(()),
-                Ok(output) => {
-                    let msg = format!(
-                        "Failed to compile code for intrinsic `{intrinsic}`: \n\nstdout:\n{}\n\nstderr:\n{}",
-                        std::str::from_utf8(&output.stdout).unwrap_or(""),
-                        std::str::from_utf8(&output.stderr).unwrap_or("")
-                    );
-                    error!("{msg}");
-
-                    Err(msg)
-                }
-                Err(e) => {
-                    error!("command for `{intrinsic}` failed with IO error: {e:?}");
-                    Err(e.to_string())
-                }
-            },
-        )
-        .collect::<Result<(), String>>()
-        .is_ok()
-}
-
-// Creates directory structure and file path mappings
-pub fn setup_c_file_paths(identifiers: &Vec<String>) -> BTreeMap<&String, String> {
-    let _ = std::fs::create_dir("c_programs");
-    identifiers
-        .par_iter()
-        .map(|identifier| {
-            let c_filename = format!(r#"c_programs/{identifier}.cpp"#);
-
-            (identifier, c_filename)
-        })
-        .collect::<BTreeMap<&String, String>>()
-}
-
 pub fn generate_c_test_loop<T: IntrinsicTypeDefinition + Sized>(
+    w: &mut impl std::io::Write,
     intrinsic: &dyn IntrinsicDefinition<T>,
     indentation: Indentation,
     additional: &str,
     passes: u32,
-    _target: &str,
-) -> String {
+) -> std::io::Result<()> {
     let body_indentation = indentation.nested();
-    format!(
+    writeln!(
+        w,
         "{indentation}for (int i=0; i<{passes}; i++) {{\n\
             {loaded_args}\
             {body_indentation}auto __return_value = {intrinsic_call}({args});\n\
@@ -123,78 +28,172 @@ pub fn generate_c_test_loop<T: IntrinsicTypeDefinition + Sized>(
     )
 }
 
-pub fn generate_c_constraint_blocks<T: IntrinsicTypeDefinition>(
+pub fn generate_c_constraint_blocks<'a, T: IntrinsicTypeDefinition + 'a>(
+    w: &mut impl std::io::Write,
     intrinsic: &dyn IntrinsicDefinition<T>,
     indentation: Indentation,
-    constraints: &[&Argument<T>],
+    constraints: &mut (impl Iterator<Item = &'a Argument<T>> + Clone),
     name: String,
-    target: &str,
-) -> String {
-    if let Some((current, constraints)) = constraints.split_last() {
-        let range = current
-            .constraint
-            .iter()
-            .map(|c| c.to_range())
-            .flat_map(|r| r.into_iter());
+) -> std::io::Result<()> {
+    let Some(current) = constraints.next() else {
+        return generate_c_test_loop(w, intrinsic, indentation, &name, PASSES);
+    };
 
-        let body_indentation = indentation.nested();
-        range
-            .map(|i| {
-                format!(
-                    "{indentation}{{\n\
-                        {body_indentation}{ty} {name} = {val};\n\
-                        {pass}\n\
-                    {indentation}}}",
-                    name = current.name,
-                    ty = current.ty.c_type(),
-                    val = i,
-                    pass = generate_c_constraint_blocks(
-                        intrinsic,
-                        body_indentation,
-                        constraints,
-                        format!("{name}-{i}"),
-                        target,
-                    )
-                )
-            })
-            .join("\n")
-    } else {
-        generate_c_test_loop(intrinsic, indentation, &name, PASSES, target)
+    let body_indentation = indentation.nested();
+    for i in current.constraint.iter().flat_map(|c| c.to_range()) {
+        let ty = current.ty.c_type();
+
+        writeln!(w, "{indentation}{{")?;
+        writeln!(w, "{body_indentation}{ty} {} = {i};", current.name)?;
+
+        generate_c_constraint_blocks(
+            w,
+            intrinsic,
+            body_indentation,
+            &mut constraints.clone(),
+            format!("{name}-{i}"),
+        )?;
+
+        writeln!(w, "{indentation}}}")?;
     }
+
+    Ok(())
 }
 
 // Compiles C test programs using specified compiler
-pub fn create_c_test_program<T: IntrinsicTypeDefinition>(
+pub fn create_c_test_function<T: IntrinsicTypeDefinition>(
+    w: &mut impl std::io::Write,
     intrinsic: &dyn IntrinsicDefinition<T>,
-    header_files: &[&str],
-    target: &str,
-    c_target: &str,
-    notices: &str,
-    arch_specific_definitions: &[&str],
-) -> String {
-    let arguments = intrinsic.arguments();
-    let constraints = arguments
-        .iter()
-        .filter(|&i| i.has_constraint())
-        .collect_vec();
-
+) -> std::io::Result<()> {
     let indentation = Indentation::default();
-    format_c_main_template(
-        notices,
-        header_files,
-        c_target,
-        arch_specific_definitions,
-        intrinsic
-            .arguments()
-            .gen_arglists_c(indentation, PASSES)
-            .as_str(),
-        generate_c_constraint_blocks(
-            intrinsic,
-            indentation.nested(),
-            constraints.as_slice(),
-            Default::default(),
-            target,
-        )
-        .as_str(),
-    )
+
+    writeln!(w, "int run_{}() {{", intrinsic.name())?;
+
+    // Define the arrays of arguments.
+    let arguments = intrinsic.arguments();
+    arguments.gen_arglists_c(w, indentation.nested(), PASSES)?;
+
+    generate_c_constraint_blocks(
+        w,
+        intrinsic,
+        indentation.nested(),
+        &mut arguments.iter().rev().filter(|&i| i.has_constraint()),
+        Default::default(),
+    )?;
+
+    writeln!(w, "    return 0;")?;
+    writeln!(w, "}}")?;
+
+    Ok(())
+}
+
+pub fn write_mod_cpp<T: IntrinsicTypeDefinition>(
+    w: &mut impl std::io::Write,
+    notice: &str,
+    architecture: &str,
+    platform_headers: &[&str],
+    intrinsics: &[impl IntrinsicDefinition<T>],
+) -> std::io::Result<()> {
+    write!(w, "{notice}")?;
+
+    for header in platform_headers {
+        writeln!(w, "#include <{header}>")?;
+    }
+
+    writeln!(
+        w,
+        r#"
+#include <iostream>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+
+template<typename T1, typename T2> T1 cast(T2 x) {{
+  static_assert(sizeof(T1) == sizeof(T2), "sizeof T1 and T2 must be the same");
+  T1 ret{{}};
+  memcpy(&ret, &x, sizeof(T1));
+  return ret;
+}}
+
+std::ostream& operator<<(std::ostream& os, float16_t value);
+
+
+
+"#
+    )?;
+
+    writeln!(w, "#ifdef __{architecture}__")?;
+    writeln!(
+        w,
+        "std::ostream& operator<<(std::ostream& os, poly128_t value);"
+    )?;
+    writeln!(w, "#endif")?;
+
+    for intrinsic in intrinsics {
+        create_c_test_function(w, intrinsic)?;
+    }
+
+    Ok(())
+}
+
+pub fn write_main_cpp<'a>(
+    w: &mut impl std::io::Write,
+    architecture: &str,
+    arch_specific_definitions: &str,
+    intrinsics: impl Iterator<Item = &'a str> + Clone,
+) -> std::io::Result<()> {
+    writeln!(w, "#include <iostream>")?;
+    writeln!(w, "#include <string>")?;
+
+    for header in ["arm_neon.h", "arm_acle.h", "arm_fp16.h"] {
+        writeln!(w, "#include <{header}>")?;
+    }
+
+    writeln!(
+        w,
+        r#"
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+
+std::ostream& operator<<(std::ostream& os, float16_t value) {{
+    uint16_t temp = 0;
+    memcpy(&temp, &value, sizeof(float16_t));
+    std::stringstream ss;
+    ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << temp;
+    os << ss.str();
+    return os;
+}}
+"#
+    )?;
+
+    writeln!(w, "#ifdef __{architecture}__")?;
+    writeln!(w, "{arch_specific_definitions }")?;
+    writeln!(w, "#endif")?;
+
+    for intrinsic in intrinsics.clone() {
+        writeln!(w, "extern int run_{intrinsic}(void);")?;
+    }
+
+    writeln!(w, "int main(int argc, char **argv) {{")?;
+    writeln!(w, "    std::string intrinsic_name = argv[1];")?;
+
+    writeln!(w, "    if (false) {{")?;
+
+    for intrinsic in intrinsics {
+        writeln!(w, "    }} else if (intrinsic_name == \"{intrinsic}\") {{")?;
+        writeln!(w, "        return run_{intrinsic}();")?;
+    }
+
+    writeln!(w, "    }} else {{")?;
+    writeln!(
+        w,
+        "        std::cerr << \"Unknown command: \" << intrinsic_name << \"\\n\";"
+    )?;
+    writeln!(w, "        return -1;")?;
+    writeln!(w, "    }}")?;
+
+    writeln!(w, "}}")?;
+
+    Ok(())
 }

--- a/library/stdarch/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -9,13 +9,21 @@ use super::indentation::Indentation;
 use super::values::value_for_array;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Sign {
+    Signed,
+    Unsigned,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TypeKind {
     BFloat,
     Float,
-    Int,
-    UInt,
+    Int(Sign),
+    Char(Sign),
     Poly,
     Void,
+    Mask,
+    Vector,
 }
 
 impl FromStr for TypeKind {
@@ -23,12 +31,17 @@ impl FromStr for TypeKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "bfloat" => Ok(Self::BFloat),
-            "float" => Ok(Self::Float),
-            "int" => Ok(Self::Int),
+            "bfloat" | "BF16" => Ok(Self::BFloat),
+            "float" | "double" | "FP16" | "FP32" | "FP64" => Ok(Self::Float),
+            "int" | "long" | "short" | "SI8" | "SI16" | "SI32" | "SI64" => {
+                Ok(Self::Int(Sign::Signed))
+            }
             "poly" => Ok(Self::Poly),
-            "uint" | "unsigned" => Ok(Self::UInt),
+            "char" => Ok(Self::Char(Sign::Signed)),
+            "uint" | "unsigned" | "UI8" | "UI16" | "UI32" | "UI64" => Ok(Self::Int(Sign::Unsigned)),
             "void" => Ok(Self::Void),
+            "MASK" => Ok(Self::Mask),
+            "M64" | "M128" | "M256" | "M512" => Ok(Self::Vector),
             _ => Err(format!("Impossible to parse argument kind {s}")),
         }
     }
@@ -42,10 +55,14 @@ impl fmt::Display for TypeKind {
             match self {
                 Self::BFloat => "bfloat",
                 Self::Float => "float",
-                Self::Int => "int",
-                Self::UInt => "uint",
+                Self::Int(Sign::Signed) => "int",
+                Self::Int(Sign::Unsigned) => "uint",
                 Self::Poly => "poly",
                 Self::Void => "void",
+                Self::Char(Sign::Signed) => "char",
+                Self::Char(Sign::Unsigned) => "unsigned char",
+                Self::Mask => "mask",
+                Self::Vector => "vector",
             }
         )
     }
@@ -56,9 +73,10 @@ impl TypeKind {
     pub fn c_prefix(&self) -> &str {
         match self {
             Self::Float => "float",
-            Self::Int => "int",
-            Self::UInt => "uint",
+            Self::Int(Sign::Signed) => "int",
+            Self::Int(Sign::Unsigned) => "uint",
             Self::Poly => "poly",
+            Self::Char(Sign::Signed) => "char",
             _ => unreachable!("Not used: {:#?}", self),
         }
     }
@@ -66,10 +84,13 @@ impl TypeKind {
     /// Gets the rust prefix for the type kind i.e. i, u, f.
     pub fn rust_prefix(&self) -> &str {
         match self {
+            Self::BFloat => "bf",
             Self::Float => "f",
-            Self::Int => "i",
-            Self::UInt => "u",
+            Self::Int(Sign::Signed) => "i",
+            Self::Int(Sign::Unsigned) => "u",
             Self::Poly => "u",
+            Self::Char(Sign::Unsigned) => "u",
+            Self::Char(Sign::Signed) => "i",
             _ => unreachable!("Unused type kind: {:#?}", self),
         }
     }
@@ -133,11 +154,14 @@ impl IntrinsicType {
     }
 
     pub fn c_scalar_type(&self) -> String {
-        format!(
-            "{prefix}{bits}_t",
-            prefix = self.kind().c_prefix(),
-            bits = self.inner_size()
-        )
+        match self.kind() {
+            TypeKind::Char(_) => String::from("char"),
+            _ => format!(
+                "{prefix}{bits}_t",
+                prefix = self.kind().c_prefix(),
+                bits = self.inner_size()
+            ),
+        }
     }
 
     pub fn rust_scalar_type(&self) -> String {
@@ -155,8 +179,8 @@ impl IntrinsicType {
                 bit_len: Some(8),
                 ..
             } => match kind {
-                TypeKind::Int => "(int)",
-                TypeKind::UInt => "(unsigned int)",
+                TypeKind::Int(Sign::Signed) => "(int)",
+                TypeKind::Int(Sign::Unsigned) => "(unsigned int)",
                 TypeKind::Poly => "(unsigned int)(uint8_t)",
                 _ => "",
             },
@@ -172,6 +196,21 @@ impl IntrinsicType {
                 128 => "",
                 _ => panic!("invalid bit_len"),
             },
+            IntrinsicType {
+                kind: TypeKind::Float,
+                bit_len: Some(bit_len),
+                ..
+            } => match bit_len {
+                16 => "(float16_t)",
+                32 => "(float)",
+                64 => "(double)",
+                128 => "",
+                _ => panic!("invalid bit_len"),
+            },
+            IntrinsicType {
+                kind: TypeKind::Char(_),
+                ..
+            } => "(char)",
             _ => "",
         }
     }
@@ -185,7 +224,7 @@ impl IntrinsicType {
         match self {
             IntrinsicType {
                 bit_len: Some(bit_len @ (8 | 16 | 32 | 64)),
-                kind: kind @ (TypeKind::Int | TypeKind::UInt | TypeKind::Poly),
+                kind: kind @ (TypeKind::Int(_) | TypeKind::Poly | TypeKind::Char(_)),
                 simd_len,
                 vec_len,
                 ..
@@ -201,7 +240,8 @@ impl IntrinsicType {
                         .format_with(",\n", |i, fmt| {
                             let src = value_for_array(*bit_len, i);
                             assert!(src == 0 || src.ilog2() < *bit_len);
-                            if *kind == TypeKind::Int && (src >> (*bit_len - 1)) != 0 {
+                            if *kind == TypeKind::Int(Sign::Signed) && (src >> (*bit_len - 1)) != 0
+                            {
                                 // `src` is a two's complement representation of a negative value.
                                 let mask = !0u64 >> (64 - *bit_len);
                                 let ones_compl = src ^ mask;
@@ -257,7 +297,7 @@ impl IntrinsicType {
                 ..
             } => false,
             IntrinsicType {
-                kind: TypeKind::Int | TypeKind::UInt | TypeKind::Poly,
+                kind: TypeKind::Int(_) | TypeKind::Poly,
                 ..
             } => true,
             _ => unimplemented!(),

--- a/library/stdarch/crates/intrinsic-test/src/common/intrinsic_helpers.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/intrinsic_helpers.rs
@@ -322,7 +322,9 @@ pub trait IntrinsicTypeDefinition: Deref<Target = IntrinsicType> {
     fn get_lane_function(&self) -> String;
 
     /// can be implemented in an `impl` block
-    fn from_c(_s: &str, _target: &str) -> Result<Box<Self>, String>;
+    fn from_c(_s: &str, _target: &str) -> Result<Self, String>
+    where
+        Self: Sized;
 
     /// Gets a string containing the typename for this type in C format.
     /// can be directly defined in `impl` blocks

--- a/library/stdarch/crates/intrinsic-test/src/common/write_file.rs
+++ b/library/stdarch/crates/intrinsic-test/src/common/write_file.rs
@@ -1,5 +1,3 @@
-use super::gen_c::create_c_test_program;
-use super::gen_c::setup_c_file_paths;
 use super::gen_rust::{create_rust_test_program, setup_rust_file_paths};
 use super::intrinsic::IntrinsicDefinition;
 use super::intrinsic_helpers::IntrinsicTypeDefinition;
@@ -9,37 +7,6 @@ use std::io::Write;
 pub fn write_file(filename: &String, code: String) {
     let mut file = File::create(filename).unwrap();
     file.write_all(code.into_bytes().as_slice()).unwrap();
-}
-
-pub fn write_c_testfiles<T: IntrinsicTypeDefinition + Sized>(
-    intrinsics: &Vec<&dyn IntrinsicDefinition<T>>,
-    target: &str,
-    c_target: &str,
-    headers: &[&str],
-    notice: &str,
-    arch_specific_definitions: &[&str],
-) -> Vec<String> {
-    let intrinsics_name_list = intrinsics
-        .iter()
-        .map(|i| i.name().clone())
-        .collect::<Vec<_>>();
-    let filename_mapping = setup_c_file_paths(&intrinsics_name_list);
-
-    intrinsics.iter().for_each(|&i| {
-        let c_code = create_c_test_program(
-            i,
-            headers,
-            target,
-            c_target,
-            notice,
-            arch_specific_definitions,
-        );
-        if let Some(filename) = filename_mapping.get(&i.name()) {
-            write_file(filename, c_code)
-        };
-    });
-
-    intrinsics_name_list
 }
 
 pub fn write_rust_testfiles<T: IntrinsicTypeDefinition>(

--- a/library/stdarch/crates/intrinsic-test/src/main.rs
+++ b/library/stdarch/crates/intrinsic-test/src/main.rs
@@ -30,12 +30,15 @@ fn main() {
 
     let test_environment = test_environment_result.unwrap();
 
+    info!("building C binaries");
     if !test_environment.build_c_file() {
         std::process::exit(2);
     }
+    info!("building Rust binaries");
     if !test_environment.build_rust_file() {
         std::process::exit(3);
     }
+    info!("comaparing outputs");
     if !test_environment.compare_outputs() {
         std::process::exit(1);
     }

--- a/library/stdarch/crates/simd-test-macro/src/lib.rs
+++ b/library/stdarch/crates/simd-test-macro/src/lib.rs
@@ -57,7 +57,7 @@ pub fn simd_test(
         .unwrap_or_else(|| panic!("target triple contained no \"-\": {target}"))
     {
         "i686" | "x86_64" | "i586" => "is_x86_feature_detected",
-        "arm" | "armv7" => "is_arm_feature_detected",
+        "arm" | "armv7" | "thumbv7neon" => "is_arm_feature_detected",
         "aarch64" | "arm64ec" | "aarch64_be" => "is_aarch64_feature_detected",
         maybe_riscv if maybe_riscv.starts_with("riscv") => "is_riscv_feature_detected",
         "powerpc" | "powerpcle" => "is_powerpc_feature_detected",

--- a/library/stdarch/crates/simd-test-macro/src/lib.rs
+++ b/library/stdarch/crates/simd-test-macro/src/lib.rs
@@ -62,7 +62,7 @@ pub fn simd_test(
         maybe_riscv if maybe_riscv.starts_with("riscv") => "is_riscv_feature_detected",
         "powerpc" | "powerpcle" => "is_powerpc_feature_detected",
         "powerpc64" | "powerpc64le" => "is_powerpc64_feature_detected",
-        "loongarch64" => "is_loongarch_feature_detected",
+        "loongarch32" | "loongarch64" => "is_loongarch_feature_detected",
         "s390x" => "is_s390x_feature_detected",
         t => panic!("unknown target: {t}"),
     };

--- a/library/stdarch/crates/std_detect/README.md
+++ b/library/stdarch/crates/std_detect/README.md
@@ -55,7 +55,7 @@ crate from working on applications in which `std` is not available.
   application.
 
 * Linux/Android:
-  * `arm{32, 64}`, `mips{32,64}{,el}`, `powerpc{32,64}{,le}`, `loongarch64`, `s390x`:
+  * `arm{32, 64}`, `mips{32,64}{,el}`, `powerpc{32,64}{,le}`, `loongarch{32,64}`, `s390x`:
     `std_detect` supports these on Linux by querying ELF auxiliary vectors (using `getauxval`
     when available), and if that fails, by querying `/proc/self/auxv`.
   * `arm64`: partial support for doing run-time feature detection by directly

--- a/library/stdarch/crates/std_detect/src/detect/arch/loongarch.rs
+++ b/library/stdarch/crates/std_detect/src/detect/arch/loongarch.rs
@@ -2,7 +2,7 @@
 
 features! {
     @TARGET: loongarch;
-    @CFG: target_arch = "loongarch64";
+    @CFG: any(target_arch = "loongarch32", target_arch = "loongarch64");
     @MACRO_NAME: is_loongarch_feature_detected;
     @MACRO_ATTRS:
     /// Checks if `loongarch` feature is enabled.

--- a/library/stdarch/crates/std_detect/src/detect/arch/mod.rs
+++ b/library/stdarch/crates/std_detect/src/detect/arch/mod.rs
@@ -49,7 +49,7 @@ cfg_if! {
     } else if #[cfg(target_arch = "mips64")] {
         #[unstable(feature = "stdarch_mips_feature_detection", issue = "111188")]
         pub use mips64::*;
-    } else if #[cfg(target_arch = "loongarch64")] {
+    } else if #[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))] {
         #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")]
         pub use loongarch::*;
     } else if #[cfg(target_arch = "s390x")] {

--- a/library/stdarch/crates/std_detect/src/detect/mod.rs
+++ b/library/stdarch/crates/std_detect/src/detect/mod.rs
@@ -103,6 +103,7 @@ pub fn features() -> impl Iterator<Item = (&'static str, bool)> {
             target_arch = "powerpc64",
             target_arch = "mips",
             target_arch = "mips64",
+            target_arch = "loongarch32",
             target_arch = "loongarch64",
             target_arch = "s390x",
         ))] {

--- a/library/stdarch/crates/std_detect/src/detect/os/linux/auxvec.rs
+++ b/library/stdarch/crates/std_detect/src/detect/os/linux/auxvec.rs
@@ -80,6 +80,7 @@ pub(crate) fn auxv() -> Result<AuxVec, ()> {
             target_arch = "riscv64",
             target_arch = "mips",
             target_arch = "mips64",
+            target_arch = "loongarch32",
             target_arch = "loongarch64",
         ))]
         {
@@ -182,6 +183,7 @@ fn auxv_from_buf(buf: &[usize]) -> Result<AuxVec, ()> {
         target_arch = "riscv64",
         target_arch = "mips",
         target_arch = "mips64",
+        target_arch = "loongarch32",
         target_arch = "loongarch64",
     ))]
     {

--- a/library/stdarch/crates/std_detect/src/detect/os/linux/mod.rs
+++ b/library/stdarch/crates/std_detect/src/detect/os/linux/mod.rs
@@ -51,7 +51,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))] {
         mod powerpc;
         pub(crate) use self::powerpc::detect_features;
-    } else if #[cfg(target_arch = "loongarch64")] {
+    } else if #[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))] {
         mod loongarch;
         pub(crate) use self::loongarch::detect_features;
     } else if #[cfg(target_arch = "s390x")] {

--- a/library/stdarch/crates/std_detect/tests/macro_trailing_commas.rs
+++ b/library/stdarch/crates/std_detect/tests/macro_trailing_commas.rs
@@ -11,6 +11,7 @@
         target_arch = "s390x",
         target_arch = "riscv32",
         target_arch = "riscv64",
+        target_arch = "loongarch32",
         target_arch = "loongarch64"
     ),
     feature(stdarch_internal)
@@ -30,7 +31,7 @@
     feature(stdarch_riscv_feature_detection)
 )]
 #![cfg_attr(
-    target_arch = "loongarch64",
+    any(target_arch = "loongarch32", target_arch = "loongarch64"),
     feature(stdarch_loongarch_feature_detection)
 )]
 
@@ -45,6 +46,7 @@
     target_arch = "s390x",
     target_arch = "riscv32",
     target_arch = "riscv64",
+    target_arch = "loongarch32",
     target_arch = "loongarch64"
 ))]
 #[macro_use]
@@ -65,8 +67,8 @@ fn aarch64() {
 }
 
 #[test]
-#[cfg(target_arch = "loongarch64")]
-fn loongarch64() {
+#[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))]
+fn loongarch() {
     let _ = is_loongarch_feature_detected!("lsx");
     let _ = is_loongarch_feature_detected!("lsx",);
 }

--- a/library/stdarch/crates/stdarch-gen-arm/Cargo.toml
+++ b/library/stdarch/crates/stdarch-gen-arm/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2024"
 
 [dependencies]
 itertools = "0.14.0"
-lazy_static = "1.4.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.5"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -6580,7 +6580,6 @@ intrinsics:
               arch: aarch64,arm64ec
 
 
-
   - name: "vmaxnm{neon_type.no}"
     doc: Floating-point Maximum Number (vector)
     arguments: ["a: {neon_type}", "b: {neon_type}"]
@@ -6592,11 +6591,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "fmaxnm.{neon_type}"
-          links:
-            - link: "llvm.aarch64.neon.fmaxnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmax, [a, b]]
 
 
   - name: "vmaxnmh_{type}"
@@ -6806,11 +6801,7 @@ intrinsics:
       - float64x1_t
       - float64x2_t
     compose:
-      - LLVMLink:
-          name: "fminnm.{neon_type}"
-          links:
-            - link: "llvm.aarch64.neon.fminnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmin, [a, b]]
 
   - name: "vminnmv{neon_type[0].no}"
     doc: "Floating-point minimum number across vector"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -6635,11 +6635,7 @@ intrinsics:
       - [float32x2_t, f32]
       - [float64x2_t, f64]
     compose:
-      - LLVMLink:
-          name: "fmaxnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fmaxnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_max, [a]]
 
   - name: "vmaxnmv{neon_type[0].no}"
     doc: Floating-point maximum number across vector
@@ -6651,11 +6647,7 @@ intrinsics:
     types:
       - [float32x4_t, f32]
     compose:
-      - LLVMLink:
-          name: "fmaxnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fmaxnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_max, [a]]
 
 
   - name: "vmaxnmv{neon_type[0].no}"
@@ -6671,11 +6663,7 @@ intrinsics:
       - [float16x4_t, f16]
       - [float16x8_t, f16]
     compose:
-      - LLVMLink:
-          name: "fmaxnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fmaxnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_max, [a]]
 
 
   - name: "vminnmv{neon_type[0].no}"
@@ -6691,11 +6679,7 @@ intrinsics:
       - [float16x4_t, f16]
       - [float16x8_t, f16]
     compose:
-      - LLVMLink:
-          name: "fminnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fminnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_min, [a]]
 
 
   - name: "vmaxv{neon_type[0].no}"
@@ -6815,11 +6799,7 @@ intrinsics:
       - [float32x2_t, "f32"]
       - [float64x2_t, "f64"]
     compose:
-      - LLVMLink:
-          name: "vminnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fminnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_min, [a]]
 
   - name: "vminnmv{neon_type[0].no}"
     doc: "Floating-point minimum number across vector"
@@ -6832,11 +6812,7 @@ intrinsics:
     types:
       - [float32x4_t, "f32"]
     compose:
-      - LLVMLink:
-          name: "vminnmv.{neon_type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.fminnmv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_min, [a]]
 
   - name: "vmovl_high{neon_type[0].noq}"
     doc: Vector move

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13286,11 +13286,7 @@ intrinsics:
       - [int16x8_t, i16, 'smaxv']
       - [int32x4_t, i32, 'smaxv']
     compose:
-      - LLVMLink:
-          name: "vmaxv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.smaxv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_max, [a]]
 
   - name: "vmaxv{neon_type[0].no}"
     doc: "Horizontal vector max."
@@ -13308,11 +13304,7 @@ intrinsics:
       - [uint16x8_t, u16, 'umaxv']
       - [uint32x4_t, u32, 'umaxv']
     compose:
-      - LLVMLink:
-          name: "vmaxv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.umaxv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_max, [a]]
 
   - name: "vmaxv{neon_type[0].no}"
     doc: "Horizontal vector max."
@@ -13349,11 +13341,7 @@ intrinsics:
       - [int16x8_t, i16, 'sminv']
       - [int32x4_t, i32, 'sminv']
     compose:
-      - LLVMLink:
-          name: "vminv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.sminv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_min, [a]]
 
   - name: "vminv{neon_type[0].no}"
     doc: "Horizontal vector min."
@@ -13371,11 +13359,7 @@ intrinsics:
       - [uint16x8_t, u16, 'uminv']
       - [uint32x4_t, u32, 'uminv']
     compose:
-      - LLVMLink:
-          name: "vminv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.uminv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_min, [a]]
 
   - name: "vminv{neon_type[0].no}"
     doc: "Horizontal vector min."

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13142,11 +13142,7 @@ intrinsics:
     types:
       - [int64x2_t, i64]
     compose:
-      - FnCall:
-          - transmute
-          - - FnCall:
-                - "vaddvq_u64"
-                - - FnCall: [transmute, [a]]
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vpaddd_u64"
     doc: "Add pairwise"
@@ -13159,7 +13155,7 @@ intrinsics:
     types:
       - [uint64x2_t, u64]
     compose:
-      - FnCall: [vaddvq_u64, [a]]
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13176,11 +13172,7 @@ intrinsics:
       - [int16x8_t, i16]
       - [int32x4_t, i32]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.saddv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13193,11 +13185,7 @@ intrinsics:
     types:
       - [int32x2_t, i32]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.saddv.i32.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13210,11 +13198,7 @@ intrinsics:
     types:
       - [int64x2_t, i64]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.saddv.i64.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13231,11 +13215,7 @@ intrinsics:
       - [uint16x8_t, u16]
       - [uint32x4_t, u32]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.uaddv.{type[1]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13248,11 +13228,7 @@ intrinsics:
     types:
       - [uint32x2_t, u32, i32]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.uaddv.{type[2]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddv{neon_type[0].no}"
     doc: "Add across vector"
@@ -13265,11 +13241,7 @@ intrinsics:
     types:
       - [uint64x2_t, u64, i64]
     compose:
-      - LLVMLink:
-          name: "vaddv{neon_type[0].no}"
-          links:
-            - link: "llvm.aarch64.neon.uaddv.{type[2]}.{neon_type[0]}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_reduce_add_unordered, [a]]
 
   - name: "vaddlv{neon_type[0].no}"
     doc: "Signed Add Long across Vector"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -13023,6 +13023,26 @@ intrinsics:
             - link: "llvm.aarch64.crc32cx"
               arch: aarch64,arm64ec
 
+  - name: "vabsd_s64"
+    doc: "Absolute Value (wrapping)."
+    arguments: ["a: {type[1]}"]
+    return_type: "{type[1]}"
+    attr:
+      - *neon-stable
+    assert_instr: [abs]
+    safety: safe
+    types:
+      - [i64, i64]
+    compose:
+      # This is behaviorally equivalent to `i64::wrapping_abs`, but keeps the value in a SIMD
+      # register. That can be beneficial when combined with other instructions. This LLVM
+      # issue provides some extra context https://github.com/llvm/llvm-project/issues/148388.
+      - LLVMLink:
+          name: "vabsd_s64"
+          links:
+             - link: "llvm.aarch64.neon.abs.i64"
+               arch: aarch64,arm64ec
+
   - name: "{type[0]}"
     doc: "Absolute Value (wrapping)."
     arguments: ["a: {type[1]}"]
@@ -13032,15 +13052,18 @@ intrinsics:
     assert_instr: [abs]
     safety: safe
     types:
-      - ['vabsd_s64', i64, i64]
       - ['vabs_s64', int64x1_t, v1i64]
       - ['vabsq_s64', int64x2_t, v2i64]
     compose:
-      - LLVMLink:
-          name: "{type[0]}"
-          links:
-            - link: "llvm.aarch64.neon.abs.{type[2]}"
-              arch: aarch64,arm64ec
+      - Let:
+          - neg
+          - "{type[1]}"
+          - FnCall: [simd_neg, [a]]
+      - Let:
+          - mask
+          - "{type[1]}"
+          - FnCall: [simd_ge, [a, neg]]
+      - FnCall: [simd_select, [mask, a, neg]]
 
   - name: "vuqadd{neon_type[0].no}"
     doc: "Signed saturating Accumulate of Unsigned value."

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -6611,11 +6611,7 @@ intrinsics:
     types:
       - f16
     compose:
-      - LLVMLink:
-          name: "vmaxh.{neon_type}"
-          links:
-            - link: "llvm.aarch64.neon.fmaxnm.{type}"
-              arch: aarch64,arm64ec
+      - FnCall: ["f16::max", [a, b]]
 
 
   - name: "vminnmh_{type}"
@@ -6630,11 +6626,7 @@ intrinsics:
     types:
       - f16
     compose:
-      - LLVMLink:
-          name: "vminh.{neon_type}"
-          links:
-            - link: "llvm.aarch64.neon.fminnm.{type}"
-              arch: aarch64,arm64ec
+      - FnCall: ["f16::min", [a, b]]
 
 
   - name: "vmaxnmv{neon_type[0].no}"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/aarch64.spec.yml
@@ -187,7 +187,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[0]}"]
     return_type: "{neon_type[1]}"
     attr: [*neon-stable]
-    assert_instr: [sabdl]
+    assert_instr: [sabdl2]
     safety: safe
     types:
       - [int8x16_t, int16x8_t, int8x8_t, uint8x8_t]
@@ -230,7 +230,7 @@ intrinsics:
           - stable
           - - 'feature = "neon_intrinsics"'
             - 'since = "1.59.0"'
-    assert_instr: [sabdl]
+    assert_instr: [sabdl2]
     safety: safe
     types:
       - [int16x8_t, int32x4_t, int16x4_t, uint16x4_t]
@@ -273,7 +273,7 @@ intrinsics:
           - stable
           - - 'feature = "neon_intrinsics"'
             - 'since = "1.59.0"'
-    assert_instr: [sabdl]
+    assert_instr: [sabdl2]
     safety: safe
     types:
       - [int32x4_t, int64x2_t, int32x2_t, uint32x2_t]
@@ -1462,7 +1462,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}"]
     return_type: "{neon_type[1]}"
     attr:
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtl]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtl2]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety: safe
     types:
@@ -1530,7 +1530,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[1]}"]
     return_type: "{neon_type[2]}"
     attr:
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtn]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtn2]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety: safe
     types:
@@ -1582,7 +1582,7 @@ intrinsics:
     arguments: ["a: {type[0]}", "b: {neon_type[1]}"]
     return_type: "{type[2]}"
     attr:
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtxn]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [fcvtxn2]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety: safe
     types:
@@ -5147,7 +5147,7 @@ intrinsics:
     attr:
       - *neon-stable
     safety: safe
-    assert_instr: [pmull]
+    assert_instr: [pmull2]
     types:
       - [poly8x16_t, poly8x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]', poly16x8_t]
     compose:
@@ -5169,7 +5169,7 @@ intrinsics:
       - *neon-aes
       - *neon-stable
     safety: safe
-    assert_instr: [pmull]
+    assert_instr: [pmull2]
     types:
       - [poly64x2_t, "p128"]
     compose:
@@ -5741,7 +5741,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[1]}"]
     return_type: "{neon_type[0]}"
     attr: [*neon-stable]
-    assert_instr: [ssubw]
+    assert_instr: [ssubw2]
     safety: safe
     types:
       - [int16x8_t, int8x16_t, int8x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]']
@@ -5762,7 +5762,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[1]}"]
     return_type: "{neon_type[0]}"
     attr: [*neon-stable]
-    assert_instr: [usubw]
+    assert_instr: [usubw2]
     safety: safe
     types:
       - [uint16x8_t, uint8x16_t, uint8x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]']
@@ -5783,7 +5783,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[0]}"]
     return_type: "{neon_type[1]}"
     attr: [*neon-stable]
-    assert_instr: [ssubl]
+    assert_instr: [ssubl2]
     safety: safe
     types:
       - [int8x16_t, int16x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]', int8x8_t]
@@ -5813,7 +5813,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[0]}"]
     return_type: "{neon_type[1]}"
     attr: [*neon-stable]
-    assert_instr: [usubl]
+    assert_instr: [usubl2]
     safety: safe
     types:
       - [uint8x16_t, uint16x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]', uint8x8_t]
@@ -9909,7 +9909,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
-      - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [uabal]]}]]
+      - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [uabal2]]}]]
     safety: safe
     types:
       - [uint16x8_t, uint8x16_t, uint8x8_t, '[8, 9, 10, 11, 12, 13, 14, 15]', '[8, 9, 10, 11, 12, 13, 14, 15]']
@@ -9936,7 +9936,7 @@ intrinsics:
     return_type: "{neon_type[0]}"
     attr:
       - *neon-stable
-      - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [sabal]]}]]
+      - FnCall: [cfg_attr, [{FnCall: [all, [test, {FnCall: [not, ['target_env = "msvc"']]}]]}, {FnCall: [assert_instr, [sabal2]]}]]
     safety: safe
     types:
       - [int16x8_t, int8x16_t, int8x16_t, '[8, 9, 10, 11, 12, 13, 14, 15]', int8x8_t, uint8x8_t]
@@ -11345,7 +11345,7 @@ intrinsics:
     arguments: ["a: {neon_type[0]}", "b: {neon_type[0]}"]
     return_type: "{neon_type[1]}"
     attr:
-      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [uabdl]]}]]
+      - FnCall: [cfg_attr, [test, {FnCall: [assert_instr, [uabdl2]]}]]
       - FnCall: [stable, ['feature = "neon_intrinsics"', 'since = "1.59.0"']]
     safety: safe
     types:

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -7223,13 +7223,7 @@ intrinsics:
       - float32x2_t
       - float32x4_t
     compose:
-      - LLVMLink:
-          name: "fmaxnm.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vmaxnm.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.fmaxnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmax, [a, b]]
 
 
   - name: "vmaxnm{neon_type.no}"
@@ -7247,13 +7241,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "fmaxnm.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vmaxnm.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.fmaxnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmax, [a, b]]
 
 
   - name: "vminnm{neon_type.no}"
@@ -7271,13 +7259,7 @@ intrinsics:
       - float16x4_t
       - float16x8_t
     compose:
-      - LLVMLink:
-          name: "fminnm.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vminnm.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.fminnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmin, [a, b]]
 
 
   - name: "vmin{neon_type.no}"
@@ -7388,13 +7370,7 @@ intrinsics:
       - float32x2_t
       - float32x4_t
     compose:
-      - LLVMLink:
-          name: "fminnm.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vminnm.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.fminnm.{neon_type}"
-              arch: aarch64,arm64ec
+      - FnCall: [simd_fmin, [a, b]]
 
   - name: "vpadd{neon_type.no}"
     doc: Floating-point add pairwise

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -9755,7 +9755,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vuzp]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9796,7 +9797,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vuzp]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [uzp2]]}]]
       - *neon-fp16
       - *neon-unstable-f16
     safety: safe

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -7135,13 +7135,8 @@ intrinsics:
       - int32x2_t
       - int32x4_t
     compose:
-      - LLVMLink:
-          name: "smax.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vmaxs.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.smax.{neon_type}"
-              arch: aarch64,arm64ec
+      - Let: [mask, "{neon_type}", {FnCall: [simd_ge, [a, b]]}]
+      - FnCall: [simd_select, [mask, a, b]]
 
   - name: "vmax{neon_type.no}"
     doc: Maximum (vector)
@@ -7162,13 +7157,8 @@ intrinsics:
       - uint32x2_t
       - uint32x4_t
     compose:
-      - LLVMLink:
-          name: "smax.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vmaxu.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.umax.{neon_type}"
-              arch: aarch64,arm64ec
+      - Let: [mask, "{neon_type}", {FnCall: [simd_ge, [a, b]]}]
+      - FnCall: [simd_select, [mask, a, b]]
 
   - name: "vmax{neon_type.no}"
     doc: Maximum (vector)
@@ -7309,13 +7299,8 @@ intrinsics:
       - int32x2_t
       - int32x4_t
     compose:
-      - LLVMLink:
-          name: "smin.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vmins.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.smin.{neon_type}"
-              arch: aarch64,arm64ec
+      - Let: [mask, "{neon_type}", {FnCall: [simd_le, [a, b]]}]
+      - FnCall: [simd_select, [mask, a, b]]
 
   - name: "vmin{neon_type.no}"
     doc: "Minimum (vector)"
@@ -7336,13 +7321,8 @@ intrinsics:
       - uint32x2_t
       - uint32x4_t
     compose:
-      - LLVMLink:
-          name: "umin.{neon_type}"
-          links:
-            - link: "llvm.arm.neon.vminu.{neon_type}"
-              arch: arm
-            - link: "llvm.aarch64.neon.umin.{neon_type}"
-              arch: aarch64,arm64ec
+      - Let: [mask, "{neon_type}", {FnCall: [simd_le, [a, b]]}]
+      - FnCall: [simd_select, [mask, a, b]]
 
   - name: "vmin{neon_type.no}"
     doc: "Minimum (vector)"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -14138,6 +14138,7 @@ intrinsics:
     doc: "Load one single-element structure and Replicate to all lanes (of one register)."
     arguments: ["ptr: {type[1]}"]
     return_type: "{neon_type[2]}"
+    big_endian_inverse: false
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, { FnCall: [assert_instr, ['"{type[3]}"']] }  ]]
@@ -14147,40 +14148,36 @@ intrinsics:
     safety:
       unsafe: [neon]
     types:
-      - ['vld1_dup_s8', '*const i8', 'int8x8_t', 'vld1.8', 'ld1r', 'vld1_lane_s8::<0>', 'i8x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1_dup_u8', '*const u8', 'uint8x8_t', 'vld1.8', 'ld1r', 'vld1_lane_u8::<0>', 'u8x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1_dup_p8', '*const p8', 'poly8x8_t', 'vld1.8', 'ld1r', 'vld1_lane_p8::<0>', 'u8x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
+      - ['vld1_dup_s8', '*const i8', 'int8x8_t', 'vld1.8', 'ld1r', 'i8x8::splat']
+      - ['vld1_dup_u8', '*const u8', 'uint8x8_t', 'vld1.8', 'ld1r', 'u8x8::splat']
+      - ['vld1_dup_p8', '*const p8', 'poly8x8_t', 'vld1.8', 'ld1r', 'u8x8::splat']
 
-      - ['vld1q_dup_s8', '*const i8', 'int8x16_t', 'vld1.8', 'ld1r', 'vld1q_lane_s8::<0>', 'i8x16::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1q_dup_u8', '*const u8', 'uint8x16_t', 'vld1.8', 'ld1r', 'vld1q_lane_u8::<0>', 'u8x16::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1q_dup_p8', '*const p8', 'poly8x16_t', 'vld1.8', 'ld1r', 'vld1q_lane_p8::<0>', 'u8x16::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]']
+      - ['vld1q_dup_s8', '*const i8', 'int8x16_t', 'vld1.8', 'ld1r', 'i8x16::splat']
+      - ['vld1q_dup_u8', '*const u8', 'uint8x16_t', 'vld1.8', 'ld1r', 'u8x16::splat']
+      - ['vld1q_dup_p8', '*const p8', 'poly8x16_t', 'vld1.8', 'ld1r', 'u8x16::splat']
 
-      - ['vld1_dup_s16', '*const i16', 'int16x4_t', 'vld1.16', 'ld1r', 'vld1_lane_s16::<0>', 'i16x4::splat(0)', '[0, 0, 0, 0]']
-      - ['vld1_dup_u16', '*const u16', 'uint16x4_t', 'vld1.16', 'ld1r', 'vld1_lane_u16::<0>', 'u16x4::splat(0)', '[0, 0, 0, 0]']
-      - ['vld1_dup_p16', '*const p16', 'poly16x4_t', 'vld1.16', 'ld1r', 'vld1_lane_p16::<0>', 'u16x4::splat(0)', '[0, 0, 0, 0]']
+      - ['vld1_dup_s16', '*const i16', 'int16x4_t', 'vld1.16', 'ld1r', 'i16x4::splat']
+      - ['vld1_dup_u16', '*const u16', 'uint16x4_t', 'vld1.16', 'ld1r', 'u16x4::splat']
+      - ['vld1_dup_p16', '*const p16', 'poly16x4_t', 'vld1.16', 'ld1r', 'u16x4::splat']
 
-      - ['vld1q_dup_s16', '*const i16', 'int16x8_t', 'vld1.16', 'ld1r', 'vld1q_lane_s16::<0>', 'i16x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1q_dup_u16', '*const u16', 'uint16x8_t', 'vld1.16', 'ld1r', 'vld1q_lane_u16::<0>', 'u16x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
-      - ['vld1q_dup_p16', '*const p16', 'poly16x8_t', 'vld1.16', 'ld1r', 'vld1q_lane_p16::<0>', 'u16x8::splat(0)', '[0, 0, 0, 0, 0, 0, 0, 0]']
+      - ['vld1q_dup_s16', '*const i16', 'int16x8_t', 'vld1.16', 'ld1r', 'i16x8::splat']
+      - ['vld1q_dup_u16', '*const u16', 'uint16x8_t', 'vld1.16', 'ld1r', 'u16x8::splat']
+      - ['vld1q_dup_p16', '*const p16', 'poly16x8_t', 'vld1.16', 'ld1r', 'u16x8::splat']
 
-      - ['vld1_dup_s32', '*const i32', 'int32x2_t', 'vld1.32', 'ld1r', 'vld1_lane_s32::<0>', 'i32x2::splat(0)', '[0, 0]']
-      - ['vld1_dup_u32', '*const u32', 'uint32x2_t', 'vld1.32', 'ld1r', 'vld1_lane_u32::<0>', 'u32x2::splat(0)', '[0, 0]']
-      - ['vld1_dup_f32', '*const f32', 'float32x2_t', 'vld1.32', 'ld1r', 'vld1_lane_f32::<0>', 'f32x2::splat(0.0)', '[0, 0]']
+      - ['vld1_dup_s32', '*const i32', 'int32x2_t', 'vld1.32', 'ld1r', 'i32x2::splat']
+      - ['vld1_dup_u32', '*const u32', 'uint32x2_t', 'vld1.32', 'ld1r', 'u32x2::splat']
+      - ['vld1_dup_f32', '*const f32', 'float32x2_t', 'vld1.32', 'ld1r', 'f32x2::splat']
 
-      - ['vld1q_dup_s32', '*const i32', 'int32x4_t', 'vld1.32', 'ld1r', 'vld1q_lane_s32::<0>', 'i32x4::splat(0)', '[0, 0, 0, 0]']
-      - ['vld1q_dup_u32', '*const u32', 'uint32x4_t', 'vld1.32', 'ld1r', 'vld1q_lane_u32::<0>', 'u32x4::splat(0)', '[0, 0, 0, 0]']
-      - ['vld1q_dup_f32', '*const f32', 'float32x4_t', 'vld1.32', 'ld1r', 'vld1q_lane_f32::<0>', 'f32x4::splat(0.0)', '[0, 0, 0, 0]']
+      - ['vld1q_dup_s32', '*const i32', 'int32x4_t', 'vld1.32', 'ld1r', 'i32x4::splat']
+      - ['vld1q_dup_u32', '*const u32', 'uint32x4_t', 'vld1.32', 'ld1r', 'u32x4::splat']
+      - ['vld1q_dup_f32', '*const f32', 'float32x4_t', 'vld1.32', 'ld1r', 'f32x4::splat']
 
-      - ['vld1q_dup_s64', '*const i64', 'int64x2_t', 'vldr', 'ld1', 'vld1q_lane_s64::<0>', 'i64x2::splat(0)', '[0, 0]']
-      - ['vld1q_dup_u64', '*const u64', 'uint64x2_t', 'vldr', 'ld1', 'vld1q_lane_u64::<0>', 'u64x2::splat(0)', '[0, 0]']
+      - ['vld1q_dup_s64', '*const i64', 'int64x2_t', 'vldr', 'ld1', 'i64x2::splat']
+      - ['vld1q_dup_u64', '*const u64', 'uint64x2_t', 'vldr', 'ld1', 'u64x2::splat']
     compose:
-      - Let:
-          - x
-          - FnCall:
-              - '{type[5]}'
-              - - ptr
-                - FnCall: [transmute, ['{type[6]}']]
-      - FnCall: ['simd_shuffle!', [x, x, '{type[7]}']]
+      - FnCall:
+          - transmute
+          - - FnCall: ['{type[5]}', ["*ptr"]]
 
   - name: "{type[0]}"
     doc: "Absolute difference and accumulate (64-bit)"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -12861,13 +12861,16 @@ intrinsics:
       - int16x8_t
       - int32x4_t
     compose:
-      - LLVMLink:
-          name: "vabs{neon_type.no}"
-          links:
-            - link: "llvm.aarch64.neon.abs.{neon_type}"
-              arch: aarch64,arm64ec
-            - link: "llvm.arm.neon.vabs.{neon_type}"
-              arch: arm
+      - Let:
+          - neg
+          - "{neon_type}"
+          - FnCall: [simd_neg, [a]]
+      - Let:
+          - mask
+          - "{neon_type}"
+          - FnCall: [simd_ge, [a, neg]]
+      - FnCall: [simd_select, [mask, a, neg]]
+
 
   - name: "vpmin{neon_type.no}"
     doc: "Folding minimum of adjacent pairs"

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -9532,7 +9532,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vtrn]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9573,7 +9574,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vtrn]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [trn2]]}]]
       - *neon-fp16
       - *neon-unstable-f16
     safety: safe

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -7874,9 +7874,9 @@ intrinsics:
     static_defs: ['const N: i32']
     safety: safe
     types:
-      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16]) }']
-      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) }']
-      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64, -N as i64]) }']
+      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16; 8]) }']
+      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N; 4]) }']
+      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64; 2]) }']
     compose:
       - FnCall: [static_assert!, ["{type[2]}"]]
       - LLVMLink:
@@ -7929,9 +7929,9 @@ intrinsics:
     static_defs: ['const N: i32']
     safety: safe
     types:
-      - [int16x8_t, uint8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16]) }']
-      - [int32x4_t, uint16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) }']
-      - [int64x2_t, uint32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64, -N as i64]) }']
+      - [int16x8_t, uint8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16; 8]) }']
+      - [int32x4_t, uint16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N; 4]) }']
+      - [int64x2_t, uint32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64; 2]) }']
     compose:
       - FnCall: [static_assert!, ["{type[2]}"]]
       - LLVMLink:
@@ -8105,9 +8105,9 @@ intrinsics:
     static_defs: ['const N: i32']
     safety: safe
     types:
-      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16]) }']
-      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) }']
-      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64, -N as i64]) }']
+      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16; 8]) }']
+      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N; 4]) }']
+      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64; 2]) }']
     compose:
       - FnCall: [static_assert!, ["{type[2]}"]]
       - LLVMLink:
@@ -8215,9 +8215,9 @@ intrinsics:
     static_defs: ['const N: i32']
     safety: safe
     types:
-      - [int16x8_t, uint8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16]) }']
-      - [int32x4_t, uint16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) }']
-      - [int64x2_t, uint32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64, -N as i64]) }']
+      - [int16x8_t, uint8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16; 8]) }']
+      - [int32x4_t, uint16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N; 4]) }']
+      - [int64x2_t, uint32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64; 2]) }']
     compose:
       - FnCall: [static_assert!, ["{type[2]}"]]
       - LLVMLink:
@@ -8939,9 +8939,9 @@ intrinsics:
     static_defs: ['const N: i32']
     safety: safe
     types:
-      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16, -N as i16]) }']
-      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N as i32, -N as i32, -N as i32, -N as i32]) }']
-      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64, -N as i64]) }']
+      - [int16x8_t, int8x8_t, 'N >= 1 && N <= 8', 'const { int16x8_t([-N as i16; 8]) }']
+      - [int32x4_t, int16x4_t, 'N >= 1 && N <= 16', 'const { int32x4_t([-N; 4]) }']
+      - [int64x2_t, int32x2_t, 'N >= 1 && N <= 32', 'const { int64x2_t([-N as i64; 2]) }']
     compose:
       - FnCall: [static_assert!, ["{type[2]}"]]
       - LLVMLink:
@@ -13862,8 +13862,8 @@ intrinsics:
       - [int8x16_t, '8',  '1 <= N && N <= 8',  'v16i8', 'int8x16_t::splat', '-N as i8']
       - [int16x4_t, '16', '1 <= N && N <= 16', 'v4i16', 'int16x4_t::splat', '-N as i16']
       - [int16x8_t, '16', '1 <= N && N <= 16', 'v8i16', 'int16x8_t::splat', '-N as i16']
-      - [int32x2_t, '32', '1 <= N && N <= 32', 'v2i32', 'int32x2_t::splat', '-N as i32']
-      - [int32x4_t, '32', '1 <= N && N <= 32', 'v4i32', 'int32x4_t::splat', '-N as i32']
+      - [int32x2_t, '32', '1 <= N && N <= 32', 'v2i32', 'int32x2_t::splat', '-N']
+      - [int32x4_t, '32', '1 <= N && N <= 32', 'v4i32', 'int32x4_t::splat', '-N']
       - [int64x1_t, '64', '1 <= N && N <= 64', 'v1i64', 'int64x1_t::splat', '-N as i64']
       - [int64x2_t, '64', '1 <= N && N <= 64', 'v2i64', 'int64x2_t::splat', '-N as i64']
     compose:
@@ -13891,8 +13891,8 @@ intrinsics:
       - [uint8x16_t, "neon,v7", '8',  'static_assert_uimm_bits!', 'N, 3',    'v16i8', 'int8x16_t::splat', 'N as i8']
       - [uint16x4_t, "neon,v7", '16', 'static_assert_uimm_bits!', 'N, 4',    'v4i16', 'int16x4_t::splat', 'N as i16']
       - [uint16x8_t, "neon,v7", '16', 'static_assert_uimm_bits!', 'N, 4',    'v8i16', 'int16x8_t::splat', 'N as i16']
-      - [uint32x2_t, "neon,v7", '32', 'static_assert!', 'N >= 0 && N <= 31', 'v2i32', 'int32x2_t::splat', 'N as i32']
-      - [uint32x4_t, "neon,v7", '32', 'static_assert!', 'N >= 0 && N <= 31', 'v4i32', 'int32x4_t::splat', 'N as i32']
+      - [uint32x2_t, "neon,v7", '32', 'static_assert!', 'N >= 0 && N <= 31', 'v2i32', 'int32x2_t::splat', 'N']
+      - [uint32x4_t, "neon,v7", '32', 'static_assert!', 'N >= 0 && N <= 31', 'v4i32', 'int32x4_t::splat', 'N']
       - [uint64x1_t, "neon,v7", '64', 'static_assert!', 'N >= 0 && N <= 63', 'v1i64', 'int64x1_t::splat', 'N as i64']
       - [uint64x2_t, "neon,v7", '64', 'static_assert!', 'N >= 0 && N <= 63', 'v2i64', 'int64x2_t::splat', 'N as i64']
       - [poly8x8_t,  "neon,v7", '8',  'static_assert_uimm_bits!', 'N, 3',     'v8i8', 'int8x8_t::splat',  'N as i8']

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -14131,8 +14131,8 @@ intrinsics:
       - ['vld1q_dup_u32', '*const u32', 'uint32x4_t', 'vld1.32', 'ld1r', 'u32x4::splat']
       - ['vld1q_dup_f32', '*const f32', 'float32x4_t', 'vld1.32', 'ld1r', 'f32x4::splat']
 
-      - ['vld1q_dup_s64', '*const i64', 'int64x2_t', 'vldr', 'ld1', 'i64x2::splat']
-      - ['vld1q_dup_u64', '*const u64', 'uint64x2_t', 'vldr', 'ld1', 'u64x2::splat']
+      - ['vld1q_dup_s64', '*const i64', 'int64x2_t', 'vldr', 'ld1r', 'i64x2::splat']
+      - ['vld1q_dup_u64', '*const u64', 'uint64x2_t', 'vldr', 'ld1r', 'u64x2::splat']
     compose:
       - FnCall:
           - transmute

--- a/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
+++ b/library/stdarch/crates/stdarch-gen-arm/spec/neon/arm_shared.spec.yml
@@ -9601,7 +9601,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vtrn]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9629,7 +9630,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vorr]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9663,7 +9665,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vtrn]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9691,7 +9694,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vzip]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe
@@ -9723,7 +9727,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, ['"vzip.16"']]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-fp16
       - *neon-unstable-f16
     safety: safe
@@ -9819,7 +9824,8 @@ intrinsics:
     attr:
       - *neon-v7
       - FnCall: [cfg_attr, [*test-is-arm, {FnCall: [assert_instr, [vtrn]]}]]
-      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip1]]}]]
+      - FnCall: [cfg_attr, [*neon-target-aarch64-arm64ec, {FnCall: [assert_instr, [zip2]]}]]
       - *neon-not-arm-stable
       - *neon-cfg-arm-unstable
     safety: safe

--- a/library/stdarch/crates/stdarch-gen-arm/src/expression.rs
+++ b/library/stdarch/crates/stdarch-gen-arm/src/expression.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use proc_macro2::{Literal, Punct, Spacing, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use regex::Regex;
@@ -7,6 +6,7 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use crate::intrinsic::Intrinsic;
 use crate::wildstring::WildStringPart;
@@ -374,10 +374,8 @@ impl FromStr for Expression {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref MACRO_RE: Regex =
-                Regex::new(r"^(?P<name>[\w\d_]+)!\((?P<ex>.*?)\);?$").unwrap();
-        }
+        static MACRO_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?P<name>[\w\d_]+)!\((?P<ex>.*?)\);?$").unwrap());
 
         if s == "SvUndef" {
             Ok(Expression::SvUndef)

--- a/library/stdarch/crates/stdarch-gen-arm/src/typekinds.rs
+++ b/library/stdarch/crates/stdarch-gen-arm/src/typekinds.rs
@@ -1,10 +1,10 @@
-use lazy_static::lazy_static;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote};
 use regex::Regex;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::fmt;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use crate::context;
 use crate::expression::{Expression, FnCall};
@@ -496,9 +496,9 @@ impl FromStr for VectorType {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r"^(?:(?:sv(?P<sv_ty>(?:uint|int|bool|float)(?:\d+)?))|(?:(?P<ty>(?:uint|int|bool|poly|float)(?:\d+)?)x(?P<lanes>(?:\d+)?)))(?:x(?P<tuple_size>2|3|4))?_t$").unwrap();
-        }
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?:(?:sv(?P<sv_ty>(?:uint|int|bool|float)(?:\d+)?))|(?:(?P<ty>(?:uint|int|bool|poly|float)(?:\d+)?)x(?P<lanes>(?:\d+)?)))(?:x(?P<tuple_size>2|3|4))?_t$").unwrap()
+        });
 
         if let Some(c) = RE.captures(s) {
             let (base_type, lanes) = Self::sanitise_lanes(
@@ -698,9 +698,8 @@ impl FromStr for BaseType {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r"^(?P<kind>[a-zA-Z]+)(?P<size>\d+)?(_t)?$").unwrap();
-        }
+        static RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^(?P<kind>[a-zA-Z]+)(?P<size>\d+)?(_t)?$").unwrap());
 
         if let Some(c) = RE.captures(s) {
             let kind = c["kind"].parse()?;

--- a/library/stdarch/crates/stdarch-gen-arm/src/wildcards.rs
+++ b/library/stdarch/crates/stdarch-gen-arm/src/wildcards.rs
@@ -1,8 +1,7 @@
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, sync::LazyLock};
 
 use crate::{
     fn_suffix::SuffixKind,
@@ -66,9 +65,9 @@ impl FromStr for Wildcard {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(r"^(?P<wildcard>\w+?)(?:_x(?P<tuple_size>[2-4]))?(?:\[(?P<index>\d+)\])?(?:\.(?P<modifiers>\w+))?(?:\s+as\s+(?P<scale_to>.*?))?$").unwrap();
-        }
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^(?P<wildcard>\w+?)(?:_x(?P<tuple_size>[2-4]))?(?:\[(?P<index>\d+)\])?(?:\.(?P<modifiers>\w+))?(?:\s+as\s+(?P<scale_to>.*?))?$").unwrap()
+        });
 
         if let Some(c) = RE.captures(s) {
             let wildcard_name = &c["wildcard"];

--- a/library/stdarch/crates/stdarch-gen-loongarch/README.md
+++ b/library/stdarch/crates/stdarch-gen-loongarch/README.md
@@ -11,7 +11,6 @@ LSX:
 # Generate bindings
 OUT_DIR=`pwd`/crates/stdarch-gen-loongarch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lsxintrin.h
 OUT_DIR=`pwd`/crates/core_arch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lsx.spec
-rustfmt crates/core_arch/src/loongarch64/lsx/generated.rs
 
 # Generate tests
 OUT_DIR=`pwd`/crates/stdarch-gen-loongarch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lsx.spec test
@@ -25,7 +24,6 @@ LASX:
 # Generate bindings
 OUT_DIR=`pwd`/crates/stdarch-gen-loongarch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lasxintrin.h
 OUT_DIR=`pwd`/crates/core_arch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lasx.spec
-rustfmt crates/core_arch/src/loongarch64/lasx/generated.rs
 
 # Generate tests
 OUT_DIR=`pwd`/crates/stdarch-gen-loongarch cargo run -p stdarch-gen-loongarch -- crates/stdarch-gen-loongarch/lasx.spec test

--- a/library/stdarch/crates/stdarch-gen-loongarch/src/main.rs
+++ b/library/stdarch/crates/stdarch-gen-loongarch/src/main.rs
@@ -280,7 +280,7 @@ fn gen_bind_body(
             let fn_output = if out_t.to_lowercase() == "void" {
                 String::new()
             } else {
-                format!("-> {}", type_to_rst(out_t, is_store))
+                format!(" -> {}", type_to_rst(out_t, is_store))
             };
             let fn_inputs = match para_num {
                 1 => format!("(a: {})", type_to_rst(in_t[0], is_store)),
@@ -304,7 +304,7 @@ fn gen_bind_body(
                 ),
                 _ => panic!("unsupported parameter number"),
             };
-            format!("fn __{current_name}{fn_inputs} {fn_output};")
+            format!("fn __{current_name}{fn_inputs}{fn_output};")
         };
         let function = format!(
             r#"    #[link_name = "llvm.loongarch.{}"]

--- a/library/stdarch/crates/stdarch-test/Cargo.toml
+++ b/library/stdarch/crates/stdarch-test/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 [dependencies]
 assert-instr-macro = { path = "../assert-instr-macro" }
 simd-test-macro = { path = "../simd-test-macro" }
-lazy_static = "1.0"
 rustc-demangle = "0.1.8"
 cfg-if = "1.0"
 

--- a/library/stdarch/crates/stdarch-test/Cargo.toml
+++ b/library/stdarch/crates/stdarch-test/Cargo.toml
@@ -20,7 +20,7 @@ cc = "1.0"
 # time, and we want to make updates to this explicit rather than automatically
 # picking up updates which might break CI with new instruction names.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasmprinter = "=0.2.67"
+wasmprinter = "=0.235"
 
 [features]
 default = []

--- a/library/stdarch/crates/stdarch-test/src/lib.rs
+++ b/library/stdarch/crates/stdarch-test/src/lib.rs
@@ -92,7 +92,13 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     };
 
     // Check whether the given instruction is part of the disassemblied body.
-    let found = expected == "nop" || instrs.iter().any(|s| s.starts_with(expected));
+    let found = expected == "nop"
+        || instrs.iter().any(|instruction| {
+            // Check that the next character is non-alphabetic. This prevents false negatives
+            // when e.g. `fminnm` was used but `fmin` was expected.
+            instruction.starts_with(expected)
+                && !instruction[expected.len()..].starts_with(|c: char| c.is_ascii_alphabetic())
+        });
 
     // Look for subroutine call instructions in the disassembly to detect whether
     // inlining failed: all intrinsics are `#[inline(always)]`, so calling one

--- a/library/stdarch/crates/stdarch-test/src/lib.rs
+++ b/library/stdarch/crates/stdarch-test/src/lib.rs
@@ -7,13 +7,11 @@
 #![allow(clippy::missing_docs_in_private_items, clippy::print_stdout)]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate cfg_if;
 
 pub use assert_instr_macro::*;
 pub use simd_test_macro::*;
-use std::{cmp, collections::HashSet, env, hash, hint::black_box, str};
+use std::{cmp, collections::HashSet, env, hash, hint::black_box, str, sync::LazyLock};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -25,9 +23,7 @@ cfg_if! {
     }
 }
 
-lazy_static! {
-    static ref DISASSEMBLY: HashSet<Function> = disassemble_myself();
-}
+static DISASSEMBLY: LazyLock<HashSet<Function>> = LazyLock::new(disassemble_myself);
 
 #[derive(Debug)]
 struct Function {

--- a/library/stdarch/crates/stdarch-test/src/lib.rs
+++ b/library/stdarch/crates/stdarch-test/src/lib.rs
@@ -94,10 +94,12 @@ pub fn assert(shim_addr: usize, fnname: &str, expected: &str) {
     // Check whether the given instruction is part of the disassemblied body.
     let found = expected == "nop"
         || instrs.iter().any(|instruction| {
-            // Check that the next character is non-alphabetic. This prevents false negatives
-            // when e.g. `fminnm` was used but `fmin` was expected.
             instruction.starts_with(expected)
-                && !instruction[expected.len()..].starts_with(|c: char| c.is_ascii_alphabetic())
+            // Check that the next character is non-alphanumeric. This prevents false negatives
+            // when e.g. `fminnm` was used but `fmin` was expected.
+            //
+            // TODO: resolve the conflicts (x86_64 and aarch64 have a bunch, probably others)
+            // && !instruction[expected.len()..].starts_with(|c: char| c.is_ascii_alphanumeric())
         });
 
     // Look for subroutine call instructions in the disassembly to detect whether

--- a/library/stdarch/examples/connect5.rs
+++ b/library/stdarch/examples/connect5.rs
@@ -558,7 +558,8 @@ fn search(pos: &Pos, alpha: i32, beta: i32, depth: i32, _ply: i32) -> i32 {
     assert_ne!(bm, MOVE_NONE);
     assert!(bs >= -EVAL_INF && bs <= EVAL_INF);
 
-    if _ply == 0 { bm } else { bs } //best move at the root node, best score elsewhere
+    // best move at the root node, best score elsewhere
+    if _ply == 0 { bm } else { bs }
 }
 
 /// Evaluation function: give different scores to different patterns after a fixed depth.
@@ -570,15 +571,11 @@ fn eval(pos: &Pos, _ply: i32) -> i32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         if check_x86_avx512_features() {
-            unsafe {
-                if check_patternlive4_avx512(pos, def) {
-                    return -4096;
-                }
-            }
-        } else {
-            if check_patternlive4(pos, def) {
+            if unsafe { check_patternlive4_avx512(pos, def) } {
                 return -4096;
             }
+        } else if check_patternlive4(pos, def) {
+            return -4096;
         }
     }
 
@@ -593,15 +590,11 @@ fn eval(pos: &Pos, _ply: i32) -> i32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         if check_x86_avx512_features() {
-            unsafe {
-                if check_patternlive4_avx512(pos, atk) {
-                    return 2560;
-                }
-            }
-        } else {
-            if check_patternlive4(pos, atk) {
+            if unsafe { check_patternlive4_avx512(pos, atk) } {
                 return 2560;
             }
+        } else if check_patternlive4(pos, atk) {
+            return 2560;
         }
     }
 
@@ -616,15 +609,11 @@ fn eval(pos: &Pos, _ply: i32) -> i32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         if check_x86_avx512_features() {
-            unsafe {
-                if check_patterndead4_avx512(pos, atk) > 0 {
-                    return 2560;
-                }
-            }
-        } else {
-            if check_patterndead4(pos, atk) > 0 {
+            if unsafe { check_patterndead4_avx512(pos, atk) > 0 } {
                 return 2560;
             }
+        } else if check_patterndead4(pos, atk) > 0 {
+            return 2560;
         }
     }
 
@@ -909,9 +898,7 @@ fn pos_is_winner_avx512(pos: &Pos) -> bool {
                                         0b00_10_10_10_10_11_10_10_10_10_11_11_11_11_11_10];
     let mut count_match: i32 = 0;
 
-    for dir in 0..2 {
-        // direction 0 and 1
-        let mut board0 = board0org[dir];
+    for mut board0 in board0org {
         let boardf = _mm512_and_si512(answer, board0);
         let temp_mask = _mm512_mask_cmpeq_epi16_mask(answer_mask[0], answer, boardf);
         count_match += _popcnt32(temp_mask as i32);

--- a/library/stdarch/triagebot.toml
+++ b/library/stdarch/triagebot.toml
@@ -1,7 +1,7 @@
 [assign]
 
 [assign.owners]
-"*" = ["@Amanieu"]
+"*" = ["@Amanieu", "@folkertdev", "@sayantn"]
 
 [ping.windows]
 message = """\


### PR DESCRIPTION
Subtree update of `stdarch` to https://github.com/rust-lang/stdarch/commit/5531955678494ee28ec02130a6d94082ad4532da.

Created using https://github.com/rust-lang/josh-sync.

I saw that there were non-trivial changes made to `std_detect` in `stdarch` recently. So I want to get them merged here before we move forward with https://github.com/rust-lang/rust/pull/143412.

r? @folkertdev