### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,10 @@ dependencies = [
  "rustc_macros",
  "rustc_serialize",
  "rustc_span",
+ "serde",
+ "serde_derive",
  "serde_json",
+ "serde_path_to_error",
  "tracing",
 ]
 
@@ -4867,6 +4870,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -74,8 +74,15 @@ impl<S: Stage> AttributeParser<S> for StabilityParser {
             template!(NameValueStr: "deprecation message"),
             |this, cx, args| {
                 reject_outside_std!(cx);
-                this.allowed_through_unstable_modules =
-                    args.name_value().and_then(|i| i.value_as_str())
+                let Some(nv) = args.name_value() else {
+                    cx.expected_name_value(cx.attr_span, None);
+                    return;
+                };
+                let Some(value_str) = nv.value_as_str() else {
+                    cx.expected_string_literal(nv.value_span, Some(nv.value_as_lit()));
+                    return;
+                };
+                this.allowed_through_unstable_modules = Some(value_str);
             },
         ),
     ];
@@ -247,7 +254,12 @@ pub(crate) fn parse_stability<S: Stage>(
     let mut feature = None;
     let mut since = None;
 
-    for param in args.list()?.mixed() {
+    let ArgParser::List(list) = args else {
+        cx.expected_list(cx.attr_span);
+        return None;
+    };
+
+    for param in list.mixed() {
         let param_span = param.span();
         let Some(param) = param.meta_item() else {
             cx.emit_err(session_diagnostics::UnsupportedLiteral {
@@ -322,7 +334,13 @@ pub(crate) fn parse_unstability<S: Stage>(
     let mut is_soft = false;
     let mut implied_by = None;
     let mut old_name = None;
-    for param in args.list()?.mixed() {
+
+    let ArgParser::List(list) = args else {
+        cx.expected_list(cx.attr_span);
+        return None;
+    };
+
+    for param in list.mixed() {
         let Some(param) = param.meta_item() else {
             cx.emit_err(session_diagnostics::UnsupportedLiteral {
                 span: param.span(),

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1742,6 +1742,21 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         call
     }
 
+    fn tail_call(
+        &mut self,
+        _llty: Self::Type,
+        _fn_attrs: Option<&CodegenFnAttrs>,
+        _fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
+        _llfn: Self::Value,
+        _args: &[Self::Value],
+        _funclet: Option<&Self::Funclet>,
+        _instance: Option<Instance<'tcx>>,
+    ) {
+        bug!(
+            "Guaranteed tail calls with the 'become' keyword are not implemented in the GCC backend"
+        );
+    }
+
     fn zext(&mut self, value: RValue<'gcc>, dest_typ: Type<'gcc>) -> RValue<'gcc> {
         // FIXME(antoyo): this does not zero-extend.
         self.gcc_int_cast(value, dest_typ)

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -15,6 +15,7 @@ use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_hir::def_id::DefId;
+use rustc_middle::bug;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, HasTypingEnv, LayoutError, LayoutOfHelpers,
@@ -24,7 +25,7 @@ use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_sanitizers::{cfi, kcfi};
 use rustc_session::config::OptLevel;
 use rustc_span::Span;
-use rustc_target::callconv::FnAbi;
+use rustc_target::callconv::{FnAbi, PassMode};
 use rustc_target::spec::{HasTargetSpec, SanitizerSet, Target};
 use smallvec::SmallVec;
 use tracing::{debug, instrument};
@@ -1429,6 +1430,29 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             fn_abi.apply_attrs_callsite(self, call);
         }
         call
+    }
+
+    fn tail_call(
+        &mut self,
+        llty: Self::Type,
+        fn_attrs: Option<&CodegenFnAttrs>,
+        fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
+        llfn: Self::Value,
+        args: &[Self::Value],
+        funclet: Option<&Self::Funclet>,
+        instance: Option<Instance<'tcx>>,
+    ) {
+        let call = self.call(llty, fn_attrs, Some(fn_abi), llfn, args, funclet, instance);
+
+        match &fn_abi.ret.mode {
+            PassMode::Ignore | PassMode::Indirect { .. } => self.ret_void(),
+            PassMode::Direct(_) | PassMode::Pair { .. } => self.ret(call),
+            mode @ PassMode::Cast { .. } => {
+                bug!("Encountered `PassMode::{mode:?}` during codegen")
+            }
+        }
+
+        llvm::LLVMSetTailCallKind(call, llvm::TailCallKind::MustTail);
     }
 
     fn zext(&mut self, val: &'ll Value, dest_ty: &'ll Type) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1452,7 +1452,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             }
         }
 
-        llvm::LLVMSetTailCallKind(call, llvm::TailCallKind::MustTail);
+        llvm::LLVMRustSetTailCallKind(call, llvm::TailCallKind::MustTail);
     }
 
     fn zext(&mut self, val: &'ll Value, dest_ty: &'ll Type) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1196,7 +1196,7 @@ unsafe extern "C" {
     pub(crate) safe fn LLVMIsGlobalConstant(GlobalVar: &Value) -> Bool;
     pub(crate) safe fn LLVMSetGlobalConstant(GlobalVar: &Value, IsConstant: Bool);
     pub(crate) safe fn LLVMSetTailCall(CallInst: &Value, IsTailCall: Bool);
-    pub(crate) safe fn LLVMSetTailCallKind(CallInst: &Value, Kind: TailCallKind);
+    pub(crate) safe fn LLVMRustSetTailCallKind(CallInst: &Value, Kind: TailCallKind);
 
     // Operations on attributes
     pub(crate) fn LLVMCreateStringAttribute(

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -97,6 +97,16 @@ pub(crate) enum ModuleFlagMergeBehavior {
 
 // Consts for the LLVM CallConv type, pre-cast to usize.
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
+#[allow(dead_code)]
+pub(crate) enum TailCallKind {
+    None = 0,
+    Tail = 1,
+    MustTail = 2,
+    NoTail = 3,
+}
+
 /// LLVM CallingConv::ID. Should we wrap this?
 ///
 /// See <https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/CallingConv.h>
@@ -1186,6 +1196,7 @@ unsafe extern "C" {
     pub(crate) safe fn LLVMIsGlobalConstant(GlobalVar: &Value) -> Bool;
     pub(crate) safe fn LLVMSetGlobalConstant(GlobalVar: &Value, IsConstant: Bool);
     pub(crate) safe fn LLVMSetTailCall(CallInst: &Value, IsTailCall: Bool);
+    pub(crate) safe fn LLVMSetTailCallKind(CallInst: &Value, Kind: TailCallKind);
 
     // Operations on attributes
     pub(crate) fn LLVMCreateStringAttribute(

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -224,10 +224,6 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
 
         if tail {
             bx.tail_call(fn_ty, fn_attrs, fn_abi, fn_ptr, llargs, self.funclet(fx), instance);
-            for &(tmp, size) in lifetime_ends_after_call {
-                bx.lifetime_end(tmp, size);
-            }
-
             return MergingSucc::False;
         }
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -160,6 +160,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
         mut unwind: mir::UnwindAction,
         lifetime_ends_after_call: &[(Bx::Value, Size)],
         instance: Option<Instance<'tcx>>,
+        tail: bool,
         mergeable_succ: bool,
     ) -> MergingSucc {
         let tcx = bx.tcx();
@@ -220,6 +221,15 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
                 }
             }
         };
+
+        if tail {
+            bx.tail_call(fn_ty, fn_attrs, fn_abi, fn_ptr, llargs, self.funclet(fx), instance);
+            for &(tmp, size) in lifetime_ends_after_call {
+                bx.lifetime_end(tmp, size);
+            }
+
+            return MergingSucc::False;
+        }
 
         if let Some(unwind_block) = unwind_block {
             let ret_llbb = if let Some((_, target)) = destination {
@@ -659,6 +669,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             unwind,
             &[],
             Some(drop_instance),
+            false,
             !maybe_null && mergeable_succ,
         )
     }
@@ -747,8 +758,19 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let (fn_abi, llfn, instance) = common::build_langcall(bx, span, lang_item);
 
         // Codegen the actual panic invoke/call.
-        let merging_succ =
-            helper.do_call(self, bx, fn_abi, llfn, &args, None, unwind, &[], Some(instance), false);
+        let merging_succ = helper.do_call(
+            self,
+            bx,
+            fn_abi,
+            llfn,
+            &args,
+            None,
+            unwind,
+            &[],
+            Some(instance),
+            false,
+            false,
+        );
         assert_eq!(merging_succ, MergingSucc::False);
         MergingSucc::False
     }
@@ -777,6 +799,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::UnwindAction::Unreachable,
             &[],
             Some(instance),
+            false,
             false,
         );
         assert_eq!(merging_succ, MergingSucc::False);
@@ -845,6 +868,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             unwind,
             &[],
             Some(instance),
+            false,
             mergeable_succ,
         ))
     }
@@ -860,6 +884,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         target: Option<mir::BasicBlock>,
         unwind: mir::UnwindAction,
         fn_span: Span,
+        tail: bool,
         mergeable_succ: bool,
     ) -> MergingSucc {
         let source_info = mir::SourceInfo { span: fn_span, ..terminator.source_info };
@@ -1003,8 +1028,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // We still need to call `make_return_dest` even if there's no `target`, since
         // `fn_abi.ret` could be `PassMode::Indirect`, even if it is uninhabited,
         // and `make_return_dest` adds the return-place indirect pointer to `llargs`.
-        let return_dest = self.make_return_dest(bx, destination, &fn_abi.ret, &mut llargs);
-        let destination = target.map(|target| (return_dest, target));
+        let destination = if !tail {
+            let return_dest = self.make_return_dest(bx, destination, &fn_abi.ret, &mut llargs);
+            target.map(|target| (return_dest, target))
+        } else {
+            None
+        };
 
         // Split the rust-call tupled arguments off.
         let (first_args, untuple) = if sig.abi() == ExternAbi::RustCall
@@ -1147,6 +1176,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             unwind,
             &lifetime_ends_after_call,
             instance,
+            tail,
             mergeable_succ,
         )
     }
@@ -1388,15 +1418,23 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 target,
                 unwind,
                 fn_span,
+                false,
                 mergeable_succ(),
             ),
-            mir::TerminatorKind::TailCall { .. } => {
-                // FIXME(explicit_tail_calls): implement tail calls in ssa backend
-                span_bug!(
-                    terminator.source_info.span,
-                    "`TailCall` terminator is not yet supported by `rustc_codegen_ssa`"
-                )
-            }
+            mir::TerminatorKind::TailCall { ref func, ref args, fn_span } => self
+                .codegen_call_terminator(
+                    helper,
+                    bx,
+                    terminator,
+                    func,
+                    args,
+                    mir::Place::from(mir::RETURN_PLACE),
+                    None,
+                    mir::UnwindAction::Unreachable,
+                    fn_span,
+                    true,
+                    mergeable_succ(),
+                ),
             mir::TerminatorKind::CoroutineDrop | mir::TerminatorKind::Yield { .. } => {
                 bug!("coroutine ops in codegen")
             }

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1046,9 +1046,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let mut lifetime_ends_after_call: Vec<(Bx::Value, Size)> = Vec::new();
         'make_args: for (i, arg) in first_args.iter().enumerate() {
             if tail && matches!(fn_abi.args[i].mode, PassMode::Indirect { .. }) {
-                bug!(
-                    r"Arguments using PassMode::Indirect are currently not supported for tail calls.
-                    See https://github.com/rust-lang/rust/pull/144232#discussion_r2218543841 for more information."
+                span_bug!(
+                    fn_span,
+                    "arguments using PassMode::Indirect are currently not supported for tail calls"
                 );
             }
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1045,6 +1045,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // to generate `lifetime_end` when the call returns.
         let mut lifetime_ends_after_call: Vec<(Bx::Value, Size)> = Vec::new();
         'make_args: for (i, arg) in first_args.iter().enumerate() {
+            if tail && matches!(fn_abi.args[i].mode, PassMode::Indirect { .. }) {
+                bug!(
+                    r"Arguments using PassMode::Indirect are currently not supported for tail calls.
+                    See https://github.com/rust-lang/rust/pull/144232#discussion_r2218543841 for more information."
+                );
+            }
+
             let mut op = self.codegen_operand(bx, &arg.node);
 
             if let (0, Some(ty::InstanceKind::Virtual(_, idx))) = (i, instance.map(|i| i.def)) {

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -595,6 +595,18 @@ pub trait BuilderMethods<'a, 'tcx>:
         funclet: Option<&Self::Funclet>,
         instance: Option<Instance<'tcx>>,
     ) -> Self::Value;
+
+    fn tail_call(
+        &mut self,
+        llty: Self::Type,
+        fn_attrs: Option<&CodegenFnAttrs>,
+        fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
+        llfn: Self::Value,
+        args: &[Self::Value],
+        funclet: Option<&Self::Funclet>,
+        instance: Option<Instance<'tcx>>,
+    );
+
     fn zext(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
 
     fn apply_attrs_to_cleanup_callsite(&mut self, llret: Self::Value);

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -1047,7 +1047,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             }
                         }
                     }
-                    lint.note("for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
+                    lint.note("for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>");
 
                     let diagnostic_msg = format!(
                         "add a dummy let to cause {migrated_variables_concat} to be fully captured"

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -569,7 +569,7 @@ lint_non_camel_case_type = {$sort} `{$name}` should have an upper camel case nam
 
 lint_non_fmt_panic = panic message is not a string literal
     .note = this usage of `{$name}!()` is deprecated; it will be a hard error in Rust 2021
-    .more_info_note = for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+    .more_info_note = for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
     .supports_fmt_note = the `{$name}!()` macro supports formatting, so there's no need for the `format!()` macro here
     .supports_fmt_suggestion = remove the `format!(..)` macro call
     .display_suggestion = add a "{"{"}{"}"}" format string to `Display` the message

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1651,7 +1651,7 @@ declare_lint! {
     "`...` range patterns are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>",
     };
 }
 
@@ -1832,7 +1832,7 @@ declare_lint! {
     "detects edition keywords being used as an identifier",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -87,7 +87,7 @@ declare_lint! {
     rewriting in `match` is an option to preserve the semantics up to Edition 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -71,7 +71,7 @@ declare_lint! {
     "`impl Trait` will capture more lifetimes than possibly intended in edition 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
+++ b/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
@@ -65,7 +65,7 @@ declare_lint! {
     /// to ensure the macros implement the desired behavior.
     ///
     /// [editions]: https://doc.rust-lang.org/edition-guide/
-    /// [macro matcher fragment specifiers]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html
+    /// [macro matcher fragment specifiers]: https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html
     /// [`cargo fix`]: https://doc.rust-lang.org/cargo/commands/cargo-fix.html
     pub EDITION_2024_EXPR_FRAGMENT_SPECIFIER,
     Allow,
@@ -73,7 +73,7 @@ declare_lint! {
     To keep the existing behavior, use the `expr_2021` fragment specifier.",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>",
+        reference: "Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/shadowed_into_iter.rs
+++ b/compiler/rustc_lint/src/shadowed_into_iter.rs
@@ -32,7 +32,7 @@ declare_lint! {
     "detects calling `into_iter` on arrays in Rust 2015 and 2018",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>",
     };
 }
 
@@ -61,7 +61,7 @@ declare_lint! {
     "detects calling `into_iter` on boxed slices in Rust 2015, 2018, and 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>"
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>"
     };
 }
 

--- a/compiler/rustc_lint/src/static_mut_refs.rs
+++ b/compiler/rustc_lint/src/static_mut_refs.rs
@@ -54,7 +54,7 @@ declare_lint! {
     "creating a shared reference to mutable static",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>",
         explain_reason: false,
     };
     @edition Edition2024 => Deny;

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1814,7 +1814,7 @@ declare_lint! {
     "suggest using `dyn Trait` for trait objects",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>",
     };
 }
 
@@ -2472,7 +2472,7 @@ declare_lint! {
     "unsafe operations in unsafe functions without an explicit unsafe block are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>",
         explain_reason: false
     };
     @edition Edition2024 => Warn;
@@ -3445,7 +3445,7 @@ declare_lint! {
     "detects usage of old versions of or-patterns",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>",
     };
 }
 
@@ -3494,7 +3494,7 @@ declare_lint! {
         prelude in future editions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>",
     };
 }
 
@@ -3534,7 +3534,7 @@ declare_lint! {
         prelude in future editions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>",
     };
 }
 
