### PR TITLE
Contract variable declarations

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3700,6 +3700,9 @@ pub struct TraitImplHeader {
 
 #[derive(Clone, Encodable, Decodable, Debug, Default, Walkable)]
 pub struct FnContract {
+    /// Declarations of variables accessible both in the `requires` and
+    /// `ensures` clauses.
+    pub declarations: ThinVec<Stmt>,
     pub requires: Option<Box<Expr>>,
     pub ensures: Option<Box<Expr>>,
 }

--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -27,7 +27,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::Block { hir_id, stmts, expr, rules, span: self.lower_span(b.span), targeted_by_break }
     }
 
-    fn lower_stmts(
+    pub(super) fn lower_stmts(
         &mut self,
         mut ast_stmts: &[Stmt],
     ) -> (&'hir [hir::Stmt<'hir>], Option<&'hir hir::Expr<'hir>>) {

--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -17,7 +17,7 @@ impl AttrProcMacro for ExpandRequires {
         annotation: TokenStream,
         annotated: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
-        expand_requires_tts(ecx, span, annotation, annotated)
+        expand_contract_clause_tts(ecx, span, annotation, annotated, kw::ContractRequires)
     }
 }
 
@@ -29,7 +29,7 @@ impl AttrProcMacro for ExpandEnsures {
         annotation: TokenStream,
         annotated: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
-        expand_ensures_tts(ecx, span, annotation, annotated)
+        expand_contract_clause_tts(ecx, span, annotation, annotated, kw::ContractEnsures)
     }
 }
 
@@ -130,42 +130,17 @@ fn expand_contract_clause(
     Ok(new_tts)
 }
 
