### PR TITLE
Update `dlmalloc` dependency of libstd

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01597dde41c0b9da50d5f8c219023d63d8f27f39a27095070fd191fddc83891"
+checksum = "fa3a2dbee57b69fbb5dbe852fa9c0925697fb0c7fbcb1593e90e5ffaedf13d51"
 dependencies = [
  "cfg-if",
  "libc",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -63,7 +63,7 @@ rand = { version = "0.9.0", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.4.0"
 
 [target.'cfg(any(all(target_family = "wasm", target_os = "unknown"), target_os = "xous", all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
-dlmalloc = { version = "0.2.4", features = ['rustc-dep-of-std'] }
+dlmalloc = { version = "0.2.10", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 fortanix-sgx-abi = { version = "0.5.0", features = [


### PR DESCRIPTION
This primarily pulls in alexcrichton/dlmalloc-rs#55 and alexcrichton/dlmalloc-rs#54 to address rust-lang/rust#144199. Notably the highest byte in the wasm address space is no longer allocatable and additionally the allocator internally uses `wrapping_add` instead of `add` on pointers since on 32-bit platforms offsets might be larger than half the address space.

Closes rust-lang/rust#144199

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
