### PR TITLE
Allow setting `release-blog-post` label with rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -28,6 +28,7 @@ allow-unauthenticated = [
     "llvm-*",
     "needs-fcp",
     "relnotes",
+    "release-blog-post",
     "requires-*",
     "regression-*",
     "rla-*",


### PR DESCRIPTION
r? release

I forgot to do this when we originally added the label and updated the generated description for relnotes issues