### PR TITLE
Add `ignore-backends` annotations in failing GCC backend ui tests

### DIFF
--- a/src/tools/compiletest/src/directives/cfg.rs
+++ b/src/tools/compiletest/src/directives/cfg.rs
@@ -285,6 +285,11 @@ fn parse_cfg_name_directive<'a>(
         if name == "gdb-version" {
             outcome = MatchOutcome::External;
         }
+
+        // Don't error out for ignore-backends,as it is handled elsewhere.
+        if name == "backends" {
+            outcome = MatchOutcome::External;
+        }
     }
 
     ParsedNameDirective {

--- a/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
@@ -2,6 +2,7 @@
 //@ ignore-android no libc
 //@ ignore-emscripten no libc
 //@ ignore-sgx no libc
+//@ ignore-backends: gcc
 //@ only-linux
 //@ compile-flags:-C panic=abort
 //@ aux-build:helper.rs

--- a/tests/ui/allocator/no_std-alloc-error-handler-default.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-default.rs
@@ -2,6 +2,7 @@
 //@ ignore-android no libc
 //@ ignore-emscripten no libc
 //@ ignore-sgx no libc
+//@ ignore-backends: gcc
 //@ only-linux
 //@ compile-flags:-C panic=abort
 //@ aux-build:helper.rs

--- a/tests/ui/asm/may_unwind.rs
+++ b/tests/ui/asm/may_unwind.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 //@ needs-asm-support
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 #![feature(asm_unwind)]
 

--- a/tests/ui/asm/x86_64/may_unwind.rs
+++ b/tests/ui/asm/x86_64/may_unwind.rs
@@ -2,6 +2,7 @@
 //@ run-pass
 //@ needs-asm-support
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 #![feature(asm_unwind)]
 

--- a/tests/ui/async-await/deep-futures-are-freeze.rs
+++ b/tests/ui/async-await/deep-futures-are-freeze.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ build-pass
 //@ compile-flags: -Copt-level=s -Clto=fat
 //@ no-prefer-dynamic

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ edition: 2021
 //@ known-bug: #108309
 

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `foo` has an incompatible type for trait
-  --> $DIR/dont-project-to-specializable-projection.rs:13:5
+  --> $DIR/dont-project-to-specializable-projection.rs:14:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found future
    |
 note: type in trait
-  --> $DIR/dont-project-to-specializable-projection.rs:9:5
+  --> $DIR/dont-project-to-specializable-projection.rs:10:5
    |
 LL |     async fn foo(_: T) -> &'static str;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     async fn foo(_: T) -> &'static str;
               found signature `fn(_) -> impl Future<Output = &'static str>`
 
 error: async associated function in trait cannot be specialized
-  --> $DIR/dont-project-to-specializable-projection.rs:13:5
+  --> $DIR/dont-project-to-specializable-projection.rs:14:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL |     default async fn foo(_: T) -> &'static str {
    = note: specialization behaves in inconsistent and surprising ways with async functions in traits, and for now is disallowed
 
 error[E0599]: no method named `poll` found for struct `Pin<&mut impl Future<Output = ()>>` in the current scope
-  --> $DIR/dont-project-to-specializable-projection.rs:48:28
+  --> $DIR/dont-project-to-specializable-projection.rs:49:28
    |
 LL |         match fut.as_mut().poll(ctx) {
    |                            ^^^^ method not found in `Pin<&mut impl Future<Output = ()>>`

--- a/tests/ui/backtrace/dylib-dep.rs
+++ b/tests/ui/backtrace/dylib-dep.rs
@@ -8,6 +8,7 @@
 //@ ignore-fuchsia Backtraces not symbolized
 //@ ignore-musl musl doesn't support dynamic libraries (at least when the original test was written).
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ compile-flags: -g -Copt-level=0 -Cstrip=none -Cforce-frame-pointers=yes
 //@ ignore-emscripten Requires custom symbolization code
 //@ aux-crate: dylib_dep_helper=dylib-dep-helper.rs

--- a/tests/ui/cfg/cfg-panic-abort.rs
+++ b/tests/ui/cfg/cfg-panic-abort.rs
@@ -1,6 +1,7 @@
 //@ build-pass
 //@ compile-flags: -C panic=abort
 //@ no-prefer-dynamic
+//@ ignore-backends: gcc
 
 #[cfg(panic = "unwind")]
 pub fn bad() -> i32 { }

--- a/tests/ui/codegen/StackColoring-not-blowup-stack-issue-40883.rs
+++ b/tests/ui/codegen/StackColoring-not-blowup-stack-issue-40883.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![allow(dead_code)]
 // check that we don't have linear stack usage with multiple calls to `push`
 

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline1.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/inline2.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/segfault.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/codegen/equal-pointers-unequal/as-cast/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/as-cast/zero.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline1.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/inline2.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/segfault.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/exposed-provenance/zero.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline1.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/inline2.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Based on https://github.com/rust-lang/rust/issues/107975#issuecomment-1432161340
 

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/segfault.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/segfault.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/codegen/equal-pointers-unequal/strict-provenance/zero.rs
+++ b/tests/ui/codegen/equal-pointers-unequal/strict-provenance/zero.rs
@@ -1,6 +1,7 @@
 //@ known-bug: #107975
 //@ compile-flags: -Copt-level=2
 //@ run-pass
+//@ ignore-backends: gcc
 
 // Derived from https://github.com/rust-lang/rust/issues/107975#issuecomment-1431758601
 

--- a/tests/ui/consts/const-eval/parse_ints.rs
+++ b/tests/ui/consts/const-eval/parse_ints.rs
@@ -1,3 +1,5 @@
+//@ ignore-backends: gcc
+
 const _OK: () = match i32::from_str_radix("-1234", 10) {
     Ok(x) => assert!(x == -1234),
     Err(_) => panic!(),

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
-  --> $DIR/parse_ints.rs:5:24
+  --> $DIR/parse_ints.rs:7:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_TOO_LOW` failed inside this call
@@ -11,7 +11,7 @@ note: inside `core::num::<impl u64>::from_ascii_radix`
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
-  --> $DIR/parse_ints.rs:6:25
+  --> $DIR/parse_ints.rs:8:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_TOO_HIGH` failed inside this call

--- a/tests/ui/consts/const_cmp_type_id.rs
+++ b/tests/ui/consts/const_cmp_type_id.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ compile-flags: -Znext-solver
 #![feature(const_type_id, const_trait_impl, const_cmp)]
 

--- a/tests/ui/consts/const_cmp_type_id.stderr
+++ b/tests/ui/consts/const_cmp_type_id.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const operator in constants
-  --> $DIR/const_cmp_type_id.rs:10:18
+  --> $DIR/const_cmp_type_id.rs:11:18
    |
 LL |         let _a = TypeId::of::<u8>() < TypeId::of::<u16>();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/issue-73976-monomorphic.rs
+++ b/tests/ui/consts/issue-73976-monomorphic.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ check-pass
 //
 // This test is complement to the test in issue-73976-polymorphic.rs.

--- a/tests/ui/consts/issue-94675.rs
+++ b/tests/ui/consts/issue-94675.rs
@@ -1,3 +1,5 @@
+//@ ignore-backends: gcc
+
 #![feature(const_trait_impl)]
 
 struct Foo<'a> {

--- a/tests/ui/consts/issue-94675.stderr
+++ b/tests/ui/consts/issue-94675.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `Vec<usize>: [const] Index<_>` is not satisfied
-  --> $DIR/issue-94675.rs:9:9
+  --> $DIR/issue-94675.rs:11:9
    |
 LL |         self.bar[0] = baz.len();
    |         ^^^^^^^^^^^
 
 error[E0277]: the trait bound `Vec<usize>: [const] IndexMut<usize>` is not satisfied
-  --> $DIR/issue-94675.rs:9:9
+  --> $DIR/issue-94675.rs:11:9
    |
 LL |         self.bar[0] = baz.len();
    |         ^^^^^^^^^^^
 
 error[E0277]: the trait bound `Vec<usize>: [const] Index<usize>` is not satisfied
-  --> $DIR/issue-94675.rs:9:9
+  --> $DIR/issue-94675.rs:11:9
    |
 LL |         self.bar[0] = baz.len();
    |         ^^^^^^^^^^^

--- a/tests/ui/consts/issue-miri-1910.rs
+++ b/tests/ui/consts/issue-miri-1910.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ error-pattern unable to turn pointer into raw bytes
 //@ normalize-stderr: "alloc[0-9]+\+0x[a-z0-9]+" -> "ALLOC"
 

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -1,5 +1,5 @@
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/issue-miri-1910.rs:7:5
+  --> $DIR/issue-miri-1910.rs:8:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `C` failed here

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ compile-flags: -Z ui-testing=no
 
 use std::{

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,11 +1,11 @@
 error[E0080]: unable to copy parts of a pointer from memory at ALLOC0
-  --> $DIR/missing_span_in_backtrace.rs:14:9
+  --> $DIR/missing_span_in_backtrace.rs:15:9
    |
-14 | /         ptr::swap_nonoverlapping(
-15 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
-16 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
-17 | |             mem::size_of::<&i32>(),
-18 | |         );
+15 | /         ptr::swap_nonoverlapping(
+16 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
+17 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
+18 | |             mem::size_of::<&i32>(),
+19 | |         );
    | |_________^ evaluation of `X` failed inside this call
    |
    = help: this code performed an operation that depends on the underlying bytes representing a pointer

--- a/tests/ui/consts/try-operator.rs
+++ b/tests/ui/consts/try-operator.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ run-pass
 
 #![feature(try_trait_v2)]

--- a/tests/ui/coroutine/panic-drops-resume.rs
+++ b/tests/ui/coroutine/panic-drops-resume.rs
@@ -2,6 +2,7 @@
 
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 

--- a/tests/ui/coroutine/panic-drops.rs
+++ b/tests/ui/coroutine/panic-drops.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 

--- a/tests/ui/coroutine/panic-safe.rs
+++ b/tests/ui/coroutine/panic-safe.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ needs-unwind
-
+//@ ignore-backends: gcc
 
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 

--- a/tests/ui/coroutine/resume-after-return.rs
+++ b/tests/ui/coroutine/resume-after-return.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ run-pass
 //@ needs-unwind
 

--- a/tests/ui/coroutine/unwind-abort-mix.rs
+++ b/tests/ui/coroutine/unwind-abort-mix.rs
@@ -6,6 +6,7 @@
 //@ aux-build:unwind-aux.rs
 //@ compile-flags: -Cpanic=abort
 //@ needs-unwind
+//@ ignore-backends: gcc
 extern crate unwind_aux;
 
 pub fn main() {

--- a/tests/ui/delegation/fn-header.rs
+++ b/tests/ui/delegation/fn-header.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ edition:2018
 //@ aux-crate:fn_header_aux=fn-header-aux.rs
+//@ ignore-backends: gcc
 
 #![feature(c_variadic)]
 #![feature(fn_delegation)]

--- a/tests/ui/drop/dynamic-drop-async.rs
+++ b/tests/ui/drop/dynamic-drop-async.rs
@@ -6,6 +6,7 @@
 //@ run-pass
 //@ needs-unwind
 //@ edition:2018
+//@ ignore-backends: gcc
 
 #![allow(unused)]
 

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 #![feature(if_let_guard)]

--- a/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/tests/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -4,6 +4,7 @@
 //@ revisions: default strict
 //@ [strict]compile-flags: -Zstrict-init-checks
 //@ needs-subprocess
+//@ ignore-backends: gcc
 
 #![allow(deprecated, invalid_value)]
 #![feature(never_type)]

--- a/tests/ui/issues/issue-14875.rs
+++ b/tests/ui/issues/issue-14875.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 // Check that values are not leaked when a dtor panics (#14875)
 

--- a/tests/ui/issues/issue-29948.rs
+++ b/tests/ui/issues/issue-29948.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 use std::panic;
 

--- a/tests/ui/iterators/iter-sum-overflow-debug.rs
+++ b/tests/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ compile-flags: -C debug_assertions=yes
 
 use std::panic;

--- a/tests/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/tests/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ compile-flags: -C overflow-checks
 
 use std::panic;

--- a/tests/ui/lto/all-crates.rs
+++ b/tests/ui/lto/all-crates.rs
@@ -2,6 +2,7 @@
 
 //@ compile-flags: -Clto=thin
 //@ no-prefer-dynamic
+//@ ignore-backends: gcc
 
 fn main() {
     println!("hello!");

--- a/tests/ui/lto/lto-thin-rustc-loads-linker-plugin.rs
+++ b/tests/ui/lto/lto-thin-rustc-loads-linker-plugin.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ compile-flags: -C lto=thin
 //@ aux-build:lto-rustc-loads-linker-plugin.rs
 //@ run-pass

--- a/tests/ui/lto/thin-lto-inlines2.rs
+++ b/tests/ui/lto/thin-lto-inlines2.rs
@@ -4,6 +4,7 @@
 //@ aux-build:thin-lto-inlines-aux.rs
 //@ no-prefer-dynamic
 //@ ignore-emscripten can't inspect instructions on emscripten
+//@ ignore-backends: gcc
 
 // We want to assert here that ThinLTO will inline across codegen units. There's
 // not really a great way to do that in general so we sort of hack around it by

--- a/tests/ui/mir/mir_drop_order.rs
+++ b/tests/ui/mir/mir_drop_order.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 
 use std::cell::RefCell;
 use std::panic;

--- a/tests/ui/mir/mir_let_chains_drop_order.rs
+++ b/tests/ui/mir/mir_let_chains_drop_order.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ edition: 2024
 
 // See `mir_drop_order.rs` for more information

--- a/tests/ui/mir/mir_match_guard_let_chains_drop_order.rs
+++ b/tests/ui/mir/mir_match_guard_let_chains_drop_order.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024

--- a/tests/ui/numbers-arithmetic/u128-as-f32.rs
+++ b/tests/ui/numbers-arithmetic/u128-as-f32.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ ignore-backends: gcc
 
 #![feature(test)]
 #![deny(overflowing_literals)]

--- a/tests/ui/panic-runtime/abort-link-to-unwinding-crates.rs
+++ b/tests/ui/panic-runtime/abort-link-to-unwinding-crates.rs
@@ -3,6 +3,7 @@
 //@ aux-build:exit-success-if-unwind.rs
 //@ no-prefer-dynamic
 //@ needs-subprocess
+//@ ignore-backends: gcc
 
 extern crate exit_success_if_unwind;
 

--- a/tests/ui/panic-runtime/abort.rs
+++ b/tests/ui/panic-runtime/abort.rs
@@ -2,6 +2,7 @@
 //@ compile-flags:-C panic=abort
 //@ no-prefer-dynamic
 //@ needs-subprocess
+//@ ignore-backends: gcc
 
 use std::env;
 use std::process::Command;

--- a/tests/ui/panic-runtime/link-to-abort.rs
+++ b/tests/ui/panic-runtime/link-to-abort.rs
@@ -2,6 +2,7 @@
 
 //@ compile-flags:-C panic=abort
 //@ no-prefer-dynamic
+//@ ignore-backends: gcc
 
 #![feature(panic_abort)]
 

--- a/tests/ui/panic-runtime/lto-abort.rs
+++ b/tests/ui/panic-runtime/lto-abort.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ run-pass
 //@ compile-flags:-C lto -C panic=abort
 //@ no-prefer-dynamic

--- a/tests/ui/parser/unclosed-delimiter-in-dep.rs
+++ b/tests/ui/parser/unclosed-delimiter-in-dep.rs
@@ -1,3 +1,5 @@
+//@ ignore-backends: gcc
+
 mod unclosed_delim_mod;
 
 fn main() {

--- a/tests/ui/process/nofile-limit.rs
+++ b/tests/ui/process/nofile-limit.rs
@@ -7,6 +7,8 @@
 //@ only-linux
 //@ no-prefer-dynamic
 //@ compile-flags: -Ctarget-feature=+crt-static -Crpath=no -Crelocation-model=static
+//@ ignore-backends: gcc
+
 #![feature(exit_status_error)]
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/ui/process/println-with-broken-pipe.rs
+++ b/tests/ui/process/println-with-broken-pipe.rs
@@ -5,6 +5,7 @@
 //@ ignore-fuchsia
 //@ ignore-horizon
 //@ ignore-android
+//@ ignore-backends: gcc
 //@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:CC"
 //@ compile-flags: -Zon-broken-pipe=error
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/std-panic-locations.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 //@ revisions: default mir-opt
 //@[mir-opt] compile-flags: -Zmir-opt-level=4
 

--- a/tests/ui/runtime/on-broken-pipe/child-processes.rs
+++ b/tests/ui/runtime/on-broken-pipe/child-processes.rs
@@ -1,6 +1,7 @@
 //@ revisions: default error kill inherit
 //@ ignore-cross-compile because aux-bin does not yet support it
 //@ only-unix because SIGPIPE is a unix thing
+//@ ignore-backends: gcc
 //@ run-pass
 //@ aux-bin:assert-sigpipe-disposition.rs
 //@ aux-crate:sigpipe_utils=sigpipe-utils.rs

--- a/tests/ui/runtime/rt-explody-panic-payloads.rs
+++ b/tests/ui/runtime/rt-explody-panic-payloads.rs
@@ -1,6 +1,7 @@
 //@ run-pass
 //@ needs-unwind
 //@ needs-subprocess
+//@ ignore-backends: gcc
 
 use std::env;
 use std::process::Command;

--- a/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
+++ b/tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
@@ -6,6 +6,7 @@
 //@ edition: 2021
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
+//@ ignore-backends: gcc
 //@ build-pass
 
 trait Iterable {

--- a/tests/ui/sanitizer/cfi/async-closures.rs
+++ b/tests/ui/sanitizer/cfi/async-closures.rs
@@ -4,6 +4,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/can-reveal-opaques.rs
+++ b/tests/ui/sanitizer/cfi/can-reveal-opaques.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi
 //@ no-prefer-dynamic
 //@ only-x86_64-unknown-linux-gnu
+//@ ignore-backends: gcc
 //@ build-pass
 
 // See comment below for why this test exists.

--- a/tests/ui/sanitizer/cfi/closures.rs
+++ b/tests/ui/sanitizer/cfi/closures.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/complex-receiver.rs
+++ b/tests/ui/sanitizer/cfi/complex-receiver.rs
@@ -5,6 +5,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/coroutine.rs
+++ b/tests/ui/sanitizer/cfi/coroutine.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ edition: 2024
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi

--- a/tests/ui/sanitizer/cfi/drop-in-place.rs
+++ b/tests/ui/sanitizer/cfi/drop-in-place.rs
@@ -2,6 +2,7 @@
 //
 // FIXME(#122848): Remove only-linux when fixed.
 //@ only-linux
+//@ ignore-backends: gcc
 //@ needs-sanitizer-cfi
 //@ compile-flags: -Clto -Copt-level=0 -Cprefer-dynamic=off -Ctarget-feature=-crt-static -Zsanitizer=cfi
 //@ run-pass

--- a/tests/ui/sanitizer/cfi/drop-no-principal.rs
+++ b/tests/ui/sanitizer/cfi/drop-no-principal.rs
@@ -3,6 +3,7 @@
 //@ needs-sanitizer-cfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries works
 //@ only-linux
+//@ ignore-backends: gcc
 //@ compile-flags: --crate-type=bin -Cprefer-dynamic=off -Clto -Zsanitizer=cfi
 //@ compile-flags: -C target-feature=-crt-static -C codegen-units=1 -C opt-level=0
 // FIXME(#118761) Should be run-pass once the labels on drop are compatible.

--- a/tests/ui/sanitizer/cfi/fn-ptr.rs
+++ b/tests/ui/sanitizer/cfi/fn-ptr.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/self-ref.rs
+++ b/tests/ui/sanitizer/cfi/self-ref.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/sized-associated-ty.rs
+++ b/tests/ui/sanitizer/cfi/sized-associated-ty.rs
@@ -4,6 +4,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/supertraits.rs
+++ b/tests/ui/sanitizer/cfi/supertraits.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/cfi/virtual-auto.rs
+++ b/tests/ui/sanitizer/cfi/virtual-auto.rs
@@ -3,6 +3,7 @@
 //@ revisions: cfi kcfi
 // FIXME(#122848) Remove only-linux once OSX CFI binaries work
 //@ only-linux
+//@ ignore-backends: gcc
 //@ [cfi] needs-sanitizer-cfi
 //@ [kcfi] needs-sanitizer-kcfi
 //@ compile-flags: -C target-feature=-crt-static

--- a/tests/ui/sanitizer/kcfi-mangling.rs
+++ b/tests/ui/sanitizer/kcfi-mangling.rs
@@ -4,6 +4,7 @@
 //@ no-prefer-dynamic
 //@ compile-flags: -C panic=abort -Zsanitizer=kcfi -C symbol-mangling-version=v0
 //@ build-pass
+//@ ignore-backends: gcc
 
 trait Foo {
     fn foo(&self);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![allow(non_camel_case_types)]
 #![feature(repr_simd, core_intrinsics)]
 

--- a/tests/ui/simd/intrinsic/generic-as.rs
+++ b/tests/ui/simd/intrinsic/generic-as.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ ignore-backends: gcc
 
 #![feature(repr_simd, core_intrinsics)]
 

--- a/tests/ui/simd/issue-17170.rs
+++ b/tests/ui/simd/issue-17170.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ ignore-backends: gcc
+
 #![feature(repr_simd)]
 
 #[repr(simd)]

--- a/tests/ui/simd/issue-39720.rs
+++ b/tests/ui/simd/issue-39720.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ ignore-backends: gcc
 
 #![feature(repr_simd, core_intrinsics)]
 

--- a/tests/ui/simd/masked-load-store.rs
+++ b/tests/ui/simd/masked-load-store.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ run-pass
 #![feature(repr_simd, core_intrinsics)]
 

--- a/tests/ui/simd/repr_packed.rs
+++ b/tests/ui/simd/repr_packed.rs
@@ -1,3 +1,4 @@
+//@ ignore-backends: gcc
 //@ run-pass
 
 #![feature(repr_simd, core_intrinsics)]

--- a/tests/ui/simd/simd-bitmask-notpow2.rs
+++ b/tests/ui/simd/simd-bitmask-notpow2.rs
@@ -2,6 +2,8 @@
 // FIXME: broken codegen on big-endian (https://github.com/rust-lang/rust/issues/127205)
 // This should be merged into `simd-bitmask` once that's fixed.
 //@ ignore-endian-big
+//@ ignore-backends: gcc
+
 #![feature(repr_simd, core_intrinsics)]
 
 #[path = "../../auxiliary/minisimd.rs"]

--- a/tests/ui/statics/const_generics.rs
+++ b/tests/ui/statics/const_generics.rs
@@ -3,6 +3,7 @@
 //! This is not an intentional guarantee, it just describes the status quo.
 
 //@ run-pass
+//@ ignore-backends: gcc
 // With optimizations, LLVM will deduplicate the constant `X` whose
 // value is `&42` to just be a reference to the static. This is correct,
 // but obscures the issue we're trying to show.

--- a/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:33:5
+  --> $DIR/const-drop-fail.rs:34:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -8,13 +8,13 @@ LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:35:5
+  --> $DIR/const-drop-fail.rs:36:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -23,7 +23,7 @@ LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`

--- a/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:33:5
+  --> $DIR/const-drop-fail.rs:34:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -8,13 +8,13 @@ LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:35:5
+  --> $DIR/const-drop-fail.rs:36:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -23,7 +23,7 @@ LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`

--- a/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:33:5
+  --> $DIR/const-drop-fail.rs:34:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -8,13 +8,13 @@ LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:35:5
+  --> $DIR/const-drop-fail.rs:36:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -23,7 +23,7 @@ LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`

--- a/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:33:5
+  --> $DIR/const-drop-fail.rs:34:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -8,13 +8,13 @@ LL |     NonTrivialDrop,
    |     ^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:35:5
+  --> $DIR/const-drop-fail.rs:36:5
    |
 LL |         const _: () = check($exp);
    |                       ----- required by a bound introduced by this call
@@ -23,7 +23,7 @@ LL |     ConstImplWithDropGlue(NonTrivialDrop),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: required by a bound in `check`
-  --> $DIR/const-drop-fail.rs:24:19
+  --> $DIR/const-drop-fail.rs:25:19
    |
 LL | const fn check<T: [const] Destruct>(_: T) {}
    |                   ^^^^^^^^^^^^^^^^ required by this bound in `check`

--- a/tests/ui/traits/const-traits/const-drop-fail.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail.rs
@@ -1,6 +1,7 @@
 //@[new_precise] compile-flags: -Znext-solver
 //@[new_stock] compile-flags: -Znext-solver
 //@ revisions: new_stock old_stock new_precise old_precise
+//@ ignore-backends: gcc
 
 #![feature(const_trait_impl, const_destruct)]
 #![cfg_attr(any(new_precise, old_precise), feature(const_precise_live_drops))]

--- a/tests/ui/uninhabited/uninhabited-transparent-return-abi.rs
+++ b/tests/ui/uninhabited/uninhabited-transparent-return-abi.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 //@ needs-unwind
+//@ ignore-backends: gcc
 // See https://github.com/rust-lang/rust/issues/135802
 
 enum Void {}


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/144125.

In the GCC backend, we don't support all ui tests yet and we have a list of tests we currently ignore available [here](https://github.com/rust-lang/rustc_codegen_gcc/blob/master/tests/failing-ui-tests.txt).

This PR adds the `ignore-backends` annotations to the corresponding ui tests.

The second commit is a fix to compiletest, complaining about `ignore-backends`.

r? @jieyouxu 