### PR TITLE
Consider `compiletest` a staged `ToolStd` tool

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -465,9 +465,6 @@
 # What custom diff tool to use for displaying compiletest tests.
 #build.compiletest-diff-tool = <none>
 
-# Whether to use the precompiled stage0 libtest with compiletest.
-#build.compiletest-use-stage0-libtest = true
-
 # Default value for the `--extra-checks` flag of tidy.
 #
 # See `./x test tidy --help` for details.

--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -462,6 +462,14 @@
 # passed to cargo invocations.
 #build.jobs = 0
 
+# Whether to force `compiletest` to be built and run against the stage 0
+# toolchain (i.e. stage 0 compiler and library).
+#
+# Both `compiletest`-managed test suites and `compiletest`'s own unit tests are
+# **not an explicitly supported configuration**, and almost certainly will incur
+# test failures against the stage 0 compiler and library.
+#build.compiletest-force-stage0 = false
+
 # What custom diff tool to use for displaying compiletest tests.
 #build.compiletest-diff-tool = <none>
 

--- a/src/bootstrap/defaults/bootstrap.dist.toml
+++ b/src/bootstrap/defaults/bootstrap.dist.toml
@@ -7,8 +7,6 @@ test-stage = 2
 doc-stage = 2
 # When compiling from source, you usually want all tools.
 extended = true
