### PR TITLE
set default for build.tidy-extra-checks to auto run all but shellcheck

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1125,10 +1125,10 @@ impl Step for Tidy {
         if builder.config.cmd.bless() {
             cmd.arg("--bless");
         }
-        if let Some(s) =
-            builder.config.cmd.extra_checks().or(builder.config.tidy_extra_checks.as_deref())
-        {
-            cmd.arg(format!("--extra-checks={s}"));
+        let extra_checks =
+            builder.config.cmd.extra_checks().unwrap_or(builder.config.tidy_extra_checks.as_str());
+        if !extra_checks.is_empty() {
+            cmd.arg(format!("--extra-checks={extra_checks}"));
         }
         let mut args = std::env::args_os();
         if args.any(|arg| arg == OsStr::new("--")) {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -299,7 +299,7 @@ pub struct Config {
     /// Whether to use the precompiled stage0 libtest with compiletest.
     pub compiletest_use_stage0_libtest: bool,
     /// Default value for `--extra-checks`
-    pub tidy_extra_checks: Option<String>,
+    pub tidy_extra_checks: String,
     pub is_running_on_ci: bool,
 
     /// Cache for determining path modifications
@@ -1014,7 +1014,8 @@ impl Config {
             optimized_compiler_builtins.unwrap_or(config.channel != "dev");
         config.compiletest_diff_tool = compiletest_diff_tool;
         config.compiletest_use_stage0_libtest = compiletest_use_stage0_libtest.unwrap_or(true);
-        config.tidy_extra_checks = tidy_extra_checks;
+        config.tidy_extra_checks = tidy_extra_checks
+            .unwrap_or_else(|| "auto:js,auto:cpp,auto:py,auto:spellcheck".to_string());
 
         let download_rustc = config.download_rustc_commit.is_some();
         config.explicit_stage_from_cli = flags_stage.is_some();


### PR DESCRIPTION
shellcheck is the only one of these tests which is not run in CI.

the `auto:` system seems to be working decently well, so I think it makes sense to enable it by default at some point.

unsure if we want to let this sit for a bit to make sure no issues come up, or optimize extra checks more, or if it's good to just move ahead with this.  my only concern would be if it makes tidy extra slow on hdd systems.

r? @Kobzol 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
