### PR TITLE
Improve `print_type`.

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -42,8 +42,13 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             | ty::UnsafeBinder(_) => self.pretty_print_type(ty),
 
             // Placeholders (all printed as `_` to uniformize them).
-            ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error(_) => {
+            ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error(_) => {
                 write!(self, "_")?;
+                Ok(())
+            }
+
+            ty::Param(param_ty) => {
+                write!(self, "{}", param_ty.name)?;
                 Ok(())
             }
 

--- a/tests/ui/issues/issue-61894.rs
+++ b/tests/ui/issues/issue-61894.rs
@@ -17,5 +17,5 @@ impl<M> Bar<M> {
 }
 
 fn main() {
-    assert_eq!(Bar(()).foo(), "issue_61894::Bar<_>::foo::f");
+    assert_eq!(Bar(()).foo(), "issue_61894::Bar<M>::foo::f");
 }


### PR DESCRIPTION
`ty::Param`s have a name, might as well print it.

r? @oli-obk 