### PR TITLE
Don't use another main test file as auxiliary

### DIFF
--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.fixed
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.fixed
@@ -1,5 +1,5 @@
 //@ edition:2018
-//@ aux-build:../removing-extern-crate.rs
+//@ aux-build: remove-extern-crate.rs
 //@ run-rustfix
 
 #![warn(rust_2018_idioms)]

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.rs
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.rs
@@ -1,16 +1,16 @@
 //@ edition:2018
-//@ aux-build:../removing-extern-crate.rs
+//@ aux-build: remove-extern-crate.rs
 //@ run-rustfix
 
 #![warn(rust_2018_idioms)]
 
 #[cfg_attr(test, "macro_use")] //~ ERROR expected
-extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+extern crate remove_extern_crate as foo; //~ WARNING unused extern crate
 extern crate core; //~ WARNING unused extern crate
 
 mod another {
     #[cfg_attr(test)] //~ ERROR expected
-    extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+    extern crate remove_extern_crate as foo; //~ WARNING unused extern crate
     extern crate core; //~ WARNING unused extern crate
 }
 

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
@@ -19,8 +19,8 @@ LL |     #[cfg_attr(test)]
 warning: unused extern crate
   --> $DIR/removing-extern-crate-malformed-cfg.rs:8:1
    |
-LL | extern crate removing_extern_crate as foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+LL | extern crate remove_extern_crate as foo;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/removing-extern-crate-malformed-cfg.rs:5:9
@@ -31,7 +31,7 @@ LL | #![warn(rust_2018_idioms)]
 help: remove the unused `extern crate`
    |
 LL - #[cfg_attr(test, "macro_use")]
-LL - extern crate removing_extern_crate as foo;
+LL - extern crate remove_extern_crate as foo;
 LL +
    |
 
@@ -50,13 +50,13 @@ LL +
 warning: unused extern crate
   --> $DIR/removing-extern-crate-malformed-cfg.rs:13:5
    |
-LL |     extern crate removing_extern_crate as foo;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+LL |     extern crate remove_extern_crate as foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 help: remove the unused `extern crate`
    |
 LL -     #[cfg_attr(test)]
-LL -     extern crate removing_extern_crate as foo;
+LL -     extern crate remove_extern_crate as foo;
 LL +
    |
 


### PR DESCRIPTION
In this case, the exact extern crate isn't very important, it just needs to not be another main test file.

This is part of the changes needed to address the spurious failures from a main test `../removing-extern-crate.rs` being both an auxiliary and a main test file, causing fs races due to multiple `rustc` processes in multiple test threads trying to build the main test file both as a main test and also as an auxiliary at around the same time.

Part 1 of rust-lang/rust#144237.

r? @RalfJung (or compiler)
