### PR TITLE
Do not include implicit desugared closure from `async fn` in closure type path

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use rustc_data_structures::intern::Interned;
-use rustc_hir::def_id::CrateNum;
+use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::definitions::DisambiguatedDefPathData;
 use rustc_middle::bug;
 use rustc_middle::ty::print::{PrettyPrinter, Print, PrintError, Printer};
@@ -108,6 +108,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -828,6 +828,7 @@ impl<'tcx> LateContext<'tcx> {
 
             fn path_append(
                 &mut self,
+                _def_id: DefId,
                 print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<(), PrintError> {

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -95,6 +95,7 @@ pub trait Printer<'tcx>: Sized {
 
     fn path_append(
         &mut self,
+        def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError>;
@@ -186,6 +187,7 @@ pub trait Printer<'tcx>: Sized {
                 }
 
                 self.path_append(
+                    def_id,
                     |cx: &mut Self| {
                         if trait_qualify_parent {
                             let trait_ref = ty::TraitRef::new(

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -357,6 +357,7 @@ impl<'tcx> Printer<'tcx> for SymbolPrinter<'tcx> {
     }
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -859,6 +859,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
     fn path_append(
         &mut self,
+        _def_id: DefId,
         print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<(), PrintError> {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -276,6 +276,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             fn path_append(
                 &mut self,
+                _def_id: DefId,
                 print_prefix: impl FnOnce(&mut Self) -> Result<(), PrintError>,
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<(), PrintError> {

--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
@@ -1,6 +1,6 @@
-// MIR for `a::{closure#0}` 0 coroutine_drop_async
+// MIR for `a` 0 coroutine_drop_async
 
-fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
+fn a(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _19;
     debug x => ((*(_1.0: &mut {async fn body of a<T>()})).0: T);
     let mut _0: std::task::Poll<()>;

--- a/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -1,6 +1,6 @@
-// MIR for `a::{closure#0}` 0 coroutine_drop_async
+// MIR for `a` 0 coroutine_drop_async
 
-fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
+fn a(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _19;
     debug x => ((*(_1.0: &mut {async fn body of a<T>()})).0: T);
     let mut _0: std::task::Poll<()>;

--- a/tests/mir-opt/building/async_await.a-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.a-{closure#0}.coroutine_resume.0.mir
@@ -1,4 +1,4 @@
-// MIR for `a::{closure#0}` 0 coroutine_resume
+// MIR for `a` 0 coroutine_resume
 /* coroutine_layout = CoroutineLayout {
     field_tys: {},
     variant_fields: {
@@ -9,7 +9,7 @@
     storage_conflicts: BitMatrix(0x0) {},
 } */
 
-fn a::{closure#0}(_1: Pin<&mut {async fn body of a()}>, _2: &mut Context<'_>) -> Poll<()> {
+fn a(_1: Pin<&mut {async fn body of a()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _4;
     let mut _0: std::task::Poll<()>;
     let mut _3: ();

--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -1,4 +1,4 @@
-// MIR for `b::{closure#0}` 0 coroutine_resume
+// MIR for `b` 0 coroutine_resume
 /* coroutine_layout = CoroutineLayout {
     field_tys: {
         _0: CoroutineSavedTy {
@@ -57,7 +57,7 @@
     },
 } */
 
-fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) -> Poll<()> {
+fn b(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) -> Poll<()> {
     debug _task_context => _38;
     let mut _0: std::task::Poll<()>;
     let _3: ();

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -20,7 +20,7 @@
               debug fut => _4;
               scope 3 {
               }
-+             scope 6 (inlined ActionPermit::<'_, T>::perform::{closure#0}) {
++             scope 6 (inlined ActionPermit::<'_, T>::perform) {
 +                 let _11: ActionPermit<'_, T>;
 +                 let mut _12: std::future::Ready<()>;
 +                 let mut _13: std::future::Ready<()>;

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -20,7 +20,7 @@
               debug fut => _4;
               scope 3 {
               }
-+             scope 6 (inlined ActionPermit::<'_, T>::perform::{closure#0}) {
++             scope 6 (inlined ActionPermit::<'_, T>::perform) {
 +                 let _11: ActionPermit<'_, T>;
 +                 let mut _12: std::future::Ready<()>;
 +                 let mut _13: std::future::Ready<()>;

--- a/tests/ui/force-inlining/deny-async.stderr
+++ b/tests/ui/force-inlining/deny-async.stderr
@@ -20,7 +20,7 @@ LL | pub fn callee_justified() {
    |
    = note: incompatible due to: #[rustc_no_mir_inline]
 
-error: `callee` could not be inlined into `async_caller::{closure#0}` but is required to be inlined
+error: `callee` could not be inlined into `async_caller` but is required to be inlined
   --> $DIR/deny-async.rs:22:5
    |
 LL |     callee();
@@ -28,7 +28,7 @@ LL |     callee();
    |
    = note: could not be inlined due to: #[rustc_no_mir_inline]
 
-error: `callee_justified` could not be inlined into `async_caller::{closure#0}` but is required to be inlined
+error: `callee_justified` could not be inlined into `async_caller` but is required to be inlined
   --> $DIR/deny-async.rs:24:5
    |
 LL |     callee_justified();


### PR DESCRIPTION
Make the path of items within an `async fn`, including the implicit `async` closure it desugars to *not* include the `{closure#0}` path segment. So `async fn` `foo::{closure#0}` gets rendered as `foo` instead in diagnostics. This *only* affects the pprinter used for diagnostics, the implicit closure is still included in symbol mangling. End users should not need to be exposed to the inner workings of async desugaring in normal circumstances.

_Noticed while looking at https://github.com/rust-lang/rust/pull/144337 / https://internals.rust-lang.org/t/post-0/23184 to modify the closure rendering without paths. Changing the test runner to use `-Zspan_free_formats` showed many cases where the previous rendering for async functions was quite confusing, particularly for those that had closures within them._