### PR TITLE
Raw Pointers are Constant PatKinds too

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -838,6 +838,8 @@ pub enum PatKind<'tcx> {
     /// * integer, bool, char or float (represented as a valtree), which will be handled by
     ///   exhaustiveness to cover exactly its own value, similar to `&str`, but these values are
     ///   much simpler.
+    /// * raw pointers derived from integers, other raw pointers will have already resulted in an
+    //    error.
     /// * `String`, if `string_deref_patterns` is enabled.
     Constant {
         value: mir::Const<'tcx>,


### PR DESCRIPTION
raw pointers can be matched on with a const pattern:
```rust
const FOO: *const u8 = core::ptr::null();

fn foo(a: *const u8) {
  match a {
    FOO => (),
    _ => todo!(),
  }
}
```
as far as I can tell this is represented with a `PatKind::Constant`: https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs#L333-L337