### PR TITLE
aarch64-nintendo-switch-freestanding - Enable CPU features that are always available in a live system (crypto instructions, plus explicit NEON).

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: "aarch64".into(),
         options: TargetOptions {
-            features: "+v8a".into(),
+            features: "+v8a,+neon,+crypto".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             link_script: Some(LINKER_SCRIPT.into()),

--- a/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_nintendo_switch_freestanding.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: "aarch64".into(),
         options: TargetOptions {
-            features: "+v8a,+neon,+crypto".into(),
+            features: "+v8a,+neon,+crypto,+crc".into(),
             linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
             linker: Some("rust-lld".into()),
             link_script: Some(LINKER_SCRIPT.into()),


### PR DESCRIPTION
~~While some NEON and crypto features may not be supported on the Nintendo Switch at boot (e.g. on the a53 cores) and this has not been tested, the features will _always_ be available if running as a sysmodule or homebrew application under Horizon/Atmosphere.~~ EDIT:  the a53 cores are fused out, these features are always available.

This has been tested with local tools personally, as well as building [emuiibo](https://github.com/XorTroll/emuiibo) as it uses both `sha` and `aes` primitives. This was tested using inline assembly in previous versions, and in current versions by using the `aes`, `ctr`, `hmac`, and `sha2` crates.

r? @jam1garner 

This ended up being much delayed from our discussions about updating this. I tested a number of individual features such as the `aes` and `sha2` target-features directly to avoid a warning message with the `crypto` feature, but that appears to be caused by https://github.com/rust-lang/rust/issues/96472 and is not actually an issue.

There is also a decision to make here about explicitly enabling the `neon` feature. I am in favor of it to be explicit, but it is not necessary as it is already enabled by the `v8a` and `crypto` features. I will defer to your decision as it does not change the actual instructions available for codegen.
