### PR TITLE
opt-dist: set `build_llvm` to false for WindowsCi

### DIFF
--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -206,7 +206,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 .skipped_tests(vec![])
                 .run_tests(true)
                 .fast_try_build(is_fast_try_build)
-                .build_llvm(true)
+                .build_llvm(false)
                 .build()?;
 
             (env, shared.build_args)


### PR DESCRIPTION
suggested in https://github.com/rust-lang/rust/pull/143898#issuecomment-3094463268. see https://github.com/rust-lang/rust/pull/143898#issuecomment-3072013360 as the reason for such test

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @ghost

cc @Kobzol for a try-job

try-job: dist-x86_64-msvc