### PR TITLE
disable cfg.has_reliable_f128 on amdgcn

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -405,6 +405,8 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         ("mips64" | "mips64r6", _) => false,
         // Selection bug <https://github.com/llvm/llvm-project/issues/95471>
         ("nvptx64", _) => false,
+        // Unsupported https://github.com/llvm/llvm-project/issues/121122
+        ("amdgpu", _) => false,
         // ABI bugs <https://github.com/rust-lang/rust/issues/125109> et al. (full
         // list at <https://github.com/rust-lang/rust/issues/116909>)
         ("powerpc" | "powerpc64", _) => false,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
I was experimenting with compiling a few kernels for amd while working on std::offload. It seems like the logic in https://github.com/rust-lang/compiler-builtins/pull/737 got removed, so I re-introduce it here. Probably should have a test to avoid another regression and make sure that f128 doesn't show up as target feature for amdgcn. It looks like currently we neither check that for nvptx, nor amdgpu. Maybe I could add two revisions to https://github.com/rust-lang/rust/blob/master/tests/ui/float/target-has-reliable-nightly-float.rs? 
r? @Flakebi 

fixes: https://github.com/rust-lang/rust/issues/144381