### PR TITLE
Avoid unnecessary `new_adt`/`new_fn_def` calls.

### DIFF
--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -400,8 +400,12 @@ pub fn structurally_relate_tys<I: Interner, R: TypeRelation<I>>(
         (ty::Placeholder(p1), ty::Placeholder(p2)) if p1 == p2 => Ok(a),
 
         (ty::Adt(a_def, a_args), ty::Adt(b_def, b_args)) if a_def == b_def => {
-            let args = relation.relate_item_args(a_def.def_id(), a_args, b_args)?;
-            Ok(Ty::new_adt(cx, a_def, args))
+            Ok(if a_args.is_empty() {
+                a
+            } else {
+                let args = relation.relate_item_args(a_def.def_id(), a_args, b_args)?;
+                if args == a_args { a } else { Ty::new_adt(cx, a_def, args) }
+            })
         }
 
         (ty::Foreign(a_id), ty::Foreign(b_id)) if a_id == b_id => Ok(Ty::new_foreign(cx, a_id)),
@@ -515,8 +519,12 @@ pub fn structurally_relate_tys<I: Interner, R: TypeRelation<I>>(
         }
 
         (ty::FnDef(a_def_id, a_args), ty::FnDef(b_def_id, b_args)) if a_def_id == b_def_id => {
-            let args = relation.relate_item_args(a_def_id, a_args, b_args)?;
-            Ok(Ty::new_fn_def(cx, a_def_id, args))
+            Ok(if a_args.is_empty() {
+                a
+            } else {
+                let args = relation.relate_item_args(a_def_id, a_args, b_args)?;
+                if args == a_args { a } else { Ty::new_fn_def(cx, a_def_id, args) }
+            })
         }
 
         (ty::FnPtr(a_sig_tys, a_hdr), ty::FnPtr(b_sig_tys, b_hdr)) => {


### PR DESCRIPTION
They can be skipped if there are no arguments, avoiding the "relate" operation work and also the subsequent interning.

r? @ghost