### PR TITLE
Partial-stabilize the basics from `bigint_helper_methods`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2447,7 +2447,7 @@ macro_rules! uint_impl {
         }
 
         /// Calculates `self` + `rhs` + `carry` and returns a tuple containing
-        /// the sum and the output carry.
+        /// the sum and the output carry (in that order).
         ///
         /// Performs "ternary addition" of two integer operands and a carry-in
         /// bit, and returns an output integer and a carry-out bit. This allows
@@ -2465,8 +2465,6 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(bigint_helper_methods)]
-        ///
         #[doc = concat!("//    3  MAX    (a = 3 × 2^", stringify!($BITS), " + 2^", stringify!($BITS), " - 1)")]
         #[doc = concat!("// +  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)")]
         /// // ---------
@@ -2483,7 +2481,7 @@ macro_rules! uint_impl {
         ///
         /// assert_eq!((sum1, sum0), (9, 6));
         /// ```
-        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[stable(feature = "unsigned_bigint_helpers", since = "CURRENT_RUSTC_VERSION")]
         #[rustc_const_unstable(feature = "bigint_helper_methods", issue = "85532")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
@@ -2559,8 +2557,6 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(bigint_helper_methods)]
-        ///
         #[doc = concat!("//    9    6    (a = 9 × 2^", stringify!($BITS), " + 6)")]
         #[doc = concat!("// -  5    7    (b = 5 × 2^", stringify!($BITS), " + 7)")]
         /// // ---------
