### PR TITLE
coverage: Treat `#[automatically_derived]` as `#[coverage(off)]`

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -110,18 +110,10 @@ pub enum DeprecatedSince {
     Err,
 }
 
-#[derive(
-    Copy,
-    Debug,
-    Eq,
-    PartialEq,
-    Encodable,
-    Decodable,
-    Clone,
-    HashStable_Generic,
-    PrintAttribute
-)]
-pub enum CoverageStatus {
+/// Successfully-parsed value of a `#[coverage(..)]` attribute.
+#[derive(Copy, Debug, Eq, PartialEq, Encodable, Decodable, Clone)]
+#[derive(HashStable_Generic, PrintAttribute)]
+pub enum CoverageAttrKind {
     On,
     Off,
 }
@@ -304,8 +296,8 @@ pub enum AttributeKind {
     /// Represents `#[const_trait]`.
     ConstTrait(Span),
 
-    /// Represents `#[coverage]`.
-    Coverage(Span, CoverageStatus),
+    /// Represents `#[coverage(..)]`.
+    Coverage(Span, CoverageAttrKind),
 
     ///Represents `#[rustc_deny_explicit_impl]`.
     DenyExplicitImpl(Span),

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,4 +1,4 @@
-use rustc_attr_data_structures::{AttributeKind, CoverageStatus, OptimizeAttr, UsedBy};
+use rustc_attr_data_structures::{AttributeKind, CoverageAttrKind, OptimizeAttr, UsedBy};
 use rustc_feature::{AttributeTemplate, template};
 use rustc_session::parse::feature_err;
 use rustc_span::{Span, Symbol, sym};
@@ -78,16 +78,16 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
             return None;
         };
 
-        let status = match arg.path().word_sym() {
-            Some(sym::off) => CoverageStatus::Off,
-            Some(sym::on) => CoverageStatus::On,
+        let kind = match arg.path().word_sym() {
+            Some(sym::off) => CoverageAttrKind::Off,
+            Some(sym::on) => CoverageAttrKind::On,
             None | Some(_) => {
                 fail_incorrect_argument(arg.span());
                 return None;
             }
         };
 
-        Some(AttributeKind::Coverage(cx.attr_span, status))
+        Some(AttributeKind::Coverage(cx.attr_span, kind))
     }
 }
 

--- a/tests/coverage/auto-derived.auto.cov-map
+++ b/tests/coverage/auto-derived.auto.cov-map
@@ -1,0 +1,47 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.auto.cov-map
+++ b/tests/coverage/auto-derived.auto.cov-map
@@ -1,15 +1,3 @@
-Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
-Number of files: 1
-- file 0 => $DIR/auto-derived.rs
-Number of expressions: 0
-Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
-- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
-- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
-- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
-Highest counter ID seen: c0
-
 Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
 Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
 Number of files: 1
@@ -19,18 +7,6 @@ Number of file 0 mappings: 4
 - Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
 - Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
 - Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
-Highest counter ID seen: c0
-
-Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
-Number of files: 1
-- file 0 => $DIR/auto-derived.rs
-Number of expressions: 0
-Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
-- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
-- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
 - Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
 Highest counter ID seen: c0
 

--- a/tests/coverage/auto-derived.auto.coverage
+++ b/tests/coverage/auto-derived.auto.coverage
@@ -23,18 +23,18 @@
    LL|       |#[cfg_attr(on, coverage(on))]
    LL|       |impl MyTrait for MyStruct {
    LL|       |    fn my_assoc_fn() {
-   LL|      1|        fn inner_fn() {
-   LL|      1|            say("in inner fn");
-   LL|      1|        }
+   LL|       |        fn inner_fn() {
+   LL|       |            say("in inner fn");
+   LL|       |        }
    LL|       |
    LL|       |        #[coverage(on)]
    LL|      1|        fn inner_fn_on() {
    LL|      1|            say("in inner fn (on)");
    LL|      1|        }
    LL|       |
-   LL|      1|        let closure = || {
-   LL|      1|            say("in closure");
-   LL|      1|        };
+   LL|       |        let closure = || {
+   LL|       |            say("in closure");
+   LL|       |        };
    LL|       |
    LL|       |        closure();
    LL|       |        inner_fn();

--- a/tests/coverage/auto-derived.auto.coverage
+++ b/tests/coverage/auto-derived.auto.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|       |    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|       |        closure();
+   LL|       |        inner_fn();
+   LL|       |        inner_fn_on();
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.base.cov-map
+++ b/tests/coverage/auto-derived.base.cov-map
@@ -1,0 +1,61 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn
+Raw bytes (34): 0x[01, 01, 00, 06, 01, 19, 05, 00, 15, 01, 0a, 0d, 00, 14, 01, 04, 09, 00, 12, 01, 01, 09, 00, 11, 01, 01, 09, 00, 14, 01, 01, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 5) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 10, 13) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 4, 9) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 17)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.base.coverage
+++ b/tests/coverage/auto-derived.base.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|      1|    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|      1|        closure();
+   LL|      1|        inner_fn();
+   LL|      1|        inner_fn_on();
+   LL|      1|    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.on.cov-map
+++ b/tests/coverage/auto-derived.on.cov-map
@@ -1,3 +1,17 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn
+Raw bytes (34): 0x[01, 01, 00, 06, 01, 19, 05, 00, 15, 01, 0a, 0d, 00, 14, 01, 04, 09, 00, 12, 01, 01, 09, 00, 11, 01, 01, 09, 00, 14, 01, 01, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 5) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 10, 13) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 4, 9) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 17)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
+Highest counter ID seen: c0
+
 Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
 Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
 Number of files: 1

