### PR TITLE
library/windows_targets: Fix macro expansion error in 'link' macro

### DIFF
--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -33,8 +33,15 @@ pub macro link_dylib {
 }
 
 #[cfg(feature = "windows_raw_dylib")]
-pub macro link($($tt:tt)*) {
-    $crate::link_raw_dylib!($($tt)*)
+pub macro link{
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
+        #[cfg_attr(not(target_arch = "x86"), link(name = $library, kind = "raw-dylib", modifiers = "+verbatim"))]
+        #[cfg_attr(target_arch = "x86", link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated"))]
+        unsafe extern $abi {
+            $(#[link_name=$link_name])?
+            pub fn $($function)*;
+        }
+    )
 }
 
 #[cfg(not(feature = "windows_raw_dylib"))]


### PR DESCRIPTION
A recent change altered the definition of the link! macro when the windows_raw_dylib feature is enabled, changing its syntax from pub macro {..} to pub macro($tt:tt) {..} in rust-lang/rust#143592

This change introduced a build failure with the error: "macros that expand to items must be delimited with braces or followed by a semicolon".

We revert this change, making it consistent with the link! macro when the windows_raw_dylib feature is not enabled.

For the case when it is not enabled, it also makes use of code repetition in order to avoid the macro expansion error. If instead we try to reuse the code, as seen in rust-lang/rust#144415, we run into the same issue of "macros that expand to items must be delimited with braces or followed by a semicolon"

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
