### PR TITLE
bootstrap: add package.json and package-lock.json to dist tarball

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1068,6 +1068,8 @@ impl Step for PlainSourceTarball {
             "bootstrap.example.toml",
             "configure",
             "license-metadata.json",
+            "package-lock.json",
+            "package.json",
             "x",
             "x.ps1",
             "x.py",


### PR DESCRIPTION
this ensures that js-related tests can still be run from within such a dist tarball.

followup to rust-lang/rust#142924

r? @Kobzol 

<!-- homu-ignore:start -->
fixes rust-lang/rust#142902
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
