### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -110,18 +110,10 @@ pub enum DeprecatedSince {
     Err,
 }
 
-#[derive(
-    Copy,
-    Debug,
-    Eq,
-    PartialEq,
-    Encodable,
-    Decodable,
-    Clone,
-    HashStable_Generic,
-    PrintAttribute
-)]
-pub enum CoverageStatus {
+/// Successfully-parsed value of a `#[coverage(..)]` attribute.
+#[derive(Copy, Debug, Eq, PartialEq, Encodable, Decodable, Clone)]
+#[derive(HashStable_Generic, PrintAttribute)]
+pub enum CoverageAttrKind {
     On,
     Off,
 }
@@ -304,8 +296,8 @@ pub enum AttributeKind {
     /// Represents `#[const_trait]`.
     ConstTrait(Span),
 
-    /// Represents `#[coverage]`.
-    Coverage(Span, CoverageStatus),
+    /// Represents `#[coverage(..)]`.
+    Coverage(Span, CoverageAttrKind),
 
     ///Represents `#[rustc_deny_explicit_impl]`.
     DenyExplicitImpl(Span),

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,4 +1,4 @@
-use rustc_attr_data_structures::{AttributeKind, CoverageStatus, OptimizeAttr, UsedBy};
+use rustc_attr_data_structures::{AttributeKind, CoverageAttrKind, OptimizeAttr, UsedBy};
 use rustc_feature::{AttributeTemplate, template};
 use rustc_session::parse::feature_err;
 use rustc_span::{Span, Symbol, sym};
@@ -78,16 +78,16 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
             return None;
         };
 
-        let status = match arg.path().word_sym() {
-            Some(sym::off) => CoverageStatus::Off,
-            Some(sym::on) => CoverageStatus::On,
+        let kind = match arg.path().word_sym() {
+            Some(sym::off) => CoverageAttrKind::Off,
+            Some(sym::on) => CoverageAttrKind::On,
             None | Some(_) => {
                 fail_incorrect_argument(arg.span());
                 return None;
             }
         };
 
-        Some(AttributeKind::Coverage(cx.attr_span, status))
+        Some(AttributeKind::Coverage(cx.attr_span, kind))
     }
 }
 

--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -47,8 +47,6 @@ pub fn inject(
         ast::ItemKind::ExternCrate(None, Ident::new(name, ident_span)),
     );
 
-    krate.items.insert(0, item);
-
     let root = (edition == Edition2015).then_some(kw::PathRoot);
 
     let import_path = root
@@ -75,6 +73,6 @@ pub fn inject(
         }),
     );
 
-    krate.items.insert(0, use_item);
+    krate.items.splice(0..0, [item, use_item]);
     krate.items.len() - orig_num_items
 }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -55,6 +55,7 @@ impl<'tcx> crate::MirPass<'tcx> for InstSimplify {
 
             let terminator = block.terminator.as_mut().unwrap();
             ctx.simplify_primitive_clone(terminator, &mut block.statements);
+            ctx.simplify_align_of_slice_val(terminator, &mut block.statements);
             ctx.simplify_intrinsic_assert(terminator);
             ctx.simplify_nounwind_call(terminator);
             simplify_duplicate_switch_targets(terminator);
@@ -250,6 +251,36 @@ impl<'tcx> InstSimplifyContext<'_, 'tcx> {
             ))),
         ));
         terminator.kind = TerminatorKind::Goto { target: *destination_block };
+    }
+
+    // Convert `align_of_val::<[T]>(ptr)` to `align_of::<T>()`, since the
+    // alignment of a slice doesn't actually depend on metadata at all
+    // and the element type is always `Sized`.
+    //
+    // This is here so it can run after inlining, where it's more useful.
+    // (LowerIntrinsics is done in cleanup, before the optimization passes.)
+    fn simplify_align_of_slice_val(
+        &self,
+        terminator: &mut Terminator<'tcx>,
+        statements: &mut Vec<Statement<'tcx>>,
+    ) {
+        if let TerminatorKind::Call {
+            func, args, destination, target: Some(destination_block), ..
+        } = &terminator.kind
+            && args.len() == 1
+            && let Some((fn_def_id, generics)) = func.const_fn_def()
+            && self.tcx.is_intrinsic(fn_def_id, sym::align_of_val)
+            && let ty::Slice(elem_ty) = *generics.type_at(0).kind()
+        {
+            statements.push(Statement::new(
+                terminator.source_info,
+                StatementKind::Assign(Box::new((
+                    *destination,
+                    Rvalue::NullaryOp(NullOp::AlignOf, elem_ty),
+                ))),
+            ));
+            terminator.kind = TerminatorKind::Goto { target: *destination_block };
+        }
     }
 
     fn simplify_nounwind_call(&self, terminator: &mut Terminator<'tcx>) {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -785,9 +785,13 @@ impl<'a> Parser<'a> {
                     ExprKind::Call(_, _) => "a function call",
                     ExprKind::Await(_, _) => "`.await`",
                     ExprKind::Use(_, _) => "`.use`",
+                    ExprKind::Yield(YieldKind::Postfix(_)) => "`.yield`",
                     ExprKind::Match(_, _, MatchKind::Postfix) => "a postfix match",
                     ExprKind::Err(_) => return Ok(with_postfix),
-                    _ => unreachable!("parse_dot_or_call_expr_with_ shouldn't produce this"),
+                    _ => unreachable!(
+                        "did not expect {:?} as an illegal postfix operator following cast",
+                        with_postfix.kind
+                    ),
                 }
             );
             let mut err = self.dcx().struct_span_err(span, msg);

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -4,7 +4,7 @@ use crate::ops::{Deref, DerefMut};
 
 /// Wrap a value and run a closure when dropped.
 ///
