### PR TITLE
rustfmt.toml: rm unused ignores

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -55,8 +55,4 @@ ignore = [
     # Code automatically generated and included.
     "compiler/rustc_codegen_gcc/src/intrinsic/archs.rs",
     "compiler/rustc_codegen_gcc/example",
-
-    # Rustfmt doesn't support use closures yet
-    "tests/mir-opt/ergonomic-clones/closure.rs",
-    "tests/codegen-llvm/ergonomic-clones/closure.rs",
 ]


### PR DESCRIPTION
Removing these ignores and running "x fmt" produced no changes, so these entries seem superfluous.