### PR TITLE
Add `#[rustc_pass_indirectly_in_non_rustic_abis]`

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -291,6 +291,7 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         {
             self = field;
         }
+
         Ty::is_pass_indirectly_in_non_rustic_abis_flag_set(self)
     }
 

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -172,6 +172,8 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug {
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
     fn is_transparent(this: TyAndLayout<'a, Self>) -> bool;
+    /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
+    fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'a, Self>) -> bool;
 }
 
 impl<'a, Ty> TyAndLayout<'a, Ty> {
@@ -267,6 +269,29 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty: TyAbiInterface<'a, C>,
     {
         Ty::is_transparent(self)
+    }
+
+    /// If this method returns `true`, then this type should always have a `PassMode` of
+    /// `Indirect { on_stack: false, .. }` when being used as the argument type of a function with a
+    /// non-Rustic ABI (this is true for structs annotated with the
+    /// `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute).
+    ///
+    /// This is used to replicate some of the behaviour of C array-to-pointer decay; however unlike
+    /// C any changes the caller makes to the passed value will not be reflected in the callee, so
+    /// the attribute is only useful for types where observing the value in the caller after the
+    /// function call isn't allowed (a.k.a. `va_list`).
+    ///
+    /// This function handles transparent types automatically.
+    pub fn pass_indirectly_in_non_rustic_abis<C>(mut self, cx: &C) -> bool
+    where
+        Ty: TyAbiInterface<'a, C> + Copy,
+    {
+        while self.is_transparent()
+            && let Some((_, field)) = self.non_1zst_field(cx)
+        {
+            self = field;
+        }
+        Ty::is_pass_indirectly_in_non_rustic_abis_flag_set(self)
     }
 
     /// Finds the one field that is not a 1-ZST.

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -88,14 +88,17 @@ bitflags! {
         const IS_C               = 1 << 0;
         const IS_SIMD            = 1 << 1;
         const IS_TRANSPARENT     = 1 << 2;
-        // Internal only for now. If true, don't reorder fields.
-        // On its own it does not prevent ABI optimizations.
+        /// Internal only for now. If true, don't reorder fields.
+        /// On its own it does not prevent ABI optimizations.
         const IS_LINEAR          = 1 << 3;
-        // If true, the type's crate has opted into layout randomization.
-        // Other flags can still inhibit reordering and thus randomization.
-        // The seed stored in `ReprOptions.field_shuffle_seed`.
+        /// If true, the type's crate has opted into layout randomization.
+        /// Other flags can still inhibit reordering and thus randomization.
+        /// The seed stored in `ReprOptions.field_shuffle_seed`.
         const RANDOMIZE_LAYOUT   = 1 << 4;
-        // Any of these flags being set prevent field reordering optimisation.
+        /// If true, the type is always passed indirectly by non-Rustic ABIs.
+        /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
+        const PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS = 1 << 5;
+        /// Any of these flags being set prevent field reordering optimisation.
         const FIELD_ORDER_UNOPTIMIZABLE   = ReprFlags::IS_C.bits()
                                  | ReprFlags::IS_SIMD.bits()
                                  | ReprFlags::IS_LINEAR.bits();

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -676,3 +676,12 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
         Some(AttributeKind::Sanitize { on_set, off_set, span: cx.attr_span })
     }
 }
+
+pub(crate) struct RustcPassIndirectlyInNonRusticAbisParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for RustcPassIndirectlyInNonRusticAbisParser {
+    const PATH: &[Symbol] = &[sym::rustc_pass_indirectly_in_non_rustic_abis];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcPassIndirectlyInNonRusticAbis;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -20,8 +20,9 @@ use crate::attributes::allow_unstable::{
 use crate::attributes::body::CoroutineParser;
 use crate::attributes::codegen_attrs::{
     ColdParser, CoverageParser, ExportNameParser, ForceTargetFeatureParser, NakedParser,
-    NoMangleParser, ObjcClassParser, ObjcSelectorParser, OptimizeParser, SanitizeParser,
-    TargetFeatureParser, TrackCallerParser, UsedParser,
+    NoMangleParser, ObjcClassParser, ObjcSelectorParser, OptimizeParser,
+    RustcPassIndirectlyInNonRusticAbisParser, SanitizeParser, TargetFeatureParser,
+    TrackCallerParser, UsedParser,
 };
 use crate::attributes::confusables::ConfusablesParser;
 use crate::attributes::crate_level::{
@@ -243,6 +244,7 @@ attribute_parsers!(
         Single<WithoutArgs<PubTransparentParser>>,
         Single<WithoutArgs<RustcCoherenceIsCoreParser>>,
         Single<WithoutArgs<RustcMainParser>>,
+        Single<WithoutArgs<RustcPassIndirectlyInNonRusticAbisParser>>,
         Single<WithoutArgs<SpecializationTraitParser>>,
         Single<WithoutArgs<StdInternalSymbolParser>>,
         Single<WithoutArgs<TrackCallerParser>>,

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -657,6 +657,12 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
+    // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
+    rustc_attr!(
+        rustc_pass_indirectly_in_non_rustic_abis, Normal, template!(Word), ErrorFollowing,
+        EncodeCrossCrate::No,
+        "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic abis."
+    ),
 
     // Limits:
     ungated!(

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -679,6 +679,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_object_lifetime_default]`.
     RustcObjectLifetimeDefault,
 
+    /// Represents `#[rustc_pass_indirectly_in_non_rustic_abis]`
+    RustcPassIndirectlyInNonRusticAbis(Span),
+
     /// Represents `#[rustc_simd_monomorphize_lane_limit = "N"]`.
     RustcSimdMonomorphizeLaneLimit(Limit),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -91,6 +91,7 @@ impl AttributeKind {
             RustcLayoutScalarValidRangeStart(..) => Yes,
             RustcMain => No,
             RustcObjectLifetimeDefault => No,
+            RustcPassIndirectlyInNonRusticAbis(..) => No,
             RustcSimdMonomorphizeLaneLimit(..) => Yes, // Affects layout computation, which needs to work cross-crate
             Sanitize { .. } => No,
             ShouldPanic { .. } => No,

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -3,7 +3,7 @@ use std::{cmp, fmt};
 
 use rustc_abi::{
     AddressSpace, Align, ExternAbi, FieldIdx, FieldsShape, HasDataLayout, LayoutData, PointeeInfo,
-    PointerKind, Primitive, ReprOptions, Scalar, Size, TagEncoding, TargetDataLayout,
+    PointerKind, Primitive, ReprFlags, ReprOptions, Scalar, Size, TagEncoding, TargetDataLayout,
     TyAbiInterface, VariantIdx, Variants,
 };
 use rustc_error_messages::DiagMessage;
@@ -1172,6 +1172,11 @@ where
 
     fn is_transparent(this: TyAndLayout<'tcx>) -> bool {
         matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().transparent())
+    }
+
+    /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
+    fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'tcx>) -> bool {
+        matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().flags.contains(ReprFlags::PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1573,6 +1573,14 @@ impl<'tcx> TyCtxt<'tcx> {
             flags.insert(ReprFlags::IS_LINEAR);
         }
 
+        // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
+        if find_attr!(
+            self.get_all_attrs(did),
+            AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)
+        ) {
+            flags.insert(ReprFlags::PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS);
+        }
+
         ReprOptions { int: size, align: max_align, pack: min_pack, flags, field_shuffle_seed }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1771,6 +1771,17 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 target: target.to_string(),
             });
         }
+        // Error on `#[repr(transparent)]` in combination with
+        // `#[rustc_pass_indirectly_in_non_rustic_abis]`
+        if is_transparent
+            && let Some(&pass_indirectly_span) =
+                find_attr!(attrs, AttributeKind::RustcPassIndirectlyInNonRusticAbis(span) => span)
+        {
+            self.dcx().emit_err(errors::TransparentIncompatible {
+                hint_spans: vec![span, pass_indirectly_span],
+                target: target.to_string(),
+            });
+        }
         if is_explicit_rust && (int_reprs > 0 || is_c || is_simd) {
             let hint_spans = hint_spans.clone().collect();
             self.dcx().emit_err(errors::ReprConflicting { hint_spans });

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -284,6 +284,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcCoherenceIsCore(..)
                     | AttributeKind::DebuggerVisualizer(..)
                     | AttributeKind::RustcMain
+                    | AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)
                     | AttributeKind::PinV2(..),
                 ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1944,6 +1944,7 @@ symbols! {
         rustc_partition_codegened,
         rustc_partition_reused,
         rustc_pass_by_value,
+        rustc_pass_indirectly_in_non_rustic_abis,
         rustc_peek,
         rustc_peek_liveness,
         rustc_peek_maybe_init,

--- a/compiler/rustc_target/src/callconv/aarch64.rs
+++ b/compiler/rustc_target/src/callconv/aarch64.rs
@@ -114,6 +114,10 @@ where
         // Not touching this...
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if !arg.layout.is_aggregate() {
         if kind == AbiKind::DarwinPCS {
             // On Darwin, when passing an i8/i16, it must be sign-extended to 32 bits,

--- a/compiler/rustc_target/src/callconv/amdgpu.rs
+++ b/compiler/rustc_target/src/callconv/amdgpu.rs
@@ -10,11 +10,15 @@ where
     ret.extend_integer_width_to(32);
 }
 
-fn classify_arg<'a, Ty, C>(_cx: &C, arg: &mut ArgAbi<'a, Ty>)
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     arg.extend_integer_width_to(32);
 }
 

--- a/compiler/rustc_target/src/callconv/arm.rs
+++ b/compiler/rustc_target/src/callconv/arm.rs
@@ -65,6 +65,10 @@ where
         // Not touching this...
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(32);
         return;

--- a/compiler/rustc_target/src/callconv/bpf.rs
+++ b/compiler/rustc_target/src/callconv/bpf.rs
@@ -1,4 +1,6 @@
 // see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/BPF/BPFCallingConv.td
+use rustc_abi::TyAbiInterface;
+
 use crate::callconv::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
@@ -9,7 +11,14 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if arg.layout.is_aggregate() || arg.layout.size.bits() > 64 {
         arg.make_indirect();
     } else {
@@ -17,7 +26,10 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }
@@ -26,7 +38,7 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(arg);
+        classify_arg(cx, arg);
     }
 }
 

