### PR TITLE
Supress swapping lhs and rhs in equality suggestion in extern macro 

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -3636,7 +3636,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .must_apply_modulo_regions()
         {
             let sm = self.tcx.sess.source_map();
-            if let Ok(rhs_snippet) = sm.span_to_snippet(rhs_expr.span)
+            // If the span of rhs_expr or lhs_expr is in an external macro,
+            // we just suppress the suggestion. See issue #139050
+            if !rhs_expr.span.in_external_macro(sm)
+                && !lhs_expr.span.in_external_macro(sm)
+                && let Ok(rhs_snippet) = sm.span_to_snippet(rhs_expr.span)
                 && let Ok(lhs_snippet) = sm.span_to_snippet(lhs_expr.span)
             {
                 err.note(format!("`{rhs_ty}` implements `PartialEq<{lhs_ty}>`"));

--- a/tests/ui/typeck/auxiliary/extern-macro-issue-139050.rs
+++ b/tests/ui/typeck/auxiliary/extern-macro-issue-139050.rs
@@ -1,0 +1,15 @@
+#[macro_export]
+macro_rules! eq {
+    (assert $a:expr, $b:expr) => {
+        match (&$a, &$b) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        "assertion failed: `(left == right)`\n  left: `{:?}`,\n right: `{:?}`",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    };
+}

--- a/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.rs
+++ b/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.rs
@@ -1,0 +1,34 @@
+// if we use lhs == rhs in a macro, we should not suggest to swap the equality
+// because the origin span of lhs and rhs can not be found. See issue #139050
+
+//@ aux-build:extern-macro-issue-139050.rs
+//@ aux-crate:ext=extern-macro-issue-139050.rs
+
+extern crate ext;
+
+use std::fmt::Debug;
+
+macro_rules! eq_local {
+    (assert $a:expr, $b:expr) => {
+        match (&$a, &$b) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    //~^ ERROR  mismatched types [E0308]
+                    panic!(
+                        "assertion failed: `(left == right)`\n  left: `{:?}`,\n right: `{:?}`",
+                        left_val, right_val
+                    );
+                }
+            }
+        }
+    };
+}
+
+pub fn foo<I: Iterator>(mut iter: I, value: &I::Item)
+where
+    Item: Eq + Debug, //~ ERROR cannot find type `Item` in this scope [E0412]
+{
+    ext::eq!(assert iter.next(), Some(value)); //~ ERROR  mismatched types [E0308]
+    eq_local!(assert iter.next(), Some(value));
+}
+fn main() {}

--- a/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
+++ b/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
@@ -12,14 +12,7 @@ LL |     ext::eq!(assert iter.next(), Some(value));
    |
    = note: expected enum `Option<_>`
               found enum `Option<&_>`
-   = note: `Option<&<I as Iterator>::Item>` implements `PartialEq<Option<<I as Iterator>::Item>>`
    = note: this error originates in the macro `ext::eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider swapping the equality
-  --> $DIR/auxiliary/extern-macro-issue-139050.rs:6:22
-   |
-LL -                 if !(*left_val == *right_val) {
-LL +                 if !(*right_val == *left_val) {
-   |
 
 error[E0308]: mismatched types
   --> $DIR/sugg-swap-equality-in-macro-issue-139050.rs:15:35

--- a/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
+++ b/tests/ui/typeck/sugg-swap-equality-in-macro-issue-139050.stderr
@@ -1,0 +1,46 @@
+error[E0412]: cannot find type `Item` in this scope
+  --> $DIR/sugg-swap-equality-in-macro-issue-139050.rs:29:5
+   |
+LL |     Item: Eq + Debug,
+   |     ^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> $DIR/sugg-swap-equality-in-macro-issue-139050.rs:31:5
+   |
+LL |     ext::eq!(assert iter.next(), Some(value));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<<I as Iterator>::Item>`, found `Option<&<I as Iterator>::Item>`
+   |
+   = note: expected enum `Option<_>`
+              found enum `Option<&_>`
+   = note: `Option<&<I as Iterator>::Item>` implements `PartialEq<Option<<I as Iterator>::Item>>`
+   = note: this error originates in the macro `ext::eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider swapping the equality
+  --> $DIR/auxiliary/extern-macro-issue-139050.rs:6:22
+   |
+LL -                 if !(*left_val == *right_val) {
+LL +                 if !(*right_val == *left_val) {
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/sugg-swap-equality-in-macro-issue-139050.rs:15:35
+   |
+LL |                 if !(*left_val == *right_val) {
+   |                                   ^^^^^^^^^^ expected `Option<<I as Iterator>::Item>`, found `Option<&<I as Iterator>::Item>`
+...
+LL |     eq_local!(assert iter.next(), Some(value));
+   |     ------------------------------------------ in this macro invocation
+   |
+   = note: expected enum `Option<_>`
+              found enum `Option<&_>`
+   = note: `Option<&<I as Iterator>::Item>` implements `PartialEq<Option<<I as Iterator>::Item>>`
+   = note: this error originates in the macro `eq_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider swapping the equality
+   |
+LL -                 if !(*left_val == *right_val) {
+LL +                 if !(*right_val == *left_val) {
+   |
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0412.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#139050 


