### PR TITLE
clif: Don't set the `compiler-builtins-no-f16-f128` feature

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -597,11 +597,6 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
 
     let mut features = String::new();
 
-    if stage != 0 && builder.config.default_codegen_backend(target).as_deref() == Some("cranelift")
-    {
-        features += "compiler-builtins-no-f16-f128 ";
-    }
-
     if builder.no_std(target) == Some(true) {
         features += " compiler-builtins-mem";
         if !target.starts_with("bpf") {


### PR DESCRIPTION
Since rust-lang/rust be35d37d8b6c ("Use the compiler to determine whether or not to enable f16 and f128"), `compiler-builtins` relies on `rustc` to report whether or not `f16` and `f128` are supported, which is reported by the backend. This means that there should no longer be any need to unconditionally disable the types for clif in Bootstrap.

Backend config: https://github.com/rust-lang/rust/blob/a955f1cd09a027363729ceed919952d09f76f28e/compiler/rustc_codegen_cranelift/src/lib.rs#L224-L233

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