--- a/compiler/rustc_target/src/callconv/hexagon.rs
+++ b/compiler/rustc_target/src/callconv/hexagon.rs
@@ -1,3 +1,5 @@
+use rustc_abi::TyAbiInterface;
+
 use crate::callconv::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
@@ -8,7 +10,14 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
         arg.make_indirect();
     } else {
@@ -16,7 +25,10 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }
@@ -25,6 +37,6 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(arg);
+        classify_arg(cx, arg);
     }
 }

--- a/compiler/rustc_target/src/callconv/loongarch.rs
+++ b/compiler/rustc_target/src/callconv/loongarch.rs
@@ -287,6 +287,11 @@ fn classify_arg<'a, Ty, C>(
         // Not touching this...
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        *avail_gprs = (*avail_gprs).saturating_sub(1);
+        return;
+    }
     if !is_vararg {
         match should_use_fp_conv(cx, &arg.layout, xlen, flen) {
             Some(FloatConv::Float(f)) if *avail_fprs >= 1 => {

--- a/compiler/rustc_target/src/callconv/m68k.rs
+++ b/compiler/rustc_target/src/callconv/m68k.rs
@@ -1,3 +1,5 @@
+use rustc_abi::TyAbiInterface;
+
 use crate::callconv::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
@@ -8,9 +10,16 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !arg.layout.is_sized() {
         // Not touching this...
+        return;
+    }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
         return;
     }
     if arg.layout.is_aggregate() {
@@ -20,7 +29,10 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }
@@ -29,6 +41,6 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(arg);
+        classify_arg(cx, arg);
     }
 }

