### PR TITLE
Remove indices from fresh ty/const vars.

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -164,8 +164,8 @@ fn const_to_valtree_inner<'tcx>(
         ty::Never
         | ty::Error(_)
         | ty::Foreign(..)
-        | ty::Infer(ty::FreshIntTy(_))
-        | ty::Infer(ty::FreshFloatTy(_))
+        | ty::Infer(ty::FreshIntTy)
+        | ty::Infer(ty::FreshFloatTy)
         // FIXME(oli-obk): we could look behind opaque types
         | ty::Alias(..)
         | ty::Param(_)
@@ -326,8 +326,8 @@ pub fn valtree_to_const_value<'tcx>(
         ty::Never
         | ty::Error(_)
         | ty::Foreign(..)
-        | ty::Infer(ty::FreshIntTy(_))
-        | ty::Infer(ty::FreshFloatTy(_))
+        | ty::Infer(ty::FreshIntTy)
+        | ty::Infer(ty::FreshFloatTy)
         | ty::Alias(..)
         | ty::Param(_)
         | ty::Bound(..)

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -521,8 +521,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
                 ty::Infer(ty::TyVar(_)) => false,
 
-                ty::Bound(..)
-                | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+                ty::Bound(..) | ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                     bug!("`is_very_trivially_sized` applied to unexpected type: {}", ty)
                 }
             }

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -347,7 +347,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ty::TyVar(_) => self.next_ty_var(DUMMY_SP),
                         ty::IntVar(_) => self.next_int_var(),
                         ty::FloatVar(_) => self.next_float_var(),
-                        ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                        ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => {
                             bug!("unexpected fresh ty outside of the trait solver")
                         }
                     }

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -386,7 +386,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
                 }
             }
 
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("encountered a fresh type during canonicalization")
             }
 
@@ -470,7 +470,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
                     }
                 }
             }
-            ty::ConstKind::Infer(InferConst::Fresh(_)) => {
+            ty::ConstKind::Infer(InferConst::Fresh) => {
                 bug!("encountered a fresh const during canonicalization")
             }
             ty::ConstKind::Bound(debruijn, _) => {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -117,9 +117,9 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
                                     if inner.float_unification_table().find(vid) == vid
                             )
                         }
-                        ty::InferTy::FreshTy(_)
-                        | ty::InferTy::FreshIntTy(_)
-                        | ty::InferTy::FreshFloatTy(_) => true,
+                        ty::InferTy::FreshTy
+                        | ty::InferTy::FreshIntTy
+                        | ty::InferTy::FreshFloatTy => true,
                     }
                 } else {
                     true
@@ -131,7 +131,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
                         ty::InferConst::Var(vid) => !self
                             .probe_const_var(vid)
                             .is_err_and(|_| self.root_const_var(vid) == vid),
-                        ty::InferConst::Fresh(_) => true,
+                        ty::InferConst::Fresh => true,
                     }
                 } else {
                     true

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1028,7 +1028,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     }
                 }
 
-                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => ty,
+                ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => ty,
             }
         } else {
             ty
@@ -1045,7 +1045,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     .probe_value(vid)
                     .known()
                     .unwrap_or(ct),
-                InferConst::Fresh(_) => ct,
+                InferConst::Fresh => ct,
             },
             ty::ConstKind::Param(_)
             | ty::ConstKind::Bound(_, _)
@@ -1448,8 +1448,8 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceLiteralEraser<'tcx> {
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
         match ty.kind() {
-            ty::Infer(ty::IntVar(_) | ty::FreshIntTy(_)) => self.tcx.types.i32,
-            ty::Infer(ty::FloatVar(_) | ty::FreshFloatTy(_)) => self.tcx.types.f64,
+            ty::Infer(ty::IntVar(_) | ty::FreshIntTy) => self.tcx.types.i32,
+            ty::Infer(ty::FloatVar(_) | ty::FreshFloatTy) => self.tcx.types.f64,
             _ => ty.super_fold_with(self),
         }
     }

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -462,7 +462,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Generalizer<'_, 'tcx> {
         // subtyping. This is basically our "occurs check", preventing
         // us from creating infinitely sized types.
         let g = match *t.kind() {
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("unexpected infer type: {t}")
             }
 

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -186,7 +186,7 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for FullTypeResolver<'a, 'tcx> {
                 ty::ConstKind::Infer(InferConst::Var(vid)) => {
                     return Err(FixupError { unresolved: super::TyOrConstInferVar::Const(vid) });
                 }
-                ty::ConstKind::Infer(InferConst::Fresh(_)) => {
+                ty::ConstKind::Infer(InferConst::Fresh) => {
                     bug!("Unexpected const in full const resolver: {:?}", c);
                 }
                 _ => {}

--- a/compiler/rustc_infer/src/infer/snapshot/fudge.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/fudge.rs
@@ -207,7 +207,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceFudger<'a, 'tcx> {
                         ty
                     }
                 }
-                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => {
                     unreachable!("unexpected fresh infcx var")
                 }
             }
@@ -244,7 +244,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for InferenceFudger<'a, 'tcx> {
                         ct
                     }
                 }
