### PR TITLE
Add `Drop::pin_drop` for pinned drops

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
@@ -15,5 +15,5 @@ impl NoArgsAttributeParser for PinV2Parser {
         Allow(Target::Struct),
         Allow(Target::Union),
     ]);
-    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PinV2;
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::PinV2;
 }

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1212,7 +1212,7 @@ pub enum AttributeKind {
     },
 
     /// Represents `#[pin_v2]`
-    PinV2,
+    PinV2(Span),
 
     /// Represents `#[prelude_import]`
     PreludeImport,

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -86,7 +86,7 @@ impl AttributeKind {
             PatchableFunctionEntry { .. } => Yes,
             Path(..) => No,
             PatternComplexityLimit { .. } => No,
-            PinV2 => Yes,
+            PinV2(..) => Yes,
             PreludeImport => No,
             ProcMacro => No,
             ProcMacroAttribute => No,

--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -12,6 +12,7 @@ use rustc_infer::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::span_bug;
 use rustc_middle::ty::util::CheckRegions;
 use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode};
+use rustc_span::sym;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
 use rustc_trait_selection::traits::{self, ObligationCtxt};
 
@@ -72,7 +73,11 @@ pub(crate) fn check_drop_impl(
                 drop_impl_did,
                 adt_def.did(),
                 adt_to_impl_args,
-            )
+            )?;
+
+            check_drop_xor_pin_drop(tcx, adt_def.did(), drop_impl_did)?;
+
+            Ok(())
         }
         _ => {
             span_bug!(tcx.def_span(drop_impl_did), "incoherent impl of Drop");
@@ -361,5 +366,70 @@ fn ensure_impl_predicates_are_implied_by_item_defn<'tcx>(
         return Err(guar.unwrap());
     }
 
+    Ok(())
+}
+
+/// This function checks at least and at most one of `Drop::drop` and `Drop::pin_drop` is implemented.
+/// It also checks that `Drop::pin_drop` must be implemented if `#[pin_v2]` is present on the type.
+fn check_drop_xor_pin_drop<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    adt_def_id: DefId,
+    drop_impl_did: LocalDefId,
+) -> Result<(), ErrorGuaranteed> {
+    let mut drop_span = None;
+    let mut pin_drop_span = None;
+    for item in tcx.associated_items(drop_impl_did).in_definition_order() {
+        match item.kind {
+            ty::AssocKind::Fn { name: sym::drop, .. } => {
+                drop_span = Some(tcx.def_span(item.def_id))
+            }
+            ty::AssocKind::Fn { name: sym::pin_drop, .. } => {
+                pin_drop_span = Some(tcx.def_span(item.def_id))
+            }
+            _ => {}
+        }
+    }
+
+    match (drop_span, pin_drop_span) {
+        (None, None) => {
+            if tcx.features().pin_ergonomics() {
+                return Err(tcx.dcx().emit_err(crate::errors::MissingOneOfTraitItem {
+                    span: tcx.def_span(drop_impl_did),
+                    note: None,
+                    missing_items_msg: "drop`, `pin_drop".to_string(),
+                }));
+            } else {
+                return Err(tcx
+                    .dcx()
+                    .span_delayed_bug(tcx.def_span(drop_impl_did), "missing `Drop::drop`"));
+            }
+        }
+        (Some(span), None) => {
+            if tcx.adt_def(adt_def_id).is_pin_project() {
+                let pin_v2_span = rustc_hir::find_attr!(tcx, adt_def_id, PinV2(attr) => *attr);
+                let adt_name = tcx.item_name(adt_def_id);
+                return Err(tcx.dcx().emit_err(crate::errors::PinV2WithoutPinDrop {
+                    span,
+                    pin_v2_span,
+                    adt_name,
+                }));
+            }
+        }
+        (None, Some(span)) => {
+            if !tcx.features().pin_ergonomics() {
+                return Err(tcx.dcx().span_delayed_bug(
+                    span,
+                    "`Drop::pin_drop` should be guarded by the library feature gate",
+                ));
+            }
+        }
+        (Some(drop_span), Some(pin_drop_span)) => {
+            return Err(tcx.dcx().emit_err(crate::errors::ConflictImplDropAndPinDrop {
+                span: tcx.def_span(drop_impl_did),
+                drop_span,
+                pin_drop_span,
+            }));
+        }
+    }
     Ok(())
 }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -24,6 +24,7 @@ use rustc_middle::ty::{
     TypeVisitable, TypeVisitableExt, Unnormalized, fold_regions,
 };
 use rustc_session::lint::builtin::UNINHABITED_STATIC;
