### PR TITLE
Add debuginfo_transparent attribute for structs

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/debuginfo.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debuginfo.rs
@@ -1,0 +1,15 @@
+use rustc_hir::Target;
+use rustc_hir::attrs::AttributeKind;
+use rustc_span::{Span, Symbol, sym};
+
+use crate::attributes::{NoArgsAttributeParser, OnDuplicate};
+use crate::context::MaybeWarn::Allow;
+use crate::context::{AllowedTargets, Stage};
+
+pub(crate) struct DebuginfoTransparentParser;
+impl<S: Stage> NoArgsAttributeParser<S> for DebuginfoTransparentParser {
+    const PATH: &[Symbol] = &[sym::debuginfo_transparent];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::DebuginfoTransparent;
+}

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod cfg;
 pub(crate) mod cfg_old;
 pub(crate) mod codegen_attrs;
 pub(crate) mod confusables;
+pub(crate) mod debuginfo;
 pub(crate) mod deprecation;
 pub(crate) mod dummy;
 pub(crate) mod inline;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -25,6 +25,7 @@ use crate::attributes::codegen_attrs::{
     TargetFeatureParser, TrackCallerParser, UsedParser,
 };
 use crate::attributes::confusables::ConfusablesParser;
+use crate::attributes::debuginfo::DebuginfoTransparentParser;
 use crate::attributes::deprecation::DeprecationParser;
 use crate::attributes::dummy::DummyParser;
 use crate::attributes::inline::{InlineParser, RustcForceInlineParser};
@@ -199,6 +200,7 @@ attribute_parsers!(
         Single<WithoutArgs<ConstStabilityIndirectParser>>,
         Single<WithoutArgs<ConstTraitParser>>,
         Single<WithoutArgs<CoroutineParser>>,
+        Single<WithoutArgs<DebuginfoTransparentParser>>,
         Single<WithoutArgs<DenyExplicitImplParser>>,
         Single<WithoutArgs<DoNotImplementViaObjectParser>>,
         Single<WithoutArgs<ExportStableParser>>,

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -880,6 +880,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No, loop_match, experimental!(loop_match)
     ),
 
+    gated!(
+        debuginfo_transparent, Normal, template!(Word), WarnFollowing,
+        EncodeCrossCrate::Yes, debuginfo_attrs, experimental!(debuginfo_transparent)
+    ),
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -459,6 +459,8 @@ declare_features! (
     (unstable, custom_inner_attributes, "1.30.0", Some(54726)),
     /// Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
     (unstable, custom_test_frameworks, "1.30.0", Some(50297)),
+    /// Allows `debuginfo_*` attributes.
+    (unstable, debuginfo_attrs, "CURRENT_RUSTC_VERSION", None),
     /// Allows declarative macros 2.0 (`macro`).
     (unstable, decl_macro, "1.17.0", Some(39412)),
     /// Allows the use of default values on struct definitions and the construction of struct

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -324,6 +324,9 @@ pub enum AttributeKind {
     /// Represents `#[coverage(..)]`.
     Coverage(Span, CoverageAttrKind),
 
+    /// Represents `#[debuginfo_transparent]`.
+    DebuginfoTransparent(Span),
+
     ///Represents `#[rustc_deny_explicit_impl]`.
     DenyExplicitImpl(Span),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -31,6 +31,7 @@ impl AttributeKind {
             ConstTrait(..) => No,
             Coroutine(..) => No,
             Coverage(..) => No,
+            DebuginfoTransparent { .. } => Yes,
             DenyExplicitImpl(..) => No,
             Deprecation { .. } => Yes,
             DoNotImplementViaObject(..) => No,

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -83,6 +83,10 @@ passes_dead_codes =
        }
     } never {$participle}
 
+passes_debuginfo_transparent =
+    attribute should be applied to `#[repr(transparent)]` types
+    .label = not a `#[repr(transparent)]` type
+
 passes_debug_visualizer_invalid =
     invalid argument
     .note_1 = expected: `natvis_file = "..."`

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -138,6 +138,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 &Attribute::Parsed(AttributeKind::TypeConst(attr_span)) => {
                     self.check_type_const(hir_id, attr_span, target)
                 }
+                &Attribute::Parsed(AttributeKind::DebuginfoTransparent(attr_span)) => {
+                    self.check_debuginfo_transparent(attr_span, span, attrs)
+                },
                 Attribute::Parsed(
                     AttributeKind::Stability {
                         span: attr_span,
@@ -2012,6 +2015,14 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     "`#[type_const]` must only be applied to trait associated constants",
                 )
                 .emit();
+        }
+    }
+
+    fn check_debuginfo_transparent(&self, attr_span: Span, span: Span, attrs: &[Attribute]) {
+        if !find_attr!(attrs, AttributeKind::Repr { reprs, .. } => reprs.iter().any(|(r, _)| r == &ReprAttr::ReprTransparent))
+            .unwrap_or(false)
+        {
+            self.dcx().emit_err(errors::DebuginfoTransparent { span, attr_span });
         }
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -113,6 +113,15 @@ pub(crate) struct AttrShouldBeAppliedToStatic {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_debuginfo_transparent)]
+pub(crate) struct DebuginfoTransparent {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_doc_expect_str)]
 pub(crate) struct DocExpectStr<'a> {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -809,6 +809,8 @@ symbols! {
         debug_tuple,
         debug_tuple_fields_finish,
         debugger_visualizer,
