### PR TITLE
Implement declarative (`macro_rules!`) attribute macros (RFC 3697)

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -409,7 +409,7 @@ pub trait Emitter {
                 if !redundant_span || always_backtrace {
                     let msg: Cow<'static, _> = match trace.kind {
                         ExpnKind::Macro(MacroKind::Attr, _) => {
-                            "this procedural macro expansion".into()
+                            "this attribute macro expansion".into()
                         }
                         ExpnKind::Macro(MacroKind::Derive, _) => {
                             "this derive macro expansion".into()

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -70,6 +70,9 @@ expand_invalid_fragment_specifier =
     invalid fragment specifier `{$fragment}`
     .help = {$help}
 
+expand_macro_args_bad_delim = macro attribute argument matchers require parentheses
+expand_macro_args_bad_delim_sugg = the delimiters should be `(` and `)`
+
 expand_macro_body_stability =
     macros cannot have body stability attributes
     .label = invalid body stability attribute

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -482,3 +482,21 @@ mod metavar_exprs {
         pub key: MacroRulesNormalizedIdent,
     }
 }
+
+#[derive(Diagnostic)]
+#[diag(expand_macro_args_bad_delim)]
+pub(crate) struct MacroArgsBadDelim {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: MacroArgsBadDelimSugg,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(expand_macro_args_bad_delim_sugg, applicability = "machine-applicable")]
+pub(crate) struct MacroArgsBadDelimSugg {
+    #[suggestion_part(code = "(")]
+    pub open: Span,
+    #[suggestion_part(code = ")")]
+    pub close: Span,
+}

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -81,11 +81,12 @@ pub(super) fn failed_to_match_macro(
     // Check whether there's a missing comma in this macro call, like `println!("{}" a);`
     if let Some((arg, comma_span)) = arg.add_comma() {
         for rule in rules {
+            let MacroRule::Func { lhs, .. } = rule else { continue };
             let parser = parser_from_cx(psess, arg.clone(), Recovery::Allowed);
             let mut tt_parser = TtParser::new(name);
 
             if let Success(_) =
-                tt_parser.parse_tt(&mut Cow::Borrowed(&parser), &rule.lhs, &mut NoopTracker)
+                tt_parser.parse_tt(&mut Cow::Borrowed(&parser), lhs, &mut NoopTracker)
             {
                 if comma_span.is_dummy() {
                     err.note("you might be missing a comma");

--- a/compiler/rustc_expand/src/mbe/macro_check.rs
+++ b/compiler/rustc_expand/src/mbe/macro_check.rs
@@ -193,15 +193,19 @@ struct MacroState<'a> {
 /// Arguments:
 /// - `psess` is used to emit diagnostics and lints
 /// - `node_id` is used to emit lints
-/// - `lhs` and `rhs` represent the rule
+/// - `args`, `lhs`, and `rhs` represent the rule
 pub(super) fn check_meta_variables(
     psess: &ParseSess,
     node_id: NodeId,
+    args: Option<&TokenTree>,
     lhs: &TokenTree,
     rhs: &TokenTree,
 ) -> Result<(), ErrorGuaranteed> {
     let mut guar = None;
     let mut binders = Binders::default();
+    if let Some(args) = args {
+        check_binders(psess, node_id, args, &Stack::Empty, &mut binders, &Stack::Empty, &mut guar);
+    }
     check_binders(psess, node_id, lhs, &Stack::Empty, &mut binders, &Stack::Empty, &mut guar);
     check_occurrences(psess, node_id, rhs, &Stack::Empty, &binders, &Stack::Empty, &mut guar);
     guar.map_or(Ok(()), Err)

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -554,6 +554,8 @@ declare_features! (
     (unstable, link_arg_attribute, "1.76.0", Some(99427)),
     /// Allows fused `loop`/`match` for direct intraprocedural jumps.
     (incomplete, loop_match, "1.90.0", Some(132306)),
+    /// Allow `macro_rules!` attribute rules
+    (unstable, macro_attr, "CURRENT_RUSTC_VERSION", Some(83527)),
     /// Give access to additional metadata about declarative macro meta-variables.
     (unstable, macro_metavar_expr, "1.61.0", Some(83527)),
     /// Provides a way to concatenate identifiers using metavariable expressions.

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -243,7 +243,7 @@ resolve_lowercase_self =
     .suggestion = try using `Self`
 
 resolve_macro_cannot_use_as_attr =
-    `{$ident}` exists, but a declarative macro cannot be used as an attribute macro
+    `{$ident}` exists, but has no `attr` rules
 
 resolve_macro_cannot_use_as_derive =
      `{$ident}` exists, but a declarative macro cannot be used as a derive macro

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -625,9 +625,21 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 };
 
                 match result {
-                    Ok((binding, flags))
-                        if sub_namespace_match(binding.macro_kind(), macro_kind) =>
-                    {
+                    Ok((binding, flags)) => {
+                        let binding_macro_kind = binding.macro_kind();
+                        // If we're looking for an attribute, that might be supported by a
+                        // `macro_rules!` macro.
+                        // FIXME: Replace this with tracking multiple macro kinds for one Def.
+                        if !(sub_namespace_match(binding_macro_kind, macro_kind)
+                            || (binding_macro_kind == Some(MacroKind::Bang)
+                                && macro_kind == Some(MacroKind::Attr)
+                                && this
+                                    .get_macro(binding.res())
+                                    .is_some_and(|macro_data| macro_data.attr_ext.is_some())))
+                        {
+                            return None;
+                        }
+
                         if finalize.is_none() || matches!(scope_set, ScopeSet::Late(..)) {
                             return Some(Ok(binding));
                         }
@@ -704,7 +716,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             innermost_result = Some((binding, flags));
                         }
                     }
-                    Ok(..) | Err(Determinacy::Determined) => {}
+                    Err(Determinacy::Determined) => {}
                     Err(Determinacy::Undetermined) => determinacy = Determinacy::Undetermined,
                 }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1028,13 +1028,14 @@ struct DeriveData {
 
 struct MacroData {
     ext: Arc<SyntaxExtension>,
+    attr_ext: Option<Arc<SyntaxExtension>>,
     nrules: usize,
     macro_rules: bool,
 }
 
 impl MacroData {
     fn new(ext: Arc<SyntaxExtension>) -> MacroData {
-        MacroData { ext, nrules: 0, macro_rules: false }
+        MacroData { ext, attr_ext: None, nrules: 0, macro_rules: false }
     }
 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1311,6 +1311,7 @@ symbols! {
         lt,
         m68k_target_feature,
         macro_at_most_once_rep,
+        macro_attr,
         macro_attributes_in_derive_output,
         macro_concat,
         macro_escape,

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -11,7 +11,7 @@ note: inside `_::__rg_oom`
   --> tests/fail/alloc/alloc_error_handler_custom.rs:LL:CC
    |
 LL | #[alloc_error_handler]
-   | ---------------------- in this procedural macro expansion
+   | ---------------------- in this attribute macro expansion
 LL | fn alloc_error_handler(layout: Layout) -> ! {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `alloc::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-1.rs:10:1
    |
 LL |    #[alloc_error_handler]
-   |    ---------------------- in this procedural macro expansion
+   |    ---------------------- in this attribute macro expansion
 LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-1.rs:10:1
    |
 LL |    #[alloc_error_handler]
-   |    ---------------------- in this procedural macro expansion
+   |    ---------------------- in this attribute macro expansion
 LL | // fn oom(
 LL | ||     info: &Layout,
 LL | || ) -> ()

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-2.rs:10:1
    |
 LL |    #[alloc_error_handler]
-   |    ---------------------- in this procedural macro expansion
+   |    ---------------------- in this attribute macro expansion
 LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {
@@ -31,7 +31,7 @@ error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-2.rs:10:1
    |
 LL |    #[alloc_error_handler]
-   |    ---------------------- in this procedural macro expansion
+   |    ---------------------- in this attribute macro expansion
 LL | // fn oom(
 LL | ||     info: Layout,
 LL | || ) {

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/alloc-error-handler-bad-signature-3.rs:10:1
    |
 LL |   #[alloc_error_handler]
-   |   ---------------------- in this procedural macro expansion
+   |   ---------------------- in this attribute macro expansion
 LL |   fn oom() -> ! {
    |  _-^^^^^^^^^^^^
 LL | |     loop {}

--- a/tests/ui/allocator/not-an-allocator.stderr
+++ b/tests/ui/allocator/not-an-allocator.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
-   | ------------------- in this procedural macro expansion
+   | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
@@ -12,18 +12,7 @@ error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
-   | ------------------- in this procedural macro expansion
-LL | static A: usize = 0;
-   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
-   |
-   = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:11
-   |
-LL | #[global_allocator]
-   | ------------------- in this procedural macro expansion
+   | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
@@ -34,7 +23,18 @@ error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
-   | ------------------- in this procedural macro expansion
+   | ------------------- in this attribute macro expansion
+LL | static A: usize = 0;
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |
+   = help: the trait `GlobalAlloc` is implemented for `System`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
+  --> $DIR/not-an-allocator.rs:2:11
+   |
+LL | #[global_allocator]
+   | ------------------- in this attribute macro expansion
 LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |

--- a/tests/ui/allocator/two-allocators.stderr
+++ b/tests/ui/allocator/two-allocators.stderr
@@ -4,7 +4,7 @@ error: cannot define multiple global allocators
 LL | static A: System = System;
    | -------------------------- previous global allocator defined here
 LL | #[global_allocator]
-   | ------------------- in this procedural macro expansion
+   | ------------------- in this attribute macro expansion
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
 

--- a/tests/ui/custom_test_frameworks/mismatch.stderr
+++ b/tests/ui/custom_test_frameworks/mismatch.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `TestDescAndFn: Testable` is not satisfied
   --> $DIR/mismatch.rs:9:1
    |
 LL | #[test]
-   | ------- in this procedural macro expansion
+   | ------- in this attribute macro expansion
 LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |

--- a/tests/ui/feature-gates/feature-gate-macro-attr.rs
+++ b/tests/ui/feature-gates/feature-gate-macro-attr.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+macro_rules! myattr { attr() {} => {} }
+//~^ ERROR `macro_rules!` attributes are unstable

--- a/tests/ui/feature-gates/feature-gate-macro-attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-macro-attr.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `macro_rules!` attributes are unstable
+  --> $DIR/feature-gate-macro-attr.rs:3:1
+   |
+LL | macro_rules! myattr { attr() {} => {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_attr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
+++ b/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
@@ -11,7 +11,7 @@ error: cannot find attribute `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:5:3
    |
 LL | macro_rules! sample { () => {} }
-   |              ------ `sample` exists, but a declarative macro cannot be used as an attribute macro
+   |              ------ `sample` exists, but has no `attr` rules
 LL |
 LL | #[sample]
    |   ^^^^^^

--- a/tests/ui/macros/macro-rules-attr-error.rs
+++ b/tests/ui/macros/macro-rules-attr-error.rs
@@ -10,4 +10,6 @@ macro_rules! local_attr {
 fn main() {
     #[local_attr]
     struct S;
+
+    local_attr!(arg); //~ ERROR: macro has no rules for function-like invocation
 }

--- a/tests/ui/macros/macro-rules-attr-error.rs
+++ b/tests/ui/macros/macro-rules-attr-error.rs
@@ -1,0 +1,13 @@
+#![feature(macro_attr)]
+
+macro_rules! local_attr {
+    attr() { $($body:tt)* } => {
+        compile_error!(concat!("local_attr: ", stringify!($($body)*)));
+    };
+    //~^^ ERROR: local_attr
+}
+
+fn main() {
+    #[local_attr]
+    struct S;
+}

--- a/tests/ui/macros/macro-rules-attr-error.stderr
+++ b/tests/ui/macros/macro-rules-attr-error.stderr
@@ -1,0 +1,13 @@
+error: local_attr: struct S;
+  --> $DIR/macro-rules-attr-error.rs:5:9
+   |
+LL |         compile_error!(concat!("local_attr: ", stringify!($($body)*)));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     #[local_attr]
+   |     ------------- in this attribute macro expansion
+   |
+   = note: this error originates in the attribute macro `local_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/macro-rules-attr-error.stderr
+++ b/tests/ui/macros/macro-rules-attr-error.stderr
@@ -9,5 +9,14 @@ LL |     #[local_attr]
    |
    = note: this error originates in the attribute macro `local_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: macro has no rules for function-like invocation `local_attr!`
+  --> $DIR/macro-rules-attr-error.rs:14:5
+   |
+LL | macro_rules! local_attr {
+   | ----------------------- this macro has no rules for function-like invocation
+...
+LL |     local_attr!(arg);
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/macro-rules-attr-infinite-recursion.rs
+++ b/tests/ui/macros/macro-rules-attr-infinite-recursion.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+#![feature(macro_attr)]
+
+macro_rules! attr {
+    attr() { $($body:tt)* } => {
+        #[attr] $($body)*
+    };
+    //~^^ ERROR: recursion limit reached
+}
+
+#[attr]
+struct S;

--- a/tests/ui/macros/macro-rules-attr-infinite-recursion.stderr
+++ b/tests/ui/macros/macro-rules-attr-infinite-recursion.stderr
@@ -1,0 +1,14 @@
+error: recursion limit reached while expanding `#[attr]`
+  --> $DIR/macro-rules-attr-infinite-recursion.rs:6:9
+   |
+LL |         #[attr] $($body)*
+   |         ^^^^^^^
+...
+LL | #[attr]
+   | ------- in this attribute macro expansion
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`macro_rules_attr_infinite_recursion`)
+   = note: this error originates in the attribute macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/macro-rules-attr-nested.rs
+++ b/tests/ui/macros/macro-rules-attr-nested.rs
@@ -1,0 +1,24 @@
+//@ run-pass
+//@ check-run-results
+#![feature(macro_attr)]
+
+macro_rules! nest {
+    attr() { struct $name:ident; } => {
+        println!("nest");
+        #[nest(1)]
+        struct $name;
+    };
+    attr(1) { struct $name:ident; } => {
+        println!("nest(1)");
+        #[nest(2)]
+        struct $name;
+    };
+    attr(2) { struct $name:ident; } => {
+        println!("nest(2)");
+    };
+}
+
+fn main() {
+    #[nest]
+    struct S;
+}

--- a/tests/ui/macros/macro-rules-attr-nested.run.stdout
+++ b/tests/ui/macros/macro-rules-attr-nested.run.stdout
@@ -1,0 +1,3 @@
+nest
+nest(1)
+nest(2)

--- a/tests/ui/macros/macro-rules-attr.rs
+++ b/tests/ui/macros/macro-rules-attr.rs
@@ -1,0 +1,90 @@
+//@ run-pass
+//@ check-run-results
+#![feature(macro_attr)]
+#![warn(unused)]
+
+#[macro_export]
+macro_rules! exported_attr {
+    attr($($args:tt)*) { $($body:tt)* } => {
+        println!(
+            "exported_attr: args={:?}, body={:?}",
+            stringify!($($args)*),
+            stringify!($($body)*),
+        );
+    };
+    { $($args:tt)* } => {
+        println!("exported_attr!({:?})", stringify!($($args)*));
+    };
+    attr() {} => {
+        unused_rule();
+    };
+    attr() {} => {
+        compile_error!();
+    };
+    {} => {
+        unused_rule();
+    };
+    {} => {
+        compile_error!();
+    };
+}
+
+macro_rules! local_attr {
+    attr($($args:tt)*) { $($body:tt)* } => {
+        println!(
+            "local_attr: args={:?}, body={:?}",
+            stringify!($($args)*),
+            stringify!($($body)*),
+        );
+    };
+    { $($args:tt)* } => {
+        println!("local_attr!({:?})", stringify!($($args)*));
+    };
+    attr() {} => { //~ WARN: never used
+        unused_rule();
+    };
+    attr() {} => {
+        compile_error!();
+    };
+    {} => { //~ WARN: never used
+        unused_rule();
+    };
+    {} => {
+        compile_error!();
+    };
+}
+
+fn main() {
+    #[crate::exported_attr]
+    struct S;
+    #[::exported_attr(arguments, key = "value")]
+    fn func(_arg: u32) {}
+    #[self::exported_attr(1)]
+    #[self::exported_attr(2)]
+    struct Twice;
+
+    crate::exported_attr!();
+    crate::exported_attr!(invoked, arguments);
+
+    #[exported_attr]
+    struct S;
+    #[exported_attr(arguments, key = "value")]
+    fn func(_arg: u32) {}
+    #[exported_attr(1)]
+    #[exported_attr(2)]
+    struct Twice;
+
+    exported_attr!();
+    exported_attr!(invoked, arguments);
+
+    #[local_attr]
+    struct S;
+    #[local_attr(arguments, key = "value")]
+    fn func(_arg: u32) {}
+    #[local_attr(1)]
+    #[local_attr(2)]
+    struct Twice;
+
+    local_attr!();
+    local_attr!(invoked, arguments);
+}

--- a/tests/ui/macros/macro-rules-attr.run.stdout
+++ b/tests/ui/macros/macro-rules-attr.run.stdout
@@ -1,0 +1,15 @@
+exported_attr: args="", body="struct S;"
+exported_attr: args="arguments, key = \"value\"", body="fn func(_arg: u32) {}"
+exported_attr: args="1", body="#[self::exported_attr(2)] struct Twice;"
+exported_attr!("")
+exported_attr!("invoked, arguments")
+exported_attr: args="", body="struct S;"
+exported_attr: args="arguments, key = \"value\"", body="fn func(_arg: u32) {}"
+exported_attr: args="1", body="#[exported_attr(2)] struct Twice;"
+exported_attr!("")
+exported_attr!("invoked, arguments")
+local_attr: args="", body="struct S;"
+local_attr: args="arguments, key = \"value\"", body="fn func(_arg: u32) {}"
+local_attr: args="1", body="#[local_attr(2)] struct Twice;"
+local_attr!("")
+local_attr!("invoked, arguments")

--- a/tests/ui/macros/macro-rules-attr.stderr
+++ b/tests/ui/macros/macro-rules-attr.stderr
@@ -1,0 +1,21 @@
+warning: rule #3 of macro `local_attr` is never used
+  --> $DIR/macro-rules-attr.rs:43:9
+   |
+LL |     attr() {} => {
+   |         ^^ ^^
+   |
+note: the lint level is defined here
+  --> $DIR/macro-rules-attr.rs:4:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_macro_rules)]` implied by `#[warn(unused)]`
+
+warning: rule #5 of macro `local_attr` is never used
+  --> $DIR/macro-rules-attr.rs:49:5
+   |
+LL |     {} => {
+   |     ^^
+
+warning: 2 warnings emitted
+

--- a/tests/ui/parser/macro/macro-attr-bad.rs
+++ b/tests/ui/parser/macro/macro-attr-bad.rs
@@ -1,0 +1,32 @@
+#![crate_type = "lib"]
+#![feature(macro_attr)]
+
+macro_rules! attr_incomplete_1 { attr }
+//~^ ERROR macro definition ended unexpectedly
+
+macro_rules! attr_incomplete_2 { attr() }
+//~^ ERROR macro definition ended unexpectedly
+
+macro_rules! attr_incomplete_3 { attr() {} }
+//~^ ERROR expected `=>`
+
+macro_rules! attr_incomplete_4 { attr() {} => }
+//~^ ERROR macro definition ended unexpectedly
+
+macro_rules! attr_noparens_1 { attr{} {} => {} }
+//~^ ERROR macro attribute argument matchers require parentheses
+
+macro_rules! attr_noparens_2 { attr[] {} => {} }
+//~^ ERROR macro attribute argument matchers require parentheses
+
+macro_rules! attr_noparens_3 { attr _ {} => {} }
+//~^ ERROR invalid macro matcher
+
+macro_rules! attr_dup_matcher_1 { attr() {$x:ident $x:ident} => {} }
+//~^ ERROR duplicate matcher binding
+
+macro_rules! attr_dup_matcher_2 { attr($x:ident $x:ident) {} => {} }
+//~^ ERROR duplicate matcher binding
+
+macro_rules! attr_dup_matcher_3 { attr($x:ident) {$x:ident} => {} }
+//~^ ERROR duplicate matcher binding

--- a/tests/ui/parser/macro/macro-attr-bad.stderr
+++ b/tests/ui/parser/macro/macro-attr-bad.stderr
@@ -1,0 +1,80 @@
+error: macro definition ended unexpectedly
+  --> $DIR/macro-attr-bad.rs:4:38
+   |
+LL | macro_rules! attr_incomplete_1 { attr }
+   |                                      ^ expected macro attr args
+
+error: macro definition ended unexpectedly
+  --> $DIR/macro-attr-bad.rs:7:40
+   |
+LL | macro_rules! attr_incomplete_2 { attr() }
+   |                                        ^ expected macro attr body
+
+error: expected `=>`, found end of macro arguments
+  --> $DIR/macro-attr-bad.rs:10:43
+   |
+LL | macro_rules! attr_incomplete_3 { attr() {} }
+   |                                           ^ expected `=>`
+
+error: macro definition ended unexpectedly
+  --> $DIR/macro-attr-bad.rs:13:46
+   |
+LL | macro_rules! attr_incomplete_4 { attr() {} => }
+   |                                              ^ expected right-hand side of macro rule
+
+error: macro attribute argument matchers require parentheses
+  --> $DIR/macro-attr-bad.rs:16:36
+   |
+LL | macro_rules! attr_noparens_1 { attr{} {} => {} }
+   |                                    ^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL - macro_rules! attr_noparens_1 { attr{} {} => {} }
+LL + macro_rules! attr_noparens_1 { attr() {} => {} }
+   |
+
+error: macro attribute argument matchers require parentheses
+  --> $DIR/macro-attr-bad.rs:19:36
+   |
+LL | macro_rules! attr_noparens_2 { attr[] {} => {} }
+   |                                    ^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL - macro_rules! attr_noparens_2 { attr[] {} => {} }
+LL + macro_rules! attr_noparens_2 { attr() {} => {} }
+   |
+
+error: invalid macro matcher; matchers must be contained in balanced delimiters
+  --> $DIR/macro-attr-bad.rs:22:37
+   |
+LL | macro_rules! attr_noparens_3 { attr _ {} => {} }
+   |                                     ^
+
+error: duplicate matcher binding
+  --> $DIR/macro-attr-bad.rs:25:52
+   |
+LL | macro_rules! attr_dup_matcher_1 { attr() {$x:ident $x:ident} => {} }
+   |                                           -------- ^^^^^^^^ duplicate binding
+   |                                           |
+   |                                           previous binding
+
+error: duplicate matcher binding
+  --> $DIR/macro-attr-bad.rs:28:49
+   |
+LL | macro_rules! attr_dup_matcher_2 { attr($x:ident $x:ident) {} => {} }
+   |                                        -------- ^^^^^^^^ duplicate binding
+   |                                        |
+   |                                        previous binding
+
+error: duplicate matcher binding
+  --> $DIR/macro-attr-bad.rs:31:51
+   |
+LL | macro_rules! attr_dup_matcher_3 { attr($x:ident) {$x:ident} => {} }
+   |                                        --------   ^^^^^^^^ duplicate binding
+   |                                        |
+   |                                        previous binding
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/parser/macro/macro-attr-recovery.rs
+++ b/tests/ui/parser/macro/macro-attr-recovery.rs
@@ -1,0 +1,19 @@
+#![crate_type = "lib"]
+#![feature(macro_attr)]
+
+macro_rules! attr {
+    attr[$($args:tt)*] { $($body:tt)* } => {
+        //~^ ERROR: macro attribute argument matchers require parentheses
+        //~v ERROR: attr:
+        compile_error!(concat!(
+            "attr: args=\"",
+            stringify!($($args)*),
+            "\" body=\"",
+            stringify!($($body)*),
+            "\"",
+        ));
+    };
+}
+
+#[attr]
+struct S;

--- a/tests/ui/parser/macro/macro-attr-recovery.stderr
+++ b/tests/ui/parser/macro/macro-attr-recovery.stderr
@@ -1,0 +1,31 @@
+error: macro attribute argument matchers require parentheses
+  --> $DIR/macro-attr-recovery.rs:5:9
+   |
+LL |     attr[$($args:tt)*] { $($body:tt)* } => {
+   |         ^^^^^^^^^^^^^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL -     attr[$($args:tt)*] { $($body:tt)* } => {
+LL +     attr($($args:tt)*) { $($body:tt)* } => {
+   |
+
+error: attr: args="" body="struct S;"
+  --> $DIR/macro-attr-recovery.rs:8:9
+   |
+LL | /         compile_error!(concat!(
+LL | |             "attr: args=\"",
+LL | |             stringify!($($args)*),
+LL | |             "\" body=\"",
+LL | |             stringify!($($body)*),
+LL | |             "\"",
+LL | |         ));
+   | |__________^
+...
+LL |   #[attr]
+   |   ------- in this attribute macro expansion
+   |
+   = note: this error originates in the attribute macro `attr` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/proc-macro/span-from-proc-macro.stderr
+++ b/tests/ui/proc-macro/span-from-proc-macro.stderr
@@ -10,7 +10,7 @@ LL |             field: MissingType
   ::: $DIR/span-from-proc-macro.rs:8:1
    |
 LL | #[error_from_attribute]
-   | ----------------------- in this procedural macro expansion
+   | ----------------------- in this attribute macro expansion
 
 error[E0412]: cannot find type `OtherMissingType` in this scope
   --> $DIR/auxiliary/span-from-proc-macro.rs:42:21

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `f32: Termination` is not satisfied
   --> $DIR/termination-trait-test-wrong-type.rs:6:31
    |
 LL | #[test]
-   | ------- in this procedural macro expansion
+   | ------- in this attribute macro expansion
 LL | fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Termination` is not implemented for `f32`
    |

--- a/tests/ui/test-attrs/issue-12997-2.stderr
+++ b/tests/ui/test-attrs/issue-12997-2.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-12997-2.rs:8:1
    |
 LL | #[bench]
-   | -------- in this procedural macro expansion
+   | -------- in this attribute macro expansion
 LL | fn bar(x: isize) { }
    | ^^^^^^^^^^^^^^^^^^^^
    | |

--- a/tests/ui/test-attrs/test-function-signature.stderr
+++ b/tests/ui/test-attrs/test-function-signature.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `i32: Termination` is not satisfied
   --> $DIR/test-function-signature.rs:9:13
    |
 LL | #[test]
-   | ------- in this procedural macro expansion
+   | ------- in this attribute macro expansion
 LL | fn bar() -> i32 {
    |             ^^^ the trait `Termination` is not implemented for `i32`
    |


### PR DESCRIPTION
This implements [RFC 3697](https://github.com/rust-lang/rust/issues/143547), "Declarative (`macro_rules!`) attribute macros".

I would suggest reading this commit-by-commit. This first introduces the
feature gate, then adds parsing for attribute rules (doing nothing with them),
then adds the ability to look up and apply `macro_rules!` attributes by path,
then adds support for local attributes, then adds a test, and finally makes
various improvements to errors.

---

- *See also the related https://github.com/rust-lang/rust/pull/145208*