-                ty::InferConst::Fresh(_) => {
+                ty::InferConst::Fresh => {
                     unreachable!("unexpected fresh infcx var")
                 }
             }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -80,11 +80,6 @@ impl<'tcx> Const<'tcx> {
     }
 
     #[inline]
-    pub fn new_fresh(tcx: TyCtxt<'tcx>, fresh: u32) -> Const<'tcx> {
-        Const::new(tcx, ty::ConstKind::Infer(ty::InferConst::Fresh(fresh)))
-    }
-
-    #[inline]
     pub fn new_infer(tcx: TyCtxt<'tcx>, infer: ty::InferConst) -> Const<'tcx> {
         Const::new(tcx, ty::ConstKind::Infer(infer))
     }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -45,8 +45,8 @@ impl<'tcx> Ty<'tcx> {
                 | Infer(
                     InferTy::IntVar(_)
                         | InferTy::FloatVar(_)
-                        | InferTy::FreshIntTy(_)
-                        | InferTy::FreshFloatTy(_)
+                        | InferTy::FreshIntTy
+                        | InferTy::FreshFloatTy
                 )
         )
     }
@@ -64,8 +64,8 @@ impl<'tcx> Ty<'tcx> {
             | Infer(
                 InferTy::IntVar(_)
                 | InferTy::FloatVar(_)
-                | InferTy::FreshIntTy(_)
-                | InferTy::FreshFloatTy(_),
+                | InferTy::FreshIntTy
+                | InferTy::FreshFloatTy,
             ) => true,
             Ref(_, x, _) | Array(x, _) | Slice(x) => x.peel_refs().is_simple_ty(),
             Tuple(tys) if tys.is_empty() => true,

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -144,9 +144,9 @@ impl<'tcx> Ty<'tcx> {
             ty::Infer(ty::FloatVar(_)) => "floating-point number".into(),
             ty::Placeholder(..) => "placeholder type".into(),
             ty::Bound(..) => "bound type".into(),
-            ty::Infer(ty::FreshTy(_)) => "fresh type".into(),
-            ty::Infer(ty::FreshIntTy(_)) => "fresh integral type".into(),
-            ty::Infer(ty::FreshFloatTy(_)) => "fresh floating-point type".into(),
+            ty::Infer(ty::FreshTy) => "fresh type".into(),
+            ty::Infer(ty::FreshIntTy) => "fresh integral type".into(),
+            ty::Infer(ty::FreshFloatTy) => "fresh floating-point type".into(),
             ty::Alias(ty::Projection | ty::Inherent, _) => "associated type".into(),
             ty::Param(p) => format!("type parameter `{p}`").into(),
             ty::Alias(ty::Opaque, ..) => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3248,7 +3248,7 @@ define_print! {
 
     ty::ExistentialTraitRef<'tcx> {
         // Use a type that can't appear in defaults of type parameters.
-        let dummy_self = Ty::new_fresh(cx.tcx(), 0);
+        let dummy_self = cx.tcx().types.fresh_ty;
         let trait_ref = self.with_self_ty(cx.tcx(), dummy_self);
         p!(print(trait_ref.print_only_trait_path()))
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -445,36 +445,6 @@ impl<'tcx> Ty<'tcx> {
     }
 
     #[inline]
-    pub fn new_fresh(tcx: TyCtxt<'tcx>, n: u32) -> Ty<'tcx> {
-        // Use a pre-interned one when possible.
-        tcx.types
-            .fresh_tys
-            .get(n as usize)
-            .copied()
-            .unwrap_or_else(|| Ty::new_infer(tcx, ty::FreshTy(n)))
-    }
-
-    #[inline]
-    pub fn new_fresh_int(tcx: TyCtxt<'tcx>, n: u32) -> Ty<'tcx> {
-        // Use a pre-interned one when possible.
-        tcx.types
-            .fresh_int_tys
-            .get(n as usize)
-            .copied()
-            .unwrap_or_else(|| Ty::new_infer(tcx, ty::FreshIntTy(n)))
-    }
-
-    #[inline]
-    pub fn new_fresh_float(tcx: TyCtxt<'tcx>, n: u32) -> Ty<'tcx> {
-        // Use a pre-interned one when possible.
-        tcx.types
-            .fresh_float_tys
-            .get(n as usize)
-            .copied()
-            .unwrap_or_else(|| Ty::new_infer(tcx, ty::FreshFloatTy(n)))
-    }
-
-    #[inline]
     pub fn new_param(tcx: TyCtxt<'tcx>, index: u32, name: Symbol) -> Ty<'tcx> {
         Ty::new(tcx, Param(ParamTy { index, name }))
     }
@@ -1361,12 +1331,12 @@ impl<'tcx> Ty<'tcx> {
 
     #[inline]
     pub fn is_fresh_ty(self) -> bool {
-        matches!(self.kind(), Infer(FreshTy(_)))
+        matches!(self.kind(), Infer(FreshTy))
     }
 
     #[inline]
     pub fn is_fresh(self) -> bool {
-        matches!(self.kind(), Infer(FreshTy(_) | FreshIntTy(_) | FreshFloatTy(_)))
+        matches!(self.kind(), Infer(FreshTy | FreshIntTy | FreshFloatTy))
     }
 
     #[inline]
@@ -1597,7 +1567,7 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Bound(..)
             | ty::Placeholder(_)
-            | ty::Infer(FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            | ty::Infer(FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("`discriminant_ty` applied to unexpected type: {:?}", self)
             }
         }
@@ -1656,7 +1626,7 @@ impl<'tcx> Ty<'tcx> {
             | ty::Pat(..)
             | ty::Bound(..)
             | ty::Placeholder(..)
-            | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => bug!(
+            | ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => bug!(
                 "`ptr_metadata_ty_or_tail` applied to unexpected type: {self:?} (tail = {tail:?})"
             ),
         }
@@ -1842,7 +1812,7 @@ impl<'tcx> Ty<'tcx> {
 
             ty::Infer(ty::TyVar(_)) => false,
 
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("`has_trivial_sizedness` applied to unexpected type: {:?}", self)
             }
         }
@@ -1933,7 +1903,7 @@ impl<'tcx> Ty<'tcx> {
             ty::Infer(infer) => match infer {
                 ty::TyVar(_) => false,
                 ty::IntVar(_) | ty::FloatVar(_) => true,
-                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => true,
+                ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => true,
             },
 
             ty::Adt(_, _)

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1495,8 +1495,8 @@ pub fn needs_drop_components_with_async<'tcx>(
     asyncness: Asyncness,
 ) -> Result<SmallVec<[Ty<'tcx>; 2]>, AlwaysRequiresDrop> {
     match *ty.kind() {
-        ty::Infer(ty::FreshIntTy(_))
-        | ty::Infer(ty::FreshFloatTy(_))
+        ty::Infer(ty::FreshIntTy)
+        | ty::Infer(ty::FreshFloatTy)
         | ty::Bool
         | ty::Int(_)
         | ty::Uint(_)

--- a/compiler/rustc_next_trait_solver/src/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonicalizer.rs
@@ -335,7 +335,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
                     );
                     CanonicalVarKind::Ty(CanonicalTyVarKind::Float)
                 }
-                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => {
                     panic!("fresh vars not expected in canonicalization")
                 }
             },
@@ -504,7 +504,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
                         }
                     }
                 }
-                ty::InferConst::Fresh(_) => todo!(),
+                ty::InferConst::Fresh => todo!(),
             },
             ty::ConstKind::Placeholder(placeholder) => match self.canonicalize_mode {
                 CanonicalizeMode::Input { .. } => CanonicalVarKind::PlaceholderConst(

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -629,7 +629,7 @@ where
             | ty::Placeholder(..)
             | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
             | ty::Error(_) => return,
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) | ty::Bound(..) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) | ty::Bound(..) => {
                 panic!("unexpected self type for `{goal:?}`")
             }
 
@@ -743,7 +743,7 @@ where
             | ty::Placeholder(..)
             | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
             | ty::Error(_) => return,
-            ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
+            ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy)
             | ty::Bound(..) => panic!("unexpected self type for `{goal:?}`"),
             ty::Dynamic(bounds, ..) => bounds,
         };

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -149,7 +149,7 @@ where
         ty::Alias(..) | ty::Param(_) | ty::Placeholder(..) => Err(NoSolution),
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{ty:?}`")
         }
 
@@ -223,7 +223,7 @@ where
         | ty::Placeholder(..) => Err(NoSolution),
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{ty:?}`")
         }
 
@@ -395,7 +395,7 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<I: Intern
         | ty::Error(_) => Err(NoSolution),
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{self_ty:?}`")
         }
     }
@@ -568,7 +568,7 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: 
         | ty::Error(_) => Err(NoSolution),
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{self_ty:?}`")
         }
     }