@@ -3571,7 +3571,7 @@ declare_lint! {
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>",
     };
     crate_level_only
 }
@@ -4100,7 +4100,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>",
         report_in_deps: true,
     };
     @edition Edition2024 => Deny;
@@ -4155,7 +4155,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>",
         report_in_deps: true,
     };
     report_in_external_macro
@@ -4740,7 +4740,7 @@ declare_lint! {
     "detects unsafe functions being used as safe functions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>",
     };
 }
 
@@ -4776,7 +4776,7 @@ declare_lint! {
     "detects missing unsafe keyword on extern declarations",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html>",
     };
 }
 
@@ -4817,7 +4817,7 @@ declare_lint! {
     "detects unsafe attributes outside of unsafe",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>",
     };
 }
 
@@ -5014,7 +5014,7 @@ declare_lint! {
     "Detect and warn on significant change in drop order in tail expression location",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>",
     };
 }
 
@@ -5053,7 +5053,7 @@ declare_lint! {
     "will be parsed as a guarded string in Rust 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>",
+        reference: "<https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>",
     };
     crate_level_only
 }

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -51,14 +51,6 @@
 //
 //===----------------------------------------------------------------------===
 
-// Define TailCallKind enum values to match LLVM's
-enum LLVMRustTailCallKind {
-  LLVMRustTailCallKindNone = 0,
-  LLVMRustTailCallKindTail = 1,
-  LLVMRustTailCallKindMustTail = 2,
-  LLVMRustTailCallKindNoTail = 3
-};
-
 using namespace llvm;
 using namespace llvm::sys;
 using namespace llvm::object;
@@ -1995,7 +1987,14 @@ extern "C" void LLVMRustSetNoSanitizeHWAddress(LLVMValueRef Global) {
   GV.setSanitizerMetadata(MD);
 }
 
