### PR TITLE
[rustdoc] Display total time and compilation time of merged doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::{panic, str};
+use std::time::{Duration, Instant};
+use std::{fmt, panic, str};
 
 pub(crate) use make::{BuildDocTestBuilder, DocTestBuilder};
 pub(crate) use markdown::test as test_markdown;
@@ -35,6 +36,50 @@ use self::rust::HirCollector;
 use crate::config::{Options as RustdocOptions, OutputFormat};
 use crate::html::markdown::{ErrorCodes, Ignore, LangString, MdRelLine};
 use crate::lint::init_lints;
+
+/// Type used to display times (compilation and total) information for merged doctests.
+struct MergedDoctestTimes {
+    total_time: Instant,
+    /// Total time spent compiling all merged doctests.
+    compilation_time: Duration,
+    /// This field is used to keep track of how many merged doctests we (tried to) compile.
+    added_compilation_times: usize,
+}
+
+impl MergedDoctestTimes {
+    fn new() -> Self {
+        Self {
+            total_time: Instant::now(),
+            compilation_time: Duration::default(),
+            added_compilation_times: 0,
+        }
+    }
+
+    fn add_compilation_time(&mut self, duration: Duration) {
+        self.compilation_time += duration;
+        self.added_compilation_times += 1;
+    }
+
+    fn display_times(&self) {
+        // If no merged doctest was compiled, then there is nothing to display since the numbers
+        // displayed by `libtest` for standalone tests are already accurate (they include both
+        // compilation and runtime).
+        if self.added_compilation_times > 0 {
+            println!("{self}");
+        }
+    }
+}
+
+impl fmt::Display for MergedDoctestTimes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "all doctests ran in {:.2}s; merged doctests compilation took {:.2}s",
+            self.total_time.elapsed().as_secs_f64(),
+            self.compilation_time.as_secs_f64(),
+        )
+    }
+}
 
 /// Options that apply to all doctests in a crate or Markdown file (for `rustdoc foo.md`).
 #[derive(Clone)]
