### PR TITLE
[Debug Info] Generate typedef nodes for ptr/ref types (and msvc arrays)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -128,6 +128,21 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
         )
     };
 
+    if cpp_like_debuginfo(cx.tcx) {
+        let array_type_name = compute_debuginfo_type_name(cx.tcx, array_type, false);
+        di_node = unsafe {
+            llvm::LLVMRustDIBuilderCreateTypedef(
+                DIB(cx),
+                di_node,
+                array_type_name.as_c_char_ptr(),
+                array_type_name.len(),
+                unknown_file_metadata(cx),
+                UNKNOWN_LINE_NUMBER,
+                None,
+            )
+        };
+    }
+
     DINodeCreationResult::new(di_node, false)
 }
 
@@ -177,8 +192,19 @@ fn build_pointer_or_reference_di_node<'ll, 'tcx>(
                 pointer_align.abi,
                 &ptr_type_debuginfo_name,
             );
+            let typedefed_ptr = unsafe {
+                llvm::LLVMRustDIBuilderCreateTypedef(
+                    DIB(cx),
+                    di_node,
+                    ptr_type_debuginfo_name.as_c_char_ptr(),
+                    ptr_type_debuginfo_name.len(),
+                    unknown_file_metadata(cx),
+                    UNKNOWN_LINE_NUMBER,
+                    None,
+                )
+            };
 
