### PR TITLE
Add more test case to check if the false note related to sealed trait suppressed

### DIFF
--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
@@ -1,5 +1,6 @@
-// We should not emit sealed traits note, see issue #143392
+// We should not emit sealed traits note, see issue #143392 and #143121
 
+/// Reported in #143392
 mod inner {
     pub trait TraitA {}
 
@@ -9,5 +10,14 @@ mod inner {
 struct Struct;
 
 impl inner::TraitB for Struct {} //~ ERROR the trait bound `Struct: TraitA` is not satisfied [E0277]
+
+/// Reported in #143121
+mod x {
+    pub trait A {}
+    pub trait B: A {}
+
+    pub struct C;
+    impl B for C {} //~ ERROR the trait bound `C: A` is not satisfied [E0277]
+}
 
 fn main(){}

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
@@ -1,20 +1,37 @@
 error[E0277]: the trait bound `Struct: TraitA` is not satisfied
-  --> $DIR/false-sealed-traits-note.rs:11:24
+  --> $DIR/false-sealed-traits-note.rs:12:24
    |
 LL | impl inner::TraitB for Struct {}
    |                        ^^^^^^ the trait `TraitA` is not implemented for `Struct`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/false-sealed-traits-note.rs:4:5
+  --> $DIR/false-sealed-traits-note.rs:5:5
    |
 LL |     pub trait TraitA {}
    |     ^^^^^^^^^^^^^^^^
 note: required by a bound in `TraitB`
-  --> $DIR/false-sealed-traits-note.rs:6:23
+  --> $DIR/false-sealed-traits-note.rs:7:23
    |
 LL |     pub trait TraitB: TraitA {}
    |                       ^^^^^^ required by this bound in `TraitB`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `C: A` is not satisfied
+  --> $DIR/false-sealed-traits-note.rs:20:16
+   |
+LL |     impl B for C {}
+   |                ^ the trait `A` is not implemented for `C`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/false-sealed-traits-note.rs:16:5
+   |
+LL |     pub trait A {}
+   |     ^^^^^^^^^^^
+note: required by a bound in `B`
+  --> $DIR/false-sealed-traits-note.rs:17:18
+   |
+LL |     pub trait B: A {}
+   |                  ^ required by this bound in `B`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#143121

I started to fix the issue but I found that this one has already been addressed in this PR (https://github.com/rust-lang/rust/pull/143431). I added an additional test to prove the reported thing has been resolved just in case. 

I think we can discard this pull request if there's no need to add such kind of tests👍🏻