### PR TITLE
Account for bare tuples and `Pin` methods in field searching logic

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2745,6 +2745,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let available_field_names = self.available_field_names(variant, expr, skip_fields);
                 if let Some(field_name) =
                     find_best_match_for_name(&available_field_names, field.ident.name, None)
+                    && !(field.ident.name.as_str().parse::<usize>().is_ok()
+                        && field_name.as_str().parse::<usize>().is_ok())
                 {
                     err.span_label(field.ident.span, "unknown field");
                     err.span_suggestion_verbose(
@@ -3360,6 +3362,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             } else if let Some(field_name) =
                 find_best_match_for_name(&field_names, field.name, None)
+                && !(field.name.as_str().parse::<usize>().is_ok()
+                    && field_name.as_str().parse::<usize>().is_ok())
             {
                 err.span_suggestion_verbose(
                     field.span,

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2792,7 +2792,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         if let SelfSource::MethodCall(expr) = source {
             let mod_id = self.tcx.parent_module(expr.hir_id).to_def_id();
-            for (fields, args) in self.get_field_candidates_considering_privacy_for_diag(
+            for fields in self.get_field_candidates_considering_privacy_for_diag(
                 span,
                 actual,
                 mod_id,
@@ -2831,7 +2831,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 })
                             },
                             candidate_field,
-                            args,
                             vec![],
                             mod_id,
                             expr.hir_id,

--- a/tests/ui/coherence/coherence-tuple-conflict.stderr
+++ b/tests/ui/coherence/coherence-tuple-conflict.stderr
@@ -12,6 +12,8 @@ error[E0609]: no field `dummy` on type `&(A, B)`
    |
 LL |     fn get(&self) -> usize { self.dummy }
    |                                   ^^^^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-19244-1.stderr
+++ b/tests/ui/consts/issue-19244-1.stderr
@@ -3,6 +3,12 @@ error[E0609]: no field `1` on type `(usize,)`
    |
 LL |     let a: [isize; TUP.1];
    |                        ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     let a: [isize; TUP.1];
+LL +     let a: [isize; TUP.0];
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-19244-1.stderr
+++ b/tests/ui/consts/issue-19244-1.stderr
@@ -4,11 +4,7 @@ error[E0609]: no field `1` on type `(usize,)`
 LL |     let a: [isize; TUP.1];
    |                        ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     let a: [isize; TUP.1];
-LL +     let a: [isize; TUP.0];
-   |
+   = note: available field is: `0`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/diagnostic-width/long-E0609.stderr
+++ b/tests/ui/diagnostic-width/long-E0609.stderr
@@ -4,6 +4,7 @@ error[E0609]: no field `field` on type `(..., ..., ..., ...)`
 LL |     x.field;
    |       ^^^^^ unknown field
    |
+   = note: available fields are: `0`, `1`, `2`, `3`
    = note: the full name for the type has been written to '$TEST_BUILD_DIR/long-E0609.long-type-$LONG_TYPE_HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
 

--- a/tests/ui/error-codes/ex-E0612.stderr
+++ b/tests/ui/error-codes/ex-E0612.stderr
@@ -4,11 +4,7 @@ error[E0609]: no field `1` on type `Foo`
 LL |    y.1;
    |      ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -    y.1;
-LL +    y.0;
-   |
+   = note: available field is: `0`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/offset-of/offset-of-tuple-field.stderr
+++ b/tests/ui/offset-of/offset-of-tuple-field.stderr
@@ -15,60 +15,108 @@ error[E0609]: no field `_0` on type `(u8, u8)`
    |
 LL |     offset_of!((u8, u8), _0);
    |                          ^^
+   |
+help: a field with a similar name exists
+   |
+LL -     offset_of!((u8, u8), _0);
+LL +     offset_of!((u8, u8), 0);
+   |
 
 error[E0609]: no field `01` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:7:26
    |
 LL |     offset_of!((u8, u8), 01);
    |                          ^^
+   |
+help: a field with a similar name exists
+   |
+LL -     offset_of!((u8, u8), 01);
+LL +     offset_of!((u8, u8), 0);
+   |
 
 error[E0609]: no field `1e2` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:8:26
    |
 LL |     offset_of!((u8, u8), 1e2);
    |                          ^^^
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1_` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:9:26
    |
 LL |     offset_of!((u8, u8), 1_u8);
    |                          ^^^^
+   |
+help: a field with a similar name exists
+   |
+LL -     offset_of!((u8, u8), 1_u8);
+LL +     offset_of!((u8, u8), 1);
+   |
 
 error[E0609]: no field `1e2` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:12:35
    |
 LL |     builtin # offset_of((u8, u8), 1e2);
    |                                   ^^^
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `_0` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:13:35
    |
 LL |     builtin # offset_of((u8, u8), _0);
    |                                   ^^
+   |
+help: a field with a similar name exists
+   |
+LL -     builtin # offset_of((u8, u8), _0);
+LL +     builtin # offset_of((u8, u8), 0);
+   |
 
 error[E0609]: no field `01` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:14:35
    |
 LL |     builtin # offset_of((u8, u8), 01);
    |                                   ^^
+   |
+help: a field with a similar name exists
+   |
+LL -     builtin # offset_of((u8, u8), 01);
+LL +     builtin # offset_of((u8, u8), 0);
+   |
 
 error[E0609]: no field `1_` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:15:35
    |
 LL |     builtin # offset_of((u8, u8), 1_u8);
    |                                   ^^^^
+   |
+help: a field with a similar name exists
+   |
+LL -     builtin # offset_of((u8, u8), 1_u8);
+LL +     builtin # offset_of((u8, u8), 1);
+   |
 
 error[E0609]: no field `2` on type `(u8, u16)`
   --> $DIR/offset-of-tuple-field.rs:18:47
    |
 LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
    |                                               ^
+   |
+help: a field with a similar name exists
+   |
+LL -     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
+LL +     offset_of!(((u8, u16), (u32, u16, u8)), 0.0);
+   |
 
 error[E0609]: no field `1e2` on type `(u8, u16)`
   --> $DIR/offset-of-tuple-field.rs:19:47
    |
 LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2);
    |                                               ^^^
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0` on type `u8`
   --> $DIR/offset-of-tuple-field.rs:21:49

--- a/tests/ui/offset-of/offset-of-tuple-field.stderr
+++ b/tests/ui/offset-of/offset-of-tuple-field.stderr
@@ -28,11 +28,7 @@ error[E0609]: no field `01` on type `(u8, u8)`
 LL |     offset_of!((u8, u8), 01);
    |                          ^^
    |
-help: a field with a similar name exists
-   |
-LL -     offset_of!((u8, u8), 01);
-LL +     offset_of!((u8, u8), 0);
-   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e2` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:8:26
@@ -80,11 +76,7 @@ error[E0609]: no field `01` on type `(u8, u8)`
 LL |     builtin # offset_of((u8, u8), 01);
    |                                   ^^
    |
-help: a field with a similar name exists
-   |
-LL -     builtin # offset_of((u8, u8), 01);
-LL +     builtin # offset_of((u8, u8), 0);
-   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1_` on type `(u8, u8)`
   --> $DIR/offset-of-tuple-field.rs:15:35
@@ -104,11 +96,7 @@ error[E0609]: no field `2` on type `(u8, u16)`
 LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
    |                                               ^
    |
-help: a field with a similar name exists
-   |
-LL -     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
-LL +     offset_of!(((u8, u16), (u32, u16, u8)), 0.0);
-   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e2` on type `(u8, u16)`
   --> $DIR/offset-of-tuple-field.rs:19:47

--- a/tests/ui/parser/float-field.stderr
+++ b/tests/ui/parser/float-field.stderr
@@ -305,6 +305,8 @@ error[E0609]: no field `1e1` on type `(u8, u8)`
    |
 LL |     { s.1.1e1; }
    |           ^^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1e1` on type `S`
   --> $DIR/float-field.rs:34:9
@@ -343,12 +345,16 @@ error[E0609]: no field `f32` on type `(u8, u8)`
    |
 LL |     { s.1.f32; }
    |           ^^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e1` on type `(u8, u8)`
   --> $DIR/float-field.rs:71:9
    |
 LL |     { s.1.1e1f32; }
    |         ^^^^^^^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error: aborting due to 57 previous errors
 

--- a/tests/ui/structs/tuple-struct-field-naming-47073.stderr
+++ b/tests/ui/structs/tuple-struct-field-naming-47073.stderr
@@ -4,11 +4,7 @@ error[E0609]: no field `00` on type `Verdict`
 LL |     let _condemned = justice.00;
    |                              ^^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     let _condemned = justice.00;
-LL +     let _condemned = justice.0;
-   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `001` on type `Verdict`
   --> $DIR/tuple-struct-field-naming-47073.rs:11:31

--- a/tests/ui/traits/well-formed-recursion-limit.stderr
+++ b/tests/ui/traits/well-formed-recursion-limit.stderr
@@ -3,12 +3,16 @@ error[E0609]: no field `ab` on type `(Box<(dyn Fn(Option<A>) -> Option<B> + 'sta
    |
 LL |     let (ab, ba) = (i.ab, i.ba);
    |                       ^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `ba` on type `(Box<(dyn Fn(Option<A>) -> Option<B> + 'static)>, Box<(dyn Fn(Option<B>) -> Option<A> + 'static)>)`
   --> $DIR/well-formed-recursion-limit.rs:12:29
    |
 LL |     let (ab, ba) = (i.ab, i.ba);
    |                             ^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
 
 error[E0275]: overflow assigning `_` to `Option<_>`
   --> $DIR/well-formed-recursion-limit.rs:15:33

--- a/tests/ui/tuple/index-invalid.stderr
+++ b/tests/ui/tuple/index-invalid.stderr
@@ -4,11 +4,7 @@ error[E0609]: no field `1` on type `(((),),)`
 LL |     let _ = (((),),).1.0;
    |                      ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     let _ = (((),),).1.0;
-LL +     let _ = (((),),).0.0;
-   |
+   = note: available field is: `0`
 
 error[E0609]: no field `1` on type `((),)`
   --> $DIR/index-invalid.rs:4:24
@@ -16,11 +12,7 @@ error[E0609]: no field `1` on type `((),)`
 LL |     let _ = (((),),).0.1;
    |                        ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     let _ = (((),),).0.1;
-LL +     let _ = (((),),).0.0;
-   |
+   = note: available field is: `0`
 
 error[E0609]: no field `000` on type `(((),),)`
   --> $DIR/index-invalid.rs:6:22

--- a/tests/ui/tuple/index-invalid.stderr
+++ b/tests/ui/tuple/index-invalid.stderr
@@ -3,18 +3,32 @@ error[E0609]: no field `1` on type `(((),),)`
    |
 LL |     let _ = (((),),).1.0;
    |                      ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     let _ = (((),),).1.0;
+LL +     let _ = (((),),).0.0;
+   |
 
 error[E0609]: no field `1` on type `((),)`
   --> $DIR/index-invalid.rs:4:24
    |
 LL |     let _ = (((),),).0.1;
    |                        ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     let _ = (((),),).0.1;
+LL +     let _ = (((),),).0.0;
+   |
 
 error[E0609]: no field `000` on type `(((),),)`
   --> $DIR/index-invalid.rs:6:22
    |
 LL |     let _ = (((),),).000.000;
    |                      ^^^ unknown field
+   |
+   = note: available field is: `0`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/tuple/missing-field-access.rs
+++ b/tests/ui/tuple/missing-field-access.rs
@@ -1,3 +1,7 @@
+// Ensure that suggestions to search for missing intermediary field accesses are available for both
+// tuple structs *and* regular tuples.
+// Ensure that we do not suggest pinning the expression just because `Pin::get_ref` exists.
+// https://github.com/rust-lang/rust/issues/144602
 use std::{fs::File, io::BufReader};
 
 struct F(BufReader<File>);
@@ -6,12 +10,7 @@ fn main() {
     let f = F(BufReader::new(File::open("x").unwrap()));
     let x = f.get_ref(); //~ ERROR E0599
     //~^ HELP one of the expressions' fields has a method of the same name
-    //~| HELP consider pinning the expression
     let f = (BufReader::new(File::open("x").unwrap()), );
     let x = f.get_ref(); //~ ERROR E0599
     //~^ HELP one of the expressions' fields has a method of the same name
-    //~| HELP consider pinning the expression
-
-    // FIXME(estebank): the pinning suggestion should not be included in either case.
-    // https://github.com/rust-lang/rust/issues/144602
 }

--- a/tests/ui/tuple/missing-field-access.rs
+++ b/tests/ui/tuple/missing-field-access.rs
@@ -1,0 +1,17 @@
+use std::{fs::File, io::BufReader};
+
+struct F(BufReader<File>);
+
+fn main() {
+    let f = F(BufReader::new(File::open("x").unwrap()));
+    let x = f.get_ref(); //~ ERROR E0599
+    //~^ HELP one of the expressions' fields has a method of the same name
+    //~| HELP consider pinning the expression
+    let f = (BufReader::new(File::open("x").unwrap()), );
+    let x = f.get_ref(); //~ ERROR E0599
+    //~^ HELP one of the expressions' fields has a method of the same name
+    //~| HELP consider pinning the expression
+
+    // FIXME(estebank): the pinning suggestion should not be included in either case.
+    // https://github.com/rust-lang/rust/issues/144602
+}

--- a/tests/ui/tuple/missing-field-access.stderr
+++ b/tests/ui/tuple/missing-field-access.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `get_ref` found for struct `F` in the current scope
-  --> $DIR/missing-field-access.rs:7:15
+  --> $DIR/missing-field-access.rs:11:15
    |
 LL | struct F(BufReader<File>);
    | -------- method `get_ref` not found for this struct
@@ -11,14 +11,9 @@ help: one of the expressions' fields has a method of the same name
    |
 LL |     let x = f.0.get_ref();
    |               ++
-help: consider pinning the expression
-   |
-LL ~     let mut pinned = std::pin::pin!(f);
-LL ~     let x = pinned.as_ref().get_ref();
-   |
 
 error[E0599]: no method named `get_ref` found for tuple `(BufReader<File>,)` in the current scope
-  --> $DIR/missing-field-access.rs:11:15
+  --> $DIR/missing-field-access.rs:14:15
    |
 LL |     let x = f.get_ref();
    |               ^^^^^^^ method not found in `(BufReader<File>,)`
@@ -27,11 +22,6 @@ help: one of the expressions' fields has a method of the same name
    |
 LL |     let x = f.0.get_ref();
    |               ++
-help: consider pinning the expression
-   |
-LL ~     let mut pinned = std::pin::pin!(f);
-LL ~     let x = pinned.as_ref().get_ref();
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/tuple/missing-field-access.stderr
+++ b/tests/ui/tuple/missing-field-access.stderr
@@ -1,0 +1,38 @@
+error[E0599]: no method named `get_ref` found for struct `F` in the current scope
+  --> $DIR/missing-field-access.rs:7:15
+   |
+LL | struct F(BufReader<File>);
+   | -------- method `get_ref` not found for this struct
+...
+LL |     let x = f.get_ref();
+   |               ^^^^^^^ method not found in `F`
+   |
+help: one of the expressions' fields has a method of the same name
+   |
+LL |     let x = f.0.get_ref();
+   |               ++
+help: consider pinning the expression
+   |
+LL ~     let mut pinned = std::pin::pin!(f);
+LL ~     let x = pinned.as_ref().get_ref();
+   |
+
+error[E0599]: no method named `get_ref` found for tuple `(BufReader<File>,)` in the current scope
+  --> $DIR/missing-field-access.rs:11:15
+   |
+LL |     let x = f.get_ref();
+   |               ^^^^^^^ method not found in `(BufReader<File>,)`
+   |
+help: one of the expressions' fields has a method of the same name
+   |
+LL |     let x = f.0.get_ref();
+   |               ++
+help: consider pinning the expression
+   |
+LL ~     let mut pinned = std::pin::pin!(f);
+LL ~     let x = pinned.as_ref().get_ref();
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/tuple/tuple-index-out-of-bounds.stderr
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.stderr
@@ -4,11 +4,7 @@ error[E0609]: no field `2` on type `Point`
 LL |     origin.2;
    |            ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     origin.2;
-LL +     origin.0;
-   |
+   = note: available fields are: `0`, `1`
 
 error[E0609]: no field `2` on type `({integer}, {integer})`
   --> $DIR/tuple-index-out-of-bounds.rs:12:11
@@ -16,11 +12,7 @@ error[E0609]: no field `2` on type `({integer}, {integer})`
 LL |     tuple.2;
    |           ^ unknown field
    |
-help: a field with a similar name exists
-   |
-LL -     tuple.2;
-LL +     tuple.0;
-   |
+   = note: available fields are: `0`, `1`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/tuple/tuple-index-out-of-bounds.stderr
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.stderr
@@ -15,6 +15,12 @@ error[E0609]: no field `2` on type `({integer}, {integer})`
    |
 LL |     tuple.2;
    |           ^ unknown field
+   |
+help: a field with a similar name exists
+   |
+LL -     tuple.2;
+LL +     tuple.0;
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When looking for the field names and types of a given type, account for tuples. This allows suggestions for incorrectly nested field accesses and field name typos to trigger as intended. Previously these suggestions only worked on `ty::Adt`, including tuple structs which are no different to tuples, so they should behave the same in suggestions.

When suggesting field access which would encounter a method not found, do not suggest pinning when those methods are on `impl Pin` itself.

```
error[E0599]: no method named `get_ref` found for tuple `(BufReader<File>,)` in the current scope
  --> $DIR/missing-field-access.rs:11:15
   |
LL |     let x = f.get_ref();
   |               ^^^^^^^ method not found in `(BufReader<File>,)`
   |
help: one of the expressions' fields has a method of the same name
   |
LL |     let x = f.0.get_ref();
   |               ++
```
instead of
```
error[E0599]: no method named `get_ref` found for tuple `(BufReader<File>,)` in the current scope
  --> $DIR/missing-field-access.rs:11:15
   |
LL |     let x = f.get_ref();
   |               ^^^^^^^ method not found in `(BufReader<File>,)`
   |
help: consider pinning the expression
   |
LL ~     let mut pinned = std::pin::pin!(f);
LL ~     let x = pinned.as_ref().get_ref();
   |
```

Fix rust-lang/rust#144602.