### PR TITLE
Don't ICE on non-TypeId metadata within TypeId

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -997,7 +997,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         ptr: Pointer<Option<M::Provenance>>,
     ) -> InterpResult<'tcx, (Ty<'tcx>, u64)> {
         let (alloc_id, offset, _meta) = self.ptr_get_alloc_id(ptr, 0)?;
-        let GlobalAlloc::TypeId { ty } = self.tcx.global_alloc(alloc_id) else {
+        let Some(GlobalAlloc::TypeId { ty }) = self.tcx.try_get_global_alloc(alloc_id) else {
             throw_ub_format!("invalid `TypeId` value: not all bytes carry type id metadata")
         };
         interp_ok((ty, offset.bytes()))

--- a/tests/ui/consts/const_transmute_type_id6.rs
+++ b/tests/ui/consts/const_transmute_type_id6.rs
@@ -1,0 +1,16 @@
+//! Test that we do not ICE and that we do report an error
+//! when placing non-TypeId provenance into a TypeId.
+
+#![feature(const_trait_impl, const_cmp)]
+
+use std::any::TypeId;
+use std::mem::transmute;
+
+const X: bool = {
+    let a = ();
+    let id: TypeId = unsafe { transmute([&raw const a; 16 / size_of::<*const ()>()]) };
+    id == id
+    //~^ ERROR: invalid `TypeId` value: not all bytes carry type id metadata
+};
+
+fn main() {}

--- a/tests/ui/consts/const_transmute_type_id6.stderr
+++ b/tests/ui/consts/const_transmute_type_id6.stderr
@@ -1,0 +1,15 @@
+error[E0080]: invalid `TypeId` value: not all bytes carry type id metadata
+  --> $DIR/const_transmute_type_id6.rs:12:5
+   |
+LL |     id == id
+   |     ^^^^^^^^ evaluation of `X` failed inside this call
+   |
+note: inside `<TypeId as PartialEq>::eq`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+note: inside `<TypeId as PartialEq>::eq::compiletime`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `crate::intrinsics::const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
fixes rust-lang/rust#144253

r? @RalfJung 