-            DINodeCreationResult { di_node, already_stored_in_typemap: false }
+            DINodeCreationResult { di_node: typedefed_ptr, already_stored_in_typemap: false }
         }
         Some(wide_pointer_kind) => {
             type_map::build_type_with_children(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -117,7 +117,7 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
     let subrange = unsafe { llvm::LLVMDIBuilderGetOrCreateSubrange(DIB(cx), 0, upper_bound) };
     let subscripts = &[subrange];
 
-    let di_node = unsafe {
+    let mut di_node = unsafe {
         llvm::LLVMDIBuilderCreateArrayType(
             DIB(cx),
             size.bits(),
@@ -131,14 +131,15 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
     if cpp_like_debuginfo(cx.tcx) {
         let array_type_name = compute_debuginfo_type_name(cx.tcx, array_type, false);
         di_node = unsafe {
-            llvm::LLVMRustDIBuilderCreateTypedef(
+            llvm::LLVMDIBuilderCreateTypedef(
                 DIB(cx),
                 di_node,
-                array_type_name.as_c_char_ptr(),
+                array_type_name.as_ptr(),
                 array_type_name.len(),
                 unknown_file_metadata(cx),
                 UNKNOWN_LINE_NUMBER,
                 None,
+                0,
             )
         };
     }
@@ -193,14 +194,15 @@ fn build_pointer_or_reference_di_node<'ll, 'tcx>(
                 &ptr_type_debuginfo_name,
             );
             let typedefed_ptr = unsafe {
-                llvm::LLVMRustDIBuilderCreateTypedef(
+                llvm::LLVMDIBuilderCreateTypedef(
                     DIB(cx),
                     di_node,
-                    ptr_type_debuginfo_name.as_c_char_ptr(),
+                    ptr_type_debuginfo_name.as_ptr(),
                     ptr_type_debuginfo_name.len(),
                     unknown_file_metadata(cx),
                     UNKNOWN_LINE_NUMBER,
                     None,
+                    0,
                 )
             };
 

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -15,6 +15,9 @@ def unwrap_unique_or_non_null(unique_or_nonnull):
     # BACKCOMPAT: rust 1.60
     # https://github.com/rust-lang/rust/commit/2a91eeac1a2d27dd3de1bf55515d765da20fd86f
     ptr = unique_or_nonnull["pointer"]
+    if ptr.type.code == gdb.TYPE_CODE_TYPEDEF:
+        ptr = ptr.cast(ptr.type.strip_typedefs())
+
     return ptr if ptr.type.code == gdb.TYPE_CODE_PTR else ptr[ptr.type.fields()[0]]
 
 

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -147,8 +147,9 @@ class StdVecProvider(printer_base):
         self._valobj = valobj
         self._length = int(valobj["len"])
         self._data_ptr = unwrap_unique_or_non_null(valobj["buf"]["inner"]["ptr"])
-        ptr_ty = gdb.Type.pointer(valobj.type.template_argument(0))
-        self._data_ptr = self._data_ptr.reinterpret_cast(ptr_ty)
+        self._data_ptr = self._data_ptr.cast(self._data_ptr.type.strip_typedefs())
+        ptr_ty = valobj.type.template_argument(0).pointer()
+        self._data_ptr = self._data_ptr.cast(ptr_ty)
 
     def to_string(self):
         return "Vec(size={})".format(self._length)
@@ -177,8 +178,9 @@ class StdVecDequeProvider(printer_base):
             cap = cap[ZERO_FIELD]
         self._cap = int(cap)
         self._data_ptr = unwrap_unique_or_non_null(valobj["buf"]["inner"]["ptr"])
-        ptr_ty = gdb.Type.pointer(valobj.type.template_argument(0))
-        self._data_ptr = self._data_ptr.reinterpret_cast(ptr_ty)
+        self._data_ptr = self._data_ptr.cast(self._data_ptr.type.strip_typedefs())
+        ptr_ty = valobj.type.template_argument(0).pointer()
+        self._data_ptr = self._data_ptr.cast(ptr_ty)
 
     def to_string(self):
         return "VecDeque(size={})".format(self._size)

--- a/tests/codegen-llvm/debug-vtable.rs
+++ b/tests/codegen-llvm/debug-vtable.rs
@@ -21,19 +21,21 @@
 
 // NONMSVC: ![[USIZE:[0-9]+]] = !DIBasicType(name: "usize"
 // MSVC: ![[USIZE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "usize"
-// NONMSVC: ![[PTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "*const ()"
-// MSVC: ![[PTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "ptr_const$<tuple$<> >"
+// NONMSVC: ![[PTR_TYPEDEF:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "*const ()", file: {{.*}}, baseType: ![[PTR:[0-9]+]])
+// MSVC: ![[PTR_TYPEDEF:[0-9]+]] = !DIDerivedType(tag: DW_TAG_typedef, name: "ptr_const$<tuple$<> >", file: {{.*}}, baseType: ![[PTR:[0-9]+]])
+// NONMSVC: ![[PTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "*const ()"
+// MSVC: ![[PTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "ptr_const$<tuple$<> >"
 
 // NONMSVC: !DIGlobalVariable(name: "<debug_vtable::Foo as debug_vtable::SomeTrait>::{vtable}"
 // MSVC: !DIGlobalVariable(name: "impl$<debug_vtable::Foo, debug_vtable::SomeTrait>::vtable$"
 
 // NONMSVC: ![[VTABLE_TY0:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "<debug_vtable::Foo as debug_vtable::SomeTrait>::{vtable_type}", {{.*}} size: {{320|160}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}} vtableHolder: ![[FOO_TYPE:[0-9]+]],
 // MSVC: ![[VTABLE_TY0:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "impl$<debug_vtable::Foo, debug_vtable::SomeTrait>::vtable_type$", {{.*}} size: {{320|160}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}} vtableHolder: ![[FOO_TYPE:[0-9]+]],
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "size", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "align", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{128|64}})
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method3", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}}, offset: {{192|96}})
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method4", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}}, offset: {{256|128}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method3", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}}, offset: {{192|96}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method4", scope: ![[VTABLE_TY0]], {{.*}} baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}}, offset: {{256|128}})
 // CHECK: ![[FOO_TYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo",
 
 // NONMSVC: !DIGlobalVariable(name: "<debug_vtable::Foo as debug_vtable::SomeTraitWithGenerics<u64, i8>>::{vtable}"
@@ -41,17 +43,17 @@
 
 // NONMSVC: ![[VTABLE_TY1:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "<debug_vtable::Foo as debug_vtable::SomeTraitWithGenerics<u64, i8>>::{vtable_type}", {{.*}}, size: {{256|128}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}}, vtableHolder: ![[FOO_TYPE]],
 // MSVC: ![[VTABLE_TY1:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "impl$<debug_vtable::Foo, debug_vtable::SomeTraitWithGenerics<u64,i8> >::vtable_type$", {{.*}}, size: {{256|128}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}}, vtableHolder: ![[FOO_TYPE]],
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "size", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "align", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{128|64}})
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method3", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}}, offset: {{192|96}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "__method3", scope: ![[VTABLE_TY1]], {{.*}} baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}}, offset: {{192|96}})
 
 // NONMSVC: !DIGlobalVariable(name: "<debug_vtable::Foo as _>::{vtable}"
 // MSVC: !DIGlobalVariable(name: "impl$<debug_vtable::Foo, _>::vtable$"
 
 // NONMSVC: ![[VTABLE_TY2:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "<debug_vtable::Foo as _>::{vtable_type}", {{.*}}, size: {{192|96}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}}, vtableHolder: ![[FOO_TYPE]],
 // MSVC: ![[VTABLE_TY2:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "impl$<debug_vtable::Foo, _>::vtable_type$", {{.*}}, size: {{192|96}}, align: {{64|32}}, flags: DIFlagArtificial, {{.*}}, vtableHolder: ![[FOO_TYPE]],
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY2]], {{.*}}, baseType: ![[PTR]], size: {{64|32}}, align: {{64|32}})
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "drop_in_place", scope: ![[VTABLE_TY2]], {{.*}}, baseType: ![[PTR_TYPEDEF]], size: {{64|32}}, align: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "size", scope: ![[VTABLE_TY2]], {{.*}}, baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{64|32}})
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "align", scope: ![[VTABLE_TY2]], {{.*}}, baseType: ![[USIZE]], size: {{64|32}}, align: {{64|32}}, offset: {{128|64}})
 

