### PR TITLE
Add support for the m68k architecture in 'object_architecture'

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3598,6 +3598,7 @@ impl Target {
             ),
             "x86" => (Architecture::I386, None),
             "s390x" => (Architecture::S390x, None),
+            "m68k" => (Architecture::M68k, None),
             "mips" | "mips32r6" => (Architecture::Mips, None),
             "mips64" | "mips64r6" => (
                 // While there are currently no builtin targets


### PR DESCRIPTION
This is a tiny PR that adds the m68k architecture to `object_architecture`. This allows us to build rmeta files for that ISA(we use the object crate to pack metadata into object files).