### PR TITLE
Suggest unwrapping when private method name is available in inner type

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -264,6 +264,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_label(within_macro_span, "due to this macro variable");
                 }
                 self.suggest_valid_traits(&mut err, item_name, out_of_scope_traits, true);
+                self.suggest_unwrapping_inner_self(&mut err, source, rcvr_ty, item_name);
                 err.emit()
             }
 

--- a/tests/ui/suggestions/enum-method-probe.fixed
+++ b/tests/ui/suggestions/enum-method-probe.fixed
@@ -56,4 +56,11 @@ fn test_option_in_unit_return() {
     //~| HELP consider using `Option::expect` to unwrap the `Foo` value, panicking if the value is an `Option::None`
 }
 
+fn test_option_private_method() {
+    let res: Option<_> = Some(vec![1, 2, 3]);
+    res.expect("REASON").len();
+    //~^ ERROR method `len` is private
+    //~| HELP consider using `Option::expect` to unwrap the `Vec<{integer}>` value, panicking if the value is an `Option::None`
+}
+
 fn main() {}

--- a/tests/ui/suggestions/enum-method-probe.rs
+++ b/tests/ui/suggestions/enum-method-probe.rs
@@ -56,4 +56,11 @@ fn test_option_in_unit_return() {
     //~| HELP consider using `Option::expect` to unwrap the `Foo` value, panicking if the value is an `Option::None`
 }
 
+fn test_option_private_method() {
+    let res: Option<_> = Some(vec![1, 2, 3]);
+    res.len();
+    //~^ ERROR method `len` is private
+    //~| HELP consider using `Option::expect` to unwrap the `Vec<{integer}>` value, panicking if the value is an `Option::None`
+}
+
 fn main() {}

--- a/tests/ui/suggestions/enum-method-probe.stderr
+++ b/tests/ui/suggestions/enum-method-probe.stderr
@@ -94,6 +94,23 @@ help: consider using `Option::expect` to unwrap the `Foo` value, panicking if th
 LL |     res.expect("REASON").get();
    |        +++++++++++++++++
 
-error: aborting due to 6 previous errors
+error[E0624]: method `len` is private
+  --> $DIR/enum-method-probe.rs:61:9
+   |
+LL |     res.len();
+   |         ^^^ private method
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: private method defined here
+   |
+note: the method `len` exists on the type `Vec<{integer}>`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: consider using `Option::expect` to unwrap the `Vec<{integer}>` value, panicking if the value is an `Option::None`
+   |
+LL |     res.expect("REASON").len();
+   |        +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0599`.
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0599, E0624.
+For more information about an error, try `rustc --explain E0599`.


### PR DESCRIPTION
Given

```rust
fn main() {
    let maybe_vec = Some(vec![1,2,3]);
    assert_eq!(maybe_vec.len(), 3);
}
```

suggest unwraping `maybe_vec` to call `.len()` on the `Vec<_>`.

```
error[E0624]: method `len` is private
  --> $DIR/enum-method-probe.rs:61:9
   |
LL |     res.len();
   |         ^^^ private method
  --> $SRC_DIR/core/src/option.rs:LL:COL
   |
   = note: private method defined here
   |
note: the method `len` exists on the type `Vec<{integer}>`
  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
help: consider using `Option::expect` to unwrap the `Vec<{integer}>` value, panicking if the value is an `Option::None`
   |
LL |     res.expect("REASON").len();
   |        +++++++++++++++++
```

When a method isn't available, we emit E0599, but when it is private we emit E0624. We now just invoke the same suggestion logic from the later that we already did in the former.

Fix rust-lang/rust#143795.