### PR TITLE
fixed typo chunks->as_chunks

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1232,7 +1232,7 @@ impl<T> [T] {
     ///
     /// [`chunks`]: slice::chunks
     /// [`rchunks_exact`]: slice::rchunks_exact
-    /// [`as_chunks`]: slice::chunks
+    /// [`as_chunks`]: slice::as_chunks
     #[stable(feature = "chunks_exact", since = "1.31.0")]
     #[rustc_const_unstable(feature = "const_slice_make_iter", issue = "137737")]
     #[inline]


### PR DESCRIPTION
Fixes rust-lang/rust#144555

info-: 
fix typo chunks -> as_chunks 

This now take us to as_chunks page when clicking on as_chunks link and not to chunks .

Thanks . 