### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -135,6 +135,7 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("libz-rs-sys", "Zlib"),
     ("normalize-line-endings", "Apache-2.0"),
     ("openssl", "Apache-2.0"),
+    ("ring", "Apache-2.0 AND ISC"),
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
     ("similar", "Apache-2.0"),
     ("sized-chunks", "MPL-2.0+"),


### PR DESCRIPTION
8 commits in 6833aa715d724437dc1247d0166afe314ab6854e..9b296973b425ffb159e12cf3cd56580fd5c85382
2025-07-13 02:25:52 +0000 to 2025-07-25 17:10:08 +0000
- Allow using Cargo-as-a-library with gix's reqwest backend (rust-lang/cargo#15653)
- Make timings graphs scalable to user's window (rust-lang/cargo#15766)
- refactor: rename arg `mode` to `intent` (rust-lang/cargo#15774)
- fix: `no-proc-macro` is overridden by subsequent edges (rust-lang/cargo#15764)
- Use `gix` for `cargo package` (rust-lang/cargo#15534)
- cargo-credential-libsecret: give FFI correctly-sized object (rust-lang/cargo#15767)
- Remove unnecessary target-c-int-width from target specs (rust-lang/cargo#15759)
- Expose artifact dependency getters in cargo-as-a-library (rust-lang/cargo#15753)