@@ -718,7 +718,7 @@ pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
         | ty::UnsafeBinder(_) => return Err(NoSolution),
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{self_ty:?}`")
         }
     }
@@ -799,7 +799,7 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
         }
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{self_ty:?}`")
         }
     }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -716,7 +716,7 @@ where
                 todo!()
             }
 
-            ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
+            ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy)
             | ty::Bound(..) => panic!(
                 "unexpected self ty `{:?}` when normalizing `<T as Pointee>::Metadata`",
                 goal.predicate.self_ty()
@@ -934,7 +934,7 @@ where
                 });
             }
 
-            ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
+            ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy)
             | ty::Bound(..) => panic!(
                 "unexpected self ty `{:?}` when normalizing `<T as DiscriminantKind>::Discriminant`",
                 goal.predicate.self_ty()

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -754,9 +754,7 @@ where
                 }
 
                 ty::Bound(..)
-                | ty::Infer(
-                    ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_),
-                ) => {
+                | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                     panic!("unexpected type `{ty:?}`")
                 }
             }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -632,7 +632,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
                 match predicate.as_ref().skip_binder() {
                     ty::ExistentialPredicate::Trait(trait_ref) => {
                         // Use a type that can't appear in defaults of type parameters.
-                        let dummy_self = Ty::new_fresh(cx.tcx, 0);
+                        let dummy_self = cx.tcx().types.fresh_ty;
                         let trait_ref = trait_ref.with_self_ty(cx.tcx, dummy_self);
                         cx.print_def_path(trait_ref.def_id, trait_ref.args)?;
                     }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -446,7 +446,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let expected_ty = self.resolve_vars_if_possible(root_ty);
                 if !matches!(
                     expected_ty.kind(),
-                    ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy(_))
+                    ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy)
                 ) {
                     // don't show type `_`
                     if span.desugaring_kind() == Some(DesugaringKind::ForLoop)

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -385,7 +385,7 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
         }
 
         ty::Bound(..)