--- a/tests/debuginfo/basic-types-metadata.rs
+++ b/tests/debuginfo/basic-types-metadata.rs
@@ -43,12 +43,12 @@
 //@ gdb-check: type = struct basic_types_metadata::main::{closure_env#0}
 //@ gdb-command:ptype closure_1
 //@ gdb-check: type = struct basic_types_metadata::main::{closure_env#1} {
-//@ gdb-check:     *mut bool,
+//@ gdb-check:     _ref__b: &bool,
 //@ gdb-check: }
 //@ gdb-command:ptype closure_2
 //@ gdb-check: type = struct basic_types_metadata::main::{closure_env#2} {
-//@ gdb-check:     *mut bool,
-//@ gdb-check:     *mut isize,
+//@ gdb-check:     _ref__b: &bool,
+//@ gdb-check:     _ref__i: &isize,
 //@ gdb-check: }
 
 //@ gdb-command:continue

--- a/tests/debuginfo/function-call.rs
+++ b/tests/debuginfo/function-call.rs
@@ -13,7 +13,7 @@
 //@ gdb-command:print fun(444, false)
 //@ gdb-check:$2 = false
 
-//@ gdb-command:print r.get_x()
+//@ gdb-command: print function_call::RegularStruct::get_x(&r)
 //@ gdb-check:$3 = 4
 
 #![allow(dead_code, unused_variables)]

--- a/tests/debuginfo/function-names.rs
+++ b/tests/debuginfo/function-names.rs
@@ -29,9 +29,9 @@
 
 // Closure
 //@ gdb-command:info functions -q function_names::.*::{closure.*