-fn expand_requires_tts(
+fn expand_contract_clause_tts(
     ecx: &mut ExtCtxt<'_>,
     attr_span: Span,
     annotation: TokenStream,
     annotated: TokenStream,
+    clause_keyword: rustc_span::Symbol,
 ) -> Result<TokenStream, ErrorGuaranteed> {
     let feature_span = ecx.with_def_site_ctxt(attr_span);
     expand_contract_clause(ecx, attr_span, annotated, |new_tts| {
         new_tts.push_tree(TokenTree::Token(
-            token::Token::from_ast_ident(Ident::new(kw::ContractRequires, feature_span)),
-            Spacing::Joint,
-        ));
-        new_tts.push_tree(TokenTree::Token(
-            token::Token::new(token::TokenKind::OrOr, attr_span),
-            Spacing::Alone,
-        ));
-        new_tts.push_tree(TokenTree::Delimited(
-            DelimSpan::from_single(attr_span),
-            DelimSpacing::new(Spacing::JointHidden, Spacing::JointHidden),
-            token::Delimiter::Brace,
-            annotation,
-        ));
-        Ok(())
-    })
-}
-
-fn expand_ensures_tts(
-    ecx: &mut ExtCtxt<'_>,
-    attr_span: Span,
-    annotation: TokenStream,
-    annotated: TokenStream,
-) -> Result<TokenStream, ErrorGuaranteed> {
-    let feature_span = ecx.with_def_site_ctxt(attr_span);
-    expand_contract_clause(ecx, attr_span, annotated, |new_tts| {
-        new_tts.push_tree(TokenTree::Token(
-            token::Token::from_ast_ident(Ident::new(kw::ContractEnsures, feature_span)),
+            token::Token::from_ast_ident(Ident::new(clause_keyword, feature_span)),
             Spacing::Joint,
         ));
         new_tts.push_tree(TokenTree::Delimited(

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -4036,6 +4036,30 @@ impl<'a> Parser<'a> {
         self.mk_expr(span, ExprKind::Err(guar))
     }
 
+    pub(crate) fn mk_unit_expr(&self, span: Span) -> Box<Expr> {
+        self.mk_expr(span, ExprKind::Tup(Default::default()))
+    }
+
+    pub(crate) fn mk_closure_expr(&self, span: Span, body: Box<Expr>) -> Box<Expr> {
+        self.mk_expr(
+            span,
+            ast::ExprKind::Closure(Box::new(ast::Closure {
+                binder: rustc_ast::ClosureBinder::NotPresent,
+                constness: rustc_ast::Const::No,
+                movability: rustc_ast::Movability::Movable,
+                capture_clause: rustc_ast::CaptureBy::Ref,
+                coroutine_kind: None,
+                fn_decl: Box::new(rustc_ast::FnDecl {
+                    inputs: Default::default(),
+                    output: rustc_ast::FnRetTy::Default(span),
+                }),
+                fn_arg_span: span,
+                fn_decl_span: span,
+                body,
+            })),
+        )
+    }
+
     /// Create expression span ensuring the span of the parent node
     /// is larger than the span of lhs and rhs, including the attributes.
     fn mk_expr_sp(&self, lhs: &Box<Expr>, lhs_span: Span, op_span: Span, rhs_span: Span) -> Span {

--- a/tests/ui/contracts/contracts-disabled-side-effect-declarations.rs
+++ b/tests/ui/contracts/contracts-disabled-side-effect-declarations.rs
@@ -3,9 +3,9 @@
 //~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
 
 extern crate core;
-use core::contracts::ensures;
+use core::contracts::requires;
 
-#[ensures(*x = 0; |_ret| true)]
+#[requires(*x = 0; true)]
 fn buggy_add(x: &mut u32, y: u32) {
     *x = *x + y;
 }

--- a/tests/ui/contracts/contracts-disabled-side-effect-declarations.stderr
+++ b/tests/ui/contracts/contracts-disabled-side-effect-declarations.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/contracts-disabled-side-effect-declarations.rs:2:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/contracts/declared-vars-referring-to-params.rs
+++ b/tests/ui/contracts/declared-vars-referring-to-params.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::{ensures, requires};
+
+// checks that variable declarations are lowered properly, with the ability to
+// access function parameters
+#[requires(let y = 2 * x; true)]
+#[ensures(move |ret| { *ret == y })]
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/declared-vars-referring-to-params.stderr
+++ b/tests/ui/contracts/declared-vars-referring-to-params.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/declared-vars-referring-to-params.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/contracts/declared-vars-used-in-ensures.rs
+++ b/tests/ui/contracts/declared-vars-used-in-ensures.rs
@@ -1,17 +1,17 @@
 //@ run-pass
+//@ compile-flags: -Zcontract-checks=yes
 #![feature(contracts)]
 //~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
 
 extern crate core;
-use core::contracts::ensures;
+use core::contracts::{ensures, requires};
 
-#[ensures(*x = 0; |_ret| true)]
-fn buggy_add(x: &mut u32, y: u32) {
-    *x = *x + y;
+#[requires(let y = 1; true)]
+#[ensures(move |_ret| { y == 1 })]
+fn foo(x: u32) -> u32 {
+    x * 2
 }
 
 fn main() {
-    let mut x = 10;
-    buggy_add(&mut x, 100);
-    assert_eq!(x, 110);
+    foo(1);
 }

--- a/tests/ui/contracts/declared-vars-used-in-ensures.stderr
+++ b/tests/ui/contracts/declared-vars-used-in-ensures.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/declared-vars-used-in-ensures.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/contracts/declared-vars-used-in-requires-and-ensures.rs
+++ b/tests/ui/contracts/declared-vars-used-in-requires-and-ensures.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::{ensures, requires};
+
+// checks that variable declarations are lowered properly, with the ability to
+// refer to them *both* in requires and ensures
+#[requires(let y = 2 * x; y > 0)]
+#[ensures(move |ret| { *ret == y })]
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/declared-vars-used-in-requires-and-ensures.stderr
+++ b/tests/ui/contracts/declared-vars-used-in-requires-and-ensures.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/declared-vars-used-in-requires-and-ensures.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/contracts/internal_machinery/contract-ast-extensions-nest.rs
+++ b/tests/ui/contracts/internal_machinery/contract-ast-extensions-nest.rs
@@ -19,8 +19,8 @@
 #![feature(contracts_internals)]
 
 fn nest(x: Baz) -> i32
-    contract_requires(|| x.baz > 0)
-    contract_ensures(|ret| *ret > 100)
+    contract_requires { x.baz > 0 }
+    contract_ensures { |ret| *ret > 100 }
 {
     loop {
         return x.baz + 50;

--- a/tests/ui/contracts/internal_machinery/contract-ast-extensions-tail.rs
+++ b/tests/ui/contracts/internal_machinery/contract-ast-extensions-tail.rs
@@ -19,8 +19,8 @@
 #![feature(contracts_internals)]
 
 fn tail(x: Baz) -> i32
-    contract_requires(|| x.baz > 0)
-    contract_ensures(|ret| *ret > 100)
+    contract_requires { x.baz > 0 }
+    contract_ensures { |ret| *ret > 100 }
 {
     x.baz + 50
 }

--- a/tests/ui/contracts/internal_machinery/contracts-lowering-ensures-is-not-inherited-when-nesting.rs
+++ b/tests/ui/contracts/internal_machinery/contracts-lowering-ensures-is-not-inherited-when-nesting.rs
@@ -3,7 +3,7 @@
 #![feature(contracts_internals)]
 
 fn outer() -> i32
-    contract_ensures(|ret| *ret > 0)
+    contract_ensures { |ret| *ret > 0 }
 {
     let inner_closure = || -> i32 { 0 };
     inner_closure();

--- a/tests/ui/contracts/internal_machinery/contracts-lowering-requires-is-not-inherited-when-nesting.rs
+++ b/tests/ui/contracts/internal_machinery/contracts-lowering-requires-is-not-inherited-when-nesting.rs
@@ -5,7 +5,7 @@
 struct Outer { outer: std::cell::Cell<i32> }
 
 fn outer(x: Outer)
-    contract_requires(|| x.outer.get() > 0)
+    contract_requires { x.outer.get() > 0 }
 {
     let inner_closure = || { };
     x.outer.set(0);

--- a/tests/ui/contracts/internal_machinery/internal-feature-gating.rs
+++ b/tests/ui/contracts/internal_machinery/internal-feature-gating.rs
@@ -11,8 +11,8 @@ fn main() {
     //~^ ERROR use of unstable library feature `contracts_internals`
 
     // ast extensions are guarded by contracts_internals feature gate
-    fn identity_1() -> i32 contract_requires(|| true) { 10 }
+    fn identity_1() -> i32 contract_requires { true } { 10 }
     //~^ ERROR contract internal machinery is for internal use only
-    fn identity_2() -> i32 contract_ensures(|_| true) { 10 }
+    fn identity_2() -> i32 contract_ensures { |_| true } { 10 }
     //~^ ERROR contract internal machinery is for internal use only
 }

--- a/tests/ui/contracts/internal_machinery/internal-feature-gating.stderr
+++ b/tests/ui/contracts/internal_machinery/internal-feature-gating.stderr
@@ -1,7 +1,7 @@
 error[E0658]: contract internal machinery is for internal use only
   --> $DIR/internal-feature-gating.rs:14:28
    |
-LL |     fn identity_1() -> i32 contract_requires(|| true) { 10 }
+LL |     fn identity_1() -> i32 contract_requires { true } { 10 }
    |                            ^^^^^^^^^^^^^^^^^
    |
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
@@ -11,7 +11,7 @@ LL |     fn identity_1() -> i32 contract_requires(|| true) { 10 }
 error[E0658]: contract internal machinery is for internal use only
   --> $DIR/internal-feature-gating.rs:16:28
    |
-LL |     fn identity_2() -> i32 contract_ensures(|_| true) { 10 }
+LL |     fn identity_2() -> i32 contract_ensures { |_| true } { 10 }
    |                            ^^^^^^^^^^^^^^^^
    |
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information

--- a/tests/ui/contracts/internal_machinery/lowering/basics.rs
+++ b/tests/ui/contracts/internal_machinery/lowering/basics.rs
@@ -1,0 +1,24 @@
+//@ run-pass
+#![feature(contracts, cfg_contract_checks, contracts_internals, core_intrinsics)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+
+// we check here if the "lowered" program behaves as expected before
+// implementing the actual lowering in the compiler
+
+fn foo(x: u32) -> u32 {
+    let post = {
+        let y = 2 * x;
+        // call contract_check_requires here to avoid borrow checker issues
+        // with variables declared in contract requires
+        core::intrinsics::contract_check_requires(|| y > 0);
+        Some(core::contracts::build_check_ensures(move |ret| *ret == y))
+    };
+
+    core::intrinsics::contract_check_ensures(post, { 2 * x })
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/internal_machinery/lowering/basics.stderr
+++ b/tests/ui/contracts/internal_machinery/lowering/basics.stderr
@@ -1,0 +1,11 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/basics.rs:2:12
+   |
+LL | #![feature(contracts, cfg_contract_checks, contracts_internals, core_intrinsics)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/contracts/requires-bool-expr-with-semicolon.rs
+++ b/tests/ui/contracts/requires-bool-expr-with-semicolon.rs
@@ -1,0 +1,18 @@
+//@ dont-require-annotations: NOTE
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::requires;
+
+#[requires(true;)]
+//~^ ERROR mismatched types [E0308]
+//~| NOTE expected `bool`, found `()`
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/requires-bool-expr-with-semicolon.stderr
+++ b/tests/ui/contracts/requires-bool-expr-with-semicolon.stderr
@@ -1,0 +1,18 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/requires-bool-expr-with-semicolon.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/requires-bool-expr-with-semicolon.rs:9:1
+   |
+LL | #[requires(true;)]
+   | ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/contracts/requires-no-final-expression.rs
+++ b/tests/ui/contracts/requires-no-final-expression.rs
@@ -1,0 +1,18 @@
+//@ dont-require-annotations: NOTE
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::requires;
+
+#[requires(let y = 1;)]
+//~^ ERROR mismatched types [E0308]
+//~| NOTE expected `bool`, found `()`
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/requires-no-final-expression.stderr
+++ b/tests/ui/contracts/requires-no-final-expression.stderr
@@ -1,0 +1,18 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/requires-no-final-expression.rs:3:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/requires-no-final-expression.rs:9:1
+   |
+LL | #[requires(let y = 1;)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This change adds contract variables that can be declared in the `requires` clause and can be referenced both in `requires` and `ensures`, subject to usual borrow checking rules. This allows any setup common to both the `requires` and `ensures` clauses to only be done once. 

In particular, one future use case would be for [Fulminate](https://dl.acm.org/doi/10.1145/3704879)-like ownership assertions in contracts, that are essentially side-effects, and executing them twice would alter the semantics of the contract.

As of this change, `requires` can now be an arbitrary sequence of statements, with the final expression being of type `bool`. They are executed in sequence as expected, before checking if the final `bool` expression holds.

This PR depends on rust-lang/rust#144438 (which has now been merged).

Contracts tracking issue: https://github.com/rust-lang/rust/issues/128044

**Other changes introduced**:
- Contract macros now wrap the content in braces to produce blocks, meaning there's no need to wrap the content in `{}` when using multiple statements. The change is backwards compatible, in that wrapping the content in `{}` still works as before. The macros also now treat `requires` and `ensures` uniformally, meaning the `requires` closure is built inside the parser, as opposed to in the macro.

**Known limiatations**:
- Contracts with variable declarations are subject to the regular borrow checking rules, and the way contracts are currently lowered limits the usefulness of contract variable declarations. Consider the below example:
  
  ```rust
  #[requires(let init_x = *x; true)]
  #[ensures(move |_| *x == 2 * init_x)]
  fn double_in_place(x: &mut i32) {
      *x *= 2;
  }
  ```
  
  We have used the new variable declarations feature to remember the initial value pointed to by `x`, however, moving `x` into the `ensures` does not pass the borrow checker, meaning the above function contract is illegal. Ideally, something like the above should be expressable in contracts.