### PR TITLE
Tweak closure string when using `-Zspan_free_formats`

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use rustc_data_structures::intern::Interned;
-use rustc_hir::def_id::CrateNum;
+use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::definitions::DisambiguatedDefPathData;
 use rustc_middle::bug;
 use rustc_middle::ty::print::{PrettyPrinter, Print, PrintError, Printer};
@@ -108,6 +108,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -828,6 +828,7 @@ impl<'tcx> LateContext<'tcx> {
 
             fn path_append(
                 &mut self,
+                _def_id: DefId,
                 print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<(), PrintError> {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -95,6 +95,7 @@ pub trait Printer<'tcx>: Sized {
 
     fn path_append(
         &mut self,
+        def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError>;
@@ -186,6 +187,7 @@ pub trait Printer<'tcx>: Sized {
                 }
 
                 self.path_append(
+                    def_id,
                     |cx: &mut Self| {
                         if trait_qualify_parent {
                             let trait_ref = ty::TraitRef::new(

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -357,6 +357,7 @@ impl<'tcx> Printer<'tcx> for SymbolPrinter<'tcx> {
     }
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -859,6 +859,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -276,6 +276,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             fn path_append(
                 &mut self,
+                _def_id: DefId,
                 print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<(), PrintError> {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1641,6 +1641,7 @@ impl<'test> TestCx<'test> {
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
                 rustc.arg("-Zwrite-long-types-to-disk=no");
+                rustc.arg("-Zspan_free_formats=yes");
                 // FIXME: use this for other modes too, for perf?
                 rustc.arg("-Cstrip=debuginfo");
             }

--- a/tests/ui/abi/simd-abi-checks-avx.stderr
+++ b/tests/ui/abi/simd-abi-checks-avx.stderr
@@ -86,7 +86,7 @@ LL |     || g()
    |
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-note: the above error was encountered while instantiating `fn in_closure::{closure#0}`
+note: the above error was encountered while instantiating `fn in_closure::{return}`
   --> $DIR/simd-abi-checks-avx.rs:81:9
    |
 LL |         in_closure()();

--- a/tests/ui/abi/simd-abi-checks-avx.stderr
+++ b/tests/ui/abi/simd-abi-checks-avx.stderr
@@ -86,7 +86,7 @@ LL |     || g()
    |
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-note: the above error was encountered while instantiating `fn in_closure::{return}`
+note: the above error was encountered while instantiating `fn in_closure::{returned closure}`
   --> $DIR/simd-abi-checks-avx.rs:81:9
    |
 LL |         in_closure()();

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -6,7 +6,7 @@ LL |         asm!("{}", in(xmm_reg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 
-error: cannot use value of type `{closure@$DIR/type-check-2.rs:48:28: 48:36}` for inline assembly
+error: cannot use value of type `test2::{asm closure}` for inline assembly
   --> $DIR/type-check-2.rs:48:28
    |
 LL |         asm!("{}", in(reg) |x: i32| x);

--- a/tests/ui/async-await/async-closures/def-path.rs
+++ b/tests/ui/async-await/async-closures/def-path.rs
@@ -6,7 +6,7 @@ fn main() {
     //~^ NOTE the expected `async` closure body
     let () = x();
     //~^ ERROR mismatched types
-    //~| NOTE this expression has type `{static main::{x}::{return}<
+    //~| NOTE this expression has type `{static main::{closure x}::{returned closure}<
     //~| NOTE expected `async` closure body, found `()`
-    //~| NOTE expected `async` closure body `{static main::{x}::{return}<
+    //~| NOTE expected `async` closure body `{static main::{closure x}::{returned closure}<
 }

--- a/tests/ui/async-await/async-closures/def-path.rs
+++ b/tests/ui/async-await/async-closures/def-path.rs
@@ -6,7 +6,7 @@ fn main() {
     //~^ NOTE the expected `async` closure body
     let () = x();
     //~^ ERROR mismatched types
-    //~| NOTE this expression has type `{static main::{closure#0}::{closure#0}<
+    //~| NOTE this expression has type `{static main::{x}::{return}<
     //~| NOTE expected `async` closure body, found `()`
-    //~| NOTE expected `async` closure body `{static main::{closure#0}::{closure#0}<
+    //~| NOTE expected `async` closure body `{static main::{x}::{return}<
 }

--- a/tests/ui/async-await/async-closures/def-path.stderr
+++ b/tests/ui/async-await/async-closures/def-path.stderr
@@ -5,11 +5,11 @@ LL |     let x = async || {};
    |                      -- the expected `async` closure body
 LL |
 LL |     let () = x();
-   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure#0}::{closure#0}}}`
+   |         ^^   --- this expression has type `{static main::{x}::{return}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{x}::{return}}}`
    |         |
    |         expected `async` closure body, found `()`
    |
-   = note: expected `async` closure body `{static main::{closure#0}::{closure#0}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure#0}::{closure#0}}}`
+   = note: expected `async` closure body `{static main::{x}::{return}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{x}::{return}}}`
                          found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/async-await/async-closures/def-path.stderr
+++ b/tests/ui/async-await/async-closures/def-path.stderr
@@ -5,11 +5,11 @@ LL |     let x = async || {};
    |                      -- the expected `async` closure body
 LL |
 LL |     let () = x();
-   |         ^^   --- this expression has type `{static main::{x}::{return}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{x}::{return}}}`
+   |         ^^   --- this expression has type `{static main::{closure x}::{returned closure}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure x}::{returned closure}}}`
    |         |
    |         expected `async` closure body, found `()`
    |
-   = note: expected `async` closure body `{static main::{x}::{return}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{x}::{return}}}`
+   = note: expected `async` closure body `{static main::{closure x}::{returned closure}<?16t> upvar_tys=?15t resume_ty=ResumeTy yield_ty=() return_ty=() witness={main::{closure x}::{returned closure}}}`
                          found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/async-await/async-closures/is-not-fn.current.stderr
+++ b/tests/ui/async-await/async-closures/is-not-fn.current.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to return `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
+error[E0271]: expected `{async closure@main::{closure needs_fn#x}}` to return `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
   --> $DIR/is-not-fn.rs:8:14
    |
 LL |     needs_fn(async || {});

--- a/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.stderr
+++ b/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.stderr
@@ -9,7 +9,7 @@ LL |         takes_asyncfn(Box::new(async || self.an_async_fn().await));
    |         |             the requirement to implement `AsyncFn` derives from here
    |         required by a bound introduced by this call
    |
-   = note: required for `Box<{async closure@$DIR/kind-due-to-arg-with-box-wrap.rs:13:32: 13:40}>` to implement `AsyncFn()`
+   = note: required for `Box<{async closure@Test::uses_takes_asyncfn::{closure Box::new#0}}>` to implement `AsyncFn()`
 note: required by a bound in `takes_asyncfn`
   --> $DIR/kind-due-to-arg-with-box-wrap.rs:18:32
    |

--- a/tests/ui/async-await/async-closures/kind-due-to-rpit.stderr
+++ b/tests/ui/async-await/async-closures/kind-due-to-rpit.stderr
@@ -10,7 +10,7 @@ LL |         let _ = foo.into();
    |                 --- closure is `AsyncFnOnce` because it moves the variable `foo` out of its environment
 LL |     };
 LL |     inner_fn
-   |     -------- return type was inferred to be `{async closure@$DIR/kind-due-to-rpit.rs:7:20: 7:33}` here
+   |     -------- return type was inferred to be `{async closure@repro<impl Into<bool>>::{closure inner_fn}}` here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/move-consuming-capture.stderr
+++ b/tests/ui/async-await/async-closures/move-consuming-capture.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `x`
   --> $DIR/move-consuming-capture.rs:15:9
    |
 LL |         let x = async move || {
-   |             - move occurs because `x` has type `{async closure@$DIR/move-consuming-capture.rs:11:17: 11:30}`, which does not implement the `Copy` trait
+   |             - move occurs because `x` has type `{async closure@main::{closure block_on#0}::{closure x}}`, which does not implement the `Copy` trait
 ...
 LL |         x().await;
    |         --- `x` moved due to this method call

--- a/tests/ui/async-await/async-closures/not-clone-closure.stderr
+++ b/tests/ui/async-await/async-closures/not-clone-closure.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `NotClonableUpvar: Clone` is not satisfied in `{async closure@$DIR/not-clone-closure.rs:27:21: 27:34}`
+error[E0277]: the trait bound `NotClonableUpvar: Clone` is not satisfied in `{async closure@we_only_care_about_clonable_upvars::{closure not_clone}}`
   --> $DIR/not-clone-closure.rs:30:15
    |
 LL |     not_clone.clone();
    |               ^^^^^ unsatisfied trait bound
    |
-   = help: within `{async closure@$DIR/not-clone-closure.rs:27:21: 27:34}`, the trait `Clone` is not implemented for `NotClonableUpvar`
+   = help: within `{async closure@we_only_care_about_clonable_upvars::{closure not_clone}}`, the trait `Clone` is not implemented for `NotClonableUpvar`
 note: required because it's used within this closure
   --> $DIR/not-clone-closure.rs:27:21
    |

--- a/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang-2.stderr
+++ b/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang-2.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `recur::<{async closure@$DIR/post-mono-higher-ranked-hang-2.rs:13:24: 13:32}>`
+error: reached the recursion limit while instantiating `recur::<{async closure@recur<{async closure@recur<{async closure@recur<{async closure@recur<{async closure@recur<...>::{closure Box::pin#0}::{closure#0}}>::{closure Box::pin#0}::{closure#0}}>::{closure Box::pin#0}::{closure#0}}>::{closure Box::pin#0}::{closure#0}}>::{closure Box::pin#0}::{closure#0}}>`
   --> $DIR/post-mono-higher-ranked-hang-2.rs:13:17
    |
 LL |           let _ = recur(&async || {
@@ -13,6 +13,7 @@ note: `recur` defined here
    |
 LL | fn recur<'l>(closure: &'l impl AsyncFn()) -> Pin<Box<dyn Future<Output = ()> + 'l>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the full type name has been written to '$TEST_BUILD_DIR/post-mono-higher-ranked-hang-2.long-type.txt'
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.stderr
+++ b/tests/ui/async-await/async-closures/post-mono-higher-ranked-hang.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `ToChain::<'_, '_>::perm_pairs::<{async closure@$DIR/post-mono-higher-ranked-hang.rs:43:45: 43:67}>`
+error: reached the recursion limit while instantiating `ToChain::<'_, '_>::perm_pairs::<{async closure@ToChain<'_, '_>::perm_pairs<{async closure@ToChain<'_, '_>::perm_pairs<...>::{closure Box::pin#0}::{closure#0}}>::{closure Box::pin#0}::{closure#0}}>`
   --> $DIR/post-mono-higher-ranked-hang.rs:43:21
    |
 LL | /                     self.perm_pairs(l, &mut async move |left_pair| {
@@ -16,6 +16,7 @@ LL | |         perm: &'l SymPerm<'db>,
 LL | |         yield_chain: &'l mut impl AsyncFnMut(&SymPerm<'db>),
 LL | |     ) -> Pin<Box<dyn std::future::Future<Output = ()> + 'l>> {
    | |____________________________________________________________^
+   = note: the full type name has been written to '$TEST_BUILD_DIR/post-mono-higher-ranked-hang.long-type.txt'
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
+++ b/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
@@ -20,7 +20,7 @@ LL |         true
    = note: expected enum `Option<()>`
               found type `bool`
 
-error[E0271]: expected `{closure@dont-ice-for-type-mismatch-in-closure-in-async.rs:6:10}` to return `bool`, but it returns `Option<()>`
+error[E0271]: expected `test::{closure call#0}` to return `bool`, but it returns `Option<()>`
   --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:6:16
    |
 LL |     call(|| -> Option<()> {

--- a/tests/ui/async-await/higher-ranked-auto-trait-16.assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-16.assumptions.stderr
@@ -6,7 +6,7 @@ LL | |         commit_if_ok(&mut ctxt, async |_| todo!()).await;
 LL | |     });
    | |______^ implementation of `AsyncFnOnce` is not general enough
    |
-   = note: `{async closure@$DIR/higher-ranked-auto-trait-16.rs:19:33: 19:42}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{async closure@operation::{closure assert_send#0}::{closure commit_if_ok#f}}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `AsyncFnOnce<(&mut Ctxt<'_>,)>`
 
 error: implementation of `AsyncFnOnce` is not general enough
@@ -17,7 +17,7 @@ LL | |         commit_if_ok(&mut ctxt, async |_| todo!()).await;
 LL | |     });
    | |______^ implementation of `AsyncFnOnce` is not general enough
    |
-   = note: `{async closure@$DIR/higher-ranked-auto-trait-16.rs:19:33: 19:42}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{async closure@operation::{closure assert_send#0}::{closure commit_if_ok#f}}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `AsyncFnOnce<(&mut Ctxt<'_>,)>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-16.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-16.no_assumptions.stderr
@@ -6,7 +6,7 @@ LL | |         commit_if_ok(&mut ctxt, async |_| todo!()).await;
 LL | |     });
    | |______^ implementation of `AsyncFnOnce` is not general enough
    |
-   = note: `{async closure@$DIR/higher-ranked-auto-trait-16.rs:19:33: 19:42}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{async closure@operation::{closure assert_send#0}::{closure commit_if_ok#f}}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `AsyncFnOnce<(&mut Ctxt<'_>,)>`
 
 error: implementation of `AsyncFnOnce` is not general enough
@@ -17,7 +17,7 @@ LL | |         commit_if_ok(&mut ctxt, async |_| todo!()).await;
 LL | |     });
    | |______^ implementation of `AsyncFnOnce` is not general enough
    |
-   = note: `{async closure@$DIR/higher-ranked-auto-trait-16.rs:19:33: 19:42}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{async closure@operation::{closure assert_send#0}::{closure commit_if_ok#f}}` must implement `AsyncFnOnce<(&mut Ctxt<'1>,)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `AsyncFnOnce<(&mut Ctxt<'_>,)>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/block-result/issue-20862.rs
+++ b/tests/ui/block-result/issue-20862.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z span_free_formats
 fn foo(x: i32) {
     |y| x + y
 //~^ ERROR: mismatched types

--- a/tests/ui/block-result/issue-20862.stderr
+++ b/tests/ui/block-result/issue-20862.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-20862.rs:2:5
+  --> $DIR/issue-20862.rs:3:5
    |
 LL | fn foo(x: i32) {
    |               - help: a return type might be missing here: `-> _`
@@ -7,10 +7,10 @@ LL |     |y| x + y
    |     ^^^^^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/issue-20862.rs:2:5: 2:8}`
+                found closure `{closure@foo::{return}}`
 
 error[E0618]: expected function, found `()`
-  --> $DIR/issue-20862.rs:7:13
+  --> $DIR/issue-20862.rs:8:13
    |
 LL | fn foo(x: i32) {
    | -------------- `foo` defined here returns `()`

--- a/tests/ui/block-result/issue-20862.stderr
+++ b/tests/ui/block-result/issue-20862.stderr
@@ -7,7 +7,7 @@ LL |     |y| x + y
    |     ^^^^^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@foo::{return}}`
+                found closure `foo::{returned closure}`
 
 error[E0618]: expected function, found `()`
   --> $DIR/issue-20862.rs:8:13

--- a/tests/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
+++ b/tests/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
@@ -4,7 +4,7 @@ error: lifetime may not live long enough
 LL |     let _action = move || {
    |                   -------
    |                   |     |
-   |                   |     return type of closure `{closure@$DIR/issue-53432-nested-closure-outlives-borrowed-value.rs:4:9: 4:11}` contains a lifetime `'2`
+   |                   |     return type of closure `main::{closure _action}::{returned closure}` contains a lifetime `'2`
    |                   lifetime `'1` represents this closure's body
 LL |         || f() // The `nested` closure
    |         ^^^^^^ returning this value requires that `'1` must outlive `'2`

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation panicked: explicit panic
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                        ^^^^^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
-note: inside `f::<{closure@$DIR/issue-81899.rs:6:31: 6:34}>`
+note: inside `f::<_CONST::{closure f#1}>`
   --> $DIR/issue-81899.rs:13:5
    |
 LL |     panic!()

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation panicked: explicit panic
 LL | const _CONST: &() = &f(&|_| {});
    |                      ^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
-note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:5:25: 5:28}>`
+note: inside `f::<_CONST::{closure#0}>`
   --> $DIR/issue-88434-minimal-example.rs:12:5
    |
 LL |     panic!()

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -4,7 +4,7 @@ error[E0080]: evaluation panicked: explicit panic
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                        ^^^^^^^^^^^^^^ evaluation of `_CONST` failed inside this call
    |
-note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:5:31: 5:34}>`
+note: inside `f::<_CONST::{closure f#1}>`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:12:5
    |
 LL |     panic!()

--- a/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
+++ b/tests/ui/borrowck/issue-95079-missing-move-in-nested-closure.stderr
@@ -24,7 +24,7 @@ error: lifetime may not live long enough
 LL |     move |()| s.chars().map(|c| format!("{}{}", c, s))
    |     --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
    |     |       |
-   |     |       return type of closure `Map<Chars<'_>, {closure@$DIR/issue-95079-missing-move-in-nested-closure.rs:11:29: 11:32}>` contains a lifetime `'2`
+   |     |       return type of closure `Map<Chars<'_>, foo2::{returned closure}::{closure _::map#0}>` contains a lifetime `'2`
    |     lifetime `'1` represents this closure's body
    |
    = note: closure implements `Fn`, so references to captured variables can't escape the closure

--- a/tests/ui/closure_context/issue-26046-fn-mut.stderr
+++ b/tests/ui/closure_context/issue-26046-fn-mut.stderr
@@ -9,7 +9,7 @@ LL |         num += 1;
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-mut.rs:4:19: 4:21}>` to `Box<(dyn Fn() + 'static)>`
+   = note: required for the cast from `Box<foo::{closure closure}>` to `Box<(dyn Fn() + 'static)>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closure_context/issue-26046-fn-once.stderr
+++ b/tests/ui/closure_context/issue-26046-fn-once.stderr
@@ -9,7 +9,7 @@ LL |         vec
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-once.rs:4:19: 4:26}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
+   = note: required for the cast from `Box<get_closure::{closure closure}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/closure-clone-requires-captured-clone.stderr
+++ b/tests/ui/closures/closure-clone-requires-captured-clone.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{closure@$DIR/closure-clone-requires-captured-clone.rs:13:19: 13:26}`
+error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `main::{closure closure}`
   --> $DIR/closure-clone-requires-captured-clone.rs:17:13
    |
 LL |     let closure = move || {
-   |                   ------- within this `{closure@$DIR/closure-clone-requires-captured-clone.rs:13:19: 13:26}`
+   |                   ------- within this `main::{closure closure}`
 ...
 LL |     closure.clone();
-   |             ^^^^^ within `{closure@$DIR/closure-clone-requires-captured-clone.rs:13:19: 13:26}`, the trait `Clone` is not implemented for `NonClone`
+   |             ^^^^^ within `main::{closure closure}`, the trait `Clone` is not implemented for `NonClone`
    |
 note: required because it's used within this closure
   --> $DIR/closure-clone-requires-captured-clone.rs:13:19

--- a/tests/ui/closures/closure-no-fn-1.stderr
+++ b/tests/ui/closures/closure-no-fn-1.stderr
@@ -7,7 +7,7 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |              expected due to this
    |
    = note: expected fn pointer `fn(u8) -> u8`
-                 found closure `{closure@$DIR/closure-no-fn-1.rs:6:29: 6:36}`
+                 found closure `main::{closure foo}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-1.rs:6:39
    |

--- a/tests/ui/closures/closure-no-fn-2.stderr
+++ b/tests/ui/closures/closure-no-fn-2.stderr
@@ -7,7 +7,7 @@ LL |     let bar: fn() -> u8 = || { b };
    |              expected due to this
    |
    = note: expected fn pointer `fn() -> u8`
-                 found closure `{closure@$DIR/closure-no-fn-2.rs:6:27: 6:29}`
+                 found closure `main::{closure bar}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-2.rs:6:32
    |

--- a/tests/ui/closures/closure-no-fn-3.stderr
+++ b/tests/ui/closures/closure-no-fn-3.stderr
@@ -1,4 +1,4 @@
-error[E0605]: non-primitive cast: `{closure@$DIR/closure-no-fn-3.rs:6:28: 6:30}` as `fn() -> u8`
+error[E0605]: non-primitive cast: `main::{closure#0}` as `fn() -> u8`
   --> $DIR/closure-no-fn-3.rs:6:27
    |
 LL |     let baz: fn() -> u8 = (|| { b }) as fn() -> u8;

--- a/tests/ui/closures/closure-no-fn-4.stderr
+++ b/tests/ui/closures/closure-no-fn-4.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____- `match` arms have incompatible types
    |
    = note: expected fn pointer `fn(usize) -> usize`
-                 found closure `{closure@$DIR/closure-no-fn-4.rs:5:18: 5:21}`
+                 found closure `main::{closure#1}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-4.rs:5:26
    |

--- a/tests/ui/closures/closure-no-fn-5.stderr
+++ b/tests/ui/closures/closure-no-fn-5.stderr
@@ -7,7 +7,7 @@ LL |     let bar: fn() -> u8 = || { a; b; c; d; e };
    |              expected due to this
    |
    = note: expected fn pointer `fn() -> u8`
-                 found closure `{closure@$DIR/closure-no-fn-5.rs:10:27: 10:29}`
+                 found closure `main::{closure bar}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-no-fn-5.rs:10:32
    |

--- a/tests/ui/closures/closure-reform-bad.stderr
+++ b/tests/ui/closures/closure-reform-bad.stderr
@@ -9,7 +9,7 @@ LL |     call_bare(f)
    |     arguments to this function are incorrect
    |
    = note: expected fn pointer `for<'a> fn(&'a str)`
-                 found closure `{closure@$DIR/closure-reform-bad.rs:10:13: 10:22}`
+                 found closure `main::{closure f}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-reform-bad.rs:10:43
    |

--- a/tests/ui/closures/closure_cap_coerce_many_fail.stderr
+++ b/tests/ui/closures/closure_cap_coerce_many_fail.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____- `match` arms have incompatible types
    |
    = note: expected fn item `fn(i32, i32) -> i32 {add}`
-              found closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:9:16: 9:22}`
+              found closure `main::{closure#0}`
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/closure_cap_coerce_many_fail.rs:18:16
@@ -23,15 +23,15 @@ LL | |         "+" => |a, b| (a + b) as i32,
    | |                ---------------------
    | |                |
    | |                the expected closure
-   | |                this is found to be of type `{closure@$DIR/closure_cap_coerce_many_fail.rs:17:16: 17:22}`
+   | |                this is found to be of type `main::{closure#1}`
 LL | |         "-" => |a, b| (a - b + cap) as i32,
    | |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected closure, found a different closure
 LL | |         _ => unimplemented!(),
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:17:16: 17:22}`
-              found closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:18:16: 18:22}`
+   = note: expected closure `main::{closure#1}`
+              found closure `main::{closure#2}`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
@@ -44,15 +44,15 @@ LL | |         "+" => |a, b| (a + b + cap) as i32,
    | |                ---------------------------
    | |                |
    | |                the expected closure
-   | |                this is found to be of type `{closure@$DIR/closure_cap_coerce_many_fail.rs:26:16: 26:22}`
+   | |                this is found to be of type `main::{closure#3}`
 LL | |         "-" => |a, b| (a - b) as i32,
    | |                ^^^^^^^^^^^^^^^^^^^^^ expected closure, found a different closure
 LL | |         _ => unimplemented!(),
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:26:16: 26:22}`
-              found closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:27:16: 27:22}`
+   = note: expected closure `main::{closure#3}`
+              found closure `main::{closure#4}`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
@@ -65,15 +65,15 @@ LL | |         "+" => |a, b| (a + b + cap) as i32,
    | |                ---------------------------
    | |                |
    | |                the expected closure
-   | |                this is found to be of type `{closure@$DIR/closure_cap_coerce_many_fail.rs:34:16: 34:22}`
+   | |                this is found to be of type `main::{closure#5}`
 LL | |         "-" => |a, b| (a - b + cap) as i32,
    | |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected closure, found a different closure
 LL | |         _ => unimplemented!(),
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:34:16: 34:22}`
-              found closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:35:16: 35:22}`
+   = note: expected closure `main::{closure#5}`
+              found closure `main::{closure#6}`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 

--- a/tests/ui/closures/correct-args-on-call-suggestion.stderr
+++ b/tests/ui/closures/correct-args-on-call-suggestion.stderr
@@ -9,7 +9,7 @@ LL |     let y: i32 = x;
    |            expected due to this
    |
    = note: expected type `i32`
-           found closure `{closure@$DIR/correct-args-on-call-suggestion.rs:4:13: 4:29}`
+           found closure `main::{closure x}`
 help: use parentheses to call this closure
    |
 LL |     let y: i32 = x(/* i32 */, /* i32 */);

--- a/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
+++ b/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.current.stderr
@@ -8,7 +8,7 @@ LL | |         x.to_string();
 LL | |     });
    | |______^ implementation of `Foo` is not general enough
    |
-   = note: `Wrap<{closure@$DIR/obligation-with-leaking-placeholders.rs:18:15: 18:18}>` must implement `Foo<'0>`, for any lifetime `'0`...
+   = note: `Wrap<main::{closure needs_foo#0}>` must implement `Foo<'0>`, for any lifetime `'0`...
    = note: ...but it actually implements `Foo<'1>`, for some specific lifetime `'1`
 
 error: aborting due to 1 previous error

--- a/tests/ui/closures/issue-90871.stderr
+++ b/tests/ui/closures/issue-90871.stderr
@@ -14,7 +14,7 @@ LL |     type_ascribe!(2, n([u8; || 1]))
    |                             ^^^^ expected `usize`, found closure
    |
    = note: expected type `usize`
-           found closure `{closure@$DIR/issue-90871.rs:4:29: 4:31}`
+           found closure `main::{constant#0}::{closure#0}`
 help: use parentheses to call this closure
    |
 LL |     type_ascribe!(2, n([u8; (|| 1)()]))

--- a/tests/ui/closures/print/closure-print-generic-1.stderr
+++ b/tests/ui/closures/print/closure-print-generic-1.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-1.rs:17:5
    |
 LL |     let c = to_fn_once(move || {
-   |         - move occurs because `c` has type `{closure@$DIR/closure-print-generic-1.rs:12:24: 12:31}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `f<T>::{closure to_fn_once#f}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/closures/print/closure-print-generic-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1: () = c;
    |                 expected due to this
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/closure-print-generic-2.rs:5:17: 5:19}`
+                found closure `f<T>::{closure c}`
 help: use parentheses to call this closure
    |
 LL |         let c1: () = c();

--- a/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{mod1::f<T>::{c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
+                found closure `{mod1::f<T>::{closure c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{mod1::f<T>::{closure#0} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
+                found closure `{mod1::f<T>::{c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-verbose-1.rs:17:5
    |
 LL |     let c = to_fn_once(move|| {
-   |         - move occurs because `c` has type `{f<T>::{to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `{f<T>::{closure to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-verbose-1.rs:17:5
    |
 LL |     let c = to_fn_once(move|| {
-   |         - move occurs because `c` has type `{f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `{f<T>::{to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{f<T>::{c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
+                found closure `{f<T>::{closure c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{f<T>::{closure#0} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
+                found closure `{f<T>::{c} closure_kind_ty=?7t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?6t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-verbose.stderr
+++ b/tests/ui/closures/print/closure-print-verbose.stderr
@@ -7,7 +7,7 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |              expected due to this
    |
    = note: expected fn pointer `fn(u8) -> u8`
-                 found closure `{main::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn((u8,)) -> u8 upvar_tys=?4t}`
+                 found closure `{main::{foo} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn((u8,)) -> u8 upvar_tys=?4t}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-print-verbose.rs:10:39
    |

--- a/tests/ui/closures/print/closure-print-verbose.stderr
+++ b/tests/ui/closures/print/closure-print-verbose.stderr
@@ -7,7 +7,7 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |              expected due to this
    |
    = note: expected fn pointer `fn(u8) -> u8`
-                 found closure `{main::{foo} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn((u8,)) -> u8 upvar_tys=?4t}`
+                 found closure `{main::{closure foo} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn((u8,)) -> u8 upvar_tys=?4t}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-print-verbose.rs:10:39
    |

--- a/tests/ui/closures/return-type-doesnt-match-bound.stderr
+++ b/tests/ui/closures/return-type-doesnt-match-bound.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:8:17}` to return `Result<(), _>`, but it returns `!`
+error[E0271]: expected `foo<F>::{closure _::or_else#0}` to return `Result<(), _>`, but it returns `!`
   --> $DIR/return-type-doesnt-match-bound.rs:8:24
    |
 LL |     f().or_else(|e| -> ! {
@@ -13,7 +13,7 @@ LL |     f().or_else(|e| -> ! {
 note: required by a bound in `Result::<T, E>::or_else`
   --> $SRC_DIR/core/src/result.rs:LL:COL
 
-error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:18:13}` to return `Result<(), _>`, but it returns `!`
+error[E0271]: expected `bar<F>::{closure c}` to return `Result<(), _>`, but it returns `!`
   --> $DIR/return-type-doesnt-match-bound.rs:18:20
    |
 LL |     let c = |e| -> ! {

--- a/tests/ui/coercion/coerce-expect-unsized-ascribed.stderr
+++ b/tests/ui/coercion/coerce-expect-unsized-ascribed.stderr
@@ -29,10 +29,10 @@ error[E0308]: mismatched types
   --> $DIR/coerce-expect-unsized-ascribed.rs:14:27
    |
 LL |     let _ = type_ascribe!(Box::new( { |x| (x as u8) }), Box<dyn Fn(i32) -> _>);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Fn(i32) -> u8>`, found `Box<{closure@...}>`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Fn(i32) -> u8>`, found `Box<main::{closure#0}>`
    |
    = note: expected struct `Box<dyn Fn(i32) -> u8>`
-              found struct `Box<{closure@$DIR/coerce-expect-unsized-ascribed.rs:14:39: 14:42}>`
+              found struct `Box<main::{closure#0}>`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-expect-unsized-ascribed.rs:15:27
@@ -85,10 +85,10 @@ error[E0308]: mismatched types
   --> $DIR/coerce-expect-unsized-ascribed.rs:22:27
    |
 LL |     let _ = type_ascribe!(&{ |x| (x as u8) }, &dyn Fn(i32) -> _);
-   |                           ^^^^^^^^^^^^^^^^^^ expected `&dyn Fn(i32) -> u8`, found `&{closure@...}`
+   |                           ^^^^^^^^^^^^^^^^^^ expected `&dyn Fn(i32) -> u8`, found `&main::{closure#1}`
    |
    = note: expected reference `&dyn Fn(i32) -> u8`
-              found reference `&{closure@$DIR/coerce-expect-unsized-ascribed.rs:22:30: 22:33}`
+              found reference `&main::{closure#1}`
 
 error[E0308]: mismatched types
   --> $DIR/coerce-expect-unsized-ascribed.rs:23:27
@@ -123,10 +123,10 @@ error[E0308]: mismatched types
   --> $DIR/coerce-expect-unsized-ascribed.rs:27:27
    |
 LL |     let _ = type_ascribe!(Box::new(|x| (x as u8)), Box<dyn Fn(i32) -> _>);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Fn(i32) -> u8>`, found `Box<{closure@...}>`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ expected `Box<dyn Fn(i32) -> u8>`, found `Box<main::{closure Box::new#0}>`
    |
    = note: expected struct `Box<dyn Fn(i32) -> u8>`
-              found struct `Box<{closure@$DIR/coerce-expect-unsized-ascribed.rs:27:36: 27:39}>`
+              found struct `Box<main::{closure Box::new#0}>`
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/confuse-field-and-method/issue-33784.stderr
+++ b/tests/ui/confuse-field-and-method/issue-33784.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `closure` found for reference `&Obj<{closure@$DIR/issue-33784.rs:25:43: 25:45}>` in the current scope
+error[E0599]: no method named `closure` found for reference `&Obj<main::{closure#0}>` in the current scope
   --> $DIR/issue-33784.rs:27:7
    |
 LL |     p.closure();
@@ -14,7 +14,7 @@ LL -     p.closure();
 LL +     p.clone();
    |
 
-error[E0599]: no method named `fn_ptr` found for reference `&&Obj<{closure@$DIR/issue-33784.rs:25:43: 25:45}>` in the current scope
+error[E0599]: no method named `fn_ptr` found for reference `&&Obj<main::{closure#0}>` in the current scope
   --> $DIR/issue-33784.rs:29:7
    |
 LL |     q.fn_ptr();

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -16,15 +16,14 @@ help: use parentheses to call this function
 LL |     check(main());
    |               ++
 
-error[E0277]: `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}` can't be used as a const parameter type
+error[E0277]: `main::{closure check#0}` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:8:11
    |
 LL |     check(|| {});
-   |     ----- ^^^^^ unsatisfied trait bound
+   |     ----- ^^^^^ the trait `UnsizedConstParamTy` is not implemented for closure `main::{closure check#0}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `UnsizedConstParamTy` is not implemented for closure `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
@@ -10,7 +10,7 @@ note: erroneous constant encountered
 LL |     const FNPTR: fn() = || Self::FAIL;
    |                            ^^^^^^^^^^
 
-note: the above error was encountered while instantiating `fn Late::<i32>::FNPTR::{closure#0}`
+note: the above error was encountered while instantiating `fn Late::<i32>::FNPTR::{{closure}}`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
@@ -10,7 +10,7 @@ note: erroneous constant encountered
 LL |     const FNPTR: fn() = || Self::FAIL;
    |                            ^^^^^^^^^^
 
-note: the above error was encountered while instantiating `fn Late::<i32>::FNPTR::{closure#0}`
+note: the above error was encountered while instantiating `fn Late::<i32>::FNPTR::{{closure}}`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
+++ b/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
@@ -7,18 +7,17 @@ LL | #![feature(contracts)]
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0277]: the trait bound `Baz: std::marker::Copy` is not satisfied in `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`
+error[E0277]: the trait bound `Baz: std::marker::Copy` is not satisfied in `doubler::{closure#1}`
   --> $DIR/contract-captures-via-closure-noncopy.rs:12:1
    |
 LL | #[core::contracts::ensures({let old = x; move |ret:&Baz| ret.baz == old.baz*2 })]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^^
    | |                                        |
-   | |                                        within this `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`
-   | |                                        this tail expression is of type `{closure@contract-captures-via-closure-noncopy.rs:12:42}`
-   | unsatisfied trait bound
+   | |                                        within this `doubler::{closure#1}`
+   | |                                        this tail expression is of type `doubler::{closure#1}`
+   | within `doubler::{closure#1}`, the trait `std::marker::Copy` is not implemented for `Baz`
    | required by a bound introduced by this call
    |
-   = help: within `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`, the trait `std::marker::Copy` is not implemented for `Baz`
 note: required because it's used within this closure
   --> $DIR/contract-captures-via-closure-noncopy.rs:12:42
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{main::{closure#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{main::{assert_sync#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{assert_sync#0}}}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{main::{closure#1} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{main::{assert_send#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{assert_send#0}}}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{main::{assert_sync#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{assert_sync#0}}}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{main::{closure assert_sync#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure assert_sync#0}}}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{main::{assert_send#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{assert_send#0}}}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{main::{closure assert_send#0} upvar_tys=() resume_ty=() yield_ty=() return_ty=() witness={main::{closure assert_send#0}}}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{main::{closure#0} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str witness={main::{closure#0}}}`
+              found coroutine `{main::{coroutine} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str witness={main::{coroutine}}}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{main::{coroutine} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str witness={main::{coroutine}}}`
+              found coroutine `{main::{closure coroutine} upvar_tys=?4t resume_ty=() yield_ty=i32 return_ty=&'?1 str witness={main::{closure coroutine}}}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/enum/closure-in-enum-issue-48838.stderr
+++ b/tests/ui/enum/closure-in-enum-issue-48838.stderr
@@ -5,7 +5,7 @@ LL |     Square = |x| x,
    |              ^^^^^ expected `isize`, found closure
    |
    = note: expected type `isize`
-           found closure `{closure@$DIR/closure-in-enum-issue-48838.rs:2:14: 2:17}`
+           found closure `Functions::Square::{constant#0}::{closure#0}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/ergonomic-clones/closure/fn-once.stderr
+++ b/tests/ui/ergonomic-clones/closure/fn-once.stderr
@@ -9,7 +9,7 @@ LL |         vec
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/fn-once.rs:7:19: 7:25}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
+   = note: required for the cast from `Box<get_closure::{closure closure}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/ergonomic-clones/closure/print-verbose.stderr
+++ b/tests/ui/ergonomic-clones/closure/print-verbose.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/print-verbose.rs:22:5
    |
 LL |     let c = to_fn_once(use || {
-   |         - move occurs because `c` has type `{f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `{f<T>::{to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/ergonomic-clones/closure/print-verbose.stderr
+++ b/tests/ui/ergonomic-clones/closure/print-verbose.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/print-verbose.rs:22:5
    |
 LL |     let c = to_fn_once(use || {
-   |         - move occurs because `c` has type `{f<T>::{to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `{f<T>::{closure to_fn_once#f} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'?9 str>, T)}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/ergonomic-clones/closure/print.stderr
+++ b/tests/ui/ergonomic-clones/closure/print.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/print.rs:20:5
    |
 LL |     let c = to_fn_once(use || {
-   |         - move occurs because `c` has type `{closure@$DIR/print.rs:15:24: 15:30}`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `f<T>::{closure to_fn_once#f}`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/tests/ui/error-codes/E0767.stderr
+++ b/tests/ui/error-codes/E0767.stderr
@@ -19,7 +19,7 @@ LL | |         }
    | |_________^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/E0767.rs:3:9: 3:11}`
+                found closure `main::{closure#0}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-emitter/multiline-removal-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.svg
@@ -1,4 +1,4 @@
-<svg width="2322px" height="4322px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1658px" height="4322px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -99,7 +99,7 @@
 </tspan>
     <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:24:4</tspan>
 </tspan>
@@ -129,21 +129,21 @@
 </tspan>
     <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+    <tspan x="10px" y="1000px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, foo::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="1018px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+    <tspan x="10px" y="1036px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, foo::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="1054px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt;: IntoIterator`</tspan>
+    <tspan x="10px" y="1072px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, foo::{closure _::map#0}::{closure _::map#0}&gt;&gt;: IntoIterator`</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="1090px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="1108px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="1126px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, foo::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
     <tspan x="10px" y="1144px">
 </tspan>
@@ -213,7 +213,7 @@
 </tspan>
     <tspan x="10px" y="1738px">
 </tspan>
-    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:35:4</tspan>
 </tspan>
@@ -243,21 +243,21 @@
 </tspan>
     <tspan x="10px" y="2008px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
 </tspan>
-    <tspan x="10px" y="2026px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+    <tspan x="10px" y="2026px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bar::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
 </tspan>
-    <tspan x="10px" y="2044px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="2044px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="2062px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+    <tspan x="10px" y="2062px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bar::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
 </tspan>
-    <tspan x="10px" y="2080px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="2080px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="2098px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt;: IntoIterator`</tspan>
+    <tspan x="10px" y="2098px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bar::{closure _::map#0}::{closure _::map#0}&gt;&gt;: IntoIterator`</tspan>
 </tspan>
-    <tspan x="10px" y="2116px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="2116px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="2134px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="2134px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="2152px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="2152px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bar::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
     <tspan x="10px" y="2170px">
 </tspan>
@@ -329,7 +329,7 @@
 </tspan>
     <tspan x="10px" y="2782px">
 </tspan>
-    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="2818px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:46:4</tspan>
 </tspan>
@@ -359,21 +359,21 @@
 </tspan>
     <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
 </tspan>
-    <tspan x="10px" y="3070px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+    <tspan x="10px" y="3070px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, baz::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
 </tspan>
-    <tspan x="10px" y="3088px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="3088px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="3106px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+    <tspan x="10px" y="3106px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, baz::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
 </tspan>
-    <tspan x="10px" y="3124px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="3124px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="3142px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt;: IntoIterator`</tspan>
+    <tspan x="10px" y="3142px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, baz::{closure _::map#0}::{closure _::map#0}&gt;&gt;: IntoIterator`</tspan>
 </tspan>
-    <tspan x="10px" y="3160px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="3160px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="3178px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="3178px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="3196px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="3196px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, baz::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
     <tspan x="10px" y="3214px">
 </tspan>
@@ -441,7 +441,7 @@
 </tspan>
     <tspan x="10px" y="3790px">
 </tspan>
-    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
 </tspan>
     <tspan x="10px" y="3826px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:56:4</tspan>
 </tspan>
@@ -471,21 +471,21 @@
 </tspan>
     <tspan x="10px" y="4060px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
 </tspan>
-    <tspan x="10px" y="4078px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+    <tspan x="10px" y="4078px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bay::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
 </tspan>
-    <tspan x="10px" y="4096px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="4096px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="4114px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+    <tspan x="10px" y="4114px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bay::{closure _::map#0}::{closure _::map#0}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
 </tspan>
-    <tspan x="10px" y="4132px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="4132px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="4150px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt;: IntoIterator`</tspan>
+    <tspan x="10px" y="4150px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, bay::{closure _::map#0}::{closure _::map#0}&gt;&gt;: IntoIterator`</tspan>
 </tspan>
-    <tspan x="10px" y="4168px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="4168px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="4186px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="4186px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
-    <tspan x="10px" y="4204px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+    <tspan x="10px" y="4204px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, bay::{closure _::map#0}&gt;&gt;: Iterator`</tspan>
 </tspan>
     <tspan x="10px" y="4222px">
 </tspan>

--- a/tests/ui/force-inlining/deny-async.stderr
+++ b/tests/ui/force-inlining/deny-async.stderr
@@ -20,7 +20,7 @@ LL | pub fn callee_justified() {
    |
    = note: incompatible due to: #[rustc_no_mir_inline]
 
-error: `callee` could not be inlined into `async_caller::{closure#0}` but is required to be inlined
+error: `callee` could not be inlined into `async_caller` but is required to be inlined
   --> $DIR/deny-async.rs:22:5
    |
 LL |     callee();
@@ -28,7 +28,7 @@ LL |     callee();
    |
    = note: could not be inlined due to: #[rustc_no_mir_inline]
 
-error: `callee_justified` could not be inlined into `async_caller::{closure#0}` but is required to be inlined
+error: `callee_justified` could not be inlined into `async_caller` but is required to be inlined
   --> $DIR/deny-async.rs:24:5
    |
 LL |     callee_justified();

--- a/tests/ui/functions-closures/fn-help-with-err.stderr
+++ b/tests/ui/functions-closures/fn-help-with-err.stderr
@@ -4,11 +4,11 @@ error[E0425]: cannot find value `oops` in this scope
 LL |     let arc = std::sync::Arc::new(oops);
    |                                   ^^^^ not found in this scope
 
-error[E0599]: no method named `bar` found for struct `Arc<{closure@$DIR/fn-help-with-err.rs:18:36: 18:38}>` in the current scope
+error[E0599]: no method named `bar` found for struct `Arc<main::{closure Arc::new#0}>` in the current scope
   --> $DIR/fn-help-with-err.rs:19:10
    |
 LL |     arc2.bar();
-   |          ^^^ method not found in `Arc<{closure@$DIR/fn-help-with-err.rs:18:36: 18:38}>`
+   |          ^^^ method not found in `Arc<main::{closure Arc::new#0}>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Bar` defines an item `bar`, perhaps you need to implement it

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-1.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-1.stderr
@@ -1,16 +1,16 @@
-error[E0599]: the method `filterx` exists for struct `Map<Repeat, {closure@$DIR/hrtb-doesnt-borrow-self-1.rs:113:27: 113:34}>`, but its trait bounds were not satisfied
+error[E0599]: the method `filterx` exists for struct `Map<Repeat, variant1::{closure _::mapx#0}>`, but its trait bounds were not satisfied
   --> $DIR/hrtb-doesnt-borrow-self-1.rs:114:22
    |
 LL | pub struct Map<S, F> {
    | -------------------- method `filterx` not found for this struct because it doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
-   |                      ^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |                      ^^^^^^^ method cannot be called on `Map<Repeat, variant1::{closure _::mapx#0}>` due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
-      `&'a mut &Map<Repeat, {closure@$DIR/hrtb-doesnt-borrow-self-1.rs:113:27: 113:34}>: Stream`
-      `&'a mut &mut Map<Repeat, {closure@$DIR/hrtb-doesnt-borrow-self-1.rs:113:27: 113:34}>: Stream`
-      `&'a mut Map<Repeat, {closure@$DIR/hrtb-doesnt-borrow-self-1.rs:113:27: 113:34}>: Stream`
+      `&'a mut &Map<Repeat, variant1::{closure _::mapx#0}>: Stream`
+      `&'a mut &mut Map<Repeat, variant1::{closure _::mapx#0}>: Stream`
+      `&'a mut Map<Repeat, variant1::{closure _::mapx#0}>: Stream`
   --> $DIR/hrtb-doesnt-borrow-self-1.rs:96:50
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-2.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-doesnt-borrow-self-2.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/hrtb-doesnt-borrow-self-2.rs:109:30: 109:37}>`, but its trait bounds were not satisfied
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, variant2::{closure _::filterx#0}>`, but its trait bounds were not satisfied
   --> $DIR/hrtb-doesnt-borrow-self-2.rs:110:24
    |
 LL | pub struct Filter<S, F> {
@@ -8,9 +8,9 @@ LL |     let count = filter.countx();
    |                        ^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
-      `&'a mut &Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/hrtb-doesnt-borrow-self-2.rs:109:30: 109:37}>: Stream`
-      `&'a mut &mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/hrtb-doesnt-borrow-self-2.rs:109:30: 109:37}>: Stream`
-      `&'a mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/hrtb-doesnt-borrow-self-2.rs:109:30: 109:37}>: Stream`
+      `&'a mut &Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, variant2::{closure _::filterx#0}>: Stream`
+      `&'a mut &mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, variant2::{closure _::filterx#0}>: Stream`
+      `&'a mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, variant2::{closure _::filterx#0}>: Stream`
   --> $DIR/hrtb-doesnt-borrow-self-2.rs:96:50
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}

--- a/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
@@ -1,4 +1,4 @@
-error[E0271]: type mismatch resolving `<L<{closure@issue-62203-hrtb-ice.rs:40:16}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
+error[E0271]: type mismatch resolving `<L<main::{closure#0}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
   --> $DIR/issue-62203-hrtb-ice.rs:39:9
    |
 LL |       let v = Unit2.m(
@@ -9,7 +9,7 @@ LL | |                 drop(x);
 LL | |                 Unit4
 LL | |             },
 LL | |         },
-   | |_________^ type mismatch resolving `<L<{closure@issue-62203-hrtb-ice.rs:40:16}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
+   | |_________^ type mismatch resolving `<L<main::{closure#0}> as T0<'r, (&u8,)>>::O == <_ as Ty<'r>>::V`
    |
 note: expected this to be `<_ as Ty<'_>>::V`
   --> $DIR/issue-62203-hrtb-ice.rs:21:14
@@ -29,7 +29,7 @@ LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
-error[E0271]: expected `{closure@issue-62203-hrtb-ice.rs:40:16}` to return `Unit3`, but it returns `Unit4`
+error[E0271]: expected `main::{closure#0}` to return `Unit3`, but it returns `Unit4`
   --> $DIR/issue-62203-hrtb-ice.rs:42:17
    |
 LL |     let v = Unit2.m(
@@ -41,7 +41,7 @@ LL |                 drop(x);
 LL |                 Unit4
    |                 ^^^^^ expected `Unit3`, found `Unit4`
    |
-note: required for `L<{closure@$DIR/issue-62203-hrtb-ice.rs:40:16: 40:19}>` to implement `for<'r> T0<'r, (&'r u8,)>`
+note: required for `L<main::{closure#0}>` to implement `for<'r> T0<'r, (&'r u8,)>`
   --> $DIR/issue-62203-hrtb-ice.rs:17:16
    |
 LL | impl<'a, A, T> T0<'a, A> for L<T>

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
@@ -1,4 +1,4 @@
-error: {foo<'{erased}>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+error: {foo<'{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
   --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.current.stderr
@@ -1,4 +1,4 @@
-error: {foo<'{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+error: {foo<'{erased}>::{returned closure} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
   --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
@@ -1,4 +1,4 @@
-error: {foo<'{erased}>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+error: {foo<'{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
   --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.next.stderr
@@ -1,4 +1,4 @@
-error: {foo<'{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+error: {foo<'{erased}>::{returned closure} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
   --> $DIR/erased-regions-in-hidden-ty.rs:12:36
    |
 LL | fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -10,7 +10,7 @@
 // Make sure that the compiler can handle `ReErased` in the hidden type of an opaque.
 
 fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
-    //~^ ERROR '{erased}>::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+    //~^ ERROR '{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
     // Can't write whole type because of lack of path sanitization
     || ()
 }

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -10,7 +10,7 @@
 // Make sure that the compiler can handle `ReErased` in the hidden type of an opaque.
 
 fn foo<'a: 'a>(x: &'a Vec<i32>) -> impl Fn() + 'static {
-    //~^ ERROR '{erased}>::{return} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
+    //~^ ERROR '{erased}>::{returned closure} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=()}
     // Can't write whole type because of lack of path sanitization
     || ()
 }

--- a/tests/ui/impl-trait/issues/issue-74282.stderr
+++ b/tests/ui/impl-trait/issues/issue-74282.stderr
@@ -14,7 +14,7 @@ LL | |     })
    | |_____^ expected opaque type, found closure
    |
    = note: expected opaque type `Closure`
-                  found closure `{closure@$DIR/issue-74282.rs:9:15: 9:17}`
+                  found closure `bop::{closure#1}`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 note: tuple struct defined here

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -112,7 +112,7 @@ error[E0700]: hidden type for `impl Fn(&'a u32)` captures lifetime that does not
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {
    |                              --                             ---------------- opaque type defined here
    |                              |
-   |                              hidden type `{closure@$DIR/must_outlive_least_region_or_bound.rs:42:5: 42:13}` captures the lifetime `'b` as defined here
+   |                              hidden type `move_lifetime_into_fn::{returned closure}` captures the lifetime `'b` as defined here
 LL |     move |_| println!("{}", y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/impl-trait/static-return-lifetime-infered.stderr
+++ b/tests/ui/impl-trait/static-return-lifetime-infered.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Iterator<Item = u32>` captures lifetime that
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
    |                         -----     ----------------------- opaque type defined here
    |                         |
-   |                         hidden type `Map<std::slice::Iter<'_, (u32, u32)>, {closure@$DIR/static-return-lifetime-infered.rs:7:27: 7:30}>` captures the anonymous lifetime defined here
+   |                         hidden type `Map<std::slice::Iter<'_, (u32, u32)>, A::iter_values_anon::{closure _::map#0}>` captures the anonymous lifetime defined here
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -19,7 +19,7 @@ error[E0700]: hidden type for `impl Iterator<Item = u32>` captures lifetime that
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
    |                    --               ----------------------- opaque type defined here
    |                    |
-   |                    hidden type `Map<std::slice::Iter<'a, (u32, u32)>, {closure@$DIR/static-return-lifetime-infered.rs:11:27: 11:30}>` captures the lifetime `'a` as defined here
+   |                    hidden type `Map<std::slice::Iter<'a, (u32, u32)>, A::iter_values::{closure _::map#0}>` captures the lifetime `'a` as defined here
 LL |         self.x.iter().map(|a| a.0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |

--- a/tests/ui/inference/hint-closure-signature-119266.stderr
+++ b/tests/ui/inference/hint-closure-signature-119266.stderr
@@ -10,7 +10,7 @@ LL |     let x: fn(i32) = x;
    |            expected due to this
    |
    = note: expected fn pointer `fn(i32)`
-                 found closure `{closure@$DIR/hint-closure-signature-119266.rs:2:13: 2:64}`
+                 found closure `main::{closure x}`
    = note: closure has signature: `fn(u8, (usize, u32), fn() -> char) -> String`
 
 error: aborting due to 1 previous error

--- a/tests/ui/intrinsics/const-eval-select-bad.stderr
+++ b/tests/ui/intrinsics/const-eval-select-bad.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{closure@$DIR/const-eval-select-bad.rs:7:27: 7:29}: const FnOnce()` is not satisfied
+error[E0277]: the trait bound `not_fn_items::{closure const_eval_select#1}: const FnOnce()` is not satisfied
   --> $DIR/const-eval-select-bad.rs:7:27
    |
 LL |     const_eval_select((), || {}, || {});

--- a/tests/ui/issues/issue-12127.stderr
+++ b/tests/ui/issues/issue-12127.stderr
@@ -11,7 +11,7 @@ note: this value implements `FnOnce`, which causes it to be moved when called
    |
 LL |         f();
    |         ^
-   = note: move occurs because `f` has type `{closure@$DIR/issue-12127.rs:8:24: 8:30}`, which does not implement the `Copy` trait
+   = note: move occurs because `f` has type `main::{closure to_fn_once#f}`, which does not implement the `Copy` trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-22638.stderr
+++ b/tests/ui/issues/issue-22638.stderr
@@ -1,4 +1,4 @@
-error: reached the recursion limit while instantiating `A::matches::<{closure@$DIR/issue-22638.rs:42:23: 42:25}>`
+error: reached the recursion limit while instantiating `A::matches::<C::matches<B::matches<...>::{closure#0}>::{closure#0}>`
   --> $DIR/issue-22638.rs:54:9
    |
 LL |         a.matches(f)
@@ -9,6 +9,7 @@ note: `A::matches` defined here
    |
 LL |     pub fn matches<F: Fn()>(&self, f: &F) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the full type name has been written to '$TEST_BUILD_DIR/issue-22638.long-type.txt'
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-24036.stderr
+++ b/tests/ui/issues/issue-24036.stderr
@@ -6,8 +6,8 @@ LL |     let mut x = |c| c + 1;
 LL |     x = |c| c + 1;
    |         ^^^^^^^^^ expected closure, found a different closure
    |
-   = note: expected closure `{closure@$DIR/issue-24036.rs:2:17: 2:20}`
-              found closure `{closure@$DIR/issue-24036.rs:3:9: 3:12}`
+   = note: expected closure `closure_to_loc::{closure x}`
+              found closure `closure_to_loc::{closure#1}`
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 

--- a/tests/ui/issues/issue-41880.stderr
+++ b/tests/ui/issues/issue-41880.stderr
@@ -5,7 +5,7 @@ LL | pub struct Iterate<T, F> {
    | ------------------------ method `iter` not found for this struct
 ...
 LL |     println!("{:?}", a.iter().take(10).collect::<Vec<usize>>());
-   |                        ^^^^ method not found in `Iterate<{integer}, {closure@$DIR/issue-41880.rs:26:24: 26:27}>`
+   |                        ^^^^ method not found in `Iterate<{integer}, main::{closure iterate#f}>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-50600.stderr
+++ b/tests/ui/issues/issue-50600.stderr
@@ -5,7 +5,7 @@ LL |     fn([u8; |x: u8| {}]),
    |             ^^^^^^^^^^ expected `usize`, found closure
    |
    = note: expected type `usize`
-           found closure `{closure@$DIR/issue-50600.rs:2:13: 2:20}`
+           found closure `Foo::0::{constant#0}::{closure#0}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-50688.stderr
+++ b/tests/ui/issues/issue-50688.stderr
@@ -5,7 +5,7 @@ LL |     [1; || {}];
    |         ^^^^^ expected `usize`, found closure
    |
    = note: expected type `usize`
-           found closure `{closure@$DIR/issue-50688.rs:2:9: 2:11}`
+           found closure `main::{constant#0}::{closure#0}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-51154.stderr
+++ b/tests/ui/issues/issue-51154.stderr
@@ -9,7 +9,7 @@ LL |     let _: Box<F> = Box::new(|| ());
    |                     arguments to this function are incorrect
    |
    = note: expected type parameter `F`
-                     found closure `{closure@$DIR/issue-51154.rs:2:30: 2:32}`
+                     found closure `foo<F>::{closure Box::new#0}`
    = help: every closure has a distinct type and so could not always match the caller-chosen type of parameter `F`
 note: associated function defined here
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/iterators/generator_capture_.stderr
+++ b/tests/ui/iterators/generator_capture_.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `f`
   --> $DIR/generator_capture_.rs:21:17
    |
 LL |     let f = {
-   |         - move occurs because `f` has type `{gen closure@$DIR/generator_capture_.rs:10:17: 10:24}`, which does not implement the `Copy` trait
+   |         - move occurs because `f` has type `{gen closure@main::{closure#0}}`, which does not implement the `Copy` trait
 ...
 LL |     let mut i = f();
    |                 --- `f` moved due to this call

--- a/tests/ui/iterators/generator_returned_from_fn.stderr
+++ b/tests/ui/iterators/generator_returned_from_fn.stderr
@@ -20,7 +20,7 @@ LL | |         for x in 5..10 {
 LL | |             yield x * 2;
 LL | |         }
 LL | |     } }
-   | |_____- return type was inferred to be `{gen closure@$DIR/generator_returned_from_fn.rs:33:13: 33:20}` here
+   | |_____- return type was inferred to be `{gen closure@capture_move::{returned closure}}` here
 
 error[E0700]: hidden type for `impl FnOnce() -> impl Iterator<Item = u32>` captures lifetime that does not appear in bounds
   --> $DIR/generator_returned_from_fn.rs:42:13
@@ -28,7 +28,7 @@ error[E0700]: hidden type for `impl FnOnce() -> impl Iterator<Item = u32>` captu
 LL |   fn capture_move_once(a: &u32) -> impl FnOnce() -> impl Iterator<Item = u32> {
    |                           ----     ------------------------------------------ opaque type defined here
    |                           |
-   |                           hidden type `{gen closure@$DIR/generator_returned_from_fn.rs:42:13: 42:20}` captures the anonymous lifetime defined here
+   |                           hidden type `{gen closure@capture_move_once::{returned closure}}` captures the anonymous lifetime defined here
 LL |       iter! { move || {
    |  _____________^
 LL | |

--- a/tests/ui/iterators/iter-macro-not-async-closure-simplified.narrow.stderr
+++ b/tests/ui/iterators/iter-macro-not-async-closure-simplified.narrow.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure-simplified.rs:21:21: 21:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure-simplified.rs:27:21
    |
 LL |     call_async_once(f);
@@ -6,7 +6,7 @@ LL |     call_async_once(f);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure-simplified.rs:21:21: 21:28}`
+   = help: the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
 note: required by a bound in `call_async_once`
   --> $DIR/iter-macro-not-async-closure-simplified.rs:18:28
    |

--- a/tests/ui/iterators/iter-macro-not-async-closure-simplified.wide.stderr
+++ b/tests/ui/iterators/iter-macro-not-async-closure-simplified.wide.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure-simplified.rs:21:21: 21:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure-simplified.rs:27:21
    |
 LL |     call_async_once(f);
-   |     --------------- ^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure-simplified.rs:21:21: 21:28}`
+   |     --------------- ^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/iterators/iter-macro-not-async-closure.stderr
+++ b/tests/ui/iterators/iter-macro-not-async-closure.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:25:34
    |
 LL |     let x = pin!(call_async_once(f));
-   |                  --------------- ^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}`
+   |                  --------------- ^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |                  |
    |                  required by a bound introduced by this call
    |
@@ -12,11 +12,11 @@ note: required by a bound in `call_async_once`
 LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
 
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:25:18
    |
 LL |     let x = pin!(call_async_once(f));
-   |                  ^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}`
+   |                  ^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |
 note: required by a bound in `call_async_once`
   --> $DIR/iter-macro-not-async-closure.rs:14:34
@@ -24,11 +24,11 @@ note: required by a bound in `call_async_once`
 LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
 
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:25:13
    |
 LL |     let x = pin!(call_async_once(f));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |
 note: required by a bound in `call_async_once`
   --> $DIR/iter-macro-not-async-closure.rs:14:34
@@ -37,11 +37,11 @@ LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:25:13
    |
 LL |     let x = pin!(call_async_once(f));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |
 note: required by a bound in `call_async_once`
   --> $DIR/iter-macro-not-async-closure.rs:14:34
@@ -50,11 +50,11 @@ LL | async fn call_async_once(f: impl AsyncFnOnce()) {
    |                                  ^^^^^^^^^^^^^ required by this bound in `call_async_once`
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}: AsyncFnOnce()` is not satisfied
+error[E0277]: the trait bound `{gen closure@main::{closure f}}: AsyncFnOnce()` is not satisfied
   --> $DIR/iter-macro-not-async-closure.rs:30:5
    |
 LL |     x.poll(&mut Context::from_waker(Waker::noop()));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@$DIR/iter-macro-not-async-closure.rs:19:21: 19:28}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsyncFnOnce()` is not implemented for `{gen closure@main::{closure f}}`
    |
 note: required by a bound in `call_async_once`
   --> $DIR/iter-macro-not-async-closure.rs:14:34

--- a/tests/ui/kindck/kindck-nonsendable-1.stderr
+++ b/tests/ui/kindck/kindck-nonsendable-1.stderr
@@ -5,10 +5,10 @@ LL |     bar(move|| foo(x));
    |     --- ------^^^^^^^
    |     |   |
    |     |   `Rc<usize>` cannot be sent between threads safely
-   |     |   within this `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`
+   |     |   within this `main::{closure bar#0}`
    |     required by a bound introduced by this call
    |
-   = help: within `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`, the trait `Send` is not implemented for `Rc<usize>`
+   = help: within `main::{closure bar#0}`, the trait `Send` is not implemented for `Rc<usize>`
 note: required because it's used within this closure
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |

--- a/tests/ui/lint/trivial_casts.stderr
+++ b/tests/ui/lint/trivial_casts.stderr
@@ -128,7 +128,7 @@ LL |     let _ = &baz as &dyn Fn(i32);
    |
    = help: cast can be replaced by coercion; this might require a temporary variable
 
-error: trivial cast: `&{closure@$DIR/trivial_casts.rs:72:13: 72:22}` as `&dyn Fn(i32)`
+error: trivial cast: `&main::{closure x}` as `&dyn Fn(i32)`
   --> $DIR/trivial_casts.rs:73:13
    |
 LL |     let _ = &x as &dyn Fn(i32);

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -34,15 +34,15 @@ help: consider further restricting type parameter `F` with trait `Output`
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
 
-error[E0277]: expected a `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+error[E0277]: expected a `FnOnce(<main::{closure _::do_something_wrapper#0} as Output<'a>>::Type)` closure, found `main::{closure _::do_something_wrapper#0}`
   --> $DIR/filter-relevant-fn-bounds.rs:20:34
    |
 LL |     wrapper.do_something_wrapper(|value| ());
-   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41} as Output<'a>>::Type)` closure, found `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+   |             -------------------- ^^^^^^^^^^ expected an `FnOnce(<main::{closure _::do_something_wrapper#0} as Output<'a>>::Type)` closure, found `main::{closure _::do_something_wrapper#0}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Output<'a>` is not implemented for closure `{closure@$DIR/filter-relevant-fn-bounds.rs:20:34: 20:41}`
+   = help: the trait `for<'a> Output<'a>` is not implemented for closure `main::{closure _::do_something_wrapper#0}`
 help: this trait has no implementations, consider adding one
   --> $DIR/filter-relevant-fn-bounds.rs:1:1
    |

--- a/tests/ui/methods/method-value-without-call.rs
+++ b/tests/ui/methods/method-value-without-call.rs
@@ -1,4 +1,5 @@
 //! Test taking a method value without parentheses
+//@ compile-flags: -Z span_free_formats
 
 struct Point {
     x: isize,

--- a/tests/ui/methods/method-value-without-call.stderr
+++ b/tests/ui/methods/method-value-without-call.stderr
@@ -1,5 +1,5 @@
 error[E0615]: attempted to take value of method `abs` on type `i32`
-  --> $DIR/method-value-without-call.rs:20:20
+  --> $DIR/method-value-without-call.rs:21:20
    |
 LL |     let _f = 10i32.abs;
    |                    ^^^ method, not a field
@@ -10,7 +10,7 @@ LL |     let _f = 10i32.abs();
    |                       ++
 
 error[E0615]: attempted to take value of method `get_x` on type `Point`
-  --> $DIR/method-value-without-call.rs:24:27
+  --> $DIR/method-value-without-call.rs:25:27
    |
 LL |     let px: isize = point.get_x;
    |                           ^^^^^ method, not a field
@@ -20,8 +20,8 @@ help: use parentheses to call the method
 LL |     let px: isize = point.get_x();
    |                                ++
 
-error[E0615]: attempted to take value of method `filter_map` on type `Filter<Map<std::slice::Iter<'_, {integer}>, {closure@$DIR/method-value-without-call.rs:30:14: 30:17}>, {closure@$DIR/method-value-without-call.rs:31:17: 31:22}>`
-  --> $DIR/method-value-without-call.rs:32:10
+error[E0615]: attempted to take value of method `filter_map` on type `Filter<Map<std::slice::Iter<'_, {integer}>, {closure@main::{_::map#0}}>, {closure@main::{_::filter#0}}>`
+  --> $DIR/method-value-without-call.rs:33:10
    |
 LL |         .filter_map;
    |          ^^^^^^^^^^ method, not a field

--- a/tests/ui/methods/method-value-without-call.stderr
+++ b/tests/ui/methods/method-value-without-call.stderr
@@ -20,7 +20,7 @@ help: use parentheses to call the method
 LL |     let px: isize = point.get_x();
    |                                ++
 
-error[E0615]: attempted to take value of method `filter_map` on type `Filter<Map<std::slice::Iter<'_, {integer}>, {closure@main::{_::map#0}}>, {closure@main::{_::filter#0}}>`
+error[E0615]: attempted to take value of method `filter_map` on type `Filter<Map<std::slice::Iter<'_, {integer}>, main::{closure _::map#0}>, main::{closure _::filter#0}>`
   --> $DIR/method-value-without-call.rs:33:10
    |
 LL |         .filter_map;

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
@@ -1,12 +1,12 @@
-error[E0277]: expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:6:29: 6:37}`
+error[E0277]: expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `main::{closure _::find#0}`
   --> $DIR/closure-arg-type-mismatch-issue-45727.rs:6:29
    |
 LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
-   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:6:29: 6:37}`
+   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `main::{closure _::find#0}`
    |                        |
    |                        required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)` is not implemented for closure `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:6:29: 6:37}`
+   = help: the trait `for<'a> FnMut(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)` is not implemented for closure `main::{closure _::find#0}`
    = note: expected a closure with signature `for<'a> fn(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)`
               found a closure with signature `fn(i32)`
 note: required by a bound in `find`
@@ -18,15 +18,15 @@ error[E0271]: expected `RangeInclusive<{integer}>` to be an iterator that yields
 LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
    |                        ^^^^ expected `&&i32`, found integer
 
-error[E0277]: expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+error[E0277]: expected a `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `main::{closure _::find#0}`
   --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:29
    |
 LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
-   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&<std::ops::RangeInclusive<{integer}> as Iterator>::Item)` closure, found `main::{closure _::find#0}`
    |                        |
    |                        required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)` is not implemented for closure `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+   = help: the trait `for<'a> FnMut(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)` is not implemented for closure `main::{closure _::find#0}`
    = note: expected a closure with signature `for<'a> fn(&'a <std::ops::RangeInclusive<{integer}> as Iterator>::Item)`
               found a closure with signature `fn(&&&i32)`
 note: required by a bound in `find`

--- a/tests/ui/mismatched_types/closure-mismatch.next.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.next.stderr
@@ -1,12 +1,11 @@
-error[E0277]: the trait bound `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}: Foo` is not satisfied
+error[E0277]: the trait bound `main::{closure baz#0}: Foo` is not satisfied
   --> $DIR/closure-mismatch.rs:12:9
    |
 LL |     baz(|_| ());
-   |     --- ^^^^^^ unsatisfied trait bound
+   |     --- ^^^^^^ the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `main::{closure baz#0}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}`
    = note: expected a closure with signature `for<'a> fn(&'a ())`
               found a closure with signature `fn(&())`
 note: this is a known limitation of the trait solver that will be lifted in the future
@@ -17,7 +16,7 @@ LL |     baz(|_| ());
    |     |   |
    |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
    |     add turbofish arguments to this call to specify the types manually, even if it's redundant
-note: required for `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}` to implement `Foo`
+note: required for `main::{closure baz#0}` to implement `Foo`
   --> $DIR/closure-mismatch.rs:7:18
    |
 LL | impl<T: Fn(&())> Foo for T {}
@@ -30,15 +29,14 @@ note: required by a bound in `baz`
 LL | fn baz<T: Foo>(_: T) {}
    |           ^^^ required by this bound in `baz`
 
-error[E0277]: the trait bound `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}: Foo` is not satisfied
+error[E0277]: the trait bound `main::{closure baz#0}: Foo` is not satisfied
   --> $DIR/closure-mismatch.rs:16:9
    |
 LL |     baz(|x| ());
-   |     --- ^^^^^^ unsatisfied trait bound
+   |     --- ^^^^^^ the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `main::{closure baz#0}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}`
    = note: expected a closure with signature `for<'a> fn(&'a ())`
               found a closure with signature `fn(&())`
 note: this is a known limitation of the trait solver that will be lifted in the future
@@ -49,7 +47,7 @@ LL |     baz(|x| ());
    |     |   |
    |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
    |     add turbofish arguments to this call to specify the types manually, even if it's redundant
-note: required for `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}` to implement `Foo`
+note: required for `main::{closure baz#0}` to implement `Foo`
   --> $DIR/closure-mismatch.rs:7:18
    |
 LL | impl<T: Fn(&())> Foo for T {}

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -15,7 +15,7 @@ help: consider adjusting the signature so it borrows its argument
 LL |     once::<&str>("str").fuse().filter(|a: &&str| true).count();
    |                                           +
 
-error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>`, but its trait bounds were not satisfied
+error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, main::{closure _::filter#0}>`, but its trait bounds were not satisfied
   --> $DIR/issue-36053-2.rs:7:55
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
@@ -24,12 +24,12 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                       doesn't satisfy `<_ as FnOnce<(&&str,)>>::Output = bool` or `_: FnMut<(&&str,)>`
    |
    = note: the following trait bounds were not satisfied:
-           `<{closure@$DIR/issue-36053-2.rs:7:39: 7:48} as FnOnce<(&&str,)>>::Output = bool`
-           which is required by `Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>: Iterator`
-           `{closure@$DIR/issue-36053-2.rs:7:39: 7:48}: FnMut<(&&str,)>`
-           which is required by `Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>: Iterator`
-           `Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>: Iterator`
-           which is required by `&mut Filter<Fuse<std::iter::Once<&str>>, {closure@$DIR/issue-36053-2.rs:7:39: 7:48}>: Iterator`
+           `<main::{closure _::filter#0} as FnOnce<(&&str,)>>::Output = bool`
+           which is required by `Filter<Fuse<std::iter::Once<&str>>, main::{closure _::filter#0}>: Iterator`
+           `main::{closure _::filter#0}: FnMut<(&&str,)>`
+           which is required by `Filter<Fuse<std::iter::Once<&str>>, main::{closure _::filter#0}>: Iterator`
+           `Filter<Fuse<std::iter::Once<&str>>, main::{closure _::filter#0}>: Iterator`
+           which is required by `&mut Filter<Fuse<std::iter::Once<&str>>, main::{closure _::filter#0}>: Iterator`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -1,5 +1,5 @@
 warning: this function depends on never type fallback being `()`
-  --> $DIR/fallback-closure-ret.rs:21:1
+  --> $DIR/fallback-closure-ret.rs:22:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -8,7 +8,7 @@ LL | fn main() {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
-  --> $DIR/fallback-closure-ret.rs:24:5
+  --> $DIR/fallback-closure-ret.rs:25:5
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ warning: 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
 warning: this function depends on never type fallback being `()`
-  --> $DIR/fallback-closure-ret.rs:21:1
+  --> $DIR/fallback-closure-ret.rs:22:1
    |
 LL | fn main() {
    | ^^^^^^^^^
@@ -31,7 +31,7 @@ LL | fn main() {
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
-  --> $DIR/fallback-closure-ret.rs:24:5
+  --> $DIR/fallback-closure-ret.rs:25:5
    |
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^

--- a/tests/ui/never_type/fallback-closure-ret.rs
+++ b/tests/ui/never_type/fallback-closure-ret.rs
@@ -9,6 +9,7 @@
 //
 //@ revisions: nofallback fallback
 //@ check-pass
+//@ compile-flags: -Z span_free_formats
 
 #![cfg_attr(fallback, feature(never_type_fallback))]
 

--- a/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
+++ b/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{closure@fallback-closure-wrap.rs:18:40}` to return `()`, but it returns `!`
+error[E0271]: expected `main::{closure Box::new#0}` to return `()`, but it returns `!`
   --> $DIR/fallback-closure-wrap.rs:19:9
    |
 LL |     let error = Closure::wrap(Box::new(move || {
@@ -8,7 +8,7 @@ LL |         panic!("Can't connect to server.");
    |
    = note: expected unit type `()`
                    found type `!`
-   = note: required for the cast from `Box<{closure@$DIR/fallback-closure-wrap.rs:18:40: 18:47}>` to `Box<dyn FnMut()>`
+   = note: required for the cast from `Box<main::{closure Box::new#0}>` to `Box<dyn FnMut()>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 mut &'^1 i32, &'^2 i32)),
                (),

--- a/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^
    |
-   = note: defining type: test::{expect_sig#f} with closure args [
+   = note: defining type: test::{closure expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 mut &'^1 i32, &'^2 i32)),
                (),

--- a/tests/ui/nll/closure-requirements/escape-argument.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^
    |
-   = note: defining type: test::{expect_sig#f} with closure args [
+   = note: defining type: test::{closure expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 mut &'^1 i32, &'^1 i32)),
                (),

--- a/tests/ui/nll/closure-requirements/escape-argument.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         let mut closure = expect_sig(|p, y| *p = y);
    |                                      ^^^^^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 mut &'^1 i32, &'^1 i32)),
                (),

--- a/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |             let mut closure1 = || p = &y;
    |                                ^^
    |
-   = note: defining type: test::{closure#0}::{closure#0} with closure args [
+   = note: defining type: test::{closure}::{closure1} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),
@@ -18,7 +18,7 @@ note: external requirements
 LL |         let mut closure = || {
    |                           ^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{closure} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),

--- a/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |             let mut closure1 = || p = &y;
    |                                ^^
    |
-   = note: defining type: test::{closure}::{closure1} with closure args [
+   = note: defining type: test::{closure closure}::{closure closure1} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),
@@ -18,7 +18,7 @@ note: external requirements
 LL |         let mut closure = || {
    |                           ^^
    |
-   = note: defining type: test::{closure} with closure args [
+   = note: defining type: test::{closure closure} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),

--- a/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |         let mut closure = || p = &y;
    |                           ^^
    |
-   = note: defining type: test::{closure} with closure args [
+   = note: defining type: test::{closure closure} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),

--- a/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |         let mut closure = || p = &y;
    |                           ^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{closure} with closure args [
                i16,
                extern "rust-call" fn(()),
                (&'?1 mut &'?2 i32, &'?3 i32),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         |_outlives1, _outlives2, _outlives3, x, y| {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'?2 &'^0 u32>, std::cell::Cell<&'^1 &'?3 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |         |_outlives1, _outlives2, _outlives3, x, y| {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'?2 &'^0 u32>, std::cell::Cell<&'^1 &'?3 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'^3 &'?2 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'^3 &'?2 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     foo(cell, |cell_a, cell_x| {
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: defining type: case1::{foo#_f} with closure args [
+   = note: defining type: case1::{closure foo#_f} with closure args [
                i32,
                for<Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&'^0 u32>)),
                (),
@@ -38,7 +38,7 @@ note: external requirements
 LL |     foo(cell, |cell_a, cell_x| {
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: defining type: case2::{foo#_f} with closure args [
+   = note: defining type: case2::{closure foo#_f} with closure args [
                i32,
                for<Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&'^0 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     foo(cell, |cell_a, cell_x| {
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: defining type: case1::{closure#0} with closure args [
+   = note: defining type: case1::{foo#_f} with closure args [
                i32,
                for<Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&'^0 u32>)),
                (),
@@ -38,7 +38,7 @@ note: external requirements
 LL |     foo(cell, |cell_a, cell_x| {
    |               ^^^^^^^^^^^^^^^^
    |
-   = note: defining type: case2::{closure#0} with closure args [
+   = note: defining type: case2::{foo#_f} with closure args [
                i32,
                for<Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 u32>, std::cell::Cell<&'^0 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'^1 u32>, &'^3 std::cell::Cell<&'^4 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'^1 u32>, &'^3 std::cell::Cell<&'^4 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'?2 &'^3 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'?1 &'^1 u32>, &'^2 std::cell::Cell<&'?2 &'^3 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'^1 &'?2 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: test::{establish_relationships#_closure} with closure args [
+   = note: defining type: test::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'^1 &'?2 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |         |_outlives1, _outlives2, x, y| {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'^1 &'?2 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |         |_outlives1, _outlives2, x, y| {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::cell::Cell<&'?1 &'^0 u32>, std::cell::Cell<&'^1 &'?2 u32>, std::cell::Cell<&'^0 u32>, std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'^1 &'?1 u32>, &'^2 std::cell::Cell<&'^3 u32>, &'^4 std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'^1 &'?1 u32>, &'^2 std::cell::Cell<&'^3 u32>, &'^4 std::cell::Cell<&'^1 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{establish_relationships#_closure} with closure args [
+   = note: defining type: supply::{closure establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'^1 &'?1 u32>, &'^2 std::cell::Cell<&'^3 &'?2 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: defining type: supply::{closure#0} with closure args [
+   = note: defining type: supply::{establish_relationships#_closure} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 std::cell::Cell<&'^1 &'?1 u32>, &'^2 std::cell::Cell<&'^3 &'?2 u32>, &'^4 std::cell::Cell<&'^1 u32>, &'^5 std::cell::Cell<&'^3 u32>)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(value, |value| {
    |                                    ^^^^^^^
    |
-   = note: defining type: supply::<'?1, T>::{establish_relationships#closure} with closure args [
+   = note: defining type: supply::<'?1, T>::{closure establish_relationships#closure} with closure args [
                i32,
                extern "rust-call" fn((T,)),
                (),

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     establish_relationships(value, |value| {
    |                                    ^^^^^^^
    |
-   = note: defining type: supply::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: supply::<'?1, T>::{establish_relationships#closure} with closure args [
                i32,
                extern "rust-call" fn((T,)),
                (),

--- a/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     expect_sig(|a, b| b); // ought to return `a`
    |                ^^^^^^
    |
-   = note: defining type: test::{expect_sig#f} with closure args [
+   = note: defining type: test::{closure expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 i32, &'^1 i32)) -> &'^0 i32,
                (),

--- a/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/tests/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     expect_sig(|a, b| b); // ought to return `a`
    |                ^^^^^^
    |
-   = note: defining type: test::{closure#0} with closure args [
+   = note: defining type: test::{expect_sig#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((&'^0 i32, &'^1 i32)) -> &'^0 i32,
                (),

--- a/tests/ui/nll/issue-54556-stephaneyfx.stderr
+++ b/tests/ui/nll/issue-54556-stephaneyfx.stderr
@@ -12,7 +12,7 @@ LL | }
    | -
    | |
    | `stmt` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Map<Rows<'_>, {closure@$DIR/issue-54556-stephaneyfx.rs:28:14: 28:19}>`
+   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Map<Rows<'_>, get_names::{closure _::map#0}>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: no_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: no_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
@@ -42,7 +42,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: correct_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: correct_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
@@ -66,7 +66,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: wrong_region::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: wrong_region::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),
@@ -104,7 +104,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: outlives_region::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: no_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: no_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
@@ -42,7 +42,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: correct_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: correct_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
                (),
@@ -66,7 +66,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: wrong_region::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: wrong_region::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),
@@ -104,7 +104,7 @@ note: external requirements
 LL |     with_signature(x, |mut y| Box::new(y.next()))
    |                       ^^^^^^^
    |
-   = note: defining type: outlives_region::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -60,7 +60,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -116,7 +116,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -141,7 +141,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -60,7 +60,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -116,7 +116,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -141,7 +141,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -45,7 +45,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -86,7 +86,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -111,7 +111,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -136,7 +136,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -45,7 +45,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -86,7 +86,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -111,7 +111,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -136,7 +136,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: one_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
@@ -2,7 +2,7 @@
 // outlive `'static`. In this case, we don't get any errors, and in fact
 // we don't even propagate constraints from the closures to the callers.
 
-//@ compile-flags:-Zverbose-internals
+//@ compile-flags:-Zverbose-internals -Z span_free_formats
 //@ check-pass
 
 #![allow(warnings)]

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -27,7 +27,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -50,7 +50,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -73,7 +73,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -96,7 +96,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.stderr
@@ -4,7 +4,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_late::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -27,7 +27,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -50,7 +50,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -73,7 +73,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: elements_outlive::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -96,7 +96,7 @@ note: no external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: one_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_late::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -43,7 +43,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>::{closure#0} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -82,7 +82,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>::{closure#0} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -107,7 +107,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>::{closure#0} with closure args [
+   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -132,7 +132,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>::{closure#0} with closure args [
+   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -157,7 +157,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: two_regions::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -198,7 +198,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions_outlive::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: two_regions_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -223,7 +223,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_late::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_late::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -43,7 +43,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
+   = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -82,7 +82,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
+   = note: defining type: projection_outlives::<'?1, '?2, '?3, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -107,7 +107,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
+   = note: defining type: elements_outlive1::<'?1, '?2, '?3, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -132,7 +132,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>::{with_signature#op} with closure args [
+   = note: defining type: elements_outlive2::<'?1, '?2, '?3, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?4 ()>, T)),
                (),
@@ -157,7 +157,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: two_regions::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -198,7 +198,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: two_regions_outlive::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: two_regions_outlive::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),
@@ -223,7 +223,7 @@ note: external requirements
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |                             ^^^^^^^^^
    |
-   = note: defining type: one_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: one_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^
    |
-   = note: defining type: generic::<T>::{closure#0} with closure args [
+   = note: defining type: generic::<T>::{twice#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &'^0 ()>>, &'^1 T)),
                (),
@@ -26,7 +26,7 @@ note: external requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^
    |
-   = note: defining type: generic_fail::<T>::{closure#0} with closure args [
+   = note: defining type: generic_fail::<T>::{twice#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &'^0 ()>>, &'^1 T)),
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^
    |
-   = note: defining type: generic::<T>::{twice#f} with closure args [
+   = note: defining type: generic::<T>::{closure twice#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &'^0 ()>>, &'^1 T)),
                (),
@@ -26,7 +26,7 @@ note: external requirements
 LL |     twice(cell, value, |a, b| invoke(a, b));
    |                        ^^^^^^
    |
-   = note: defining type: generic_fail::<T>::{twice#f} with closure args [
+   = note: defining type: generic_fail::<T>::{closure twice#f} with closure args [
                i16,
                for<Region(BrAnon), Region(BrAnon)> extern "rust-call" fn((std::option::Option<std::cell::Cell<&'?1 &'^0 ()>>, &'^1 T)),
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(x, |y| y)
    |                       ^^^
    |
-   = note: defining type: no_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: no_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '?2)>,
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(x, |y| y)
    |                       ^^^
    |
-   = note: defining type: no_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: no_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '?2)>,
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: no_region::<T>::{with_signature#op} with closure args [
+   = note: defining type: no_region::<T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?1 ()>, T)),
                (),
@@ -41,7 +41,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: correct_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: correct_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -65,7 +65,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: wrong_region::<'?1, T>::{with_signature#op} with closure args [
+   = note: defining type: wrong_region::<'?1, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -104,7 +104,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: outlives_region::<'?1, '?2, T>::{with_signature#op} with closure args [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{closure with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.stderr
@@ -4,7 +4,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: no_region::<T>::{closure#0} with closure args [
+   = note: defining type: no_region::<T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?1 ()>, T)),
                (),
@@ -41,7 +41,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: correct_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: correct_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -65,7 +65,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: wrong_region::<'?1, T>::{closure#0} with closure args [
+   = note: defining type: wrong_region::<'?1, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?2 ()>, T)),
                (),
@@ -104,7 +104,7 @@ note: external requirements
 LL |     with_signature(a, b, |x, y| {
    |                          ^^^^^^
    |
-   = note: defining type: outlives_region::<'?1, '?2, T>::{closure#0} with closure args [
+   = note: defining type: outlives_region::<'?1, '?2, T>::{with_signature#op} with closure args [
                i32,
                extern "rust-call" fn((std::cell::Cell<&'?3 ()>, T)),
                (),

--- a/tests/ui/parser/expr-as-stmt.stderr
+++ b/tests/ui/parser/expr-as-stmt.stderr
@@ -217,7 +217,7 @@ LL |     { true } || { true }
    |              ^^^^^^^^^^^ expected `bool`, found closure
    |
    = note: expected type `bool`
-           found closure `{closure@$DIR/expr-as-stmt.rs:51:14: 51:16}`
+           found closure `attack_from_mars::{returned closure}`
 help: parentheses are required to parse this as an expression
    |
 LL |     ({ true }) || { true }

--- a/tests/ui/parser/struct-literals-in-invalid-places.stderr
+++ b/tests/ui/parser/struct-literals-in-invalid-places.stderr
@@ -222,7 +222,7 @@ LL |     while || Foo { x: 3 }.hi() {
    |           ^^^^^^^^^^^^^^^^^^^^ expected `bool`, found closure
    |
    = note: expected type `bool`
-           found closure `{closure@$DIR/struct-literals-in-invalid-places.rs:43:11: 43:13}`
+           found closure `main::{closure#1}`
 help: use parentheses to call this closure
    |
 LL |     while (|| Foo { x: 3 }.hi())() {

--- a/tests/ui/pattern/non-structural-match-types.stderr
+++ b/tests/ui/pattern/non-structural-match-types.stderr
@@ -11,7 +11,7 @@ LL |         AnyOption::<_>::NONE => {}
    |
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
 
-error: constant of non-structural type `Option<{closure@$DIR/non-structural-match-types.rs:15:16: 15:18}>` in a pattern
+error: constant of non-structural type `Option<defines::{closure#0}>` in a pattern
   --> $DIR/non-structural-match-types.rs:16:9
    |
 LL | impl<T> AnyOption<T> {

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -42,7 +42,7 @@ LL |     f(Box::new(|a| {
    |                --- captured by this `FnMut` closure
 LL |
 LL |         foo(f);
-   |             ^ move occurs because `f` has type `{closure@$DIR/borrowck-call-is-borrow-issue-12224.rs:52:17: 52:58}`, which does not implement the `Copy` trait
+   |             ^ move occurs because `f` has type `test7::{closure f}`, which does not implement the `Copy` trait
    |
 help: consider cloning the value if the performance cost is acceptable
    |

--- a/tests/ui/span/move-closure.stderr
+++ b/tests/ui/span/move-closure.stderr
@@ -7,7 +7,7 @@ LL |     let x: () = move || ();
    |            expected due to this
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/move-closure.rs:5:17: 5:24}`
+                found closure `main::{closure x}`
 help: use parentheses to call this closure
    |
 LL |     let x: () = (move || ())();

--- a/tests/ui/stable-mir-print/async-closure.stdout
+++ b/tests/ui/stable-mir-print/async-closure.stdout
@@ -3,7 +3,7 @@
 fn foo() -> () {
     let mut _0: ();
     let  _1: i32;
-    let  _2: {async closure@$DIR/async-closure.rs:9:13: 9:21};
+    let  _2: {async closure@foo::{closure x}};
     let mut _3: &i32;
     debug y => _1;
     debug x => _2;
@@ -21,7 +21,7 @@ fn foo() -> () {
         return;
     }
 }
-fn foo::{closure x}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
+fn foo::{closure x}(_1: &{async closure@foo::{closure x}}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
     let mut _0: {async closure body@$DIR/async-closure.rs:9:22: 11:6};
     let mut _2: &i32;
     let mut _3: &i32;

--- a/tests/ui/stable-mir-print/async-closure.stdout
+++ b/tests/ui/stable-mir-print/async-closure.stdout
@@ -21,7 +21,7 @@ fn foo() -> () {
         return;
     }
 }
-fn foo::{closure#0}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
+fn foo::{x}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
     let mut _0: {async closure body@$DIR/async-closure.rs:9:22: 11:6};
     let mut _2: &i32;
     let mut _3: &i32;
@@ -35,7 +35,7 @@ fn foo::{closure#0}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {a
         return;
     }
 }
-fn foo::{closure#0}::{closure#0}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
+fn foo::{x}::{return}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: Poll<()>;
     let  _3: i32;
     let mut _4: &i32;
@@ -73,7 +73,7 @@ fn foo::{closure#0}::{closure#0}(_1: Pin<&mut {async closure body@$DIR/async-clo
         unreachable;
     }
 }
-fn foo::{closure#0}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
+fn foo::{x}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: Poll<()>;
     let  _3: i32;
     let mut _4: &i32;

--- a/tests/ui/stable-mir-print/async-closure.stdout
+++ b/tests/ui/stable-mir-print/async-closure.stdout
@@ -21,7 +21,7 @@ fn foo() -> () {
         return;
     }
 }
-fn foo::{x}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
+fn foo::{closure x}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async closure body@$DIR/async-closure.rs:9:22: 11:6} {
     let mut _0: {async closure body@$DIR/async-closure.rs:9:22: 11:6};
     let mut _2: &i32;
     let mut _3: &i32;
@@ -35,7 +35,7 @@ fn foo::{x}(_1: &{async closure@$DIR/async-closure.rs:9:13: 9:21}) -> {async clo
         return;
     }
 }
-fn foo::{x}::{return}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
+fn foo::{closure x}::{returned closure}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: Poll<()>;
     let  _3: i32;
     let mut _4: &i32;
@@ -73,7 +73,7 @@ fn foo::{x}::{return}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:2
         unreachable;
     }
 }
-fn foo::{x}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
+fn foo::{closure x}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-closure.rs:9:22: 11:6}>, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: Poll<()>;
     let  _3: i32;
     let mut _4: &i32;

--- a/tests/ui/stable-mir-print/operands.stdout
+++ b/tests/ui/stable-mir-print/operands.stdout
@@ -454,8 +454,8 @@ fn more_operands::{constant#0}() -> usize {
         return;
     }
 }
-fn closures(_1: bool, _2: bool) -> {closure@$DIR/operands.rs:47:5: 47:19} {
-    let mut _0: {closure@$DIR/operands.rs:47:5: 47:19};
+fn closures(_1: bool, _2: bool) -> closures::{returned closure} {
+    let mut _0: closures::{returned closure};
     debug x => _1;
     debug z => _2;
     bb0: {
@@ -463,7 +463,7 @@ fn closures(_1: bool, _2: bool) -> {closure@$DIR/operands.rs:47:5: 47:19} {
         return;
     }
 }
-fn closures::{returned closure}(_1: {closure@$DIR/operands.rs:47:5: 47:19}, _2: bool) -> bool {
+fn closures::{returned closure}(_1: closures::{returned closure}, _2: bool) -> bool {
     let mut _0: bool;
     let mut _3: bool;
     let mut _4: bool;

--- a/tests/ui/stable-mir-print/operands.stdout
+++ b/tests/ui/stable-mir-print/operands.stdout
@@ -463,7 +463,7 @@ fn closures(_1: bool, _2: bool) -> {closure@$DIR/operands.rs:47:5: 47:19} {
         return;
     }
 }
-fn closures::{closure#0}(_1: {closure@$DIR/operands.rs:47:5: 47:19}, _2: bool) -> bool {
+fn closures::{return}(_1: {closure@$DIR/operands.rs:47:5: 47:19}, _2: bool) -> bool {
     let mut _0: bool;
     let mut _3: bool;
     let mut _4: bool;

--- a/tests/ui/stable-mir-print/operands.stdout
+++ b/tests/ui/stable-mir-print/operands.stdout
@@ -463,7 +463,7 @@ fn closures(_1: bool, _2: bool) -> {closure@$DIR/operands.rs:47:5: 47:19} {
         return;
     }
 }
-fn closures::{return}(_1: {closure@$DIR/operands.rs:47:5: 47:19}, _2: bool) -> bool {
+fn closures::{returned closure}(_1: {closure@$DIR/operands.rs:47:5: 47:19}, _2: bool) -> bool {
     let mut _0: bool;
     let mut _3: bool;
     let mut _4: bool;

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -26,7 +26,7 @@ LL | |     };
    | |_____^ expected `dyn Fn`, found closure
    |
    = note: expected trait object `(dyn Fn() -> u32 + 'static)`
-                   found closure `{closure@$DIR/issue-24446.rs:2:35: 2:44}`
+                   found closure `foo::{foo closure}`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -17,15 +17,15 @@ help: use parentheses to call this function
 LL |     bar(foo());
    |            ++
 
-error[E0277]: `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
+error[E0277]: `{async closure@main::{closure async_closure}}` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:9
    |
 LL |     bar(async_closure);
-   |     --- ^^^^^^^^^^^^^ `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}` is not a future
+   |     --- ^^^^^^^^^^^^^ `{async closure@main::{closure async_closure}}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:25: 10:33}`
+   = help: the trait `Future` is not implemented for `{async closure@main::{closure async_closure}}`
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:6:16
    |

--- a/tests/ui/suggestions/call-boxed.stderr
+++ b/tests/ui/suggestions/call-boxed.stderr
@@ -6,10 +6,10 @@ LL |     let mut x = 1i32;
 LL |     let y = Box::new(|| 1);
    |                      -- the found closure
 LL |     x = y;
-   |         ^ expected `i32`, found `Box<{closure@call-boxed.rs:3:22}>`
+   |         ^ expected `i32`, found `Box<main::{closure Box::new#0}>`
    |
    = note: expected type `i32`
-            found struct `Box<{closure@$DIR/call-boxed.rs:3:22: 3:24}>`
+            found struct `Box<main::{closure Box::new#0}>`
 help: use parentheses to call this closure
    |
 LL |     x = y();

--- a/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
+++ b/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async closure@dont-suggest-boxing-async-closure-body.rs:9:9}` to return `Box<_>`, but it returns `{async closure body@$DIR/dont-suggest-boxing-async-closure-body.rs:9:23: 9:25}`
+error[E0271]: expected `{async closure@main::{closure foo#x}}` to return `Box<_>`, but it returns `{async closure body@$DIR/dont-suggest-boxing-async-closure-body.rs:9:23: 9:25}`
   --> $DIR/dont-suggest-boxing-async-closure-body.rs:9:9
    |
 LL |     foo(async move || {});
@@ -18,12 +18,12 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-boxing-async-closure-body.rs:11:9
    |
 LL |     bar(async move || {});
-   |     --- ^^^^^^^^^^^^^^^^ expected `Box<dyn FnOnce() -> _>`, found `{async closure@dont-suggest-boxing-async-closure-body.rs:11:9}`
+   |     --- ^^^^^^^^^^^^^^^^ expected `Box<dyn FnOnce() -> _>`, found `{async closure@main::{closure bar#x}}`
    |     |
    |     arguments to this function are incorrect
    |
    = note: expected struct `Box<(dyn FnOnce() -> _ + 'static)>`
-             found closure `{async closure@$DIR/dont-suggest-boxing-async-closure-body.rs:11:9: 11:22}`
+             found closure `{async closure@main::{closure bar#x}}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 note: function defined here
   --> $DIR/dont-suggest-boxing-async-closure-body.rs:6:4

--- a/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -16,15 +16,14 @@ help: use parentheses to call this function
 LL |     bar(foo());
    |            ++
 
-error[E0277]: the trait bound `{closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:21}: T` is not satisfied
+error[E0277]: the trait bound `main::{closure closure}: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:19:9
    |
 LL |     bar(closure);
-   |     --- ^^^^^^^ unsatisfied trait bound
+   |     --- ^^^^^^^ the trait `T` is not implemented for closure `main::{closure closure}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `T` is not implemented for closure `{closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:21}`
 note: required by a bound in `bar`
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16
    |

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -276,7 +276,7 @@ LL |     let _: usize = closure;
    |            expected due to this
    |
    = note: expected type `usize`
-           found closure `{closure@$DIR/fn-or-tuple-struct-without-args.rs:45:19: 45:21}`
+           found closure `main::{closure closure}`
 help: use parentheses to call this closure
    |
 LL |     let _: usize = closure();

--- a/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.stderr
+++ b/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.stderr
@@ -8,7 +8,7 @@ LL | |
 LL | |         .filter_map(|_| foo(src))
    | |_________________________________^
    |
-   = note: hidden type `FilterMap<std::slice::Iter<'static, i32>, {closure@$DIR/explicit-lifetime-suggestion-in-proper-span-issue-121267.rs:9:21: 9:24}>` captures lifetime `'_`
+   = note: hidden type `FilterMap<std::slice::Iter<'static, i32>, bar::{closure _::filter_map#0}>` captures lifetime `'_`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -15,7 +15,7 @@ error[E0700]: hidden type for `impl FnOnce()` captures lifetime that does not ap
 LL |   fn foo<G, T>(g: G, dest: &mut T) -> impl FnOnce()
    |                            ------     ------------- opaque type defined here
    |                            |
-   |                            hidden type `{closure@$DIR/missing-lifetimes-in-signature.rs:19:5: 19:12}` captures the anonymous lifetime defined here
+   |                            hidden type `foo<G, T>::{returned closure}` captures the anonymous lifetime defined here
 ...
 LL | /     move || {
 LL | |

--- a/tests/ui/suggestions/return-closures.stderr
+++ b/tests/ui/suggestions/return-closures.stderr
@@ -8,7 +8,7 @@ LL |     |x: &i32| 1i32
    |     ^^^^^^^^^^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/return-closures.rs:3:5: 3:14}`
+                found closure `foo::{returned closure}`
 
 error[E0308]: mismatched types
   --> $DIR/return-closures.rs:9:5
@@ -20,7 +20,7 @@ LL |     || i
    |     ^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/return-closures.rs:9:5: 9:7}`
+                found closure `bar<impl Sized>::{returned closure}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/sugg-else-for-closure.stderr
+++ b/tests/ui/suggestions/sugg-else-for-closure.stderr
@@ -7,8 +7,8 @@ LL |     let _s = y.unwrap_or(|| x.split('.').nth(1).unwrap());
    |                arguments to this method are incorrect
    |
    = note: expected reference `&str`
-                found closure `{closure@$DIR/sugg-else-for-closure.rs:6:26: 6:28}`
-help: the return type of this call is `{closure@$DIR/sugg-else-for-closure.rs:6:26: 6:28}` due to the type of the argument passed
+                found closure `main::{closure _::unwrap_or#0}`
+help: the return type of this call is `main::{closure _::unwrap_or#0}` due to the type of the argument passed
   --> $DIR/sugg-else-for-closure.rs:6:14
    |
 LL |     let _s = y.unwrap_or(|| x.split('.').nth(1).unwrap());

--- a/tests/ui/suggestions/suggest-box.stderr
+++ b/tests/ui/suggestions/suggest-box.stderr
@@ -11,7 +11,7 @@ LL | |     };
    | |_____^ expected `Box<dyn Fn() -> Result<(), ()>>`, found closure
    |
    = note: expected struct `Box<dyn Fn() -> Result<(), ()>>`
-             found closure `{closure@$DIR/suggest-box.rs:4:47: 4:49}`
+             found closure `main::{closure _x}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
    |

--- a/tests/ui/suggestions/types/into-inference-needs-type.rs
+++ b/tests/ui/suggestions/types/into-inference-needs-type.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z span_free_formats
 #[derive(Debug)]
 enum MyError {
     MainError

--- a/tests/ui/suggestions/types/into-inference-needs-type.stderr
+++ b/tests/ui/suggestions/types/into-inference-needs-type.stderr
@@ -4,8 +4,8 @@ error[E0283]: type annotations needed
 LL |         .into()?;
    |          ^^^^
    |
-   = note: cannot satisfy `_: From<FilterMap<Map<std::slice::Iter<'_, &str>, {closure@main::{_::map#0}}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
-   = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, {closure@main::{_::map#0}}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
+   = note: cannot satisfy `_: From<FilterMap<Map<std::slice::Iter<'_, &str>, main::{closure _::map#0}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
+   = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, main::{closure _::map#0}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
 help: try using a fully qualified path to specify the expected types
    |
 LL ~     let list = <FilterMap<Map<std::slice::Iter<'_, &str>, _>, _> as Into<T>>::into(vec

--- a/tests/ui/suggestions/types/into-inference-needs-type.stderr
+++ b/tests/ui/suggestions/types/into-inference-needs-type.stderr
@@ -1,11 +1,11 @@
 error[E0283]: type annotations needed
-  --> $DIR/into-inference-needs-type.rs:12:10
+  --> $DIR/into-inference-needs-type.rs:13:10
    |
 LL |         .into()?;
    |          ^^^^
    |
-   = note: cannot satisfy `_: From<FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
-   = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, {closure@$DIR/into-inference-needs-type.rs:10:14: 10:17}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
+   = note: cannot satisfy `_: From<FilterMap<Map<std::slice::Iter<'_, &str>, {closure@main::{_::map#0}}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>>`
+   = note: required for `FilterMap<Map<std::slice::Iter<'_, &str>, {closure@main::{_::map#0}}>, fn(Option<&str>) -> Option<Option<&str>> {Option::<Option<&str>>::Some}>` to implement `Into<_>`
 help: try using a fully qualified path to specify the expected types
    |
 LL ~     let list = <FilterMap<Map<std::slice::Iter<'_, &str>, _>, _> as Into<T>>::into(vec

--- a/tests/ui/suggestions/unnamable-types.stderr
+++ b/tests/ui/suggestions/unnamable-types.stderr
@@ -22,7 +22,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | const C: _ = || 42;
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `{closure@unnamable-types.rs:17:14}` cannot be named
+note: however, the inferred type `C::{C closure}` cannot be named
   --> $DIR/unnamable-types.rs:17:14
    |
 LL | const C: _ = || 42;
@@ -34,7 +34,7 @@ error: missing type for `const` item
 LL | const D = S { t: { let i = 0; move || -> i32 { i } } };
    |        ^
    |
-note: however, the inferred type `S<{closure@unnamable-types.rs:23:31}>` cannot be named
+note: however, the inferred type `S<D::{closure#0}>` cannot be named
   --> $DIR/unnamable-types.rs:23:11
    |
 LL | const D = S { t: { let i = 0; move || -> i32 { i } } };

--- a/tests/ui/threads-sendsync/rc-is-not-send.stderr
+++ b/tests/ui/threads-sendsync/rc-is-not-send.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 LL |       thread::spawn(move || {
    |       ------------- ^------
    |       |             |
-   |  _____|_____________within this `{closure@$DIR/rc-is-not-send.rs:25:19: 25:26}`
+   |  _____|_____________within this `main::{closure spawn#0}`
    | |     |
    | |     required by a bound introduced by this call
 LL | |
@@ -13,7 +13,7 @@ LL | |         println!("{:?}", y);
 LL | |     });
    | |_____^ `Rc<()>` cannot be sent between threads safely
    |
-   = help: within `{closure@$DIR/rc-is-not-send.rs:25:19: 25:26}`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `main::{closure spawn#0}`, the trait `Send` is not implemented for `Rc<()>`
 note: required because it appears within the type `Port<()>`
   --> $DIR/rc-is-not-send.rs:7:8
    |

--- a/tests/ui/traits/const-traits/call.stderr
+++ b/tests/ui/traits/const-traits/call.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{closure@$DIR/call.rs:7:14: 7:22}: [const] Fn()` is not satisfied
+error[E0277]: the trait bound `_::{closure#0}: [const] Fn()` is not satisfied
   --> $DIR/call.rs:7:13
    |
 LL |     assert!((const || true)());

--- a/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
+++ b/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{closure@$DIR/const-closure-parse-not-item.rs:8:5: 8:18}: [const] Fn()` is not satisfied
+error[E0277]: the trait bound `test::{returned closure}: [const] Fn()` is not satisfied
   --> $DIR/const-closure-parse-not-item.rs:7:20
    |
 LL | const fn test() -> impl [const] Fn() {

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{closure@$DIR/const_closure-const_trait_impl-ice-113381.rs:15:6: 15:14}: [const] Fn()` is not satisfied
+error[E0277]: the trait bound `main::{closure#0}: [const] Fn()` is not satisfied
   --> $DIR/const_closure-const_trait_impl-ice-113381.rs:15:5
    |
 LL |     (const || (()).foo())();

--- a/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
@@ -8,7 +8,7 @@ LL |     const move || {
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0277]: the trait bound `{closure@$DIR/ice-112822-expected-type-for-param.rs:5:5: 5:18}: [const] Fn()` is not satisfied
+error[E0277]: the trait bound `test::{returned closure}: [const] Fn()` is not satisfied
   --> $DIR/ice-112822-expected-type-for-param.rs:3:20
    |
 LL | const fn test() -> impl [const] Fn() {

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `{closure@$DIR/non-const-op-const-closure-non-const-outer.rs:13:6: 13:14}: [const] Fn()` is not satisfied
+error[E0277]: the trait bound `main::{closure#0}: [const] Fn()` is not satisfied
   --> $DIR/non-const-op-const-closure-non-const-outer.rs:13:5
    |
 LL |     (const || { (()).foo() })();

--- a/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
+++ b/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
@@ -16,15 +16,14 @@ help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`, 
 LL |     takes(function as fn(Argument) -> Return);
    |                    +++++++++++++++++++++++++
 
-error[E0277]: the trait bound `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11: 16:34}: Trait` is not satisfied
+error[E0277]: the trait bound `main::{closure takes#0}: Trait` is not satisfied
   --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11
    |
 LL |     takes(|_: Argument| -> Return { todo!() });
-   |     ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |     ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for closure `main::{closure takes#0}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11: 16:34}`
    = help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`
 note: required by a bound in `takes`
   --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:11:18

--- a/tests/ui/traits/next-solver/diagnostics/coerce-in-may-coerce.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/coerce-in-may-coerce.stderr
@@ -2,7 +2,7 @@ error[E0308]: arguments to this function are incorrect
   --> $DIR/coerce-in-may-coerce.rs:17:5
    |
 LL |     arg_error((), || ());
-   |     ^^^^^^^^^ --  ----- expected `()`, found `{closure@$DIR/coerce-in-may-coerce.rs:17:19: 17:21}`
+   |     ^^^^^^^^^ --  ----- expected `()`, found `main::{closure arg_error#y}`
    |               |
    |               expected `<fn() as Mirror>::Assoc`, found `()`
    |

--- a/tests/ui/tuple/wrong_argument_ice-4.stderr
+++ b/tests/ui/tuple/wrong_argument_ice-4.stderr
@@ -6,7 +6,7 @@ LL |       (|| {})(|| {
 LL | |
 LL | |         let b = 1;
 LL | |     });
-   | |_____- unexpected argument of type `{closure@$DIR/wrong_argument_ice-4.rs:2:13: 2:15}`
+   | |_____- unexpected argument of type `main::{closure#1}`
    |
 note: closure defined here
   --> $DIR/wrong_argument_ice-4.rs:2:6

--- a/tests/ui/type-alias-impl-trait/issue-63279.rs
+++ b/tests/ui/type-alias-impl-trait/issue-63279.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z span_free_formats
 #![feature(type_alias_impl_trait)]
 
 type Closure = impl FnOnce();

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -23,7 +23,7 @@ LL |     || -> Closure { || () }
    |                     ^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@c::{return}::{return}}`
+                found closure `c::{returned closure}::{returned closure}`
 help: use parentheses to call this closure
    |
 LL |     || -> Closure { (|| ())() }
@@ -36,7 +36,7 @@ LL |     || -> Closure { || () }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@c::{return}}`
+                found closure `c::{returned closure}`
 help: use parentheses to call this closure
    |
 LL |     (|| -> Closure { || () })()

--- a/tests/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-63279.stderr
@@ -1,5 +1,5 @@
 error[E0277]: expected a `FnOnce()` closure, found `()`
-  --> $DIR/issue-63279.rs:6:11
+  --> $DIR/issue-63279.rs:7:11
    |
 LL | fn c() -> Closure {
    |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
@@ -8,7 +8,7 @@ LL | fn c() -> Closure {
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
 error[E0277]: expected a `FnOnce()` closure, found `()`
-  --> $DIR/issue-63279.rs:8:11
+  --> $DIR/issue-63279.rs:9:11
    |
 LL |     || -> Closure { || () }
    |           ^^^^^^^ expected an `FnOnce()` closure, found `()`
@@ -17,26 +17,26 @@ LL |     || -> Closure { || () }
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-63279.rs:8:21
+  --> $DIR/issue-63279.rs:9:21
    |
 LL |     || -> Closure { || () }
    |                     ^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/issue-63279.rs:8:21: 8:23}`
+                found closure `{closure@c::{return}::{return}}`
 help: use parentheses to call this closure
    |
 LL |     || -> Closure { (|| ())() }
    |                     +     +++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-63279.rs:8:5
+  --> $DIR/issue-63279.rs:9:5
    |
 LL |     || -> Closure { || () }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found closure
    |
    = note: expected unit type `()`
-                found closure `{closure@$DIR/issue-63279.rs:8:5: 8:18}`
+                found closure `{closure@c::{return}}`
 help: use parentheses to call this closure
    |
 LL |     (|| -> Closure { || () })()

--- a/tests/ui/type/type-check/point-at-inference-issue-116155.stderr
+++ b/tests/ui/type/type-check/point-at-inference-issue-116155.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/point-at-inference-issue-116155.rs:15:23
    |
 LL |     s.constrain(c);
-   |     -           - this argument has type `{closure@$DIR/point-at-inference-issue-116155.rs:13:13: 13:15}`...
+   |     -           - this argument has type `main::{closure c}`...
    |     |
    |     ... which causes `s` to have type `S<bool>`
 LL |     let _: S<usize> = s;

--- a/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.stderr
+++ b/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.stderr
@@ -1,4 +1,4 @@
-error[E0608]: cannot index into a value of type `Map<[usize; 1], {closure@$DIR/bad-index-modulo-higher-ranked-regions.rs:23:32: 23:45}>`
+error[E0608]: cannot index into a value of type `Map<[usize; 1], main::{closure#0}>`
   --> $DIR/bad-index-modulo-higher-ranked-regions.rs:23:55
    |
 LL |     Map { inner: [0_usize], f: |_, i: usize| 1_usize }[0];

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `TakeWhile<&mut IntoIter<u8>, {closure@issue-31173.rs:7:21}>` to be an iterator that yields `&_`, but it yields `u8`
+error[E0271]: expected `TakeWhile<&mut IntoIter<u8>, get_tok::{closure _::take_while#0}>` to be an iterator that yields `&_`, but it yields `u8`
   --> $DIR/issue-31173.rs:11:10
    |
 LL |         .cloned()
@@ -21,7 +21,7 @@ LL | |         })
 note: required by a bound in `cloned`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}>>`, but its trait bounds were not satisfied
+error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, get_tok::{closure _::take_while#0}>>`, but its trait bounds were not satisfied
   --> $DIR/issue-31173.rs:12:10
    |
 LL |       let temp: Vec<u8> = it
@@ -37,10 +37,10 @@ LL | |         .collect();
    |
    |
    = note: the following trait bounds were not satisfied:
-           `<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}> as Iterator>::Item = &_`
-           which is required by `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}>>: Iterator`
-           `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}>>: Iterator`
-           which is required by `&mut Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}>>: Iterator`
+           `<TakeWhile<&mut std::vec::IntoIter<u8>, get_tok::{closure _::take_while#0}> as Iterator>::Item = &_`
+           which is required by `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, get_tok::{closure _::take_while#0}>>: Iterator`
+           `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, get_tok::{closure _::take_while#0}>>: Iterator`
+           which is required by `&mut Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, get_tok::{closure _::take_while#0}>>: Iterator`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/return_type_containing_closure.stderr
+++ b/tests/ui/typeck/return_type_containing_closure.stderr
@@ -5,7 +5,7 @@ LL |     vec!['a'].iter().map(|c| c)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Map<Iter<'_, char>, {closure@...}>`
    |
    = note: expected unit type `()`
-                 found struct `Map<std::slice::Iter<'_, char>, {closure@$DIR/return_type_containing_closure.rs:3:26: 3:29}>`
+                 found struct `Map<std::slice::Iter<'_, char>, foo::{closure _::map#0}>`
 help: consider using a semicolon here
    |
 LL |     vec!['a'].iter().map(|c| c);

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -560,7 +560,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:240:29}>, {closure@typeck_type_placeholder_item.rs:240:49}>` cannot be named
+note: however, the inferred type `Map<Filter<Range<i32>, _::{closure _::filter#0}>, _::{closure _::map#0}>` cannot be named
   --> $DIR/typeck_type_placeholder_item.rs:240:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
@@ -634,7 +634,7 @@ LL | const _: Option<_> = map(value);
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}>` in constants
+error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<_::{closure _::filter#0}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:240:22
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
@@ -642,7 +642,7 @@ LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:240:29: 240:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:240:49: 240:52}>` in constants
+error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, _::{closure _::filter#0}> as Iterator>::map::<i32, _::{closure _::map#0}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:240:45
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);

--- a/tests/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-static-call-wrong-trait.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `call` found for closure `{closure@$DIR/unboxed-closures-static-call-wrong-trait.rs:6:26: 6:29}` in the current scope
+error[E0599]: no method named `call` found for closure `main::{closure to_fn_mut#f}` in the current scope
   --> $DIR/unboxed-closures-static-call-wrong-trait.rs:7:10
    |
 LL |     mut_.call((0, ));
-   |          ^^^^ method not found in `{closure@$DIR/unboxed-closures-static-call-wrong-trait.rs:6:26: 6:29}`
+   |          ^^^^ method not found in `main::{closure to_fn_mut#f}`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Implementation of (an interpretation of) the proposed output in https://internals.rust-lang.org/t/post-0/23184 for closures.

For closures in the local crate, we look at where the closure comes from in order to give them a locally reasonable name:
    
      - closures assigned to binding `let a`, `{a}`
      - closures passed directly as arguments in function call,
        `{function_name#parameter_name_or_position}`
      - closures passed directly as arguments in method call,
        `{Trait::method#parameter_name_or_position}`
      - closures assigned to statics or consts, the item's name
      - closures returned from functions, methods and closures, `{return}`

Do not include implicit desugared closure from async fn in closure type path: `async_fn_name` instead of `async_fn_name::{closure#0}`.