### PR TITLE
Allow pretty printing paths with `-Zself-profile-events=args`

### DIFF
--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -551,6 +551,11 @@ impl SelfProfilerRef {
     pub fn get_self_profiler(&self) -> Option<Arc<SelfProfiler>> {
         self.profiler.clone()
     }
+
+    /// Is expensive recording of query keys and/or function arguments enabled?
+    pub fn is_args_recording_enabled(&self) -> bool {
+        self.enabled() && self.event_filter_mask.intersects(EventFilter::ARGS)
+    }
 }
 
 /// A helper for recording costly arguments to self-profiling events. Used with

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -313,6 +313,7 @@ impl Session {
             || self.opts.unstable_opts.query_dep_graph
             || self.opts.unstable_opts.dump_mir.is_some()
             || self.opts.unstable_opts.unpretty.is_some()
+            || self.prof.is_args_recording_enabled()
             || self.opts.output_types.contains_key(&OutputType::Mir)
             || std::env::var_os("RUSTC_LOG").is_some()
         {

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1233,6 +1233,10 @@ Exercises sanitizer support. See [Sanitizer | The rustc book](https://doc.rust-l
 
 Tests with erroneous ways of using `self`, such as using `this.x` syntax as seen in other languages, having it not be the first argument, or using it in a non-associated function (no `impl` or `trait`). It also contains correct uses of `self` which have previously been observed to cause ICEs.
 
+## `tests/ui/self-profile/`: self-profiling
+
+Tests related to the self-profiler (`-Zself-profile`) functionality of rustc.
+
 ## `tests/ui/sepcomp/`: Separate Compilation
 
 In this directory, multiple crates are compiled, but some of them have `inline` functions, meaning they must be inlined into a different crate despite having been compiled separately.

--- a/tests/ui/self-profile/pretty_print_no_ice.rs
+++ b/tests/ui/self-profile/pretty_print_no_ice.rs
@@ -1,0 +1,14 @@
+// Checks that when we use `-Zself-profile-events=args`, it is possible to pretty print paths
+// using `trimmed_def_paths` even without producing diagnostics.
+//
+// Issue: <https://github.com/rust-lang/rust/issues/144457>.
+
+//@ compile-flags: -Zself-profile={{build-base}} -Zself-profile-events=args
+//@ build-pass
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+
+fn main() {
+    AtomicUsize::new(0).load(Relaxed);
+}


### PR DESCRIPTION
`-Zself-profile-events=args` is pretty heavy and can pretty print a lot of stuff. Rather than hunting down specific cases where this happens, I'd just allow calling `trimmed_def_paths` in this mode.

Fixes: https://github.com/rust-lang/rust/issues/144457

r? @RalfJung