-extern "C" void LLVMSetTailCallKind(LLVMValueRef Call,
+enum LLVMRustTailCallKind {
+  LLVMRustTailCallKindNone = 0,
+  LLVMRustTailCallKindTail = 1,
+  LLVMRustTailCallKindMustTail = 2,
+  LLVMRustTailCallKindNoTail = 3
+};
+
+extern "C" void LLVMRustSetTailCallKind(LLVMValueRef Call,
                                         LLVMRustTailCallKind Kind) {
   CallInst *CI = unwrap<CallInst>(Call);
   switch (Kind) {

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -51,6 +51,14 @@
 //
 //===----------------------------------------------------------------------===
 
+// Define TailCallKind enum values to match LLVM's
+enum LLVMRustTailCallKind {
+  LLVMRustTailCallKindNone = 0,
+  LLVMRustTailCallKindTail = 1,
+  LLVMRustTailCallKindMustTail = 2,
+  LLVMRustTailCallKindNoTail = 3
+};
+
 using namespace llvm;
 using namespace llvm::sys;
 using namespace llvm::object;
@@ -1985,4 +1993,23 @@ extern "C" void LLVMRustSetNoSanitizeHWAddress(LLVMValueRef Global) {
     MD = GV.getSanitizerMetadata();
   MD.NoHWAddress = true;
   GV.setSanitizerMetadata(MD);
+}
+
+extern "C" void LLVMSetTailCallKind(LLVMValueRef Call,
+                                        LLVMRustTailCallKind Kind) {
+  CallInst *CI = unwrap<CallInst>(Call);
+  switch (Kind) {
+  case LLVMRustTailCallKindNone:
+    CI->setTailCallKind(CallInst::TCK_None);
+    break;
+  case LLVMRustTailCallKindTail:
+    CI->setTailCallKind(CallInst::TCK_Tail);
+    break;
+  case LLVMRustTailCallKindMustTail:
+    CI->setTailCallKind(CallInst::TCK_MustTail);
+    break;
+  case LLVMRustTailCallKindNoTail:
+    CI->setTailCallKind(CallInst::TCK_NoTail);
+    break;
+  }
 }

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -330,3 +330,6 @@ metadata_wasm_import_form =
 
 metadata_whole_archive_needs_static =
     linking modifier `whole-archive` is only compatible with `static` linking kind
+
+metadata_raw_dylib_malformed =
+    link name must be well-formed if link kind is `raw-dylib`

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -815,3 +815,10 @@ pub struct AsyncDropTypesInDependency {
     pub extern_crate: Symbol,
     pub local_crate: Symbol,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_raw_dylib_malformed)]
+pub struct RawDylibMalformed {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -143,10 +143,8 @@ impl<'tcx> MonoItem<'tcx> {
         };
 
         // Similarly, the executable entrypoint must be instantiated exactly once.
-        if let Some((entry_def_id, _)) = tcx.entry_fn(()) {
-            if instance.def_id() == entry_def_id {
-                return InstantiationMode::GloballyShared { may_conflict: false };
-            }
+        if tcx.is_entrypoint(instance.def_id()) {
+            return InstantiationMode::GloballyShared { may_conflict: false };
         }
 
         // If the function is #[naked] or contains any other attribute that requires exactly-once

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2152,9 +2152,6 @@ rustc_queries! {
         desc { |tcx| "collecting child items of module `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
-    query extern_mod_stmt_cnum(def_id: LocalDefId) -> Option<CrateNum> {
-        desc { |tcx| "computing crate imported by `{}`", tcx.def_path_str(def_id) }
-    }
 
     /// Gets the number of definitions in a foreign crate.
     ///

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -3373,6 +3373,11 @@ impl<'tcx> TyCtxt<'tcx> {
         self.resolutions(()).module_children.get(&def_id).map_or(&[], |v| &v[..])
     }
 
+    /// Return the crate imported by given use item.
+    pub fn extern_mod_stmt_cnum(self, def_id: LocalDefId) -> Option<CrateNum> {
+        self.resolutions(()).extern_crate_map.get(&def_id).copied()
+    }
+
     pub fn resolver_for_lowering(self) -> &'tcx Steal<(ty::ResolverAstLowering, Arc<ast::Crate>)> {
         self.resolver_for_lowering_raw(()).0
     }
@@ -3428,8 +3433,6 @@ pub struct DeducedParamAttrs {
 }
 
 pub fn provide(providers: &mut Providers) {
-    providers.extern_mod_stmt_cnum =
-        |tcx, id| tcx.resolutions(()).extern_crate_map.get(&id).cloned();
     providers.is_panic_runtime =
         |tcx, LocalCrate| contains_name(tcx.hir_krate_attrs(), sym::panic_runtime);
     providers.is_compiler_builtins =

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -3402,6 +3402,20 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn do_not_recommend_impl(self, def_id: DefId) -> bool {
         self.get_diagnostic_attr(def_id, sym::do_not_recommend).is_some()
     }
+
+    /// Whether this def is one of the special bin crate entrypoint functions that must have a
+    /// monomorphization and also not be internalized in the bin crate.
+    pub fn is_entrypoint(self, def_id: DefId) -> bool {
+        if self.is_lang_item(def_id, LangItem::Start) {
+            return true;
+        }
+        if let Some((entry_def_id, _)) = self.entry_fn(())
+            && entry_def_id == def_id
+        {
+            return true;
+        }
+        false
+    }
 }
 
 /// Parameter attributes that can only be determined by examining the body of a function instead

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1582,6 +1582,15 @@ impl<'v> RootCollector<'_, 'v> {
             return;
         };
 
+        let main_instance = Instance::mono(self.tcx, main_def_id);
+        if self.tcx.should_codegen_locally(main_instance) {
+            self.output.push(create_fn_mono_item(
+                self.tcx,
+                main_instance,
+                self.tcx.def_span(main_def_id),
+            ));
+        }
+
         let Some(start_def_id) = self.tcx.lang_items().start_fn() else {
             self.tcx.dcx().emit_fatal(errors::StartNotFound);
         };

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -285,6 +285,9 @@ pub fn check_builtin_meta_item(
                 | sym::rustc_do_not_implement_via_object
                 | sym::rustc_coinductive
                 | sym::const_trait
+                | sym::stable
+                | sym::unstable
+                | sym::rustc_allowed_through_unstable_modules
                 | sym::rustc_specialization_trait
                 | sym::rustc_unsafe_specialization_marker
                 | sym::rustc_allow_incoherent_impl

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1255,7 +1255,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             return;
         }
 
-        if self.tcx.extern_mod_stmt_cnum(hir_id.owner).is_none() {
+        if self.tcx.extern_mod_stmt_cnum(hir_id.owner.def_id).is_none() {
             self.tcx.emit_node_span_lint(
                 INVALID_DOC_ATTRIBUTES,
                 hir_id,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -26,7 +26,7 @@ use rustc_errors::{MultiSpan, listify};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LocalDefId, LocalModDefId};
 use rustc_hir::intravisit::{self, InferKind, Visitor};
-use rustc_hir::{AmbigArg, ForeignItemKind, ItemId, ItemKind, PatKind};
+use rustc_hir::{AmbigArg, ForeignItemId, ItemId, PatKind};
 use rustc_middle::middle::privacy::{EffectiveVisibilities, EffectiveVisibility, Level};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::print::PrintTraitRefExt as _;
@@ -599,18 +599,13 @@ impl<'tcx> EmbargoVisitor<'tcx> {
 
             DefKind::Struct | DefKind::Union => {
                 // While structs and unions have type privacy, their fields do not.
-                let item = self.tcx.hir_expect_item(def_id);
-                if let hir::ItemKind::Struct(_, _, ref struct_def)
-                | hir::ItemKind::Union(_, _, ref struct_def) = item.kind
-                {
-                    for field in struct_def.fields() {
-                        let field_vis = self.tcx.local_visibility(field.def_id);
-                        if field_vis.is_accessible_from(module, self.tcx) {
-                            self.reach(field.def_id, macro_ev).ty();
-                        }
+                let struct_def = self.tcx.adt_def(def_id);
+                for field in struct_def.non_enum_variant().fields.iter() {
+                    let def_id = field.did.expect_local();
+                    let field_vis = self.tcx.local_visibility(def_id);
+                    if field_vis.is_accessible_from(module, self.tcx) {
+                        self.reach(def_id, macro_ev).ty();
                     }
-                } else {
-                    bug!("item {:?} with DefKind {:?}", item, def_kind);
                 }
             }
 
@@ -1640,66 +1635,29 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'_, 'tcx> {
                 self.check(def_id, item_visibility, effective_vis).generics().predicates();
             }
             DefKind::Enum => {
-                let item = tcx.hir_item(id);
-                if let hir::ItemKind::Enum(_, _, ref def) = item.kind {
-                    self.check_unnameable(item.owner_id.def_id, effective_vis);
+                self.check_unnameable(def_id, effective_vis);
+                self.check(def_id, item_visibility, effective_vis).generics().predicates();
 
-                    self.check(item.owner_id.def_id, item_visibility, effective_vis)
-                        .generics()
-                        .predicates();
-
-                    for variant in def.variants {
-                        for field in variant.data.fields() {
-                            self.check(field.def_id, item_visibility, effective_vis).ty();
-                        }
-                    }
-                }
-            }
-            // Subitems of foreign modules have their own publicity.
-            DefKind::ForeignMod => {
-                let item = tcx.hir_item(id);
-                if let hir::ItemKind::ForeignMod { items, .. } = item.kind {
-                    for &foreign_item in items {
-                        let foreign_item = tcx.hir_foreign_item(foreign_item);
-
-                        let ev = self.get(foreign_item.owner_id.def_id);
-                        let vis = tcx.local_visibility(foreign_item.owner_id.def_id);
-
-                        if let ForeignItemKind::Type = foreign_item.kind {
-                            self.check_unnameable(foreign_item.owner_id.def_id, ev);
-                        }
-
-                        self.check(foreign_item.owner_id.def_id, vis, ev)
-                            .generics()
-                            .predicates()
-                            .ty();
-                    }
+                let adt = tcx.adt_def(id.owner_id);
+                for field in adt.all_fields() {
+                    self.check(field.did.expect_local(), item_visibility, effective_vis).ty();
                 }
             }
             // Subitems of structs and unions have their own publicity.
             DefKind::Struct | DefKind::Union => {
-                let item = tcx.hir_item(id);
-                if let hir::ItemKind::Struct(_, _, ref struct_def)
-                | hir::ItemKind::Union(_, _, ref struct_def) = item.kind
-                {
-                    self.check_unnameable(item.owner_id.def_id, effective_vis);
-                    self.check(item.owner_id.def_id, item_visibility, effective_vis)
-                        .generics()
-                        .predicates();
+                self.check_unnameable(def_id, effective_vis);
+                self.check(def_id, item_visibility, effective_vis).generics().predicates();
 
-                    for field in struct_def.fields() {
-                        let field_visibility = tcx.local_visibility(field.def_id);
-                        let field_ev = self.get(field.def_id);
+                let adt = tcx.adt_def(id.owner_id);
+                for field in adt.all_fields() {
+                    let visibility = min(item_visibility, field.vis.expect_local(), tcx);
+                    let field_ev = self.get(field.did.expect_local());
 
-                        self.check(
-                            field.def_id,
-                            min(item_visibility, field_visibility, tcx),
-                            field_ev,
-                        )
-                        .ty();
-                    }
+                    self.check(field.did.expect_local(), visibility, field_ev).ty();
                 }
             }
+            // Subitems of foreign modules have their own publicity.
+            DefKind::ForeignMod => {}
             // An inherent impl is public when its type is public
             // Subitems of inherent impls have their own publicity.
             // A trait impl is public when both its type and its trait are public
@@ -1755,6 +1713,19 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'_, 'tcx> {
             _ => {}
         }
     }
+
+    fn check_foreign_item(&mut self, id: ForeignItemId) {
+        let tcx = self.tcx;
+        let def_id = id.owner_id.def_id;
+        let item_visibility = tcx.local_visibility(def_id);
+        let effective_vis = self.get(def_id);
+
+        if let DefKind::ForeignTy = self.tcx.def_kind(def_id) {
+            self.check_unnameable(def_id, effective_vis);
+        }
+
+        self.check(def_id, item_visibility, effective_vis).generics().predicates().ty();
+    }
 }
 
 pub fn provide(providers: &mut Providers) {
@@ -1783,20 +1754,13 @@ fn check_mod_privacy(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
         if let Some(body_id) = tcx.hir_maybe_body_owned_by(def_id) {
             visitor.visit_nested_body(body_id.id());
         }
-    }
 
-    for id in module.free_items() {
-        if let ItemKind::Impl(i) = tcx.hir_item(id).kind {
-            if let Some(item) = i.of_trait {
-                let trait_ref = tcx.impl_trait_ref(id.owner_id.def_id).unwrap();
-                let trait_ref = trait_ref.instantiate_identity();
-                visitor.span = item.path.span;
-                let _ = visitor.visit_def_id(
-                    trait_ref.def_id,
-                    "trait",
-                    &trait_ref.print_only_trait_path(),
-                );
-            }
+        if let DefKind::Impl { of_trait: true } = tcx.def_kind(def_id) {
+            let trait_ref = tcx.impl_trait_ref(def_id).unwrap();
+            let trait_ref = trait_ref.instantiate_identity();
+            visitor.span = tcx.hir_expect_item(def_id).expect_impl().of_trait.unwrap().path.span;
+            let _ =
+                visitor.visit_def_id(trait_ref.def_id, "trait", &trait_ref.print_only_trait_path());
         }
     }
 }
@@ -1887,7 +1851,11 @@ fn check_private_in_public(tcx: TyCtxt<'_>, (): ()) {
     // Check for private types in public interfaces.
     let mut checker = PrivateItemsInPublicInterfacesChecker { tcx, effective_visibilities };
 
-    for id in tcx.hir_free_items() {
+    let crate_items = tcx.hir_crate_items(());
+    for id in crate_items.free_items() {
         checker.check_item(id);
+    }
+    for id in crate_items.foreign_items() {
+        checker.check_foreign_item(id);
     }
 }

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -509,9 +509,8 @@ fn collect_link_data<'input, F: BrokenLinkCallback<'input>>(
     display_text.map(String::into_boxed_str)
 }
 
-/// Returns a tuple containing a span encompassing all the document fragments and a boolean that is
-/// `true` if any of the fragments are from a macro expansion.
-pub fn span_of_fragments_with_expansion(fragments: &[DocFragment]) -> Option<(Span, bool)> {
+/// Returns a span encompassing all the document fragments.
+pub fn span_of_fragments(fragments: &[DocFragment]) -> Option<Span> {
     let (first_fragment, last_fragment) = match fragments {
         [] => return None,
         [first, .., last] => (first, last),
@@ -520,15 +519,7 @@ pub fn span_of_fragments_with_expansion(fragments: &[DocFragment]) -> Option<(Sp
     if first_fragment.span == DUMMY_SP {
         return None;
     }
-    Some((
-        first_fragment.span.to(last_fragment.span),
-        fragments.iter().any(|frag| frag.from_expansion),
-    ))
-}
-
-/// Returns a span encompassing all the document fragments.
-pub fn span_of_fragments(fragments: &[DocFragment]) -> Option<Span> {
-    span_of_fragments_with_expansion(fragments).map(|(sp, _)| sp)
+    Some(first_fragment.span.to(last_fragment.span))
 }
 
 /// Attempts to match a range of bytes from parsed markdown to a `Span` in the source code.
@@ -686,7 +677,7 @@ pub fn source_span_for_markdown_range_inner(
         }
     }
 
-    let (span, _) = span_of_fragments_with_expansion(fragments)?;
+    let span = span_of_fragments(fragments)?;
     let src_span = span.from_inner(InnerSpan::new(
         md_range.start + start_bytes,
         md_range.end + start_bytes + end_bytes,

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -336,12 +336,12 @@ impl LinkSelfContained {
         if let Some(component_to_enable) = component.strip_prefix('+') {
             self.explicitly_set = None;
             self.enabled_components
-                .insert(LinkSelfContainedComponents::from_str(component_to_enable)?);
+                .insert(LinkSelfContainedComponents::from_str(component_to_enable).ok()?);
             Some(())
         } else if let Some(component_to_disable) = component.strip_prefix('-') {
             self.explicitly_set = None;
             self.disabled_components
-                .insert(LinkSelfContainedComponents::from_str(component_to_disable)?);
+                .insert(LinkSelfContainedComponents::from_str(component_to_disable).ok()?);
             Some(())
         } else {
             None

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1295,7 +1295,7 @@ pub mod parse {
     }
 
     pub(crate) fn parse_linker_flavor(slot: &mut Option<LinkerFlavorCli>, v: Option<&str>) -> bool {
-        match v.and_then(LinkerFlavorCli::from_str) {
+        match v.and_then(|v| LinkerFlavorCli::from_str(v).ok()) {
             Some(lf) => *slot = Some(lf),
             _ => return false,
         }

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -12,7 +12,10 @@ rustc_fs_util = { path = "../rustc_fs_util" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
+serde = "1.0.219"
+serde_derive = "1.0.219"
 serde_json = "1.0.59"
+serde_path_to_error = "0.1.17"
 tracing = "0.1"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_target/src/json.rs
+++ b/compiler/rustc_target/src/json.rs
@@ -114,3 +114,18 @@ impl ToJson for rustc_abi::CanonAbi {
         self.to_string().to_json()
     }
 }
+
+macro_rules! serde_deserialize_from_str {
+    ($ty:ty) => {
+        impl<'de> serde::Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                FromStr::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+pub(crate) use serde_deserialize_from_str;

--- a/compiler/rustc_target/src/tests.rs
+++ b/compiler/rustc_target/src/tests.rs
@@ -2,8 +2,7 @@ use crate::spec::Target;
 
 #[test]
 fn report_unused_fields() {
-    let json = serde_json::from_str(
-        r#"
+    let json = r#"
     {
         "arch": "powerpc64",
         "data-layout": "e-m:e-i64:64-n32:64",
@@ -11,47 +10,8 @@ fn report_unused_fields() {
         "target-pointer-width": "64",
         "code-mode": "foo"
     }
-    "#,
-    )
-    .unwrap();
-    let warnings = Target::from_json(json).unwrap().1;
-    assert_eq!(warnings.warning_messages().len(), 1);
-    assert!(warnings.warning_messages().join("\n").contains("code-mode"));
-}
-
-#[test]
-fn report_incorrect_json_type() {
-    let json = serde_json::from_str(
-        r#"
-    {
-        "arch": "powerpc64",
-        "data-layout": "e-m:e-i64:64-n32:64",
-        "llvm-target": "powerpc64le-elf",
-        "target-pointer-width": "64",
-        "link-env-remove": "foo"
-    }
-    "#,
-    )
-    .unwrap();
-    let warnings = Target::from_json(json).unwrap().1;
-    assert_eq!(warnings.warning_messages().len(), 1);
-    assert!(warnings.warning_messages().join("\n").contains("link-env-remove"));
-}
-
-#[test]
-fn no_warnings_for_valid_target() {
-    let json = serde_json::from_str(
-        r#"
-    {
-        "arch": "powerpc64",
-        "data-layout": "e-m:e-i64:64-n32:64",
-        "llvm-target": "powerpc64le-elf",
-        "target-pointer-width": "64",
-        "link-env-remove": ["foo"]
-    }
-    "#,
-    )
-    .unwrap();
-    let warnings = Target::from_json(json).unwrap().1;
-    assert_eq!(warnings.warning_messages().len(), 0);
+    "#;
+    let result = Target::from_json(json);
+    eprintln!("{result:#?}");
+    assert!(result.is_err());
 }

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -20,6 +20,25 @@ impl<T> Rev<T> {
     pub(in crate::iter) fn new(iter: T) -> Rev<T> {
         Rev { iter }
     }
+
+    /// Consumes the `Rev`, returning the inner iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(rev_into_inner)]
+    ///
+    /// let s = "foobar";
+    /// let mut rev = s.chars().rev();
+    /// assert_eq!(rev.next(), Some('r'));
+    /// assert_eq!(rev.next(), Some('a'));
+    /// assert_eq!(rev.next(), Some('b'));
+    /// assert_eq!(rev.into_inner().collect::<String>(), "foo");
+    /// ```
+    #[unstable(feature = "rev_into_inner", issue = "144277")]
+    pub fn into_inner(self) -> T {
+        self.iter
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/coretests/tests/num/dec2flt/float.rs
+++ b/library/coretests/tests/num/dec2flt/float.rs
@@ -1,13 +1,14 @@
 use core::num::dec2flt::float::RawFloat;
 
+use crate::num::{ldexp_f32, ldexp_f64};
+
 // FIXME(f16_f128): enable on all targets once possible.
 #[test]
 #[cfg(target_has_reliable_f16)]
 fn test_f16_integer_decode() {
     assert_eq!(3.14159265359f16.integer_decode(), (1608, -9, 1));
     assert_eq!((-8573.5918555f16).integer_decode(), (1072, 3, -1));
-    #[cfg(not(miri))] // miri doesn't have powf16
-    assert_eq!(2f16.powf(14.0).integer_decode(), (1 << 10, 4, 1));
+    assert_eq!(crate::num::ldexp_f16(1.0, 14).integer_decode(), (1 << 10, 4, 1));
     assert_eq!(0f16.integer_decode(), (0, -25, 1));
     assert_eq!((-0f16).integer_decode(), (0, -25, -1));
     assert_eq!(f16::INFINITY.integer_decode(), (1 << 10, 6, 1));
@@ -23,8 +24,7 @@ fn test_f16_integer_decode() {
 fn test_f32_integer_decode() {
     assert_eq!(3.14159265359f32.integer_decode(), (13176795, -22, 1));
     assert_eq!((-8573.5918555f32).integer_decode(), (8779358, -10, -1));
-    // Set 2^100 directly instead of using powf, because it doesn't guarantee precision
-    assert_eq!(1.2676506e30_f32.integer_decode(), (8388608, 77, 1));
+    assert_eq!(ldexp_f32(1.0, 100).integer_decode(), (8388608, 77, 1));
     assert_eq!(0f32.integer_decode(), (0, -150, 1));
     assert_eq!((-0f32).integer_decode(), (0, -150, -1));
     assert_eq!(f32::INFINITY.integer_decode(), (8388608, 105, 1));
@@ -40,8 +40,7 @@ fn test_f32_integer_decode() {
 fn test_f64_integer_decode() {
     assert_eq!(3.14159265359f64.integer_decode(), (7074237752028906, -51, 1));
     assert_eq!((-8573.5918555f64).integer_decode(), (4713381968463931, -39, -1));
-    // Set 2^100 directly instead of using powf, because it doesn't guarantee precision
-    assert_eq!(1.2676506002282294e30_f64.integer_decode(), (4503599627370496, 48, 1));
+    assert_eq!(ldexp_f64(1.0, 100).integer_decode(), (4503599627370496, 48, 1));
     assert_eq!(0f64.integer_decode(), (0, -1075, 1));
     assert_eq!((-0f64).integer_decode(), (0, -1075, -1));
     assert_eq!(f64::INFINITY.integer_decode(), (4503599627370496, 972, 1));

--- a/library/coretests/tests/num/flt2dec/estimator.rs
+++ b/library/coretests/tests/num/flt2dec/estimator.rs
@@ -1,5 +1,7 @@
 use core::num::flt2dec::estimator::*;
 
+use crate::num::ldexp_f64;
+
 #[test]
 fn test_estimate_scaling_factor() {
     macro_rules! assert_almost_eq {
@@ -56,7 +58,7 @@ fn test_estimate_scaling_factor() {
     let step = if cfg!(miri) { 37 } else { 1 };
 
     for i in (-1074..972).step_by(step) {
-        let expected = super::ldexp_f64(1.0, i).log10().ceil();
+        let expected = ldexp_f64(1.0, i).log10().ceil();
         assert_almost_eq!(estimate_scaling_factor(1, i as i16), expected as i16);
     }
 }

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -54,6 +54,27 @@ macro_rules! assume_usize_width {
     }
 }
 
+/// Return `a * 2^b`.
+#[cfg(target_has_reliable_f16)]
+fn ldexp_f16(a: f16, b: i32) -> f16 {
+    ldexp_f64(a as f64, b) as f16
+}
+
+/// Return `a * 2^b`.
+fn ldexp_f32(a: f32, b: i32) -> f32 {
+    ldexp_f64(a as f64, b) as f32
+}
+
+/// Return `a * 2^b`.
+fn ldexp_f64(a: f64, b: i32) -> f64 {
+    unsafe extern "C" {
+        fn ldexp(x: f64, n: i32) -> f64;
+    }
+    // SAFETY: assuming a correct `ldexp` has been supplied, the given arguments cannot possibly
+    // cause undefined behavior
+    unsafe { ldexp(a, b) }
+}
+
 /// Helper function for testing numeric operations
 pub fn test_num<T>(ten: T, two: T)
 where

--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -86,11 +86,11 @@ impl TcpStream {
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        unsupported()
+        self.inner.peer_addr()
     }
 
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
-        unsupported()
+        self.inner.socket_addr()
     }
 
     pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
@@ -114,7 +114,7 @@ impl TcpStream {
     }
 
     pub fn nodelay(&self) -> io::Result<bool> {
-        unsupported()
+        self.inner.nodelay()
     }
 
     pub fn set_ttl(&self, _: u32) -> io::Result<()> {
@@ -122,7 +122,7 @@ impl TcpStream {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        unsupported()
+        self.inner.ttl()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
@@ -140,7 +140,9 @@ impl fmt::Debug for TcpStream {
     }
 }
 
-pub struct TcpListener(!);
+pub struct TcpListener {
+    inner: tcp::Tcp,
+}
 
 impl TcpListener {
     pub fn bind(_: io::Result<&SocketAddr>) -> io::Result<TcpListener> {
@@ -148,45 +150,45 @@ impl TcpListener {
     }
 
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
-        self.0
+        unsupported()
     }
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.0
+        unsupported()
     }
 
     pub fn duplicate(&self) -> io::Result<TcpListener> {
-        self.0
+        unsupported()
     }
 
     pub fn set_ttl(&self, _: u32) -> io::Result<()> {
-        self.0
+        unsupported()
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        self.0
+        self.inner.ttl()
     }
 
     pub fn set_only_v6(&self, _: bool) -> io::Result<()> {
-        self.0
+        unsupported()
     }
 
     pub fn only_v6(&self) -> io::Result<bool> {
-        self.0
+        unsupported()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        self.0
+        unsupported()
     }
 
     pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
-        self.0
+        unsupported()
     }
 }
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0
+        todo!()
     }
 }
 

--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -1,6 +1,8 @@
 use super::tcp4;
 use crate::io;
 use crate::net::SocketAddr;
+use crate::ptr::NonNull;
+use crate::sys::{helpers, unsupported};
 use crate::time::Duration;
 
 pub(crate) enum Tcp {
@@ -29,6 +31,46 @@ impl Tcp {
     pub(crate) fn read(&self, buf: &mut [u8], timeout: Option<Duration>) -> io::Result<usize> {
         match self {
             Self::V4(client) => client.read(buf, timeout),
+        }
+    }
+
+    pub(crate) fn ttl(&self) -> io::Result<u32> {
+        match self {
+            Self::V4(client) => client.get_mode_data().map(|x| x.time_to_live.into()),
+        }
+    }
+
+    pub(crate) fn nodelay(&self) -> io::Result<bool> {
+        match self {
+            Self::V4(client) => {
+                let temp = client.get_mode_data()?;
+                match NonNull::new(temp.control_option) {
+                    Some(x) => unsafe { Ok(x.as_ref().enable_nagle.into()) },
+                    None => unsupported(),
+                }
+            }
+        }
+    }
+
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        match self {
+            Self::V4(client) => client.get_mode_data().map(|x| {
+                SocketAddr::new(
+                    helpers::ipv4_from_r_efi(x.access_point.remote_address).into(),
+                    x.access_point.remote_port,
+                )
+            }),
+        }
+    }
+
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        match self {
+            Self::V4(client) => client.get_mode_data().map(|x| {
+                SocketAddr::new(
+                    helpers::ipv4_from_r_efi(x.access_point.station_address).into(),
+                    x.access_point.station_port,
+                )
+            }),
         }
     }
 }

--- a/library/std/src/sys/net/connection/uefi/tcp4.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp4.rs
@@ -67,6 +67,24 @@ impl Tcp4 {
         if r.is_error() { Err(crate::io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
     }
 
+    pub(crate) fn get_mode_data(&self) -> io::Result<tcp4::ConfigData> {
+        let mut config_data = tcp4::ConfigData::default();
+        let protocol = self.protocol.as_ptr();
+
+        let r = unsafe {
+            ((*protocol).get_mode_data)(
+                protocol,
+                crate::ptr::null_mut(),
+                &mut config_data,
+                crate::ptr::null_mut(),
+                crate::ptr::null_mut(),
+                crate::ptr::null_mut(),
+            )
+        };
+
+        if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(config_data) }
+    }
+
     pub(crate) fn connect(&self, timeout: Option<Duration>) -> io::Result<()> {
         let evt = unsafe { self.create_evt() }?;
         let completion_token =

--- a/library/std/src/sys/pal/uefi/helpers.rs
+++ b/library/std/src/sys/pal/uefi/helpers.rs
@@ -761,3 +761,7 @@ impl Drop for OwnedEvent {
 pub(crate) const fn ipv4_to_r_efi(addr: crate::net::Ipv4Addr) -> efi::Ipv4Address {
     efi::Ipv4Address { addr: addr.octets() }
 }
+
+pub(crate) const fn ipv4_from_r_efi(ip: efi::Ipv4Address) -> crate::net::Ipv4Addr {
+    crate::net::Ipv4Addr::new(ip.addr[0], ip.addr[1], ip.addr[2], ip.addr[3])
+}

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1113,6 +1113,12 @@ impl Step for Tidy {
             8 * std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get) as u32
         });
         cmd.arg(jobs.to_string());
+        // pass the path to the npm command used for installing js deps.
+        if let Some(npm) = &builder.config.npm {
+            cmd.arg(npm);
+        } else {
+            cmd.arg("npm");
+        }
         if builder.is_verbose() {
             cmd.arg("--verbose");
         }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -444,7 +444,7 @@ fn add_exe_suffix(input: String, target: &TargetTuple) -> String {
     let exe_suffix = match target {
         TargetTuple::TargetTuple(_) => Target::expect_builtin(target).options.exe_suffix,
         TargetTuple::TargetJson { contents, .. } => {
-            Target::from_json(contents.parse().unwrap()).unwrap().0.options.exe_suffix
+            Target::from_json(contents).unwrap().0.options.exe_suffix
         }
     };
     input + &exe_suffix

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -100,9 +100,22 @@ pub(crate) fn build_index(
     let crate_doc =
         short_markdown_summary(&krate.module.doc_value(), &krate.module.link_names(cache));
 
+    #[derive(Eq, Ord, PartialEq, PartialOrd)]
+    struct SerSymbolAsStr(Symbol);
+
+    impl Serialize for SerSymbolAsStr {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.0.as_str().serialize(serializer)
+        }
+    }
+
+    type AliasMap = BTreeMap<SerSymbolAsStr, Vec<usize>>;
     // Aliases added through `#[doc(alias = "...")]`. Since a few items can have the same alias,
     // we need the alias element to have an array of items.
-    let mut aliases: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    let mut aliases: AliasMap = BTreeMap::new();
 
     // Sort search index items. This improves the compressibility of the search index.
     cache.search_index.sort_unstable_by(|k1, k2| {
@@ -116,7 +129,7 @@ pub(crate) fn build_index(
     // Set up alias indexes.
     for (i, item) in cache.search_index.iter().enumerate() {
         for alias in &item.aliases[..] {
-            aliases.entry(alias.to_string()).or_default().push(i);
+            aliases.entry(SerSymbolAsStr(*alias)).or_default().push(i);
         }
     }
 
@@ -474,7 +487,7 @@ pub(crate) fn build_index(
         // The String is alias name and the vec is the list of the elements with this alias.
         //
         // To be noted: the `usize` elements are indexes to `items`.
-        aliases: &'a BTreeMap<String, Vec<usize>>,
+        aliases: &'a AliasMap,
         // Used when a type has more than one impl with an associated item with the same name.
         associated_item_disambiguators: &'a Vec<(usize, String)>,
         // A list of shard lengths encoded as vlqhex. See the comment in write_vlqhex_to_string

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -328,7 +328,7 @@ error: creating a shared reference to mutable static
 LL |         if X.is_some() {
    |            ^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[deny(static_mut_refs)]` on by default
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -378,6 +378,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "serde",
     "serde_derive",
     "serde_json",
+    "serde_path_to_error",
     "sha1",
     "sha2",
     "sharded-slab",

--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -50,6 +50,7 @@ pub fn check(
     ci_info: &CiInfo,
     librustdoc_path: &Path,
     tools_path: &Path,
+    npm: &Path,
     bless: bool,
     extra_checks: Option<&str>,
     pos_args: &[String],
@@ -61,6 +62,7 @@ pub fn check(
         ci_info,
         librustdoc_path,
         tools_path,
+        npm,
         bless,
         extra_checks,
         pos_args,
@@ -75,6 +77,7 @@ fn check_impl(
     ci_info: &CiInfo,
     librustdoc_path: &Path,
     tools_path: &Path,
+    npm: &Path,
     bless: bool,
     extra_checks: Option<&str>,
     pos_args: &[String],
@@ -293,7 +296,7 @@ fn check_impl(
     }
 
     if js_lint || js_typecheck {
-        rustdoc_js::npm_install(root_path, outdir)?;
+        rustdoc_js::npm_install(root_path, outdir, npm)?;
     }
 
     if js_lint {

--- a/src/tools/tidy/src/ext_tool_checks/rustdoc_js.rs
+++ b/src/tools/tidy/src/ext_tool_checks/rustdoc_js.rs
@@ -23,9 +23,8 @@ fn spawn_cmd(cmd: &mut Command) -> Result<Child, io::Error> {
 }
 
 /// install all js dependencies from package.json.
-pub(super) fn npm_install(root_path: &Path, outdir: &Path) -> Result<(), super::Error> {
-    // FIXME(lolbinarycat): make this obey build.npm bootstrap option
-    npm::install(root_path, outdir, Path::new("npm"))?;
+pub(super) fn npm_install(root_path: &Path, outdir: &Path, npm: &Path) -> Result<(), super::Error> {
+    npm::install(root_path, outdir, npm)?;
     Ok(())
 }
 

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
     let concurrency: NonZeroUsize =
         FromStr::from_str(&env::args().nth(4).expect("need concurrency"))
             .expect("concurrency must be a number");
+    let npm: PathBuf = env::args_os().nth(5).expect("need name/path of npm command").into();
 
     let root_manifest = root_path.join("Cargo.toml");
     let src_path = root_path.join("src");
@@ -182,6 +183,7 @@ fn main() {
             &ci_info,
             &librustdoc_path,
             &tools_path,
+            &npm,
             bless,
             extra_checks,
             pos_args

--- a/tests/codegen-llvm/become-musttail.rs
+++ b/tests/codegen-llvm/become-musttail.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: -C opt-level=0 -Cpanic=abort -C no-prepopulate-passes
+//@ needs-unwind
+
+#![crate_type = "lib"]
+#![feature(explicit_tail_calls)]
+
+// CHECK-LABEL: define {{.*}}@fibonacci(
+#[no_mangle]
+#[inline(never)]
+pub fn fibonacci(n: u64, a: u64, b: u64) -> u64 {
+    // CHECK: musttail call {{.*}}@fibonacci(
+    // CHECK-NEXT: ret u64
+    match n {
+        0 => a,
+        1 => b,
+        _ => become fibonacci(n - 1, b, a + b),
+    }
+}

--- a/tests/codegen-llvm/become-musttail.rs
+++ b/tests/codegen-llvm/become-musttail.rs
@@ -9,7 +9,7 @@
 #[inline(never)]
 pub fn fibonacci(n: u64, a: u64, b: u64) -> u64 {
     // CHECK: musttail call {{.*}}@fibonacci(
-    // CHECK-NEXT: ret u64
+    // CHECK-NEXT: ret i64
     match n {
         0 => a,
         1 => b,

--- a/tests/run-make/rustdoc-target-spec-json-path/target.json
+++ b/tests/run-make/rustdoc-target-spec-json-path/target.json
@@ -6,7 +6,6 @@
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,
-  "has-elf-tls": true,
   "has-rpath": true,
   "linker-is-gnu": true,
   "llvm-target": "x86_64-unknown-linux-gnu",

--- a/tests/run-make/target-specs/endianness-mismatch.json
+++ b/tests/run-make/target-specs/endianness-mismatch.json
@@ -5,7 +5,6 @@
     "llvm-target": "x86_64-unknown-linux-gnu",
     "target-endian": "big",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
     "arch": "x86_64",
     "os": "linux"
 }

--- a/tests/run-make/target-specs/my-awesome-platform.json
+++ b/tests/run-make/target-specs/my-awesome-platform.json
@@ -4,8 +4,6 @@
     "llvm-target": "i686-unknown-linux-gnu",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "target-c-int-width": "32",
     "arch": "x86",
-    "os": "linux",
-    "morestack": false
+    "os": "linux"
 }

--- a/tests/run-make/target-specs/my-incomplete-platform.json
+++ b/tests/run-make/target-specs/my-incomplete-platform.json
@@ -3,8 +3,6 @@
     "linker-flavor": "gcc",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "target-c-int-width": "32",
     "arch": "x86",
-    "os": "foo",
-    "morestack": false
+    "os": "foo"
 }

--- a/tests/run-make/target-specs/my-x86_64-unknown-linux-gnu-platform.json
+++ b/tests/run-make/target-specs/my-x86_64-unknown-linux-gnu-platform.json
@@ -5,8 +5,6 @@
     "llvm-target": "x86_64-unknown-linux-gnu",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
     "arch": "x86_64",
-    "os": "linux",
-    "morestack": false
+    "os": "linux"
 }

--- a/tests/run-make/target-specs/require-explicit-cpu.json
+++ b/tests/run-make/target-specs/require-explicit-cpu.json
@@ -4,7 +4,6 @@
     "llvm-target": "i686-unknown-linux-gnu",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "target-c-int-width": "32",
     "arch": "x86",
     "os": "linux",
     "need-explicit-cpu": true

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -8,8 +8,6 @@
 use run_make_support::{diff, rfs, rustc};
 
 fn main() {
-    rustc().input("foo.rs").target("my-awesome-platform.json").crate_type("lib").emit("asm").run();
-    assert!(!rfs::read_to_string("foo.s").contains("morestack"));
     rustc()
         .input("foo.rs")
         .target("my-invalid-platform.json")
@@ -19,7 +17,7 @@ fn main() {
         .input("foo.rs")
         .target("my-incomplete-platform.json")
         .run_fail()
-        .assert_stderr_contains("Field llvm-target");
+        .assert_stderr_contains("missing field `llvm-target`");
     rustc()
         .env("RUST_TARGET_PATH", ".")
         .input("foo.rs")

--- a/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.rs
+++ b/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.rs
@@ -1,4 +1,4 @@
-// Regression test for issue #105056.
+// issue: <https://github.com/rust-lang/rust/issues/105056>
 //@ edition: 2021
 
 fn f(_: impl Trait<T = Copy>) {}
@@ -22,5 +22,12 @@ type Obj = dyn Trait<T = Clone>;
 //~| HELP you can add the `dyn` keyword if you want a trait object
 
 trait Trait { type T; }
+
+// Don't suggest assoc ty bounds when we have parenthesized args (the underlying assoc type
+// binding `Output` isn't introduced by `=` but by `->`, suggesting `:` wouldn't be valid).
+// issue: <https://github.com/rust-lang/rust/issues/140543>
+fn i(_: impl Fn() -> std::fmt::Debug) {}
+//~^ ERROR expected a type, found a trait
+//~| HELP you can add the `dyn` keyword if you want a trait object
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.stderr
+++ b/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.stderr
@@ -57,6 +57,17 @@ help: you can add the `dyn` keyword if you want a trait object
 LL | type Obj = dyn Trait<T = dyn Clone>;
    |                          +++
 
-error: aborting due to 4 previous errors
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggest-assoc-ty-bound-on-eq-bound.rs:29:22
+   |
+LL | fn i(_: impl Fn() -> std::fmt::Debug) {}
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | fn i(_: impl Fn() -> dyn std::fmt::Debug) {}
+   |                      +++
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |         let sfoo: *mut Foo = &mut SFOO;
    |                              ^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/check-cfg/my-awesome-platform.json
+++ b/tests/ui/check-cfg/my-awesome-platform.json
@@ -4,7 +4,6 @@
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
     "os": "ericos",
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",

--- a/tests/ui/closures/2229_closure_analysis/issue-90465.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-90465.stderr
@@ -10,7 +10,7 @@ LL |         let _ = f0;
 LL | }
    | - in Rust 2018, `f0` is dropped here along with the closure, but in Rust 2021 `f0` is not part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/issue-90465.rs:3:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -7,7 +7,7 @@ LL |     thread::spawn(move || unsafe {
 LL |         *fptr.0 = 20;
    |         ------- in Rust 2018, this closure captures all of `fptr`, but in Rust 2021, it will only capture `fptr.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/auto_traits.rs:2:9
    |
@@ -34,7 +34,7 @@ LL |     thread::spawn(move || unsafe {
 LL |         *fptr.0.0 = 20;
    |         --------- in Rust 2018, this closure captures all of `fptr`, but in Rust 2021, it will only capture `fptr.0.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
@@ -56,7 +56,7 @@ LL |         let f_1 = f.1;
 LL | }
    | - in Rust 2018, `f` is dropped here, but in Rust 2021, only `f.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f` to be fully captured
    |
 LL ~     let c = || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/closure-body-macro-fragment.stderr
@@ -15,7 +15,7 @@ LL | |         println!("{:?}", x);
 LL | |     });
    | |______- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/closure-body-macro-fragment.rs:4:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/insignificant_drop_attr_migrations.rs:3:9
    |
@@ -34,7 +34,7 @@ LL |         let _t = t.1;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = move || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/macro.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/macro.stderr
@@ -7,7 +7,7 @@ LL |     let _ = || dbg!(a.0);
 LL | }
    | - in Rust 2018, `a` is dropped here, but in Rust 2021, only `a.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/macro.rs:5:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/migrations_rustfix.rs:2:9
    |
@@ -31,7 +31,7 @@ LL |     let c = || t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; t.0 };

--- a/tests/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -10,7 +10,7 @@ LL |     let result = panic::catch_unwind(move || {
 LL |         f.0()
    |         --- in Rust 2018, this closure captures all of `f`, but in Rust 2021, it will only capture `f.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/mir_calls_to_shims.rs:4:9
    |

--- a/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -13,7 +13,7 @@ LL |         let _f_2 = f2.1;
 LL | }
    | - in Rust 2018, `f2` is dropped here, but in Rust 2021, only `f2.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/multi_diagnostics.rs:2:9
    |
@@ -34,7 +34,7 @@ LL |     let c = || {
 LL |         let _f_1 = f1.0;
    |                    ---- in Rust 2018, this closure captures all of `f1`, but in Rust 2021, it will only capture `f1.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -56,7 +56,7 @@ LL |
 LL |         let _f_2 = f1.2;
    |                    ---- in Rust 2018, this closure captures all of `f1`, but in Rust 2021, it will only capture `f1.2`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -81,7 +81,7 @@ LL | }
    | in Rust 2018, `f1` is dropped here, but in Rust 2021, only `f1.0` will be dropped here as part of the closure
    | in Rust 2018, `f1` is dropped here, but in Rust 2021, only `f1.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `f1` to be fully captured
    |
 LL ~     let c = || {
@@ -104,7 +104,7 @@ LL |
 LL |         *fptr2.0 = 20;
    |         -------- in Rust 2018, this closure captures all of `fptr2`, but in Rust 2021, it will only capture `fptr2.0`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {

--- a/tests/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -10,7 +10,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/precise.rs:3:9
    |
@@ -44,7 +44,7 @@ LL | }
    | in Rust 2018, `u` is dropped here, but in Rust 2021, only `u.0.1` will be dropped here as part of the closure
    | in Rust 2018, `u` is dropped here, but in Rust 2021, only `u.1.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `u` to be fully captured
    |
 LL ~     let c = || {

--- a/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -20,7 +20,7 @@ LL | }
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.0` will be dropped here as part of the closure
    | in Rust 2018, `t2` is dropped here, but in Rust 2021, only `t2.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/significant_drop.rs:2:9
    |
@@ -50,7 +50,7 @@ LL | }
    | in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL ~     let c = || {
@@ -69,7 +69,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -88,7 +88,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -107,7 +107,7 @@ LL |         let _t = t.0;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -126,7 +126,7 @@ LL |         let _t = t.1;
 LL | }
    | - in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t` to be fully captured
    |
 LL ~     let c = || {
@@ -150,7 +150,7 @@ LL | }
    | in Rust 2018, `t1` is dropped here, but in Rust 2021, only `t1.1` will be dropped here as part of the closure
    | in Rust 2018, `t` is dropped here, but in Rust 2021, only `t.1` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL ~     let c = move || {
@@ -169,7 +169,7 @@ LL |                 tuple.0;
 LL |         }
    |         - in Rust 2018, `tuple` is dropped here, but in Rust 2021, only `tuple.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~             let c = || {
@@ -188,7 +188,7 @@ LL |             tuple.0;
 LL |     };
    |     - in Rust 2018, `tuple` is dropped here, but in Rust 2021, only `tuple.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tuple` to be fully captured
    |
 LL ~         let c = || {
@@ -204,7 +204,7 @@ LL |         let _c = || tup.0;
 LL | }
    | - in Rust 2018, `tup` is dropped here, but in Rust 2021, only `tup.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 help: add a dummy let to cause `tup` to be fully captured
    |
 LL |         let _c = || { let _ = &tup; tup.0 };

--- a/tests/ui/codegen/mismatched-data-layout.json
+++ b/tests/ui/codegen/mismatched-data-layout.json
@@ -4,7 +4,6 @@
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "target-c-int-width": "32",
     "os": "none",
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",

--- a/tests/ui/codegen/mismatched-data-layouts.rs
+++ b/tests/ui/codegen/mismatched-data-layouts.rs
@@ -5,6 +5,7 @@
 //@ compile-flags: --crate-type=lib --target={{src-base}}/codegen/mismatched-data-layout.json -Z unstable-options
 //@ normalize-stderr: "`, `[A-Za-z0-9-:]*`" -> "`, `normalized data layout`"
 //@ normalize-stderr: "layout, `[A-Za-z0-9-:]*`" -> "layout, `normalized data layout`"
+//@ normalize-stderr: "`mismatched-data-layout-\d+`" -> "`mismatched-data-layout-<hash>`"
 
 #![feature(lang_items, no_core, auto_traits)]
 #![no_core]

--- a/tests/ui/codegen/mismatched-data-layouts.stderr
+++ b/tests/ui/codegen/mismatched-data-layouts.stderr
@@ -1,4 +1,4 @@
-error: data-layout for target `mismatched-data-layout-7193370089426056427`, `normalized data layout`, differs from LLVM target's `x86_64-unknown-none-gnu` default layout, `normalized data layout`
+error: data-layout for target `mismatched-data-layout-<hash>`, `normalized data layout`, differs from LLVM target's `x86_64-unknown-none-gnu` default layout, `normalized data layout`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
+++ b/tests/ui/consts/const-eval/const_panic_stability.e2018.stderr
@@ -5,7 +5,7 @@ LL |     panic!({ "foo" });
    |            ^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: `#[warn(non_fmt_panics)]` on by default
 help: add a "{}" format string to `Display` the message
    |

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |     let ptr = unsafe { &mut BB };
    |                        ^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -16,7 +16,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -186,7 +186,7 @@ LL | type H = Fn(u8) -> (u8)::Output;
    |          ^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -27,7 +27,7 @@ LL | |     }, e.mark(3), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#3` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -75,7 +75,7 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -107,7 +107,7 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -139,7 +139,7 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -171,7 +171,7 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -193,7 +193,7 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -223,7 +223,7 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -252,7 +252,7 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -281,7 +281,7 @@ LL |         if let true = e.err(9).is_ok() {} else {
    |                       this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -310,7 +310,7 @@ LL |         if let Ok(_v) = e.err(8) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -339,7 +339,7 @@ LL |         if let Ok(_) = e.err(7) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -368,7 +368,7 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -397,7 +397,7 @@ LL |         if let Ok(_v) = e.err(5) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -426,7 +426,7 @@ LL |         if let Ok(_) = e.err(4) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |
@@ -455,7 +455,7 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:504:1
    |

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = Droppy.get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-gated.rs:14:1
    |

--- a/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
@@ -14,7 +14,7 @@ LL | |     };
    | |_____- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-with-macro.rs:22:1
    |

--- a/tests/ui/drop/lint-if-let-rescope.stderr
+++ b/tests/ui/drop/lint-if-let-rescope.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = droppy().get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -47,7 +47,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  -------- this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -89,7 +89,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -120,7 +120,7 @@ LL |     if let Some(1) = { if let Some(_value) = Droppy.get() { Some(1) } else 
    |                                              this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -146,7 +146,7 @@ LL |     if (if let Some(_value) = droppy().get() { true } else { false }) {
    |                               this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -172,7 +172,7 @@ LL |     } else if (((if let Some(_value) = droppy().get() { true } else { false
    |                                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -198,7 +198,7 @@ LL |     while (if let Some(_value) = droppy().get() { false } else { true }) {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
@@ -224,7 +224,7 @@ LL |     if let Some(_value) = Some((droppy(), ()).1) {} else {}
    |                                this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:97:51
    |

--- a/tests/ui/drop/lint-tail-expr-drop-order-borrowck.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order-borrowck.stderr
@@ -7,7 +7,7 @@ LL |     let _ = { String::new().as_str() }.len();
    |               this temporary value will be dropped at the end of the block
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: the lint level is defined here
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:6:9
    |
@@ -23,7 +23,7 @@ LL |     f(unsafe { String::new().as_str() }.len());
    |                this temporary value will be dropped at the end of the block
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: relative drop order changing in Rust 2024
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:31:9
@@ -35,7 +35,7 @@ LL |         &mut || 0
    |         borrow later used here
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: relative drop order changing in Rust 2024
   --> $DIR/lint-tail-expr-drop-order-borrowck.rs:43:9
@@ -46,7 +46,7 @@ LL |     g({ &f() });
    |     borrow later used by call
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -17,7 +17,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -54,7 +54,7 @@ LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -86,7 +86,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -118,7 +118,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -145,7 +145,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -167,7 +167,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
@@ -199,7 +199,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:193:5
    |
@@ -231,7 +231,7 @@ LL |     ));
    |       - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -23,7 +23,7 @@ LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
@@ -5,7 +5,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
@@ -5,7 +5,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                         ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: A) -> dyn A; }
@@ -32,7 +32,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: dyn B) -> B; }
@@ -45,7 +45,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                         ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: B) -> dyn B; }
@@ -58,7 +58,7 @@ LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -100,7 +100,7 @@ LL | trait A { fn g(b: B) -> B; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning.old.stderr
@@ -23,7 +23,7 @@ LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
@@ -5,7 +5,7 @@ LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/bare-trait-dont-suggest-dyn.rs:5:9
    |

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -5,7 +5,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |                 ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/dyn-2018-edition-lint.rs:2:8
    |
@@ -23,7 +23,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |                                   ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
@@ -36,7 +36,7 @@ LL |     let _x: &SomeTrait = todo!();
    |              ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _x: &dyn SomeTrait = todo!();

--- a/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -5,7 +5,7 @@ LL |         <fmt::Debug>::fmt(self, f)
    |          ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/dyn-angle-brackets.rs:4:9
    |

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -5,7 +5,7 @@ LL | fn m() {
    | ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:22:17
@@ -25,7 +25,7 @@ LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:37:5
@@ -44,7 +44,7 @@ LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
   --> $DIR/never-type-fallback-breaking.rs:50:5
@@ -63,7 +63,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:62:19
@@ -82,7 +82,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:76:17
@@ -104,7 +104,7 @@ LL | fn m() {
    | ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:22:17
@@ -125,7 +125,7 @@ LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:37:5
@@ -146,7 +146,7 @@ LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
   --> $DIR/never-type-fallback-breaking.rs:50:5
@@ -167,7 +167,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:62:19
@@ -188,7 +188,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:76:17

--- a/tests/ui/entry-point/auxiliary/main_functions.rs
+++ b/tests/ui/entry-point/auxiliary/main_functions.rs
@@ -1,1 +1,4 @@
 pub fn boilerplate() {}
+
+#[inline]
+pub fn local_codegen() {}

--- a/tests/ui/entry-point/imported_main_local_codegen.rs
+++ b/tests/ui/entry-point/imported_main_local_codegen.rs
@@ -1,0 +1,11 @@
+//@ run-pass
+//@ aux-build:main_functions.rs
+//@ compile-flags: -Ccodegen-units=1024
+
+// This is a regression test for https://github.com/rust-lang/rust/issues/144052.
+// Entrypoint functions call each other in ways that CGU partitioning doesn't know about. So there
+// is a special check to not internalize any of them. But internalizing them can be okay if there
+// are few enough CGUs, so we use a lot of CGUs in this test to hit the bad case.
+
+extern crate main_functions;
+pub use main_functions::local_codegen as main;

--- a/tests/ui/ergonomic-clones/closure/rfc2229-migration.stderr
+++ b/tests/ui/ergonomic-clones/closure/rfc2229-migration.stderr
@@ -10,7 +10,7 @@ LL |         let x = a.0;
 LL | }
    | - in Rust 2018, `a` is dropped here, but in Rust 2021, only `a.0` will be dropped here as part of the closure
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
 note: the lint level is defined here
   --> $DIR/rfc2229-migration.rs:5:9
    |

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -5,7 +5,7 @@ LL |     let _ = MyIterator::next;
    |             ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/explicit-tail-calls/recursion-no-tce.rs
+++ b/tests/ui/explicit-tail-calls/recursion-no-tce.rs
@@ -1,4 +1,4 @@
-//@ run-fail
+//@ run-crash
 
 use std::hint::black_box;
 

--- a/tests/ui/explicit-tail-calls/recursion-no-tce.rs
+++ b/tests/ui/explicit-tail-calls/recursion-no-tce.rs
@@ -1,0 +1,16 @@
+//@ run-fail
+
+use std::hint::black_box;
+
+pub fn count(curr: u64, top: u64) -> u64 {
+   if black_box(curr) >= top {
+        curr
+   } else {
+        count(curr + 1, top)
+   }
+}
+
+fn main() {
+    println!("{}",
+    count(0, black_box(1000000)));
+}

--- a/tests/ui/explicit-tail-calls/recursion-no-tce.rs
+++ b/tests/ui/explicit-tail-calls/recursion-no-tce.rs
@@ -11,6 +11,5 @@ pub fn count(curr: u64, top: u64) -> u64 {
 }
 
 fn main() {
-    println!("{}",
-    count(0, black_box(1000000)));
+    println!("{}", count(0, black_box(1000000)));
 }

--- a/tests/ui/explicit-tail-calls/recursion-tce.rs
+++ b/tests/ui/explicit-tail-calls/recursion-tce.rs
@@ -1,0 +1,17 @@
+//@ run-pass
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+use std::hint::black_box;
+
+pub fn count(curr: u64, top: u64) -> u64 {
+   if black_box(curr) >= top {
+        curr
+   } else {
+        become count(curr + 1, top)
+   }
+}
+
+fn main() {
+    println!("{}", count(0, black_box(1000000)));
+}

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -5,7 +5,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |                        ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    |                        ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
@@ -5,7 +5,7 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024-machine-applicable.rs:9:10
    |

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
@@ -5,7 +5,7 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:7:10
    |
@@ -29,7 +29,7 @@ LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                         ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:11:16
    |
@@ -48,7 +48,7 @@ LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                                 ^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:17:24
    |
@@ -67,7 +67,7 @@ LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                                               ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:29:23
    |
@@ -86,7 +86,7 @@ LL | fn apit(_: &impl Sized) -> impl Sized {}
    |                            ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:33:12
    |
@@ -111,7 +111,7 @@ LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    |                                      ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:37:16
    |
@@ -136,7 +136,7 @@ LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
    |                                     ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:41:19
    |
@@ -155,7 +155,7 @@ LL | pub fn parens(x: &i32) -> &impl Clone { x }
    |                            ^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:45:18
    |

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -5,7 +5,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    |                 ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -25,7 +25,7 @@ LL |     let g = BitXor::bitor;
    |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let g = <dyn BitXor>::bitor;

--- a/tests/ui/issues/issue-39367.stderr
+++ b/tests/ui/issues/issue-39367.stderr
@@ -9,7 +9,7 @@ LL | |                     (Box::new(__static_ref_initialize()));
 LL | |             });
    | |______________^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -5,7 +5,7 @@ LL |     Trait::nonexistent(());
    |     ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -19,7 +19,7 @@ LL |     eq::<dyn, Foo>
    |               ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/iterators/into-iter-on-arrays-2018.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-2018.stderr
@@ -5,7 +5,7 @@ LL |     let _: Iter<'_, i32> = array.into_iter();
    |                                  ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
    = note: `#[warn(array_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     let _: Iter<'_, i32> = Box::new(array).into_iter();
    |                                            ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:22:43
@@ -34,7 +34,7 @@ LL |     let _: Iter<'_, i32> = Rc::new(array).into_iter();
    |                                           ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:25:41
@@ -43,7 +43,7 @@ LL |     let _: Iter<'_, i32> = Array(array).into_iter();
    |                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-2018.rs:32:24
@@ -52,7 +52,7 @@ LL |     for _ in [1, 2, 3].into_iter() {}
    |                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     for _ in [1, 2, 3].into_iter() {}

--- a/tests/ui/iterators/into-iter-on-arrays-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-arrays-lint.stderr
@@ -5,7 +5,7 @@ LL |     small.into_iter();
    |           ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
    = note: `#[warn(array_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     [1, 2].into_iter();
    |            ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     [1, 2].into_iter();
@@ -44,7 +44,7 @@ LL |     big.into_iter();
    |         ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     big.into_iter();
@@ -63,7 +63,7 @@ LL |     [0u8; 33].into_iter();
    |               ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     [0u8; 33].into_iter();
@@ -82,7 +82,7 @@ LL |     Box::new(small).into_iter();
    |                     ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:27:22
@@ -91,7 +91,7 @@ LL |     Box::new([1, 2]).into_iter();
    |                      ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:30:19
@@ -100,7 +100,7 @@ LL |     Box::new(big).into_iter();
    |                   ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:33:25
@@ -109,7 +109,7 @@ LL |     Box::new([0u8; 33]).into_iter();
    |                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:37:31
@@ -118,7 +118,7 @@ LL |     Box::new(Box::new(small)).into_iter();
    |                               ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:40:32
@@ -127,7 +127,7 @@ LL |     Box::new(Box::new([1, 2])).into_iter();
    |                                ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:43:29
@@ -136,7 +136,7 @@ LL |     Box::new(Box::new(big)).into_iter();
    |                             ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
   --> $DIR/into-iter-on-arrays-lint.rs:46:35
@@ -145,7 +145,7 @@ LL |     Box::new(Box::new([0u8; 33])).into_iter();
    |                                   ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 
 warning: 12 warnings emitted
 

--- a/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
@@ -5,7 +5,7 @@ LL |     let _: Iter<'_, i32> = boxed_slice.into_iter();
    |                                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     let _: Iter<'_, i32> = Box::new(boxed_slice.clone()).into_iter();
    |                                                          ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:22:57
@@ -34,7 +34,7 @@ LL |     let _: Iter<'_, i32> = Rc::new(boxed_slice.clone()).into_iter();
    |                                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:25:55
@@ -43,7 +43,7 @@ LL |     let _: Iter<'_, i32> = Array(boxed_slice.clone()).into_iter();
    |                                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:32:48
@@ -52,7 +52,7 @@ LL |     for _ in (Box::new([1, 2, 3]) as Box<[_]>).into_iter() {}
    |                                                ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL -     for _ in (Box::new([1, 2, 3]) as Box<[_]>).into_iter() {}

--- a/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
@@ -5,7 +5,7 @@ LL |     boxed.into_iter();
    |           ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -25,7 +25,7 @@ LL |     Box::new(boxed.clone()).into_iter();
    |                             ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-lint.rs:16:39
@@ -34,7 +34,7 @@ LL |     Box::new(Box::new(boxed.clone())).into_iter();
    |                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: 3 warnings emitted
 

--- a/tests/ui/linkage-attr/raw-dylib/elf/empty.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/empty.rs
@@ -1,0 +1,11 @@
+//@ only-x86_64-unknown-linux-gnu
+//@ needs-dynamic-linking
+//@ build-pass
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+
+#[link(name = "hack", kind = "raw-dylib")]
+unsafe extern "C" {}
+
+fn main() {}

--- a/tests/ui/linkage-attr/raw-dylib/elf/glibc-x86_64.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/glibc-x86_64.rs
@@ -1,0 +1,74 @@
+//@ only-x86_64-unknown-linux-gnu
+//@ needs-dynamic-linking
+//@ run-pass
+//@ compile-flags: -Cpanic=abort
+//@ edition: 2024
+
+#![allow(incomplete_features)]
+#![feature(raw_dylib_elf)]
+#![no_std]
+#![no_main]
+
+use core::ffi::{c_char, c_int};
+
+extern "C" fn callback(
+    _fpath: *const c_char,
+    _sb: *const (),
+    _tflag: c_int,
+    _ftwbuf: *const (),
+) -> c_int {
+    0
+}
+
+#[link(name = "libc.so.6", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    #[link_name = "nftw@GLIBC_2.2.5"]
+    unsafe fn nftw_2_2_5(
+        dirpath: *const c_char,
+        f: extern "C" fn(*const c_char, *const (), c_int, *const ()) -> c_int,
+        nopenfd: c_int,
+        flags: c_int,
+    ) -> c_int;
+    #[link_name = "nftw@GLIBC_2.3.3"]
+    unsafe fn nftw_2_3_3(
+        dirpath: *const c_char,
+        f: extern "C" fn(*const c_char, *const (), c_int, *const ()) -> c_int,
+        nopenfd: c_int,
+        flags: c_int,
+    ) -> c_int;
+    #[link_name = "exit@GLIBC_2.2.5"]
+    safe fn exit(status: i32) -> !;
+    unsafe fn __libc_start_main() -> c_int;
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn main() -> ! {
+    unsafe {
+        // The old `nftw` does not check whether unknown flags are set.
+        let res = nftw_2_2_5(c".".as_ptr(), callback, 20, 1 << 30);
+        assert_eq!(res, 0);
+    }
+    unsafe {
+        // The new `nftw` does.
+        let res = nftw_2_3_3(c".".as_ptr(), callback, 20, 1 << 30);
+        assert_eq!(res, -1);
+    }
+    exit(0);
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo<'_>) -> ! {
+    exit(1);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rust_eh_personality(
+    _version: i32,
+    _actions: i32,
+    _exception_class: u64,
+    _exception_object: *mut (),
+    _context: *mut (),
+) -> i32 {
+    exit(1);
+}

--- a/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.rs
+++ b/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.rs
@@ -1,0 +1,20 @@
+//@ only-elf
+//@ needs-dynamic-linking
+//@ check-fail
+
+#![feature(raw_dylib_elf)]
+#![allow(incomplete_features)]
+
+#[link(name = "libc.so.6", kind = "raw-dylib", modifiers = "+verbatim")]
+unsafe extern "C" {
+    #[link_name = "exit@"]
+    pub safe fn exit_0(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "@GLIBC_2.2.5"]
+    pub safe fn exit_1(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "ex\0it@GLIBC_2.2.5"]
+    pub safe fn exit_2(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+    #[link_name = "exit@@GLIBC_2.2.5"]
+    pub safe fn exit_3(status: i32) -> !; //~ ERROR link name must be well-formed if link kind is `raw-dylib`
+}
+
+fn main() {}

--- a/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/elf/malformed-link-name.stderr
@@ -1,0 +1,26 @@
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:11:5
+   |
+LL |     pub safe fn exit_0(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:13:5
+   |
+LL |     pub safe fn exit_1(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:15:5
+   |
+LL |     pub safe fn exit_2(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: link name must be well-formed if link kind is `raw-dylib`
+  --> $DIR/malformed-link-name.rs:17:5
+   |
+LL |     pub safe fn exit_3(status: i32) -> !;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -5,7 +5,7 @@ LL |     Dyn::func();
    |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL |     ::Dyn::func();
    |     ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn (::Dyn)>::func();
@@ -32,7 +32,7 @@ LL |     Dyn::CONST;
    |     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Dyn>::CONST;
@@ -45,7 +45,7 @@ LL |     let _: Dyn::Ty;
    |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: <dyn Dyn>::Ty;

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-allow.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL |         0...100 => true,
    |          ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn ellipsis-inclusive-range-patterns` implied by `--force-warn rust-2021-compatibility`
 
 warning: 1 warning emitted

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -5,7 +5,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    |                         ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/lint/inclusive-range-pattern-syntax.stderr
+++ b/tests/ui/lint/inclusive-range-pattern-syntax.stderr
@@ -5,7 +5,7 @@ LL |         1...2 => {}
    |          ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/inclusive-range-pattern-syntax.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |         &1...2 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(1..=2)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/lint/lint-attr-everywhere-early.stderr
+++ b/tests/ui/lint/lint-attr-everywhere-early.stderr
@@ -391,7 +391,7 @@ LL |         Match{f1: 0...100} => {}
    |                    ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/lint-attr-everywhere-early.rs:138:16
    |
@@ -489,7 +489,7 @@ LL |             f1: 0...100,
    |                  ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/lint-attr-everywhere-early.rs:174:20
    |

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a mutable reference to mutable static
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
@@ -31,7 +31,7 @@ warning: creating a shared reference to mutable static
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -40,7 +40,7 @@ warning: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -53,7 +53,7 @@ warning: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -66,7 +66,7 @@ warning: creating a shared reference to mutable static
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -79,7 +79,7 @@ warning: creating a shared reference to mutable static
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -88,7 +88,7 @@ warning: creating a shared reference to mutable static
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -97,7 +97,7 @@ warning: creating a shared reference to mutable static
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -110,7 +110,7 @@ warning: creating a shared reference to mutable static
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -123,7 +123,7 @@ warning: creating a shared reference to mutable static
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a mutable reference to mutable static
@@ -135,7 +135,7 @@ LL |         &mut ($x.0)
 LL |         let _x = bar!(FOO);
    |                  --------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: this warning originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -4,7 +4,7 @@ error: creating a shared reference to mutable static
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[deny(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ error: creating a mutable reference to mutable static
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
@@ -31,7 +31,7 @@ error: creating a shared reference to mutable static
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -40,7 +40,7 @@ error: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -53,7 +53,7 @@ error: creating a shared reference to mutable static
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -66,7 +66,7 @@ error: creating a shared reference to mutable static
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -79,7 +79,7 @@ error: creating a shared reference to mutable static
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -88,7 +88,7 @@ error: creating a shared reference to mutable static
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static
@@ -97,7 +97,7 @@ error: creating a shared reference to mutable static
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -110,7 +110,7 @@ error: creating a shared reference to mutable static
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -123,7 +123,7 @@ error: creating a shared reference to mutable static
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a mutable reference to mutable static
@@ -135,7 +135,7 @@ LL |         &mut ($x.0)
 LL |         let _x = bar!(FOO);
    |                  --------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
@@ -5,7 +5,7 @@ LL |     ($e:expr) => {
    |         ^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>
 note: the lint level is defined here
   --> $DIR/expr_2021_cargo_fix_edition.rs:4:9
    |
@@ -23,7 +23,7 @@ LL |     ($($i:expr)*) => { };
    |           ^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
+   = note: for more information, see Migration Guide <https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html>
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
 LL |     ($($i:expr_2021)*) => { };

--- a/tests/ui/macros/macro-or-patterns-back-compat.stderr
+++ b/tests/ui/macros/macro-or-patterns-back-compat.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! foo { ($x:pat | $y:pat) => {} }
    |                     ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 note: the lint level is defined here
   --> $DIR/macro-or-patterns-back-compat.rs:4:9
    |
@@ -19,7 +19,7 @@ LL | macro_rules! bar { ($($x:pat)+ | $($y:pat)+) => {} }
    |                       ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:19:21
@@ -28,7 +28,7 @@ LL | macro_rules! ogg { ($x:pat | $y:pat_param) => {} }
    |                     ^^^^^^ help: use pat_param to preserve semantics: `$x:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: the meaning of the `pat` fragment specifier is changing in Rust 2021, which may affect this macro
   --> $DIR/macro-or-patterns-back-compat.rs:23:26
@@ -37,7 +37,7 @@ LL |     ( $expr:expr , $( $( $pat:pat )|+ => $expr_arm:expr ),+ ) => {
    |                          ^^^^^^^^ help: use pat_param to preserve semantics: `$pat:pat_param`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/or-patterns-macro-rules.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html>
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/non-fmt-panic.stderr
+++ b/tests/ui/macros/non-fmt-panic.stderr
@@ -74,7 +74,7 @@ LL |     assert!(false, S);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", S);
@@ -87,7 +87,7 @@ LL |     assert!(false, 123);
    |                    ^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", 123);
@@ -100,7 +100,7 @@ LL |     assert!(false, Some(123));
    |                    ^^^^^^^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `Option<i32>`
    |
 LL |     assert!(false, "{:?}", Some(123));
@@ -125,7 +125,7 @@ LL |     panic!(C);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", C);
@@ -138,7 +138,7 @@ LL |     panic!(S);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", S);
@@ -151,7 +151,7 @@ LL |     unreachable!(S);
    |                  ^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", S);
@@ -164,7 +164,7 @@ LL |     unreachable!(S);
    |                  ^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", S);
@@ -177,7 +177,7 @@ LL |     std::panic!(123);
    |                 ^^^
    |
    = note: this usage of `std::panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     std::panic!("{}", 123);
@@ -195,7 +195,7 @@ LL |     core::panic!(&*"abc");
    |                  ^^^^^^^
    |
    = note: this usage of `core::panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     core::panic!("{}", &*"abc");
@@ -208,7 +208,7 @@ LL |     panic!(Some(123));
    |            ^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `Option<i32>`
    |
 LL |     panic!("{:?}", Some(123));
@@ -262,7 +262,7 @@ LL |     panic!(a!());
    |            ^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", a!());
@@ -280,7 +280,7 @@ LL |     unreachable!(a!());
    |                  ^^^^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     unreachable!("{}", a!());
@@ -293,7 +293,7 @@ LL |     panic!(format!("{}", 1));
    |            ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -308,7 +308,7 @@ LL |     unreachable!(format!("{}", 1));
    |                  ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `unreachable!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `unreachable!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -323,7 +323,7 @@ LL |     assert!(false, format!("{}", 1));
    |                    ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `assert!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -338,7 +338,7 @@ LL |     debug_assert!(false, format!("{}", 1));
    |                          ^^^^^^^^^^^^^^^^
    |
    = note: this usage of `debug_assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
    = note: the `debug_assert!()` macro supports formatting, so there's no need for the `format!()` macro here
 help: remove the `format!(..)` macro call
    |
@@ -353,7 +353,7 @@ LL |     panic![123];
    |            ^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!["{}", 123];
@@ -371,7 +371,7 @@ LL |     panic!{123};
    |            ^^^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!{"{}", 123};
@@ -391,7 +391,7 @@ LL |     panic!(v);
    |     help: use std::panic::panic_any instead: `std::panic::panic_any`
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:79:20
@@ -400,7 +400,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:83:12
@@ -409,7 +409,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `T`
    |
 LL |     panic!("{:?}", v);
@@ -427,7 +427,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{:?}" format string to use the `Debug` implementation of `T`
    |
 LL |     assert!(false, "{:?}", v);
@@ -440,7 +440,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", v);
@@ -458,7 +458,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", v);
@@ -471,7 +471,7 @@ LL |     panic!(v);
    |            ^
    |
    = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     panic!("{}", v);
@@ -489,7 +489,7 @@ LL |     assert!(false, v);
    |                    ^
    |
    = note: this usage of `assert!()` is deprecated; it will be a hard error in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
 help: add a "{}" format string to `Display` the message
    |
 LL |     assert!(false, "{}", v);

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn smeg() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
   --> $DIR/defaulted-never-note.rs:32:9
@@ -28,7 +28,7 @@ LL | fn smeg() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
   --> $DIR/defaulted-never-note.rs:32:9

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -5,7 +5,7 @@ LL | fn def() {
    | ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:12:19
@@ -26,7 +26,7 @@ LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:22:5
@@ -48,7 +48,7 @@ LL | fn def() {
    | ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:12:19
@@ -70,7 +70,7 @@ LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:22:5

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
@@ -25,7 +25,7 @@ LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:50:13
@@ -47,7 +47,7 @@ LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
@@ -68,7 +68,7 @@ LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:50:13

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
   --> $DIR/diverging-fallback-no-leak.rs:20:23
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
   --> $DIR/diverging-fallback-no-leak.rs:20:23

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail
   --> $DIR/diverging-fallback-unconstrained-return.rs:39:23
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail
   --> $DIR/diverging-fallback-unconstrained-return.rs:39:23

--- a/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
+++ b/tests/ui/never_type/dont-suggest-turbofish-from-expansion.stderr
@@ -5,7 +5,7 @@ LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23
@@ -32,7 +32,7 @@ LL | fn main() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dont-suggest-turbofish-from-expansion.rs:14:23

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
   --> $DIR/fallback-closure-ret.rs:24:5
@@ -28,7 +28,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
   --> $DIR/fallback-closure-ret.rs:24:5

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -5,7 +5,7 @@ LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
   --> $DIR/impl_trait_fallback.rs:8:25
@@ -24,7 +24,7 @@ LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
   --> $DIR/impl_trait_fallback.rs:8:25

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
@@ -5,7 +5,7 @@ LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9
@@ -32,7 +32,7 @@ LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -141,7 +141,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -157,7 +157,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -173,7 +173,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -185,7 +185,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -201,7 +201,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -217,7 +217,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -233,7 +233,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -249,7 +249,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -265,7 +265,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -280,7 +280,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -150,7 +150,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -166,7 +166,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -182,7 +182,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -194,7 +194,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -210,7 +210,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -226,7 +226,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -242,7 +242,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -258,7 +258,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -274,7 +274,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 
@@ -289,7 +289,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -4,7 +4,7 @@ warning: creating a mutable reference to mutable static
 LL |         S1 { a: unsafe { &mut X1 } }
    |                          ^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer

--- a/tests/ui/parser/recover/recover-pat-ranges.stderr
+++ b/tests/ui/parser/recover/recover-pat-ranges.stderr
@@ -191,7 +191,7 @@ LL |         (1 + 4)...1 * 2 => (),
    |                ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default
 
 error: aborting due to 13 previous errors; 1 warning emitted

--- a/tests/ui/parser/recover/recover-range-pats.stderr
+++ b/tests/ui/parser/recover/recover-range-pats.stderr
@@ -339,7 +339,7 @@ LL |     if let 0...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/recover-range-pats.rs:6:9
    |
@@ -353,7 +353,7 @@ LL |     if let 0...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:46:13
@@ -362,7 +362,7 @@ LL |     if let X...3 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:49:13
@@ -371,7 +371,7 @@ LL |     if let X...Y = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:52:16
@@ -380,7 +380,7 @@ LL |     if let true...Y = 0 {}
    |                ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:55:13
@@ -389,7 +389,7 @@ LL |     if let X...true = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:58:14
@@ -398,7 +398,7 @@ LL |     if let .0...Y = 0 {}
    |              ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:62:13
@@ -407,7 +407,7 @@ LL |     if let X... .0 = 0 {}
    |             ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:137:20
@@ -419,7 +419,7 @@ LL |     mac2!(0, 1);
    |     ----------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0029]: only `char` and numeric types are allowed in range patterns

--- a/tests/ui/parser/trait-object-trait-parens.stderr
+++ b/tests/ui/parser/trait-object-trait-parens.stderr
@@ -32,7 +32,7 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -57,7 +57,7 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
@@ -81,7 +81,7 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;

--- a/tests/ui/privacy/associated-item-privacy-trait.stderr
+++ b/tests/ui/privacy/associated-item-privacy-trait.stderr
@@ -75,6 +75,17 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: trait `PrivTr` is private
+  --> $DIR/associated-item-privacy-trait.rs:29:14
+   |
+LL |         impl PrivTr for u8 {}
+   |              ^^^^^^ private trait
+...
+LL |     priv_trait::mac!();
+   |     ------------------ in this macro invocation
+   |
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:46:21
    |
@@ -316,17 +327,6 @@ LL |     priv_parent_substs::mac!();
    |     -------------------------- in this macro invocation
    |
    = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: trait `PrivTr` is private
-  --> $DIR/associated-item-privacy-trait.rs:29:14
-   |
-LL |         impl PrivTr for u8 {}
-   |              ^^^^^^ private trait
-...
-LL |     priv_trait::mac!();
-   |     ------------------ in this macro invocation
-   |
-   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 30 previous errors
 

--- a/tests/ui/privacy/private-in-public-warn.stderr
+++ b/tests/ui/privacy/private-in-public-warn.stderr
@@ -84,42 +84,6 @@ note: but type `types::Priv` is only usable at visibility `pub(self)`
 LL |     struct Priv;
    |     ^^^^^^^^^^^
 
-error: type `types::Priv` is more private than the item `types::ES`
-  --> $DIR/private-in-public-warn.rs:27:9
-   |
-LL |         pub static ES: Priv;
-   |         ^^^^^^^^^^^^^^^^^^^ static `types::ES` is reachable at visibility `pub(crate)`
-   |
-note: but type `types::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:9:5
-   |
-LL |     struct Priv;
-   |     ^^^^^^^^^^^
-
-error: type `types::Priv` is more private than the item `types::ef1`
-  --> $DIR/private-in-public-warn.rs:28:9
-   |
-LL |         pub fn ef1(arg: Priv);
-   |         ^^^^^^^^^^^^^^^^^^^^^^ function `types::ef1` is reachable at visibility `pub(crate)`
-   |
-note: but type `types::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:9:5
-   |
-LL |     struct Priv;
-   |     ^^^^^^^^^^^
-
-error: type `types::Priv` is more private than the item `types::ef2`
-  --> $DIR/private-in-public-warn.rs:29:9
-   |
-LL |         pub fn ef2() -> Priv;
-   |         ^^^^^^^^^^^^^^^^^^^^^ function `types::ef2` is reachable at visibility `pub(crate)`
-   |
-note: but type `types::Priv` is only usable at visibility `pub(self)`
-  --> $DIR/private-in-public-warn.rs:9:5
-   |
-LL |     struct Priv;
-   |     ^^^^^^^^^^^
-
 error[E0446]: private type `types::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:32:9
    |
@@ -394,6 +358,42 @@ note: but type `Priv2` is only usable at visibility `pub(self)`
    |
 LL |     struct Priv2;
    |     ^^^^^^^^^^^^
+
+error: type `types::Priv` is more private than the item `types::ES`
+  --> $DIR/private-in-public-warn.rs:27:9
+   |
+LL |         pub static ES: Priv;
+   |         ^^^^^^^^^^^^^^^^^^^ static `types::ES` is reachable at visibility `pub(crate)`
+   |
+note: but type `types::Priv` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:9:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+
+error: type `types::Priv` is more private than the item `types::ef1`
+  --> $DIR/private-in-public-warn.rs:28:9
+   |
+LL |         pub fn ef1(arg: Priv);
+   |         ^^^^^^^^^^^^^^^^^^^^^^ function `types::ef1` is reachable at visibility `pub(crate)`
+   |
+note: but type `types::Priv` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:9:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
+
+error: type `types::Priv` is more private than the item `types::ef2`
+  --> $DIR/private-in-public-warn.rs:29:9
+   |
+LL |         pub fn ef2() -> Priv;
+   |         ^^^^^^^^^^^^^^^^^^^^^ function `types::ef2` is reachable at visibility `pub(crate)`
+   |
+note: but type `types::Priv` is only usable at visibility `pub(self)`
+  --> $DIR/private-in-public-warn.rs:9:5
+   |
+LL |     struct Priv;
+   |     ^^^^^^^^^^^
 
 warning: bounds on generic parameters in type aliases are not enforced
   --> $DIR/private-in-public-warn.rs:41:23

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.rs
@@ -1,5 +1,6 @@
-// We should not emit sealed traits note, see issue #143392
+// We should not emit sealed traits note, see issue #143392 and #143121
 
+/// Reported in #143392
 mod inner {
     pub trait TraitA {}
 
@@ -9,5 +10,14 @@ mod inner {
 struct Struct;
 
 impl inner::TraitB for Struct {} //~ ERROR the trait bound `Struct: TraitA` is not satisfied [E0277]
+
+/// Reported in #143121
+mod x {
+    pub trait A {}
+    pub trait B: A {}
+
+    pub struct C;
+    impl B for C {} //~ ERROR the trait bound `C: A` is not satisfied [E0277]
+}
 
 fn main(){}

--- a/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
+++ b/tests/ui/privacy/sealed-traits/false-sealed-traits-note.stderr
@@ -1,20 +1,37 @@
 error[E0277]: the trait bound `Struct: TraitA` is not satisfied
-  --> $DIR/false-sealed-traits-note.rs:11:24
+  --> $DIR/false-sealed-traits-note.rs:12:24
    |
 LL | impl inner::TraitB for Struct {}
    |                        ^^^^^^ the trait `TraitA` is not implemented for `Struct`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/false-sealed-traits-note.rs:4:5
+  --> $DIR/false-sealed-traits-note.rs:5:5
    |
 LL |     pub trait TraitA {}
    |     ^^^^^^^^^^^^^^^^
 note: required by a bound in `TraitB`
-  --> $DIR/false-sealed-traits-note.rs:6:23
+  --> $DIR/false-sealed-traits-note.rs:7:23
    |
 LL |     pub trait TraitB: TraitA {}
    |                       ^^^^^^ required by this bound in `TraitB`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `C: A` is not satisfied
+  --> $DIR/false-sealed-traits-note.rs:20:16
+   |
+LL |     impl B for C {}
+   |                ^ the trait `A` is not implemented for `C`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/false-sealed-traits-note.rs:16:5
+   |
+LL |     pub trait A {}
+   |     ^^^^^^^^^^^
+note: required by a bound in `B`
+  --> $DIR/false-sealed-traits-note.rs:17:18
+   |
+LL |     pub trait B: A {}
+   |                  ^ required by this bound in `B`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence.stderr
@@ -16,7 +16,7 @@ LL |         &0...9 => {}
    |         ^^^^^^ help: use `..=` for an inclusive range: `&(0..=9)`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/range-inclusive-pattern-precedence.rs:7:9
    |

--- a/tests/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/tests/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -16,7 +16,7 @@ LL |         box 0...9 => {}
    |              ^^^ help: use `..=` for an inclusive range
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/range-inclusive-pattern-precedence2.rs:5:9
    |

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -79,7 +79,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = help: in order for the call to be safe, the context requires the following additional target feature: sse2
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 note: an unsafe function restricts its caller, but its body is safe by default

--- a/tests/ui/rust-2021/array-into-iter-ambiguous.stderr
+++ b/tests/ui/rust-2021/array-into-iter-ambiguous.stderr
@@ -5,7 +5,7 @@ LL |     let y = points.into_iter();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyIntoIter::into_iter(points)`
    |
    = warning: this changes meaning in Rust 2021
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html>
 note: the lint level is defined here
   --> $DIR/array-into-iter-ambiguous.rs:5:9
    |

--- a/tests/ui/rust-2021/future-prelude-collision-generic-trait.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-generic-trait.stderr
@@ -5,7 +5,7 @@ LL |         U::try_from(self)
    |         ^^^^^^^^^^^ help: disambiguate the associated function: `<U as PyTryFrom<'_, _>>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-generic-trait.rs:5:9
    |

--- a/tests/ui/rust-2021/future-prelude-collision-generic.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-generic.stderr
@@ -5,7 +5,7 @@ LL |     Generic::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic<'_, _> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-generic.rs:5:9
    |
@@ -19,7 +19,7 @@ LL |     Generic::<'static, i32>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<'static, i32> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-generic.rs:34:5
@@ -28,7 +28,7 @@ LL |     Generic::<'_, _>::from_iter(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Generic::<'_, _> as MyFromIter>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 3 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-imported.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-imported.stderr
@@ -5,7 +5,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-imported.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `crate::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:53:22
@@ -28,7 +28,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `super::m::TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision-imported.rs:64:22
@@ -37,7 +37,7 @@ LL |         let _: u32 = 3u8.try_into().unwrap();
    |                      ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 4 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-macros.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-macros.stderr
@@ -5,7 +5,7 @@ LL |     foo!().try_into(todo!());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyTry::try_into(foo!(), todo!())`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-macros.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |     <bar!()>::try_from(0);
    |     ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<bar!() as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision-turbofish.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision-turbofish.stderr
@@ -5,7 +5,7 @@ LL |     x.try_into::<usize>().or(Err("foo"))?.checked_sub(1);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision-turbofish.rs:6:9
    |
@@ -19,7 +19,7 @@ LL |     x.try_into::<usize>().or(Err("foo"))?;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `AnnotatableTryInto::try_into::<usize>(x)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/rust-2021/future-prelude-collision.stderr
+++ b/tests/ui/rust-2021/future-prelude-collision.stderr
@@ -5,7 +5,7 @@ LL |     let _: u32 = 3u8.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(3u8)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-prelude-collision.rs:4:9
    |
@@ -19,7 +19,7 @@ LL |     let _ = u32::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^ help: disambiguate the associated function: `<u32 as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:66:13
@@ -28,7 +28,7 @@ LL |     let _ = <Vec<u8>>::from_iter(vec![1u8, 2, 3, 4, 5, 6].into_iter());
    |             ^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<u8> as FromByteIterator>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:74:18
@@ -37,7 +37,7 @@ LL |     let _: u32 = <_>::try_from(3u8).unwrap();
    |                  ^^^^^^^^^^^^^ help: disambiguate the associated function: `<_ as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:79:18
@@ -46,7 +46,7 @@ LL |     let _: u32 = (&3u8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(*(&3u8))`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:84:18
@@ -55,7 +55,7 @@ LL |     let _: u32 = 3.0.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(&3.0)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait method `try_into` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:90:18
@@ -64,7 +64,7 @@ LL |     let _: u32 = mut_ptr.try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `TryIntoU32::try_into(mut_ptr as *const _)`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: trait-associated function `try_from` will become ambiguous in Rust 2021
   --> $DIR/future-prelude-collision.rs:95:13
@@ -73,7 +73,7 @@ LL |     let _ = U32Alias::try_from(3u8).unwrap();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<U32Alias as TryFromU8>::try_from`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 
 warning: 8 warnings emitted
 

--- a/tests/ui/rust-2021/generic-type-collision.stderr
+++ b/tests/ui/rust-2021/generic-type-collision.stderr
@@ -5,7 +5,7 @@ LL |     <Vec<i32>>::from_iter(None);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<i32> as MyTrait<_>>::from_iter`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/generic-type-collision.rs:4:9
    |

--- a/tests/ui/rust-2021/inherent-dyn-collision.stderr
+++ b/tests/ui/rust-2021/inherent-dyn-collision.stderr
@@ -5,7 +5,7 @@ LL |         get_dyn_trait().try_into().unwrap()
    |         ^^^^^^^^^^^^^^^ help: disambiguate the method call: `(&*get_dyn_trait())`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
   --> $DIR/inherent-dyn-collision.rs:8:9
    |

--- a/tests/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/tests/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -5,7 +5,7 @@ LL |     m2!(z"hey");
    |         ^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-prefixes-migration.rs:5:9
    |
@@ -23,7 +23,7 @@ LL |     m2!(prefix"hey");
    |         ^^^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m2!(prefix "hey");
@@ -36,7 +36,7 @@ LL |     m3!(hey#123);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #123);
@@ -49,7 +49,7 @@ LL |     m3!(hey#hey);
    |         ^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     m3!(hey #hey);
@@ -62,7 +62,7 @@ LL |     #name = #kind#value
    |              ^^^^ unknown prefix
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/reserving-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL |     #name = #kind #value

--- a/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
+++ b/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
@@ -5,7 +5,7 @@ LL |     let y = points.into_iter();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyIntoIter::into_iter(points)`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/intoiterator-box-slice.html>
 note: the lint level is defined here
   --> $DIR/box-slice-into-iter-ambiguous.rs:5:9
    |

--- a/tests/ui/rust-2024/gen-kw.e2015.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2015.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2018.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2018.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(async {}).poll(&mut context());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-poll-async-block.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(()).poll();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(()))`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/future-poll-not-future-pinned.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/prelude-migration/in_2024_compatibility.stderr
@@ -5,7 +5,7 @@ LL |     core::pin::pin!(async {}).poll(&mut context());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/in_2024_compatibility.rs:3:9
    |

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
@@ -5,7 +5,7 @@ LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/into-future-adt.rs:7:9
    |

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
@@ -5,7 +5,7 @@ LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
   --> $DIR/into-future-not-into-future.rs:7:9
    |

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -35,7 +35,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-lexing.rs:4:9
    |
@@ -53,7 +53,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -66,7 +66,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -79,7 +79,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -92,7 +92,7 @@ LL |     demo7!(### "foo"###);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(# ## "foo"###);
@@ -105,7 +105,7 @@ LL |     demo7!(### "foo"###);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(## # "foo"###);
@@ -118,7 +118,7 @@ LL |     demo7!(### "foo"###);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"# ##);
@@ -131,7 +131,7 @@ LL |     demo7!(### "foo"###);
    |                      ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"## #);
@@ -144,7 +144,7 @@ LL |     demo5!(###"foo"#);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# ##"foo"#);
@@ -157,7 +157,7 @@ LL |     demo5!(###"foo"#);
    |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## #"foo"#);
@@ -170,7 +170,7 @@ LL |     demo5!(###"foo"#);
    |              ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(### "foo"#);
@@ -183,7 +183,7 @@ LL |     demo5!(#"foo"###);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# "foo"###);
@@ -196,7 +196,7 @@ LL |     demo5!(#"foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"# ##);
@@ -209,7 +209,7 @@ LL |     demo5!(#"foo"###);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"## #);
@@ -222,7 +222,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -235,7 +235,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -248,7 +248,7 @@ LL |     demo4!(Ñ#""#);
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(Ñ# ""#);
@@ -261,7 +261,7 @@ LL |     demo3!(🙃#"");
    |              ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(🙃# "");

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -5,7 +5,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-migration.rs:5:9
    |
@@ -23,7 +23,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -36,7 +36,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -49,7 +49,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -62,7 +62,7 @@ LL |     demo6!(### "foo"##);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(# ## "foo"##);
@@ -75,7 +75,7 @@ LL |     demo6!(### "foo"##);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(## # "foo"##);
@@ -88,7 +88,7 @@ LL |     demo6!(### "foo"##);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(### "foo"# #);
@@ -101,7 +101,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -114,7 +114,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -127,7 +127,7 @@ LL |     demo2!(#"");
    |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "");
@@ -140,7 +140,7 @@ LL |     demo3!(#""#);
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# ""#);
@@ -153,7 +153,7 @@ LL |     demo3!(##"");
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"");
@@ -166,7 +166,7 @@ LL |     demo3!(##"");
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "");
@@ -179,7 +179,7 @@ LL |     demo2!(#"foo");
    |            ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "foo");
@@ -192,7 +192,7 @@ LL |     demo3!(##"foo");
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"foo");
@@ -205,7 +205,7 @@ LL |     demo3!(##"foo");
    |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "foo");
@@ -218,7 +218,7 @@ LL |     demo3!(#"foo"#);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# "foo"#);
@@ -231,7 +231,7 @@ LL |     demo4!(##"foo"#);
    |            ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(# #"foo"#);
@@ -244,7 +244,7 @@ LL |     demo4!(##"foo"#);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(## "foo"#);
@@ -257,7 +257,7 @@ LL |     demo5!(##"foo"##);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# #"foo"##);
@@ -270,7 +270,7 @@ LL |     demo5!(##"foo"##);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## "foo"##);
@@ -283,7 +283,7 @@ LL |     demo5!(##"foo"##);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(##"foo"# #);

--- a/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
@@ -5,7 +5,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/in_2024_compatibility.rs:1:9
    |

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
@@ -5,7 +5,7 @@ LL | tt!([no_mangle]);
    |      ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/unsafe-attributes-fix.rs:2:9
    |
@@ -26,7 +26,7 @@ LL | ident!(no_mangle);
    | ----------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -40,7 +40,7 @@ LL | meta!(no_mangle);
    |       ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta!(unsafe(no_mangle));
@@ -53,7 +53,7 @@ LL | meta2!(export_name = "baw");
    |        ^^^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta2!(unsafe(export_name = "baw"));
@@ -69,7 +69,7 @@ LL | ident2!(export_name, "bars");
    | ---------------------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident2` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -86,7 +86,7 @@ LL | with_cfg_attr!();
    | ---------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `with_cfg_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -100,7 +100,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | #[unsafe(no_mangle)]

--- a/tests/ui/rust-2024/unsafe-env-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>
 note: the lint level is defined here
   --> $DIR/unsafe-env-suggestion.rs:3:9
    |
@@ -24,7 +24,7 @@ LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html>
 help: you can wrap the call in an `unsafe` block if you can guarantee that the environment access only happens in single-threaded code
    |
 LL +     // TODO: Audit that the environment access only happens in single-threaded code.

--- a/tests/ui/rust-2024/unsafe-env.e2021.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2021.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1

--- a/tests/ui/rust-2024/unsafe-env.e2024.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2024.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `std::env::set_var` is unsafe and requires
 LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `std::env::remove_var` is unsafe and requi
 LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `set_var` is unsafe and requires unsafe block

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
@@ -14,7 +14,7 @@ LL | | }
    | |_^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html>
 note: the lint level is defined here
   --> $DIR/unsafe-extern-suggestion.rs:3:9
    |

--- a/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -1,26 +1,38 @@
-error: malformed `unstable` attribute input
+error[E0539]: malformed `unstable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:8:5
    |
 LL |     #[unstable]
-   |     ^^^^^^^^^^^ help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
+   |     ^^^^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
 
-error: malformed `unstable` attribute input
+error[E0539]: malformed `unstable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:11:5
    |
 LL |     #[unstable = "b"]
-   |     ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
+   |     ^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[unstable(feature = "name", reason = "...", issue = "N")]`
 
-error: malformed `stable` attribute input
+error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:14:5
    |
 LL |     #[stable]
-   |     ^^^^^^^^^ help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |     ^^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
-error: malformed `stable` attribute input
+error[E0539]: malformed `stable` attribute input
   --> $DIR/stability-attribute-sanity-4.rs:17:5
    |
 LL |     #[stable = "a"]
-   |     ^^^^^^^^^^^^^^^ help: must be of the form: `#[stable(feature = "name", since = "version")]`
+   |     ^^^^^^^^^^^^^^^
+   |     |
+   |     expected this to be a list
+   |     help: must be of the form: `#[stable(feature = "name", since = "version")]`
 
 error[E0542]: missing 'since'
   --> $DIR/stability-attribute-sanity-4.rs:21:5
@@ -42,5 +54,5 @@ LL |     #[deprecated = "a"]
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0542, E0543.
-For more information about an error, try `rustc --explain E0542`.
+Some errors have detailed explanations: E0539, E0542, E0543.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL | static n: &'static usize = unsafe { &n_mut };
    |                                     ^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |     let _ = unsafe { (&TEST) as *const usize };
    |                      ^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a mutable reference to mutable static
 LL |     let _ = unsafe { (&mut TEST) as *const usize };
    |                      ^^^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 3);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 
@@ -14,7 +14,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 4);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -23,7 +23,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 5);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -32,7 +32,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, 15);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -41,7 +41,7 @@ warning: creating a shared reference to mutable static
 LL |     assert_eq!(static_mut_xc::a, -3);
    |                ^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static
@@ -50,7 +50,7 @@ warning: creating a shared reference to mutable static
 LL |     static_bound(&static_mut_xc::a);
    |                  ^^^^^^^^^^^^^^^^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
@@ -63,7 +63,7 @@ warning: creating a mutable reference to mutable static
 LL |     static_bound_set(&mut static_mut_xc::a);
    |                      ^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -4,7 +4,7 @@ warning: creating a shared reference to mutable static
 LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
    |                                    ^^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
@@ -18,7 +18,7 @@ warning: creating a shared reference to mutable static
 LL |         assert_eq!(S, *(S as *const *const u8));
    |                    ^ shared reference to mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: 2 warnings emitted

--- a/tests/ui/suggestions/issue-116434-2015.stderr
+++ b/tests/ui/suggestions/issue-116434-2015.stderr
@@ -5,7 +5,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -52,7 +52,7 @@ LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn handle() -> dyn DbHandle;
@@ -65,7 +65,7 @@ LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/suggestions/issue-61963.stderr
+++ b/tests/ui/suggestions/issue-61963.stderr
@@ -5,7 +5,7 @@ LL |     bar: Box<Bar>,
    |              ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 note: the lint level is defined here
   --> $DIR/issue-61963.rs:4:9
    |
@@ -23,7 +23,7 @@ LL | pub struct Foo {
    | ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | dyn pub struct Foo {

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -68,7 +68,7 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |                           ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -82,7 +82,7 @@ LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |                         ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
@@ -95,7 +95,7 @@ LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |                          ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -5,7 +5,7 @@ LL | fn foo(_x: Foo + Send) {
    |            ^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
@@ -5,7 +5,7 @@ LL | impl Foo<i64> {
    |      ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -23,7 +23,7 @@ LL | impl Foo<i64> {
    |      ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: if this is a dyn-compatible trait, use `dyn`
    |

--- a/tests/ui/traits/unspecified-self-in-trait-ref.stderr
+++ b/tests/ui/traits/unspecified-self-in-trait-ref.stderr
@@ -5,7 +5,7 @@ LL |     let a = Foo::lol();
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -25,7 +25,7 @@ LL |     let b = Foo::<_>::lol();
    |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let b = <dyn Foo::<_>>::lol();
@@ -44,7 +44,7 @@ LL |     let c = Bar::lol();
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let c = <dyn Bar>::lol();
@@ -63,7 +63,7 @@ LL |     let d = Bar::<usize, _>::lol();
    |             ^^^^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let d = <dyn Bar::<usize, _>>::lol();
@@ -82,7 +82,7 @@ LL |     let e = Bar::<usize>::lol();
    |             ^^^^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let e = <dyn Bar::<usize>>::lol();

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:8:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition_2024_default.rs:11:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/in_2024_compatibility.rs:6:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
@@ -53,7 +53,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:23:1
@@ -73,7 +73,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -82,7 +82,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:11:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     let y = *x;
    |             ^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:23:1
@@ -46,7 +46,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     y + *x
    |         ^^ dereference of raw pointer
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -55,7 +55,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     let y = BAZ;
    |             ^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:36:1
@@ -69,7 +69,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     y + BAZ
    |         ^^^ use of mutable static
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
@@ -81,7 +81,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:58:1
@@ -99,7 +99,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
    = note: this error originates in the macro `unsafe_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -5,7 +5,7 @@ LL | trait Foo<const N: Bar<2>> {
    |                    ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
 help: if this is a dyn-compatible trait, use `dyn`
    |
@@ -19,7 +19,7 @@ LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
 help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Bar<const M: dyn Foo<2>> {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#143374 (Unquerify extern_mod_stmt_cnum.)
 - rust-lang/rust#143838 (std: net: uefi: Add support to query connection data)
 - rust-lang/rust#144014 (don't link to the nightly version of the Edition Guide in stable lints)
 - rust-lang/rust#144094 (Ensure we codegen the main fn)
 - rust-lang/rust#144218 (Use serde for target spec json deserialize)
 - rust-lang/rust#144221 (generate elf symbol version in raw-dylib)
 - rust-lang/rust#144232 (Implement support for `become` and explicit tail call codegen for the LLVM backend)
 - rust-lang/rust#144240 (Add more test case to check if the false note related to sealed trait suppressed)
 - rust-lang/rust#144247 (coretests/num: use ldexp instead of hard-coding a power of 2)
 - rust-lang/rust#144276 (Use less HIR in check_private_in_public.)
 - rust-lang/rust#144278 (add Rev::into_inner)
 - rust-lang/rust#144317 (pass build.npm from bootstrap to tidy and use it for npm install)
 - rust-lang/rust#144320 (rustdoc: avoid allocating a temp String for aliases in search index)
 - rust-lang/rust#144334 (rustc_resolve: get rid of unused rustdoc::span_of_fragments_with_expansion)
 - rust-lang/rust#144335 (Don't suggest assoc ty bound on non-angle-bracketed problematic assoc ty binding)
 - rust-lang/rust#144358 (Stop using the old `validate_attr` logic for stability attributes)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=143374,143838,144014,144094,144218,144221,144232,144240,144247,144276,144278,144317,144320,144334,144335,144358)
<!-- homu-ignore:end -->