-/// This is useful for quickly creating desructors inline.
+/// This is useful for quickly creating destructors inline.
 ///
 /// # Examples
 ///

--- a/tests/coverage/auto-derived.auto.cov-map
+++ b/tests/coverage/auto-derived.auto.cov-map
@@ -1,0 +1,47 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.auto.cov-map
+++ b/tests/coverage/auto-derived.auto.cov-map
@@ -1,15 +1,3 @@
-Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
-Number of files: 1
-- file 0 => $DIR/auto-derived.rs
-Number of expressions: 0
-Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
-- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
-- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
-- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
-Highest counter ID seen: c0
-
 Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
 Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
 Number of files: 1
@@ -19,18 +7,6 @@ Number of file 0 mappings: 4
 - Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
 - Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
 - Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
-Highest counter ID seen: c0
-
-Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
-Number of files: 1
-- file 0 => $DIR/auto-derived.rs
-Number of expressions: 0
-Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
-- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
-- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
 - Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
 Highest counter ID seen: c0
 

--- a/tests/coverage/auto-derived.auto.coverage
+++ b/tests/coverage/auto-derived.auto.coverage
@@ -23,18 +23,18 @@
    LL|       |#[cfg_attr(on, coverage(on))]
    LL|       |impl MyTrait for MyStruct {
    LL|       |    fn my_assoc_fn() {
-   LL|      1|        fn inner_fn() {
-   LL|      1|            say("in inner fn");
-   LL|      1|        }
+   LL|       |        fn inner_fn() {
+   LL|       |            say("in inner fn");
+   LL|       |        }
    LL|       |
    LL|       |        #[coverage(on)]
    LL|      1|        fn inner_fn_on() {
    LL|      1|            say("in inner fn (on)");
    LL|      1|        }
    LL|       |
-   LL|      1|        let closure = || {
-   LL|      1|            say("in closure");
-   LL|      1|        };
+   LL|       |        let closure = || {
+   LL|       |            say("in closure");
+   LL|       |        };
    LL|       |
    LL|       |        closure();
    LL|       |        inner_fn();

--- a/tests/coverage/auto-derived.auto.coverage
+++ b/tests/coverage/auto-derived.auto.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|       |    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|       |        closure();
+   LL|       |        inner_fn();
+   LL|       |        inner_fn_on();
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.base.cov-map
+++ b/tests/coverage/auto-derived.base.cov-map
@@ -1,0 +1,61 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn
+Raw bytes (34): 0x[01, 01, 00, 06, 01, 19, 05, 00, 15, 01, 0a, 0d, 00, 14, 01, 04, 09, 00, 12, 01, 01, 09, 00, 11, 01, 01, 09, 00, 14, 01, 01, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 5) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 10, 13) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 4, 9) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 17)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.base.coverage
+++ b/tests/coverage/auto-derived.base.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|      1|    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|      1|        closure();
+   LL|      1|        inner_fn();
+   LL|      1|        inner_fn_on();
+   LL|      1|    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.on.cov-map
+++ b/tests/coverage/auto-derived.on.cov-map
@@ -1,3 +1,17 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn
+Raw bytes (34): 0x[01, 01, 00, 06, 01, 19, 05, 00, 15, 01, 0a, 0d, 00, 14, 01, 04, 09, 00, 12, 01, 01, 09, 00, 11, 01, 01, 09, 00, 14, 01, 01, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 6
+- Code(Counter(0)) at (prev + 25, 5) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 10, 13) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 4, 9) to (start + 0, 18)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 17)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
+Highest counter ID seen: c0
+
 Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
 Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
 Number of files: 1

--- a/tests/coverage/auto-derived.on.cov-map
+++ b/tests/coverage/auto-derived.on.cov-map
@@ -1,0 +1,47 @@
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1a, 09, 00, 16, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1e, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 26, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::inner_fn_on
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 1f, 09, 00, 19, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 23, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 31, 9) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: <auto_derived::MyStruct as auto_derived::MyTrait>::my_assoc_fn::{closure#0}
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 23, 1a, 00, 1b, 01, 01, 0d, 00, 10, 01, 00, 11, 00, 1d, 01, 01, 09, 00, 0a]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 35, 26) to (start + 0, 27)
+- Code(Counter(0)) at (prev + 1, 13) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 0, 17) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+Highest counter ID seen: c0
+
+Function name: auto_derived::main
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 00, 0a, 01, 01, 05, 00, 1a, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/auto-derived.rs
+Number of expressions: 0
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 51, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+

