### PR TITLE
Add powerpc64le-unknown-linux-musl to CI rustc targets

### DIFF
--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -875,6 +875,7 @@ pub(crate) fn is_download_ci_available(target_triple: &str, llvm_assertions: boo
         "powerpc-unknown-linux-gnu",
         "powerpc64-unknown-linux-gnu",
         "powerpc64le-unknown-linux-gnu",
+        "powerpc64le-unknown-linux-musl",
         "riscv64gc-unknown-linux-gnu",
         "s390x-unknown-linux-gnu",
         "x86_64-apple-darwin",


### PR DESCRIPTION
I missed this in the promotion to tier 2 with host tools.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
