### PR TITLE
expand: Micro-optimize prelude injection

### DIFF
--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -47,8 +47,6 @@ pub fn inject(
         ast::ItemKind::ExternCrate(None, Ident::new(name, ident_span)),
     );
 
-    krate.items.insert(0, item);
-
     let root = (edition == Edition2015).then_some(kw::PathRoot);
 
     let import_path = root
@@ -75,6 +73,6 @@ pub fn inject(
         }),
     );
 
-    krate.items.insert(0, use_item);
+    krate.items.splice(0..0, [item, use_item]);
     krate.items.len() - orig_num_items
 }

--- a/tests/pretty/asm.pp
+++ b/tests/pretty/asm.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-mode:expanded
 //@ pp-exact:asm.pp
 //@ only-x86_64

--- a/tests/pretty/cast-lt.pp
+++ b/tests/pretty/cast-lt.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:cast-lt.pp

--- a/tests/pretty/dollar-crate.pp
+++ b/tests/pretty/dollar-crate.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:dollar-crate.pp

--- a/tests/pretty/expanded-and-path-remap-80832.pp
+++ b/tests/pretty/expanded-and-path-remap-80832.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // Test for issue 80832
 //
 //@ pretty-mode:expanded

--- a/tests/pretty/format-args-str-escape.pp
+++ b/tests/pretty/format-args-str-escape.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:format-args-str-escape.pp

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -4,10 +4,10 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn b<C>(e: C) { }
 

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-fn-params.pp

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -3,10 +3,10 @@
 //@ pp-exact:hir-fn-variadic.pp
 
 #![feature(c_variadic)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 extern "C" {
     unsafe fn foo(x: i32, va1: ...);

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-if-else.pp

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -5,10 +5,10 @@
 // This tests the pretty-printing of lifetimes in lots of ways.
 
 #![allow(unused)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 struct Foo<'a> {
     x: &'a u32,

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-attr.pp

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-loop.pp

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-struct-expr.pp

--- a/tests/pretty/if-else.pp
+++ b/tests/pretty/if-else.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:if-else.pp

--- a/tests/pretty/issue-12590-c.pp
+++ b/tests/pretty/issue-12590-c.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:issue-12590-c.pp

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir,typed
 //@ pp-exact:issue-4264.pp

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // Test to print lifetimes on HIR pretty-printing.
 
 //@ pretty-compare-only

--- a/tests/pretty/never-pattern.pp
+++ b/tests/pretty/never-pattern.pp
@@ -7,10 +7,10 @@
 #![allow(incomplete_features)]
 #![feature(never_patterns)]
 #![feature(never_type)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn f(x: Result<u32, !>) { _ = match x { Ok(x) => x, Err(!) , }; }
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -4,10 +4,10 @@
 
 #![feature(pin_ergonomics)]
 #![allow(dead_code, incomplete_features)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 use std::pin::Pin;
 

--- a/tests/pretty/postfix-match/precedence.pp
+++ b/tests/pretty/postfix-match/precedence.pp
@@ -1,10 +1,10 @@
 #![feature(prelude_import)]
 #![no_std]
 #![feature(postfix_match)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 use std::ops::Add;
 

--- a/tests/pretty/shebang-at-top.pp
+++ b/tests/pretty/shebang-at-top.pp
@@ -1,10 +1,10 @@
 #!/usr/bin/env rust
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-mode:expanded
 //@ pp-exact:shebang-at-top.pp
 //@ pretty-compare-only

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: --crate-type=lib --test --remap-path-prefix={{src-base}}/=/the/src/ --remap-path-prefix={{src-base}}\=/the/src/
 //@ pretty-compare-only
 //@ pretty-mode:expanded

--- a/tests/ui/asm/unpretty-expanded.stdout
+++ b/tests/ui/asm/unpretty-expanded.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
@@ -1,8 +1,8 @@
 #![feature(prelude_import)]
-#[prelude_import]
-use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2021::*;
 //@ edition: 2021
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass

--- a/tests/ui/codemap_tests/unicode.expanded.stdout
+++ b/tests/ui/codemap_tests/unicode.expanded.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ revisions: normal expanded
 //@[expanded] check-pass
 //@[expanded]compile-flags: -Zunpretty=expanded

