### PR TITLE
add AnonConstKind to non_trivial_const_arg diagnostics

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -120,7 +120,7 @@ resolve_const_param_in_enum_discriminant =
     const parameters may not be used in enum discriminant values
 
 resolve_const_param_in_non_trivial_anon_const =
-    const parameters may only be used as standalone arguments here, i.e. `{$name}`
+    const parameters may only be used as standalone arguments in {$place}, i.e. `{$name}`
 
 resolve_constructor_private_if_any_field_private =
     a constructor is private if any of the fields is private

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1007,7 +1007,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ParamInTyOfConstParam { name } => {
                 self.dcx().create_err(errs::ParamInTyOfConstParam { span, name })
             }
-            ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type } => {
+            ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type , place} => {
                 self.dcx().create_err(errs::ParamInNonTrivialAnonConst {
                     span,
                     name,
@@ -1017,6 +1017,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         .sess
                         .is_nightly_build()
                         .then_some(errs::ParamInNonTrivialAnonConstHelp),
+                    place: place.unwrap(),
                 })
             }
             ResolutionError::ParamInEnumDiscriminant { name, param_kind: is_type } => self

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1007,7 +1007,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ParamInTyOfConstParam { name } => {
                 self.dcx().create_err(errs::ParamInTyOfConstParam { span, name })
             }
