### PR TITLE
Account for `.yield` in illegal postfix operator message

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -785,9 +785,13 @@ impl<'a> Parser<'a> {
                     ExprKind::Call(_, _) => "a function call",
                     ExprKind::Await(_, _) => "`.await`",
                     ExprKind::Use(_, _) => "`.use`",
+                    ExprKind::Yield(YieldKind::Postfix(_)) => "`.yield`",
                     ExprKind::Match(_, _, MatchKind::Postfix) => "a postfix match",
                     ExprKind::Err(_) => return Ok(with_postfix),
-                    _ => unreachable!("parse_dot_or_call_expr_with_ shouldn't produce this"),
+                    _ => unreachable!(
+                        "did not expect {:?} as an illegal postfix operator following cast",
+                        with_postfix.kind
+                    ),
                 }
             );
             let mut err = self.dcx().struct_span_err(span, msg);

--- a/tests/ui/coroutine/postfix-yield-after-cast.rs
+++ b/tests/ui/coroutine/postfix-yield-after-cast.rs
@@ -1,0 +1,10 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144527>.
+
+#![feature(yield_expr, coroutines)]
+
+fn main() {
+    #[coroutine] || {
+        0 as u8.yield
+        //~^ ERROR cast cannot be followed by `.yield`
+    };
+}

--- a/tests/ui/coroutine/postfix-yield-after-cast.stderr
+++ b/tests/ui/coroutine/postfix-yield-after-cast.stderr
@@ -1,0 +1,13 @@
+error: cast cannot be followed by `.yield`
+  --> $DIR/postfix-yield-after-cast.rs:7:9
+   |
+LL |         0 as u8.yield
+   |         ^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (0 as u8).yield
+   |         +       +
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#144527