--- a/compiler/rustc_target/src/callconv/mips.rs
+++ b/compiler/rustc_target/src/callconv/mips.rs
@@ -1,4 +1,4 @@
-use rustc_abi::{HasDataLayout, Size};
+use rustc_abi::{HasDataLayout, Size, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, Uniform};
 
@@ -14,18 +14,26 @@ where
     }
 }
 
-fn classify_arg<Ty, C>(cx: &C, arg: &mut ArgAbi<'_, Ty>, offset: &mut Size)
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, offset: &mut Size)
 where
+    Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
     if !arg.layout.is_sized() {
+        // FIXME: Update offset?
         // Not touching this...
         return;
     }
     let dl = cx.data_layout();
-    let size = arg.layout.size;
     let align = arg.layout.align.abi.max(dl.i32_align).min(dl.i64_align);
 
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        *offset = offset.align_to(align) + dl.pointer_size().align_to(align);
+        return;
+    }
+
+    let size = arg.layout.size;
     if arg.layout.is_aggregate() {
         let pad_i32 = !offset.is_aligned(align);
         arg.cast_to_and_pad_i32(Uniform::new(Reg::i32(), size), pad_i32);
@@ -36,8 +44,9 @@ where
     *offset = offset.align_to(align) + size.align_to(align);
 }
 
-pub(crate) fn compute_abi_info<Ty, C>(cx: &C, fn_abi: &mut FnAbi<'_, Ty>)
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
 where
+    Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
     let mut offset = Size::ZERO;

--- a/compiler/rustc_target/src/callconv/mips64.rs
+++ b/compiler/rustc_target/src/callconv/mips64.rs
@@ -82,6 +82,10 @@ where
         extend_integer_width_mips(arg, 64);
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
 
     let dl = cx.data_layout();
     let size = arg.layout.size;

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -703,13 +703,6 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "bpf" => bpf::compute_abi_info(cx, self),
             arch => panic!("no lowering implemented for {arch}"),
         }