-            ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type , place} => {
+            ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type, place } => {
                 self.dcx().create_err(errs::ParamInNonTrivialAnonConst {
                     span,
                     name,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -387,7 +387,7 @@ pub(crate) struct ParamInNonTrivialAnonConst {
     pub(crate) param_kind: ParamKindInNonTrivialAnonConst,
     #[subdiagnostic]
     pub(crate) help: Option<ParamInNonTrivialAnonConstHelp>,
-    pub(crate) place: AnonConstKind
+    pub(crate) place: AnonConstKind,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
-use crate::late::PatternSource;
+use crate::late::{PatternSource, AnonConstKind};
 use crate::{Res, fluent_generated as fluent};
 
 #[derive(Diagnostic)]
@@ -387,6 +387,7 @@ pub(crate) struct ParamInNonTrivialAnonConst {
     pub(crate) param_kind: ParamKindInNonTrivialAnonConst,
     #[subdiagnostic]
     pub(crate) help: Option<ParamInNonTrivialAnonConstHelp>,
+    pub(crate) place: AnonConstKind
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
-use crate::late::{PatternSource, AnonConstKind};
+use crate::late::{AnonConstKind, PatternSource};
 use crate::{Res, fluent_generated as fluent};
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1239,7 +1239,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 res_err = Some((span, CannotCaptureDynamicEnvironmentInFnItem));
                             }
                         }
-                        RibKind::ConstantItem(_, item) => {
+                        RibKind::ConstantItem(_, item, _) => {
                             // Still doesn't deal with upvars
                             if let Some(span) = finalize {
                                 let (span, resolution_error) = match item {
@@ -1340,7 +1340,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             }
                         }
 
-                        RibKind::ConstantItem(trivial, _) => {
+                        RibKind::ConstantItem(trivial, _, kind) => {
                             if let ConstantHasGenerics::No(cause) = trivial {
                                 // HACK(min_const_generics): If we encounter `Self` in an anonymous
                                 // constant we can't easily tell if it's generic at this stage, so
@@ -1371,6 +1371,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                                     name: rib_ident.name,
                                                     param_kind:
                                                         ParamKindInNonTrivialAnonConst::Type,
+                                                    place: kind,
+
                                                 }
                                             }
                                         };
@@ -1431,7 +1433,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             }
                         }
 
-                        RibKind::ConstantItem(trivial, _) => {
+                        RibKind::ConstantItem(trivial, _, kind) => {
                             if let ConstantHasGenerics::No(cause) = trivial {
                                 if let Some(span) = finalize {
                                     let error = match cause {
@@ -1447,6 +1449,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                                 param_kind: ParamKindInNonTrivialAnonConst::Const {
                                                     name: rib_ident.name,
                                                 },
+                                                place: kind,
                                             }
                                         }
                                     };

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1372,7 +1372,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                                     param_kind:
                                                         ParamKindInNonTrivialAnonConst::Type,
                                                     place: kind,
-
                                                 }
                                             }
                                         };

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -88,8 +88,8 @@ impl IntoDiagArg for AnonConstKind {
             AnonConstKind::FieldDefaultValue => "field default value",
             AnonConstKind::InlineConst => "inline const",
             AnonConstKind::ConstArg(is_repeat_expr) => match is_repeat_expr {
-                IsRepeatExpr::No => "array repeat expression",
-                IsRepeatExpr::Yes => "const generic args",
+                IsRepeatExpr::No => "const generic args",
+                IsRepeatExpr::Yes => "array repeat expression",
             },
         }))
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -64,7 +64,7 @@ pub(crate) enum PatternSource {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum IsRepeatExpr {
+pub(crate) enum IsRepeatExpr {
     No,
     Yes,
 }
@@ -74,11 +74,26 @@ struct IsNeverPattern;
 /// Describes whether an `AnonConst` is a type level const arg or
 /// some other form of anon const (i.e. inline consts or enum discriminants)
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum AnonConstKind {
+pub(crate) enum AnonConstKind {
     EnumDiscriminant,
     FieldDefaultValue,
     InlineConst,
     ConstArg(IsRepeatExpr),
+}
+
+impl IntoDiagArg for AnonConstKind {
+    fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
+        DiagArgValue::Str(Cow::Borrowed(match self {
+            AnonConstKind::EnumDiscriminant => "enum discriminant",
+            AnonConstKind::FieldDefaultValue => "field default value",
+            AnonConstKind::InlineConst => "inline const",
+            AnonConstKind::ConstArg(is_repeat_expr) => match is_repeat_expr {
+                    IsRepeatExpr::No => "array repeat expression",
+                    IsRepeatExpr::Yes => "const generic args",
+                }
+            },
+        ))
+    }
 }
 
 impl PatternSource {
@@ -214,7 +229,7 @@ pub(crate) enum RibKind<'ra> {
     ///
     /// The item may reference generic parameters in trivial constant expressions.
     /// All other constants aren't allowed to use generic params at all.
-    ConstantItem(ConstantHasGenerics, Option<(Ident, ConstantItemKind)>),
+    ConstantItem(ConstantHasGenerics, Option<(Ident, ConstantItemKind)>, Option<AnonConstKind>),
 
     /// We passed through a module item.
     Module(Module<'ra>),
@@ -2989,19 +3004,21 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         &mut self,
         is_repeat: IsRepeatExpr,
         may_use_generics: ConstantHasGenerics,
+        anon_const_kind: Option<AnonConstKind>,
         item: Option<(Ident, ConstantItemKind)>,
         f: impl FnOnce(&mut Self),
     ) {
         let f = |this: &mut Self| {
-            this.with_rib(ValueNS, RibKind::ConstantItem(may_use_generics, item), |this| {
+            this.with_rib(ValueNS, RibKind::ConstantItem(may_use_generics, item, anon_const_kind), |this| {
                 this.with_rib(
                     TypeNS,
                     RibKind::ConstantItem(
                         may_use_generics.force_yes_if(is_repeat == IsRepeatExpr::Yes),
                         item,
+                        anon_const_kind,
                     ),
                     |this| {
-                        this.with_label_rib(RibKind::ConstantItem(may_use_generics, item), f);
+                        this.with_label_rib(RibKind::ConstantItem(may_use_generics, item, anon_const_kind), f);
                     },
                 )
             })
@@ -3518,7 +3535,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
     fn resolve_const_body(&mut self, expr: &'ast Expr, item: Option<(Ident, ConstantItemKind)>) {
         self.with_lifetime_rib(LifetimeRibKind::Elided(LifetimeRes::Infer), |this| {
-            this.with_constant_rib(IsRepeatExpr::No, ConstantHasGenerics::Yes, item, |this| {
+            this.with_constant_rib(IsRepeatExpr::No, ConstantHasGenerics::Yes, None, item, |this| {
                 this.visit_expr(expr)
             });
         })
@@ -4728,7 +4745,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             }
         };
 
-        self.with_constant_rib(is_repeat_expr, may_use_generics, None, |this| {
+        self.with_constant_rib(is_repeat_expr, may_use_generics, Some(anon_const_kind), None, |this| {
             this.with_lifetime_rib(LifetimeRibKind::Elided(LifetimeRes::Infer), |this| {
                 resolve_expr(this);
             });

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -33,8 +33,7 @@ use tracing::debug;
 use super::NoConstantGenericsReason;
 use crate::diagnostics::{ImportSuggestion, LabelSuggestion, TypoSuggestion};
 use crate::late::{
-    AliasPossibility, LateResolutionVisitor, LifetimeBinderKind, LifetimeRes, LifetimeRibKind,
-    LifetimeUseSet, QSelf, RibKind,
+    AliasPossibility, AnonConstKind, LateResolutionVisitor, LifetimeBinderKind, LifetimeRes, LifetimeRibKind, LifetimeUseSet, QSelf, RibKind
 };
 use crate::ty::fast_reject::SimplifiedType;
 use crate::{
@@ -3344,6 +3343,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                             .sess
                             .is_nightly_build()
                             .then_some(errors::ParamInNonTrivialAnonConstHelp),
+                        place: AnonConstKind::InlineConst,
                     })
                     .emit();
             }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -33,7 +33,8 @@ use tracing::debug;
 use super::NoConstantGenericsReason;
 use crate::diagnostics::{ImportSuggestion, LabelSuggestion, TypoSuggestion};
 use crate::late::{
-    AliasPossibility, AnonConstKind, LateResolutionVisitor, LifetimeBinderKind, LifetimeRes, LifetimeRibKind, LifetimeUseSet, QSelf, RibKind
+    AliasPossibility, AnonConstKind, LateResolutionVisitor, LifetimeBinderKind, LifetimeRes,
+    LifetimeRibKind, LifetimeUseSet, QSelf, RibKind,
 };
 use crate::ty::fast_reject::SimplifiedType;
 use crate::{

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -70,7 +70,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{
     self, DelegationFnSig, Feed, MainDefinition, RegisteredTools, ResolverAstLowering,
-    ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility,
+    ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility
 };
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::lint::BuiltinLintDiag;
@@ -302,7 +302,11 @@ enum ResolutionError<'ra> {
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.
-    ParamInNonTrivialAnonConst { name: Symbol, param_kind: ParamKindInNonTrivialAnonConst, place: Option<AnonConstKind> },
+    ParamInNonTrivialAnonConst {
+        name: Symbol,
+        param_kind: ParamKindInNonTrivialAnonConst,
+        place: Option<AnonConstKind>,
+    },
     /// generic parameters must not be used inside enum discriminants.
     ///
     /// This error is emitted even with `generic_const_exprs`.

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -70,7 +70,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{
     self, DelegationFnSig, Feed, MainDefinition, RegisteredTools, ResolverAstLowering,
-    ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility
+    ResolverGlobalCtxt, TyCtxt, TyCtxtFeed, Visibility,
 };
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::lint::BuiltinLintDiag;
@@ -96,8 +96,8 @@ pub mod rustdoc;
 
 pub use macros::registered_tools_ast;
 
-use crate::ref_mut::{CmCell, CmRefCell};
 use crate::late::AnonConstKind;
+use crate::ref_mut::{CmCell, CmRefCell};
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -97,6 +97,7 @@ pub mod rustdoc;
 pub use macros::registered_tools_ast;
 
 use crate::ref_mut::{CmCell, CmRefCell};
+use crate::late::AnonConstKind;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
@@ -301,7 +302,7 @@ enum ResolutionError<'ra> {
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.
-    ParamInNonTrivialAnonConst { name: Symbol, param_kind: ParamKindInNonTrivialAnonConst },
+    ParamInNonTrivialAnonConst { name: Symbol, param_kind: ParamKindInNonTrivialAnonConst, place: Option<AnonConstKind> },
     /// generic parameters must not be used inside enum discriminants.
     ///
     /// This error is emitted even with `generic_const_exprs`.

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: [u8; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -58,7 +58,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in array repeat expression, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -112,7 +112,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -166,7 +166,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
@@ -7,7 +7,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |                                   ------ in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -20,7 +20,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |                                          ------ in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -30,7 +30,7 @@ error: generic parameters may not be used in const operations
 LL | fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
    |                                              ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 3 previous errors

--- a/tests/ui/const-generics/early/macro_rules-braces.stderr
+++ b/tests/ui/const-generics/early/macro_rules-braces.stderr
@@ -26,7 +26,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: foo!({{ N }});
    |                    ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -35,7 +35,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: bar!({ N });
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -44,7 +44,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: baz!({{ N }});
    |                    ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -53,7 +53,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: biz!({ N });
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 6 previous errors

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
@@ -7,7 +7,7 @@ LL |         N
 LL | fn foo<const N: usize>() -> A<{{ y!() }}> {
    |                                  ---- in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
@@ -7,7 +7,7 @@ LL |         { N }
 LL | fn foo<const N: usize>() -> A<{ y!() }> {
    |                                 ---- in this macro invocation
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | fn foo<const N: usize>() -> A<{ { N } }> {
    |                                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |                                                ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     arr: [u8; CFG.arr_size],
    |               ^^^ cannot perform const operation using `CFG`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `CFG`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `CFG`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: `Config` is forbidden as the type of a const generic parameter

--- a/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     SmallVec<{ D * 2 }>:,
    |                ^ cannot perform const operation using `D`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `D`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `D`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0747]: constant provided when a type was expected

--- a/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type Arr<const N: usize> = [u8; N - 1];
    |                                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     Condition<{ LHS <= RHS }>: True
    |                 ^^^ cannot perform const operation using `LHS`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `LHS`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `LHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     Condition<{ LHS <= RHS }>: True
    |                        ^^^ cannot perform const operation using `RHS`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `RHS`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `RHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                         ^ cannot perform const operation using `I`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `I`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `I`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -31,7 +31,7 @@ error: generic parameters may not be used in const operations
 LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |                                    ^ cannot perform const operation using `J`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `J`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `J`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 4 previous errors

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in this context.
    |                   ^ cannot perform const operation using `S`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `S`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `S`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |                                     ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: `Option<usize>` is forbidden as the type of a const generic parameter

--- a/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
+++ b/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL | fn const_param<const N: usize>() -> [u8; N + 1] {
    |                                          ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/issues/issue-80375.stderr
+++ b/tests/ui/const-generics/issues/issue-80375.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct MyArray<const COUNT: usize>([u8; COUNT + 1]);
    |                                         ^^^^^ cannot perform const operation using `COUNT`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `COUNT`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `COUNT`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -16,7 +16,7 @@ error: generic parameters may not be used in const operations
 LL |     legacy_const_generics::foo(0, N + 1, 2);
    |                                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |                                      ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL | struct Break1<const N: usize>([u8; { { N } }]);
    |                                        ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     let _: [u8; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -31,7 +31,7 @@ error: generic parameters may not be used in const operations
 LL |     let _ = [0; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in array repeat expression, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     bar::<{ [1; N] }>();
    |                 ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
@@ -13,7 +13,7 @@ error: generic parameters may not be used in const operations
 LL |     bar::<{ [1; { N + 1 }] }>();
    |                   ^ cannot perform const operation using `N`
    |
-   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: const parameters may only be used as standalone arguments in const generic args, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
rust-lang/rust#142387 

r? @compiler-errors

one thing I am not sure about is if AnonConstKind is always available (if not not sure how to make it optional since IntoDiagArg is not implemented for Option). Especially in one of the late diagnostics there is no context to add AnonConstKind to an error (some diagnostics about lifetimes).  
