### PR TITLE
Fix `./x check bootstrap` (again)

### DIFF
--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -1,13 +1,17 @@
 //! This module serves two purposes:
-//!     1. It is part of the `utils` module and used in other parts of bootstrap.
-//!     2. It is embedded inside bootstrap shims to avoid a dependency on the bootstrap library.
-//!        Therefore, this module should never use any other bootstrap module. This reduces binary
-//!        size and improves compilation time by minimizing linking time.
+//!
+//! 1. It is part of the `utils` module and used in other parts of bootstrap.
+//! 2. It is embedded inside bootstrap shims to avoid a dependency on the bootstrap library.
+//!    Therefore, this module should never use any other bootstrap module. This reduces binary size
+//!    and improves compilation time by minimizing linking time.
+
+// # Note on tests
+//
+// If we were to declare a tests submodule here, the shim binaries that include this module via
+// `#[path]` would fail to find it, which breaks `./x check bootstrap`. So instead the unit tests
+// for this module are in `super::tests::shared_helpers_tests`.
 
 #![allow(dead_code)]
-
-#[cfg(test)]
-mod tests;
 
 use std::env;
 use std::ffi::OsString;
@@ -15,10 +19,6 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::process::Command;
 use std::str::FromStr;
-
-// If we were to declare a tests submodule here, the shim binaries that include this
-// module via `#[path]` would fail to find it, which breaks `./x check bootstrap`.
-// So instead the unit tests for this module are in `super::tests::shared_helpers_tests`.
 
 /// Returns the environment variable which the dynamic library lookup path
 /// resides in for this platform.

--- a/src/bootstrap/src/utils/tests/mod.rs
+++ b/src/bootstrap/src/utils/tests/mod.rs
@@ -12,6 +12,10 @@ use crate::{Build, Config, Flags, t};
 
 pub mod git;
 
+// Note: tests for `shared_helpers` is separate here, as otherwise shim binaries that include the
+// `shared_helpers` via `#[path]` would fail to find it, breaking `./x check bootstrap`.
+mod shared_helpers_tests;
+
 /// Holds temporary state of a bootstrap test.
 /// Right now it is only used to redirect the build directory of the bootstrap
 /// invocation, in the future it would be great if we could actually execute

--- a/src/bootstrap/src/utils/tests/shared_helpers_tests.rs
+++ b/src/bootstrap/src/utils/tests/shared_helpers_tests.rs
@@ -1,3 +1,10 @@
+//! The `shared_helpers` module can't have its own tests submodule, because that would cause
+//! problems for the shim binaries that include it via `#[path]`, so instead those unit tests live
+//! here.
+//!
+//! To prevent tidy from complaining about this file not being named `tests.rs`, it lives inside a
+//! submodule directory named `tests`.
+
 use crate::utils::shared_helpers::parse_value_from_args;
 
 #[test]

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -40,6 +40,7 @@ COPY host-x86_64/pr-check-1/validate-toolstate.sh /scripts/
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.
 ENV SCRIPT \
+  python3 ../x.py check bootstrap && \
   /scripts/check-default-config-profiles.sh && \
   python3 ../x.py build src/tools/build-manifest && \
   python3 ../x.py test --stage 0 src/tools/compiletest && \


### PR DESCRIPTION
Redoes rust-lang/rust#134883 and reverts 40c2ca96411caaeab1563ff9041879f742d1d71b from rust-lang/rust#142416. Unfortunately I missed this during review.

- Commit 1: Reverts 40c2ca96411caaeab1563ff9041879f742d1d71b and re-applies rust-lang/rust#134883.
- Commit 2: Check `./x check bootstrap` in `pr-check-1` to catch "obvious" problems like this.

r? Kobzol