### PR TITLE
tests: aarch64-outline-atomics: Remove hardcoded target

### DIFF
--- a/tests/assembly-llvm/asm/aarch64-outline-atomics.rs
+++ b/tests/assembly-llvm/asm/aarch64-outline-atomics.rs
@@ -1,7 +1,5 @@
 //@ assembly-output: emit-asm
 //@ compile-flags: -Copt-level=3
-//@ compile-flags: --target aarch64-unknown-linux-gnu
-//@ needs-llvm-components: aarch64
 //@ only-aarch64
 //@ only-linux
 


### PR DESCRIPTION
Since this test is limited to aarch64 and linux hosts, the `--target` flag is entirely unnecessary and only breaks this on musl hosts. Let the compiler use the default target instead.