-//@ gdb-check:[...]static fn function_names::generic_func::{closure#0}<i32>(*mut function_names::generic_func::{closure_env#0}<i32>);
-//@ gdb-check:[...]static fn function_names::main::{closure#0}(*mut function_names::main::{closure_env#0});
-//@ gdb-check:[...]static fn function_names::{impl#2}::impl_function::{closure#0}<i32, i32>(*mut function_names::{impl#2}::impl_function::{closure_env#0}<i32, i32>);
+//@ gdb-check:[...]static fn function_names::generic_func::{closure#0}<i32>(&function_names::generic_func::{closure_env#0}<i32>);
+//@ gdb-check:[...]static fn function_names::main::{closure#0}(&function_names::main::{closure_env#0});
+//@ gdb-check:[...]static fn function_names::{impl#2}::impl_function::{closure#0}<i32, i32>(&function_names::{impl#2}::impl_function::{closure_env#0}<i32, i32>);
 
 // Coroutine
 // Coroutines don't seem to appear in GDB's symbol table.

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -166,10 +166,10 @@
 
 // FOREIGN TYPES
 //@ gdb-command:whatis foreign1
-//@ gdb-check:type = *mut type_names::{extern#0}::ForeignType1
+//@ gdb-check:type = *const type_names::{extern#0}::ForeignType1
 
 //@ gdb-command:whatis foreign2
-//@ gdb-check:type = *mut type_names::mod1::{extern#0}::ForeignType2
+//@ gdb-check:type = *const type_names::mod1::{extern#0}::ForeignType2
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/debuginfo/unit-type.rs
+++ b/tests/debuginfo/unit-type.rs
@@ -9,10 +9,10 @@
 //@ gdb-command: run
 
 //@ gdb-command: print _ref
-//@ gdb-check: $1 = (*mut ()) 0x[...]
+//@ gdb-check: $1 = (&()) 0x[...]
 
 //@ gdb-command: print _ptr
-//@ gdb-check: $2 = (*mut ()) 0x[...]
+//@ gdb-check: $2 = (*const ()) 0x[...]
 
 //@ gdb-command: print _local
 //@ gdb-check: $3 = ()


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144394)*
<!-- homu-ignore:end -->

This kills like 17 birds with 1 stone. It allows displaying the proper `&`/`&mut`/`*const`/`*mut` type name for `*-gnu` targets, and fixes a bunch of issues with visualizing `*-msvc` targets.

In short, none of the debuggers (in their current states) respect the "name" field that is passed to `LLVMRustDIBuilderCreatePointerType`. That field *does* appear in the `DWARF` data, but GDB and LLDB don't care. 

