### PR TITLE
Additional tce tests

### DIFF
--- a/tests/crashes/144293-indirect-ops-llvm.rs
+++ b/tests/crashes/144293-indirect-ops-llvm.rs
@@ -1,0 +1,42 @@
+//@ known-bug: #144293
+// Same as recursion-etc but eggs LLVM emission into giving indirect arguments.
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+use std::hint::black_box;
+
+struct U64Wrapper {
+    pub x: u64,
+    pub arbitrary: String,
+}
+
+fn count(curr: U64Wrapper, top: U64Wrapper) -> U64Wrapper {
+    if black_box(curr.x) >= top.x {
+        curr
+    } else {
+        become count(
+            U64Wrapper {
+                x: curr.x + 1,
+                arbitrary: curr.arbitrary,
+            },
+            top,
+        )
+    }
+}
+
+fn main() {
+    println!(
+        "{}",
+        count(
+            U64Wrapper {
+                x: 0,
+                arbitrary: "hello!".into()
+            },
+            black_box(U64Wrapper {
+                x: 1000000,
+                arbitrary: "goodbye!".into()
+            })
+        )
+        .x
+    );
+}

--- a/tests/ui/explicit-tail-calls/drop-order.rs
+++ b/tests/ui/explicit-tail-calls/drop-order.rs
@@ -1,5 +1,3 @@
-// FIXME(explicit_tail_calls): enable this test once rustc_codegen_ssa supports tail calls
-//@ ignore-test: tail calls are not implemented in rustc_codegen_ssa yet, so this causes 🧊
 //@ run-pass
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]

--- a/tests/ui/explicit-tail-calls/indexer.rs
+++ b/tests/ui/explicit-tail-calls/indexer.rs
@@ -1,0 +1,22 @@
+//@ run-pass
+// Indexing taken from
+// https://github.com/phi-go/rfcs/blob/guaranteed-tco/text%2F0000-explicit-tail-calls.md#tail-call-elimination
+// no other test has utilized the "function table"
+// described in the RFC aside from this one at this point.
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+fn f0(_: usize) {}
+fn f1(_: usize) {}
+fn f2(_: usize) {}
+
+fn indexer(idx: usize) {
+    let v: [fn(usize); 3] = [f0, f1, f2];
+    become v[idx](idx)
+}
+
+fn main() {
+    for idx in 0..3 {
+        indexer(idx);
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @oli-obk 

Adds known-bug tests for LLVM emissions regarding indirect operands for TCE. Also includes a test, `indexer.rs`, referring to function_table behavior described by the RFC.

Depends on rust-lang/rust#144232

Closes rust-lang/rust#144293 