### PR TITLE
Fix test module path in riscv.rs to resolve correctly under Rust module rules

### DIFF
--- a/library/std_detect/src/detect/os/riscv.rs
+++ b/library/std_detect/src/detect/os/riscv.rs
@@ -135,4 +135,5 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
 }
 
 #[cfg(test)]
+#[path = "riscv/tests.rs"]
 mod tests;


### PR DESCRIPTION
### What this PR does
This PR fixes a build failure when running `./x test` due to Rust being unable to locate the `tests` module declared in `library/std_detect/src/detect/os/riscv.rs`.
Rust's default module resolution expects `mod tests;` to resolve to `os/tests.rs` or `os/tests/mod.rs`. However, in this case, the tests are located in `os/riscv/tests.rs`.
To correct this, I explicitly set the path using:
```rust
#[cfg(test)]
#[path = "riscv/tests.rs"]
mod tests;
````
This allows the test module to be compiled correctly when testing, without needing to inline or move the file.

### Why it's needed
Without this change, `./x test` fails with:
```
error[E0583]: file not found for module `tests`
```
This fix enables successful test discovery and execution on `riscv.rs`.

### Notes
* No functional logic changes were made.
* Only affects test compilation.
```