-# Use libtest built from the source tree instead of the precompiled one from stage 0.
-compiletest-use-stage0-libtest = false
 
 # Most users installing from source want to build all parts of the project from source.
 [llvm]

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -496,7 +496,7 @@ macro_rules! bootstrap_tool {
                     build_compiler: self.compiler,
                     target: self.target,
                     tool: $tool_name,
-                    mode: if is_unstable {
+                    mode: if is_unstable || !builder.config.compiletest_force_stage0 {
                         // use in-tree libraries for unstable features
                         Mode::ToolStd
                     } else {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -491,13 +491,12 @@ macro_rules! bootstrap_tool {
                 )*
 
                 let is_unstable = false $(|| $unstable)*;
-                let compiletest_wants_stage0 = $tool_name == "compiletest" && builder.config.compiletest_use_stage0_libtest;
 
                 builder.ensure(ToolBuild {
                     build_compiler: self.compiler,
                     target: self.target,
                     tool: $tool_name,
-                    mode: if is_unstable && !compiletest_wants_stage0 {
+                    mode: if is_unstable {
                         // use in-tree libraries for unstable features
                         Mode::ToolStd
                     } else {

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1531,22 +1531,32 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("check")
                 .path("compiletest")
-                .render_steps(), @"[check] rustc 0 <host> -> Compiletest 1 <host>");
-    }
-
-    #[test]
-    fn check_compiletest_stage1_libtest() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("check")
-                .path("compiletest")
-                .args(&["--set", "build.compiletest-use-stage0-libtest=false"])
                 .render_steps(), @r"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [check] rustc 1 <host> -> Compiletest 2 <host>
         ");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_compiletest_stage0_no_force() {
+        let ctx = TestCtx::new();
+        ctx.config("test").path("compiletest").stage(0).run();
+    }
+
+    #[test]
+    fn test_compiletest_force_stage0() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("test")
+                .path("compiletest")
+                .stage(0)
+                .args(&[
+                    "--set", "build.compiletest-force-stage0=true"
+                ])
+                .render_steps(), @"[build] rustdoc 0 <host>");
     }
 
     #[test]

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -296,8 +296,6 @@ pub struct Config {
     /// Command for visual diff display, e.g. `diff-tool --color=always`.
     pub compiletest_diff_tool: Option<String>,
 
-    /// Whether to use the precompiled stage0 libtest with compiletest.
-    pub compiletest_use_stage0_libtest: bool,
     /// Default value for `--extra-checks`
     pub tidy_extra_checks: Option<String>,
     pub is_running_on_ci: bool,
@@ -747,7 +745,6 @@ impl Config {
             optimized_compiler_builtins,
             jobs,
             compiletest_diff_tool,
-            compiletest_use_stage0_libtest,
             tidy_extra_checks,
             ccache,
             exclude,
@@ -1013,7 +1010,6 @@ impl Config {
         config.optimized_compiler_builtins =
             optimized_compiler_builtins.unwrap_or(config.channel != "dev");
         config.compiletest_diff_tool = compiletest_diff_tool;
-        config.compiletest_use_stage0_libtest = compiletest_use_stage0_libtest.unwrap_or(true);
         config.tidy_extra_checks = tidy_extra_checks;
 
         let download_rustc = config.download_rustc_commit.is_some();

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -293,6 +293,10 @@ pub struct Config {
     /// `paths=["foo", "bar"]`.
     pub paths: Vec<PathBuf>,
 
+    /// Force `compiletest` to be built and tested with stage 0 (compiler, library). Note that
+    /// `compiletest`'s own unit tests are not guaranteed to pass against stage 0 (compiler,
+    /// library)!
+    pub compiletest_force_stage0: bool,
     /// Command for visual diff display, e.g. `diff-tool --color=always`.
     pub compiletest_diff_tool: Option<String>,
 
@@ -744,6 +748,7 @@ impl Config {
             android_ndk,
             optimized_compiler_builtins,
             jobs,
+            compiletest_force_stage0,
             compiletest_diff_tool,
             tidy_extra_checks,
             ccache,
@@ -1009,7 +1014,10 @@ impl Config {
 
         config.optimized_compiler_builtins =
             optimized_compiler_builtins.unwrap_or(config.channel != "dev");
+
+        config.compiletest_force_stage0 = compiletest_force_stage0.unwrap_or(false);
         config.compiletest_diff_tool = compiletest_diff_tool;
+
         config.tidy_extra_checks = tidy_extra_checks;
 
         let download_rustc = config.download_rustc_commit.is_some();

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -67,6 +67,7 @@ define_config! {
         android_ndk: Option<PathBuf> = "android-ndk",
         optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
         jobs: Option<u32> = "jobs",
+        compiletest_force_stage0: Option<bool> = "compiletest-force-stage0",
         compiletest_diff_tool: Option<String> = "compiletest-diff-tool",
         tidy_extra_checks: Option<String> = "tidy-extra-checks",
         ccache: Option<StringOrBool> = "ccache",

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -68,7 +68,6 @@ define_config! {
         optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
         jobs: Option<u32> = "jobs",
         compiletest_diff_tool: Option<String> = "compiletest-diff-tool",
-        compiletest_use_stage0_libtest: Option<bool> = "compiletest-use-stage0-libtest",
         tidy_extra_checks: Option<String> = "tidy-extra-checks",
         ccache: Option<StringOrBool> = "ccache",
         exclude: Option<Vec<PathBuf>> = "exclude",

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -486,4 +486,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Removed `rust.description` and `llvm.ccache` as it was deprecated in #137723 and #136941 long time ago.",
     },
+    ChangeInfo {
+        change_id: 144563,
+        severity: ChangeSeverity::Warning,
+        summary: "Removed `build.compiletest-use-stage0-libtest` as `compiletest` is now considered a staged `ToolStd` tool. The possibility to run `compiletest`-managed test suites or `compiletest` unit tests against a stage 0 compiler is retained, but instead of `COMPILETEST_FORCE_STAGE0` env var, it is now a proper config option `build.compiletest-force-stage0`.",
+    },
 ];

--- a/src/ci/citool/tests/test-jobs.yml
+++ b/src/ci/citool/tests/test-jobs.yml
@@ -27,7 +27,7 @@ runners:
     <<: *base-job
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests
-    SCRIPT: ./x.py check compiletest --set build.compiletest-use-stage0-libtest=true && ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc -- --exact
+    SCRIPT: ./x.py check compiletest && ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc -- --exact
     RUST_CONFIGURE_ARGS: --build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc
     RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
     # Ensure that host tooling is tested on our minimum supported macOS version.

--- a/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-1/Dockerfile
@@ -43,10 +43,9 @@ ENV SCRIPT \
   python3 ../x.py check bootstrap && \
   /scripts/check-default-config-profiles.sh && \
   python3 ../x.py build src/tools/build-manifest && \
-  python3 ../x.py test --stage 0 src/tools/compiletest && \
-  python3 ../x.py check compiletest --set build.compiletest-use-stage0-libtest=true && \
   python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
   python3 ../x.py check --set build.optimized-compiler-builtins=false core alloc std --target=aarch64-unknown-linux-gnu,i686-pc-windows-msvc,i686-unknown-linux-gnu,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-pc-windows-msvc && \
   /scripts/validate-toolstate.sh && \
   reuse --include-submodules lint && \
-  python3 ../x.py test collect-license-metadata
+  python3 ../x.py test collect-license-metadata && \
+  python3 ../x.py test src/tools/compiletest

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -90,5 +90,5 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 COPY scripts/shared.sh /scripts/
 
 ENV SCRIPT /tmp/checktools.sh ../x.py && \
-  python3 ../x.py check compiletest --set build.compiletest-use-stage0-libtest=true && \
+  python3 ../x.py check compiletest && \
   python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--jobs 1'"

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -78,7 +78,7 @@ runners:
 
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests
-    SCRIPT: ./x.py check compiletest --set build.compiletest-use-stage0-libtest=true && ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc -- --exact
+    SCRIPT: ./x.py check compiletest && ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc -- --exact
     RUST_CONFIGURE_ARGS: --build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc
     # Ensure that host tooling is tested on our minimum supported macOS version.
     MACOSX_DEPLOYMENT_TARGET: 10.12


### PR DESCRIPTION
Before this PR (i.e. currently), `compiletest` was in a weird state where it exhibits behavior of both `ToolBootstrap` tools and `ToolStd` tools ~~until you observe it~~. At the time, this is because `compiletest` depended on libtest, but we felt like it was nice to support "faster" checks for `compiletest` by allowing it to be built with and thus test against stage 0 libtest. However, this scheme turns out problematic. `compiletest`, even after removing dependencing on libtest via the new executor, very much depends on unstable features of both $\left\langle \text{compiler}, \text{library} \right\rangle$:

- `#![feature(internal_output_capture)]` of $\text{library}$.
- Target spec JSONs and output of print requests of $\text{compiler}$.

And this influences the unit tests of `compiletest` itself. Thus, `compiletest` is very much a staged tool (host-only).

This PR tries to reconcile this situation by being faithful to `compiletest`'s nature: that `compiletest` in its current formulation is very much a staged tool. It's possible for `compiletest` to be a bootstrap tool and testable with the stage 0 $\left\langle \text{compiler}, \text{library} \right\rangle$, if we can manage to:

1. Drop `compiletest`'s dependency on `#![feature(internal_output_capture)]` library feature, and
2. Devise an alternative mechanism to sync built-in target specification between `compiletest` and the compiler that is properly synchronized.

### Commits

- Commit 1: Yanks the `build.compiletest-use-stage0-libtest` config, this was no longer relevant after we removed the dependency on libtest entirely.
- Commit 2: Adjust CI jobs to not try to use `build.compiletest-use-stage0-libtest` or `./x test compiletest --stage=0`. For `pr-check-1` specifically, I moved `./x test compiletest` to the last, because this will necessarily require building $\left\langle \text{compiler}\_{1}, \text{library}\_{1} \right\rangle$ to check `compiletest`. Unfortunately, this does mean we lose the ability to "fast-reject". However, I argue that the old "fast-reject" was actually wrong -- that meant testing `compiletest`'s own unit tests was against $\text{compiler}\_{0}$, which is suspect as e.g. target spec can change between $\text{compiler}\_{0}$ and $\text{compiler}\_{1}$, as PRs (like rust-lang/rust#144443) modifying target spec will need to do.
- Commit 3: Instead of the ad-hoc `COMPILETEST_FORCE_STAGE0` env var previously that did not go through bootstrap's config handling at all, this PR adds a first-class `build.compiletest-force-stage0` option to preserve the ability to run `compiletest`-managed test suites and `compiletest`'s own unit tests against a provided $\text{compiler}\_{0}$. This is used by e.g. cg\_clif. Previously, the incantation would be `COMPILETEST_FORCE_STAGE0=1 ./x test run-make --stage=0`, but with this PR, it will be `./x test run-make --stage=0 --set build.compiletest-force-stage0=true`. In any case, running both `compiletest`-managed test suites (e.g. `tests/run-make`) or `compiletest`'s own unit/self tests against $\text{compiler}\_{0}$ is **not an explicitly supported configuration**, and so **must not be exercised in `rust-lang/rust` CI**.
- Commit 4: Introduces a change tracker entry for the above changes.

This should unblock rust-lang/rust#144443.

