### PR TITLE
Enable const-vector.rs test on RISC-V (riscv64)

### DIFF
--- a/tests/codegen-llvm/const-vector.rs
+++ b/tests/codegen-llvm/const-vector.rs
@@ -15,6 +15,7 @@
 #![feature(arm_target_feature)]
 #![feature(mips_target_feature)]
 #![allow(non_camel_case_types)]
+#![feature(riscv_target_feature)]
 
 #[path = "../auxiliary/minisimd.rs"]
 mod minisimd;
@@ -42,6 +43,7 @@ extern "unadjusted" {
 #[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 #[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
+#[cfg_attr(target_arch = "riscv64", target_feature(enable = "v"))]
 pub fn do_call() {
     unsafe {
         // CHECK: call void @test_i8x2(<2 x i8> <i8 32, i8 64>


### PR DESCRIPTION
This PR replaces [#144283](https://github.com/rust-lang/rust/pull/144283) to resolve merge conflicts.

This PR adds support for running the `tests/codegen/const-vector.rs` test on the RISC-V (riscv64) architecture.

Previously, this test would fail on RISC-V targets due to architecture-specific code generation issues. This patch modifies the test to ensure compatibility while preserving its intent.

The change has been tested locally using `./x test` on a riscv64 target, and the test now passes as expected.

### Notes:
- This change is scoped specifically to improve RISC-V compatibility.
- It does not affect behavior or test results on other architectures.