### PR TITLE
fix(std): Fix undefined reference to __my_thread_exit on QNX 8.0

### DIFF
--- a/library/std/src/sys/backtrace.rs
+++ b/library/std/src/sys/backtrace.rs
@@ -113,7 +113,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
                         res = bt_fmt.frame().symbol(frame, symbol);
                     }
                 });
-                #[cfg(target_os = "nto")]
+                #[cfg(all(target_os = "nto", any(target_env = "nto70", target_env = "nto71")))]
                 if libc::__my_thread_exit as *mut libc::c_void == frame.ip() {
                     if !hit && print {
                         use crate::backtrace_rs::SymbolName;


### PR DESCRIPTION
When cross-compiling for the x86_64/aarch64-unknown-nto-qnx800 target (QNX SDP 8.0), the build fails during the final link stage with the error:
```
error: linking with `qcc` failed: exit status: 1
  ...
  = note: undefined reference to `__my_thread_exit'
 ```

- **On QNX 7.1**: The __my_thread_exit symbol is defined and exported by the main C library (libc.a/libc.so). The std backtrace code can therefore successfully take its address at compile time.

- **On QNX 8.0**: As part of a toolchain modernization, this symbol has been refactored. It is no longer present in any of the standard system libraries (.a or .so).

This patch addresses the problem at its source by conditionally compiling the problematic code.

Fixes rust-lang/rust#142726

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
