### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2849,7 +2849,7 @@ impl InlineAsmOperand {
     }
 }
 
-#[derive(Clone, Copy, Encodable, Decodable, Debug, HashStable_Generic, Walkable)]
+#[derive(Clone, Copy, Encodable, Decodable, Debug, HashStable_Generic, Walkable, PartialEq, Eq)]
 pub enum AsmMacro {
     /// The `asm!` macro
     Asm,

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -433,6 +433,9 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         // This rules out anything that doesn't have `long double` = `binary128`; <= 32 bits
         // (ld is `f64`), anything other than Linux (Windows and MacOS use `f64`), and `x86`
         // (ld is 80-bit extended precision).
+        //
+        // musl does not implement the symbols required for f128 math at all.
+        _ if target_env == "musl" => false,
         ("x86_64", _) => false,
         (_, "linux") if target_pointer_width == 64 => true,
         _ => false,

--- a/compiler/rustc_errors/src/markdown/term.rs
+++ b/compiler/rustc_errors/src/markdown/term.rs
@@ -18,7 +18,7 @@ thread_local! {
 pub(crate) fn entrypoint(stream: &MdStream<'_>, buf: &mut Buffer) -> io::Result<()> {
     #[cfg(not(test))]
     if let Some((w, _)) = termize::dimensions() {
-        WIDTH.with(|c| c.set(std::cmp::min(w, DEFAULT_COLUMN_WIDTH)));
+        WIDTH.set(std::cmp::min(w, DEFAULT_COLUMN_WIDTH));
     }
     write_stream(stream, buf, None, 0)?;
     buf.write_all(b"\n")
@@ -84,7 +84,7 @@ fn write_tt(tt: &MdTree<'_>, buf: &mut Buffer, indent: usize) -> io::Result<()> 
             reset_cursor();
         }
         MdTree::HorizontalRule => {
-            (0..WIDTH.with(Cell::get)).for_each(|_| buf.write_all(b"-").unwrap());
+            (0..WIDTH.get()).for_each(|_| buf.write_all(b"-").unwrap());
             reset_cursor();
         }
         MdTree::Heading(n, stream) => {
@@ -121,7 +121,7 @@ fn write_tt(tt: &MdTree<'_>, buf: &mut Buffer, indent: usize) -> io::Result<()> 
 
 /// End of that block, just wrap the line
 fn reset_cursor() {
-    CURSOR.with(|cur| cur.set(0));
+    CURSOR.set(0);
 }
 
 /// Change to be generic on Write for testing. If we have a link URL, we don't
@@ -144,7 +144,7 @@ fn write_wrapping<B: io::Write>(
                 buf.write_all(ind_ws)?;
                 cur.set(indent);
             }
-            let ch_count = WIDTH.with(Cell::get) - cur.get();
+            let ch_count = WIDTH.get() - cur.get();
             let mut iter = to_write.char_indices();
             let Some((end_idx, _ch)) = iter.nth(ch_count) else {
                 // Write entire line

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1062,7 +1062,6 @@ pub(crate) struct UnusedParens {
 /// ```
 /// type Example = Box<dyn Fn() -> &'static dyn Send>;
 /// ```
-#[derive(Copy, Clone)]
 enum NoBoundsException {
     /// The type must be parenthesized.
     None,
@@ -1343,8 +1342,12 @@ impl EarlyLintPass for UnusedParens {
             ast::TyKind::Ref(_, mut_ty) | ast::TyKind::Ptr(mut_ty) => {
                 // If this type itself appears in no-bounds position, we propagate its
                 // potentially tighter constraint or risk a false posive (issue 143653).
-                let own_constraint = self.in_no_bounds_pos.get(&ty.id).copied();
-                let constraint = own_constraint.unwrap_or(NoBoundsException::OneBound);
+                let own_constraint = self.in_no_bounds_pos.get(&ty.id);
+                let constraint = match own_constraint {
+                    Some(NoBoundsException::None) => NoBoundsException::None,
+                    Some(NoBoundsException::OneBound) => NoBoundsException::OneBound,
+                    None => NoBoundsException::OneBound,
+                };
                 self.in_no_bounds_pos.insert(mut_ty.ty.id, constraint);
             }
             ast::TyKind::TraitObject(bounds, _) | ast::TyKind::ImplTrait(_, bounds) => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -86,7 +86,7 @@ macro_rules! define_helper {
 
             impl $helper {
                 pub fn new() -> $helper {
-                    $helper($tl.with(|c| c.replace(true)))
+                    $helper($tl.replace(true))
                 }
             }
 
@@ -100,12 +100,12 @@ macro_rules! define_helper {
 
             impl Drop for $helper {
                 fn drop(&mut self) {
-                    $tl.with(|c| c.set(self.0))
+                    $tl.set(self.0)
                 }
             }
 
             pub fn $name() -> bool {
-                $tl.with(|c| c.get())
+                $tl.get()
             }
         )+
     }

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -86,9 +86,15 @@ mir_build_confused = missing patterns are not covered because `{$variable}` is i
 
 mir_build_const_continue_bad_const = could not determine the target branch for this `#[const_continue]`
     .label = this value is too generic
-    .note = the value must be a literal or a monomorphic const
 
 mir_build_const_continue_missing_value = a `#[const_continue]` must break to a label with a value
+
+mir_build_const_continue_not_const = could not determine the target branch for this `#[const_continue]`
+    .help = try extracting the expression into a `const` item
+
+mir_build_const_continue_not_const_const_block = `const` blocks may use generics, and are not evaluated early enough
+mir_build_const_continue_not_const_const_other = this value must be a literal or a monomorphic const
+mir_build_const_continue_not_const_constant_parameter = constant parameters may use generics, and are not evaluated early enough
 
 mir_build_const_continue_unknown_jump_target = the target of this `#[const_continue]` is not statically known
     .label = this value must be a literal or a monomorphic const

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -1214,6 +1214,38 @@ pub(crate) struct LoopMatchArmWithGuard {
 }
 
 #[derive(Diagnostic)]
+#[diag(mir_build_const_continue_not_const)]
+#[help]
+pub(crate) struct ConstContinueNotMonomorphicConst {
+    #[primary_span]
+    pub span: Span,
+
+    #[subdiagnostic]
+    pub reason: ConstContinueNotMonomorphicConstReason,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum ConstContinueNotMonomorphicConstReason {
+    #[label(mir_build_const_continue_not_const_constant_parameter)]
+    ConstantParameter {
+        #[primary_span]
+        span: Span,
+    },
+
+    #[label(mir_build_const_continue_not_const_const_block)]
+    ConstBlock {
+        #[primary_span]
+        span: Span,
+    },
+
+    #[label(mir_build_const_continue_not_const_const_other)]
+    Other {
+        #[primary_span]
+        span: Span,
+    },
+}
+
+#[derive(Diagnostic)]
 #[diag(mir_build_const_continue_bad_const)]
 pub(crate) struct ConstContinueBadConst {
     #[primary_span]

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -720,7 +720,7 @@ fn incremental_verify_ich_failed<Tcx>(
         static INSIDE_VERIFY_PANIC: Cell<bool> = const { Cell::new(false) };
     };
 
-    let old_in_panic = INSIDE_VERIFY_PANIC.with(|in_panic| in_panic.replace(true));
+    let old_in_panic = INSIDE_VERIFY_PANIC.replace(true);
 
     if old_in_panic {
         tcx.sess().dcx().emit_err(crate::error::Reentrant);
@@ -739,7 +739,7 @@ fn incremental_verify_ich_failed<Tcx>(
         panic!("Found unstable fingerprints for {dep_node:?}: {}", result());
     }
 
-    INSIDE_VERIFY_PANIC.with(|in_panic| in_panic.set(old_in_panic));
+    INSIDE_VERIFY_PANIC.set(old_in_panic);
 }
 
 /// Ensure that either this query has all green inputs or been executed.

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -90,11 +90,10 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-abi"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cafc2274c10fab234f176b25903ce17e690fca7597090d50880e047a0389c5"
+checksum = "5efc85edd5b83e8394f4371dd0da6859dff63dd387dab8568fece6af4cde6f84"
 dependencies = [
- "compiler_builtins",
  "rustc-std-workspace-core",
 ]
 

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -68,7 +68,7 @@ rand_xorshift = "0.4.0"
 dlmalloc = { version = "0.2.4", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-fortanix-sgx-abi = { version = "0.5.0", features = [
+fortanix-sgx-abi = { version = "0.6.1", features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -267,7 +267,7 @@ pub fn send(event_set: u64, tcs: Option<Tcs>) -> IoResult<()> {
 /// Usercall `insecure_time`. See the ABI documentation for more information.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn insecure_time() -> Duration {
-    let t = unsafe { raw::insecure_time() };
+    let t = unsafe { raw::insecure_time().0 };
     Duration::new(t / 1_000_000_000, (t % 1_000_000_000) as _)
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1380,6 +1380,11 @@ where
 }
 
 /// The internal representation of a `Thread` handle
+/// 
+/// We explicitly set the alignment for our guarantee in Thread::into_raw. This
+/// allows applications to stuff extra metadata bits into the alignment, which
+/// can be rather useful when working with atomics.
+#[repr(align(8))]
 struct Inner {
     name: Option<ThreadNameString>,
     id: ThreadId,
@@ -1563,7 +1568,8 @@ impl Thread {
     /// Consumes the `Thread`, returning a raw pointer.
     ///
     /// To avoid a memory leak the pointer must be converted
-    /// back into a `Thread` using [`Thread::from_raw`].
+    /// back into a `Thread` using [`Thread::from_raw`]. The pointer is
+    /// guaranteed to be aligned to at least 8 bytes.
     ///
     /// # Examples
     ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1380,7 +1380,7 @@ where
 }
 
 /// The internal representation of a `Thread` handle
-/// 
+///
 /// We explicitly set the alignment for our guarantee in Thread::into_raw. This
 /// allows applications to stuff extra metadata bits into the alignment, which
 /// can be rather useful when working with atomics.

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -568,7 +568,11 @@ function preLoadCss(cssUrl) {
                 break;
             case "-":
                 ev.preventDefault();
-                collapseAllDocs();
+                collapseAllDocs(false);
+                break;
+            case "_":
+                ev.preventDefault();
+                collapseAllDocs(true);
                 break;
 
             case "?":
@@ -1038,11 +1042,14 @@ function preLoadCss(cssUrl) {
         innerToggle.children[0].innerText = "Summary";
     }
 
-    function collapseAllDocs() {
+    /**
+     * @param {boolean} collapseImpls - also collapse impl blocks if set to true
+     */
+    function collapseAllDocs(collapseImpls) {
         const innerToggle = document.getElementById(toggleAllDocsId);
         addClass(innerToggle, "will-expand");
         onEachLazy(document.getElementsByClassName("toggle"), e => {
-            if (e.parentNode.id !== "implementations-list" ||
+            if ((collapseImpls || e.parentNode.id !== "implementations-list") ||
                 (!hasClass(e, "implementors-toggle") &&
                  !hasClass(e, "type-contents-toggle"))
             ) {
@@ -1053,7 +1060,10 @@ function preLoadCss(cssUrl) {
         innerToggle.children[0].innerText = "Show all";
     }
 
-    function toggleAllDocs() {
+    /**
+     * @param {MouseEvent=} ev
+     */
+    function toggleAllDocs(ev) {
         const innerToggle = document.getElementById(toggleAllDocsId);
         if (!innerToggle) {
             return;
@@ -1061,7 +1071,7 @@ function preLoadCss(cssUrl) {
         if (hasClass(innerToggle, "will-expand")) {
             expandAllDocs();
         } else {
-            collapseAllDocs();
+            collapseAllDocs(ev !== undefined && ev.shiftKey);
         }
     }
 
@@ -1519,6 +1529,10 @@ function preLoadCss(cssUrl) {
             ["&#9166;", "Go to active search result"],
             ["+", "Expand all sections"],
             ["-", "Collapse all sections"],
+            // for the sake of brevity, we don't say "inherint impl blocks",
+            // although that would be more correct,
+            // since trait impl blocks are collapsed by -
+            ["_", "Collapse all sections, including impl blocks"],
         ].map(x => "<dt>" +
             x[0].split(" ")
                 .map((y, index) => ((index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " "))

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -418,7 +418,9 @@ class RustdocToolbarElement extends HTMLElement {
         <div id="help-button" tabindex="-1">
             <a href="${rootPath}help.html"><span class="label">Help</span></a>
         </div>
-        <button id="toggle-all-docs"><span class="label">Summary</span></button>`;
+        <button id="toggle-all-docs"
+title="Collapse sections (shift-click to also collapse impl blocks)"><span
+class="label">Summary</span></button>`;
     }
 }
 window.customElements.define("rustdoc-toolbar", RustdocToolbarElement);

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -854,6 +854,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-openbsd",
     "ignore-pass",
     "ignore-powerpc",
+    "ignore-powerpc64",
     "ignore-remote",
     "ignore-riscv64",
     "ignore-rustc-debug-assertions",

--- a/tests/debuginfo/basic-types-globals-metadata.rs
+++ b/tests/debuginfo/basic-types-globals-metadata.rs
@@ -60,8 +60,10 @@ fn main() {
     _zzz(); // #break
 
     let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
-    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
-    // not exist on some targets like PowerPC
+    // FIXME: Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which
+    // does not exist on some targets like PowerPC.
+    // See https://github.com/llvm/llvm-project/issues/97981 and
+    // https://github.com/rust-lang/compiler-builtins/issues/655
     let b = unsafe { F16 };
 }
 

--- a/tests/debuginfo/basic-types-globals-metadata.rs
+++ b/tests/debuginfo/basic-types-globals-metadata.rs
@@ -59,7 +59,10 @@ static mut F64: f64 = 3.5;
 fn main() {
     _zzz(); // #break
 
-    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F16, F32, F64) };
+    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
+    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
+    // not exist on some targets like PowerPC
+    let b = unsafe { F16 };
 }
 
 fn _zzz() {()}

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -64,8 +64,10 @@ fn main() {
     _zzz(); // #break
 
     let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
-    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
-    // not exist on some targets like PowerPC
+    // FIXME: Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which
+    // does not exist on some targets like PowerPC.
+    // See https://github.com/llvm/llvm-project/issues/97981 and
+    // https://github.com/rust-lang/compiler-builtins/issues/655
     let b = unsafe { F16 };
 }
 

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -63,7 +63,10 @@ static mut F64: f64 = 3.5;
 fn main() {
     _zzz(); // #break
 
-    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F16, F32, F64) };
+    let a = unsafe { (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64) };
+    // N.B. Including f16 and f32 in the same tuple emits `__gnu_h2f_ieee`, which does
+    // not exist on some targets like PowerPC
+    let b = unsafe { F16 };
 }
 
 fn _zzz() {()}

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -3,6 +3,7 @@
 //@ compile-flags:-g
 //@ ignore-windows-gnu: #128973
 //@ ignore-aarch64-unknown-linux-gnu (gdb tries to read from 0x0; FIXME: #128973)
+//@ ignore-powerpc64: #128973 on both -gnu and -musl
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/ui/asm/named-asm-labels.stderr
+++ b/tests/ui/asm/named-asm-labels.stderr
@@ -475,16 +475,7 @@ LL |         #[warn(named_asm_labels)]
    |                ^^^^^^^^^^^^^^^^
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:178:17
-   |
-LL |     naked_asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1)
-   |                 ^^^^^
-   |
-   = help: only local labels of the form `<number>:` should be used in inline asm
-   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
-
-error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:185:20
+  --> $DIR/named-asm-labels.rs:183:20
    |
 LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
    |                    ^^^^^
@@ -493,25 +484,16 @@ LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noret
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:193:17
+  --> $DIR/named-asm-labels.rs:201:17
    |
-LL |     naked_asm!(".Laaa: nop; ret;")
+LL |     naked_asm!(".Lccc: nop; ret;")
    |                 ^^^^^
    |
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:203:21
-   |
-LL |         naked_asm!(".Lbbb: nop; ret;")
-   |                     ^^^^^
-   |
-   = help: only local labels of the form `<number>:` should be used in inline asm
-   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
-
-error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:212:15
+  --> $DIR/named-asm-labels.rs:221:15
    |
 LL |         asm!("closure1: nop");
    |               ^^^^^^^^
@@ -520,7 +502,7 @@ LL |         asm!("closure1: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:216:15
+  --> $DIR/named-asm-labels.rs:225:15
    |
 LL |         asm!("closure2: nop");
    |               ^^^^^^^^
@@ -529,7 +511,7 @@ LL |         asm!("closure2: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:226:19
+  --> $DIR/named-asm-labels.rs:235:19
    |
 LL |             asm!("closure3: nop");
    |                   ^^^^^^^^
@@ -537,5 +519,14 @@ LL |             asm!("closure3: nop");
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
-error: aborting due to 56 previous errors; 1 warning emitted
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:246:21
+   |
+LL |         naked_asm!(".Lbbb: nop; ret;")
+   |                     ^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: aborting due to 55 previous errors; 1 warning emitted
 

--- a/tests/ui/float/target-has-reliable-nightly-float.rs
+++ b/tests/ui/float/target-has-reliable-nightly-float.rs
@@ -19,8 +19,10 @@ pub fn has_f128() {}
 pub fn has_f128_math() {}
 
 fn main() {
-    if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
-        // Aarch64+Linux is one target that has support for all features, so use it to spot
+    if cfg!(target_arch = "aarch64") &&
+        cfg!(target_os = "linux") &&
+        cfg!(not(target_env = "musl")) {
+        // Aarch64+GNU+Linux is one target that has support for all features, so use it to spot
         // check that the compiler does indeed enable these gates.
 
         assert!(cfg!(target_has_reliable_f16));

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.fixed
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.fixed
@@ -7,6 +7,6 @@ trait MyTrait {}
 fn foo(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait) + Send + Sync>) {}
 
 //~v ERROR unnecessary parentheses around type
-fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+fn bar(_: Box<dyn FnMut(&mut u32) -> &mut dyn MyTrait>) {}
 
 fn main() {}

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.rs
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+
+#![deny(unused_parens)]
+#![allow(warnings)]
+trait MyTrait {}
+
+fn foo(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait) + Send + Sync>) {}
+
+fn main() {}

--- a/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.stderr
+++ b/tests/ui/lint/unused/unused-parens-false-positive-issue-143653.stderr
@@ -1,0 +1,19 @@
+error: unnecessary parentheses around type
+  --> $DIR/unused-parens-false-positive-issue-143653.rs:10:43
+   |
+LL | fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+   |                                           ^           ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-false-positive-issue-143653.rs:3:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL - fn bar(_: Box<dyn FnMut(&mut u32) -> &mut (dyn MyTrait)>) {}
+LL + fn bar(_: Box<dyn FnMut(&mut u32) -> &mut dyn MyTrait>) {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/loop-match/suggest-const-item.rs
+++ b/tests/ui/loop-match/suggest-const-item.rs
@@ -1,0 +1,174 @@
+#![allow(incomplete_features)]
+#![feature(loop_match)]
+#![feature(generic_const_items)]
+#![crate_type = "lib"]
+
+const fn const_fn() -> i32 {
+    1
+}
+
+#[unsafe(no_mangle)]
+fn suggest_const_block<const N: i32>() -> i32 {
+    let mut state = 0;
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                0 => {
+                    #[const_continue]
+                    break 'blk const_fn();
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+                1 => {
+                    #[const_continue]
+                    break 'blk const { const_fn() };
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+                2 => {
+                    #[const_continue]
+                    break 'blk N;
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+                _ => {
+                    #[const_continue]
+                    break 'blk 1 + 1;
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+            }
+        }
+    }
+    state
+}
+
+struct S;
+
+impl S {
+    const M: usize = 42;
+
+    fn g() {
+        let mut state = 0;
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    0 => {
+                        #[const_continue]
+                        break 'blk Self::M;
+                    }
+                    _ => panic!(),
+                }
+            }
+        }
+    }
+}
+
+trait T {
+    const N: usize;
+
+    fn f() {
+        let mut state = 0;
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    0 => {
+                        #[const_continue]
+                        break 'blk Self::N;
+                        //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                    }
+                    _ => panic!(),
+                }
+            }
+        }
+    }
+}
+
+impl T for S {
+    const N: usize = 1;
+}
+
+impl S {
+    fn h() {
+        let mut state = 0;
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    0 => {
+                        #[const_continue]
+                        break 'blk Self::N;
+                    }
+                    _ => panic!(),
+                }
+            }
+        }
+    }
+}
+
+trait T2<U> {
+    const L: u32;
+
+    fn p() {
+        let mut state = 0;
+        #[loop_match]
+        loop {
+            state = 'blk: {
+                match state {
+                    0 => {
+                        #[const_continue]
+                        break 'blk Self::L;
+                        //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                    }
+                    _ => panic!(),
+                }
+            }
+        }
+    }
+}
+
+const SIZE_OF<T>: usize = size_of::<T>();
+
+fn q<T>() {
+    let mut state = 0;
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                0 => {
+                    #[const_continue]
+                    break 'blk SIZE_OF::<T>;
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+                _ => panic!(),
+            }
+        }
+    }
+}
+
+trait Trait<T> {
+    const X: usize = 9000;
+    const Y: usize = size_of::<T>();
+}
+
+impl<T> Trait<T> for () {}
+
+fn r<T>() {
+    let mut state = 0;
+    #[loop_match]
+    loop {
+        state = 'blk: {
+            match state {
+                0 => {
+                    #[const_continue]
+                    break 'blk <() as Trait<T>>::X;
+                }
+                1 => {
+                    #[const_continue]
+                    break 'blk <() as Trait<T>>::Y;
+                    //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                }
+                _ => panic!(),
+            }
+        }
+    }
+}

--- a/tests/ui/loop-match/suggest-const-item.stderr
+++ b/tests/ui/loop-match/suggest-const-item.stderr
@@ -1,0 +1,58 @@
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:19:32
+   |
+LL |                     break 'blk const_fn();
+   |                                ^^^^^^^^^^ this value must be a literal or a monomorphic const
+   |
+   = help: try extracting the expression into a `const` item
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:24:32
+   |
+LL |                     break 'blk const { const_fn() };
+   |                                ^^^^^^^^^^^^^^^^^^^^ `const` blocks may use generics, and are not evaluated early enough
+   |
+   = help: try extracting the expression into a `const` item
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:29:32
+   |
+LL |                     break 'blk N;
+   |                                ^ constant parameters may use generics, and are not evaluated early enough
+   |
+   = help: try extracting the expression into a `const` item
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:34:32
+   |
+LL |                     break 'blk 1 + 1;
+   |                                ^^^^^ this value must be a literal or a monomorphic const
+   |
+   = help: try extracting the expression into a `const` item
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:76:36
+   |
+LL |                         break 'blk Self::N;
+   |                                    ^^^^^^^ this value is too generic
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:119:36
+   |
+LL |                         break 'blk Self::L;
+   |                                    ^^^^^^^ this value is too generic
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:139:32
+   |
+LL |                     break 'blk SIZE_OF::<T>;
+   |                                ^^^^^^^^^^^^ this value is too generic
+
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/suggest-const-item.rs:167:32
+   |
+LL |                     break 'blk <() as Trait<T>>::Y;
+   |                                ^^^^^^^^^^^^^^^^^^^ this value is too generic
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#140871 (Don't lint against named labels in `naked_asm!`)
 - rust-lang/rust#141663 (rustdoc: add ways of collapsing all impl blocks)
 - rust-lang/rust#143272 (Upgrade the `fortanix-sgx-abi` dependency)
 - rust-lang/rust#143585 (`loop_match`: suggest extracting to a `const` item)
 - rust-lang/rust#143698 (Fix unused_parens false positive)
 - rust-lang/rust#143859 (Guarantee 8 bytes of alignment in Thread::into_raw)
 - rust-lang/rust#144160 (tests: debuginfo: Work around or disable broken tests on powerpc)
 - rust-lang/rust#144412 (Small cleanup: Use LocalKey<Cell> methods more)
 - rust-lang/rust#144431 (Disable has_reliable_f128_math on musl targets)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140871,141663,143272,143585,143698,143859,144160,144412,144431)
<!-- homu-ignore:end -->