### PR TITLE
fix(debuginfo): disable overflow check for recursive non-enum types

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
@@ -285,8 +285,8 @@ pub(super) fn build_type_with_children<'ll, 'tcx>(
         //     Item(T),
         // }
         // ```
-        let is_expanding_recursive =
-            debug_context(cx).adt_stack.borrow().iter().any(|(parent_def_id, parent_args)| {
+        let is_expanding_recursive = adt_def.is_enum()
+            && debug_context(cx).adt_stack.borrow().iter().any(|(parent_def_id, parent_args)| {
                 if def_id == *parent_def_id {
                     args.iter().zip(parent_args.iter()).any(|(arg, parent_arg)| {
                         if let (Some(arg), Some(parent_arg)) = (arg.as_type(), parent_arg.as_type())

--- a/tests/codegen-llvm/debuginfo-cyclic-structure.rs
+++ b/tests/codegen-llvm/debuginfo-cyclic-structure.rs
@@ -1,0 +1,32 @@
+//@ compile-flags:-g -Copt-level=0 -C panic=abort
+
+// Check that debug information exists for structures containing loops (cyclic references).
+// Previously it may incorrectly prune member information during recursive type inference check.
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Arc<debuginfo_cyclic_structure::Inner<alloc::sync::Arc<debuginfo_cyclic_structure::Handle{{.*}}elements: ![[FIELDS:[0-9]+]]
+// CHECK: ![[FIELDS]] = !{!{{.*}}}
+// CHECK-NOT: ![[FIELDS]] = !{}
+
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+struct Inner<T> {
+    buffer: Box<MaybeUninit<T>>,
+}
+struct Shared {
+    shared: Arc<Inner<Arc<Handle>>>,
+}
+struct Handle {
+    shared: Shared,
+}
+struct Core {
+    inner: Arc<Inner<Arc<Handle>>>,
+}
+
+#[no_mangle]
+extern "C" fn test() {
+    let с = Core { inner: Arc::new(Inner { buffer: Box::new(MaybeUninit::uninit()) }) };
+    std::hint::black_box(с);
+}


### PR DESCRIPTION
Commit b10edb4 introduce an overflow check when generating debuginfo for expanding recursive types. While this check works correctly for enums, it can incorrectly prune valid debug information for structures.

For example see rust-lang/rust#143241 (https://github.com/rust-lang/rust/issues/143241#issuecomment-3073721477). Furthermore, for structures such check does not make sense, since structures with recursively expanding types simply will not compile (there is a `hir_analysis_recursive_generic_parameter` for that).

closes rust-lang/rust#143241