@@ -295,6 +340,7 @@ pub(crate) fn run_tests(
 
     let mut nb_errors = 0;
     let mut ran_edition_tests = 0;
+    let mut times = MergedDoctestTimes::new();
     let target_str = rustdoc_options.target.to_string();
 
     for (MergeableTestKey { edition, global_crate_attrs_hash }, mut doctests) in mergeable_tests {
@@ -314,13 +360,15 @@ pub(crate) fn run_tests(
         for (doctest, scraped_test) in &doctests {
             tests_runner.add_test(doctest, scraped_test, &target_str);
         }
-        if let Ok(success) = tests_runner.run_merged_tests(
+        let (duration, ret) = tests_runner.run_merged_tests(
             rustdoc_test_options,
             edition,
             &opts,
             &test_args,
             rustdoc_options,
-        ) {
+        );
+        times.add_compilation_time(duration);
+        if let Ok(success) = ret {
             ran_edition_tests += 1;
             if !success {
                 nb_errors += 1;
@@ -354,11 +402,13 @@ pub(crate) fn run_tests(
         test::test_main_with_exit_callback(&test_args, standalone_tests, None, || {
             // We ensure temp dir destructor is called.
             std::mem::drop(temp_dir.take());
+            times.display_times();
         });
     }
     if nb_errors != 0 {
         // We ensure temp dir destructor is called.
         std::mem::drop(temp_dir);
+        times.display_times();
         // libtest::ERROR_EXIT_CODE is not public but it's the same value.
         std::process::exit(101);
     }
@@ -496,16 +546,19 @@ impl RunnableDocTest {
 ///
 /// This is the function that calculates the compiler command line, invokes the compiler, then
 /// invokes the test or tests in a separate executable (if applicable).
+///
+/// Returns a tuple containing the `Duration` of the compilation and the `Result` of the test.
 fn run_test(
     doctest: RunnableDocTest,
     rustdoc_options: &RustdocOptions,
     supports_color: bool,
     report_unused_externs: impl Fn(UnusedExterns),
-) -> Result<(), TestFailure> {
+) -> (Duration, Result<(), TestFailure>) {
     let langstr = &doctest.langstr;
     // Make sure we emit well-formed executable names for our target.
     let rust_out = add_exe_suffix("rust_out".to_owned(), &rustdoc_options.target);
     let output_file = doctest.test_opts.outdir.path().join(rust_out);
+    let instant = Instant::now();
 
     // Common arguments used for compiling the doctest runner.
     // On merged doctests, the compiler is invoked twice: once for the test code itself,
@@ -589,7 +642,7 @@ fn run_test(
         if std::fs::write(&input_file, &doctest.full_test_code).is_err() {
             // If we cannot write this file for any reason, we leave. All combined tests will be
             // tested as standalone tests.
-            return Err(TestFailure::CompileError);
+            return (Duration::default(), Err(TestFailure::CompileError));
         }
         if !rustdoc_options.nocapture {
             // If `nocapture` is disabled, then we don't display rustc's output when compiling
@@ -660,7 +713,7 @@ fn run_test(
         if std::fs::write(&runner_input_file, merged_test_code).is_err() {
             // If we cannot write this file for any reason, we leave. All combined tests will be
             // tested as standalone tests.
-            return Err(TestFailure::CompileError);
+            return (instant.elapsed(), Err(TestFailure::CompileError));
         }
         if !rustdoc_options.nocapture {
             // If `nocapture` is disabled, then we don't display rustc's output when compiling
@@ -713,7 +766,7 @@ fn run_test(
     let _bomb = Bomb(&out);
     match (output.status.success(), langstr.compile_fail) {
         (true, true) => {
-            return Err(TestFailure::UnexpectedCompilePass);
+            return (instant.elapsed(), Err(TestFailure::UnexpectedCompilePass));
         }
         (true, false) => {}
         (false, true) => {
@@ -729,17 +782,18 @@ fn run_test(
                     .collect();
 
                 if !missing_codes.is_empty() {
-                    return Err(TestFailure::MissingErrorCodes(missing_codes));
+                    return (instant.elapsed(), Err(TestFailure::MissingErrorCodes(missing_codes)));
                 }
             }
         }
         (false, false) => {
-            return Err(TestFailure::CompileError);
+            return (instant.elapsed(), Err(TestFailure::CompileError));
         }
     }
 
+    let duration = instant.elapsed();
     if doctest.no_run {
-        return Ok(());
+        return (duration, Ok(()));
     }
 
     // Run the code!
@@ -771,17 +825,17 @@ fn run_test(
         cmd.output()
     };
     match result {
-        Err(e) => return Err(TestFailure::ExecutionError(e)),
+        Err(e) => return (duration, Err(TestFailure::ExecutionError(e))),
         Ok(out) => {
             if langstr.should_panic && out.status.success() {
-                return Err(TestFailure::UnexpectedRunPass);
+                return (duration, Err(TestFailure::UnexpectedRunPass));
             } else if !langstr.should_panic && !out.status.success() {
-                return Err(TestFailure::ExecutionFailure(out));
+                return (duration, Err(TestFailure::ExecutionFailure(out)));
             }
         }
     }
 
-    Ok(())
+    (duration, Ok(()))
 }
 
 /// Converts a path intended to use as a command to absolute if it is
@@ -1071,7 +1125,7 @@ fn doctest_run_fn(
         no_run: scraped_test.no_run(&rustdoc_options),
         merged_test_code: None,
     };
-    let res =
+    let (_, res) =
         run_test(runnable_test, &rustdoc_options, doctest.supports_color, report_unused_externs);
 
     if let Err(err) = res {

--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::time::Duration;
 
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_span::edition::Edition;
@@ -67,6 +68,10 @@ impl DocTestRunner {
         self.nb_tests += 1;
     }
 
+    /// Returns a tuple containing the `Duration` of the compilation and the `Result` of the test.
+    ///
+    /// If compilation failed, it will return `Err`, otherwise it will return `Ok` containing if
+    /// the test ran successfully.
     pub(crate) fn run_merged_tests(
         &mut self,
         test_options: IndividualTestOptions,
@@ -74,7 +79,7 @@ impl DocTestRunner {
         opts: &GlobalTestOptions,
         test_args: &[String],
         rustdoc_options: &RustdocOptions,
-    ) -> Result<bool, ()> {
+    ) -> (Duration, Result<bool, ()>) {
         let mut code = "\
 #![allow(unused_extern_crates)]
 #![allow(internal_features)]
@@ -204,9 +209,9 @@ std::process::Termination::report(test::test_main(test_args, tests, None))
             no_run: false,
             merged_test_code: Some(code),
         };
-        let ret =
+        let (duration, ret) =
             run_test(runnable_test, rustdoc_options, self.supports_color, |_: UnusedExterns| {});
-        if let Err(TestFailure::CompileError) = ret { Err(()) } else { Ok(ret.is_ok()) }
+        (duration, if let Err(TestFailure::CompileError) = ret { Err(()) } else { Ok(ret.is_ok()) })
     }
 }
 

--- a/tests/rustdoc-ui/2024-doctests-checks.rs
+++ b/tests/rustdoc-ui/2024-doctests-checks.rs
@@ -3,6 +3,8 @@
 //@ compile-flags: --test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
 
 /// ```

--- a/tests/rustdoc-ui/2024-doctests-checks.stdout
+++ b/tests/rustdoc-ui/2024-doctests-checks.stdout
@@ -1,12 +1,13 @@
 
 running 1 test
-test $DIR/2024-doctests-checks.rs - Foo (line 8) ... ok
+test $DIR/2024-doctests-checks.rs - Foo (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/2024-doctests-checks.rs - Foo (line 15) ... ok
+test $DIR/2024-doctests-checks.rs - Foo (line 17) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/2024-doctests-crate-attribute.rs
+++ b/tests/rustdoc-ui/2024-doctests-crate-attribute.rs
@@ -4,6 +4,8 @@
 //@ normalize-stdout: "tests/rustdoc-ui" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 
 /// This doctest is used to ensure that if a crate attribute is present,
 /// it will not be part of the merged doctests.

--- a/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
+++ b/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
@@ -1,12 +1,13 @@
 
 running 1 test
-test $DIR/2024-doctests-crate-attribute.rs - Foo (line 20) ... ok
+test $DIR/2024-doctests-crate-attribute.rs - Foo (line 22) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/2024-doctests-crate-attribute.rs - Foo (line 11) ... ok
+test $DIR/2024-doctests-crate-attribute.rs - Foo (line 13) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/dead-code-2024.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.rs
@@ -4,6 +4,8 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]

--- a/tests/rustdoc-ui/doctest/dead-code-2024.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.stdout
@@ -1,18 +1,18 @@
 
 running 1 test
-test $DIR/dead-code-2024.rs - f (line 13) - compile ... FAILED
+test $DIR/dead-code-2024.rs - f (line 15) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-2024.rs - f (line 13) stdout ----
+---- $DIR/dead-code-2024.rs - f (line 15) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-2024.rs:14:7
+  --> $DIR/dead-code-2024.rs:16:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-2024.rs:12:9
+  --> $DIR/dead-code-2024.rs:14:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -23,7 +23,8 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-2024.rs - f (line 13)
+    $DIR/dead-code-2024.rs - f (line 15)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/dead-code-items.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-items.rs
@@ -4,6 +4,8 @@
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 #![doc(test(attr(deny(warnings))))]

--- a/tests/rustdoc-ui/doctest/dead-code-items.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-items.stdout
@@ -1,30 +1,30 @@
 
 running 13 tests
-test $DIR/dead-code-items.rs - A (line 32) - compile ... ok
-test $DIR/dead-code-items.rs - A (line 88) - compile ... ok
-test $DIR/dead-code-items.rs - A::field (line 39) - compile ... FAILED
-test $DIR/dead-code-items.rs - A::method (line 94) - compile ... ok
-test $DIR/dead-code-items.rs - C (line 22) - compile ... FAILED
-test $DIR/dead-code-items.rs - Enum (line 70) - compile ... FAILED
-test $DIR/dead-code-items.rs - Enum::Variant1 (line 77) - compile ... FAILED
-test $DIR/dead-code-items.rs - MyTrait (line 103) - compile ... FAILED
-test $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 110) - compile ... FAILED
-test $DIR/dead-code-items.rs - S (line 14) - compile ... ok
-test $DIR/dead-code-items.rs - U (line 48) - compile ... ok
-test $DIR/dead-code-items.rs - U::field (line 55) - compile ... FAILED
-test $DIR/dead-code-items.rs - U::field2 (line 61) - compile ... ok
+test $DIR/dead-code-items.rs - A (line 34) - compile ... ok
+test $DIR/dead-code-items.rs - A (line 90) - compile ... ok
+test $DIR/dead-code-items.rs - A::field (line 41) - compile ... FAILED
+test $DIR/dead-code-items.rs - A::method (line 96) - compile ... ok
+test $DIR/dead-code-items.rs - C (line 24) - compile ... FAILED
+test $DIR/dead-code-items.rs - Enum (line 72) - compile ... FAILED
+test $DIR/dead-code-items.rs - Enum::Variant1 (line 79) - compile ... FAILED
+test $DIR/dead-code-items.rs - MyTrait (line 105) - compile ... FAILED
+test $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112) - compile ... FAILED
+test $DIR/dead-code-items.rs - S (line 16) - compile ... ok
+test $DIR/dead-code-items.rs - U (line 50) - compile ... ok
+test $DIR/dead-code-items.rs - U::field (line 57) - compile ... FAILED
+test $DIR/dead-code-items.rs - U::field2 (line 63) - compile ... ok
 
 failures:
 
----- $DIR/dead-code-items.rs - A::field (line 39) stdout ----
+---- $DIR/dead-code-items.rs - A::field (line 41) stdout ----
 error: trait `DeadCodeInField` is never used
-  --> $DIR/dead-code-items.rs:40:7
+  --> $DIR/dead-code-items.rs:42:7
    |
 LL | trait DeadCodeInField {}
    |       ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:38:9
+  --> $DIR/dead-code-items.rs:40:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -32,15 +32,15 @@ LL | #![deny(dead_code)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - C (line 22) stdout ----
+---- $DIR/dead-code-items.rs - C (line 24) stdout ----
 error: unused variable: `unused_error`
-  --> $DIR/dead-code-items.rs:23:5
+  --> $DIR/dead-code-items.rs:25:5
    |
 LL | let unused_error = 5;
    |     ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_error`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:20:9
+  --> $DIR/dead-code-items.rs:22:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -49,15 +49,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - Enum (line 70) stdout ----
+---- $DIR/dead-code-items.rs - Enum (line 72) stdout ----
 error: unused variable: `not_dead_code_but_unused`
-  --> $DIR/dead-code-items.rs:71:5
+  --> $DIR/dead-code-items.rs:73:5
    |
 LL | let not_dead_code_but_unused = 5;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_not_dead_code_but_unused`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:68:9
+  --> $DIR/dead-code-items.rs:70:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -66,15 +66,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - Enum::Variant1 (line 77) stdout ----
+---- $DIR/dead-code-items.rs - Enum::Variant1 (line 79) stdout ----
 error: unused variable: `unused_in_variant`
-  --> $DIR/dead-code-items.rs:80:17
+  --> $DIR/dead-code-items.rs:82:17
    |
 LL | fn main() { let unused_in_variant = 5; }
    |                 ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_in_variant`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:75:9
+  --> $DIR/dead-code-items.rs:77:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -83,15 +83,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - MyTrait (line 103) stdout ----
+---- $DIR/dead-code-items.rs - MyTrait (line 105) stdout ----
 error: trait `StillDeadCodeAtMyTrait` is never used
-  --> $DIR/dead-code-items.rs:104:7
+  --> $DIR/dead-code-items.rs:106:7
    |
 LL | trait StillDeadCodeAtMyTrait { }
    |       ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:102:9
+  --> $DIR/dead-code-items.rs:104:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -99,15 +99,15 @@ LL | #![deny(dead_code)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 110) stdout ----
+---- $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112) stdout ----
 error: unused variable: `unused_in_impl`
-  --> $DIR/dead-code-items.rs:113:17
+  --> $DIR/dead-code-items.rs:115:17
    |
 LL | fn main() { let unused_in_impl = 5; }
    |                 ^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_in_impl`
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:108:9
+  --> $DIR/dead-code-items.rs:110:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -116,15 +116,15 @@ LL | #![deny(warnings)]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
----- $DIR/dead-code-items.rs - U::field (line 55) stdout ----
+---- $DIR/dead-code-items.rs - U::field (line 57) stdout ----
 error: trait `DeadCodeInUnionField` is never used
-  --> $DIR/dead-code-items.rs:56:7
+  --> $DIR/dead-code-items.rs:58:7
    |
 LL | trait DeadCodeInUnionField {}
    |       ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-items.rs:54:9
+  --> $DIR/dead-code-items.rs:56:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
@@ -134,13 +134,14 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-items.rs - A::field (line 39)
-    $DIR/dead-code-items.rs - C (line 22)
-    $DIR/dead-code-items.rs - Enum (line 70)
-    $DIR/dead-code-items.rs - Enum::Variant1 (line 77)
-    $DIR/dead-code-items.rs - MyTrait (line 103)
-    $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 110)
-    $DIR/dead-code-items.rs - U::field (line 55)
+    $DIR/dead-code-items.rs - A::field (line 41)
+    $DIR/dead-code-items.rs - C (line 24)
+    $DIR/dead-code-items.rs - Enum (line 72)
+    $DIR/dead-code-items.rs - Enum::Variant1 (line 79)
+    $DIR/dead-code-items.rs - MyTrait (line 105)
+    $DIR/dead-code-items.rs - MyTrait::my_trait_fn (line 112)
+    $DIR/dead-code-items.rs - U::field (line 57)
 
 test result: FAILED. 6 passed; 7 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/dead-code-module-2.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-module-2.rs
@@ -4,6 +4,8 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 #![doc(test(attr(allow(unused_variables))))]

--- a/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
@@ -1,24 +1,24 @@
 
 running 1 test
-test $DIR/dead-code-module-2.rs - g (line 24) - compile ... ok
+test $DIR/dead-code-module-2.rs - g (line 26) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/dead-code-module-2.rs - my_mod::f (line 16) - compile ... FAILED
+test $DIR/dead-code-module-2.rs - my_mod::f (line 18) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-module-2.rs - my_mod::f (line 16) stdout ----
+---- $DIR/dead-code-module-2.rs - my_mod::f (line 18) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-module-2.rs:17:7
+  --> $DIR/dead-code-module-2.rs:19:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-module-2.rs:15:9
+  --> $DIR/dead-code-module-2.rs:17:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -29,7 +29,8 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-module-2.rs - my_mod::f (line 16)
+    $DIR/dead-code-module-2.rs - my_mod::f (line 18)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/dead-code-module.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-module.rs
@@ -4,6 +4,8 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 mod my_mod {

--- a/tests/rustdoc-ui/doctest/dead-code-module.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module.stdout
@@ -1,18 +1,18 @@
 
 running 1 test
-test $DIR/dead-code-module.rs - my_mod::f (line 14) - compile ... FAILED
+test $DIR/dead-code-module.rs - my_mod::f (line 16) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-module.rs - my_mod::f (line 14) stdout ----
+---- $DIR/dead-code-module.rs - my_mod::f (line 16) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-module.rs:15:7
+  --> $DIR/dead-code-module.rs:17:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-module.rs:13:9
+  --> $DIR/dead-code-module.rs:15:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -23,7 +23,8 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-module.rs - my_mod::f (line 14)
+    $DIR/dead-code-module.rs - my_mod::f (line 16)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
@@ -2,6 +2,8 @@
 //@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 // https://github.com/rust-lang/rust/issues/130470

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
@@ -22,3 +22,4 @@ failures:
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/edition-2024-error-output.rs
+++ b/tests/rustdoc-ui/doctest/edition-2024-error-output.rs
@@ -6,6 +6,8 @@
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "panicked at .+rs:" -> "panicked at $$TMP:"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ rustc-env:RUST_BACKTRACE=0
 //@ failure-status: 101
 

--- a/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
+++ b/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
@@ -1,10 +1,10 @@
 
 running 1 test
-test $DIR/edition-2024-error-output.rs - (line 12) ... FAILED
+test $DIR/edition-2024-error-output.rs - (line 14) ... FAILED
 
 failures:
 
----- $DIR/edition-2024-error-output.rs - (line 12) stdout ----
+---- $DIR/edition-2024-error-output.rs - (line 14) stdout ----
 Test executable failed (exit status: 101).
 
 stderr:
@@ -18,7 +18,8 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:
-    $DIR/edition-2024-error-output.rs - (line 12)
+    $DIR/edition-2024-error-output.rs - (line 14)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
@@ -5,6 +5,8 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 /// ```should_panic

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
@@ -1,14 +1,15 @@
 
 running 1 test
-test $DIR/failed-doctest-should-panic.rs - Foo (line 10) - should panic ... FAILED
+test $DIR/failed-doctest-should-panic.rs - Foo (line 12) - should panic ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-should-panic.rs - Foo (line 10) stdout ----
-note: test did not panic as expected at $DIR/failed-doctest-should-panic.rs:10:0
+---- $DIR/failed-doctest-should-panic.rs - Foo (line 12) stdout ----
+note: test did not panic as expected at $DIR/failed-doctest-should-panic.rs:12:0
 
 failures:
-    $DIR/failed-doctest-should-panic.rs - Foo (line 10)
+    $DIR/failed-doctest-should-panic.rs - Foo (line 12)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/failed-doctest-test-crate.rs - m (line 14) ... FAILED
+test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-test-crate.rs - m (line 14) stdout ----
+---- $DIR/failed-doctest-test-crate.rs - m (line 16) stdout ----
 error[E0432]: unresolved import `test`
-  --> $DIR/failed-doctest-test-crate.rs:15:5
+  --> $DIR/failed-doctest-test-crate.rs:17:5
    |
 LL | use test::*;
    |     ^^^^ use of unresolved module or unlinked crate `test`
@@ -22,7 +22,7 @@ For more information about this error, try `rustc --explain E0432`.
 Couldn't compile the test.
 
 failures:
-    $DIR/failed-doctest-test-crate.rs - m (line 14)
+    $DIR/failed-doctest-test-crate.rs - m (line 16)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/failed-doctest-test-crate.rs - m (line 14) ... FAILED
+test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-test-crate.rs - m (line 14) stdout ----
+---- $DIR/failed-doctest-test-crate.rs - m (line 16) stdout ----
 error[E0432]: unresolved import `test`
-  --> $DIR/failed-doctest-test-crate.rs:15:5
+  --> $DIR/failed-doctest-test-crate.rs:17:5
    |
 LL | use test::*;
    |     ^^^^ use of unresolved module or unlinked crate `test`
@@ -19,7 +19,8 @@ For more information about this error, try `rustc --explain E0432`.
 Couldn't compile the test.
 
 failures:
-    $DIR/failed-doctest-test-crate.rs - m (line 14)
+    $DIR/failed-doctest-test-crate.rs - m (line 16)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.rs
@@ -7,6 +7,8 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 /// <https://github.com/rust-lang/rust/pull/137899#discussion_r1976743383>

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/relative-path-include-bytes-132203.rs - (line 18) ... FAILED
+test $DIR/relative-path-include-bytes-132203.rs - (line 20) ... FAILED
 
 failures:
 
----- $DIR/relative-path-include-bytes-132203.rs - (line 18) stdout ----
+---- $DIR/relative-path-include-bytes-132203.rs - (line 20) stdout ----
 error: couldn't read `$DIR/relative-dir-empty-file`: $FILE_NOT_FOUND_MSG (os error 2)
-  --> $DIR/relative-path-include-bytes-132203.rs:19:9
+  --> $DIR/relative-path-include-bytes-132203.rs:21:9
    |
 LL | let x = include_bytes!("relative-dir-empty-file");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/relative-path-include-bytes-132203.rs - (line 18)
+    $DIR/relative-path-include-bytes-132203.rs - (line 20)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
@@ -4,3 +4,4 @@ test $DIR/auxiliary/relative-dir.md - (line 1) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -9,6 +9,8 @@
 //@ normalize-stdout: "tests.rustdoc-ui.doctest." -> "$$DIR/"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: "`: .* \(os error 2\)" -> "`: $$FILE_NOT_FOUND_MSG (os error 2)"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 
 // https://github.com/rust-lang/rust/issues/132203
 // This version, because it's edition2024, passes thanks to the new

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
@@ -9,6 +9,8 @@
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: "panicked at .+rs:" -> "panicked at $$TMP:"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 //@ rustc-env:RUST_BACKTRACE=0
 

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
@@ -1,12 +1,12 @@
 
 running 3 tests
-test $DIR/stdout-and-stderr.rs - (line 15) ... FAILED
-test $DIR/stdout-and-stderr.rs - (line 20) ... FAILED
-test $DIR/stdout-and-stderr.rs - (line 24) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 17) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 22) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 26) ... FAILED
 
 failures:
 
----- $DIR/stdout-and-stderr.rs - (line 15) stdout ----
+---- $DIR/stdout-and-stderr.rs - (line 17) stdout ----
 Test executable failed (exit status: 101).
 
 stdout:
@@ -21,7 +21,7 @@ assertion `left == right` failed
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
----- $DIR/stdout-and-stderr.rs - (line 20) stdout ----
+---- $DIR/stdout-and-stderr.rs - (line 22) stdout ----
 Test executable failed (exit status: 101).
 
 stderr:
@@ -33,14 +33,15 @@ assertion `left == right` failed
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
----- $DIR/stdout-and-stderr.rs - (line 24) stdout ----
+---- $DIR/stdout-and-stderr.rs - (line 26) stdout ----
 Test executable failed (exit status: 1).
 
 
 failures:
-    $DIR/stdout-and-stderr.rs - (line 15)
-    $DIR/stdout-and-stderr.rs - (line 20)
-    $DIR/stdout-and-stderr.rs - (line 24)
+    $DIR/stdout-and-stderr.rs - (line 17)
+    $DIR/stdout-and-stderr.rs - (line 22)
+    $DIR/stdout-and-stderr.rs - (line 26)
 
 test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME

--- a/tests/rustdoc-ui/doctest/wrong-ast-2024.rs
+++ b/tests/rustdoc-ui/doctest/wrong-ast-2024.rs
@@ -3,6 +3,8 @@
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"
+//@ normalize-stdout: "ran in \d+\.\d+s" -> "ran in $$TIME"
+//@ normalize-stdout: "compilation took \d+\.\d+s" -> "compilation took $$TIME"
 //@ failure-status: 101
 
 /// ```

--- a/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
+++ b/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
@@ -1,17 +1,17 @@
 
 running 1 test
-test $DIR/wrong-ast-2024.rs - three (line 18) - should panic ... ok
+test $DIR/wrong-ast-2024.rs - three (line 20) - should panic ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 2 tests
-test $DIR/wrong-ast-2024.rs - one (line 8) ... FAILED
-test $DIR/wrong-ast-2024.rs - two (line 13) ... FAILED
+test $DIR/wrong-ast-2024.rs - one (line 10) ... FAILED
+test $DIR/wrong-ast-2024.rs - two (line 15) ... FAILED
 
 failures:
 
----- $DIR/wrong-ast-2024.rs - one (line 8) stdout ----
+---- $DIR/wrong-ast-2024.rs - one (line 10) stdout ----
 error[E0758]: unterminated block comment
   --> $DIR/wrong-ast-2024.rs:$LINE:$COL
    |
@@ -22,7 +22,7 @@ error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0758`.
 Couldn't compile the test.
----- $DIR/wrong-ast-2024.rs - two (line 13) stdout ----
+---- $DIR/wrong-ast-2024.rs - two (line 15) stdout ----
 error: unexpected closing delimiter: `}`
   --> $DIR/wrong-ast-2024.rs:$LINE:$COL
    |
@@ -34,8 +34,9 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/wrong-ast-2024.rs - one (line 8)
-    $DIR/wrong-ast-2024.rs - two (line 13)
+    $DIR/wrong-ast-2024.rs - one (line 10)
+    $DIR/wrong-ast-2024.rs - two (line 15)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+all doctests ran in $TIME; merged doctests compilation took $TIME


### PR DESCRIPTION
Fixes rust-lang/rust#144270.

Does it look good to you @kpreid?

<img width="908" height="263" alt="image" src="https://github.com/user-attachments/assets/cd5d082d-c4e0-42ed-91dd-bd263b413dcd" />