--- a/tests/coverage/auto-derived.on.coverage
+++ b/tests/coverage/auto-derived.on.coverage
@@ -22,7 +22,7 @@
    LL|       |#[cfg_attr(on, automatically_derived)]
    LL|       |#[cfg_attr(on, coverage(on))]
    LL|       |impl MyTrait for MyStruct {
-   LL|       |    fn my_assoc_fn() {
+   LL|      1|    fn my_assoc_fn() {
    LL|      1|        fn inner_fn() {
    LL|      1|            say("in inner fn");
    LL|      1|        }
@@ -36,10 +36,10 @@
    LL|      1|            say("in closure");
    LL|      1|        };
    LL|       |
-   LL|       |        closure();
-   LL|       |        inner_fn();
-   LL|       |        inner_fn_on();
-   LL|       |    }
+   LL|      1|        closure();
+   LL|      1|        inner_fn();
+   LL|      1|        inner_fn_on();
+   LL|      1|    }
    LL|       |}
    LL|       |
    LL|       |#[coverage(off)]

--- a/tests/coverage/auto-derived.on.coverage
+++ b/tests/coverage/auto-derived.on.coverage
@@ -1,0 +1,54 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2024
+   LL|       |//@ revisions: base auto on
+   LL|       |
+   LL|       |// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+   LL|       |//
+   LL|       |// The actual behaviour is an implementation detail, so this test mostly exists
+   LL|       |// to show when that behaviour has been accidentally or deliberately changed.
+   LL|       |//
+   LL|       |// Revision guide:
+   LL|       |// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+   LL|       |// - auto: Test how `#[automatically_derived]` affects instrumentation
+   LL|       |// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+   LL|       |
+   LL|       |struct MyStruct;
+   LL|       |
+   LL|       |trait MyTrait {
+   LL|       |    fn my_assoc_fn();
+   LL|       |}
+   LL|       |
+   LL|       |#[cfg_attr(auto, automatically_derived)]
+   LL|       |#[cfg_attr(on, automatically_derived)]
+   LL|       |#[cfg_attr(on, coverage(on))]
+   LL|       |impl MyTrait for MyStruct {
+   LL|       |    fn my_assoc_fn() {
+   LL|      1|        fn inner_fn() {
+   LL|      1|            say("in inner fn");
+   LL|      1|        }
+   LL|       |
+   LL|       |        #[coverage(on)]
+   LL|      1|        fn inner_fn_on() {
+   LL|      1|            say("in inner fn (on)");
+   LL|      1|        }
+   LL|       |
+   LL|      1|        let closure = || {
+   LL|      1|            say("in closure");
+   LL|      1|        };
+   LL|       |
+   LL|       |        closure();
+   LL|       |        inner_fn();
+   LL|       |        inner_fn_on();
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |#[inline(never)]
+   LL|       |fn say(s: &str) {
+   LL|       |    println!("{s}");
+   LL|       |}
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    MyStruct::my_assoc_fn();
+   LL|      1|}
+

--- a/tests/coverage/auto-derived.rs
+++ b/tests/coverage/auto-derived.rs
@@ -1,0 +1,53 @@
+#![feature(coverage_attribute)]
+//@ edition: 2024
+//@ revisions: base auto on
+
+// Tests for how `#[automatically_derived]` affects coverage instrumentation.
+//
+// The actual behaviour is an implementation detail, so this test mostly exists
+// to show when that behaviour has been accidentally or deliberately changed.
+//
+// Revision guide:
+// - base: Test baseline instrumentation behaviour without `#[automatically_derived]`
+// - auto: Test how `#[automatically_derived]` affects instrumentation
+// - on:   Test interaction between auto-derived and `#[coverage(on)]`
+
+struct MyStruct;
+
+trait MyTrait {
+    fn my_assoc_fn();
+}
+
+#[cfg_attr(auto, automatically_derived)]
+#[cfg_attr(on, automatically_derived)]
+#[cfg_attr(on, coverage(on))]
+impl MyTrait for MyStruct {
+    fn my_assoc_fn() {
+        fn inner_fn() {
+            say("in inner fn");
+        }
+
+        #[coverage(on)]
+        fn inner_fn_on() {
+            say("in inner fn (on)");
+        }
+
+        let closure = || {
+            say("in closure");
+        };
+
+        closure();
+        inner_fn();
+        inner_fn_on();
+    }
+}
+
+#[coverage(off)]
+#[inline(never)]
+fn say(s: &str) {
+    println!("{s}");
+}
+
+fn main() {
+    MyStruct::my_assoc_fn();
+}

--- a/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
@@ -1,0 +1,20 @@
+- // MIR for `of_val_slice` before InstSimplify-after-simplifycfg
++ // MIR for `of_val_slice` after InstSimplify-after-simplifycfg
+  
+  fn of_val_slice(_1: &[T]) -> usize {
+      debug slice => _1;
+      let mut _0: usize;
+      let mut _2: *const [T];
+  
+      bb0: {
+          StorageLive(_2);
+          _2 = &raw const (*_1);
+          _0 = std::intrinsics::align_of_val::<[T]>(move _2) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_2);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
@@ -9,7 +9,9 @@
       bb0: {
           StorageLive(_2);
           _2 = &raw const (*_1);
-          _0 = std::intrinsics::align_of_val::<[T]>(move _2) -> [return: bb1, unwind unreachable];
+-         _0 = std::intrinsics::align_of_val::<[T]>(move _2) -> [return: bb1, unwind unreachable];
++         _0 = AlignOf(T);
++         goto -> bb1;
       }
   
       bb1: {

--- a/tests/mir-opt/instsimplify/align_of_slice.rs
+++ b/tests/mir-opt/instsimplify/align_of_slice.rs
@@ -1,0 +1,13 @@
+//@ test-mir-pass: InstSimplify-after-simplifycfg
+//@ needs-unwind
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// EMIT_MIR align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
+pub fn of_val_slice<T>(slice: &[T]) -> usize {
+    // CHECK-LABEL: fn of_val_slice(_1: &[T])
+    // CHECK: _2 = &raw const (*_1);
+    // CHECK: _0 = std::intrinsics::align_of_val::<[T]>(move _2)
+    unsafe { core::intrinsics::align_of_val(slice) }
+}

--- a/tests/mir-opt/instsimplify/align_of_slice.rs
+++ b/tests/mir-opt/instsimplify/align_of_slice.rs
@@ -7,7 +7,6 @@
 // EMIT_MIR align_of_slice.of_val_slice.InstSimplify-after-simplifycfg.diff
 pub fn of_val_slice<T>(slice: &[T]) -> usize {
     // CHECK-LABEL: fn of_val_slice(_1: &[T])
-    // CHECK: _2 = &raw const (*_1);
-    // CHECK: _0 = std::intrinsics::align_of_val::<[T]>(move _2)
+    // CHECK: _0 = AlignOf(T);
     unsafe { core::intrinsics::align_of_val(slice) }
 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -70,24 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
         StorageLive(_6);
-        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+        _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
-    }
-
-    bb2: {
+        _6 = AlignOf(T);
         StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
         _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
-    bb3: {
+    bb2: {
         StorageLive(_9);
         _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_11);
@@ -95,16 +92,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _10 = discriminant(_8);
         _11 = move _10 as usize (IntToInt);
         StorageDead(_10);
-        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb3, unwind unreachable];
+    }
+
+    bb3: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb4;
     }
 
     bb4: {
-        StorageDead(_11);
-        StorageDead(_9);
-        goto -> bb5;
-    }
-
-    bb5: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-abort.mir
@@ -1,0 +1,111 @@
+// MIR for `generic_in_place` after PreCodegen
+
+fn generic_in_place(_1: *mut Box<[T]>) -> () {
+    debug ptr => _1;
+    let mut _0: ();
+    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
+        scope 2 (inlined <Box<[T]> as Drop>::drop) {
+            let _2: std::ptr::NonNull<[T]>;
+            let mut _3: *mut [T];
+            let mut _4: *const [T];
+            let _12: ();
+            scope 3 {
+                let _8: std::ptr::alignment::AlignmentEnum;
+                scope 4 {
+                    scope 12 (inlined Layout::size) {
+                    }
+                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                            }
+                        }
+                    }
+                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                        }
+                    }
+                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        let mut _9: *mut u8;
+                        scope 19 (inlined Layout::size) {
+                        }
+                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        }
+                        scope 21 (inlined std::alloc::dealloc) {
+                            let mut _11: usize;
+                            scope 22 (inlined Layout::size) {
+                            }
+                            scope 23 (inlined Layout::align) {
+                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                                    let mut _10: u32;
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
+                    }
+                }
+                scope 7 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 8 {
+                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                            let mut _7: std::ptr::Alignment;
+                        }
+                    }
+                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    }
+                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
+        StorageLive(_4);
+        _3 = copy _2 as *mut [T] (Transmute);
+        _4 = copy _2 as *const [T] (Transmute);
+        StorageLive(_6);
+        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
+    }
+
+    bb2: {
+        StorageLive(_7);
+        _7 = copy _6 as std::ptr::Alignment (Transmute);
+        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_4);
+        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+    }
+
+    bb3: {
+        StorageLive(_9);
+        _9 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = discriminant(_8);
+        _11 = move _10 as usize (IntToInt);
+        StorageDead(_10);
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+    }
+
+    bb4: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb5;
+    }
+
+    bb5: {
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -70,24 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
         StorageLive(_6);
-        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+        _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
-    }
-
-    bb2: {
+        _6 = AlignOf(T);
         StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
         _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
-    bb3: {
+    bb2: {
         StorageLive(_9);
         _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_11);
@@ -95,16 +92,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _10 = discriminant(_8);
         _11 = move _10 as usize (IntToInt);
         StorageDead(_10);
-        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb3, unwind unreachable];
+    }
+
+    bb3: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb4;
     }
 
     bb4: {
-        StorageDead(_11);
-        StorageDead(_9);
-        goto -> bb5;
-    }
-
-    bb5: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.32bit.panic-unwind.mir
@@ -1,0 +1,111 @@
+// MIR for `generic_in_place` after PreCodegen
+
+fn generic_in_place(_1: *mut Box<[T]>) -> () {
+    debug ptr => _1;
+    let mut _0: ();
+    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
+        scope 2 (inlined <Box<[T]> as Drop>::drop) {
+            let _2: std::ptr::NonNull<[T]>;
+            let mut _3: *mut [T];
+            let mut _4: *const [T];
+            let _12: ();
+            scope 3 {
+                let _8: std::ptr::alignment::AlignmentEnum;
+                scope 4 {
+                    scope 12 (inlined Layout::size) {
+                    }
+                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                            }
+                        }
+                    }
+                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                        }
+                    }
+                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        let mut _9: *mut u8;
+                        scope 19 (inlined Layout::size) {
+                        }
+                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        }
+                        scope 21 (inlined std::alloc::dealloc) {
+                            let mut _11: usize;
+                            scope 22 (inlined Layout::size) {
+                            }
+                            scope 23 (inlined Layout::align) {
+                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                                    let mut _10: u32;
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
+                    }
+                }
+                scope 7 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 8 {
+                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                            let mut _7: std::ptr::Alignment;
+                        }
+                    }
+                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    }
+                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
+        StorageLive(_4);
+        _3 = copy _2 as *mut [T] (Transmute);
+        _4 = copy _2 as *const [T] (Transmute);
+        StorageLive(_6);
+        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
+    }
+
+    bb2: {
+        StorageLive(_7);
+        _7 = copy _6 as std::ptr::Alignment (Transmute);
+        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_4);
+        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+    }
+
+    bb3: {
+        StorageLive(_9);
+        _9 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = discriminant(_8);
+        _11 = move _10 as usize (IntToInt);
+        StorageDead(_10);
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+    }
+
+    bb4: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb5;
+    }
+
+    bb5: {
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -70,24 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
         StorageLive(_6);
-        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+        _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
-    }
-
-    bb2: {
+        _6 = AlignOf(T);
         StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
         _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
-    bb3: {
+    bb2: {
         StorageLive(_9);
         _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_11);
@@ -95,16 +92,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _10 = discriminant(_8);
         _11 = move _10 as usize (IntToInt);
         StorageDead(_10);
-        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb3, unwind unreachable];
+    }
+
+    bb3: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb4;
     }
 
     bb4: {
-        StorageDead(_11);
-        StorageDead(_9);
-        goto -> bb5;
-    }
-
-    bb5: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-abort.mir
@@ -1,0 +1,111 @@
+// MIR for `generic_in_place` after PreCodegen
+
+fn generic_in_place(_1: *mut Box<[T]>) -> () {
+    debug ptr => _1;
+    let mut _0: ();
+    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
+        scope 2 (inlined <Box<[T]> as Drop>::drop) {
+            let _2: std::ptr::NonNull<[T]>;
+            let mut _3: *mut [T];
+            let mut _4: *const [T];
+            let _12: ();
+            scope 3 {
+                let _8: std::ptr::alignment::AlignmentEnum;
+                scope 4 {
+                    scope 12 (inlined Layout::size) {
+                    }
+                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                            }
+                        }
+                    }
+                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                        }
+                    }
+                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        let mut _9: *mut u8;
+                        scope 19 (inlined Layout::size) {
+                        }
+                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        }
+                        scope 21 (inlined std::alloc::dealloc) {
+                            let mut _11: usize;
+                            scope 22 (inlined Layout::size) {
+                            }
+                            scope 23 (inlined Layout::align) {
+                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                                    let mut _10: u64;
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
+                    }
+                }
+                scope 7 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 8 {
+                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                            let mut _7: std::ptr::Alignment;
+                        }
+                    }
+                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    }
+                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
+        StorageLive(_4);
+        _3 = copy _2 as *mut [T] (Transmute);
+        _4 = copy _2 as *const [T] (Transmute);
+        StorageLive(_6);
+        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
+    }
+
+    bb2: {
+        StorageLive(_7);
+        _7 = copy _6 as std::ptr::Alignment (Transmute);
+        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_4);
+        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+    }
+
+    bb3: {
+        StorageLive(_9);
+        _9 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = discriminant(_8);
+        _11 = move _10 as usize (IntToInt);
+        StorageDead(_10);
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+    }
+
+    bb4: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb5;
+    }
+
+    bb5: {
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -70,24 +70,21 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _3 = copy _2 as *mut [T] (Transmute);
         _4 = copy _2 as *const [T] (Transmute);
         StorageLive(_6);
-        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+        _5 = std::intrinsics::size_of_val::<[T]>(move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
-    }
-
-    bb2: {
+        _6 = AlignOf(T);
         StorageLive(_7);
         _7 = copy _6 as std::ptr::Alignment (Transmute);
         _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
-        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+        switchInt(copy _5) -> [0: bb4, otherwise: bb2];
     }
 
-    bb3: {
+    bb2: {
         StorageLive(_9);
         _9 = copy _3 as *mut u8 (PtrToPtr);
         StorageLive(_11);
@@ -95,16 +92,16 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
         _10 = discriminant(_8);
         _11 = move _10 as usize (IntToInt);
         StorageDead(_10);
-        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb3, unwind unreachable];
+    }
+
+    bb3: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb4;
     }
 
     bb4: {
-        StorageDead(_11);
-        StorageDead(_9);
-        goto -> bb5;
-    }
-
-    bb5: {
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.PreCodegen.after.64bit.panic-unwind.mir
@@ -1,0 +1,111 @@
+// MIR for `generic_in_place` after PreCodegen
+
+fn generic_in_place(_1: *mut Box<[T]>) -> () {
+    debug ptr => _1;
+    let mut _0: ();
+    scope 1 (inlined drop_in_place::<Box<[T]>> - shim(Some(Box<[T]>))) {
+        scope 2 (inlined <Box<[T]> as Drop>::drop) {
+            let _2: std::ptr::NonNull<[T]>;
+            let mut _3: *mut [T];
+            let mut _4: *const [T];
+            let _12: ();
+            scope 3 {
+                let _8: std::ptr::alignment::AlignmentEnum;
+                scope 4 {
+                    scope 12 (inlined Layout::size) {
+                    }
+                    scope 13 (inlined Unique::<[T]>::cast::<u8>) {
+                        scope 14 (inlined NonNull::<[T]>::cast::<u8>) {
+                            scope 15 (inlined NonNull::<[T]>::as_ptr) {
+                            }
+                        }
+                    }
+                    scope 16 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                        scope 17 (inlined Unique::<u8>::as_non_null_ptr) {
+                        }
+                    }
+                    scope 18 (inlined <std::alloc::Global as Allocator>::deallocate) {
+                        let mut _9: *mut u8;
+                        scope 19 (inlined Layout::size) {
+                        }
+                        scope 20 (inlined NonNull::<u8>::as_ptr) {
+                        }
+                        scope 21 (inlined std::alloc::dealloc) {
+                            let mut _11: usize;
+                            scope 22 (inlined Layout::size) {
+                            }
+                            scope 23 (inlined Layout::align) {
+                                scope 24 (inlined std::ptr::Alignment::as_usize) {
+                                    let mut _10: u64;
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 5 (inlined Unique::<[T]>::as_ptr) {
+                    scope 6 (inlined NonNull::<[T]>::as_ptr) {
+                    }
+                }
+                scope 7 (inlined Layout::for_value_raw::<[T]>) {
+                    let mut _5: usize;
+                    let mut _6: usize;
+                    scope 8 {
+                        scope 11 (inlined #[track_caller] Layout::from_size_align_unchecked) {
+                            let mut _7: std::ptr::Alignment;
+                        }
+                    }
+                    scope 9 (inlined size_of_val_raw::<[T]>) {
+                    }
+                    scope 10 (inlined align_of_val_raw::<[T]>) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy (((*_1).0: std::ptr::Unique<[T]>).0: std::ptr::NonNull<[T]>);
+        StorageLive(_4);
+        _3 = copy _2 as *mut [T] (Transmute);
+        _4 = copy _2 as *const [T] (Transmute);
+        StorageLive(_6);
+        _5 = std::intrinsics::size_of_val::<[T]>(copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = std::intrinsics::align_of_val::<[T]>(move _4) -> [return: bb2, unwind unreachable];
+    }
+
+    bb2: {
+        StorageLive(_7);
+        _7 = copy _6 as std::ptr::Alignment (Transmute);
+        _8 = move (_7.0: std::ptr::alignment::AlignmentEnum);
+        StorageDead(_7);
+        StorageDead(_6);
+        StorageDead(_4);
+        switchInt(copy _5) -> [0: bb5, otherwise: bb3];
+    }
+
+    bb3: {
+        StorageLive(_9);
+        _9 = copy _3 as *mut u8 (PtrToPtr);
+        StorageLive(_11);
+        StorageLive(_10);
+        _10 = discriminant(_8);
+        _11 = move _10 as usize (IntToInt);
+        StorageDead(_10);
+        _12 = alloc::alloc::__rust_dealloc(move _9, move _5, move _11) -> [return: bb4, unwind unreachable];
+    }
+
+    bb4: {
+        StorageDead(_11);
+        StorageDead(_9);
+        goto -> bb5;
+    }
+
+    bb5: {
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -O -Zmir-opt-level=2
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+// EMIT_MIR_FOR_EACH_BIT_WIDTH
+
+#![crate_type = "lib"]
+
+// EMIT_MIR drop_boxed_slice.generic_in_place.PreCodegen.after.mir
+pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
+    // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
+    // CHECK: (inlined <Box<[T]> as Drop>::drop)
+    // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
+    // CHECK: [[ALIGN:_.+]] = std::intrinsics::align_of_val::<[T]>
+    // CHECK: [[B:_.+]] = copy [[ALIGN]] as std::ptr::Alignment (Transmute);
+    // CHECK: [[C:_.+]] = move ([[B]].0: std::ptr::alignment::AlignmentEnum);
+    // CHECK: [[D:_.+]] = discriminant([[C]]);
+    // CHECK: [[E:_.+]] = move [[D]] as usize (IntToInt);
+    // CHECK: = alloc::alloc::__rust_dealloc({{.+}}, move [[SIZE]], move [[E]]) ->
+    std::ptr::drop_in_place(ptr)
+}

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.rs
@@ -9,7 +9,7 @@ pub unsafe fn generic_in_place<T: Copy>(ptr: *mut Box<[T]>) {
     // CHECK-LABEL: fn generic_in_place(_1: *mut Box<[T]>)
     // CHECK: (inlined <Box<[T]> as Drop>::drop)
     // CHECK: [[SIZE:_.+]] = std::intrinsics::size_of_val::<[T]>
-    // CHECK: [[ALIGN:_.+]] = std::intrinsics::align_of_val::<[T]>
+    // CHECK: [[ALIGN:_.+]] = AlignOf(T);
     // CHECK: [[B:_.+]] = copy [[ALIGN]] as std::ptr::Alignment (Transmute);
     // CHECK: [[C:_.+]] = move ([[B]].0: std::ptr::alignment::AlignmentEnum);
     // CHECK: [[D:_.+]] = discriminant([[C]]);

--- a/tests/pretty/asm.pp
+++ b/tests/pretty/asm.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-mode:expanded
 //@ pp-exact:asm.pp
 //@ only-x86_64

--- a/tests/pretty/cast-lt.pp
+++ b/tests/pretty/cast-lt.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:cast-lt.pp

--- a/tests/pretty/dollar-crate.pp
+++ b/tests/pretty/dollar-crate.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:dollar-crate.pp

--- a/tests/pretty/expanded-and-path-remap-80832.pp
+++ b/tests/pretty/expanded-and-path-remap-80832.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // Test for issue 80832
 //
 //@ pretty-mode:expanded

--- a/tests/pretty/format-args-str-escape.pp
+++ b/tests/pretty/format-args-str-escape.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:format-args-str-escape.pp

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -4,10 +4,10 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn b<C>(e: C) { }
 

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-fn-params.pp

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -3,10 +3,10 @@
 //@ pp-exact:hir-fn-variadic.pp
 
 #![feature(c_variadic)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 extern "C" {
     unsafe fn foo(x: i32, va1: ...);

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-if-else.pp

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -5,10 +5,10 @@
 // This tests the pretty-printing of lifetimes in lots of ways.
 
 #![allow(unused)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 struct Foo<'a> {
     x: &'a u32,

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-attr.pp

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-pretty-loop.pp

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir
 //@ pp-exact:hir-struct-expr.pp

--- a/tests/pretty/if-else.pp
+++ b/tests/pretty/if-else.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:if-else.pp

--- a/tests/pretty/issue-12590-c.pp
+++ b/tests/pretty/issue-12590-c.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:issue-12590-c.pp

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-compare-only
 //@ pretty-mode:hir,typed
 //@ pp-exact:issue-4264.pp

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // Test to print lifetimes on HIR pretty-printing.
 
 //@ pretty-compare-only

--- a/tests/pretty/never-pattern.pp
+++ b/tests/pretty/never-pattern.pp
@@ -7,10 +7,10 @@
 #![allow(incomplete_features)]
 #![feature(never_patterns)]
 #![feature(never_type)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn f(x: Result<u32, !>) { _ = match x { Ok(x) => x, Err(!) , }; }
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -4,10 +4,10 @@
 
 #![feature(pin_ergonomics)]
 #![allow(dead_code, incomplete_features)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 use std::pin::Pin;
 

--- a/tests/pretty/postfix-match/precedence.pp
+++ b/tests/pretty/postfix-match/precedence.pp
@@ -1,10 +1,10 @@
 #![feature(prelude_import)]
 #![no_std]
 #![feature(postfix_match)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 use std::ops::Add;
 

--- a/tests/pretty/shebang-at-top.pp
+++ b/tests/pretty/shebang-at-top.pp
@@ -1,10 +1,10 @@
 #!/usr/bin/env rust
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ pretty-mode:expanded
 //@ pp-exact:shebang-at-top.pp
 //@ pretty-compare-only

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: --crate-type=lib --test --remap-path-prefix={{src-base}}/=/the/src/ --remap-path-prefix={{src-base}}\=/the/src/
 //@ pretty-compare-only
 //@ pretty-mode:expanded

--- a/tests/ui/asm/unpretty-expanded.stdout
+++ b/tests/ui/asm/unpretty-expanded.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
@@ -1,8 +1,8 @@
 #![feature(prelude_import)]
-#[prelude_import]
-use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2021::*;
 //@ edition: 2021
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass

--- a/tests/ui/codemap_tests/unicode.expanded.stdout
+++ b/tests/ui/codemap_tests/unicode.expanded.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ revisions: normal expanded
 //@[expanded] check-pass
 //@[expanded]compile-flags: -Zunpretty=expanded

--- a/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -6,10 +6,10 @@
 //@ edition: 2015
 
 #![crate_type = "lib"]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 trait Foo<const KIND : bool = true> {}
 

--- a/tests/ui/coroutine/postfix-yield-after-cast.rs
+++ b/tests/ui/coroutine/postfix-yield-after-cast.rs
@@ -1,0 +1,10 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144527>.
+
+#![feature(yield_expr, coroutines)]
+
+fn main() {
+    #[coroutine] || {
+        0 as u8.yield
+        //~^ ERROR cast cannot be followed by `.yield`
+    };
+}

--- a/tests/ui/coroutine/postfix-yield-after-cast.stderr
+++ b/tests/ui/coroutine/postfix-yield-after-cast.stderr
@@ -1,0 +1,13 @@
+error: cast cannot be followed by `.yield`
+  --> $DIR/postfix-yield-after-cast.rs:7:9
+   |
+LL |         0 as u8.yield
+   |         ^^^^^^^
+   |
+help: try surrounding the expression in parentheses
+   |
+LL |         (0 as u8).yield
+   |         +       +
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/deriving/built-in-proc-macro-scope.stdout
+++ b/tests/ui/deriving/built-in-proc-macro-scope.stdout
@@ -6,10 +6,10 @@
 //@ edition:2015
 
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 #[macro_use]
 extern crate another_proc_macro;

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -17,10 +17,10 @@
 #![crate_type = "lib"]
 #![allow(dead_code)]
 #![allow(deprecated)]
-#[prelude_import]
-use std::prelude::rust_2021::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2021::*;
 
 // Empty struct.
 struct Empty;

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
@@ -4,10 +4,10 @@
 //@ compile-flags: -Zunpretty=expanded
 //@ edition: 2015
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 use std::marker::CoercePointee;
 
 pub trait MyTrait<T: ?Sized> {}

--- a/tests/ui/deriving/proc-macro-attribute-mixing.stdout
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.stdout
@@ -12,10 +12,10 @@
 //@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 #[macro_use]
 extern crate another_proc_macro;

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // This ensures that ICEs like rust#94953 don't happen
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ edition: 2015
 

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
@@ -5,10 +5,10 @@
 //@ edition: 2015
 
 #![feature(core_intrinsics, generic_assert)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn arbitrary_consuming_method_for_demonstration_purposes() {
     let elem = 1i32;

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -16,10 +16,10 @@ Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro
 // in the stdout
 
 #![no_std /* 0#0 */]
-#[prelude_import /* 0#1 */]
-use core /* 0#1 */::prelude /* 0#1 */::rust_2018 /* 0#1 */::*;
 #[macro_use /* 0#1 */]
 extern crate core /* 0#1 */;
+#[prelude_import /* 0#1 */]
+use core /* 0#1 */::prelude /* 0#1 */::rust_2018 /* 0#1 */::*;
 // Don't load unnecessary hygiene information from std
 extern crate std /* 0#0 */;
 

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -36,10 +36,10 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 
 #![feature /* 0#0 */(decl_macro)]
 #![no_std /* 0#0 */]
-#[prelude_import /* 0#1 */]
-use ::core /* 0#1 */::prelude /* 0#1 */::rust_2015 /* 0#1 */::*;
 #[macro_use /* 0#1 */]
 extern crate core /* 0#2 */;
+#[prelude_import /* 0#1 */]
+use ::core /* 0#1 */::prelude /* 0#1 */::rust_2015 /* 0#1 */::*;
 // Don't load unnecessary hygiene information from std
 extern crate std /* 0#0 */;
 

--- a/tests/ui/proc-macro/quote/debug.stdout
+++ b/tests/ui/proc-macro/quote/debug.stdout
@@ -12,10 +12,10 @@
 
 #![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 extern crate proc_macro;
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
@@ -1,9 +1,9 @@
 #![feature(prelude_import)]
 #![no_std]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
 //@ edition: 2015

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -3,10 +3,10 @@
 //@ edition: 2015
 
 #![feature(type_alias_impl_trait)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 trait Animal { }
 

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
 //@ edition: 2015

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/exhaustive-asm.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.expanded.stdout
@@ -1,8 +1,8 @@
 #![feature(prelude_import)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 //@ revisions: expanded hir
 //@[expanded]compile-flags: -Zunpretty=expanded
 //@[expanded]check-pass

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -29,10 +29,10 @@
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 #[prelude_import]
 use self::prelude::*;

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -28,10 +28,10 @@
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 #[prelude_import]
 use self::prelude::*;

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/interpolation-expanded.stdout
+++ b/tests/ui/unpretty/interpolation-expanded.stdout
@@ -10,10 +10,10 @@
 // synthesizing parentheses indiscriminately; only where necessary.
 
 #![feature(if_let_guard)]
-#[prelude_import]
-use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
 
 macro_rules! expr { ($expr:expr) => { $expr }; }
 

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,7 +1,7 @@
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
 //@ edition: 2015

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -8,10 +8,10 @@
 //@ compile-flags: -Zunpretty=hir,typed
 //@ edition: 2015
 #![allow(dead_code)]
-#[prelude_import]
-use ::std::prelude::rust_2015::*;
 #[attr = MacroUse {arguments: UseAll}]
 extern crate std;
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
 
 fn main() ({ } as ())
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#144560 (coverage: Treat `#[automatically_derived]` as `#[coverage(off)]`)
 - rust-lang/rust#144566 (Simplify `align_of_val::<[T]>(…)` → `align_of::<T>()`)
 - rust-lang/rust#144587 (expand: Micro-optimize prelude injection)
 - rust-lang/rust#144589 (Account for `.yield` in illegal postfix operator message)
 - rust-lang/rust#144615 (Make resolve_fn_signature responsible for its own rib.)
 - rust-lang/rust#144634 (Fix typo in `DropGuard` doc)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=144560,144566,144587,144589,144615,144634)
<!-- homu-ignore:end -->