-        // Double check that any argument types annotated with the
-        // `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute are passed indirectly.
-        for arg in &self.args {
-            if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
-                assert!(matches!(arg.mode, PassMode::Indirect { on_stack: false, .. }));
-            }
-        }
     }
 
     pub fn adjust_for_rust_abi<C>(&mut self, cx: &C)

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -677,31 +677,38 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             }
             "amdgpu" => amdgpu::compute_abi_info(cx, self),
             "arm" => arm::compute_abi_info(cx, self),
-            "avr" => avr::compute_abi_info(self),
+            "avr" => avr::compute_abi_info(cx, self),
             "loongarch32" | "loongarch64" => loongarch::compute_abi_info(cx, self),
-            "m68k" => m68k::compute_abi_info(self),
-            "csky" => csky::compute_abi_info(self),
+            "m68k" => m68k::compute_abi_info(cx, self),
+            "csky" => csky::compute_abi_info(cx, self),
             "mips" | "mips32r6" => mips::compute_abi_info(cx, self),
             "mips64" | "mips64r6" => mips64::compute_abi_info(cx, self),
             "powerpc" => powerpc::compute_abi_info(cx, self),
             "powerpc64" => powerpc64::compute_abi_info(cx, self),
             "s390x" => s390x::compute_abi_info(cx, self),
-            "msp430" => msp430::compute_abi_info(self),
+            "msp430" => msp430::compute_abi_info(cx, self),
             "sparc" => sparc::compute_abi_info(cx, self),
             "sparc64" => sparc64::compute_abi_info(cx, self),
             "nvptx64" => {
                 if abi == ExternAbi::PtxKernel || abi == ExternAbi::GpuKernel {
                     nvptx64::compute_ptx_kernel_abi_info(cx, self)
                 } else {
-                    nvptx64::compute_abi_info(self)
+                    nvptx64::compute_abi_info(cx, self)
                 }
             }
-            "hexagon" => hexagon::compute_abi_info(self),
+            "hexagon" => hexagon::compute_abi_info(cx, self),
             "xtensa" => xtensa::compute_abi_info(cx, self),
             "riscv32" | "riscv64" => riscv::compute_abi_info(cx, self),
             "wasm32" | "wasm64" => wasm::compute_abi_info(cx, self),
-            "bpf" => bpf::compute_abi_info(self),
+            "bpf" => bpf::compute_abi_info(cx, self),
             arch => panic!("no lowering implemented for {arch}"),
+        }
+        // Double check that any argument types annotated with the
+        // `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute are passed indirectly.
+        for arg in &self.args {
+            if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+                assert!(matches!(arg.mode, PassMode::Indirect { on_stack: false, .. }));
+            }
         }
     }
 

--- a/compiler/rustc_target/src/callconv/msp430.rs
+++ b/compiler/rustc_target/src/callconv/msp430.rs
@@ -1,6 +1,8 @@
 // Reference: MSP430 Embedded Application Binary Interface
 // https://www.ti.com/lit/an/slaa534a/slaa534a.pdf
 
+use rustc_abi::TyAbiInterface;
+
 use crate::callconv::{ArgAbi, FnAbi};
 
 // 3.5 Structures or Unions Passed and Returned by Reference
@@ -17,7 +19,14 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if arg.layout.is_aggregate() && arg.layout.size.bits() > 32 {
         arg.make_indirect();
     } else {
@@ -25,7 +34,10 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }
@@ -34,6 +46,6 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(arg);
+        classify_arg(cx, arg);
     }
 }

--- a/compiler/rustc_target/src/callconv/nvptx64.rs
+++ b/compiler/rustc_target/src/callconv/nvptx64.rs
@@ -11,7 +11,14 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if arg.layout.is_aggregate() && arg.layout.is_sized() {
         classify_aggregate(arg)
     } else if arg.layout.size.bits() < 32 && arg.layout.is_sized() {
@@ -81,7 +88,10 @@ where
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }
@@ -90,7 +100,7 @@ pub(crate) fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(arg);
+        classify_arg(cx, arg);
     }
 }
 

--- a/compiler/rustc_target/src/callconv/powerpc.rs
+++ b/compiler/rustc_target/src/callconv/powerpc.rs
@@ -1,3 +1,5 @@
+use rustc_abi::TyAbiInterface;
+
 use crate::callconv::{ArgAbi, FnAbi};
 use crate::spec::HasTargetSpec;
 
@@ -9,7 +11,10 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
     }
 }
 
-fn classify_arg<Ty>(cx: &impl HasTargetSpec, arg: &mut ArgAbi<'_, Ty>) {
+fn classify_arg<'a, Ty, C: HasTargetSpec>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if arg.is_ignore() {
         // powerpc-unknown-linux-{gnu,musl,uclibc} doesn't ignore ZSTs.
         if cx.target_spec().os == "linux"
@@ -20,14 +25,17 @@ fn classify_arg<Ty>(cx: &impl HasTargetSpec, arg: &mut ArgAbi<'_, Ty>) {
         }
         return;
     }
