### PR TITLE
library/windows_targets: Fix macro expansion error in 'link' macro

### DIFF
--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -33,23 +33,13 @@ pub macro link_dylib {
 }
 
 #[cfg(feature = "windows_raw_dylib")]
-pub macro link($($tt:tt)*) {
-    $crate::link_raw_dylib!($($tt)*)
+pub macro link {
+    ($($tt:tt)*) => ($crate::link_raw_dylib!($($tt)*))
 }
 
 #[cfg(not(feature = "windows_raw_dylib"))]
 pub macro link {
-    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
-        // Note: the windows-targets crate uses a pre-built Windows.lib import library which we don't
-        // have in this repo. So instead we always link kernel32.lib and add the rest of the import
-        // libraries below by using an empty extern block. This works because extern blocks are not
-        // connected to the library given in the #[link] attribute.
-        #[link(name = "kernel32")]
-        unsafe extern $abi {
-            $(#[link_name=$link_name])?
-            pub fn $($function)*;
-        }
-    )
+    ($($tt:tt)*) => ($crate::link_dylib!($($tt)*))
 }
 
 #[cfg(not(feature = "windows_raw_dylib"))]


### PR DESCRIPTION
A recent change altered the definition of the link! macro when the windows_raw_dylib feature is enabled, changing its syntax from pub macro {..} to pub macro($tt:tt) {..} in https://github.com/rust-lang/rust/pull/143592

This change introduced a build failure with the error: "macros that expand to items must be delimited with braces or followed by a semicolon". 

We also modify the non windows_raw_dylib link to make use of the link_dylib macro

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
