### PR TITLE
[RTE-513] Bugfix: Ensure sleep takes long enough on SGX platform

### DIFF
--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -242,7 +242,7 @@ where
         let timeout = duration.map_or(raw::WAIT_NO, |duration| {
             cmp::min((u64::MAX - 1) as u128, duration.as_nanos()) as u64
         });
-        match wait(event_mask, timeout) {
+        match wait_ex(event_mask, timeout, 0..=10) {
             Ok(eventset) => {
                 if event_mask == 0 {
                     rtabort!("expected wait() to return Err, found Ok.");

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -19,6 +19,16 @@ fn sleep_very_long() {
 }
 
 #[test]
+fn sleep() {
+    let now = Instant::now();
+    let period = Duration::from_millis(100);
+    thread::sleep(period);
+
+    let elapsed = now.elapsed();
+    assert!(elapsed >= period);
+}
+
+#[test]
 fn sleep_until() {
     let now = Instant::now();
     let period = Duration::from_millis(100);


### PR DESCRIPTION
*Summary*
The `thread::sleep` function documentation states:
> Puts the current thread to sleep for at least the specified amount of time.

And for `thread::sleep_until`:
> Puts the current thread to sleep until the specified deadline has passed.

These did not hold for the `x86_64-fortanix-unknown-sgx` platform. This PR fixes this issue.

*More details*
The attack model on Intel SGX states that enclaves should not rely on timing to be accurate within an enclave. To ensure that users do not rely on the accuracy of the `wait` usercall (see the [ABI](https://edp.fortanix.com/docs/api/fortanix_sgx_abi/struct.Usercalls.html#method.wait)), we randomized the specified timeout with +/-10%. This was causing issues when the timeout was reduced. This PR fixes the issue by picking a random duration of up to +10% (i.e., the duration will never be reduced).
The issue was caught when rust-lang/rust#141829 added a test for `sleep_until`. There wasn't a test in the standard library to verify that `thread::sleep` sleeps for at least the specified amount of time.  Such a test is added as well.

cc: @jethrogb @aditijannu