+        debuginfo_attrs,
+        debuginfo_transparent,
         decl_macro,
         declare_lint_pass,
         decode,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -108,6 +108,7 @@
 #![feature(const_eval_select)]
 #![feature(core_intrinsics)]
 #![feature(coverage_attribute)]
+#![feature(debuginfo_attrs)]
 #![feature(disjoint_bitor)]
 #![feature(internal_impls_macro)]
 #![feature(ip)]

--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -18,6 +18,7 @@ macro_rules! define_valid_range_type {
         #[repr(transparent)]
         #[rustc_layout_scalar_valid_range_start($low)]
         #[rustc_layout_scalar_valid_range_end($high)]
+        #[debuginfo_transparent]
         $(#[$m])*
         $vis struct $name($int);
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -72,6 +72,7 @@ use crate::{fmt, hash, intrinsics, mem, ptr};
 #[rustc_layout_scalar_valid_range_start(1)]
 #[rustc_nonnull_optimization_guaranteed]
 #[rustc_diagnostic_item = "NonNull"]
+#[debuginfo_transparent]
 pub struct NonNull<T: PointeeSized> {
     // Remember to use `.as_ptr()` instead of `.pointer`, as field projecting to
     // this is banned by <https://github.com/rust-lang/compiler-team/issues/807>.

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -32,6 +32,7 @@ use crate::ptr::NonNull;
 )]
 #[doc(hidden)]
 #[repr(transparent)]
+#[debuginfo_transparent]
 pub struct Unique<T: PointeeSized> {
     pointer: NonNull<T>,
     // NOTE: this marker has no consequences for variance, but is necessary

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -102,6 +102,7 @@ pub fn check(
 
     walk_many(
         &[
+            &tests_path.join("debuginfo"),
             &tests_path.join("ui"),
             &tests_path.join("ui-fulldeps"),
             &tests_path.join("rustdoc-ui"),

--- a/tests/debuginfo/debuginfo-attrs.rs
+++ b/tests/debuginfo/debuginfo-attrs.rs
@@ -1,0 +1,39 @@
+//@ compile-flags:-g
+
+// gate-test-debuginfo_attrs
+// Tests the `#[debuginfo_transparent]` attribute.
+
+// === CDB TESTS ==================================================================================
+// cdb-command: g
+
+// cdb-command: dx transparent
+// cdb-check:transparent           : 1 [Type: u32]
+// cdb-check:    [<Raw View>]     [Type: u32]
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print transparent
+// gdb-check:[...]$1 = 1
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:v transparent
+// lldb-check:[...] 1
+
+#![feature(debuginfo_attrs)]
+
+#[repr(transparent)]
+#[debuginfo_transparent]
+struct Transparent(u32);
+
+fn main() {
+    let transparent = Transparent(1);
+
+    zzz(); // #break
+}
+
+fn zzz() {}

--- a/tests/debuginfo/strings-and-strs.rs
+++ b/tests/debuginfo/strings-and-strs.rs
@@ -8,7 +8,7 @@
 // gdb-command:run
 
 // gdb-command:print plain_string
-// gdb-check:$1 = alloc::string::String {vec: alloc::vec::Vec<u8, alloc::alloc::Global> {buf: alloc::raw_vec::RawVec<u8, alloc::alloc::Global> {inner: alloc::raw_vec::RawVecInner<alloc::alloc::Global> {ptr: core::ptr::unique::Unique<u8> {pointer: core::ptr::non_null::NonNull<u8> {pointer: 0x[...]}, _marker: core::marker::PhantomData<u8>}, cap: core::num::niche_types::UsizeNoHighBit (5), alloc: alloc::alloc::Global}, _marker: core::marker::PhantomData<u8>}, len: 5}}
+// gdb-check:$1 = alloc::string::String {vec: alloc::vec::Vec<u8, alloc::alloc::Global> {buf: alloc::raw_vec::RawVec<u8, alloc::alloc::Global> {inner: alloc::raw_vec::RawVecInner<alloc::alloc::Global> {ptr: 0x[...], cap: 5, alloc: alloc::alloc::Global}, _marker: core::marker::PhantomData<u8>}, len: 5}}
 
 // gdb-command:print plain_str
 // gdb-check:$2 = "Hello"
@@ -20,7 +20,7 @@
 // gdb-check:$4 = ("Hello", "World")
 
 // gdb-command:print str_in_rc
-// gdb-check:$5 = alloc::rc::Rc<&str, alloc::alloc::Global> {ptr: core::ptr::non_null::NonNull<alloc::rc::RcInner<&str>> {pointer: 0x[...]}, phantom: core::marker::PhantomData<alloc::rc::RcInner<&str>>, alloc: alloc::alloc::Global}
+// gdb-check:$5 = alloc::rc::Rc<&str, alloc::alloc::Global> {ptr: 0x[...], alloc: alloc::alloc::Global}
 
 // === LLDB TESTS ==================================================================================
 // lldb-command:run
@@ -38,7 +38,6 @@
 
 // lldb-command:v str_in_rc
 // lldb-check:(alloc::rc::Rc<&str, alloc::alloc::Global>) str_in_rc = strong=1, weak=0 { value = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } }
-
 
 #![allow(unused_variables)]
 


### PR DESCRIPTION
This attribute causes the struct to be unwrapped at the debuginfo level the same way that repr(transparent) unwraps it at the ABI level. This is useful for preventing types like NonNull and Unique from making the debuginfo harder to read when pretty printers aren't used.