### PR TITLE
Enable dwarf-mixed-versions-lto.rs test on RISC-V (riscv64)

### DIFF
--- a/tests/assembly-llvm/dwarf-mixed-versions-lto.rs
+++ b/tests/assembly-llvm/dwarf-mixed-versions-lto.rs
@@ -1,6 +1,7 @@
 // This test ensures that if LTO occurs between crates with different DWARF versions, we
 // will choose the highest DWARF version for the final binary. This matches Clang's behavior.
 // Note: `.2byte` directive is used on MIPS.
+// Note: `.half` directive is used on RISC-V.
 
 //@ only-linux
 //@ aux-build:dwarf-mixed-versions-lto-aux.rs
@@ -15,6 +16,6 @@ fn main() {
 }
 
 // CHECK: .section .debug_info
-// CHECK-NOT: {{\.(short|hword|2byte)}} 2
-// CHECK-NOT: {{\.(short|hword|2byte)}} 4
-// CHECK: {{\.(short|hword|2byte)}} 5
+// CHECK-NOT: {{\.(short|hword|2byte|half)}} 2
+// CHECK-NOT: {{\.(short|hword|2byte|half)}} 4
+// CHECK: {{\.(short|hword|2byte|half)}} 5


### PR DESCRIPTION
This PR replaces [#144284](https://github.com/rust-lang/rust/pull/144284) to resolve merge conflicts.

This PR adds support for running the `tests/assembly/dwarf-mixed-versions-lto.rs` test on the RISC-V (riscv64) architecture.

Previously, this test would fail on RISC-V targets due to architecture-specific code generation issues. This patch modifies the test to ensure compatibility while preserving its intent.

The change has been tested locally using `./x test` on a riscv64 target, and the test now passes as expected.

### Notes:
- This change is scoped specifically to improve RISC-V compatibility.
- It does not affect behavior or test results on other architectures.