### PR TITLE
canonicalize build root in `tests/run-make/linker-warning`

### DIFF
--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -64,7 +64,9 @@ fn main() {
             .normalize(r#"/rustc[^/_-]*/"#, "/rustc/")
             .normalize("libpanic_abort", "libpanic_unwind")
             .normalize(
-                regex::escape(run_make_support::build_root().to_str().unwrap()),
+                regex::escape(
+                    run_make_support::build_root().canonicalize().unwrap().to_str().unwrap(),
+                ),
                 "/build-root",
             )
             .normalize(r#""[^"]*\/symbols.o""#, "\"/symbols.o\"")


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? jieyouxu

This is similar to rust-lang/rust#139823 -- the test fails for me because my build dir is a symlink.
