### PR TITLE
fix: Reject upvar scrutinees for `loop_match`

### DIFF
--- a/tests/ui/loop-match/upvar-scrutinee.rs
+++ b/tests/ui/loop-match/upvar-scrutinee.rs
@@ -1,0 +1,81 @@
+#![allow(incomplete_features)]
+#![feature(loop_match)]
+
+#[derive(Clone, Copy)]
+enum State {
+    A,
+    B,
+}
+
+fn main() {
+    let mut state = State::A;
+
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                State::A => {
+                    #[const_continue]
+                    break 'blk State::B;
+                }
+                State::B => {
+                    return;
+                }
+            }
+        }
+    }
+
+    || {
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    //~^ ERROR invalid match on `#[loop_match]` state
+                    State::A => {
+                        #[const_continue]
+                        break 'blk State::B;
+                    }
+                    State::B => {
+                        return;
+                    }
+                }
+            }
+        }
+    };
+
+    || {
+        let mut state = state;
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    State::A => {
+                        #[const_continue]
+                        break 'blk State::B;
+                    }
+                    State::B => {
+                        return;
+                    }
+                }
+            }
+        }
+    };
+
+    move || {
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    //~^ ERROR invalid match on `#[loop_match]` state
+                    State::A => {
+                        #[const_continue]
+                        break 'blk State::B;
+                    }
+                    State::B => {
+                        return;
+                    }
+                }
+            }
+        }
+    };
+}

--- a/tests/ui/loop-match/upvar-scrutinee.stderr
+++ b/tests/ui/loop-match/upvar-scrutinee.stderr
@@ -1,0 +1,18 @@
+error: invalid match on `#[loop_match]` state
+  --> $DIR/upvar-scrutinee.rs:32:23
+   |
+LL |                 match state {
+   |                       ^^^^^
+   |
+   = note: a local variable must be the scrutinee within a `#[loop_match]`
+
+error: invalid match on `#[loop_match]` state
+  --> $DIR/upvar-scrutinee.rs:68:23
+   |
+LL |                 match state {
+   |                       ^^^^^
+   |
+   = note: a local variable must be the scrutinee within a `#[loop_match]`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/144051

I think we should reject upvars as they are not locals but somewhat like field access