-    if arg.layout.is_aggregate() {
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) || arg.layout.is_aggregate() {
         arg.make_indirect();
     } else {
         arg.extend_integer_width_to(32);
     }
 }
 
-pub(crate) fn compute_abi_info<Ty>(cx: &impl HasTargetSpec, fn_abi: &mut FnAbi<'_, Ty>) {
+pub(crate) fn compute_abi_info<'a, Ty, C: HasTargetSpec>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+where
+    Ty: TyAbiInterface<'a, C> + Copy,
+{
     if !fn_abi.ret.is_ignore() {
         classify_ret(&mut fn_abi.ret);
     }

--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -52,6 +52,10 @@ where
         // Not touching this...
         return;
     }
+    if !is_ret && arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(64);
         return;

--- a/compiler/rustc_target/src/callconv/riscv.rs
+++ b/compiler/rustc_target/src/callconv/riscv.rs
@@ -290,7 +290,13 @@ fn classify_arg<'a, Ty, C>(
     Ty: TyAbiInterface<'a, C> + Copy,
 {
     if !arg.layout.is_sized() {
+        // FIXME: Update avail_gprs?
         // Not touching this...
+        return;
+    }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        *avail_gprs = (*avail_gprs).saturating_sub(1);
         return;
     }
     if !is_vararg {

--- a/compiler/rustc_target/src/callconv/s390x.rs
+++ b/compiler/rustc_target/src/callconv/s390x.rs
@@ -37,6 +37,10 @@ where
         }
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
 
     let size = arg.layout.size;
     if size.bits() <= 128 {

--- a/compiler/rustc_target/src/callconv/sparc.rs
+++ b/compiler/rustc_target/src/callconv/sparc.rs
@@ -1,4 +1,4 @@
-use rustc_abi::{HasDataLayout, Size};
+use rustc_abi::{HasDataLayout, Size, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, Uniform};
 
@@ -14,15 +14,22 @@ where
     }
 }
 
-fn classify_arg<Ty, C>(cx: &C, arg: &mut ArgAbi<'_, Ty>, offset: &mut Size)
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, offset: &mut Size)
 where
+    Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
     if !arg.layout.is_sized() {
+        // FIXME: Update offset?
         // Not touching this...
         return;
     }
     let dl = cx.data_layout();
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        *offset += dl.pointer_size();
+        return;
+    }
     let size = arg.layout.size;
     let align = arg.layout.align.abi.max(dl.i32_align).min(dl.i64_align);
 
@@ -36,8 +43,9 @@ where
     *offset = offset.align_to(align) + size.align_to(align);
 }
 
-pub(crate) fn compute_abi_info<Ty, C>(cx: &C, fn_abi: &mut FnAbi<'_, Ty>)
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
 where
+    Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
     let mut offset = Size::ZERO;

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -140,6 +140,10 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
 {
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(64);
         return;

--- a/compiler/rustc_target/src/callconv/wasm.rs
+++ b/compiler/rustc_target/src/callconv/wasm.rs
@@ -52,6 +52,10 @@ where
         // Not touching this...
         return;
     }
+    if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        arg.make_indirect();
+        return;
+    }
     arg.extend_integer_width_to(32);
     if arg.layout.is_aggregate() && !unwrap_trivial_aggregate(cx, arg) {
         arg.make_indirect();

--- a/compiler/rustc_target/src/callconv/x86.rs
+++ b/compiler/rustc_target/src/callconv/x86.rs
@@ -64,6 +64,11 @@ where
             continue;
         }
 
+        if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+            arg.make_indirect();
+            continue;
+        }
+
         let t = cx.target_spec();
         let align_4 = Align::from_bytes(4).unwrap();
         let align_16 = Align::from_bytes(16).unwrap();

--- a/compiler/rustc_target/src/callconv/x86_64.rs
+++ b/compiler/rustc_target/src/callconv/x86_64.rs
@@ -183,7 +183,13 @@ where
 
     let mut x86_64_arg_or_ret = |arg: &mut ArgAbi<'a, Ty>, is_arg: bool| {
         if !arg.layout.is_sized() {
+            // FIXME: Update int_regs?
             // Not touching this...
+            return;
+        }
+        if is_arg && arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+            int_regs = int_regs.saturating_sub(1);
+            arg.make_indirect();
             return;
         }
         let mut cls_or_mem = classify_arg(cx, arg);

