### PR TITLE
Fix test intrinsic-raw_eq-const-bad for big-endian

### DIFF
--- a/tests/ui/consts/const-eval/union-const-eval-field.rs
+++ b/tests/ui/consts/const-eval/union-const-eval-field.rs
@@ -1,5 +1,6 @@
 //@ dont-require-annotations: NOTE
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
+//@ normalize-stderr: "([[:xdigit:]]{2}\s){4}(__\s){4}\s+│\s+([?|\.]){4}\W{4}" -> "HEX_DUMP"
 
 type Field1 = i32;
 type Field2 = f32;

--- a/tests/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/tests/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,21 +1,21 @@
 error[E0080]: reading memory at ALLOC0[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
-  --> $DIR/union-const-eval-field.rs:29:37
+  --> $DIR/union-const-eval-field.rs:30:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
    |                                     ^^^^^^^^^^^^ evaluation of `read_field3::FIELD3` failed here
    |
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               00 00 80 3f __ __ __ __                         │ ...?░░░░
+               HEX_DUMP
            }
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:31:5
+  --> $DIR/union-const-eval-field.rs:32:5
    |
 LL |     FIELD3
    |     ^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:31:5
+  --> $DIR/union-const-eval-field.rs:32:5
    |
 LL |     FIELD3
    |     ^^^^^^

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
@@ -1,3 +1,4 @@
+//@ normalize-stderr: "[[:xdigit:]]{2} __ ([[:xdigit:]]{2}\s){2}" -> "HEX_DUMP"
 #![feature(core_intrinsics)]
 
 const RAW_EQ_PADDING: bool = unsafe {

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -1,15 +1,15 @@
 error[E0080]: reading memory at ALLOC0[0x0..0x4], but memory is uninitialized at [0x1..0x2], and this operation requires initialized memory
-  --> $DIR/intrinsic-raw_eq-const-bad.rs:4:5
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:5:5
    |
 LL |     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_PADDING` failed here
    |
    = note: the raw bytes of the constant (size: 4, align: 2) {
-               01 __ 02 00                                     │ .░..
+               HEX_DUMP                                    │ .░..
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/intrinsic-raw_eq-const-bad.rs:9:5
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:10:5
    |
 LL |     std::intrinsics::raw_eq(&(&0), &(&1))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_PTR` failed here
@@ -18,7 +18,7 @@ LL |     std::intrinsics::raw_eq(&(&0), &(&1))
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: accessing memory with alignment 1, but alignment 4 is required
-  --> $DIR/intrinsic-raw_eq-const-bad.rs:16:5
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:17:5
    |
 LL |     std::intrinsics::raw_eq(aref, aref)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here


### PR DESCRIPTION
The test fails on s390x and presumably other big-endian systems, due to print of raw values. To fix the tests remove the raw output values in the error note with normalize-stderr.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
