### PR TITLE
rustdoc: avoid allocating a temp String for aliases in search index

### DIFF
--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -100,9 +100,22 @@ pub(crate) fn build_index(
     let crate_doc =
         short_markdown_summary(&krate.module.doc_value(), &krate.module.link_names(cache));
 
+    #[derive(Eq, Ord, PartialEq, PartialOrd)]
+    struct SerSymbolAsStr(Symbol);
+
+    impl Serialize for SerSymbolAsStr {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.0.as_str().serialize(serializer)
+        }
+    }
+
+    type AliasMap = BTreeMap<SerSymbolAsStr, Vec<usize>>;
     // Aliases added through `#[doc(alias = "...")]`. Since a few items can have the same alias,
     // we need the alias element to have an array of items.
-    let mut aliases: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    let mut aliases: AliasMap = BTreeMap::new();
 
     // Sort search index items. This improves the compressibility of the search index.
     cache.search_index.sort_unstable_by(|k1, k2| {
@@ -116,7 +129,7 @@ pub(crate) fn build_index(
     // Set up alias indexes.
     for (i, item) in cache.search_index.iter().enumerate() {
         for alias in &item.aliases[..] {
-            aliases.entry(alias.to_string()).or_default().push(i);
+            aliases.entry(SerSymbolAsStr(*alias)).or_default().push(i);
         }
     }
 
@@ -474,7 +487,7 @@ pub(crate) fn build_index(
         // The String is alias name and the vec is the list of the elements with this alias.
         //
         // To be noted: the `usize` elements are indexes to `items`.
-        aliases: &'a BTreeMap<String, Vec<usize>>,
+        aliases: &'a AliasMap,
         // Used when a type has more than one impl with an associated item with the same name.
         associated_item_disambiguators: &'a Vec<(usize, String)>,
         // A list of shard lengths encoded as vlqhex. See the comment in write_vlqhex_to_string


### PR DESCRIPTION
Here's the optimization I talked about in https://github.com/rust-lang/rust/pull/143988#discussion_r2208524163

I got around the Serialize issue using the newtype pattern.  The wrapper type could be factored out into a helper that would work with anything that impls `AsRef<&str>`, but I'm not sure if that would be helpful anywhere else.

r? @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
