### PR TITLE
libtest: print the type of test being run

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -257,9 +257,9 @@ fn on_test_event(
     out: &mut dyn OutputFormatter,
 ) -> io::Result<()> {
     match (*event).clone() {
-        TestEvent::TeFiltered(filtered_tests, shuffle_seed) => {
+        TestEvent::TeFiltered(filtered_tests, shuffle_seed, group_kind) => {
             st.total = filtered_tests;
-            out.write_run_start(filtered_tests, shuffle_seed)?;
+            out.write_run_start(filtered_tests, shuffle_seed, group_kind)?;
         }
         TestEvent::TeFilteredOut(filtered_out) => {
             st.filtered_out = filtered_out;

--- a/library/test/src/event.rs
+++ b/library/test/src/event.rs
@@ -4,6 +4,7 @@
 use super::test_result::TestResult;
 use super::time::TestExecTime;
 use super::types::{TestDesc, TestId};
+use crate::TestGroupKind;
 
 #[derive(Debug, Clone)]
 pub struct CompletedTest {
@@ -28,7 +29,7 @@ impl CompletedTest {
 
 #[derive(Debug, Clone)]
 pub enum TestEvent {
-    TeFiltered(usize, Option<u64>),
+    TeFiltered(usize, Option<u64>, TestGroupKind),
     TeWait(TestDesc),
     TeResult(CompletedTest),
     TeTimeout(TestDesc),

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -94,7 +94,12 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
             ))
     }
 
-    fn write_run_start(&mut self, test_count: usize, shuffle_seed: Option<u64>) -> io::Result<()> {
+    fn write_run_start(
+        &mut self,
+        test_count: usize,
+        shuffle_seed: Option<u64>,
+        _kind: super::TestGroupKind,
+    ) -> io::Result<()> {
         let shuffle_seed_json = if let Some(shuffle_seed) = shuffle_seed {
             format!(r#", "shuffle_seed": {shuffle_seed}"#)
         } else {

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -54,6 +54,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         &mut self,
         _test_count: usize,
         _shuffle_seed: Option<u64>,
+        _group_kind: super::TestGroupKind,
     ) -> io::Result<()> {
         // We write xml header on run start
         self.write_message("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
@@ -187,7 +188,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
 fn parse_class_name(desc: &TestDesc) -> (String, String) {
     match desc.test_type {
         TestType::UnitTest => parse_class_name_unit(desc),
-        TestType::DocTest => parse_class_name_doc(desc),
+        TestType::DocTest { merged: _ } => parse_class_name_doc(desc),
         TestType::IntegrationTest => parse_class_name_integration(desc),
         TestType::Unknown => (String::from("unknown"), String::from(desc.name.as_slice())),
     }

--- a/library/test/src/formatters/mod.rs
+++ b/library/test/src/formatters/mod.rs
@@ -21,7 +21,12 @@ pub(crate) trait OutputFormatter {
     fn write_test_discovered(&mut self, desc: &TestDesc, test_type: &str) -> io::Result<()>;
     fn write_discovery_finish(&mut self, state: &ConsoleTestDiscoveryState) -> io::Result<()>;
 
-    fn write_run_start(&mut self, test_count: usize, shuffle_seed: Option<u64>) -> io::Result<()>;
+    fn write_run_start(
+        &mut self,
+        test_count: usize,
+        shuffle_seed: Option<u64>,
+        kind: TestGroupKind,
+    ) -> io::Result<()>;
     fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()>;
     fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()>;
     fn write_result(
@@ -42,4 +47,23 @@ pub(crate) fn write_stderr_delimiter(test_output: &mut Vec<u8>, test_name: &Test
         None => (),
     }
     writeln!(test_output, "---- {test_name} stderr ----").unwrap();
+}
+
+/// Controls what type of message is printed when running tests.
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug)]
+pub enum TestGroupKind {
+    Regular,
+    DocTestMerged,
+    DocTestStandalone,
+}
+
+impl TestGroupKind {
+    fn qualifier(&self) -> &str {
+        match self {
+            TestGroupKind::Regular => "",
+            TestGroupKind::DocTestMerged => "merged doc",
+            TestGroupKind::DocTestStandalone => "standalone doc",
+        }
+    }
 }

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -206,14 +206,20 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
         ))
     }
 
-    fn write_run_start(&mut self, test_count: usize, shuffle_seed: Option<u64>) -> io::Result<()> {
+    fn write_run_start(
+        &mut self,
+        test_count: usize,
+        shuffle_seed: Option<u64>,
+        kind: super::TestGroupKind,
+    ) -> io::Result<()> {
         let noun = if test_count != 1 { "tests" } else { "test" };
         let shuffle_seed_msg = if let Some(shuffle_seed) = shuffle_seed {
             format!(" (shuffle seed: {shuffle_seed})")
         } else {
             String::new()
         };
-        self.write_plain(format!("\nrunning {test_count} {noun}{shuffle_seed_msg}\n"))
+        let qual = kind.qualifier();
+        self.write_plain(format!("\nrunning {test_count} {qual}{noun}{shuffle_seed_msg}\n"))
     }
 
     fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -197,7 +197,12 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
         Ok(())
     }
 
-    fn write_run_start(&mut self, test_count: usize, shuffle_seed: Option<u64>) -> io::Result<()> {
+    fn write_run_start(
+        &mut self,
+        test_count: usize,
+        shuffle_seed: Option<u64>,
+        kind: super::TestGroupKind,
+    ) -> io::Result<()> {
         self.total_test_count = test_count;
         let noun = if test_count != 1 { "tests" } else { "test" };
         let shuffle_seed_msg = if let Some(shuffle_seed) = shuffle_seed {
@@ -205,7 +210,8 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
         } else {
             String::new()
         };
-        self.write_plain(format!("\nrunning {test_count} {noun}{shuffle_seed_msg}\n"))
+        let qual = kind.qualifier();
+        self.write_plain(format!("\nrunning {test_count} {qual}{noun}{shuffle_seed_msg}\n"))
     }
 
     fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -35,6 +35,7 @@ pub use cli::TestOpts;
 pub use self::ColorConfig::*;
 pub use self::bench::{Bencher, black_box};
 pub use self::console::run_tests_console;
+pub use self::formatters::TestGroupKind;
 pub use self::options::{ColorConfig, Options, OutputFormat, RunIgnored, ShouldPanic};
 pub use self::types::TestName::*;
 pub use self::types::*;
@@ -327,6 +328,19 @@ where
     if !opts.bench_benchmarks {
         filtered_tests = convert_benchmarks_to_tests(filtered_tests);
     }
+    let group_kind = match filtered_tests.get(0).map(|x| x.desc.test_type) {
+        // if all remaining tests are the same kind of doctest, we will print a different message.
+        Some(ty @ TestType::DocTest { merged })
+            if filtered_tests.iter().all(|t| t.desc.test_type == ty) =>
+        {
+            if merged {
+                TestGroupKind::DocTestMerged
+            } else {
+                TestGroupKind::DocTestStandalone
+            }
+        }
+        _ => TestGroupKind::Regular,
+    };
 
     for test in filtered_tests {
         let mut desc = test.desc;
@@ -348,7 +362,7 @@ where
 
     let shuffle_seed = get_shuffle_seed(opts);
 
-    let event = TestEvent::TeFiltered(filtered.total_len(), shuffle_seed);
+    let event = TestEvent::TeFiltered(filtered.total_len(), shuffle_seed, group_kind);
     notify_about_test_event(event)?;
 
     let concurrency = opts.test_threads.unwrap_or_else(get_concurrency);

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -379,7 +379,7 @@ fn time_test_failure_template(test_type: TestType) -> TestResult {
 
 #[test]
 fn test_error_on_exceed() {
-    let types = [TestType::UnitTest, TestType::IntegrationTest, TestType::DocTest];
+    let types = [TestType::UnitTest, TestType::IntegrationTest, TestType::DocTest { merged: true }];
 
     for test_type in types.iter() {
         let result = time_test_failure_template(*test_type);
@@ -433,9 +433,9 @@ fn test_time_options_threshold() {
         (TestType::IntegrationTest, integration.warn.as_millis() - 1, false, false),
         (TestType::IntegrationTest, integration.warn.as_millis(), true, false),
         (TestType::IntegrationTest, integration.critical.as_millis(), true, true),
-        (TestType::DocTest, doc.warn.as_millis() - 1, false, false),
-        (TestType::DocTest, doc.warn.as_millis(), true, false),
-        (TestType::DocTest, doc.critical.as_millis(), true, true),
+        (TestType::DocTest { merged: false }, doc.warn.as_millis() - 1, false, false),
+        (TestType::DocTest { merged: false }, doc.warn.as_millis(), true, false),
+        (TestType::DocTest { merged: false }, doc.critical.as_millis(), true, true),
     ];
 
     for (test_type, time, expected_warn, expected_critical) in test_vector.iter() {

--- a/library/test/src/time.rs
+++ b/library/test/src/time.rs
@@ -167,7 +167,7 @@ impl TestTimeOptions {
         match test.test_type {
             TestType::UnitTest => self.unit_threshold.warn,
             TestType::IntegrationTest => self.integration_threshold.warn,
-            TestType::DocTest => self.doctest_threshold.warn,
+            TestType::DocTest { merged: _ } => self.doctest_threshold.warn,
             TestType::Unknown => time_constants::UNKNOWN_WARN,
         }
     }
@@ -176,7 +176,7 @@ impl TestTimeOptions {
         match test.test_type {
             TestType::UnitTest => self.unit_threshold.critical,
             TestType::IntegrationTest => self.integration_threshold.critical,
-            TestType::DocTest => self.doctest_threshold.critical,
+            TestType::DocTest { merged: _ } => self.doctest_threshold.critical,
             TestType::Unknown => time_constants::UNKNOWN_CRITICAL,
         }
     }

--- a/library/test/src/types.rs
+++ b/library/test/src/types.rs
@@ -21,7 +21,7 @@ pub enum TestType {
     /// Integration-style tests are expected to be in the `tests` folder of the crate.
     IntegrationTest,
     /// Doctests are created by the `librustdoc` manually, so it's a different type of test.
-    DocTest,
+    DocTest { merged: bool },
     /// Tests for the sources that don't follow the project layout convention
     /// (e.g. tests in raw `main.rs` compiled by calling `rustc --test` directly).
     Unknown,
@@ -252,6 +252,7 @@ pub struct TestDescAndFn {
 }
 
 impl TestDescAndFn {
+    /// Generate a new merged doctest
     pub const fn new_doctest(
         test_name: &'static str,
         ignore: bool,
@@ -278,7 +279,7 @@ impl TestDescAndFn {
                 } else {
                     options::ShouldPanic::No
                 },
-                test_type: TestType::DocTest,
+                test_type: TestType::DocTest { merged: true },
             },
             testfn,
         }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -391,6 +391,7 @@ pub(crate) fn run_tests(
                 opts.clone(),
                 Arc::clone(rustdoc_options),
                 unused_extern_reports.clone(),
+                false,
             ));
         }
     }
@@ -1017,7 +1018,7 @@ impl CreateRunnableDocTests {
             || self.rustdoc_options.nocapture
             || self.rustdoc_options.test_args.iter().any(|arg| arg == "--show-output");
         if is_standalone {
-            let test_desc = self.generate_test_desc_and_fn(doctest, scraped_test);
+            let test_desc = self.generate_test_desc_and_fn(doctest, scraped_test, false);
             self.standalone_tests.push(test_desc);
         } else {
             self.mergeable_tests
@@ -1038,6 +1039,7 @@ impl CreateRunnableDocTests {
         &mut self,
         test: DocTestBuilder,
         scraped_test: ScrapedDocTest,
+        merged: bool,
     ) -> test::TestDescAndFn {
         if !scraped_test.langstr.compile_fail {
             self.compiling_test_count.fetch_add(1, Ordering::SeqCst);
@@ -1049,16 +1051,66 @@ impl CreateRunnableDocTests {
             self.opts.clone(),
             Arc::clone(&self.rustdoc_options),
             self.unused_extern_reports.clone(),
+            merged,
         )
     }
 }
 
+#[cfg(not(bootstrap))]
 fn generate_test_desc_and_fn(
     test: DocTestBuilder,
     scraped_test: ScrapedDocTest,
     opts: GlobalTestOptions,
     rustdoc_options: Arc<RustdocOptions>,
     unused_externs: Arc<Mutex<Vec<UnusedExterns>>>,
+    merged: bool,
+) -> test::TestDescAndFn {
+    let target_str = rustdoc_options.target.to_string();
+    let rustdoc_test_options =
+        IndividualTestOptions::new(&rustdoc_options, &test.test_id, scraped_test.path());
+
+    debug!("creating test {}: {}", scraped_test.name, scraped_test.text);
+    test::TestDescAndFn {
+        desc: test::TestDesc {
+            name: test::DynTestName(scraped_test.name.clone()),
+            ignore: match scraped_test.langstr.ignore {
+                Ignore::All => true,
+                Ignore::None => false,
+                Ignore::Some(ref ignores) => ignores.iter().any(|s| target_str.contains(s)),
+            },
+            ignore_message: None,
+            source_file: "",
+            start_line: 0,
+            start_col: 0,
+            end_line: 0,
+            end_col: 0,
+            // compiler failures are test failures
+            should_panic: test::ShouldPanic::No,
+            compile_fail: scraped_test.langstr.compile_fail,
+            no_run: scraped_test.no_run(&rustdoc_options),
+            test_type: test::TestType::DocTest { merged },
+        },
+        testfn: test::DynTestFn(Box::new(move || {
+            doctest_run_fn(
+                rustdoc_test_options,
+                opts,
+                test,
+                scraped_test,
+                rustdoc_options,
+                unused_externs,
+            )
+        })),
+    }
+}
+
+#[cfg(bootstrap)]
+fn generate_test_desc_and_fn(
+    test: DocTestBuilder,
+    scraped_test: ScrapedDocTest,
+    opts: GlobalTestOptions,
+    rustdoc_options: Arc<RustdocOptions>,
+    unused_externs: Arc<Mutex<Vec<UnusedExterns>>>,
+    _merged: bool,
 ) -> test::TestDescAndFn {
     let target_str = rustdoc_options.target.to_string();
     let rustdoc_test_options =

--- a/tests/run-make/doctests-merge/doctest-2021.stdout
+++ b/tests/run-make/doctests-merge/doctest-2021.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test doctest.rs - (line 4) ... ok
 test doctest.rs - init (line 8) ... ok
 

--- a/tests/run-make/doctests-merge/doctest-2024.stdout
+++ b/tests/run-make/doctests-merge/doctest-2024.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 merged doctests
 test doctest.rs - (line 4) ... ok
 test doctest.rs - init (line 8) ... ok
 

--- a/tests/run-make/doctests-merge/doctest-standalone.stdout
+++ b/tests/run-make/doctests-merge/doctest-standalone.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test doctest-standalone.rs - (line 4) ... ok
 test doctest-standalone.rs - init (line 8) ... ok
 

--- a/tests/rustdoc-ui/2024-doctests-checks.stdout
+++ b/tests/rustdoc-ui/2024-doctests-checks.stdout
@@ -1,11 +1,11 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/2024-doctests-checks.rs - Foo (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
-running 1 test
+running 1 standalone doctest
 test $DIR/2024-doctests-checks.rs - Foo (line 17) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
+++ b/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
@@ -1,11 +1,11 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/2024-doctests-crate-attribute.rs - Foo (line 22) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
-running 1 test
+running 1 standalone doctest
 test $DIR/2024-doctests-crate-attribute.rs - Foo (line 13) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/cfg-test.stdout
+++ b/tests/rustdoc-ui/doctest/cfg-test.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/cfg-test.rs - Bar (line 27) ... ok
 test $DIR/cfg-test.rs - Foo (line 19) ... ok
 

--- a/tests/rustdoc-ui/doctest/check-cfg-test.stdout
+++ b/tests/rustdoc-ui/doctest/check-cfg-test.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/check-cfg-test.rs - Foo (line 8) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/comment-in-attr-134221-2.stdout
+++ b/tests/rustdoc-ui/doctest/comment-in-attr-134221-2.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/comment-in-attr-134221-2.rs - (line 11) ... FAILED
 test $DIR/comment-in-attr-134221-2.rs - (line 7) ... ok
 

--- a/tests/rustdoc-ui/doctest/comment-in-attr-134221.stdout
+++ b/tests/rustdoc-ui/doctest/comment-in-attr-134221.stdout
@@ -1,5 +1,5 @@
 
-running 3 tests
+running 3 standalone doctests
 test $DIR/comment-in-attr-134221.rs - (line 11) ... FAILED
 test $DIR/comment-in-attr-134221.rs - (line 17) ... FAILED
 test $DIR/comment-in-attr-134221.rs - (line 23) ... FAILED

--- a/tests/rustdoc-ui/doctest/dead-code-2024.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/dead-code-2024.rs - f (line 15) - compile ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/dead-code-items.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-items.stdout
@@ -1,5 +1,5 @@
 
-running 13 tests
+running 13 standalone doctests
 test $DIR/dead-code-items.rs - A (line 34) - compile ... ok
 test $DIR/dead-code-items.rs - A (line 90) - compile ... ok
 test $DIR/dead-code-items.rs - A::field (line 41) - compile ... FAILED

--- a/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module-2.stdout
@@ -1,11 +1,11 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/dead-code-module-2.rs - g (line 26) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
-running 1 test
+running 1 standalone doctest
 test $DIR/dead-code-module-2.rs - my_mod::f (line 18) - compile ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/dead-code-module.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-module.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/dead-code-module.rs - my_mod::f (line 16) - compile ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/dead-code.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/dead-code.rs - f (line 12) - compile ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/display-output.stdout
+++ b/tests/rustdoc-ui/doctest/display-output.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/display-output.rs - foo (line 9) ... ok
 
 successes:

--- a/tests/rustdoc-ui/doctest/doc-comment-multi-line-attr.stdout
+++ b/tests/rustdoc-ui/doctest/doc-comment-multi-line-attr.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doc-comment-multi-line-attr.rs - (line 7) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/doc-comment-multi-line-cfg-attr.stdout
+++ b/tests/rustdoc-ui/doctest/doc-comment-multi-line-cfg-attr.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doc-comment-multi-line-cfg-attr.rs - Bar (line 6) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/doc-test-doctest-feature.stdout
+++ b/tests/rustdoc-ui/doctest/doc-test-doctest-feature.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doc-test-doctest-feature.rs - Foo (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/doc-test-rustdoc-feature.stdout
+++ b/tests/rustdoc-ui/doctest/doc-test-rustdoc-feature.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doc-test-rustdoc-feature.rs - Foo (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/doctest-multiline-crate-attribute.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-multiline-crate-attribute.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doctest-multiline-crate-attribute.rs - f (line 6) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/doctest-output-include-fail.md - (line 3) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
@@ -1,5 +1,5 @@
 
-running 3 tests
+running 3 standalone doctests
 test $DIR/doctest-output.rs - (line 12) ... ok
 test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
 test $DIR/doctest-output.rs - foo::bar (line 22) ... ok

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
@@ -1,5 +1,5 @@
 
-running 3 tests
+running 3 merged doctests
 test $DIR/doctest-output.rs - (line 12) ... ok
 test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
 test $DIR/doctest-output.rs - foo::bar (line 22) ... ok

--- a/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
+++ b/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/edition-2024-error-output.rs - (line 14) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/extern-crate.stdout
+++ b/tests/rustdoc-ui/doctest/extern-crate.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/extern-crate.rs - foo (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/failed-doctest-compile-fail.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-compile-fail.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-compile-fail.rs - Foo (line 9) - compile fail ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/failed-doctest-missing-codes.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-missing-codes.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-missing-codes.rs - Foo (line 9) - compile fail ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-output.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-output.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
 test $DIR/failed-doctest-output.rs - SomeStruct (line 15) ... FAILED
 

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic-2021.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-should-panic-2021.rs - Foo (line 10) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/failed-doctest-should-panic.rs - Foo (line 12) - should panic ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2015.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-test-crate.edition2024.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/failed-doctest-test-crate.rs - m (line 16) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-macro-calls.fail.stdout
@@ -1,5 +1,5 @@
 
-running 4 tests
+running 4 standalone doctests
 test $DIR/main-alongside-macro-calls.rs - (line 19) ... ok
 test $DIR/main-alongside-macro-calls.rs - (line 24) ... ok
 test $DIR/main-alongside-macro-calls.rs - (line 28) ... FAILED

--- a/tests/rustdoc-ui/doctest/main-alongside-macro-calls.pass.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-macro-calls.pass.stdout
@@ -1,5 +1,5 @@
 
-running 4 tests
+running 4 standalone doctests
 test $DIR/main-alongside-macro-calls.rs - (line 19) ... ok
 test $DIR/main-alongside-macro-calls.rs - (line 24) ... ok
 test $DIR/main-alongside-macro-calls.rs - (line 28) - compile fail ... ok

--- a/tests/rustdoc-ui/doctest/main-alongside-stmts.stdout
+++ b/tests/rustdoc-ui/doctest/main-alongside-stmts.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/main-alongside-stmts.rs - (line 17) ... ok
 test $DIR/main-alongside-stmts.rs - (line 26) ... ok
 

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 merged doctests
 test $DIR/merged-ignore-no_run.rs - ignored (line 7) ... ignored
 test $DIR/merged-ignore-no_run.rs - no_run (line 12) - compile ... ok
 

--- a/tests/rustdoc-ui/doctest/nested-main.stdout
+++ b/tests/rustdoc-ui/doctest/nested-main.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/nested-main.rs - foo (line 10) ... ok
 test $DIR/nested-main.rs - foo2 (line 19) ... ok
 

--- a/tests/rustdoc-ui/doctest/no-run-flag.stdout
+++ b/tests/rustdoc-ui/doctest/no-run-flag.stdout
@@ -1,5 +1,5 @@
 
-running 7 tests
+running 7 standalone doctests
 test $DIR/no-run-flag.rs - f (line 11) - compile ... ok
 test $DIR/no-run-flag.rs - f (line 14) ... ignored
 test $DIR/no-run-flag.rs - f (line 17) - compile ... ok

--- a/tests/rustdoc-ui/doctest/nocapture-fail.stdout
+++ b/tests/rustdoc-ui/doctest/nocapture-fail.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/nocapture-fail.rs - Foo (line 7) - compile fail ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/nocapture.stdout
+++ b/tests/rustdoc-ui/doctest/nocapture.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 hello!
 test $DIR/nocapture.rs - Foo (line 6) ... ok
 

--- a/tests/rustdoc-ui/doctest/non-local-defs-impl.stdout
+++ b/tests/rustdoc-ui/doctest/non-local-defs-impl.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/non-local-defs-impl.rs - doctest (line 13) - compile ... FAILED
 test $DIR/non-local-defs-impl.rs - doctest (line 25) - compile ... ok
 

--- a/tests/rustdoc-ui/doctest/non_local_defs.stdout
+++ b/tests/rustdoc-ui/doctest/non_local_defs.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/non_local_defs.rs - (line 7) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/per-target-ignores.stdout
+++ b/tests/rustdoc-ui/doctest/per-target-ignores.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/per-target-ignores.rs - foo (line 7) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/relative-path-include-bytes-132203.rs - (line 20) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/auxiliary/relative-dir.md - (line 1) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/run-directory.correct.stdout
+++ b/tests/rustdoc-ui/doctest/run-directory.correct.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/run-directory.rs - foo (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/run-directory.incorrect.stdout
+++ b/tests/rustdoc-ui/doctest/run-directory.incorrect.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/run-directory.rs - foo (line 19) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
+++ b/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/rustflags-multiple-args.rs - Bar (line 9) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/rustflags.stdout
+++ b/tests/rustdoc-ui/doctest/rustflags.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/rustflags.rs - Bar (line 6) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
@@ -1,5 +1,5 @@
 
-running 3 tests
+running 3 merged doctests
 test $DIR/stdout-and-stderr.rs - (line 17) ... FAILED
 test $DIR/stdout-and-stderr.rs - (line 22) ... FAILED
 test $DIR/stdout-and-stderr.rs - (line 26) ... FAILED

--- a/tests/rustdoc-ui/doctest/test-no_std.stdout
+++ b/tests/rustdoc-ui/doctest/test-no_std.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/test-no_std.rs - f (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/doctest/test-type.stdout
+++ b/tests/rustdoc-ui/doctest/test-type.stdout
@@ -1,5 +1,5 @@
 
-running 5 tests
+running 5 standalone doctests
 test $DIR/test-type.rs - f (line 12) ... ignored
 test $DIR/test-type.rs - f (line 15) - compile ... ok
 test $DIR/test-type.rs - f (line 21) - compile fail ... ok

--- a/tests/rustdoc-ui/doctest/unparseable-doc-test.stdout
+++ b/tests/rustdoc-ui/doctest/unparseable-doc-test.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/unparseable-doc-test.rs - foo (line 7) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/doctest/warn-main-not-called.stdout
+++ b/tests/rustdoc-ui/doctest/warn-main-not-called.stdout
@@ -1,5 +1,5 @@
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/warn-main-not-called.rs - (line 10) ... ok
 test $DIR/warn-main-not-called.rs - (line 19) ... ok
 

--- a/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
+++ b/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
@@ -1,11 +1,11 @@
 
-running 1 test
+running 1 merged doctest
 test $DIR/wrong-ast-2024.rs - three (line 20) - should panic ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
-running 2 tests
+running 2 standalone doctests
 test $DIR/wrong-ast-2024.rs - one (line 10) ... FAILED
 test $DIR/wrong-ast-2024.rs - two (line 15) ... FAILED
 

--- a/tests/rustdoc-ui/doctest/wrong-ast.stdout
+++ b/tests/rustdoc-ui/doctest/wrong-ast.stdout
@@ -1,5 +1,5 @@
 
-running 3 tests
+running 3 standalone doctests
 test $DIR/wrong-ast.rs - one (line 6) ... FAILED
 test $DIR/wrong-ast.rs - three (line 16) ... ok
 test $DIR/wrong-ast.rs - two (line 11) ... FAILED

--- a/tests/rustdoc-ui/issues/issue-80992.stdout
+++ b/tests/rustdoc-ui/issues/issue-80992.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/issue-80992.rs - test (line 7) - compile fail ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/issues/issue-81662-shortness.stdout
+++ b/tests/rustdoc-ui/issues/issue-81662-shortness.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/issue-81662-shortness.rs - foo (line 7) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/issues/issue-91134.stdout
+++ b/tests/rustdoc-ui/issues/issue-91134.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test $DIR/issue-91134.rs - Something (line 10) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test remapped_path/remap-path-prefix-failed-doctest-output.rs - SomeStruct (line 11) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test remapped_path/remap-path-prefix-invalid-doctest.rs - SomeStruct (line 10) ... FAILED
 
 failures:

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.stdout
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.stdout
@@ -1,5 +1,5 @@
 
-running 1 test
+running 1 standalone doctest
 test remapped_path/remap-path-prefix-passed-doctest-output.rs - SomeStruct (line 11) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144596)*
<!-- homu-ignore:end -->

supplemental to https://github.com/rust-lang/rust/pull/144308

unfortunately because stage1 rustdoc is checked in CI, we need to use `cfg(bootstrap)` for the transitional period.

cc @GuillaumeGomez 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
