### PR TITLE
Make `libtest::ERROR_EXIT_CODE` const public to not redefine it in rustdoc

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -89,8 +89,8 @@ use options::RunStrategy;
 use test_result::*;
 use time::TestExecTime;
 
-// Process exit code to be used to indicate test failures.
-const ERROR_EXIT_CODE: i32 = 101;
+/// Process exit code to be used to indicate test failures.
+pub const ERROR_EXIT_CODE: i32 = 101;
 
 const SECONDARY_TEST_INVOKER_VAR: &str = "__RUST_TEST_INVOKE";
 const SECONDARY_TEST_BENCH_BENCHMARKS_VAR: &str = "__RUST_TEST_BENCH_BENCHMARKS";

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -410,7 +410,7 @@ pub(crate) fn run_tests(
         std::mem::drop(temp_dir);
         times.display_times();
         // libtest::ERROR_EXIT_CODE is not public but it's the same value.
-        std::process::exit(101);
+        std::process::exit(test::ERROR_EXIT_CODE);
     }
 }
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -409,8 +409,9 @@ pub(crate) fn run_tests(
         // We ensure temp dir destructor is called.
         std::mem::drop(temp_dir);
         times.display_times();
-        // libtest::ERROR_EXIT_CODE is not public but it's the same value.
-        std::process::exit(test::ERROR_EXIT_CODE);
+        // FIXME(GuillaumeGomez): Uncomment the next line once #144297 has been merged.
+        // std::process::exit(test::ERROR_EXIT_CODE);
+        std::process::exit(101);
     }
 }
 


### PR DESCRIPTION
I think it's better to make this constant public so it can be used by crates using `libtest` as dependency.

As a side-note, I will update https://github.com/rust-lang/rust/pull/143900 to make use of this constant once this is current PR is merged.