### PR TITLE
Only run bootstrap tests in `x test` on CI

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3132,7 +3132,11 @@ impl Step for Bootstrap {
     }
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/bootstrap")
+        // Bootstrap tests might not be perfectly self-contained and can depend on the external
+        // environment, submodules that are checked out, etc.
+        // Therefore we only run them by default on CI.
+        let runs_on_ci = run.builder.config.is_running_on_ci;
+        run.path("src/bootstrap").default_condition(runs_on_ci)
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
Discussed at https://rust-lang.zulipchat.com/#narrow/channel/122652-new-members/topic/Linux.20Distribution/with/530839642. The bootstrap tests can be sensitive of the environment where they are executed. And now that they are executed very early in the test pipeline, it can be annoying for people who just try to do `x test` when it fails on bootstrap tests.

We could move the bootstrap tests back to the end of the `x test` pipeline, but then it would just fail later. I'd prefer to only run them on CI by default.

Fixes: https://github.com/rust-lang/rust/issues/143973