### PR TITLE
rustdoc: save target modifiers

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -173,6 +173,9 @@ pub(crate) struct Options {
 
     /// Arguments to be used when compiling doctests.
     pub(crate) doctest_build_args: Vec<String>,
+
+    /// Target modifiers.
+    pub(crate) target_modifiers: BTreeMap<OptionsTargetModifiers, String>,
 }
 
 impl fmt::Debug for Options {
@@ -846,6 +849,7 @@ impl Options {
             unstable_features,
             expanded_args: args,
             doctest_build_args,
+            target_modifiers,
         };
         let render_options = RenderOptions {
             output,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -214,6 +214,7 @@ pub(crate) fn create_config(
         scrape_examples_options,
         expanded_args,
         remap_path_prefix,
+        target_modifiers,
         ..
     }: RustdocOptions,
     render_options: &RenderOptions,
@@ -277,6 +278,7 @@ pub(crate) fn create_config(
         } else {
             OutputTypes::new(&[])
         },
+        target_modifiers,
         ..Options::default()
     };
 

--- a/tests/run-make/rustdoc-target-modifiers/c.rs
+++ b/tests/run-make/rustdoc-target-modifiers/c.rs
@@ -1,0 +1,7 @@
+#![allow(internal_features)]
+#![feature(lang_items, no_core)]
+#![no_core]
+
+fn f() {
+    d::f();
+}

--- a/tests/run-make/rustdoc-target-modifiers/d.rs
+++ b/tests/run-make/rustdoc-target-modifiers/d.rs
@@ -1,0 +1,12 @@
+#![allow(internal_features)]
+#![feature(lang_items, no_core)]
+#![no_core]
+
+#[lang = "pointee_sized"]
+pub trait PointeeSized {}
+#[lang = "meta_sized"]
+pub trait MetaSized: PointeeSized {}
+#[lang = "sized"]
+pub trait Sized: MetaSized {}
+
+pub fn f() {}

--- a/tests/run-make/rustdoc-target-modifiers/rmake.rs
+++ b/tests/run-make/rustdoc-target-modifiers/rmake.rs
@@ -1,0 +1,28 @@
+//! Test that target modifiers are taken into account by `rustdoc`.
+//!
+//! Otherwise, `rustdoc` errors when trying to generate documentation
+//! using dependencies (e.g. `core`) that set a target modifier.
+//!
+//! Please see https://github.com/rust-lang/rust/issues/144521.
+
+use run_make_support::{rustc, rustdoc};
+
+fn main() {
+    rustc()
+        .input("d.rs")
+        .edition("2024")
+        .crate_type("rlib")
+        .emit("metadata")
+        .sysroot("/dev/null")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("-Zfixed-x18")
+        .run();
+
+    rustdoc()
+        .input("c.rs")
+        .crate_type("rlib")
+        .extern_("d", "libd.rmeta")
+        .target("aarch64-unknown-none-softfloat")
+        .arg("-Zfixed-x18")
+        .run();
+}


### PR DESCRIPTION
`rustdoc` was filling a `target_modifiers` variable, but it was not using the result.

In turn, that means that trying to use a dependency that set a target modifier fails.

For instance, running:

```sh
RUSTC_BOOTSTRAP=1 rustc --edition=2024 --target=aarch64-unknown-none-softfloat --sysroot=/dev/null --emit=metadata -Zfixed-x18 --crate-type rlib --crate-name core $(rustc --print sysroot)/lib/rustlib/src/rust/library/core/src/lib.rs

echo '#![allow(internal_features)]
' | RUSTC_BOOTSTRAP=1 rustdoc --edition=2021 --target=aarch64-unknown-none-softfloat --sysroot=/dev/null -Zfixed-x18 --extern core=libcore.rmeta -
```

will fail with:

```text
error: mixing `-Zfixed-x18` will cause an ABI mismatch in crate `rust_out`
  |
  = help: the `-Zfixed-x18` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
  = note: unset `-Zfixed-x18` in this crate is incompatible with `-Zfixed-x18=` in dependency `core`
  = help: set `-Zfixed-x18=` in this crate or unset `-Zfixed-x18` in `core`
  = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=fixed-x18` to silence this error
```

Thus save the targets modifiers in `Options` to then pass it to the session options, so that eventually the diff can be performed as expected in `report_incompatible_target_modifiers()`.

Cc: @azhogin
Fixes: https://github.com/rust-lang/rust/issues/144521

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