--- a/compiler/rustc_target/src/callconv/x86_win32.rs
+++ b/compiler/rustc_target/src/callconv/x86_win32.rs
@@ -46,6 +46,11 @@ pub(crate) fn compute_abi_info<'a, Ty, C>(
             continue;
         }
 
+        if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+            arg.make_indirect();
+            continue;
+        }
+
         // FIXME: MSVC 2015+ will pass the first 3 vector arguments in [XYZ]MM0-2
         // See https://reviews.llvm.org/D72114 for Clang behavior
 

--- a/compiler/rustc_target/src/callconv/xtensa.rs
+++ b/compiler/rustc_target/src/callconv/xtensa.rs
@@ -15,7 +15,7 @@ const NUM_RET_GPRS: u64 = 4;
 const MAX_ARG_IN_REGS_SIZE: u64 = NUM_ARG_GPRS * 32;
 const MAX_RET_IN_REGS_SIZE: u64 = NUM_RET_GPRS * 32;
 
-fn classify_ret_ty<'a, Ty, C>(arg: &mut ArgAbi<'_, Ty>)
+fn classify_ret_ty<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
 {
@@ -26,7 +26,7 @@ where
     // The rules for return and argument types are the same,
     // so defer to `classify_arg_ty`.
     let mut arg_gprs_left = NUM_RET_GPRS;
-    classify_arg_ty(arg, &mut arg_gprs_left, MAX_RET_IN_REGS_SIZE);
+    classify_arg_ty(cx, arg, &mut arg_gprs_left, true);
     // Ret args cannot be passed via stack, we lower to indirect and let the backend handle the invisible reference
     match arg.mode {
         super::PassMode::Indirect { attrs: _, meta_attrs: _, ref mut on_stack } => {
@@ -36,11 +36,23 @@ where
     }
 }
 
-fn classify_arg_ty<'a, Ty, C>(arg: &mut ArgAbi<'_, Ty>, arg_gprs_left: &mut u64, max_size: u64)
-where
+fn classify_arg_ty<'a, Ty, C>(
+    cx: &C,
+    arg: &mut ArgAbi<'a, Ty>,
+    arg_gprs_left: &mut u64,
+    is_ret: bool,
+) where
     Ty: TyAbiInterface<'a, C> + Copy,
 {
     assert!(*arg_gprs_left <= NUM_ARG_GPRS, "Arg GPR tracking underflow");
+
+    let max_size = if is_ret { MAX_RET_IN_REGS_SIZE } else { MAX_ARG_IN_REGS_SIZE };
+
+    if !is_ret && arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+        *arg_gprs_left = arg_gprs_left.saturating_sub(1);
+        arg.make_indirect();
+        return;
+    }
 
     // Ignore empty structs/unions.
     if arg.layout.is_zst() {
@@ -95,13 +107,13 @@ where
     }
 }
 
-pub(crate) fn compute_abi_info<'a, Ty, C>(_cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
+pub(crate) fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
     if !fn_abi.ret.is_ignore() {
-        classify_ret_ty(&mut fn_abi.ret);
+        classify_ret_ty(cx, &mut fn_abi.ret);
     }
 
     let mut arg_gprs_left = NUM_ARG_GPRS;
@@ -110,7 +122,7 @@ where
         if arg.is_ignore() {
             continue;
         }
-        classify_arg_ty(arg, &mut arg_gprs_left, MAX_ARG_IN_REGS_SIZE);
+        classify_arg_ty(cx, arg, &mut arg_gprs_left, false);
     }
 }
 

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -1,3 +1,4 @@
+use std::assert_matches::assert_matches;
 use std::iter;
 
 use rustc_abi::Primitive::Pointer;
@@ -388,6 +389,12 @@ fn fn_abi_sanity_check<'tcx>(
             if let PassMode::Indirect { on_stack, .. } = arg.mode {
                 assert!(!on_stack, "rust abi shouldn't use on_stack");
             }
+        } else if arg.layout.pass_indirectly_in_non_rustic_abis(cx) {
+            assert_matches!(
+                arg.mode,
+                PassMode::Indirect { on_stack: false, .. },
+                "the {spec_abi} ABI does not implement `#[rustc_pass_indirectly_in_non_rustic_abis]`"
+            );
         }
 
         match &arg.mode {

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -299,3 +299,15 @@ impl<'f> Drop for VaListImpl<'f> {
         // This works for now, since `va_end` is a no-op on all current LLVM targets.
     }
 }
+
+// Checks (via an assert in `compiler/rustc_ty_utils/src/abi.rs`) that the C ABI for the current
+// target correctly implements `rustc_pass_indirectly_in_non_rustic_abis`.
+const _: () = {
+    #[repr(C)]
+    #[rustc_pass_indirectly_in_non_rustic_abis]
+    struct Type(usize);
+
+    const extern "C" fn c(_: Type) {}
+
+    c(Type(0))
+};

