### PR TITLE
Add a test case for the issue #129882

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/auxiliary/feature-attribute-missing-in-dependent-crate-ice-aux.rs
+++ b/tests/ui/const-generics/generic_const_exprs/auxiliary/feature-attribute-missing-in-dependent-crate-ice-aux.rs
@@ -1,0 +1,9 @@
+#![feature(generic_const_exprs)]
+
+pub struct Error(());
+
+pub trait FromSlice: Sized {
+    const SIZE: usize = std::mem::size_of::<Self>();
+
+    fn validate_slice(bytes: &[[u8; Self::SIZE]]) -> Result<(), Error>;
+}

--- a/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.rs
+++ b/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.rs
@@ -1,0 +1,19 @@
+//! Regression test to ensure that using the `generic_const_exprs` feature in a library crate
+//! without enabling it in a dependent crate does not lead to an ICE.
+//!
+//! Issue: <https://github.com/rust-lang/rust/issues/129882>
+
+//@ aux-build:feature-attribute-missing-in-dependent-crate-ice-aux.rs
+
+extern crate feature_attribute_missing_in_dependent_crate_ice_aux as aux;
+
+struct Wrapper<const F: usize>(i64);
+
+impl<const F: usize> aux::FromSlice for Wrapper<F> {
+    fn validate_slice(_: &[[u8; Self::SIZE]]) -> Result<(), aux::Error> {
+        //~^ ERROR generic `Self` types are currently not permitted in anonymous constants
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
@@ -1,0 +1,14 @@
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/feature-attribute-missing-in-dependent-crate-ice.rs:13:33
+   |
+LL |     fn validate_slice(_: &[[u8; Self::SIZE]]) -> Result<(), aux::Error> {
+   |                                 ^^^^
+   |
+note: not a concrete type
+  --> $DIR/feature-attribute-missing-in-dependent-crate-ice.rs:12:41
+   |
+LL | impl<const F: usize> aux::FromSlice for Wrapper<F> {
+   |                                         ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
It ensures that using the `generic_const_exprs` feature in a library crate without enabling it in a dependent crate does not lead to an ICE.

Closes https://github.com/rust-lang/rust/issues/129882.