@@ -2577,7 +2573,7 @@ macro_rules! uint_impl {
         ///
         #[doc = concat!("assert_eq!((diff1, diff0), (3, ", stringify!($SelfT), "::MAX));")]
         /// ```
-        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[stable(feature = "unsigned_bigint_helpers", since = "CURRENT_RUSTC_VERSION")]
         #[rustc_const_unstable(feature = "bigint_helper_methods", issue = "85532")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
@@ -2651,10 +2647,12 @@ macro_rules! uint_impl {
         /// indicating whether an arithmetic overflow would occur. If an
         /// overflow would have occurred then the wrapped value is returned.
         ///
+        /// If you want the *value* of the overflow, rather than just *whether*
+        /// an overflow occurred, see [`Self::carrying_mul`].
+        ///
         /// # Examples
         ///
-        /// Please note that this example is shared among integer types, which is why why `u32`
-        /// is used.
+        /// Please note that this example is shared among integer types, which is why `u32` is used.
         ///
         /// ```
         /// assert_eq!(5u32.overflowing_mul(2), (10, false));
@@ -2670,15 +2668,37 @@ macro_rules! uint_impl {
             (a as Self, b)
         }
 
-        /// Calculates the complete product `self * rhs` without the possibility to overflow.
+        /// Calculates the complete double-width product `self * rhs`.
         ///
         /// This returns the low-order (wrapping) bits and the high-order (overflow) bits
-        /// of the result as two separate values, in that order.
+        /// of the result as two separate values, in that order. As such,
+        /// `a.widening_mul(b).0` produces the same result as `a.wrapping_mul(b)`.
+        ///
+        /// If you also need to add a value and carry to the wide result, then you want
+        /// [`Self::carrying_mul_add`] instead.
         ///
         /// If you also need to add a carry to the wide result, then you want
         /// [`Self::carrying_mul`] instead.
         ///
+        /// If you just want to know *whether* the multiplication overflowed, then you
+        /// want [`Self::overflowing_mul`] instead.
+        ///
         /// # Examples
+        ///
+        /// ```
+        /// #![feature(bigint_helper_methods)]
+        #[doc = concat!("assert_eq!(5_", stringify!($SelfT), ".widening_mul(7), (35, 0));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.widening_mul(", stringify!($SelfT), "::MAX), (1, ", stringify!($SelfT), "::MAX - 1));")]
+        /// ```
+        ///
+        /// Compared to other `*_mul` methods:
+        /// ```
+        /// #![feature(bigint_helper_methods)]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::widening_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, 3));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::overflowing_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), (0, true));")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::wrapping_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), 0);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::checked_mul(1 << ", stringify!($BITS_MINUS_ONE), ", 6), None);")]
+        /// ```
         ///
         /// Please note that this example is shared among integer types, which is why `u32` is used.
         ///
@@ -2706,14 +2726,13 @@ macro_rules! uint_impl {
         /// additional amount of overflow. This allows for chaining together multiple
         /// multiplications to create "big integers" which represent larger values.
         ///
-        /// If you don't need the `carry`, then you can use [`Self::widening_mul`] instead.
+        /// If you also need to add a value, then use [`Self::carrying_mul_add`].
         ///
         /// # Examples
         ///
         /// Please note that this example is shared among integer types, which is why `u32` is used.
         ///
         /// ```
-        /// #![feature(bigint_helper_methods)]
         /// assert_eq!(5u32.carrying_mul(2, 0), (10, 0));
         /// assert_eq!(5u32.carrying_mul(2, 10), (20, 0));
         /// assert_eq!(1_000_000_000u32.carrying_mul(10, 0), (1410065408, 2));
@@ -2771,7 +2790,7 @@ macro_rules! uint_impl {
         ///     789_u16.wrapping_mul(456).wrapping_add(123),
         /// );
         /// ```
-        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[stable(feature = "unsigned_bigint_helpers", since = "CURRENT_RUSTC_VERSION")]
         #[rustc_const_unstable(feature = "bigint_helper_methods", issue = "85532")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
@@ -2780,18 +2799,20 @@ macro_rules! uint_impl {
             Self::carrying_mul_add(self, rhs, carry, 0)
         }
 
-        /// Calculates the "full multiplication" `self * rhs + carry1 + carry2`
-        /// without the possibility to overflow.
+        /// Calculates the "full multiplication" `self * rhs + carry1 + carry2`.
         ///
         /// This returns the low-order (wrapping) bits and the high-order (overflow) bits
         /// of the result as two separate values, in that order.
+        ///
+        /// This cannot overflow, as the double-width result has exactly enough
+        /// space for the largest possible result. This is equivalent to how, in
+        /// decimal, 9 × 9 + 9 + 9 = 81 + 18 = 99 = 9×10⁰ + 9×10¹ = 10² - 1.
         ///
         /// Performs "long multiplication" which takes in an extra amount to add, and may return an
         /// additional amount of overflow. This allows for chaining together multiple
         /// multiplications to create "big integers" which represent larger values.
         ///
-        /// If you don't need either `carry`, then you can use [`Self::widening_mul`] instead,
-        /// and if you only need one `carry`, then you can use [`Self::carrying_mul`] instead.
+        /// If you don't need the `add` part, then you can use [`Self::carrying_mul`] instead.
         ///
         /// # Examples
         ///
@@ -2799,7 +2820,6 @@ macro_rules! uint_impl {
         /// which explains why `u32` is used here.
         ///
         /// ```
-        /// #![feature(bigint_helper_methods)]
         /// assert_eq!(5u32.carrying_mul_add(2, 0, 0), (10, 0));
         /// assert_eq!(5u32.carrying_mul_add(2, 10, 10), (30, 0));
         /// assert_eq!(1_000_000_000u32.carrying_mul_add(10, 0, 0), (1410065408, 2));
@@ -2816,8 +2836,6 @@ macro_rules! uint_impl {
         /// using `u8` for simplicity of the demonstration.
         ///
         /// ```
-        /// #![feature(bigint_helper_methods)]
-        ///
         /// fn quadratic_mul<const N: usize>(a: [u8; N], b: [u8; N]) -> [u8; N] {
         ///     let mut out = [0; N];
         ///     for j in 0..N {
@@ -2832,13 +2850,13 @@ macro_rules! uint_impl {
         /// // -1 * -1 == 1
         /// assert_eq!(quadratic_mul([0xFF; 3], [0xFF; 3]), [1, 0, 0]);
         ///
-        /// assert_eq!(u32::wrapping_mul(0x9e3779b9, 0x7f4a7c15), 0xCFFC982D);
+        /// assert_eq!(u32::wrapping_mul(0x9e3779b9, 0x7f4a7c15), 0xcffc982d);
         /// assert_eq!(
         ///     quadratic_mul(u32::to_le_bytes(0x9e3779b9), u32::to_le_bytes(0x7f4a7c15)),
-        ///     u32::to_le_bytes(0xCFFC982D)
+        ///     u32::to_le_bytes(0xcffc982d)
         /// );
         /// ```
-        #[unstable(feature = "bigint_helper_methods", issue = "85532")]
+        #[stable(feature = "unsigned_bigint_helpers", since = "CURRENT_RUSTC_VERSION")]
         #[rustc_const_unstable(feature = "bigint_helper_methods", issue = "85532")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]


### PR DESCRIPTION
Direct link to p-FCP comment: https://github.com/rust-lang/rust/pull/144494#issuecomment-3133172161

After libs-api discussion, this is now the following methods:

- [`uN::carrying_add`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.carrying_add): uN + uN + bool -> (uN, bool)
- [`uN::borrowing_sub`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.borrowing_sub): uN + uN + bool -> (uN, bool)
- [`uN::carrying_mul`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.carrying_mul): uN * uN + uN -> (uN, uN)
- [`uN::carrying_mul_add`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.carrying_mul_add): uN * uN + uN + uN -> (uN, uN)

Specifically, these are the ones that are specifically about working with `uN` as a "digit" (or "limb") where the output, despite being larger than can fit in a single digit, wants to be phrased in terms of those *digits*, not in terms of a wider type.

(This leaves open the possibility of things like `widening_mul: u32 * u32 -> u64` for places where one wants to only think in terms of the *number*s, rather than as carries between multiple digits.  Though of course discussions about how best to phrase such a thing are best for the tracking issue, not for this PR.)

---

**Original PR description**:

A [conversation on IRLO](https://internals.rust-lang.org/t/methods-for-splitting-integers-into-their-halves/23210/7?u=scottmcm) the other day pushed me to write this up 🙂 

This PR proposes a partial stabilization of `bigint_helper_methods` (rust-lang/rust#85532), focusing on a basic set that hopefully can be non-controversial.  Specifically:

- [`uN::carrying_add`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.carrying_add): uN + uN + bool -> (uN, bool)
- [`uN::widening_mul`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.widening_mul): uN * uN -> (uN, uN)
- [`uN::carrying_mul_add`](https://doc.rust-lang.org/nightly/std/primitive.u64.html#method.carrying_mul_add): uN * uN + uN + uN -> (uN, uN)

Why these?

- We should let people write Rust without needing to be backend experts to know what the magic incantation is to do this.  Even `carrying_add`, which doesn't seem that complicated, actually broke in 1.82 (see rust-lang/rust#133674) so we should just offer something fit-for-purpose rather than making people keep up with whatever the secret sauce is today.  We also get to do things that users cannot, like have the LLVM version emit operations on `i256` in the implementation of `u128::carrying_mul_add` (https://rust.godbolt.org/z/cjG7eKcxd).
- Unsigned only because the behaviour is much clearer than when signed is involved, as everything is just unsigned (vs questions like whether `iN * iN` should give `(uN, iN)`) and carries can only happen in one direction (vs questions about whether the carry from `-128_u8 + -128_u8` should be considered `-1`).
- `carrying_add` is the core [full adder](https://en.wikipedia.org/wiki/Adder_(electronics)#Full_adder) primitive for implementing addition.
- `carrying_mul_add` is the core primitive for [grade school](https://en.wikipedia.org/wiki/Multiplication_algorithm#Long_multiplication) multiplication (see the example in its docs for why both carries are needed).
- `widening_mul` even though it's not strictly needed (its implementation is just `carrying_mul_add(a, b, 0, 0)` right now) as the simplest way for users to get to [cranelift's `umulhi`](https://docs.rs/cranelift/latest/cranelift/prelude/trait.InstBuilder.html#method.umulhi), RISC-V's `MULHU`, Arm's `UMULL`, etc.  (For example, I added an ISLE pattern https://github.com/bytecodealliance/wasmtime/commit/d12e4237de867d58d8c3451d77ee7547e9492550#diff-2041f67049d5ac3d8f62ea91d3cb45cdb8608d5f5cdab988731ae2addf90ef01 so Cranelift can notice what's happening from the fallback, even if the intrinsics aren't overridden specifically.  And on x86 this is one of the simplest possible non-trivial functions <https://rust.godbolt.org/z/4oadWKTc1> because `MUL` puts the results in exactly the registers that the scalar pair result happens to want.)

(I did not const-stabilize them in this PR because [the fallbacks](https://github.com/rust-lang/rust/blob/master/library/core/src/intrinsics/fallback.rs) are using `#[const_trait]` plus there's two [new intrinsic](https://doc.rust-lang.org/nightly/std/intrinsics/fn.disjoint_bitor.html)s involved, so I didn't want to *also* open those cans of worms here.  Given that both intrinsics *have* fallbacks, and thus don't do anything that can't already be expressed in existing Rust, const-stabilizing these should be straight-forward once the underlying machinery is allowed on stable.  But that doesn't need to keep these from being usable at runtime in the mean time.)