### PR TITLE
Introduce `Symbol::with_interner`.

### DIFF
--- a/compiler/rustc_macros/src/symbols.rs
+++ b/compiler/rustc_macros/src/symbols.rs
@@ -288,7 +288,7 @@ fn symbols_with_errors(input: TokenStream) -> (TokenStream, Vec<syn::Error>) {
         const SYMBOL_DIGITS_BASE: u32 = #symbol_digits_base;
 
         /// The number of predefined symbols; this is the first index for
-        /// extra pre-interned symbols in an Interner created via
+        /// extra pre-interned symbols in an interner created via
         /// [`Interner::with_extra_symbols`].
         pub const PREDEFINED_SYMBOLS_COUNT: u32 = #predefined_symbols_count;
 

--- a/src/librustdoc/html/url_parts_builder.rs
+++ b/src/librustdoc/html/url_parts_builder.rs
@@ -146,22 +146,17 @@ impl<'a> Extend<&'a str> for UrlPartsBuilder {
 
 impl FromIterator<Symbol> for UrlPartsBuilder {
     fn from_iter<T: IntoIterator<Item = Symbol>>(iter: T) -> Self {
-        // This code has to be duplicated from the `&str` impl because of
-        // `Symbol::as_str`'s lifetimes.
-        let iter = iter.into_iter();
-        let mut builder = Self::with_capacity_bytes(AVG_PART_LENGTH * iter.size_hint().0);
-        iter.for_each(|part| builder.push(part.as_str()));
-        builder
+        Symbol::with_interner(|interner| {
+            UrlPartsBuilder::from_iter(iter.into_iter().map(|sym| interner.get_str(sym)))
+        })
     }
 }
 
 impl Extend<Symbol> for UrlPartsBuilder {
     fn extend<T: IntoIterator<Item = Symbol>>(&mut self, iter: T) {
-        // This code has to be duplicated from the `&str` impl because of
-        // `Symbol::as_str`'s lifetimes.
-        let iter = iter.into_iter();
-        self.buf.reserve(AVG_PART_LENGTH * iter.size_hint().0);
-        iter.for_each(|part| self.push(part.as_str()));
+        Symbol::with_interner(|interner| {
+            self.extend(iter.into_iter().map(|sym| interner.get_str(sym)))
+        })
     }
 }
 


### PR DESCRIPTION
It lets you get the contents of multiple symbols with a single TLS lookup and interner lock, instead of one per symbol.

r? @petrochenkov 