### PR TITLE
Add a ratchet for moving all standard library tests to separate packages

### DIFF
--- a/library/rustc-std-workspace-alloc/Cargo.toml
+++ b/library/rustc-std-workspace-alloc/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2024"
 
 [lib]
 path = "lib.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 alloc = { path = "../alloc" }

--- a/library/rustc-std-workspace-core/Cargo.toml
+++ b/library/rustc-std-workspace-core/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2024"
 
 [lib]
 path = "lib.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 core = { path = "../core", public = true }

--- a/library/rustc-std-workspace-std/Cargo.toml
+++ b/library/rustc-std-workspace-std/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2024"
 
 [lib]
 path = "lib.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 std = { path = "../std" }

--- a/library/std_detect/src/detect/macros.rs
+++ b/library/std_detect/src/detect/macros.rs
@@ -131,14 +131,13 @@ macro_rules! features {
             };
         }
 
-        #[test] //tidy:skip
         #[deny(unexpected_cfgs)]
         #[deny(unfulfilled_lint_expectations)]
-        fn unexpected_cfgs() {
+        const _: () = {
             $(
                 check_cfg_feature!($feature, $feature_lit $(, without cfg check: $feature_cfg_check)? $(: $($target_feature_lit),*)?);
             )*
-        }
+        };
 
         /// Each variant denotes a position in a bitset for a particular feature.
         ///

--- a/library/std_detect/src/detect/os/riscv.rs
+++ b/library/std_detect/src/detect/os/riscv.rs
@@ -135,4 +135,5 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
 }
 
 #[cfg(test)]
+#[path = "riscv/tests.rs"]
 mod tests;

--- a/library/sysroot/Cargo.toml
+++ b/library/sysroot/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.0.0"
 edition = "2024"
 
 [lib]
+test = false
+bench = false
 # make sure this crate isn't included in public standard library docs
 doc = false
 

--- a/library/windows_targets/Cargo.toml
+++ b/library/windows_targets/Cargo.toml
@@ -4,6 +4,11 @@ description = "A drop-in replacement for the real windows-targets crate for use 
 version = "0.0.0"
 edition = "2024"
 
