### PR TITLE
Fix Ord, Eq and Hash implementation of panic::Location

### DIFF
--- a/library/coretests/tests/panic/location.rs
+++ b/library/coretests/tests/panic/location.rs
@@ -3,6 +3,23 @@ use core::panic::Location;
 // Note: Some of the following tests depend on the source location,
 // so please be careful when editing this file.
 
+mod file_a;
+mod file_b;
+mod file_c;
+
+// A small shuffled set of locations for testing, along with their true order.
+const LOCATIONS: [(usize, &'static Location<'_>); 9] = [
+    (7, file_c::two()),
+    (0, file_a::one()),
+    (3, file_b::one()),
+    (5, file_b::three()),
+    (8, file_c::three()),
+    (6, file_c::one()),
+    (2, file_a::three()),
+    (4, file_b::two()),
+    (1, file_a::two()),
+];
+
 #[test]
 fn location_const_caller() {
     const _CALLER_REFERENCE: &Location<'static> = Location::caller();
@@ -20,7 +37,7 @@ fn location_const_file() {
 fn location_const_line() {
     const CALLER: &Location<'static> = Location::caller();
     const LINE: u32 = CALLER.line();
-    assert_eq!(LINE, 21);
+    assert_eq!(LINE, 38);
 }
 
 #[test]
@@ -34,6 +51,28 @@ fn location_const_column() {
 fn location_debug() {
     let f = format!("{:?}", Location::caller());
     assert!(f.contains(&format!("{:?}", file!())));
-    assert!(f.contains("35"));
+    assert!(f.contains("52"));
     assert!(f.contains("29"));
+}
+
+#[test]
+fn location_eq() {
+    for (i, a) in LOCATIONS {
+        for (j, b) in LOCATIONS {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn location_ord() {
+    let mut locations = LOCATIONS.clone();
+    locations.sort_by_key(|(_o, l)| **l);
+    for (correct, (order, _l)) in locations.iter().enumerate() {
+        assert_eq!(correct, *order);
+    }
 }

--- a/library/coretests/tests/panic/location/file_a.rs
+++ b/library/coretests/tests/panic/location/file_a.rs
@@ -1,0 +1,15 @@
+use core::panic::Location;
+
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+pub const fn one() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn two() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn three() -> &'static Location<'static> {
+    Location::caller()
+}

--- a/library/coretests/tests/panic/location/file_b.rs
+++ b/library/coretests/tests/panic/location/file_b.rs
@@ -1,0 +1,15 @@
+use core::panic::Location;
+
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+pub const fn one() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn two() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn three() -> &'static Location<'static> {
+    Location::caller()
+}

--- a/library/coretests/tests/panic/location/file_c.rs
+++ b/library/coretests/tests/panic/location/file_c.rs
@@ -1,0 +1,11 @@
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+// This is used for testing column ordering of Location, hence this ugly one-liner.
+// We must fmt skip the entire containing module or else tidy will still complain.
+#[rustfmt::skip]
+mod no_fmt {
+    use core::panic::Location;
+    pub const fn one() -> &'static Location<'static> { Location::caller() }    pub const fn two() -> &'static Location<'static> { Location::caller() }    pub const fn three() -> &'static Location<'static> { Location::caller() }
+}
+
+pub use no_fmt::*;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/144486.

Now properly compares/hashes the filename rather than the pointer to the string.