-        | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+        | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
             panic!("unexpected type `{self_ty:?}`")
         }
     };

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -511,7 +511,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                         ty::ConstKind::Infer(var) => {
                             let var = match var {
                                 ty::InferConst::Var(vid) => TyOrConstInferVar::Const(vid),
-                                ty::InferConst::Fresh(_) => {
+                                ty::InferConst::Fresh => {
                                     bug!("encountered fresh const in fulfill")
                                 }
                             };

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -28,8 +28,8 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         // None of these types have a destructor and hence they do not
         // require anything in particular to outlive the dtor's
         // execution.
-        ty::Infer(ty::FreshIntTy(_))
-        | ty::Infer(ty::FreshFloatTy(_))
+        ty::Infer(ty::FreshIntTy)
+        | ty::Infer(ty::FreshFloatTy)
         | ty::Bool
         | ty::Int(_)
         | ty::Uint(_)

--- a/compiler/rustc_trait_selection/src/traits/select/_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/_match.rs
@@ -64,9 +64,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstFreshVars<'tcx> {
         match (a.kind(), b.kind()) {
             (
                 _,
-                &ty::Infer(ty::FreshTy(_))
-                | &ty::Infer(ty::FreshIntTy(_))
-                | &ty::Infer(ty::FreshFloatTy(_)),
+                &ty::Infer(ty::FreshTy) | &ty::Infer(ty::FreshIntTy) | &ty::Infer(ty::FreshFloatTy),
             ) => Ok(a),
 
             (&ty::Infer(_), _) | (_, &ty::Infer(_)) => {
@@ -90,7 +88,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for MatchAgainstFreshVars<'tcx> {
         }
 
         match (a.kind(), b.kind()) {
-            (_, ty::ConstKind::Infer(InferConst::Fresh(_))) => {
+            (_, ty::ConstKind::Infer(InferConst::Fresh)) => {
                 return Ok(a);
             }
 

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -810,7 +810,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
                 }
 
-                ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+                ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                     bug!(
                         "asked to assemble auto trait candidates of unexpected type: {:?}",
                         self_ty
@@ -1212,7 +1212,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // Only appears when assembling higher-ranked `for<T> T: Clone`.
             ty::Bound(..) => {}
 
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("asked to assemble builtin bounds of unexpected type: {:?}", self_ty);
             }
         }
@@ -1280,7 +1280,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // Only appears when assembling higher-ranked `for<T> T: Sized`.
             ty::Bound(..) => {}
 
-            ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("asked to assemble builtin bounds of unexpected type: {:?}", self_ty);
             }
         }
@@ -1377,10 +1377,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::Infer(
                 ty::InferTy::IntVar(_)
                 | ty::InferTy::FloatVar(_)
-                | ty::InferTy::FreshIntTy(_)
-                | ty::InferTy::FreshFloatTy(_),
+                | ty::InferTy::FreshIntTy
+                | ty::InferTy::FreshFloatTy,
             ) => {}
-            ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy(_)) => {
+            ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy) => {
                 candidates.ambiguous = true;
             }
         }