+[lib]
+test = false
+bench = false
+doc = false
+
 [features]
 # Enable using raw-dylib for Windows imports.
 # This will eventually be the default.

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -127,9 +127,9 @@ fn main() {
         check!(pal, &library_path);
 
         // Checks that need to be done for both the compiler and std libraries.
-        check!(unit_tests, &src_path);
-        check!(unit_tests, &compiler_path);
-        check!(unit_tests, &library_path);
+        check!(unit_tests, &src_path, false);
+        check!(unit_tests, &compiler_path, false);
+        check!(unit_tests, &library_path, true);
 
         if bins::check_filesystem_support(&[&root_path], &output_directory) {
             check!(bins, &root_path);

--- a/src/tools/tidy/src/unit_tests.rs
+++ b/src/tools/tidy/src/unit_tests.rs
@@ -1,44 +1,60 @@
 //! Tidy check to ensure `#[test]` and `#[bench]` are not used directly inside
-//! `core` or `alloc`.
+//! of the standard library.
 //!
 //! `core` and `alloc` cannot be tested directly due to duplicating lang items.
 //! All tests and benchmarks must be written externally in
 //! `{coretests,alloctests}/{tests,benches}`.
 //!
-//! Outside of `core` and `alloc`, tests and benchmarks should be outlined into
-//! separate files named `tests.rs` or `benches.rs`, or directories named
+//! Outside of the standard library, tests and benchmarks should be outlined
+//! into separate files named `tests.rs` or `benches.rs`, or directories named
 //! `tests` or `benches` unconfigured during normal build.
 
 use std::path::Path;
 
 use crate::walk::{filter_dirs, walk};
 
-pub fn check(root_path: &Path, bad: &mut bool) {
-    let core = root_path.join("core");
-    let core_copy = core.clone();
-    let is_core = move |path: &Path| path.starts_with(&core);
-    let alloc = root_path.join("alloc");
-    let alloc_copy = alloc.clone();
-    let is_alloc = move |path: &Path| path.starts_with(&alloc);
-
+pub fn check(root_path: &Path, stdlib: bool, bad: &mut bool) {
     let skip = move |path: &Path, is_dir| {
         let file_name = path.file_name().unwrap_or_default();
+
+        // Skip excluded directories and non-rust files
         if is_dir {
-            filter_dirs(path)
-                || path.ends_with("src/doc")
-                || (file_name == "tests" || file_name == "benches")
-                    && !is_core(path)
-                    && !is_alloc(path)
+            if filter_dirs(path) || path.ends_with("src/doc") {
+                return true;
+            }
         } else {
             let extension = path.extension().unwrap_or_default();
-            extension != "rs"
-                || (file_name == "tests.rs" || file_name == "benches.rs")
-                    && !is_core(path)
-                    && !is_alloc(path)
-                // Tests which use non-public internals and, as such, need to
-                // have the types in the same crate as the tests themselves. See
-                // the comment in alloctests/lib.rs.
-                || path.ends_with("library/alloc/src/collections/btree/borrow/tests.rs")
+            if extension != "rs" {
+                return true;
+            }
+        }
+
+        // Tests in a separate package are always allowed
+        if is_dir && file_name != "tests" && file_name.as_encoded_bytes().ends_with(b"tests") {
+            return true;
+        }
+
+        if !stdlib {
+            // Outside of the standard library tests may also be in separate files in the same crate
+            if is_dir {
+                if file_name == "tests" || file_name == "benches" {
+                    return true;
+                }
+            } else {
+                if file_name == "tests.rs" || file_name == "benches.rs" {
+                    return true;
+                }
+            }
+        }
+
+        if is_dir {
+            // FIXME remove those exceptions once no longer necessary
+            file_name == "std_detect" || file_name == "std" || file_name == "test"
+        } else {
+            // Tests which use non-public internals and, as such, need to
+            // have the types in the same crate as the tests themselves. See
+            // the comment in alloctests/lib.rs.
+            path.ends_with("library/alloc/src/collections/btree/borrow/tests.rs")
                 || path.ends_with("library/alloc/src/collections/btree/map/tests.rs")
                 || path.ends_with("library/alloc/src/collections/btree/node/tests.rs")
                 || path.ends_with("library/alloc/src/collections/btree/set/tests.rs")
@@ -50,22 +66,30 @@ pub fn check(root_path: &Path, bad: &mut bool) {
 
     walk(root_path, skip, &mut |entry, contents| {
         let path = entry.path();
-        let is_core = path.starts_with(&core_copy);
-        let is_alloc = path.starts_with(&alloc_copy);
+        let package = path
+            .strip_prefix(root_path)
+            .unwrap()
+            .components()
+            .next()
+            .unwrap()
+            .as_os_str()
+            .to_str()
+            .unwrap();
         for (i, line) in contents.lines().enumerate() {
             let line = line.trim();
             let is_test = || line.contains("#[test]") && !line.contains("`#[test]");
             let is_bench = || line.contains("#[bench]") && !line.contains("`#[bench]");
             let manual_skip = line.contains("//tidy:skip");
             if !line.starts_with("//") && (is_test() || is_bench()) && !manual_skip {
-                let explanation = if is_core {
-                    "`core` unit tests and benchmarks must be placed into `coretests`"
-                } else if is_alloc {
-                    "`alloc` unit tests and benchmarks must be placed into `alloctests`"
+                let explanation = if stdlib {
+                    format!(
+                        "`{package}` unit tests and benchmarks must be placed into `{package}tests`"
+                    )
                 } else {
                     "unit tests and benchmarks must be placed into \
                          separate files or directories named \
                          `tests.rs`, `benches.rs`, `tests` or `benches`"
+                        .to_owned()
                 };
                 let name = if is_test() { "test" } else { "bench" };
                 tidy_error!(

--- a/src/tools/tidy/src/unit_tests.rs
+++ b/src/tools/tidy/src/unit_tests.rs
@@ -79,8 +79,7 @@ pub fn check(root_path: &Path, stdlib: bool, bad: &mut bool) {
             let line = line.trim();
             let is_test = || line.contains("#[test]") && !line.contains("`#[test]");
             let is_bench = || line.contains("#[bench]") && !line.contains("`#[bench]");
-            let manual_skip = line.contains("//tidy:skip");
-            if !line.starts_with("//") && (is_test() || is_bench()) && !manual_skip {
+            if !line.starts_with("//") && (is_test() || is_bench()) {
                 let explanation = if stdlib {
                     format!(
                         "`{package}` unit tests and benchmarks must be placed into `{package}tests`"


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/136642 is the previous PR in this series. See https://github.com/rust-lang/rust/pull/135937 for the rationale of wanting to move all standard library tests to separate packages.

This also fixes std_detect testing on riscv.