### PR TITLE
coretests/num: use ldexp instead of hard-coding a power of 2

### DIFF
--- a/library/coretests/tests/num/dec2flt/float.rs
+++ b/library/coretests/tests/num/dec2flt/float.rs
@@ -1,13 +1,14 @@
 use core::num::dec2flt::float::RawFloat;
 
+use crate::num::{ldexp_f32, ldexp_f64};
+
 // FIXME(f16_f128): enable on all targets once possible.
 #[test]
 #[cfg(target_has_reliable_f16)]
 fn test_f16_integer_decode() {
     assert_eq!(3.14159265359f16.integer_decode(), (1608, -9, 1));
     assert_eq!((-8573.5918555f16).integer_decode(), (1072, 3, -1));
-    #[cfg(not(miri))] // miri doesn't have powf16
-    assert_eq!(2f16.powf(14.0).integer_decode(), (1 << 10, 4, 1));
+    assert_eq!(crate::num::ldexp_f16(1.0, 14).integer_decode(), (1 << 10, 4, 1));
     assert_eq!(0f16.integer_decode(), (0, -25, 1));
     assert_eq!((-0f16).integer_decode(), (0, -25, -1));
     assert_eq!(f16::INFINITY.integer_decode(), (1 << 10, 6, 1));
@@ -23,8 +24,7 @@ fn test_f16_integer_decode() {
 fn test_f32_integer_decode() {
     assert_eq!(3.14159265359f32.integer_decode(), (13176795, -22, 1));
     assert_eq!((-8573.5918555f32).integer_decode(), (8779358, -10, -1));
-    // Set 2^100 directly instead of using powf, because it doesn't guarantee precision
-    assert_eq!(1.2676506e30_f32.integer_decode(), (8388608, 77, 1));
+    assert_eq!(ldexp_f32(1.0, 100).integer_decode(), (8388608, 77, 1));
     assert_eq!(0f32.integer_decode(), (0, -150, 1));
     assert_eq!((-0f32).integer_decode(), (0, -150, -1));
     assert_eq!(f32::INFINITY.integer_decode(), (8388608, 105, 1));
@@ -40,8 +40,7 @@ fn test_f32_integer_decode() {
 fn test_f64_integer_decode() {
     assert_eq!(3.14159265359f64.integer_decode(), (7074237752028906, -51, 1));
     assert_eq!((-8573.5918555f64).integer_decode(), (4713381968463931, -39, -1));
-    // Set 2^100 directly instead of using powf, because it doesn't guarantee precision
-    assert_eq!(1.2676506002282294e30_f64.integer_decode(), (4503599627370496, 48, 1));
+    assert_eq!(ldexp_f64(1.0, 100).integer_decode(), (4503599627370496, 48, 1));
     assert_eq!(0f64.integer_decode(), (0, -1075, 1));
     assert_eq!((-0f64).integer_decode(), (0, -1075, -1));
     assert_eq!(f64::INFINITY.integer_decode(), (4503599627370496, 972, 1));

--- a/library/coretests/tests/num/flt2dec/estimator.rs
+++ b/library/coretests/tests/num/flt2dec/estimator.rs
@@ -1,5 +1,7 @@
 use core::num::flt2dec::estimator::*;
 
+use crate::num::ldexp_f64;
+
 #[test]
 fn test_estimate_scaling_factor() {
     macro_rules! assert_almost_eq {
@@ -56,7 +58,7 @@ fn test_estimate_scaling_factor() {
     let step = if cfg!(miri) { 37 } else { 1 };
 
     for i in (-1074..972).step_by(step) {
-        let expected = super::ldexp_f64(1.0, i).log10().ceil();
+        let expected = ldexp_f64(1.0, i).log10().ceil();
         assert_almost_eq!(estimate_scaling_factor(1, i as i16), expected as i16);
     }
 }

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -54,6 +54,27 @@ macro_rules! assume_usize_width {
     }
 }
 
+/// Return `a * 2^b`.
+#[cfg(target_has_reliable_f16)]
+fn ldexp_f16(a: f16, b: i32) -> f16 {
+    ldexp_f64(a as f64, b) as f16
+}
+
+/// Return `a * 2^b`.
+fn ldexp_f32(a: f32, b: i32) -> f32 {
+    ldexp_f64(a as f64, b) as f32
+}
+
+/// Return `a * 2^b`.
+fn ldexp_f64(a: f64, b: i32) -> f64 {
+    unsafe extern "C" {
+        fn ldexp(x: f64, n: i32) -> f64;
+    }
+    // SAFETY: assuming a correct `ldexp` has been supplied, the given arguments cannot possibly
+    // cause undefined behavior
+    unsafe { ldexp(a, b) }
+}
+
 /// Helper function for testing numeric operations
 pub fn test_num<T>(ten: T, two: T)
 where


### PR DESCRIPTION
r? @tgross35 