### PR TITLE
Fix async closures not reproducible

### DIFF
--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -526,7 +526,7 @@ impl<'tcx> CodegenUnit<'tcx> {
     ) -> Vec<(MonoItem<'tcx>, MonoItemData)> {
         // The codegen tests rely on items being process in the same order as
         // they appear in the file, so for local items, we sort by span first
-        #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord)]
         struct ItemSortKey<'tcx>(Option<Span>, SymbolName<'tcx>);
 
         fn item_sort_key<'tcx>(tcx: TyCtxt<'tcx>, item: MonoItem<'tcx>) -> ItemSortKey<'tcx> {

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -12,7 +12,6 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_hashes::Hash128;
 use rustc_hir::ItemId;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdSet, LOCAL_CRATE};
-use rustc_index::Idx;
 use rustc_macros::{HashStable, TyDecodable, TyEncodable};
 use rustc_query_system::ich::StableHashingContext;
 use rustc_session::config::OptLevel;
@@ -527,8 +526,8 @@ impl<'tcx> CodegenUnit<'tcx> {
     ) -> Vec<(MonoItem<'tcx>, MonoItemData)> {
         // The codegen tests rely on items being process in the same order as
         // they appear in the file, so for local items, we sort by node_id first
-        #[derive(PartialEq, Eq, PartialOrd, Ord)]
-        struct ItemSortKey<'tcx>(Option<usize>, SymbolName<'tcx>);
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+        struct ItemSortKey<'tcx>(Option<Span>, SymbolName<'tcx>);
 
         fn item_sort_key<'tcx>(tcx: TyCtxt<'tcx>, item: MonoItem<'tcx>) -> ItemSortKey<'tcx> {
             ItemSortKey(
@@ -539,7 +538,9 @@ impl<'tcx> CodegenUnit<'tcx> {
                             // instances into account. The others don't matter for
                             // the codegen tests and can even make item order
                             // unstable.
-                            InstanceKind::Item(def) => def.as_local().map(Idx::index),
+                            InstanceKind::Item(def) => {
+                                def.as_local().map(|def_id|tcx.def_span(def_id))
+                            },
                             InstanceKind::VTableShim(..)
                             | InstanceKind::ReifyShim(..)
                             | InstanceKind::Intrinsic(..)
@@ -556,8 +557,8 @@ impl<'tcx> CodegenUnit<'tcx> {
                             | InstanceKind::AsyncDropGlueCtorShim(..) => None,
                         }
                     }
-                    MonoItem::Static(def_id) => def_id.as_local().map(Idx::index),
-                    MonoItem::GlobalAsm(item_id) => Some(item_id.owner_id.def_id.index()),
+                    MonoItem::Static(def_id) => def_id.as_local().map(|def_id|tcx.def_span(def_id)),
+                    MonoItem::GlobalAsm(item_id) => Some(tcx.def_span(item_id.owner_id.def_id)),
                 },
                 item.symbol_name(tcx),
             )

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -539,8 +539,8 @@ impl<'tcx> CodegenUnit<'tcx> {
                             // the codegen tests and can even make item order
                             // unstable.
                             InstanceKind::Item(def) => {
-                                def.as_local().map(|def_id|tcx.def_span(def_id))
-                            },
+                                def.as_local().map(|def_id| tcx.def_span(def_id))
+                            }
                             InstanceKind::VTableShim(..)
                             | InstanceKind::ReifyShim(..)
                             | InstanceKind::Intrinsic(..)
@@ -557,7 +557,9 @@ impl<'tcx> CodegenUnit<'tcx> {
                             | InstanceKind::AsyncDropGlueCtorShim(..) => None,
                         }
                     }
-                    MonoItem::Static(def_id) => def_id.as_local().map(|def_id|tcx.def_span(def_id)),
+                    MonoItem::Static(def_id) => {
+                        def_id.as_local().map(|def_id| tcx.def_span(def_id))
+                    }
                     MonoItem::GlobalAsm(item_id) => Some(tcx.def_span(item_id.owner_id.def_id)),
                 },
                 item.symbol_name(tcx),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

[parallel rustc: async closures not reproducible](https://github.com/rust-lang/rust/issues/140425#top) is caused by the nondeterministic orders for generated `DefId` of the synthetic function of an async closure under parallel compilation.

Now, we fix it using `Span` instead of `DefId` in the sort function.

This behavior hasn't added into any test until we have a test suit for the parallel frontend. (See https://github.com/rust-lang/rust/pull/143953/#issuecomment-3085371168)

Update rust-lang/rust#113349

r? @oli-obk 
cc @matthiaskrgr @Zoxc 