### PR TITLE
Warn when relying on default musl target static linkage behaviour

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -74,6 +74,7 @@ declare_lint_pass! {
         MISPLACED_DIAGNOSTIC_ATTRIBUTES,
         MISSING_ABI,
         MISSING_UNSAFE_ON_EXTERN,
+        MUSL_MISSING_CRT_STATIC,
         MUST_NOT_SUSPEND,
         NAMED_ARGUMENTS_USED_POSITIONALLY,
         NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
@@ -5592,4 +5593,18 @@ declare_lint! {
         reason: fcw!(FutureReleaseError #154024),
         report_in_deps: false,
     };
+}
+
+declare_lint! {
+    /// The `musl_missing_crt_static` lint detects when code is compiled for a target using musl libc
+    /// without explicitly specifying `+crt-static` or `-crt-static`.
+    ///
+    /// ### Explanation
+    ///
+    /// The musl targets will change to be dynamically linked by default in the future, to avoid a
+    /// sudden change in behavior, the desired linkage should be specified in the interim period.
+    pub MUSL_MISSING_CRT_STATIC,
+    Warn,
+    "on musl targets, the default for `crt-static` will change; explicitly set `+crt-static` or `-crt-static`",
+    // TOOD: Does this need a FutureIncompatibleInfo entry?
 }

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -692,3 +692,8 @@ pub(crate) struct ThinLtoNotSupportedByBackend;
 #[derive(Diagnostic)]
 #[diag("`-Zpacked-stack` is only supported on s390x")]
 pub(crate) struct UnsupportedPackedStack;
+
+#[derive(Diagnostic)]
+#[diag("on musl targets, the implicit default for `crt-static` is going to change")]
+#[help("explicitly pass `-C target-feature=+crt-static` or `-C target-feature=-crt-static`")]
+pub struct MuslMissingCrtStatic;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::{env, io};
 
+use rustc_ast::ast;
 use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
 use rustc_data_structures::profiling::{SelfProfiler, SelfProfilerRef};
@@ -17,11 +18,12 @@ use rustc_errors::emitter::{DynEmitter, HumanReadableErrorType, OutputTheme, std
 use rustc_errors::json::JsonEmitter;
 use rustc_errors::timings::TimingSectionHandler;
 use rustc_errors::{
-    Diag, DiagCtxt, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed, FatalAbort,
-    TerminalUrl,
+    DecorateDiagCompat, Diag, DiagCtxt, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed,
+    FatalAbort, TerminalUrl,
 };
 use rustc_feature::UnstableFeatures;
 use rustc_hir::limit::Limit;
+use rustc_lint_defs::builtin::MUSL_MISSING_CRT_STATIC;
 use rustc_macros::StableHash;
 pub use rustc_span::def_id::StableCrateId;
 use rustc_span::edition::Edition;
@@ -29,7 +31,7 @@ use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{RealFileName, Span, Symbol};
 use rustc_target::asm::InlineAsmArch;
 use rustc_target::spec::{
-    Arch, CodeModel, DebuginfoKind, Os, PanicStrategy, RelocModel, RelroLevel, SanitizerSet,
+    Arch, CodeModel, DebuginfoKind, Env, Os, PanicStrategy, RelocModel, RelroLevel, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProtector, SymbolVisibility, Target,
     TargetTuple, TlsModel, apple,
 };
@@ -41,6 +43,7 @@ use crate::config::{
     FunctionReturn, Input, InstrumentCoverage, OptLevel, OutFileName, OutputType,
     SwitchWithOptPath,
 };
+use crate::errors::MuslMissingCrtStatic;
 use crate::filesearch::FileSearch;
 use crate::lint::LintId;
 use crate::parse::ParseSess;
@@ -396,6 +399,15 @@ impl Session {
             // We can't check `#![crate_type = "proc-macro"]` here.
             false
         } else {
+            if self.target.env == Env::Musl && self.target.crt_static_default {
+                self.psess.opt_span_buffer_lint(
+                    MUSL_MISSING_CRT_STATIC,
+                    None,
+                    ast::CRATE_NODE_ID,
+                    DecorateDiagCompat(Box::new(|dcx, _, _| dcx.create_warn(MuslMissingCrtStatic))),
+                );
+            }
+
             self.target.crt_static_default
         }
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144513)*
<!-- homu-ignore:end -->

This introduces a new lint, "musl_missing_crt_static" that warns when compiling code for a musl target that defaults to static linkage without explicitly specifying `-Ctarget-feature=+crt-static`.

The targets will be changed to link dynamically by default in the future, after which this lint can be removed again.

See the accepted MCP https://github.com/rust-lang/compiler-team/issues/422 which proposed this lint.
Tracking: https://github.com/rust-lang/rust/issues/59302

TODO: Decide on a deadline and write a blog post about this?

Example in action (on a `powerpc64le-unknown-linux-musl` host):

```sh
$ rustc test.rs
warning: on musl targets, the implicit default for `crt-static` is going to change
  |
  = help: explicitly pass `-C target-feature=+crt-static` or `-C target-feature=-crt-static`
  = note: `#[warn(musl_missing_crt_static)]` on by default

warning: 1 warning emitted
$ rustc test.rs -Ctarget-feature=-crt-static
$ rustc test.rs -Ctarget-feature=+crt-static
# notice that no warning is emitted
```

The lint will *not* be emitted on targets that already default to dynamic linkage, like e.g. the loongarch64 targets.