--- a/tests/ui/abi/pass-indirectly-attr.rs
+++ b/tests/ui/abi/pass-indirectly-attr.rs
@@ -1,0 +1,16 @@
+//@ check-fail
+//@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
+//@ compile-flags: -O
+
+#![feature(rustc_attrs)]
+#![crate_type = "lib"]
+
+#[repr(C)]
+#[rustc_pass_indirectly_in_non_rustic_abis]
+pub struct Type(u8);
+
+#[rustc_abi(debug)]
+pub extern "C" fn func(_: Type) {}
+//~^ ERROR fn_abi_of(func) = FnAbi {
+//~^^ ERROR mode: Indirect {
+//~^^^ ERROR on_stack: false,

--- a/tests/ui/abi/pass-indirectly-attr.rs
+++ b/tests/ui/abi/pass-indirectly-attr.rs
@@ -1,16 +1,38 @@
+//@ add-minicore
 //@ check-fail
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
-//@ compile-flags: -O
+//@ ignore-backends: gcc
 
 #![feature(rustc_attrs)]
 #![crate_type = "lib"]
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 #[rustc_pass_indirectly_in_non_rustic_abis]
 pub struct Type(u8);
 
 #[rustc_abi(debug)]
-pub extern "C" fn func(_: Type) {}
-//~^ ERROR fn_abi_of(func) = FnAbi {
-//~^^ ERROR mode: Indirect {
-//~^^^ ERROR on_stack: false,
+pub extern "C" fn extern_c(_: Type) {}
+//~^ ERROR fn_abi_of(extern_c) = FnAbi {
+//~| ERROR mode: Indirect
+//~| ERROR on_stack: false,
+//~| ERROR conv: C,
+
+#[rustc_abi(debug)]
+pub extern "Rust" fn extern_rust(_: Type) {}
+//~^ ERROR fn_abi_of(extern_rust) = FnAbi {
+//~| ERROR mode: Cast
+//~| ERROR conv: Rust
+
+#[repr(transparent)]
+struct Inner(u64);
+
+#[rustc_pass_indirectly_in_non_rustic_abis]
+//~^ ERROR transparent struct cannot have other repr hints
+#[repr(transparent)]
+struct Wrapper(Inner);