+use rustc_span::sym;
 use rustc_target::spec::{AbiMap, AbiMapping};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits;
@@ -1347,6 +1348,15 @@ fn check_impl_items_against_trait<'tcx>(
             if !is_implemented_here {
                 let full_impl_span = tcx.hir_span_with_body(tcx.local_def_id_to_hir_id(impl_id));
                 match tcx.eval_default_body_stability(trait_item_id, full_impl_span) {
+                    // When the feature `pin_ergonomics` is disabled, we report `Drop::drop` is missing,
+                    // instead of `Drop::drop` is unstable that might be confusing.
+                    EvalResult::Deny { .. }
+                        if !tcx.features().pin_ergonomics()
+                            && tcx.is_lang_item(trait_ref.def_id, hir::LangItem::Drop)
+                            && tcx.item_name(trait_item_id) == sym::drop =>
+                    {
+                        missing_items.push(tcx.associated_item(trait_item_id));
+                    }
                     EvalResult::Deny { feature, reason, issue, .. } => default_body_is_unstable(
                         tcx,
                         full_impl_span,

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -94,7 +94,7 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_session::errors::feature_err;
 use rustc_span::def_id::CRATE_DEF_ID;
-use rustc_span::{BytePos, DUMMY_SP, Ident, Span, Symbol, kw, sym};
+use rustc_span::{BytePos, DUMMY_SP, Ident, Span, Symbol, kw};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::error_reporting::infer::ObligationCauseExt as _;
 use rustc_trait_selection::error_reporting::traits::suggestions::ReturnsVisitor;

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1986,3 +1986,35 @@ pub(crate) struct EiiDefkindMismatchStaticSafety {
     pub span: Span,
     pub eii_name: Symbol,
 }
+
+#[derive(Diagnostic)]
+#[diag("conflicting implementations of `Drop::drop` and `Drop::pin_drop`")]
+pub(crate) struct ConflictImplDropAndPinDrop {
+    #[primary_span]
+    pub span: Span,
+    #[label("`drop(&mut self)` implemented here")]
+    pub drop_span: Span,
+    #[label("`pin_drop(&pin mut self)` implemented here")]
+    pub pin_drop_span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag("`{$adt_name}` must implement `pin_drop`")]
+#[help("structurally pinned types must keep `Pin`'s safety contract")]
+pub(crate) struct PinV2WithoutPinDrop {
+    #[primary_span]
+    #[suggestion(
+        "implement `pin_drop` instead",
+        code = "fn pin_drop(&pin mut self)",
+        applicability = "maybe-incorrect"
+    )]
+    pub span: Span,
+    #[note("`{$adt_name}` is marked `#[pin_v2]` here")]
+    #[suggestion(
+        "remove the `#[pin_v2]` attribute if it is not intended for structurally pinning",
+        code = "",
+        applicability = "maybe-incorrect"
+    )]
+    pub pin_v2_span: Option<Span>,
+    pub adt_name: Symbol,
+}

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -37,9 +37,12 @@ pub(crate) fn check_legal_trait_for_method_call(
     receiver: Option<Span>,
     expr_span: Span,
     trait_id: DefId,
-    _body_id: DefId,
+    body_id: DefId,
 ) -> Result<(), ErrorGuaranteed> {
-    if tcx.is_lang_item(trait_id, LangItem::Drop) {
+    if tcx.is_lang_item(trait_id, LangItem::Drop)
+        // Allow calling `Drop::pin_drop` in `Drop::drop`
+        && !tcx.is_lang_item(tcx.parent(body_id), LangItem::Drop)
+    {
         let sugg = if let Some(receiver) = receiver.filter(|s| !s.is_empty()) {
             errors::ExplicitDestructorCallSugg::Snippet {
                 lo: expr_span.shrink_to_lo().to(receiver.shrink_to_lo()),

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -349,7 +349,7 @@ impl AdtDefData {
             debug!("found non-exhaustive variant list for {:?}", did);
             flags = flags | AdtFlags::IS_VARIANT_LIST_NON_EXHAUSTIVE;
         }
-        if find_attr!(tcx, did, PinV2) {
+        if find_attr!(tcx, did, PinV2(..)) {
             debug!("found pin-project type {:?}", did);
             flags |= AdtFlags::IS_PIN_PROJECT;
         }

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -462,6 +462,11 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                             CallToFunctionWith { function: func_did, missing, build_enabled },
                         );
                     }
+                    if let Some(trait_did) = self.tcx.trait_of_assoc(func_did)
+                        && self.tcx.is_lang_item(trait_did, hir::LangItem::Drop)
+                    {
+                        self.requires_unsafe(expr.span, CallDropExplicitly(func_did));
+                    }
                 }
             }
             ExprKind::RawBorrow { arg, .. } => {
@@ -662,6 +667,8 @@ enum UnsafeOpKind {
         build_enabled: Vec<Symbol>,
     },
     UnsafeBinderCast,
+    /// Calling `Drop::drop` or `Drop::pin_drop` explicitly.
+    CallDropExplicitly(DefId),
 }
 
 use UnsafeOpKind::*;
@@ -830,6 +837,9 @@ impl UnsafeOpKind {
                     unsafe_not_inherited_note,
                 },
             ),
+            CallDropExplicitly(_) => {
+                span_bug!(span, "`Drop::drop` or `Drop::pin_drop` should not be called explicitly")
+            }
         }
     }
 