This patch wraps the pointer nodes (and msvc array type) in a typedef before finalizing them. Worth noting, this typedef trick is [already being used for `*-msvc` primitive types.](https://github.com/rust-lang/rust/blob/master/compiler%2Frustc_codegen_llvm%2Fsrc%2Fdebuginfo%2Fmetadata.rs#L793-L816)

# `*-gnu` 

Mainly fixes type-name output. Screenshots should be self-explanatory. 

## GDB

GDB by default hard-codes pointer types to `*mut`. This "fixes" that without requiring a code change in GDB, but that's mostly just a happy side effect.

<img width="899" height="560" alt="image" src="https://github.com/user-attachments/assets/800dd7b7-4ca8-4e19-936d-0ec94111a394" />

## LLDB

`TypeSystemClang` ignores the `name` field of the pointer in the `DWARF` info. Using a typedef sidesteps that deficiency. We could maybe modify `TypeSystemClang` so this isn't necessary, but since it relies on `clang` (read: c/c++) compiler type representations under the hood, I'm not sure if pointers can *have* names and it's not really reasonable to change clang itself to accommodate rust.

<img width="964" height="560" alt="image" src="https://github.com/user-attachments/assets/7c69173d-09cb-49b3-913a-c2fac0b8985e" />



# `*-msvc`

As opposed to `DWARF`, the `name` field does not exist anywhere in the `PDB` data. There are 2 reasons for this

1. [Pointer nodes do not contain a name field](http://www.openwatcom.org/ftp/devel/docs/CodeView.pdf#page=34)

2. Primitive types are [unique, special nodes](http://www.openwatcom.org/ftp/devel/docs/CodeView.pdf#page=59) that have an additional [unique, special representation for pointer-to-primitive](http://www.openwatcom.org/ftp/devel/docs/CodeView.pdf#page=60)

The issue with this is with container types, for example `Vec`. `Vec<T>`'s heap pointer is not a `*mut T`, it's a `*mut u8` that is cast to a `T` when needed using (more or less) `PhantomData<T>`. From the type's perspective, `T` only "exists" in the generic parameters. That means the debugger, working from the type's perspective, must look it up **by name**, (e.g. `Vec<ref$<u8> >` must look up the string "ref$\<u8\>"). 

Since those type names aren't in the PDB data, the lookup fails, the debugger cannot cast the heap pointer, and thus cannot visualize the elements of the container.

In LLDB, the sole arbiter of "what types exist" when doing a type lookup is the PDB data itself. I'm sure the `msdia` works the same way, but LLDB's native PDB parser checks the type stream, and any pointer-node-to-`T` is formatted C-style as `T *`. This problem also affects Microsoft's debugger.

`array$<T,N>` also needs a typedef, as arrays have a [bespoke node](http://www.openwatcom.org/ftp/devel/docs/CodeView.pdf#page=39) whose "name" field is also ignored in favor of the C-style format (e.g. `T[N]`). If you use Visual Sudio's natvis diagnostics logging, you can see errors such as this:

```
Natvis: C:\Users\ant_b\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\etc\liballoc.natvis(10,23): Error: identifier "array$<u32,7>" is undefined
    Error while evaluating '(array$<u32,7>*)buf.inner.ptr.pointer.pointer' in the context of type 'sample.exe!alloc::vec::Vec<array$<u32,7>,alloc::alloc::Global>'.
```

## LLDB (via CodeLLDB)

<img width="767" height="398" alt="image" src="https://github.com/user-attachments/assets/b17e6c8e-23e0-4980-8b90-95119a987c47" />

## CDB via Visual Studio 2022

<img width="882" height="335" alt="image" src="https://github.com/user-attachments/assets/c57ba7a8-7b6c-4049-9d30-4fd0f7eb94a8" />

## CDB via C/C++ extension in Visual Studio Code

The output is identical to Visual Studio, but I want to make a special note because i had to jump through a few hoops to get it to work correctly. Built with stable, it worked the same as the "Before" image from Visual Studio, but built with the patched compiler the `Vec` visualizer wasn't working.

Clearly based on the Visual Studio "After" screenshot, the natvis files still work. If you [binary-patch the extension so that it outputs verbose logging info](https://github.com/microsoft/vscode-cpptools/issues/10343#issuecomment-2628300741) it appears it never even tried to load `liballoc.natvis` for some reason?

I manually placed the natvis files in `C:\Users\<USER>\.vscode\extensions\ms-vscode.cpptools-1.26.3-win32-x64\debugAdapters\vsdbg\bin\Visualizers\` and it worked fine so iunno. Probably worth someone else testing too. Might also be because I'm only using a stage1 build instead of a full toolchain install? I'm not sure.

# Alternatives

I tried some fiddling with using the `reference` debug info node (which does have a valid counterpart in both `DWARF` and `PDB`). The issue is that LLDB uses `TypeSystemClang`, which is very C/C++-oriented. In Rust, references are borrowing pointers. In C++ references are not objects, they are not guaranteed to have a representation at run-time. That means no array-of-refs, no ref-to-ref, no pointer-to-ref. LLDB seems to interpret ref-to-ref incorrectly. That *can* be worked around but [the hack necessary for that is heinous](https://github.com/Walnut356/rust/blob/8d70c407b97dcfc2ab0086901213c6ee4338fd6e/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs#L193) and infects [the visualizers too](https://github.com/rust-lang/rust/commit/dd893c22117b21a36b5e6b2aff6377902d2b9ed5). It also means *without* the visualizers, the type-name output is sorta worse than it is now.

