### PR TITLE
Stop compilation early if macro expansion failed

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1224,6 +1224,7 @@ pub struct ExtCtxt<'a> {
     pub(super) expanded_inert_attrs: MarkedAttrs,
     /// `-Zmacro-stats` data.
     pub macro_stats: FxHashMap<(Symbol, MacroKind), MacroStat>,
+    pub nb_macro_errors: usize,
 }
 
 impl<'a> ExtCtxt<'a> {
@@ -1254,6 +1255,7 @@ impl<'a> ExtCtxt<'a> {
             expanded_inert_attrs: MarkedAttrs::new(),
             buffered_early_lint: vec![],
             macro_stats: Default::default(),
+            nb_macro_errors: 0,
         }
     }
 
@@ -1313,6 +1315,12 @@ impl<'a> ExtCtxt<'a> {
     /// Stops backtracing at include! boundary.
     pub fn expansion_cause(&self) -> Option<Span> {
         self.current_expansion.id.expansion_cause()
+    }
+
+    /// This method increases the internal macro errors count and then call `trace_macros_diag`.
+    pub fn macro_error_and_trace_macros_diag(&mut self) {
+        self.nb_macro_errors += 1;
+        self.trace_macros_diag();
     }
 
     pub fn trace_macros_diag(&mut self) {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -693,7 +693,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             crate_name: self.cx.ecfg.crate_name,
         });
 
-        self.cx.trace_macros_diag();
+        self.cx.macro_error_and_trace_macros_diag();
         guar
     }
 
@@ -707,7 +707,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     ) -> ErrorGuaranteed {
         let guar =
             self.cx.dcx().emit_err(WrongFragmentKind { span, kind: kind.name(), name: &mac.path });
-        self.cx.trace_macros_diag();
+        self.cx.macro_error_and_trace_macros_diag();
         guar
     }
 
@@ -1048,7 +1048,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 }
                 annotate_err_with_kind(&mut err, kind, span);
                 let guar = err.emit();
-                self.cx.trace_macros_diag();
+                self.cx.macro_error_and_trace_macros_diag();
                 kind.dummy(span, guar)
             }
         }

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -299,6 +299,7 @@ enum EofMatcherPositions {
 }
 
 /// Represents the possible results of an attempted parse.
