### PR TITLE
Hint that choose_pivot returns index in bounds

### DIFF
--- a/library/core/src/slice/sort/select.rs
+++ b/library/core/src/slice/sort/select.rs
@@ -101,8 +101,7 @@ fn partition_at_index_loop<'a, T, F>(
         // slice. Partition the slice into elements equal to and elements greater than the pivot.
         // This case is usually hit when the slice contains many duplicate elements.
         if let Some(p) = ancestor_pivot {
-            // SAFETY: choose_pivot promises to return a valid pivot position.
-            let pivot = unsafe { v.get_unchecked(pivot_pos) };
+            let pivot = &v[pivot_pos];
 
             if !is_less(p, pivot) {
                 let num_lt = partition(v, pivot_pos, &mut |a, b| !is_less(b, a));

--- a/library/core/src/slice/sort/stable/quicksort.rs
+++ b/library/core/src/slice/sort/stable/quicksort.rs
@@ -37,10 +37,6 @@ pub fn quicksort<T, F: FnMut(&T, &T) -> bool>(
         limit -= 1;
 
         let pivot_pos = choose_pivot(v, is_less);
-        // SAFETY: choose_pivot promises to return a valid pivot index.
-        unsafe {
-            intrinsics::assume(pivot_pos < v.len());
-        }
 
         // SAFETY: We only access the temporary copy for Freeze types, otherwise
         // self-modifications via `is_less` would not be observed and this would

--- a/library/core/src/slice/sort/unstable/quicksort.rs
+++ b/library/core/src/slice/sort/unstable/quicksort.rs
@@ -48,8 +48,7 @@ pub(crate) fn quicksort<'a, T, F>(
         // slice. Partition the slice into elements equal to and elements greater than the pivot.
         // This case is usually hit when the slice contains many duplicate elements.
         if let Some(p) = ancestor_pivot {
-            // SAFETY: We assume choose_pivot yields an in-bounds position.
-            if !is_less(p, unsafe { v.get_unchecked(pivot_pos) }) {
+            if !is_less(p, &v[pivot_pos]) {
                 let num_lt = partition(v, pivot_pos, &mut |a, b| !is_less(b, a));
 
                 // Continue sorting elements greater than the pivot. We know that `num_lt` contains


### PR DESCRIPTION
Instead of using `unsafe` in multiple places, one `hint::assert_unchecked` allows use of safe code instead.

Part of #rust-lang/rust#144326