### PR TITLE
editorconfig: don't trim trailing whitespace in tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,17 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
 insert_final_newline = true
+
+# some tests need trailing whitespace in output snapshots
+[!tests/]
+trim_trailing_whitespace = true
+# for actual source code files of test, we still don't want trailing whitespace
+[tests/**.{rs,js}]
+trim_trailing_whitespace = true
+# these specific source files need to have trailing whitespace.
+[tests/ui/{frontmatter/frontmatter-whitespace-3.rs,parser/shebang/shebang-space.rs}]
+trim_trailing_whitespace = false
 
 [!src/llvm-project]
 indent_style = space


### PR DESCRIPTION
some test snapshot files require trailing whitespace, and previously manually editing those snapshot files (as is required for run-make tests and some platform-specific tests) in an editor with editorconfig support would cause that whitespace to be removed, [causing CI failures like this one](https://github.com/rust-lang/rust/pull/144596#issuecomment-3130442996)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
