### PR TITLE
Enable T-compiler backport nomination

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -50,6 +50,21 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
+# [backport.*] sections autonominate pull requests for a backport
+# see: https://forge.rust-lang.org/triagebot/backport.html
+
+[backport.t-compiler-beta-backport]
+# The pull request MUST have one of these labels
+required-pr-labels = ["T-compiler"]
+# The regression MUST have this label
+required-issue-label = "regression-from-stable-to-beta"
+# if the above conditions matches, the PR will receive these labels
+add-labels = ["beta-nominated"]
+
+[backport.t-compiler-stable-backport]
+required-pr-labels = ["T-compiler"]
+required-issue-label = "regression-from-stable-to-stable"
+add-labels = ["stable-nominated"]
 
 # ------------------------------------------------------------------------------
 # Ping groups


### PR DESCRIPTION
This patches the triagebot.toml so that it will trigger a backport label on pull requests fixing regressions. Applying a backport label will trigger creating a Zulip thread. For now the configuration only for `T-compiler` labeled regressions.

Comments in the code explain how it works. Documentation [on the forge](https://forge.rust-lang.org/triagebot/backport.html).

```
[backport.foo]

# The pull request MUST have one of these labels
required_pr_labels = ["T-compiler"]

# The regression MUST have this label
required_issue_label = "regression-from-stable-to-beta"

# if the above conditions matches, the PR will receive these labels
add_labels = ["beta-nominated"]
```

Anything to think about before merging this?

thanks for a review