### PR TITLE
Allow the global allocator to use thread-local storage and std::thread::current()

### DIFF
--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -115,6 +115,31 @@ use crate::{cmp, ptr};
 ///   Whether allocations happen or not is not part of the program behavior, even if it
 ///   could be detected via an allocator that tracks allocations by printing or otherwise
 ///   having side effects.
+///
+/// # Re-entrance
+///
+/// When implementing a global allocator one has to be careful not to create an infinitely recursive
+/// implementation by accident, as many constructs in the Rust standard library may allocate in
+/// their implementation. For example, on some platforms [`std::sync::Mutex`] may allocate, so using
+/// it is highly problematic in a global allocator.
+///
+/// Generally speaking for this reason one should stick to library features available through
+/// [`core`], and avoid using [`std`] in a global allocator. A few features from [`std`] are
+/// guaranteed to not use `#[global_allocator]` to allocate:
+///
+///  - [`std::thread_local`],
+///  - [`std::thread::current`],
+///  - [`std::thread::park`] and [`std::thread::Thread`]'s [`unpark`] method and
+/// [`Clone`] implementation.
+///
+/// [`std`]: ../../std/index.html
+/// [`std::sync::Mutex`]: ../../std/sync/struct.Mutex.html
+/// [`std::thread_local`]: ../../std/macro.thread_local.html
+/// [`std::thread::current`]: ../../std/thread/fn.current.html
+/// [`std::thread::park`]: ../../std/thread/fn.park.html
+/// [`std::thread::Thread`]: ../../std/thread/struct.Thread.html
+/// [`unpark`]: ../../std/thread/struct.Thread.html#method.unpark
+
 #[stable(feature = "global_alloc", since = "1.28.0")]
 pub unsafe trait GlobalAlloc {
     /// Allocates memory as described by the given `layout`.

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -11,7 +11,7 @@
 //!
 //! This attribute allows configuring the choice of global allocator.
 //! You can use this to implement a completely custom global allocator
-//! to route all default allocation requests to a custom object.
+//! to route all[^system-alloc] default allocation requests to a custom object.
 //!
 //! ```rust
 //! use std::alloc::{GlobalAlloc, System, Layout};
@@ -52,6 +52,13 @@
 //!
 //! The `#[global_allocator]` can only be used once in a crate
 //! or its recursive dependencies.
+//!
+//! [^system-alloc]: Note that the Rust standard library internals may still
+//! directly call [`System`] when necessary (for example for the runtime
+//! support typically required to implement a global allocator, see [re-entrance] on [`GlobalAlloc`]
+//! for more details).
+//!
+//! [re-entrance]: trait.GlobalAlloc.html#re-entrance
 
 #![deny(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "alloc_module", since = "1.28.0")]

--- a/library/std/src/sys/pal/sgx/abi/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/mod.rs
@@ -3,6 +3,7 @@
 use core::arch::global_asm;
 use core::sync::atomic::{Atomic, AtomicUsize, Ordering};
 
+use crate::alloc::System;
 use crate::io::Write;
 
 // runtime features
@@ -63,7 +64,9 @@ unsafe extern "C" fn tcs_init(secondary: bool) {
 #[unsafe(no_mangle)]
 extern "C" fn entry(p1: u64, p2: u64, p3: u64, secondary: bool, p4: u64, p5: u64) -> EntryReturn {
     // FIXME: how to support TLS in library mode?
-    let tls = Box::new(tls::Tls::new());
+    // We use the System allocator here such that the global allocator may use
+    // thread-locals.
+    let tls = Box::new_in(tls::Tls::new(), System);
     let tls_guard = unsafe { tls.activate() };
 
     if secondary {

--- a/library/std/src/sys/pal/sgx/abi/tls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/tls/mod.rs
@@ -89,13 +89,6 @@ impl Tls {
         ActiveTls { tls: self }
     }
 
-    #[allow(unused)]
-    pub unsafe fn activate_persistent(self: Box<Self>) {
-        // FIXME: Needs safety information. See entry.S for `set_tls_ptr` definition.
-        let ptr = Box::into_raw(self).cast_const().cast::<u8>();
-        unsafe { set_tls_ptr(ptr) };
-    }
-
     unsafe fn current<'a>() -> &'a Tls {
         // FIXME: Needs safety information. See entry.S for `set_tls_ptr` definition.
         unsafe { &*(get_tls_ptr() as *const Tls) }

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -14,6 +14,7 @@ use crate::sys::weak::dlsym;
 #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "nto",))]
 use crate::sys::weak::weak;
 use crate::sys::{os, stack_overflow};
+use crate::thread::{ThreadInit, current};
 use crate::time::Duration;
 use crate::{cmp, io, ptr};
 #[cfg(not(any(
@@ -30,11 +31,6 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 256 * 1024;
 #[cfg(any(target_os = "espidf", target_os = "nuttx"))]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 0; // 0 indicates that the stack size configured in the ESP-IDF/NuttX menuconfig system should be used
 
-struct ThreadData {
-    name: Option<Box<str>>,
-    f: Box<dyn FnOnce()>,
-}
-
 pub struct Thread {
     id: libc::pthread_t,
 }
@@ -47,13 +43,8 @@ unsafe impl Sync for Thread {}
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub unsafe fn new(
-        stack: usize,
-        name: Option<&str>,
-        f: Box<dyn FnOnce()>,
-    ) -> io::Result<Thread> {
-        let data = Box::new(ThreadData { name: name.map(Box::from), f });
-
+    pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
+        let data = init;
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
         let mut attr = DropGuard::new(&mut attr, |attr| {
@@ -116,12 +107,16 @@ impl Thread {
 
         extern "C" fn thread_start(data: *mut libc::c_void) -> *mut libc::c_void {
             unsafe {
-                let data = Box::from_raw(data as *mut ThreadData);
-                // Next, set up our stack overflow handler which may get triggered if we run
-                // out of stack.
-                let _handler = stack_overflow::Handler::new(data.name);
-                // Finally, let's run some code.
-                (data.f)();
+                // SAFETY: we are simply recreating the box that was leaked earlier.
+                let init = Box::from_raw(data as *mut ThreadInit);
+                let rust_start = init.init();
+
+                // Set up our thread name and stack overflow handler which may get triggered
+                // if we run out of stack.
+                let thread = current();
+                let _handler = stack_overflow::Handler::new(thread.name().map(Box::from));
+
+                rust_start();
             }
             ptr::null_mut()
         }

--- a/library/std/src/sys/thread/unsupported.rs
+++ b/library/std/src/sys/thread/unsupported.rs
@@ -4,6 +4,12 @@ use crate::num::NonZero;
 use crate::thread::ThreadInit;
 use crate::time::Duration;
 
+// Silence dead code warnings for the otherwise unused ThreadInit::init() call.
+#[expect(dead_code)]
+fn dummy_init_call(init: Box<ThreadInit>) {
+    drop(init.init());
+}
+
 pub struct Thread(!);
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 64 * 1024;

--- a/library/std/src/sys/thread/unsupported.rs
+++ b/library/std/src/sys/thread/unsupported.rs
@@ -1,6 +1,7 @@
 use crate::ffi::CStr;
 use crate::io;
 use crate::num::NonZero;
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 
 pub struct Thread(!);
@@ -9,11 +10,7 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 64 * 1024;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(
-        _stack: usize,
-        _name: Option<&str>,
-        _p: Box<dyn FnOnce()>,
-    ) -> io::Result<Thread> {
+    pub unsafe fn new(_stack: usize, _init: Box<ThreadInit>) -> io::Result<Thread> {
         Err(io::Error::UNSUPPORTED_PLATFORM)
     }
 

--- a/library/std/src/sys/thread/wasip1.rs
+++ b/library/std/src/sys/thread/wasip1.rs
@@ -7,6 +7,7 @@ use crate::mem;
 use crate::num::NonZero;
 #[cfg(target_feature = "atomics")]
 use crate::sys::os;
+#[cfg(target_feature = "atomics")]
 use crate::thread::ThreadInit;
 use crate::time::Duration;
 #[cfg(target_feature = "atomics")]

--- a/library/std/src/sys/thread/wasip1.rs
+++ b/library/std/src/sys/thread/wasip1.rs
@@ -7,6 +7,7 @@ use crate::mem;
 use crate::num::NonZero;
 #[cfg(target_feature = "atomics")]
 use crate::sys::os;
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 #[cfg(target_feature = "atomics")]
 use crate::{cmp, ptr};
@@ -73,12 +74,8 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
 #[cfg(target_feature = "atomics")]
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(
-        stack: usize,
-        _name: Option<&str>,
-        p: Box<dyn FnOnce()>,
-    ) -> io::Result<Thread> {
-        let p = Box::into_raw(Box::new(p));
+    pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
+        let data = Box::into_raw(init);
         let mut native: libc::pthread_t = unsafe { mem::zeroed() };
         let mut attr: libc::pthread_attr_t = unsafe { mem::zeroed() };
         assert_eq!(unsafe { libc::pthread_attr_init(&mut attr) }, 0);
@@ -100,28 +97,28 @@ impl Thread {
             }
         };
 
-        let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, p as *mut _) };
-        // Note: if the thread creation fails and this assert fails, then p will
+        let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, data as *mut _) };
+        // Note: if the thread creation fails and this assert fails, then data will
         // be leaked. However, an alternative design could cause double-free
         // which is clearly worse.
         assert_eq!(unsafe { libc::pthread_attr_destroy(&mut attr) }, 0);
 
         return if ret != 0 {
-            // The thread failed to start and as a result p was not consumed. Therefore, it is
+            // The thread failed to start and as a result data was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
             unsafe {
-                drop(Box::from_raw(p));
+                drop(Box::from_raw(data));
             }
             Err(io::Error::from_raw_os_error(ret))
         } else {
             Ok(Thread { id: native })
         };
 
-        extern "C" fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
-            unsafe {
-                // Finally, let's run some code.
-                Box::from_raw(main as *mut Box<dyn FnOnce()>)();
-            }
+        extern "C" fn thread_start(data: *mut libc::c_void) -> *mut libc::c_void {
+            // SAFETY: we are simply recreating the box that was leaked earlier.
+            let init = unsafe { Box::from_raw(data as *mut ThreadInit) };
+            let rust_start = init.init();
+            rust_start();
             ptr::null_mut()
         }
     }

--- a/library/std/src/sys/thread/windows.rs
+++ b/library/std/src/sys/thread/windows.rs
@@ -8,6 +8,7 @@ use crate::sys::pal::time::WaitableTimer;
 use crate::sys::pal::{dur2timeout, to_u16s};
 use crate::sys::{c, stack_overflow};
 use crate::sys_common::FromInner;
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 use crate::{io, ptr};
 
@@ -20,23 +21,19 @@ pub struct Thread {
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub unsafe fn new(
-        stack: usize,
-        _name: Option<&str>,
-        p: Box<dyn FnOnce()>,
-    ) -> io::Result<Thread> {
-        let p = Box::into_raw(Box::new(p));
+    pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
+        let data = Box::into_raw(init);
 
         // CreateThread rounds up values for the stack size to the nearest page size (at least 4kb).
         // If a value of zero is given then the default stack size is used instead.
         // SAFETY: `thread_start` has the right ABI for a thread's entry point.
-        // `p` is simply passed through to the new thread without being touched.
+        // `data` is simply passed through to the new thread without being touched.
         let ret = unsafe {
             let ret = c::CreateThread(
                 ptr::null_mut(),
                 stack,
                 Some(thread_start),
-                p as *mut _,
+                data as *mut _,
                 c::STACK_SIZE_PARAM_IS_A_RESERVATION,
                 ptr::null_mut(),
             );
@@ -45,19 +42,21 @@ impl Thread {
         return if let Ok(handle) = ret.try_into() {
             Ok(Thread { handle: Handle::from_inner(handle) })
         } else {
-            // The thread failed to start and as a result p was not consumed. Therefore, it is
+            // The thread failed to start and as a result data was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
-            unsafe { drop(Box::from_raw(p)) };
+            unsafe { drop(Box::from_raw(data)) };
             Err(io::Error::last_os_error())
         };
 
-        unsafe extern "system" fn thread_start(main: *mut c_void) -> u32 {
-            // Next, reserve some stack space for if we otherwise run out of stack.
+        unsafe extern "system" fn thread_start(data: *mut c_void) -> u32 {
+            // SAFETY: we are simply recreating the box that was leaked earlier.
+            let init = unsafe { Box::from_raw(data as *mut ThreadInit) };
+            let rust_start = init.init();
+
+            // Reserve some stack space for if we otherwise run out of stack.
             stack_overflow::reserve_stack();
-            // Finally, let's run some code.
-            // SAFETY: We are simply recreating the box that was leaked earlier.
-            // It's the responsibility of the one who call `Thread::new` to ensure this is safe to call here.
-            unsafe { Box::from_raw(main as *mut Box<dyn FnOnce()>)() };
+
+            rust_start();
             0
         }
     }

--- a/library/std/src/sys/thread/xous.rs
+++ b/library/std/src/sys/thread/xous.rs
@@ -7,6 +7,7 @@ use crate::os::xous::ffi::{
     map_memory, update_memory_flags,
 };
 use crate::os::xous::services::{TicktimerScalar, ticktimer_server};
+use crate::thread::ThreadInit;
 use crate::time::Duration;
 
 pub struct Thread {
@@ -19,12 +20,8 @@ pub const GUARD_PAGE_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(
-        stack: usize,
-        _name: Option<&str>,
-        p: Box<dyn FnOnce()>,
-    ) -> io::Result<Thread> {
-        let p = Box::into_raw(Box::new(p));
+    pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
+        let data = Box::into_raw(init);
         let mut stack_size = crate::cmp::max(stack, MIN_STACK_SIZE);
 
         if (stack_size & 4095) != 0 {
@@ -65,7 +62,7 @@ impl Thread {
         let tid = create_thread(
             thread_start as *mut usize,
             &mut stack_plus_guard_pages[GUARD_PAGE_SIZE..(stack_size + GUARD_PAGE_SIZE)],
-            p as usize,
+            data as usize,
             guard_page_pre,
             stack_size,
             0,
@@ -73,14 +70,14 @@ impl Thread {
         .map_err(|code| io::Error::from_raw_os_error(code as i32))?;
 
         extern "C" fn thread_start(
-            main: *mut usize,
+            data: *mut usize,
             guard_page_pre: usize,
             stack_size: usize,
         ) -> ! {
-            unsafe {
-                // Run the contents of the new thread.
-                Box::from_raw(main as *mut Box<dyn FnOnce()>)();
-            }
+            // SAFETY: we are simply recreating the box that was leaked earlier.
+            let init = unsafe { Box::from_raw(data as *mut ThreadInit) };
+            let rust_start = init.init();
+            rust_start();
 
             // Destroy TLS, which will free the TLS page and call the destructor for
             // any thread local storage (if any).

--- a/library/std/src/sys/thread_local/destructors/list.rs
+++ b/library/std/src/sys/thread_local/destructors/list.rs
@@ -7,7 +7,9 @@ static DTORS: RefCell<Vec<(*mut u8, unsafe extern "C" fn(*mut u8)), System>> =
     RefCell::new(Vec::new_in(System));
 
 pub unsafe fn register(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
-    let Ok(mut dtors) = DTORS.try_borrow_mut() else { rtabort!("unreachable") };
+    let Ok(mut dtors) = DTORS.try_borrow_mut() else {
+        rtabort!("the System allocator may not use TLS with destructors")
+    };
     guard::enable();
     dtors.push((t, dtor));
 }

--- a/library/std/src/sys/thread_local/destructors/list.rs
+++ b/library/std/src/sys/thread_local/destructors/list.rs
@@ -1,19 +1,14 @@
+use crate::alloc::System;
 use crate::cell::RefCell;
 use crate::sys::thread_local::guard;
 
 #[thread_local]
-static DTORS: RefCell<Vec<(*mut u8, unsafe extern "C" fn(*mut u8))>> = RefCell::new(Vec::new());
+static DTORS: RefCell<Vec<(*mut u8, unsafe extern "C" fn(*mut u8)), System>> =
+    RefCell::new(Vec::new_in(System));
 
 pub unsafe fn register(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
-    let Ok(mut dtors) = DTORS.try_borrow_mut() else {
-        // This point can only be reached if the global allocator calls this
-        // function again.
-        // FIXME: maybe use the system allocator instead?
-        rtabort!("the global allocator may not use TLS with destructors");
-    };
-
+    let Ok(mut dtors) = DTORS.try_borrow_mut() else { rtabort!("unreachable") };
     guard::enable();
-
     dtors.push((t, dtor));
 }
 
@@ -36,7 +31,7 @@ pub unsafe fn run() {
             }
             None => {
                 // Free the list memory.
-                *dtors = Vec::new();
+                *dtors = Vec::new_in(System);
                 break;
             }
         }

--- a/library/std/src/sys/thread_local/key/xous.rs
+++ b/library/std/src/sys/thread_local/key/xous.rs
@@ -186,6 +186,11 @@ pub unsafe fn destroy_tls() {
     };
 }
 
+// This is marked inline(never) to prevent dealloc calls from being reordered
+// to after the TLS has been destroyed.
+// See https://github.com/rust-lang/rust/pull/144465#pullrequestreview-3289729950
+// for more context.
+#[inline(never)]
 unsafe fn run_dtors() {
     let mut any_run = true;
 

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -270,15 +270,16 @@ fn init_current(current: *mut ()) -> Thread {
         // extra TLS write above shouldn't matter. The alternative is nearly always
         // a stack overflow.
 
-        // If you came across this message, contact the author of your allocator.
-        // If you are said author: A surprising amount of functions inside the
-        // standard library (e.g. `Mutex`, `thread_local!`, `File` when using long
-        // paths, even `panic!` when using unwinding), need memory allocation, so
-        // you'll get circular dependencies all over the place when using them.
-        // I (joboet) highly recommend using only APIs from core in your allocator
-        // and implementing your own system abstractions. Still, if you feel that
-        // a particular API should be entirely allocation-free, feel free to open
-        // an issue on the Rust repository, we'll see what we can do.
+        // If you came across this message, contact the author of your
+        // allocator. If you are said author: A surprising amount of functions
+        // inside the standard library (e.g. `Mutex`, `File` when using long
+        // paths, even `panic!` when using unwinding), need memory allocation,
+        // so you'll get circular dependencies all over the place when using
+        // them. I (joboet) highly recommend using only APIs from core in your
+        // allocator and implementing your own system abstractions. Still, if
+        // you feel that a particular API should be entirely allocation-free,
+        // feel free to open an issue on the Rust repository, we'll see what we
+        // can do.
         rtabort!(
             "\n\
             Attempted to access thread-local data while allocating said data.\n\

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -269,23 +269,13 @@ fn init_current(current: *mut ()) -> Thread {
         // BUSY exists solely for this check, but as it is in the slow path, the
         // extra TLS write above shouldn't matter. The alternative is nearly always
         // a stack overflow.
-
-        // If you came across this message, contact the author of your
-        // allocator. If you are said author: A surprising amount of functions
-        // inside the standard library (e.g. `Mutex`, `File` when using long
-        // paths, even `panic!` when using unwinding), need memory allocation,
-        // so you'll get circular dependencies all over the place when using
-        // them. I (joboet) highly recommend using only APIs from core in your
-        // allocator and implementing your own system abstractions. Still, if
-        // you feel that a particular API should be entirely allocation-free,
-        // feel free to open an issue on the Rust repository, we'll see what we
-        // can do.
+        //
+        // If we reach this point it means our initialization routine ended up
+        // calling current() either directly, or indirectly through the global
+        // allocator, which is a bug either way as we may not call the global
+        // allocator in current().
         rtabort!(
-            "\n\
-            Attempted to access thread-local data while allocating said data.\n\
-            Do not access functions that allocate in the global allocator!\n\
-            This is a bug in the global allocator.\n\
-            "
+            "init_current() was re-entrant, which indicates a bug in the Rust threading implementation"
         )
     } else {
         debug_assert_eq!(current, DESTROYED);

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -24,12 +24,17 @@ use crate::fmt;
 /// [`with`]) within a thread, and values that implement [`Drop`] get
 /// destructed when a thread exits. Some platform-specific caveats apply, which
 /// are explained below.
-/// Note that if the destructor panics, the whole process will be [aborted].
+/// Note that, should the destructor panic, the whole process will be [aborted].
+/// On platforms where initialization requires memory allocation, this is
+/// performed directly through [`System`], allowing the [global allocator]
+/// to make use of thread local storage.
 ///
 /// A `LocalKey`'s initializer cannot recursively depend on itself. Using a
 /// `LocalKey` in this way may cause panics, aborts, or infinite recursion on
 /// the first call to `with`.
 ///
+/// [`System`]: crate::alloc::System
+/// [global allocator]: crate::alloc
 /// [aborted]: crate::process::abort
 ///
 /// # Single-thread Synchronization

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1307,14 +1307,13 @@ impl ThreadId {
 
                 // SAFETY: we have an exclusive lock on the counter.
                 unsafe {
-                    if *COUNTER.get() == u64::MAX {
-                        COUNTER_LOCKED.store(false, Ordering::Release);
-                        exhausted()
-                    } else {
-                        let id = *COUNTER.get() + 1;
+                    if let Some(id) = (*COUNTER.get()).checked_add(1) {
                         *COUNTER.get() = id;
                         COUNTER_LOCKED.store(false, Ordering::Release);
                         ThreadId(NonZero::new(id).unwrap())
+                    } else {
+                        COUNTER_LOCKED.store(false, Ordering::Release);
+                        exhausted()
                     }
                 }
             }

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -218,13 +218,13 @@ pub mod local_impl {
 /// the global allocator works.
 pub(crate) struct ThreadInit {
     pub handle: Thread,
-    pub rust_start: Box<dyn FnOnce()>,
+    pub rust_start: Box<dyn FnOnce() + Send>,
 }
 
 impl ThreadInit {
     /// Initialize the 'current thread' mechanism on this thread, returning the
     /// Rust entry point.
-    pub fn init(self: Box<Self>) -> Box<dyn FnOnce()> {
+    pub fn init(self: Box<Self>) -> Box<dyn FnOnce() + Send> {
         // Set the current thread before any (de)allocations on the global allocator occur,
         // so that it may call std::thread::current() in its implementation. This is also
         // why we take Box<Self>, to ensure the Box is not destroyed until after this point.

--- a/tests/debuginfo/thread.rs
+++ b/tests/debuginfo/thread.rs
@@ -14,7 +14,7 @@
 //
 //@ cdb-command:dx t,d
 //@ cdb-check:t,d              : [...] [Type: std::thread::Thread *]
-//@ cdb-check:[...] inner [...][Type: core::pin::Pin<alloc::sync::Arc<std::thread::Inner,alloc::alloc::Global> >]
+//@ cdb-check:[...] inner [...][Type: core::pin::Pin<alloc::sync::Arc<std::thread::Inner,std::alloc::System> >]
 
 use std::thread;
 

--- a/tests/ui/threads-sendsync/tls-in-global-alloc.rs
+++ b/tests/ui/threads-sendsync/tls-in-global-alloc.rs
@@ -2,27 +2,46 @@
 //@ needs-threads
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::thread::Thread;
-use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread::{Thread, ThreadId};
 
 static GLOBAL: AtomicUsize = AtomicUsize::new(0);
+static SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS: AtomicBool = AtomicBool::new(false);
+static LOCAL_TRY_WITH_SUCCEEDED_ALLOC: AtomicBool = AtomicBool::new(false);
+static LOCAL_TRY_WITH_SUCCEEDED_DEALLOC: AtomicBool = AtomicBool::new(false);
 
-struct Local(Thread);
+struct LocalForAllocatorWithoutDrop(ThreadId);
 
-thread_local! {
-    static LOCAL: Local = {
-        GLOBAL.fetch_or(1, Ordering::Relaxed);
-        Local(std::thread::current())
-    };
-}
+struct LocalForAllocatorWithDrop(Thread);
 
-impl Drop for Local {
+impl Drop for LocalForAllocatorWithDrop {
     fn drop(&mut self) {
         GLOBAL.fetch_or(2, Ordering::Relaxed);
     }
 }
 
-static SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS: AtomicBool = AtomicBool::new(false);
+struct LocalForUser(u32);
+
+impl Drop for LocalForUser {
+    // A user might call the global allocator in a thread-local drop.
+    fn drop(&mut self) {
+        self.0 += 1;
+        drop(black_box(Box::new(self.0)))
+    }
+}
+
+thread_local! {
+    static LOCAL_FOR_USER0: LocalForUser = LocalForUser(0);
+    static LOCAL_FOR_ALLOCATOR_WITHOUT_DROP: LocalForAllocatorWithoutDrop = {
+        LocalForAllocatorWithoutDrop(std::thread::current().id())
+    };
+    static LOCAL_FOR_ALLOCATOR_WITH_DROP: LocalForAllocatorWithDrop = {
+        GLOBAL.fetch_or(1, Ordering::Relaxed);
+        LocalForAllocatorWithDrop(std::thread::current())
+    };
+    static LOCAL_FOR_USER1: LocalForUser = LocalForUser(1);
+}
 
 #[global_allocator]
 static ALLOC: Alloc = Alloc;
@@ -33,9 +52,19 @@ unsafe impl GlobalAlloc for Alloc {
         // Make sure we aren't re-entrant.
         assert!(!SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.load(Ordering::Relaxed));
         SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(true, Ordering::Relaxed);
-        LOCAL.with(|local| {
+
+        // Should be infallible.
+        LOCAL_FOR_ALLOCATOR_WITHOUT_DROP.with(|local| {
+            assert!(local.0 == std::thread::current().id());
+        });
+
+        // May fail once thread-local destructors start running, and ours has
+        // been ran.
+        let try_with_ret = LOCAL_FOR_ALLOCATOR_WITH_DROP.try_with(|local| {
             assert!(local.0.id() == std::thread::current().id());
         });
+        LOCAL_TRY_WITH_SUCCEEDED_ALLOC.fetch_or(try_with_ret.is_ok(), Ordering::Relaxed);
+
         let ret = unsafe { System.alloc(layout) };
         SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(false, Ordering::Relaxed);
         ret
@@ -45,9 +74,19 @@ unsafe impl GlobalAlloc for Alloc {
         // Make sure we aren't re-entrant.
         assert!(!SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.load(Ordering::Relaxed));
         SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(true, Ordering::Relaxed);
-        LOCAL.with(|local| {
+
+        // Should be infallible.
+        LOCAL_FOR_ALLOCATOR_WITHOUT_DROP.with(|local| {
+            assert!(local.0 == std::thread::current().id());
+        });
+
+        // May fail once thread-local destructors start running, and ours has
+        // been ran.
+        let try_with_ret = LOCAL_FOR_ALLOCATOR_WITH_DROP.try_with(|local| {
             assert!(local.0.id() == std::thread::current().id());
         });
+        LOCAL_TRY_WITH_SUCCEEDED_DEALLOC.fetch_or(try_with_ret.is_ok(), Ordering::Relaxed);
+
         unsafe { System.dealloc(ptr, layout) }
         SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(false, Ordering::Relaxed);
     }
@@ -55,10 +94,14 @@ unsafe impl GlobalAlloc for Alloc {
 
 fn main() {
     std::thread::spawn(|| {
+        LOCAL_FOR_USER0.with(|l| assert!(l.0 == 0));
         std::hint::black_box(vec![1, 2]);
         assert!(GLOBAL.load(Ordering::Relaxed) == 1);
+        LOCAL_FOR_USER1.with(|l| assert!(l.0 == 1));
     })
     .join()
     .unwrap();
     assert!(GLOBAL.load(Ordering::Relaxed) == 3);
+    assert!(LOCAL_TRY_WITH_SUCCEEDED_ALLOC.load(Ordering::Relaxed));
+    assert!(LOCAL_TRY_WITH_SUCCEEDED_DEALLOC.load(Ordering::Relaxed));
 }

--- a/tests/ui/threads-sendsync/tls-in-global-alloc.rs
+++ b/tests/ui/threads-sendsync/tls-in-global-alloc.rs
@@ -1,0 +1,64 @@
+//@ run-pass
+//@ needs-threads
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::thread::Thread;
+use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+
+static GLOBAL: AtomicUsize = AtomicUsize::new(0);
+
+struct Local(Thread);
+
+thread_local! {
+    static LOCAL: Local = {
+        GLOBAL.fetch_or(1, Ordering::Relaxed);
+        Local(std::thread::current())
+    };
+}
+
+impl Drop for Local {
+    fn drop(&mut self) {
+        GLOBAL.fetch_or(2, Ordering::Relaxed);
+    }
+}
+
+static SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS: AtomicBool = AtomicBool::new(false);
+
+#[global_allocator]
+static ALLOC: Alloc = Alloc;
+struct Alloc;
+
+unsafe impl GlobalAlloc for Alloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Make sure we aren't re-entrant.
+        assert!(!SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.load(Ordering::Relaxed));
+        SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(true, Ordering::Relaxed);
+        LOCAL.with(|local| {
+            assert!(local.0.id() == std::thread::current().id());
+        });
+        let ret = unsafe { System.alloc(layout) };
+        SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(false, Ordering::Relaxed);
+        ret
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // Make sure we aren't re-entrant.
+        assert!(!SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.load(Ordering::Relaxed));
+        SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(true, Ordering::Relaxed);
+        LOCAL.with(|local| {
+            assert!(local.0.id() == std::thread::current().id());
+        });
+        unsafe { System.dealloc(ptr, layout) }
+        SHOULD_PANIC_ON_GLOBAL_ALLOC_ACCESS.store(false, Ordering::Relaxed);
+    }
+}
+
+fn main() {
+    std::thread::spawn(|| {
+        std::hint::black_box(vec![1, 2]);
+        assert!(GLOBAL.load(Ordering::Relaxed) == 1);
+    })
+    .join()
+    .unwrap();
+    assert!(GLOBAL.load(Ordering::Relaxed) == 3);
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115209.

Currently the thread-local storage implementation uses the `Global` allocator if it needs to allocate memory in some places. This effectively means the global allocator can not use thread-local variables. This is a shame as an allocator is precisely one of the locations where you'd *really* want to use thread-locals. We also see that this lead to hacks such as https://github.com/rust-lang/rust/pull/116402, where we detect re-entrance and abort.

So I've made the places where I could find allocation happening in the TLS implementation use the `System` allocator instead. I also applied this change to the storage allocated for a `Thread` handle so that it may be used care-free in the global allocator as well, for e.g. registering it to a central place or parking primitives.

r? @joboet 