### PR TITLE
Fix RISC-V Test Failures in ./x test for Multiple Codegen Cases

### DIFF
--- a/tests/codegen-llvm/enum/enum-aggregate.rs
+++ b/tests/codegen-llvm/enum/enum-aggregate.rs
@@ -27,7 +27,7 @@ fn make_none_bool() -> Option<bool> {
 
 #[no_mangle]
 fn make_some_ordering(x: Ordering) -> Option<Ordering> {
-    // CHECK-LABEL: i8 @make_some_ordering(i8 %x)
+    // CHECK-LABEL: i8 @make_some_ordering(i8{{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i8 %x
     Some(x)
@@ -35,7 +35,7 @@ fn make_some_ordering(x: Ordering) -> Option<Ordering> {
 
 #[no_mangle]
 fn make_some_u16(x: u16) -> Option<u16> {
-    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16 %x)
+    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16{{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: %0 = insertvalue { i16, i16 } { i16 1, i16 poison }, i16 %x, 1
     // CHECK-NEXT: ret { i16, i16 } %0
@@ -52,7 +52,7 @@ fn make_none_u16() -> Option<u16> {
 
 #[no_mangle]
 fn make_some_nzu32(x: NonZero<u32>) -> Option<NonZero<u32>> {
-    // CHECK-LABEL: i32 @make_some_nzu32(i32 %x)
+    // CHECK-LABEL: i32 @make_some_nzu32(i32{{.*}}%x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i32 %x
     Some(x)
@@ -114,7 +114,7 @@ fn make_uninhabited_err_indirectly(n: Never) -> Result<u32, Never> {
 fn make_fully_uninhabited_result(v: u32, n: Never) -> Result<(u32, Never), (Never, u32)> {
     // Actually reaching this would be UB, so we don't actually build a result.
 
-    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32 %v)
+    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32{{.*}}%v)
     // CHECK-NEXT: start:
     // CHECK-NEXT: call void @llvm.trap()
     // CHECK-NEXT: call void @llvm.trap()

--- a/tests/codegen-llvm/enum/enum-match.rs
+++ b/tests/codegen-llvm/enum/enum-match.rs
@@ -739,7 +739,7 @@ pub enum Tricky {
 
 const _: () = assert!(std::intrinsics::discriminant_value(&Tricky::V100) == 100);
 
-// CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef %e)
+// CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef{{.*}}%e)
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %e, -66
 // CHECK-NEXT: %[[IS_NICHE:.+]] = icmp ult i8 %[[REL_VAR]], -56

--- a/tests/codegen-llvm/enum/enum-transparent-extract.rs
+++ b/tests/codegen-llvm/enum/enum-transparent-extract.rs
@@ -9,7 +9,7 @@ pub enum Never {}
 
 #[no_mangle]
 pub fn make_unmake_result_never(x: i32) -> i32 {
-    // CHECK-LABEL: define i32 @make_unmake_result_never(i32 %x)
+    // CHECK-LABEL: define i32 @make_unmake_result_never(i32{{.*}}%x)
     // CHECK: start:
     // CHECK-NEXT: ret i32 %x
 

--- a/tests/codegen-llvm/repeat-operand-zero-len.rs
+++ b/tests/codegen-llvm/repeat-operand-zero-len.rs
@@ -11,7 +11,7 @@
 #[repr(transparent)]
 pub struct Wrapper<T, const N: usize>([T; N]);
 
-// CHECK-LABEL: define {{.+}}do_repeat{{.+}}(i32 noundef %x)
+// CHECK-LABEL: define {{.+}}do_repeat{{.+}}(i32 noundef{{.*}}%x)
 // CHECK-NEXT: start:
 // CHECK-NOT: alloca
 // CHECK-NEXT: ret void
@@ -23,6 +23,6 @@ pub fn do_repeat<T: Copy, const N: usize>(x: T) -> Wrapper<T, N> {
 // CHECK-LABEL: @trigger_repeat_zero_len
 #[no_mangle]
 pub fn trigger_repeat_zero_len() -> Wrapper<u32, 0> {
-    // CHECK: call void {{.+}}do_repeat{{.+}}(i32 noundef 4)
+    // CHECK: call void {{.+}}do_repeat{{.+}}(i32 noundef{{.*}}4)
     do_repeat(4)
 }

--- a/tests/codegen-llvm/uninhabited-transparent-return-abi.rs
+++ b/tests/codegen-llvm/uninhabited-transparent-return-abi.rs
@@ -36,7 +36,7 @@ pub fn test_uninhabited_ret_by_ref() {
 pub fn test_uninhabited_ret_by_ref_with_arg(rsi: u32) {
     // CHECK: %_2 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_2)
-    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef %rsi) #2
+    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef{{.*}}%rsi) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque_with_arg(rsi);


### PR DESCRIPTION
This PR addresses and resolves several test failures that occurred when running `./x test` on the RISC-V architecture. The issues were due to platform-specific behavior, ABI differences, or code generation inconsistencies specific to RISC-V.

The following tests have been fixed:

- `codegen-llvm/enum/enum-match.rs`
- `codegen-llvm/enum/enum-transparent-extract.rs`
- `codegen-llvm/repeat-operand-zero-len.rs`
- `codegen-llvm/enum/enum-aggregate.rs`
- `codegen-llvm/uninhabited-transparent-return-abi.rs`

All changes have been tested locally with `./x test` on a RISC-V target and now pass as expected.

### Notes:
- These fixes are scoped specifically to enable full test suite compliance for RISC-V targets.
- No changes were made that affect other architectures.