### PR TITLE
Upgrade semicolon_in_expressions_from_macros from warn to deny

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2838,7 +2838,7 @@ declare_lint! {
     /// [issue #79813]: https://github.com/rust-lang/rust/issues/79813
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
-    Warn,
+    Deny,
     "trailing semicolon in macro body used as expression",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.rs
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.rs
@@ -1,9 +1,8 @@
-//@ check-pass
-// Ensure that trailing semicolons cause warnings by default
+// Ensure that trailing semicolons cause errors by default
 
 macro_rules! foo {
     () => {
-        true; //~  WARN trailing semicolon in macro
+        true; //~  ERROR trailing semicolon in macro
               //~| WARN this was previously
     }
 }

--- a/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.stderr
+++ b/tests/ui/lint/semicolon-in-expressions-from-macros/warn-semicolon-in-expressions-from-macros.stderr
@@ -1,5 +1,5 @@
-warning: trailing semicolon in macro used in expression position
-  --> $DIR/warn-semicolon-in-expressions-from-macros.rs:6:13
+error: trailing semicolon in macro used in expression position
+  --> $DIR/warn-semicolon-in-expressions-from-macros.rs:5:13
    |
 LL |         true;
    |             ^
@@ -9,14 +9,14 @@ LL |         _ => foo!()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: trailing semicolon in macro used in expression position
-  --> $DIR/warn-semicolon-in-expressions-from-macros.rs:6:13
+error: trailing semicolon in macro used in expression position
+  --> $DIR/warn-semicolon-in-expressions-from-macros.rs:5:13
    |
 LL |         true;
    |             ^
@@ -26,6 +26,6 @@ LL |         _ => foo!()
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/lint-trailing-macro-call.rs
+++ b/tests/ui/macros/lint-trailing-macro-call.rs
@@ -1,12 +1,10 @@
-//@ check-pass
-//
 // Ensures that we properly lint
 // a removed 'expression' resulting from a macro
 // in trailing expression position
 
 macro_rules! expand_it {
     () => {
-        #[cfg(false)] 25; //~  WARN trailing semicolon in macro
+        #[cfg(false)] 25; //~  ERROR trailing semicolon in macro
                           //~| WARN this was previously
     }
 }

--- a/tests/ui/macros/lint-trailing-macro-call.stderr
+++ b/tests/ui/macros/lint-trailing-macro-call.stderr
@@ -1,5 +1,5 @@
-warning: trailing semicolon in macro used in expression position
-  --> $DIR/lint-trailing-macro-call.rs:9:25
+error: trailing semicolon in macro used in expression position
+  --> $DIR/lint-trailing-macro-call.rs:7:25
    |
 LL |         #[cfg(false)] 25;
    |                         ^
@@ -11,14 +11,14 @@ LL |     expand_it!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
-warning: trailing semicolon in macro used in expression position
-  --> $DIR/lint-trailing-macro-call.rs:9:25
+error: trailing semicolon in macro used in expression position
+  --> $DIR/lint-trailing-macro-call.rs:7:25
    |
 LL |         #[cfg(false)] 25;
    |                         ^
@@ -30,6 +30,6 @@ LL |     expand_it!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `expand_it`
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `expand_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-context.rs
+++ b/tests/ui/macros/macro-context.rs
@@ -6,7 +6,7 @@ macro_rules! m {
                             //~| ERROR macro expansion ignores `;`
                             //~| ERROR cannot find type `i` in this scope
                             //~| ERROR cannot find value `i` in this scope
-                            //~| WARN trailing semicolon in macro
+                            //~| ERROR trailing semicolon in macro
                             //~| WARN this was previously
 }
 

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -64,7 +64,7 @@ LL |     let i = m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: trailing semicolon in macro used in expression position
+error: trailing semicolon in macro used in expression position
   --> $DIR/macro-context.rs:3:15
    |
 LL |     () => ( i ; typeof );
@@ -75,15 +75,15 @@ LL |     let i = m!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0412, E0425.
 For more information about an error, try `rustc --explain E0412`.
 Future incompatibility report: Future breakage diagnostic:
-warning: trailing semicolon in macro used in expression position
+error: trailing semicolon in macro used in expression position
   --> $DIR/macro-context.rs:3:15
    |
 LL |     () => ( i ; typeof );
@@ -94,6 +94,6 @@ LL |     let i = m!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/macro-in-expression-context.fixed
+++ b/tests/ui/macros/macro-in-expression-context.fixed
@@ -3,12 +3,12 @@
 macro_rules! foo {
     () => {
         assert_eq!("A", "A");
-        //~^ WARN trailing semicolon in macro
+        //~^ ERROR trailing semicolon in macro
         //~| WARN this was previously
         //~| NOTE macro invocations at the end of a block
         //~| NOTE to ignore the value produced by the macro
         //~| NOTE for more information
-        //~| NOTE `#[warn(semicolon_in_expressions_from_macros)]` on by default
+        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` on by default
         assert_eq!("B", "B");
     }
     //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following

--- a/tests/ui/macros/macro-in-expression-context.rs
+++ b/tests/ui/macros/macro-in-expression-context.rs
@@ -3,12 +3,12 @@
 macro_rules! foo {
     () => {
         assert_eq!("A", "A");
-        //~^ WARN trailing semicolon in macro
+        //~^ ERROR trailing semicolon in macro
         //~| WARN this was previously
         //~| NOTE macro invocations at the end of a block
         //~| NOTE to ignore the value produced by the macro
         //~| NOTE for more information
-        //~| NOTE `#[warn(semicolon_in_expressions_from_macros)]` on by default
+        //~| NOTE `#[deny(semicolon_in_expressions_from_macros)]` on by default
         assert_eq!("B", "B");
     }
     //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following

--- a/tests/ui/macros/macro-in-expression-context.stderr
+++ b/tests/ui/macros/macro-in-expression-context.stderr
@@ -13,7 +13,7 @@ help: you might be missing a semicolon here
 LL |     foo!();
    |           +
 
-warning: trailing semicolon in macro used in expression position
+error: trailing semicolon in macro used in expression position
   --> $DIR/macro-in-expression-context.rs:5:29
    |
 LL |         assert_eq!("A", "A");
@@ -26,13 +26,13 @@ LL |     foo!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-warning: trailing semicolon in macro used in expression position
+error: trailing semicolon in macro used in expression position
   --> $DIR/macro-in-expression-context.rs:5:29
    |
 LL |         assert_eq!("A", "A");
@@ -45,6 +45,6 @@ LL |     foo!()
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `foo`
-   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
-   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[deny(semicolon_in_expressions_from_macros)]` on by default
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
This is already warn-by-default, and a future compatibility warning (FCW) that warns in dependencies. Upgrade it to deny-by-default, as the next step towards hard error.

Per https://github.com/rust-lang/rust/issues/79813#issuecomment-3109105631