@@ -1424,7 +1424,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 candidates.vec.push(BikeshedGuaranteedNoDropCandidate);
             }
 
-            ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 candidates.ambiguous = true;
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1321,7 +1321,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 ));
             }
 
-            ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 panic!("unexpected type `{self_ty:?}`")
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2150,7 +2150,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             ty::Alias(..)
             | ty::Param(_)
             | ty::Placeholder(..)
-            | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
+            | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy)
             | ty::Bound(..) => {
                 bug!("asked to assemble `Sized` of unexpected type: {:?}", self_ty);
             }
@@ -2234,7 +2234,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             | ty::Placeholder(..)
             | ty::Bound(..)
             | ty::Ref(_, _, ty::Mutability::Mut)
-            | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("asked to assemble builtin bounds of unexpected type: {:?}", self_ty);
             }
         }
@@ -2297,7 +2297,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             | ty::Param(..)
             | ty::Alias(ty::Projection | ty::Inherent | ty::Free, ..)
             | ty::Bound(..)
-            | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            | ty::Infer(ty::TyVar(_) | ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy) => {
                 bug!("asked to assemble constituent types of unexpected type: {:?}", t);
             }
 

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -97,26 +97,24 @@ pub enum InferConst {
     /// Infer the value of the const.
     Var(ConstVid),
     /// A fresh const variable. See `infer::freshen` for more details.
-    Fresh(u32),
+    Fresh,
 }
 
 impl fmt::Debug for InferConst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InferConst::Var(var) => write!(f, "{var:?}"),
-            InferConst::Fresh(var) => write!(f, "Fresh({var:?})"),
+            InferConst::Fresh => write!(f, "Fresh"),
         }
     }
 }
 
 #[cfg(feature = "nightly")]
 impl<CTX> HashStable<CTX> for InferConst {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
         match self {
-            InferConst::Var(_) => {
-                panic!("const variables should not be hashed: {self:?}")
-            }
-            InferConst::Fresh(i) => i.hash_stable(hcx, hasher),
+            InferConst::Var(_) => panic!("const variables should not be hashed: {self:?}"),
+            InferConst::Fresh => {}
         }
     }
 }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -265,7 +265,7 @@ impl<I: Interner> FlagComputation<I> {
             }
 
             ty::Infer(infer) => match infer {
-                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy => {
                     self.add_flags(TypeFlags::HAS_TY_FRESH)
                 }
 
@@ -452,7 +452,7 @@ impl<I: Interner> FlagComputation<I> {
                 self.add_flags(TypeFlags::HAS_CT_PROJECTION);
             }
             ty::ConstKind::Infer(infer) => match infer {
-                ty::InferConst::Fresh(_) => self.add_flags(TypeFlags::HAS_CT_FRESH),
+                ty::InferConst::Fresh => self.add_flags(TypeFlags::HAS_CT_FRESH),
                 ty::InferConst::Var(_) => self.add_flags(TypeFlags::HAS_CT_INFER),
             },
             ty::ConstKind::Bound(debruijn, _) => {

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -105,8 +105,8 @@ where
                     -- they should have been handled earlier"
             )
         }