--- a/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -6,10 +6,10 @@
 //@ edition: 2015
 
 #![crate_type = "lib"]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 trait Foo<const KIND : bool = true> {}
 

--- a/tests/ui/deriving/built-in-proc-macro-scope.stdout
+++ b/tests/ui/deriving/built-in-proc-macro-scope.stdout
@@ -6,10 +6,10 @@
 //@ edition:2015
 
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 #[macro_use]
 extern crate another_proc_macro;

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -17,10 +17,10 @@
 #![crate_type = "lib"]
 #![allow(dead_code)]
 #![allow(deprecated)]
-#[prelude_import]
-use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2021::*;
 
 // Empty struct.
 struct Empty;

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
@@ -4,10 +4,10 @@
 //@ compile-flags: -Zunpretty=expanded
 //@ edition: 2015
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 use std::marker::CoercePointee;
 
 pub trait MyTrait<T: ?Sized> {}

--- a/tests/ui/deriving/proc-macro-attribute-mixing.stdout
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.stdout
@@ -12,10 +12,10 @@
 //@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 #[macro_use]
 extern crate another_proc_macro;

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // This ensures that ICEs like rust#94953 don't happen
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ edition: 2015
 

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
@@ -5,10 +5,10 @@
 //@ edition: 2015
 
 #![feature(core_intrinsics, generic_assert)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn arbitrary_consuming_method_for_demonstration_purposes() {
     let elem = 1i32;

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -16,10 +16,10 @@ Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro
 // in the stdout
 
 #![no_std /* 0#0 */]
-#[prelude_import /* 0#1 */]
-use core /* 0#1 */::prelude /* 0#1 */::rust_2018 /* 0#1 */::*;
 #[macro_use /* 0#1 */]
 extern crate core /* 0#1 */;
+#[prelude_import /* 0#1 */]
+use core /* 0#1 */::prelude /* 0#1 */::rust_2018 /* 0#1 */::*;
 // Don't load unnecessary hygiene information from std
 extern crate std /* 0#0 */;
 

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -36,10 +36,10 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 
 #![feature /* 0#0 */(decl_macro)]
 #![no_std /* 0#0 */]
-#[prelude_import /* 0#1 */]
-use ::core /* 0#1 */::prelude /* 0#1 */::rust_2015 /* 0#1 */::*;
 #[macro_use /* 0#1 */]
 extern crate core /* 0#2 */;
+#[prelude_import /* 0#1 */]
+use ::core /* 0#1 */::prelude /* 0#1 */::rust_2015 /* 0#1 */::*;
 // Don't load unnecessary hygiene information from std
 extern crate std /* 0#0 */;
 

--- a/tests/ui/proc-macro/quote/debug.stdout
+++ b/tests/ui/proc-macro/quote/debug.stdout
@@ -12,10 +12,10 @@
 
 #![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 extern crate proc_macro;
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
 //@ edition: 2015

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -3,10 +3,10 @@
 //@ edition: 2015
 
 #![feature(type_alias_impl_trait)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 trait Animal { }
 

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
 //@ edition: 2015

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/exhaustive-asm.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.expanded.stdout
@@ -1,8 +1,8 @@
 #![feature(prelude_import)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -29,10 +29,10 @@
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 #[prelude_import]
 use self::prelude::*;

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -28,10 +28,10 @@
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 #[prelude_import]
 use self::prelude::*;

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/interpolation-expanded.stdout
+++ b/tests/ui/unpretty/interpolation-expanded.stdout
@@ -10,10 +10,10 @@
 // synthesizing parentheses indiscriminately; only where necessary.
 
 #![feature(if_let_guard)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 macro_rules! expr { ($expr:expr) => { $expr }; }
 

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -8,10 +8,10 @@
 //@ compile-flags: -Zunpretty=hir,typed
 //@ edition: 2015
 #![allow(dead_code)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn main() ({ } as ())
 


### PR DESCRIPTION
Use `splice` to avoid shifting the other items twice.
Put `extern crate std;` first so it's already resolved when we resolve `::std::prelude::rust_20XX`.