--- a/tests/ui/abi/pass-indirectly-attr.stderr
+++ b/tests/ui/abi/pass-indirectly-attr.stderr
@@ -1,0 +1,84 @@
+error: fn_abi_of(func) = FnAbi {
+           args: [
+               ArgAbi {
+                   layout: TyAndLayout {
+                       ty: Type,
+                       layout: Layout {
+                           size: Size(1 bytes),
+                           align: AbiAlign {
+                               abi: Align(1 bytes),
+                           },
+                           backend_repr: Memory {
+                               sized: true,
+                           },
+                           fields: Arbitrary {
+                               offsets: [
+                                   Size(0 bytes),
+                               ],
+                               memory_index: [
+                                   0,
+                               ],
+                           },
+                           largest_niche: None,
+                           uninhabited: false,
+                           variants: Single {
+                               index: 0,
+                           },
+                           max_repr_align: None,
+                           unadjusted_abi_align: Align(1 bytes),
+                           randomization_seed: $SEED,
+                       },
+                   },
+                   mode: Indirect {
+                       attrs: ArgAttributes {
+                           regular: CapturesAddress | NoAlias | NonNull | NoUndef,
+                           arg_ext: None,
+                           pointee_size: Size(1 bytes),
+                           pointee_align: Some(
+                               Align(1 bytes),
+                           ),
+                       },
+                       meta_attrs: None,
+                       on_stack: false,
+                   },
+               },
+           ],
+           ret: ArgAbi {
+               layout: TyAndLayout {
+                   ty: (),
+                   layout: Layout {
+                       size: Size(0 bytes),
+                       align: AbiAlign {
+                           abi: Align(1 bytes),
+                       },
+                       backend_repr: Memory {
+                           sized: true,
+                       },
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       largest_niche: None,
+                       uninhabited: false,
+                       variants: Single {
+                           index: 0,
+                       },
+                       max_repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
+                       randomization_seed: $SEED,
+                   },
+               },
+               mode: Ignore,
+           },
+           c_variadic: false,
+           fixed_count: 1,
+           conv: C,
+           can_unwind: false,
+       }
+  --> $DIR/pass-indirectly-attr.rs:13:1
+   |
+LL | pub extern "C" fn func(_: Type) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/abi/pass-indirectly-attr.stderr
+++ b/tests/ui/abi/pass-indirectly-attr.stderr
@@ -1,4 +1,13 @@
-error: fn_abi_of(func) = FnAbi {
+error[E0692]: transparent struct cannot have other repr hints
+  --> $DIR/pass-indirectly-attr.rs:35:1
+   |
+LL | #[rustc_pass_indirectly_in_non_rustic_abis]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | struct Wrapper(Inner);
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: fn_abi_of(extern_c) = FnAbi {
            args: [
                ArgAbi {
                    layout: TyAndLayout {
@@ -75,10 +84,111 @@ error: fn_abi_of(func) = FnAbi {
            conv: C,
            can_unwind: false,
        }
-  --> $DIR/pass-indirectly-attr.rs:13:1
+  --> $DIR/pass-indirectly-attr.rs:20:1
    |
-LL | pub extern "C" fn func(_: Type) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub extern "C" fn extern_c(_: Type) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: fn_abi_of(extern_rust) = FnAbi {
+           args: [
+               ArgAbi {
+                   layout: TyAndLayout {
+                       ty: Type,
+                       layout: Layout {
+                           size: Size(1 bytes),
+                           align: AbiAlign {
+                               abi: Align(1 bytes),
+                           },
+                           backend_repr: Memory {
+                               sized: true,
+                           },
+                           fields: Arbitrary {
+                               offsets: [
+                                   Size(0 bytes),
+                               ],
+                               memory_index: [
+                                   0,
+                               ],
+                           },
+                           largest_niche: None,
+                           uninhabited: false,
+                           variants: Single {
+                               index: 0,
+                           },
+                           max_repr_align: None,
+                           unadjusted_abi_align: Align(1 bytes),
+                           randomization_seed: $SEED,
+                       },
+                   },
+                   mode: Cast {
+                       pad_i32: false,
+                       cast: CastTarget {
+                           prefix: [
+                               None,
+                               None,
+                               None,
+                               None,
+                               None,
+                               None,
+                               None,
+                               None,
+                           ],
+                           rest_offset: None,
+                           rest: Uniform {
+                               unit: Reg {
+                                   kind: Integer,
+                                   size: Size(1 bytes),
+                               },
+                               total: Size(1 bytes),
+                               is_consecutive: false,
+                           },
+                           attrs: ArgAttributes {
+                               regular: ,
+                               arg_ext: None,
+                               pointee_size: Size(0 bytes),
+                               pointee_align: None,
+                           },
+                       },
+                   },
+               },
+           ],
+           ret: ArgAbi {
+               layout: TyAndLayout {
+                   ty: (),
+                   layout: Layout {
+                       size: Size(0 bytes),
+                       align: AbiAlign {
+                           abi: Align(1 bytes),
+                       },
+                       backend_repr: Memory {
+                           sized: true,
+                       },
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       largest_niche: None,
+                       uninhabited: false,
+                       variants: Single {
+                           index: 0,
+                       },
+                       max_repr_align: None,
+                       unadjusted_abi_align: Align(1 bytes),
+                       randomization_seed: $SEED,
+                   },
+               },
+               mode: Ignore,
+           },
+           c_variadic: false,
+           fixed_count: 1,
+           conv: Rust,
+           can_unwind: false,
+       }
+  --> $DIR/pass-indirectly-attr.rs:27:1
+   |
+LL | pub extern "Rust" fn extern_rust(_: Type) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0692`.

--- a/tests/ui/attributes/pass-indirectly.rs
+++ b/tests/ui/attributes/pass-indirectly.rs
@@ -1,0 +1,15 @@
+//@ check-fail
+
+#![feature(rustc_attrs)]
+#![crate_type = "lib"]
+
+#[rustc_pass_indirectly_in_non_rustic_abis]
+//~^ ERROR: `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute cannot be used on functions
+fn not_a_struct() {}
+
+#[repr(C)]
+#[rustc_pass_indirectly_in_non_rustic_abis]
+struct YesAStruct {
+    foo: u8,
+    bar: u16,
+}

--- a/tests/ui/attributes/pass-indirectly.stderr
+++ b/tests/ui/attributes/pass-indirectly.stderr
@@ -1,0 +1,10 @@
+error: `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute cannot be used on functions
+  --> $DIR/pass-indirectly.rs:6:1
+   |
+LL | #[rustc_pass_indirectly_in_non_rustic_abis]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[rustc_pass_indirectly_in_non_rustic_abis]` can only be applied to structs
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This PR adds an internal `#[rustc_pass_indirectly_in_non_rustic_abis]` attribute that can be applied to structs. Structs marked with this attribute will always be passed using `PassMode::Indirect { on_stack: false, .. }` when being passed by value to functions with non-Rustic calling conventions. This is needed by rust-lang/rust#141980; see that PR for further details.

cc @joshtriplett