### PR TITLE
Disable non_exhaustive_omitted_patterns within matches! macro

### DIFF
--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -933,6 +933,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
     fn check_gated_lint(&self, lint_id: LintId, span: Span, lint_from_cli: bool) -> bool {
         let feature = if let Some(feature) = lint_id.lint.feature_gate
             && !self.features.enabled(feature)
+            && !span.allows_unstable(feature)
         {
             // Lint is behind a feature that is not enabled; eventually return false.
             feature

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -426,8 +426,10 @@ pub macro debug_assert_matches($($arg:tt)*) {
 #[macro_export]
 #[stable(feature = "matches_macro", since = "1.42.0")]
 #[rustc_diagnostic_item = "matches_macro"]
+#[allow_internal_unstable(non_exhaustive_omitted_patterns_lint, stmt_expr_attributes)]
 macro_rules! matches {
     ($expression:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
+        #[allow(non_exhaustive_omitted_patterns)]
         match $expression {
             $pattern $(if $guard)? => true,
             _ => false

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -76,6 +76,7 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(next_index)]
+#![feature(non_exhaustive_omitted_patterns_lint)]
 #![feature(numfmt)]
 #![feature(pattern)]
 #![feature(pointer_is_aligned_to)]

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -213,3 +213,9 @@ fn _expression() {
         }
     );
 }
+
+#[deny(non_exhaustive_omitted_patterns)]
+fn _matches_does_not_trigger_non_exhaustive_omitted_patterns_lint(o: core::sync::atomic::Ordering) {
+    // Ordering is a #[non_exhaustive] enum from a separate crate
+    let _m = matches!(o, core::sync::atomic::Ordering::Relaxed);
+}

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-abort.mir
@@ -8,12 +8,14 @@ fn num_to_digit(_1: char) -> u32 {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
             let mut _3: isize;
+            scope 3 {
+            }
         }
     }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 5 {
         }
     }
 

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.32bit.panic-unwind.mir
@@ -8,12 +8,14 @@ fn num_to_digit(_1: char) -> u32 {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
             let mut _3: isize;
+            scope 3 {
+            }
         }
     }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 5 {
         }
     }
 

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-abort.mir
@@ -8,12 +8,14 @@ fn num_to_digit(_1: char) -> u32 {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
             let mut _3: isize;
+            scope 3 {
+            }
         }
     }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 5 {
         }
     }
 

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.64bit.panic-unwind.mir
@@ -8,12 +8,14 @@ fn num_to_digit(_1: char) -> u32 {
         let _2: std::option::Option<u32>;
         scope 2 (inlined Option::<u32>::is_some) {
             let mut _3: isize;
+            scope 3 {
+            }
         }
     }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 4 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 5 {
         }
     }
 

--- a/tests/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.diff
@@ -7,6 +7,8 @@
       let mut _2: bool;
       let mut _3: isize;
 +     let mut _4: isize;
+      scope 1 {
+      }
   
       bb0: {
           StorageLive(_2);

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
@@ -25,9 +25,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         }
         scope 8 (inlined Option::<u16>::is_none) {
             scope 9 (inlined Option::<u16>::is_some) {
+                scope 10 {
+                }
             }
         }
-        scope 10 (inlined core::num::<impl u16>::wrapping_add) {
+        scope 11 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
@@ -25,9 +25,11 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         }
         scope 8 (inlined Option::<u16>::is_none) {
             scope 9 (inlined Option::<u16>::is_some) {
+                scope 10 {
+                }
             }
         }
-        scope 10 (inlined core::num::<impl u16>::wrapping_add) {
+        scope 11 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 

--- a/tests/mir-opt/pre-codegen/matches_macro.issue_77355_opt.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/matches_macro.issue_77355_opt.PreCodegen.after.mir
@@ -4,6 +4,8 @@ fn issue_77355_opt(_1: Foo) -> u64 {
     debug num => _1;
     let mut _0: u64;
     let mut _2: isize;
+    scope 1 {
+    }
 
     bb0: {
         _2 = discriminant(_1);


### PR DESCRIPTION
Closes rust-lang/rust#117304.

I believe I can skip all of the bootstrap stuff mentioned in https://github.com/rust-lang/rust/issues/117304#issuecomment-1784414453 due to https://blog.rust-lang.org/inside-rust/2025/05/29/redesigning-the-initial-bootstrap-sequence/, right?

cc @Jules-Bertholet 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