@@ -1034,6 +1044,13 @@ impl UnsafeOpKind {
             }
             UnsafeBinderCast => {
                 dcx.emit_err(UnsafeBinderCastRequiresUnsafe { span, unsafe_not_inherited_note });
+            }
+            CallDropExplicitly(did) => {
+                dcx.emit_err(CallDropExplicitlyRequiresUnsafe {
+                    span,
+                    unsafe_not_inherited_note,
+                    function: tcx.def_path_str(*did),
+                });
             }
         }
     }

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -562,6 +562,16 @@ pub(crate) struct UnsafeBinderCastRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
 }
 
+#[derive(Diagnostic)]
+#[diag("call `{$function}` explicitly is unsafe and requires unsafe block", code = E0133)]
+pub(crate) struct CallDropExplicitlyRequiresUnsafe {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) function: String,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
+}
+
 #[derive(Subdiagnostic)]
 #[label("items do not inherit unsafety from separate enclosing items")]
 pub(crate) struct UnsafeNotInheritedNote {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -259,7 +259,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::PatchableFunctionEntry { .. }
                     | AttributeKind::Path(..)
                     | AttributeKind::PatternComplexityLimit { .. }
-                    | AttributeKind::PinV2
+                    | AttributeKind::PinV2(..)
                     | AttributeKind::PreludeImport
                     | AttributeKind::ProfilerRuntime
                     | AttributeKind::RecursionLimit { .. }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1520,6 +1520,7 @@ symbols! {
         pic,
         pie,
         pin,
+        pin_drop,
         pin_ergonomics,
         pin_v2,
         platform_intrinsics,

--- a/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
@@ -4,7 +4,9 @@ set -ex
 
 ##### Test stage 1 #####
 
-../x.py --stage 1 test --skip src/tools/tidy
+# linkchecker is skipped because mixing old rustc/rustdoc with new standard
+# library causes problems with generating correct links.
+../x.py --stage 1 test --skip src/tools/tidy --skip src/tools/linkchecker
 
 # Run the `mir-opt` tests again but this time for a 32-bit target.
 # This enforces that tests using `// EMIT_MIR_FOR_EACH_BIT_WIDTH` have

--- a/tests/codegen-units/item-collection/drop-glue-eager.rs
+++ b/tests/codegen-units/item-collection/drop-glue-eager.rs
@@ -10,6 +10,7 @@ struct StructWithDrop {
 
 impl Drop for StructWithDrop {
     //~ MONO_ITEM fn <StructWithDrop as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <StructWithDrop as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 
@@ -24,6 +25,7 @@ enum EnumWithDrop {
 
 impl Drop for EnumWithDrop {
     //~ MONO_ITEM fn <EnumWithDrop as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <EnumWithDrop as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 
@@ -34,6 +36,7 @@ enum EnumNoDrop {
 // We should be able to monomorphize drops for struct with lifetimes.
 impl<'a> Drop for StructWithDropAndLt<'a> {
     //~ MONO_ITEM fn <StructWithDropAndLt<'_> as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <StructWithDropAndLt<'_> as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 
@@ -52,5 +55,6 @@ struct StructWithLtAndPredicate<'a: 'a> {
 // We should be able to monomorphize drops for struct with lifetimes.
 impl<'a> Drop for StructWithLtAndPredicate<'a> {
     //~ MONO_ITEM fn <StructWithLtAndPredicate<'_> as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <StructWithLtAndPredicate<'_> as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }

--- a/tests/codegen-units/item-collection/drop_in_place_intrinsic.rs
+++ b/tests/codegen-units/item-collection/drop_in_place_intrinsic.rs
@@ -9,6 +9,7 @@ struct StructWithDtor(u32);
 
 impl Drop for StructWithDtor {
     //~ MONO_ITEM fn <StructWithDtor as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <StructWithDtor as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 //~ MONO_ITEM fn start

--- a/tests/codegen-units/item-collection/generic-drop-glue.rs
+++ b/tests/codegen-units/item-collection/generic-drop-glue.rs
@@ -39,6 +39,7 @@ struct NonGenericWithDrop(#[allow(dead_code)] i32);
 
 impl Drop for NonGenericWithDrop {
     //~ MONO_ITEM fn <NonGenericWithDrop as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <NonGenericWithDrop as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 

--- a/tests/codegen-units/item-collection/non-generic-closures.rs
+++ b/tests/codegen-units/item-collection/non-generic-closures.rs
@@ -74,5 +74,6 @@ struct PresentDrop;
 
 impl Drop for PresentDrop {
     //~ MONO_ITEM fn <PresentDrop as std::ops::Drop>::drop @@ non_generic_closures-cgu.0[External]
+    //~ MONO_ITEM fn <PresentDrop as std::ops::Drop>::pin_drop @@ non_generic_closures-cgu.0[External]
     fn drop(&mut self) {}
 }

--- a/tests/codegen-units/item-collection/non-generic-drop-glue.rs
+++ b/tests/codegen-units/item-collection/non-generic-drop-glue.rs
@@ -11,6 +11,7 @@ struct StructWithDrop {
 
 impl Drop for StructWithDrop {
     //~ MONO_ITEM fn <StructWithDrop as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <StructWithDrop as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 
@@ -25,6 +26,7 @@ enum EnumWithDrop {
 
 impl Drop for EnumWithDrop {
     //~ MONO_ITEM fn <EnumWithDrop as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <EnumWithDrop as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 

--- a/tests/codegen-units/item-collection/transitive-drop-glue.rs
+++ b/tests/codegen-units/item-collection/transitive-drop-glue.rs
@@ -13,6 +13,7 @@ struct Leaf;
 
 impl Drop for Leaf {
     //~ MONO_ITEM fn <Leaf as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <Leaf as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 

--- a/tests/codegen-units/item-collection/tuple-drop-glue.rs
+++ b/tests/codegen-units/item-collection/tuple-drop-glue.rs
@@ -9,6 +9,7 @@ struct Dropped;
 
 impl Drop for Dropped {
     //~ MONO_ITEM fn <Dropped as std::ops::Drop>::drop
+    //~ MONO_ITEM fn <Dropped as std::ops::Drop>::pin_drop
     fn drop(&mut self) {}
 }
 

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -11,6 +11,12 @@ impl Foo {
     fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
 }
 
+impl Drop for Foo {
+    //~^ ERROR not all trait items implemented, missing: `drop`
+    fn pin_drop(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+    //~^ ERROR use of unstable library feature `pin_ergonomics` [E0658]
+}
+
 fn foo(mut x: Pin<&mut Foo>) {
     Foo::foo_sugar(x.as_mut());
     Foo::foo_sugar_const(x.as_ref());
@@ -69,6 +75,10 @@ mod not_compiled {
         fn foo(self: Pin<&mut Self>) {}
         fn foo_sugar(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
         fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
+    }
+
+    impl Drop for Foo {
+        fn pin_drop(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
     }
 
     fn foo(mut x: Pin<&mut Foo>) {

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -19,7 +19,17 @@ LL |     fn foo_sugar_const(&pin const self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:17:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:16:18
+   |
+LL |     fn pin_drop(&pin mut self) {}
+   |                  ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:23:14
    |
 LL |     let _y: &pin mut Foo = x;
    |              ^^^
@@ -29,7 +39,7 @@ LL |     let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:21:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:27:14
    |
 LL |     let _y: &pin const Foo = x;
    |              ^^^
@@ -39,7 +49,7 @@ LL |     let _y: &pin const Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:24:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:30:18
    |
 LL | fn foo_sugar(_: &pin mut Foo) {}
    |                  ^^^
@@ -49,7 +59,7 @@ LL | fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:36:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:42:18
    |
 LL | fn baz_sugar(_: &pin const Foo) {}
    |                  ^^^
@@ -59,7 +69,7 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:39:31
+  --> $DIR/feature-gate-pin_ergonomics.rs:45:31
    |
 LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    |                               ^^^
@@ -69,7 +79,7 @@ LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:44:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:50:23
    |
 LL |     let x: Pin<&_> = &pin const Foo;
    |                       ^^^
@@ -79,7 +89,7 @@ LL |     let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:51:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:57:6
    |
 LL |     &pin mut x: &pin mut i32,
    |      ^^^
@@ -89,7 +99,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:51:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:57:18
    |
 LL |     &pin mut x: &pin mut i32,
    |                  ^^^
@@ -99,7 +109,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:54:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:60:6
    |
 LL |     &pin const y: &'a pin const i32,
    |      ^^^
@@ -109,7 +119,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:54:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:60:23
    |
 LL |     &pin const y: &'a pin const i32,
    |                       ^^^
@@ -119,7 +129,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:57:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:63:9
    |
 LL |     ref pin mut z: i32,
    |         ^^^
@@ -129,7 +139,7 @@ LL |     ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:58:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:64:9
    |
 LL |     ref pin const w: i32,
    |         ^^^
@@ -139,7 +149,7 @@ LL |     ref pin const w: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:70:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:76:23
    |
 LL |         fn foo_sugar(&pin mut self) {}
    |                       ^^^
@@ -149,7 +159,7 @@ LL |         fn foo_sugar(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:71:29
+  --> $DIR/feature-gate-pin_ergonomics.rs:77:29
    |
 LL |         fn foo_sugar_const(&pin const self) {}
    |                             ^^^
@@ -159,7 +169,17 @@ LL |         fn foo_sugar_const(&pin const self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:77:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:81:22
+   |
+LL |         fn pin_drop(&pin mut self) {}
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:87:18
    |
 LL |         let _y: &pin mut Foo = x;
    |                  ^^^
@@ -169,7 +189,7 @@ LL |         let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:80:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:90:22
    |
 LL |     fn foo_sugar(_: &pin mut Foo) {}
    |                      ^^^
@@ -179,7 +199,7 @@ LL |     fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:92:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:102:22
    |
 LL |     fn baz_sugar(_: &pin const Foo) {}
    |                      ^^^
@@ -189,7 +209,7 @@ LL |     fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:95:35
+  --> $DIR/feature-gate-pin_ergonomics.rs:105:35
    |
 LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    |                                   ^^^
@@ -199,7 +219,7 @@ LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:100:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:110:27
    |
 LL |         let x: Pin<&_> = &pin const Foo;
    |                           ^^^
@@ -209,7 +229,7 @@ LL |         let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:107:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:117:10
    |
 LL |         &pin mut x: &pin mut i32,
    |          ^^^
@@ -219,7 +239,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:107:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:117:22
    |
 LL |         &pin mut x: &pin mut i32,
    |                      ^^^
@@ -229,7 +249,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:110:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:120:10
    |
 LL |         &pin const y: &'a pin const i32,
    |          ^^^
@@ -239,7 +259,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:110:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:120:27
    |
 LL |         &pin const y: &'a pin const i32,
    |                           ^^^
@@ -249,7 +269,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:113:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:123:13
    |
 LL |         ref pin mut z: i32,
    |             ^^^
@@ -259,7 +279,7 @@ LL |         ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:114:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:124:13
    |
 LL |         ref pin const w: i32,
    |             ^^^
@@ -278,8 +298,26 @@ LL | #[pin_v2]
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: use of unstable library feature `pin_ergonomics`
+  --> $DIR/feature-gate-pin_ergonomics.rs:16:5
+   |
+LL |     fn pin_drop(&pin mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/feature-gate-pin_ergonomics.rs:14:1
+   |
+LL | impl Drop for Foo {
+   | ^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:28:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:34:9
    |
 LL | fn bar(x: Pin<&mut Foo>) {
    |        - move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -289,7 +327,7 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:14:15
+  --> $DIR/feature-gate-pin_ergonomics.rs:20:15
    |
 LL | fn foo(mut x: Pin<&mut Foo>) {
    |    ---        ^^^^^^^^^^^^^ this parameter takes ownership of the value
@@ -297,7 +335,7 @@ LL | fn foo(mut x: Pin<&mut Foo>) {
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:33:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:39:5
    |
 LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -316,7 +354,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 30 previous errors
+error: aborting due to 34 previous errors
 
-Some errors have detailed explanations: E0382, E0658.
-For more information about an error, try `rustc --explain E0382`.
+Some errors have detailed explanations: E0046, E0382, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/pin-ergonomics/pinned-drop-check.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.rs
@@ -1,0 +1,127 @@
+//@ edition:2024
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+// This test ensures that at least and at most one of `drop` and `pin_drop`
+// are implemented for types that implement `Drop`.
+
+mod drop_only {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&mut self) {} // ok, only `drop` is implemented
+    }
+
+    impl Drop for Bar {
+        fn drop(&mut self) {} //~ ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod pin_drop_only {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn pin_drop(&pin mut self) {} // ok, only `pin_drop` is implemented
+    }
+
+    impl Drop for Bar {
+        fn pin_drop(&pin mut self) {} // ok, non-`#[pin_v2]` can also implement `pin_drop`
+    }
+}
+
+mod both {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        //~^ ERROR conflicting implementations of `Drop::drop` and `Drop::pin_drop`
+        fn drop(&mut self) {}
+        fn pin_drop(&pin mut self) {}
+    }
+
+    impl Drop for Bar {
+        //~^ ERROR conflicting implementations of `Drop::drop` and `Drop::pin_drop`
+        fn drop(&mut self) {}
+        fn pin_drop(&pin mut self) {}
+    }
+}
+
+mod neither {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {} //~ ERROR not all trait items implemented, missing one of: `drop`, `pin_drop` [E0046]
+    impl Drop for Bar {} //~ ERROR not all trait items implemented, missing one of: `drop`, `pin_drop` [E0046]
+}
+
+mod drop_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&pin mut self) {} //~ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+    impl Drop for Bar {
+        fn drop(&pin mut self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+        //~| ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod pin_drop_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn pin_drop(&mut self) {} //~ ERROR method `pin_drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn pin_drop(&mut self) {} //~ ERROR method `pin_drop` has an incompatible type for trait [E0053]
+    }
+}
+
+mod explicit_call_pin_drop {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            Drop::pin_drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+    impl Drop for Bar {
+        fn drop(&mut self) {
+            //~^ ERROR `Bar` must implement `pin_drop`
+            Drop::pin_drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+}
+
+mod explicit_call_drop {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn pin_drop(&pin mut self) {
+            Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+    impl Drop for Bar {
+        fn pin_drop(&pin mut self) {
+            Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pinned-drop-check.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.stderr
@@ -1,0 +1,183 @@
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:18:9
+   |
+LL |         fn drop(&mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:10:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop(&mut self) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error: conflicting implementations of `Drop::drop` and `Drop::pin_drop`
+  --> $DIR/pinned-drop-check.rs:41:5
+   |
+LL |     impl Drop for Foo {
+   |     ^^^^^^^^^^^^^^^^^
+LL |
+LL |         fn drop(&mut self) {}
+   |         ------------------ `drop(&mut self)` implemented here
+LL |         fn pin_drop(&pin mut self) {}
+   |         -------------------------- `pin_drop(&pin mut self)` implemented here
+
+error: conflicting implementations of `Drop::drop` and `Drop::pin_drop`
+  --> $DIR/pinned-drop-check.rs:47:5
+   |
+LL |     impl Drop for Bar {
+   |     ^^^^^^^^^^^^^^^^^
+LL |
+LL |         fn drop(&mut self) {}
+   |         ------------------ `drop(&mut self)` implemented here
+LL |         fn pin_drop(&pin mut self) {}
+   |         -------------------------- `pin_drop(&pin mut self)` implemented here
+
+error[E0046]: not all trait items implemented, missing one of: `drop`, `pin_drop`
+  --> $DIR/pinned-drop-check.rs:59:5
+   |
+LL |     impl Drop for Foo {}
+   |     ^^^^^^^^^^^^^^^^^ missing one of `drop`, `pin_drop` in implementation
+
+error[E0046]: not all trait items implemented, missing one of: `drop`, `pin_drop`
+  --> $DIR/pinned-drop-check.rs:60:5
+   |
+LL |     impl Drop for Bar {}
+   |     ^^^^^^^^^^^^^^^^^ missing one of `drop`, `pin_drop` in implementation
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:72:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:65:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL |         fn pin_drop(&pin mut self) {}
+   |            ++++
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:69:17
+   |
+LL |         fn drop(&pin mut self) {}
+   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Foo`, found `Pin<&mut drop_wrong_type::Foo>`
+   |
+   = note: expected signature `fn(&mut drop_wrong_type::Foo)`
+              found signature `fn(Pin<&mut drop_wrong_type::Foo>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(&pin mut self) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:72:17
+   |
+LL |         fn drop(&pin mut self) {}
+   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Bar`, found `Pin<&mut drop_wrong_type::Bar>`
+   |
+   = note: expected signature `fn(&mut drop_wrong_type::Bar)`
+              found signature `fn(Pin<&mut drop_wrong_type::Bar>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(&pin mut self) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error[E0053]: method `pin_drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:84:21
+   |
+LL |         fn pin_drop(&mut self) {}
+   |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Foo>`, found `&mut pin_drop_wrong_type::Foo`
+   |
+   = note: expected signature `fn(Pin<&mut pin_drop_wrong_type::Foo>)`
+              found signature `fn(&mut pin_drop_wrong_type::Foo)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn pin_drop(&mut self) {}
+LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Foo>) {}
+   |
+
+error[E0053]: method `pin_drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:88:21
+   |
+LL |         fn pin_drop(&mut self) {}
+   |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Bar>`, found `&mut pin_drop_wrong_type::Bar`
+   |
+   = note: expected signature `fn(Pin<&mut pin_drop_wrong_type::Bar>)`
+              found signature `fn(&mut pin_drop_wrong_type::Bar)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn pin_drop(&mut self) {}
+LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Bar>) {}
+   |
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:103:9
+   |
+LL |         fn drop(&mut self) {
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:94:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop(&mut self) {
+LL +         fn pin_drop(&pin mut self) {
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:99:13
+   |
+LL |             Drop::pin_drop(todo!());
+   |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
+
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:105:13
+   |
+LL |             Drop::pin_drop(todo!());
+   |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
+
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:117:13
+   |
+LL |             Drop::drop(todo!());
+   |             ^^^^^^^^^^ explicit destructor calls not allowed
+
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:122:13
+   |
+LL |             Drop::drop(todo!());
+   |             ^^^^^^^^^^ explicit destructor calls not allowed
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0040, E0046, E0053.
+For more information about an error, try `rustc --explain E0040`.

--- a/tests/ui/pin-ergonomics/pinned-drop-unsafety-check.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-unsafety-check.rs
@@ -1,0 +1,88 @@
+#![no_std]
+#![no_core]
+#![feature(no_core, pin_ergonomics, lang_items)]
+#![allow(incomplete_features)]
+
+// This checks that calling `Drop::pin_drop` and `Drop::drop` explicitly is unsafe
+// and requires unsafe block.
+// Note that this tiny-`core` library ignores `Unpin` related stuffs as we don't care about that,
+// and thus the `Pin` type is just simply a wrapper around a pointer.
+
+#[lang = "drop"]
+trait Drop {
+    fn drop(&mut self) {
+        Self::pin_drop(Pin { pointer: self });
+        //~^ ERROR call `Drop::pin_drop` explicitly is unsafe and requires unsafe block
+        unsafe { Self::pin_drop(Pin { pointer: self }) }; // ok
+    }
+
+    fn pin_drop(self: Pin<&mut Self>) {
+        Self::drop(self.pointer);
+        //~^ ERROR call `Drop::drop` explicitly is unsafe and requires unsafe block
+        unsafe { Self::drop(self.pointer) }; // ok
+    }
+}
+
+#[lang = "pin"]
+// This is a dummy `Pin` type that is just simply a wrapper around a pointer.
+struct Pin<T> {
+    pointer: T,
+}
+
+#[lang = "deref"]
+trait Deref: PointeeSized {
+    #[lang = "deref_target"]
+    type Target: PointeeSized;
+
+    fn deref(&self) -> &Self::Target;
+}
+
+#[lang = "deref_mut"]
+trait DerefMut: Deref + PointeeSized {
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+impl<Ptr: Deref> Deref for Pin<Ptr> {
+    type Target = Ptr::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.pointer
+    }
+}
+
+// skip the `Unpin` check, as this test doesn't care about that.
+impl<Ptr: DerefMut> DerefMut for Pin<Ptr> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.pointer
+    }
+}
+
+impl<T: PointeeSized> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "sized"]
+trait Sized: MetaSized {}
+
+#[lang = "meta_sized"]
+trait MetaSized: PointeeSized {}
+
+#[lang = "pointee_sized"]
+trait PointeeSized {}
+
+#[lang = "legacy_receiver"]
+trait LegacyReceiver: PointeeSized {}
+
+impl<T: PointeeSized> LegacyReceiver for &T {}
+impl<T: PointeeSized> LegacyReceiver for &mut T {}
+impl<Ptr: LegacyReceiver> LegacyReceiver for Pin<Ptr> {}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pinned-drop-unsafety-check.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-unsafety-check.stderr
@@ -1,0 +1,15 @@
+error[E0133]: call `Drop::pin_drop` explicitly is unsafe and requires unsafe block
+  --> $DIR/pinned-drop-unsafety-check.rs:14:9
+   |
+LL |         Self::pin_drop(Pin { pointer: self });
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0133]: call `Drop::drop` explicitly is unsafe and requires unsafe block
+  --> $DIR/pinned-drop-unsafety-check.rs:20:9
+   |
+LL |         Self::drop(self.pointer);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/pin-ergonomics/pinned-drop.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop.rs
@@ -1,0 +1,52 @@
+//@ run-pass
+//@ edition:2024
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, Waker};
+
+#[pin_v2]
+struct Foo {
+    dropped: Arc<AtomicBool>,
+}
+
+impl Foo {
+    fn new(dropped: Arc<AtomicBool>) -> Self {
+        Self { dropped }
+    }
+}
+
+impl Drop for Foo {
+    fn pin_drop(self: Pin<&mut Self>) {
+        self.dropped.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Future for Foo {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(())
+    }
+}
+
+fn block_on<T, F: Future<Output = T>>(mut f: F) -> T {
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+
+    let f = &pin mut f;
+    loop {
+        if let Poll::Ready(ret) = f.poll(&mut cx) {
+            break ret;
+        }
+    }
+}
+
+fn main() {
+    let dropped = Arc::new(AtomicBool::new(false));
+    block_on(Foo::new(dropped.clone()));
+    assert!(dropped.load(Ordering::Relaxed));
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144537)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR is part of the `pin_ergonomics` experiment (the tracking issue is rust-lang/rust#130494). It allows implementing `Drop` with a pinned `self` receiver, which is required for safe pin-projection.

Implementations:
- [x] At least and at most one of `drop` and `pin_drop` should be implemented.
- [x] No direct call of `drop` or `pin_drop`. They should only be called by the drop glue.
- [x] `pin_drop` must and must only be used with types that support pin-projection (i.e. types with `#[pin_v2]`).
- [ ] Allows writing `fn drop(&pin mut self)` and desugars to `fn pin_drop(&pin mut self)`. (Will be in the next PRs)