### PR TITLE
mbe: Use concrete type for `get_unused_rule`

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::default::Default;
 use std::iter;
 use std::path::Component::Prefix;
@@ -361,17 +362,13 @@ where
 }
 
 /// Represents a thing that maps token trees to Macro Results
-pub trait TTMacroExpander {
+pub trait TTMacroExpander: Any {
     fn expand<'cx>(
         &self,
         ecx: &'cx mut ExtCtxt<'_>,
         span: Span,
         input: TokenStream,
     ) -> MacroExpanderResult<'cx>;
-
-    fn get_unused_rule(&self, _rule_i: usize) -> Option<(&Ident, Span)> {
-        None
-    }
 }
 
 pub type MacroExpanderResult<'cx> = ExpandResult<Box<dyn MacResult + 'cx>, ()>;
@@ -379,7 +376,7 @@ pub type MacroExpanderResult<'cx> = ExpandResult<Box<dyn MacResult + 'cx>, ()>;
 pub type MacroExpanderFn =
     for<'cx> fn(&'cx mut ExtCtxt<'_>, Span, TokenStream) -> MacroExpanderResult<'cx>;
 
-impl<F> TTMacroExpander for F
+impl<F: 'static> TTMacroExpander for F
 where
     F: for<'cx> Fn(&'cx mut ExtCtxt<'_>, Span, TokenStream) -> MacroExpanderResult<'cx>,
 {

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -22,7 +22,7 @@ mod placeholders;
 mod proc_macro_server;
 mod stats;
 
-pub use mbe::macro_rules::compile_declarative_macro;
+pub use mbe::macro_rules::{MacroRulesMacroExpander, compile_declarative_macro};
 pub mod base;
 pub mod config;
 pub mod expand;

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -128,12 +128,20 @@ pub(super) struct MacroRule {
     rhs: mbe::TokenTree,
 }
 
-struct MacroRulesMacroExpander {
+pub struct MacroRulesMacroExpander {
     node_id: NodeId,
     name: Ident,
     span: Span,
     transparency: Transparency,
     rules: Vec<MacroRule>,
+}
+
+impl MacroRulesMacroExpander {
+    pub fn get_unused_rule(&self, rule_i: usize) -> Option<(&Ident, Span)> {
+        // If the rhs contains an invocation like `compile_error!`, don't report it as unused.
+        let rule = &self.rules[rule_i];
+        if has_compile_error_macro(&rule.rhs) { None } else { Some((&self.name, rule.lhs_span)) }
+    }
 }
 
 impl TTMacroExpander for MacroRulesMacroExpander {
@@ -153,12 +161,6 @@ impl TTMacroExpander for MacroRulesMacroExpander {
             input,
             &self.rules,
         ))
-    }
-
-    fn get_unused_rule(&self, rule_i: usize) -> Option<(&Ident, Span)> {
-        // If the rhs contains an invocation like `compile_error!`, don't report it as unused.
-        let rule = &self.rules[rule_i];
-        if has_compile_error_macro(&rule.rhs) { None } else { Some((&self.name, rule.lhs_span)) }
     }
 }
 


### PR DESCRIPTION
Rather than adding `get_unused_rule` to the `TTMacroExpander` trait, put
it on the concrete `MacroRulesMacroExpander`, and downcast to that type
via `Any` in order to call it.

Suggested-by: Vadim Petrochenkov <vadim.petrochenkov@gmail.com>

r? @petrochenkov
