### PR TITLE
Fix RISC-V Test Failures in ./x test for Multiple Codegen Cases

### DIFF
--- a/tests/codegen-llvm/enum/enum-aggregate.rs
+++ b/tests/codegen-llvm/enum/enum-aggregate.rs
@@ -27,7 +27,7 @@ fn make_none_bool() -> Option<bool> {
 
 #[no_mangle]
 fn make_some_ordering(x: Ordering) -> Option<Ordering> {
-    // CHECK-LABEL: i8 @make_some_ordering(i8 %x)
+    // CHECK-LABEL: i8 @make_some_ordering(i8{{( signext)?}} %x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i8 %x
     Some(x)
@@ -35,7 +35,7 @@ fn make_some_ordering(x: Ordering) -> Option<Ordering> {
 
 #[no_mangle]
 fn make_some_u16(x: u16) -> Option<u16> {
-    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16 %x)
+    // CHECK-LABEL: { i16, i16 } @make_some_u16(i16{{( zeroext)?}} %x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: %0 = insertvalue { i16, i16 } { i16 1, i16 poison }, i16 %x, 1
     // CHECK-NEXT: ret { i16, i16 } %0
@@ -52,7 +52,7 @@ fn make_none_u16() -> Option<u16> {
 
 #[no_mangle]
 fn make_some_nzu32(x: NonZero<u32>) -> Option<NonZero<u32>> {
-    // CHECK-LABEL: i32 @make_some_nzu32(i32 %x)
+    // CHECK-LABEL: i32 @make_some_nzu32(i32{{( signext)?}} %x)
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret i32 %x
     Some(x)
@@ -114,7 +114,7 @@ fn make_uninhabited_err_indirectly(n: Never) -> Result<u32, Never> {
 fn make_fully_uninhabited_result(v: u32, n: Never) -> Result<(u32, Never), (Never, u32)> {
     // Actually reaching this would be UB, so we don't actually build a result.
 
-    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32 %v)
+    // CHECK-LABEL: { i32, i32 } @make_fully_uninhabited_result(i32{{( signext)?}} %v)
     // CHECK-NEXT: start:
     // CHECK-NEXT: call void @llvm.trap()
     // CHECK-NEXT: call void @llvm.trap()

--- a/tests/codegen-llvm/enum/enum-match.rs
+++ b/tests/codegen-llvm/enum/enum-match.rs
@@ -739,7 +739,7 @@ pub enum Tricky {
 
 const _: () = assert!(std::intrinsics::discriminant_value(&Tricky::V100) == 100);
 
-// CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef %e)
+// CHECK-LABEL: define noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @discriminant6(i8 noundef{{( zeroext)?}} %e)
 // CHECK-NEXT: start:
 // CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %e, -66
 // CHECK-NEXT: %[[IS_NICHE:.+]] = icmp ult i8 %[[REL_VAR]], -56

--- a/tests/codegen-llvm/enum/enum-transparent-extract.rs
+++ b/tests/codegen-llvm/enum/enum-transparent-extract.rs
@@ -9,7 +9,7 @@ pub enum Never {}
 
 #[no_mangle]
 pub fn make_unmake_result_never(x: i32) -> i32 {
-    // CHECK-LABEL: define i32 @make_unmake_result_never(i32 %x)
+    // CHECK-LABEL: define i32 @make_unmake_result_never(i32{{( signext)?}} %x)
     // CHECK: start:
     // CHECK-NEXT: ret i32 %x
 

--- a/tests/codegen-llvm/repeat-operand-zero-len.rs
+++ b/tests/codegen-llvm/repeat-operand-zero-len.rs
@@ -11,7 +11,7 @@
 #[repr(transparent)]
 pub struct Wrapper<T, const N: usize>([T; N]);
 
-// CHECK-LABEL: define {{.+}}do_repeat{{.+}}(i32 noundef %x)
+// CHECK-LABEL: define {{.+}}do_repeat{{.+}}(i32 noundef{{( signext)?}} %x)
 // CHECK-NEXT: start:
 // CHECK-NOT: alloca
 // CHECK-NEXT: ret void
@@ -23,6 +23,6 @@ pub fn do_repeat<T: Copy, const N: usize>(x: T) -> Wrapper<T, N> {
 // CHECK-LABEL: @trigger_repeat_zero_len
 #[no_mangle]
 pub fn trigger_repeat_zero_len() -> Wrapper<u32, 0> {
-    // CHECK: call void {{.+}}do_repeat{{.+}}(i32 noundef 4)
+    // CHECK: call void {{.+}}do_repeat{{.+}}(i32 noundef{{( signext)?}} 4)
     do_repeat(4)
 }

--- a/tests/codegen-llvm/transmute-scalar.rs
+++ b/tests/codegen-llvm/transmute-scalar.rs
@@ -1,8 +1,9 @@
 //@ add-core-stubs
-//@ compile-flags: -C opt-level=0 -C no-prepopulate-passes
+//@ compile-flags: -C opt-level=0 -C no-prepopulate-passes --target=x86_64-unknown-linux-gnu
+//@ needs-llvm-components: x86
 
 #![crate_type = "lib"]
-#![feature(no_core, repr_simd, arm_target_feature, mips_target_feature, s390x_target_feature)]
+#![feature(no_core, repr_simd)]
 #![no_core]
 extern crate minicore;
 
@@ -117,11 +118,7 @@ struct S([i64; 1]);
 // CHECK-NEXT: %[[TEMP:.+]] = load i64, ptr %[[RET]]
 // CHECK-NEXT: ret i64 %[[TEMP]]
 #[no_mangle]
-#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
-#[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
-#[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
 pub extern "C" fn single_element_simd_to_scalar(b: S) -> i64 {
     unsafe { mem::transmute(b) }
 }
@@ -133,11 +130,7 @@ pub extern "C" fn single_element_simd_to_scalar(b: S) -> i64 {
 // CHECK-NEXT: %[[TEMP:.+]] = load <1 x i64>, ptr %[[RET]]
 // CHECK-NEXT: ret <1 x i64> %[[TEMP]]
 #[no_mangle]
-#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
-#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
 #[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
-#[cfg_attr(target_arch = "mips", target_feature(enable = "msa"))]
-#[cfg_attr(target_arch = "s390x", target_feature(enable = "vector"))]
 pub extern "C" fn scalar_to_single_element_simd(b: i64) -> S {
     unsafe { mem::transmute(b) }
 }

--- a/tests/codegen-llvm/uninhabited-transparent-return-abi.rs
+++ b/tests/codegen-llvm/uninhabited-transparent-return-abi.rs
@@ -36,7 +36,7 @@ pub fn test_uninhabited_ret_by_ref() {
 pub fn test_uninhabited_ret_by_ref_with_arg(rsi: u32) {
     // CHECK: %_2 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0({{(i64 24, )?}}ptr nonnull %_2)
-    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef %rsi) #2
+    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef{{( signext)?}} %rsi) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque_with_arg(rsi);


### PR DESCRIPTION
This PR resolves several test failures encountered when running `./x test` on the RISC-V architecture. These failures were caused by platform-specific behavior, ABI differences, or codegen inconsistencies unique to RISC-V.

The following test cases have been fixed to ensure compatibility with RISC-V:

* `codegen-llvm/enum/enum-match.rs`
* `codegen-llvm/enum/enum-transparent-extract.rs`
* `codegen-llvm/repeat-operand-zero-len.rs`
* `codegen-llvm/enum/enum-aggregate.rs`
* `codegen-llvm/uninhabited-transparent-return-abi.rs`

In addition, this PR adjusts `tests/codegen-llvm/transmute-scalar.rs` to explicitly specify the target architecture:

```rust
//@ compile-flags: --target=x86_64-unknown-linux-gnu
//@ needs-llvm-components: x86
```

As suggested by @nikic, this test is not target-specific and already uses `minicore`, implying it is meant to run against a stable triple regardless of the host architecture. Explicitly setting the target ensures consistent codegen behavior, particularly when testing on non-x86 platforms such as riscv64.

All changes have been tested locally on a RISC-V target and now pass as expected.

### Notes:

* These fixes are scoped specifically to enable full test suite compliance for RISC-V.
* No changes impact other architectures.
* The change to `transmute-scalar.rs` aligns with the intent of [[#143915](https://github.com/rust-lang/rust/pull/143915)](https://github.com/rust-lang/rust/pull/143915) and prevents architecture-dependent discrepancies during CI or local testing.