--- a/tests/coverage/auto-derived.on.cov-map
+++ b/tests/coverage/auto-derived.on.cov-map
@@ -1,0 +1,47 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.on.coverage
+++ b/tests/coverage/auto-derived.on.coverage
@@ -22,7 +22,7 @@
    LL|       |#[cfg_attr(on, automatically_derived)]
    LL|       |#[cfg_attr(on, coverage(on))]
    LL|       |impl MyTrait for MyStruct {
-   LL|       |    fn my_assoc_fn() {
+   LL|      1|    fn my_assoc_fn() {
    LL|      1|        fn inner_fn() {
    LL|      1|            say("in inner fn");
    LL|      1|        }
@@ -36,10 +36,10 @@
    LL|      1|            say("in closure");
    LL|      1|        };
    LL|       |
-   LL|       |        closure();
-   LL|       |        inner_fn();
-   LL|       |        inner_fn_on();
-   LL|       |    }
+   LL|      1|        closure();
+   LL|      1|        inner_fn();
+   LL|      1|        inner_fn_on();
+   LL|      1|    }
    LL|       |}
    LL|       |
    LL|       |#[coverage(off)]

--- a/tests/coverage/auto-derived.on.coverage
+++ b/tests/coverage/auto-derived.on.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|       |    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|       |        closure();
+   LL|       |        inner_fn();
+   LL|       |        inner_fn_on();
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.rs
+++ b/tests/coverage/auto-derived.rs
@@ -1,0 +1,53 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+//@ revisions: base auto on
+
+// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+//
+// The actual behaviour is an implementation detail, so this test mostly exists
+// to show when that behaviour has been accidentally or deliberately changed.
+//
+// Revision guide:
+// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+// - auto: Test how `#[automatically_derived]` affects instrumentation
+// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+
+struct MyStruct;
+
+trait MyTrait {
+    fn my_assoc_fn();
+}
+
+#[cfg_attr(auto, automatically_derived)]
+#[cfg_attr(on, automatically_derived)]
+#[cfg_attr(on, coverage(on))]
+impl MyTrait for MyStruct {
+    fn my_assoc_fn() {
+        fn inner_fn() {
+            say("in inner fn");
+        }
+
+        #[coverage(on)]
+        fn inner_fn_on() {
+            say("in inner fn (on)");
+        }
+
+        let closure = || {
+            say("in closure");
+        };
+
+        closure();
+        inner_fn();
+        inner_fn_on();
+    }
+}
+
+#[coverage(off)]
+#[inline(never)]
+fn say(s: &str) {
+    println!("{s}");
+}
+
+fn main() {
+    MyStruct::my_assoc_fn();
+}


### PR DESCRIPTION
One of the contributing factors behind https://github.com/rust-lang/rust/issues/141577#issuecomment-3120667286 was the presence of derive-macro-generated code containing nested closures.

Coverage instrumentation already has a heuristic for skipping code marked with `#[automatically_derived]` (rust-lang/rust#120185), because derived code is usually not worth instrumenting, and also has a tendency to trigger vexing edge-case bugs in coverage instrumentation or coverage codegen.

However, the existing heuristic only applied to the associated items directly within an auto-derived impl block, and had no effect on closures or nested items within those associated items.

This PR therefore extends the search for `#[coverage(..)]` attributes to also treat `#[automatically_derived]` as an implied `#[coverage(off)]` for the purposes of coverage instrumentation.

---

This change doesn’t rule out an entire category of bugs, because it only affects code that actually uses the auto-derived attribute. But it should reduce the overall chance of edge-case macro span bugs being observed in the wild.