### PR TITLE
Refactor `expect.., found ..` into structured fluent error message

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -1017,3 +1017,21 @@ parse_where_generics = generic parameters on `where` clauses are reserved for fu
 
 parse_zero_chars = empty character literal
     .label = {parse_zero_chars}
+
+parse_expected_one_of_found = expected one of {$expected}, found {$found}
+
+parse_expected_one_of_found_much = expected one of {$expected}, found {$found}
+
+parse_expected_found = expected {$expected}, found {$found}
+
+parse_unexpected_token = unexpected token: {$found}
+
+parse_expected_comma_or_gt = expected one of `,` or `>`, found {$found}
+    .label = expected one of `,` or `>`
+
+
+parse_expected_expression_found = expected expression, found {$found}
+    .label = expected expression
+
+parse_expected_expression_found_eof = expected expression, found end of {$origin}
+    .label = expected expression

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -3610,3 +3610,58 @@ pub(crate) struct ExpectedRegisterClassOrExplicitRegister {
     #[primary_span]
     pub(crate) span: Span,
 }
+
+// Expression parsing errors
+#[derive(Diagnostic)]
+#[diag(parse_expected_expression_found)]
+pub(crate) struct ExpectedExpressionFound {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub found: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_expected_expression_found_eof)]
+pub(crate) struct ExpectedExpressionFoundEof {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub origin: String,
+}
+
+// Expected tokens error structures
+#[derive(Diagnostic)]
+#[diag(parse_expected_one_of_found)]
+pub(crate) struct ExpectedOneOfFound {
+    #[primary_span]
+    pub span: Span,
+    pub expected: String,
+    pub found: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_expected_one_of_found_much)]
+pub(crate) struct ExpectedOneOfFoundMuch {
+    #[primary_span]
+    pub span: Span,
+    pub expected: String,
+    pub found: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_expected_found)]
+pub(crate) struct ExpectedFound {
+    #[primary_span]
+    pub span: Span,
+    pub expected: String,
+    pub found: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(parse_unexpected_token)]
+pub(crate) struct UnexpectedToken {
+    #[primary_span]
+    pub span: Span,
+    pub found: String,
+}


### PR DESCRIPTION
This change refactored some hard-coded error messages in `rustc_parse` to structured diagnostics using the Fluent system, and improved the macro expansion error handling mechanism.

1. Refactored the error message system: Changed the `expected_one_of_not_found` and `expected_expression_found` functions from manually constructing error messages to using #[derive(Diagnostic)] structures. Added structured error types with fluent messages.
2. Improvements to Macro Expansion Error Handling. In `rustc_expand/src/mbe/diagnostics.rs`, changed macro expansion error handling from relying on string matching to using Fluent messages and structured parameters.

(It seems that the number of lines of code has increased, and I'm not sure if the change is worth it. But I think at least some of the changes make sense.)