### PR TITLE
bump cargo_metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,20 +443,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cfca2aaa699835ba88faf58a06342a314a950d2b9686165e038286c30316868"
@@ -1364,7 +1350,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
- "cargo_metadata 0.18.1",
+ "cargo_metadata 0.21.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5369,7 +5355,7 @@ name = "tidy"
 version = "0.1.0"
 dependencies = [
  "build_helper",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.21.0",
  "fluent-syntax",
  "ignore",
  "miropt-test-tools",

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -9,7 +9,7 @@ description = "Produces a manifest of all the copyrighted materials in the Rust 
 [dependencies]
 anyhow = "1.0.65"
 askama = "0.14.0"
-cargo_metadata = "0.18.1"
+cargo_metadata = "0.21"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1"

--- a/src/tools/generate-copyright/src/cargo_metadata.rs
+++ b/src/tools/generate-copyright/src/cargo_metadata.rs
@@ -92,7 +92,8 @@ pub fn get_metadata(
                 continue;
             }
             // otherwise it's an out-of-tree dependency
-            let package_id = Package { name: package.name, version: package.version.to_string() };
+            let package_id =
+                Package { name: package.name.to_string(), version: package.version.to_string() };
             output.insert(
                 package_id,
                 PackageMetadata {

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,7 @@ autobins = false
 
 [dependencies]
 build_helper = { path = "../../build_helper" }
-cargo_metadata = "0.19"
+cargo_metadata = "0.21"
 regex = "1"
 miropt-test-tools = { path = "../miropt-test-tools" }
 walkdir = "2"


### PR DESCRIPTION
Bumps cargo_metadata. Change that required fixes is: https://github.com/oli-obk/cargo_metadata/commit/e3373d02e79dc64adbecb3fe32fecc1dd324bba6