+#[derive(Debug)]
 pub(crate) enum ParseResult<T, F> {
     /// Parsed successfully.
     Success(T),

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -280,7 +280,7 @@ fn expand_macro<'cx>(
             // Retry and emit a better error.
             let (span, guar) =
                 diagnostics::failed_to_match_macro(cx.psess(), sp, def_span, name, arg, rules);
-            cx.trace_macros_diag();
+            cx.macro_error_and_trace_macros_diag();
             DummyResult::any(span, guar)
         }
     }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -208,6 +208,10 @@ fn configure_and_expand(
         // Expand macros now!
         let krate = sess.time("expand_crate", || ecx.monotonic_expander().expand_crate(krate));
 
+        if ecx.nb_macro_errors > 0 {
+            sess.dcx().abort_if_errors();
+        }
+
         // The rest is error reporting and stats
 
         sess.psess.buffered_lints.with_lock(|buffered_lints: &mut Vec<BufferedEarlyLint>| {

--- a/tests/ui/const-generics/min_const_generics/macro-fail-const.rs
+++ b/tests/ui/const-generics/min_const_generics/macro-fail-const.rs
@@ -1,24 +1,13 @@
-struct Example<const N: usize>;
-
-macro_rules! external_macro {
-  () => {{
-    //~^ ERROR expected type
-    const X: usize = 1337;
-    X
-  }}
-}
-
 trait Marker<const N: usize> {}
+struct Example<const N: usize>;
 impl<const N: usize> Marker<N> for Example<N> {}
 
 fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+  //~^ ERROR: type provided when a constant was expected
+  //~| ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
+  //~^ ERROR: type provided when a constant was expected
 }
-
-fn from_marker(_: impl Marker<{
-    #[macro_export]
-    macro_rules! inline { () => {{ 3 }} }; inline!()
-}>) {}
 
 fn main() {
   let _ok = Example::<{
@@ -27,12 +16,8 @@ fn main() {
       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
       //~^ ERROR expected type
       //~| ERROR expected type
-    };
+    }
     gimme_a_const!(run)
   }>;
-
-  let _fail = Example::<external_macro!()>;
-
-  let _fail = Example::<gimme_a_const!()>;
-  //~^ ERROR: unexpected end of macro invocation
+  let _ok = Example::<{gimme_a_const!(marker)}>;
 }

--- a/tests/ui/const-generics/min_const_generics/macro-fail-const.stderr
+++ b/tests/ui/const-generics/min_const_generics/macro-fail-const.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:27:27
+  --> $DIR/macro-fail-const.rs:16:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:27:27
+  --> $DIR/macro-fail-const.rs:16:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -26,34 +26,26 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: expected type, found `{`
-  --> $DIR/macro-fail.rs:4:10
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail-const.rs:5:33
    |
-LL |   () => {{
-   |          ^ expected type
-...
-LL |   let _fail = Example::<external_macro!()>;
-   |                         -----------------
-   |                         |
-   |                         this macro call doesn't expand to a type
-   |                         in this macro invocation
-   |
-   = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:36:25
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail-const.rs:5:33
    |
-LL |     macro_rules! gimme_a_const {
-   |     -------------------------- when calling this macro
-...
-LL |   let _fail = Example::<gimme_a_const!()>;
-   |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: while trying to match meta-variable `$rusty:ident`
-  --> $DIR/macro-fail.rs:27:8
-   |
-LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
-   |        ^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail-const.rs:8:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -26,7 +26,7 @@ pub fn check_async() {
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
 
-    let _recovery_witness: () = 0; //~ ERROR mismatched types
+    let _recovery_witness: () = 0; // not emitted because of the macro parsing error
 }
 
 //~? ERROR macro expansion ends with an incomplete expression

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -61,14 +61,5 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     if passes_tt!(async) == 1 {}
    |                        ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error[E0308]: mismatched types
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:29:33
-   |
-LL |     let _recovery_witness: () = 0;
-   |                            --   ^ expected `()`, found integer
-   |                            |
-   |                            expected due to this
+error: aborting due to 6 previous errors
 
-error: aborting due to 7 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -36,8 +36,6 @@ pub fn check_async() {
     if local_passes_tt!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
-
-    let _recovery_witness: () = 0; //~ ERROR mismatched types
 }
 
 //~? ERROR macro expansion ends with an incomplete expression

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -73,14 +73,5 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     if local_passes_tt!(async) == 1 {}
    |                              ^ expected one of `move`, `use`, `{`, `|`, or `||`
 
-error[E0308]: mismatched types
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:40:33
-   |
-LL |     let _recovery_witness: () = 0;
-   |                            --   ^ expected `()`, found integer
-   |                            |
-   |                            expected due to this
+error: aborting due to 8 previous errors
 
-error: aborting due to 9 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/macros/trace-macro.rs
+++ b/tests/ui/macros/trace-macro.rs
@@ -3,4 +3,7 @@
 
 fn main() {
     println!("Hello, World!");
+    //~^ NOTE trace_macro
+    //~| NOTE expanding `println!
+    //~| NOTE to `{
 }

--- a/tests/ui/offset-of/offset-of-tuple-field.rs
+++ b/tests/ui/offset-of/offset-of-tuple-field.rs
@@ -1,0 +1,22 @@
+#![feature(builtin_syntax)]
+
+use std::mem::offset_of;
+
+fn main() {
+    offset_of!((u8, u8), _0); //~ ERROR no field `_0`
+    offset_of!((u8, u8), 01); //~ ERROR no field `01`
+    offset_of!((u8, u8), 1e2); //~ ERROR no field `1e2`
+    offset_of!((u8, u8), 1_u8); //~ ERROR no field `1_`
+    //~| ERROR suffixes on a tuple index
+
+    builtin # offset_of((u8, u8), 1e2); //~ ERROR no field `1e2`
+    builtin # offset_of((u8, u8), _0); //~ ERROR no field `_0`
+    builtin # offset_of((u8, u8), 01); //~ ERROR no field `01`
+    builtin # offset_of((u8, u8), 1_u8); //~ ERROR no field `1_`
+    //~| ERROR suffixes on a tuple index
+
+    offset_of!(((u8, u16), (u32, u16, u8)), 0.2); //~ ERROR no field `2`
+    offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2); //~ ERROR no field `1e2`
+    offset_of!(((u8, u16), (u32, u16, u8)), 1.2);
+    offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0); //~ ERROR no field `0`
+}

--- a/tests/ui/offset-of/offset-of-tuple-field.stderr
+++ b/tests/ui/offset-of/offset-of-tuple-field.stderr
@@ -1,0 +1,81 @@
+error: suffixes on a tuple index are invalid
+  --> $DIR/offset-of-tuple-field.rs:15:35
+   |
+LL |     builtin # offset_of((u8, u8), 1_u8);
+   |                                   ^^^^ invalid suffix `u8`
+
+error: suffixes on a tuple index are invalid
+  --> $DIR/offset-of-tuple-field.rs:9:26
+   |
+LL |     offset_of!((u8, u8), 1_u8);
+   |                          ^^^^ invalid suffix `u8`
+
+error[E0609]: no field `_0` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:6:26
+   |
+LL |     offset_of!((u8, u8), _0);
+   |                          ^^
+
+error[E0609]: no field `01` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:7:26
+   |
+LL |     offset_of!((u8, u8), 01);
+   |                          ^^
+
+error[E0609]: no field `1e2` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:8:26
+   |
+LL |     offset_of!((u8, u8), 1e2);
+   |                          ^^^
+
+error[E0609]: no field `1_` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:9:26
+   |
+LL |     offset_of!((u8, u8), 1_u8);
+   |                          ^^^^
+
+error[E0609]: no field `1e2` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:12:35
+   |
+LL |     builtin # offset_of((u8, u8), 1e2);
+   |                                   ^^^
+
+error[E0609]: no field `_0` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:13:35
+   |
+LL |     builtin # offset_of((u8, u8), _0);
+   |                                   ^^
+
+error[E0609]: no field `01` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:14:35
+   |
+LL |     builtin # offset_of((u8, u8), 01);
+   |                                   ^^
+
+error[E0609]: no field `1_` on type `(u8, u8)`
+  --> $DIR/offset-of-tuple-field.rs:15:35
+   |
+LL |     builtin # offset_of((u8, u8), 1_u8);
+   |                                   ^^^^
+
+error[E0609]: no field `2` on type `(u8, u16)`
+  --> $DIR/offset-of-tuple-field.rs:18:47
+   |
+LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
+   |                                               ^
+
+error[E0609]: no field `1e2` on type `(u8, u16)`
+  --> $DIR/offset-of-tuple-field.rs:19:47
+   |
+LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2);
+   |                                               ^^^
+
+error[E0609]: no field `0` on type `u8`
+  --> $DIR/offset-of-tuple-field.rs:21:49
+   |
+LL |     offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0);
+   |                                                 ^
+
+error: aborting due to 13 previous errors
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/offset-of/offset-of-tuple.rs
+++ b/tests/ui/offset-of/offset-of-tuple.rs
@@ -3,20 +3,10 @@
 use std::mem::offset_of;
 
 fn main() {
-    offset_of!((u8, u8), _0); //~ ERROR no field `_0`
-    offset_of!((u8, u8), 01); //~ ERROR no field `01`
-    offset_of!((u8, u8), 1e2); //~ ERROR no field `1e2`
-    offset_of!((u8, u8), 1_u8); //~ ERROR no field `1_`
-    //~| ERROR suffixes on a tuple index
     offset_of!((u8, u8), +1); //~ ERROR no rules expected
     offset_of!((u8, u8), -1); //~ ERROR offset_of expects dot-separated field and variant names
     offset_of!((u8, u8), 1.); //~ ERROR offset_of expects dot-separated field and variant names
     offset_of!((u8, u8), 1 .); //~ ERROR unexpected token: `)`
-    builtin # offset_of((u8, u8), 1e2); //~ ERROR no field `1e2`
-    builtin # offset_of((u8, u8), _0); //~ ERROR no field `_0`
-    builtin # offset_of((u8, u8), 01); //~ ERROR no field `01`
-    builtin # offset_of((u8, u8), 1_u8); //~ ERROR no field `1_`
-    //~| ERROR suffixes on a tuple index
     // We need to put these into curly braces, otherwise only one of the
     // errors will be emitted and the others suppressed.
     { builtin # offset_of((u8, u8), +1) }; //~ ERROR leading `+` is not supported
@@ -27,11 +17,6 @@ fn main() {
 type ComplexTup = (((u8, u8), u8), u8);
 
 fn nested() {
-    offset_of!(((u8, u16), (u32, u16, u8)), 0.2); //~ ERROR no field `2`
-    offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2); //~ ERROR no field `1e2`
-    offset_of!(((u8, u16), (u32, u16, u8)), 1.2);
-    offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0); //~ ERROR no field `0`
-
     // All combinations of spaces (this sends different tokens to the parser)
     offset_of!(ComplexTup, 0.0.1.); //~ ERROR unexpected token: `)`
     offset_of!(ComplexTup, 0 .0.1.); //~ ERROR unexpected token: `)`

--- a/tests/ui/offset-of/offset-of-tuple.stderr
+++ b/tests/ui/offset-of/offset-of-tuple.stderr
@@ -1,11 +1,5 @@
-error: suffixes on a tuple index are invalid
-  --> $DIR/offset-of-tuple.rs:18:35
-   |
-LL |     builtin # offset_of((u8, u8), 1_u8);
-   |                                   ^^^^ invalid suffix `u8`
-
 error: leading `+` is not supported
-  --> $DIR/offset-of-tuple.rs:22:37
+  --> $DIR/offset-of-tuple.rs:12:37
    |
 LL |     { builtin # offset_of((u8, u8), +1) };
    |                                     ^ unexpected `+`
@@ -17,67 +11,61 @@ LL +     { builtin # offset_of((u8, u8), 1) };
    |
 
 error: offset_of expects dot-separated field and variant names
-  --> $DIR/offset-of-tuple.rs:23:38
+  --> $DIR/offset-of-tuple.rs:13:38
    |
 LL |     { builtin # offset_of((u8, u8), 1.) };
    |                                      ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:24:40
+  --> $DIR/offset-of-tuple.rs:14:40
    |
 LL |     { builtin # offset_of((u8, u8), 1 .) };
    |                                        ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:47:45
+  --> $DIR/offset-of-tuple.rs:32:45
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0.1.) };
    |                                             ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:48:46
+  --> $DIR/offset-of-tuple.rs:33:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0 .0.1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:49:47
+  --> $DIR/offset-of-tuple.rs:34:47
    |
 LL |     { builtin # offset_of(ComplexTup, 0 . 0.1.) };
    |                                               ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:50:46
+  --> $DIR/offset-of-tuple.rs:35:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0. 0.1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:51:46
+  --> $DIR/offset-of-tuple.rs:36:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0 .1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:52:47
+  --> $DIR/offset-of-tuple.rs:37:47
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0 . 1.) };
    |                                               ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:53:46
+  --> $DIR/offset-of-tuple.rs:38:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0. 1.) };
    |                                              ^
 
-error: suffixes on a tuple index are invalid
-  --> $DIR/offset-of-tuple.rs:9:26
-   |
-LL |     offset_of!((u8, u8), 1_u8);
-   |                          ^^^^ invalid suffix `u8`
-
 error: no rules expected `+`
-  --> $DIR/offset-of-tuple.rs:11:26
+  --> $DIR/offset-of-tuple.rs:6:26
    |
 LL |     offset_of!((u8, u8), +1);
    |                          ^ no rules expected this token in macro call
@@ -86,131 +74,64 @@ note: while trying to match meta-variable `$fields:expr`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: offset_of expects dot-separated field and variant names
-  --> $DIR/offset-of-tuple.rs:12:26
+  --> $DIR/offset-of-tuple.rs:7:26
    |
 LL |     offset_of!((u8, u8), -1);
    |                          ^^
 
 error: offset_of expects dot-separated field and variant names
-  --> $DIR/offset-of-tuple.rs:13:27
+  --> $DIR/offset-of-tuple.rs:8:27
    |
 LL |     offset_of!((u8, u8), 1.);
    |                           ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:14:29
+  --> $DIR/offset-of-tuple.rs:9:29
    |
 LL |     offset_of!((u8, u8), 1 .);
    |                             ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:36:34
+  --> $DIR/offset-of-tuple.rs:21:34
    |
 LL |     offset_of!(ComplexTup, 0.0.1.);
    |                                  ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:37:35
+  --> $DIR/offset-of-tuple.rs:22:35
    |
 LL |     offset_of!(ComplexTup, 0 .0.1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:38:36
+  --> $DIR/offset-of-tuple.rs:23:36
    |
 LL |     offset_of!(ComplexTup, 0 . 0.1.);
    |                                    ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:39:35
+  --> $DIR/offset-of-tuple.rs:24:35
    |
 LL |     offset_of!(ComplexTup, 0. 0.1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:40:35
+  --> $DIR/offset-of-tuple.rs:25:35
    |
 LL |     offset_of!(ComplexTup, 0.0 .1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:41:36
+  --> $DIR/offset-of-tuple.rs:26:36
    |
 LL |     offset_of!(ComplexTup, 0.0 . 1.);
    |                                    ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:42:35
+  --> $DIR/offset-of-tuple.rs:27:35
    |
 LL |     offset_of!(ComplexTup, 0.0. 1.);
    |                                   ^
 
-error[E0609]: no field `_0` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:6:26
-   |
-LL |     offset_of!((u8, u8), _0);
-   |                          ^^
+error: aborting due to 21 previous errors
 
-error[E0609]: no field `01` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:7:26
-   |
-LL |     offset_of!((u8, u8), 01);
-   |                          ^^
-
-error[E0609]: no field `1e2` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:8:26
-   |
-LL |     offset_of!((u8, u8), 1e2);
-   |                          ^^^
-
-error[E0609]: no field `1_` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:9:26
-   |
-LL |     offset_of!((u8, u8), 1_u8);
-   |                          ^^^^
-
-error[E0609]: no field `1e2` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:15:35
-   |
-LL |     builtin # offset_of((u8, u8), 1e2);
-   |                                   ^^^
-
-error[E0609]: no field `_0` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:16:35
-   |
-LL |     builtin # offset_of((u8, u8), _0);
-   |                                   ^^
-
-error[E0609]: no field `01` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:17:35
-   |
-LL |     builtin # offset_of((u8, u8), 01);
-   |                                   ^^
-
-error[E0609]: no field `1_` on type `(u8, u8)`
-  --> $DIR/offset-of-tuple.rs:18:35
-   |
-LL |     builtin # offset_of((u8, u8), 1_u8);
-   |                                   ^^^^
-
-error[E0609]: no field `2` on type `(u8, u16)`
-  --> $DIR/offset-of-tuple.rs:30:47
-   |
-LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
-   |                                               ^
-
-error[E0609]: no field `1e2` on type `(u8, u16)`
-  --> $DIR/offset-of-tuple.rs:31:47
-   |
-LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2);
-   |                                               ^^^
-
-error[E0609]: no field `0` on type `u8`
-  --> $DIR/offset-of-tuple.rs:33:49
-   |
-LL |     offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0);
-   |                                                 ^
-
-error: aborting due to 34 previous errors
-
-For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate-macro.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate-macro.rs
@@ -1,0 +1,14 @@
+// gate-test-if_let_guard
+
+fn main() {
+    macro_rules! use_expr {
+        ($e:expr) => {
+            match () {
+                () if $e => {}
+                _ => {}
+            }
+        }
+    }
+    use_expr!(let 0 = 1);
+    //~^ ERROR no rules expected keyword `let`
+}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate-macro.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate-macro.stderr
@@ -1,0 +1,17 @@
+error: no rules expected keyword `let`
+  --> $DIR/feature-gate-macro.rs:12:15
+   |
+LL |     macro_rules! use_expr {
+   |     --------------------- when calling this macro
+...
+LL |     use_expr!(let 0 = 1);
+   |               ^^^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$e:expr`
+  --> $DIR/feature-gate-macro.rs:5:10
+   |
+LL |         ($e:expr) => {
+   |          ^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
@@ -64,8 +64,6 @@ fn _macros() {
         //~^ ERROR `if let` guards are experimental
         _ => {}
     }
-    use_expr!(let 0 = 1);
-    //~^ ERROR no rules expected keyword `let`
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -149,21 +149,6 @@ LL |     use_expr!((let 0 = 1));
    = note: only supported directly in conditions of `if` and `while` expressions
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: no rules expected keyword `let`
-  --> $DIR/feature-gate.rs:67:15
-   |
-LL |     macro_rules! use_expr {
-   |     --------------------- when calling this macro
-...
-LL |     use_expr!(let 0 = 1);
-   |               ^^^ no rules expected this token in macro call
-   |
-note: while trying to match meta-variable `$e:expr`
-  --> $DIR/feature-gate.rs:48:10
-   |
-LL |         ($e:expr) => {
-   |          ^^^^^^^
-
 error[E0658]: `if let` guards are experimental
   --> $DIR/feature-gate.rs:7:12
    |
@@ -230,6 +215,6 @@ LL |         () if let 0 = 1 => {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
-error: aborting due to 20 previous errors
+error: aborting due to 19 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/self/self_type_keyword.rs
+++ b/tests/ui/self/self_type_keyword.rs
@@ -18,8 +18,6 @@ pub fn main() {
         //~| ERROR cannot find unit struct, unit variant or constant `Self`
         ref mut Self => (),
         //~^ ERROR expected identifier, found keyword `Self`
-        Self!() => (),
-        //~^ ERROR cannot find macro `Self` in this scope
         Foo { Self } => (),
         //~^ ERROR expected identifier, found keyword `Self`
         //~| ERROR mismatched types

--- a/tests/ui/self/self_type_keyword.stderr
+++ b/tests/ui/self/self_type_keyword.stderr
@@ -36,34 +36,28 @@ LL |         ref mut Self => (),
    |                 ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:23:15
+  --> $DIR/self_type_keyword.rs:21:15
    |
 LL |         Foo { Self } => (),
    |               ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:31:26
+  --> $DIR/self_type_keyword.rs:29:26
    |
 LL |     extern crate core as Self;
    |                          ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:36:32
+  --> $DIR/self_type_keyword.rs:34:32
    |
 LL |     use std::option::Option as Self;
    |                                ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:41:11
+  --> $DIR/self_type_keyword.rs:39:11
    |
 LL |     trait Self {}
    |           ^^^^ expected identifier, found keyword
-
-error: cannot find macro `Self` in this scope
-  --> $DIR/self_type_keyword.rs:21:9
-   |
-LL |         Self!() => (),
-   |         ^^^^
 
 error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword.rs:16:13
@@ -86,7 +80,7 @@ LL | struct Bar<'Self>;
    = help: consider removing `'Self`, referring to it in a field, or using a marker such as `PhantomData`
 
 error[E0308]: mismatched types
-  --> $DIR/self_type_keyword.rs:23:9
+  --> $DIR/self_type_keyword.rs:21:9
    |
 LL |     match 15 {
    |           -- this expression has type `{integer}`
@@ -95,12 +89,12 @@ LL |         Foo { Self } => (),
    |         ^^^^^^^^^^^^ expected integer, found `Foo`
 
 error[E0026]: struct `Foo` does not have a field named `Self`
-  --> $DIR/self_type_keyword.rs:23:15
+  --> $DIR/self_type_keyword.rs:21:15
    |
 LL |         Foo { Self } => (),
    |               ^^^^ struct `Foo` does not have this field
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0026, E0308, E0392, E0531.
 For more information about an error, try `rustc --explain E0026`.

--- a/tests/ui/self/self_type_macro_name.rs
+++ b/tests/ui/self/self_type_macro_name.rs
@@ -1,0 +1,6 @@
+pub fn main() {
+    match 15 {
+        Self!() => (),
+        //~^ ERROR cannot find macro `Self` in this scope
+    }
+}

--- a/tests/ui/self/self_type_macro_name.stderr
+++ b/tests/ui/self/self_type_macro_name.stderr
@@ -1,0 +1,8 @@
+error: cannot find macro `Self` in this scope
+  --> $DIR/self_type_macro_name.rs:3:9
+   |
+LL |         Self!() => (),
+   |         ^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/const-traits/macro-bare-trait-objects-const-trait-bounds.rs
+++ b/tests/ui/traits/const-traits/macro-bare-trait-objects-const-trait-bounds.rs
@@ -13,7 +13,7 @@ macro_rules! check {
         compile_error!("ty");
     };
     (const $Trait:path) => {};
-    ([const] $Trait:path) => {};
+    ([const] $Trait:path) => { [const] Trait };
 }
 
 check! { const Trait }

--- a/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.rs
+++ b/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.rs
@@ -4,18 +4,19 @@
 // Setting the edition to 2018 since we don't regress `demo! { dyn const }` in Rust <2018.
 //@ edition:2018
 
+trait Trait {}
+
 macro_rules! demo {
-    ($ty:ty) => { compile_error!("ty"); };
-    //~^ ERROR ty
-    //~| ERROR ty
-    (impl $c:ident Trait) => {};
-    (dyn $c:ident Trait) => {};
+    (impl $c:ident Trait) => { impl $c Trait {} };
+    //~^ ERROR inherent
+    //~| WARN trait objects without an explicit `dyn` are deprecated
+    //~| WARN this is accepted in the current edition
+    (dyn $c:ident Trait) => { dyn $c Trait {} }; //~ ERROR macro expansion
 }
 
 demo! { impl const Trait }
 //~^ ERROR const trait impls are experimental
 
 demo! { dyn const Trait }
-//~^ ERROR const trait impls are experimental
 
 fn main() {}

--- a/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.stderr
+++ b/tests/ui/traits/const-traits/macro-const-trait-bound-theoretical-regression.stderr
@@ -1,27 +1,31 @@
-error: ty
-  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:8:19
+error: macro expansion ignores keyword `dyn` and any tokens following
+  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:14:31
    |
-LL |     ($ty:ty) => { compile_error!("ty"); };
-   |                   ^^^^^^^^^^^^^^^^^^^^
-...
-LL | demo! { impl const Trait }
-   | -------------------------- in this macro invocation
-   |
-   = note: this error originates in the macro `demo` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: ty
-  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:8:19
-   |
-LL |     ($ty:ty) => { compile_error!("ty"); };
-   |                   ^^^^^^^^^^^^^^^^^^^^
+LL |     (dyn $c:ident Trait) => { dyn $c Trait {} };
+   |                               ^^^
 ...
 LL | demo! { dyn const Trait }
-   | ------------------------- in this macro invocation
+   | ------------------------- caused by the macro expansion here
    |
+   = note: the usage of `demo!` is likely invalid in item context
+
+error: inherent impls cannot be `const`
+  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:10:40
+   |
+LL |     (impl $c:ident Trait) => { impl $c Trait {} };
+   |                                        ^^^^^ inherent impl for this type
+...
+LL | demo! { impl const Trait }
+   | --------------------------
+   | |            |
+   | |            `const` because of this
+   | in this macro invocation
+   |
+   = note: only trait implementations may be annotated with `const`
    = note: this error originates in the macro `demo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:15:14
+  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:17:14
    |
 LL | demo! { impl const Trait }
    |              ^^^^^
@@ -30,16 +34,24 @@ LL | demo! { impl const Trait }
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: const trait impls are experimental
-  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:18:13
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/macro-const-trait-bound-theoretical-regression.rs:10:40
    |
-LL | demo! { dyn const Trait }
-   |             ^^^^^
+LL |     (impl $c:ident Trait) => { impl $c Trait {} };
+   |                                        ^^^^^
+...
+LL | demo! { impl const Trait }
+   | -------------------------- in this macro invocation
    |
-   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
-   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: `#[warn(bare_trait_objects)]` on by default
+   = note: this warning originates in the macro `demo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might have intended to implement this trait for a given type
+   |
+LL |     (impl $c:ident Trait) => { impl $c Trait for /* Type */ {} };
+   |                                              ++++++++++++++
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes rust-lang/rust#116180.

So there isn't really a type that is central for macro expansion and some errors are actually emitted (because the resolution happens after the expansion I suppose) after the expansion pass (like "not found macro"). Sometimes, errors are only emitted on the second "try" (to improve error output). So I couldn't reach a similar solution than what was done in https://github.com/rust-lang/rust/pull/133937 and suggested by @estebank in https://github.com/rust-lang/rust/issues/116180#issuecomment-3109468922. But maybe I missed something?

So in the end, I realized that there is method called every time (except one, described below) a macro error is actually emitted: `ExtCtxt::trace_macros_diag`. Considering I updated what it did, I renamed it into `macro_error_and_trace_macros_diag` to better reflect it.

There is only one call of `trace_macros_diag` which isn't reporting an error but just used for `macro_trace` feature, so I kept it as is.

r? @oli-obk 