-        (_, ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)))
-        | (ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)), _)
+        (_, ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy))
+        | (ty::Infer(ty::FreshTy | ty::FreshIntTy | ty::FreshFloatTy), _)
             if infcx.next_trait_solver() =>
         {
             panic!("We do not expect to encounter `Fresh` variables in the new solver")

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -759,11 +759,11 @@ pub enum InferTy {
     /// `rustc_infer::infer::freshen` for more details.
     ///
     /// Compare with [`TyVar`][Self::TyVar].
-    FreshTy(u32),
+    FreshTy,
     /// Like [`FreshTy`][Self::FreshTy], but as a replacement for [`IntVar`][Self::IntVar].
-    FreshIntTy(u32),
+    FreshIntTy,
     /// Like [`FreshTy`][Self::FreshTy], but as a replacement for [`FloatVar`][Self::FloatVar].
-    FreshFloatTy(u32),
+    FreshFloatTy,
 }
 
 impl UnifyValue for IntVarValue {
@@ -841,7 +841,7 @@ impl<CTX> HashStable<CTX> for InferTy {
             TyVar(_) | IntVar(_) | FloatVar(_) => {
                 panic!("type variables should not be hashed: {self:?}")
             }
-            FreshTy(v) | FreshIntTy(v) | FreshFloatTy(v) => v.hash_stable(ctx, hasher),
+            FreshTy | FreshIntTy | FreshFloatTy => {}
         }
     }
 }
@@ -853,9 +853,9 @@ impl fmt::Display for InferTy {
             TyVar(_) => write!(f, "_"),
             IntVar(_) => write!(f, "{}", "{integer}"),
             FloatVar(_) => write!(f, "{}", "{float}"),
-            FreshTy(v) => write!(f, "FreshTy({v})"),
-            FreshIntTy(v) => write!(f, "FreshIntTy({v})"),
-            FreshFloatTy(v) => write!(f, "FreshFloatTy({v})"),
+            FreshTy => write!(f, "FreshTy"),
+            FreshIntTy => write!(f, "FreshIntTy"),
+            FreshFloatTy => write!(f, "FreshFloatTy"),
         }
     }
 }
@@ -885,9 +885,9 @@ impl fmt::Debug for InferTy {
             TyVar(ref v) => v.fmt(f),
             IntVar(ref v) => v.fmt(f),
             FloatVar(ref v) => v.fmt(f),
-            FreshTy(v) => write!(f, "FreshTy({v:?})"),
-            FreshIntTy(v) => write!(f, "FreshIntTy({v:?})"),
-            FreshFloatTy(v) => write!(f, "FreshFloatTy({v:?})"),
+            FreshTy => write!(f, "FreshTy"),
+            FreshIntTy => write!(f, "FreshIntTy"),
+            FreshFloatTy => write!(f, "FreshFloatTy"),
         }
     }
 }

--- a/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.rs
+++ b/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.rs
@@ -19,7 +19,7 @@ fn foo<I: rustc_type_ir::Interner>(cx: I, did: I::DefId) {
 }
 
 fn main() {
-    let _ = rustc_type_ir::InferConst::Fresh(42);
+    let _ = rustc_type_ir::InferConst::Fresh;
 //~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals
     let _: rustc_type_ir::InferConst;
 //~^ ERROR: do not use `rustc_type_ir` unless you are implementing type system internals

--- a/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.stderr
+++ b/tests/ui-fulldeps/internal-lints/direct-use-of-rustc-type-ir.stderr
@@ -22,7 +22,7 @@ LL | fn foo<I: rustc_type_ir::Interner>(cx: I, did: I::DefId) {
 error: do not use `rustc_type_ir` unless you are implementing type system internals
   --> $DIR/direct-use-of-rustc-type-ir.rs:22:13
    |
-LL |     let _ = rustc_type_ir::InferConst::Fresh(42);
+LL |     let _ = rustc_type_ir::InferConst::Fresh;
    |             ^^^^^^^^^^^^^
    |
    = note: use `rustc_middle::ty` instead


### PR DESCRIPTION
Each of `InferTy::Fresh{Ty,IntTy,FloatTy}` and `InferConst::Fresh` have a `u32` index. It turns out the index is only used for some weak sanity checking during freshening and can be removed, making these values a bit like `ReErased`.

This change simplifies things quite a bit, e.g. `TypeFreshener` no longers needs maps, and we can eliminate a bunch of pre-interned fresh types.

r? @lcnr