### PR TITLE
Fix typo in `DropGuard` doc

### DIFF
--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -4,7 +4,7 @@ use crate::ops::{Deref, DerefMut};
 
 /// Wrap a value and run a closure when dropped.
 ///
-/// This is useful for quickly creating desructors inline.
+/// This is useful for quickly creating destructors inline.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Follows-up rust-lang/rust#144236 (I happened to see the typo yesterday but didn’t think it should delay the PR’s merge so I kept quiet, sorryyyyy).