### PR TITLE
Option::as_slice: fix comment

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -842,7 +842,7 @@ impl<T> Option<T> {
         // just needs to be aligned, which it is because `&self` is aligned and
         // the offset used is a multiple of alignment.
         //
-        // In the new version, the intrinsic always returns a pointer to an
+        // Here we assume that `offset_of!` always returns an offset to an
         // in-bounds and correctly aligned position for a `T` (even if in the
         // `None` case it's just padding).
         unsafe {


### PR DESCRIPTION
The implementation got changed in https://github.com/rust-lang/rust/pull/117525 without updating the comment. Now the comment makes no sense any more since there is no intrinsic that returns a pointer in this function any more.

(It is also very strange to say "in the new version" in a comment -- what is that supposed to tell someone reading the code 2 years later? That wording was introduced even earlier, in https://github.com/rust-lang/rust/pull/109179.)

Cc @GKFX @petrochenkov @llogiq @scottmcm 