### PR TITLE
Disable has_reliable_f128_math on musl targets

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -433,6 +433,9 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // This rules out anything that doesn't have `long double` = `binary128`; <= 32 bits
         // (ld is `f64`), anything other than Linux (Windows and MacOS use `f64`), and `x86`
         // (ld is 80-bit extended precision).
+        //
+        // musl does not implement the symbols required for f128 math at all.
+        _ if target_env == "musl" => false,
         ("x86_64", _) => false,
         (_, "linux") if target_pointer_width == 64 => true,
         _ => false,

--- a/tests/ui/float/target-has-reliable-nightly-float.rs
+++ b/tests/ui/float/target-has-reliable-nightly-float.rs
@@ -19,8 +19,10 @@ pub fn has_f128() {}
 pub fn has_f128_math() {}
 
 fn main() {
-    if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
-        // Aarch64+Linux is one target that has support for all features, so use it to spot
+    if cfg!(target_arch = "aarch64") &&
+        cfg!(target_os = "linux") &&
+        cfg!(not(target_env = "musl")) {
+        // Aarch64+GNU+Linux is one target that has support for all features, so use it to spot
         // check that the compiler does indeed enable these gates.
 
         assert!(cfg!(target_has_reliable_f16));


### PR DESCRIPTION
musl does not implement the symbols required by rustc for f128 maths. Disable the associated cfg for all musl targets and adjust the tests accordingly.

Closes rust-lang/rust#144423