### PR TITLE
Implementation: `#[feature(nonpoison_once)]`

### DIFF
--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -79,7 +79,7 @@ union Data<T, F> {
 /// ```
 #[stable(feature = "lazy_cell", since = "1.80.0")]
 pub struct LazyLock<T, F = fn() -> T> {
-    // FIXME(nonpoison_once): if possible, switch to nonpoison version once it is available
+    /// We use `poison::Once` here to enable the `force_mut` method.
     once: Once,
     data: UnsafeCell<Data<T, F>>,
 }

--- a/library/std/src/sync/nonpoison.rs
+++ b/library/std/src/sync/nonpoison.rs
@@ -33,10 +33,13 @@ impl fmt::Display for WouldBlock {
 pub use self::mutex::MappedMutexGuard;
 #[unstable(feature = "nonpoison_mutex", issue = "134645")]
 pub use self::mutex::{Mutex, MutexGuard};
+#[unstable(feature = "nonpoison_once", issue = "134645")]
+pub use self::once::Once;
 #[unstable(feature = "mapped_lock_guards", issue = "117108")]
 pub use self::rwlock::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 #[unstable(feature = "nonpoison_rwlock", issue = "134645")]
 pub use self::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 mod mutex;
+mod once;
 mod rwlock;

--- a/library/std/src/sync/nonpoison/once.rs
+++ b/library/std/src/sync/nonpoison/once.rs
@@ -1,0 +1,221 @@
+use crate::fmt;
+use crate::sys::sync as sys;
+
+/// A low-level synchronization primitive for one-time global execution that ignores poisoning.
+///
+/// For more information about `Once`, check out the documentation for the poisoning variant (which
+/// can be found at [`poison::Once`]).
+///
+/// [`poison::Once`]: crate::sync::poison::Once
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Once;
+///
+/// static START: Once = Once::new();
+///
+/// START.call_once(|| {
+///     // run initialization here
+/// });
+/// ```
+#[unstable(feature = "nonpoison_once", issue = "134645")]
+pub struct Once {
+    inner: sys::Once,
+}
+
+impl Once {
+    /// Creates a new `Once` value.
+    #[inline]
+    #[unstable(feature = "nonpoison_once", issue = "134645")]
+    #[must_use]
+    pub const fn new() -> Once {
+        Once { inner: sys::Once::new() }
+    }
+
+    /// Performs an initialization routine once and only once. The given closure
+    /// will be executed if this is the first time `call_once` has been called,
+    /// and otherwise the routine will *not* be invoked.
+    ///
+    /// This method will block the calling thread if another initialization
+    /// routine is currently running.
+    ///
+    /// When this function returns, it is guaranteed that some initialization
+    /// has run and completed (it might not be the closure specified). It is also
+    /// guaranteed that any memory writes performed by the executed closure can
+    /// be reliably observed by other threads at this point (there is a
+    /// happens-before relation between the closure and code executing after the
+    /// return).
+    ///
+    /// If the given closure recursively invokes `call_once` on the same [`Once`]
+    /// instance, the exact behavior is not specified: allowed outcomes are
+    /// a panic or a deadlock.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(nonpoison_once)]
+    ///
+    /// use std::sync::nonpoison::Once;
+    ///
+    /// static mut VAL: usize = 0;
+    /// static INIT: Once = Once::new();
+    ///
+    /// // Accessing a `static mut` is unsafe much of the time, but if we do so
+    /// // in a synchronized fashion (e.g., write once or read all) then we're
+    /// // good to go!
+    /// //
+    /// // This function will only call `expensive_computation` once, and will
+    /// // otherwise always return the value returned from the first invocation.
+    /// fn get_cached_val() -> usize {
+    ///     unsafe {
+    ///         INIT.call_once(|| {
+    ///             VAL = expensive_computation();
+    ///         });
+    ///         VAL
+    ///     }
+    /// }
+    ///
+    /// fn expensive_computation() -> usize {
+    ///     // ...
+    /// # 2
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// The closure `f` will only be executed once even if this is called concurrently amongst many
+    /// threads. If the closure panics, the calling thread will panic and the `Once` will remain in
+    /// an incompleted state.
+    ///
+    /// In contrast to the [`poison::Once`] variant, all calls to `call_once` will ignore panics in
+    /// other threads. This method is identical to the [`poison::Once::call_once_force`] method.
+    ///
+    /// If you need observability into whether any threads have panicked while calling `call_once`,
+    /// see [`poison::Once`].
+    ///
+    /// [`poison::Once`]: crate::sync::poison::Once
+    /// [`poison::Once::call_once_force`]: crate::sync::poison::Once::call_once_force
+    ///
+    /// ```
+    /// #![feature(nonpoison_once)]
+    ///
+    /// use std::sync::nonpoison::Once;
+    /// use std::thread;
+    ///
+    /// static INIT: Once = Once::new();
+    ///
+    /// // Panic during `call_once`.
+    /// let handle = thread::spawn(|| {
+    ///     INIT.call_once(|| panic!());
+    /// });
+    /// assert!(handle.join().is_err());
+    ///
+    /// // `call_once` will still run from a different thread.
+    /// INIT.call_once(|| {
+    ///     assert_eq!(2 + 2, 4);
+    /// });
+    /// ```
+    #[inline]
+    #[unstable(feature = "nonpoison_once", issue = "134645")]
+    #[track_caller]
+    pub fn call_once<F>(&self, f: F)
+    where
+        F: FnOnce(),
+    {
+        // Fast path check.
+        if self.inner.is_completed() {
+            return;
+        }
+
+        let mut f = Some(f);
+        self.inner.call(true, &mut |_| f.take().unwrap()());
+    }
+
+    /// Returns `true` if some [`call_once()`] call has completed
+    /// successfully. Specifically, `is_completed` will return false in
+    /// the following situations:
+    ///   * [`call_once()`] was not called at all,
+    ///   * [`call_once()`] was called, but has not yet completed
+    ///
+    /// This function returning `false` does not mean that [`Once`] has not been
+    /// executed. For example, it may have been executed in the time between
+    /// when `is_completed` starts executing and when it returns, in which case
+    /// the `false` return value would be stale (but still permissible).
+    ///
+    /// [`call_once()`]: Once::call_once
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(nonpoison_once)]
+    ///
+    /// use std::sync::nonpoison::Once;
+    ///
+    /// static INIT: Once = Once::new();
+    ///
+    /// assert_eq!(INIT.is_completed(), false);
+    /// INIT.call_once(|| {
+    ///     assert_eq!(INIT.is_completed(), false);
+    /// });
+    /// assert_eq!(INIT.is_completed(), true);
+    /// ```
+    ///
+    /// ```
+    /// #![feature(nonpoison_once)]
+    ///
+    /// use std::sync::nonpoison::Once;
+    /// use std::thread;
+    ///
+    /// static INIT: Once = Once::new();
+    ///
+    /// assert_eq!(INIT.is_completed(), false);
+    /// let handle = thread::spawn(|| {
+    ///     INIT.call_once(|| panic!());
+    /// });
+    /// assert!(handle.join().is_err());
+    /// assert_eq!(INIT.is_completed(), false);
+    /// ```
+    #[inline]
+    #[unstable(feature = "nonpoison_once", issue = "134645")]
+    pub fn is_completed(&self) -> bool {
+        self.inner.is_completed()
+    }
+
+    /// Blocks the current thread until initialization has completed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::sync::Once;
+    /// use std::thread;
+    ///
+    /// static READY: Once = Once::new();
+    ///
+    /// let thread = thread::spawn(|| {
+    ///     READY.wait();
+    ///     println!("everything is ready");
+    /// });
+    ///
+    /// READY.call_once(|| println!("performing setup"));
+    /// ```
+    ///
+    /// This function will continue to block even if a thread initializing via [`call_once()`] has
+    /// panicked. This behavior is identical to the [`poison::Once::wait_force`] method.
+    ///
+    /// [`call_once()`]: Once::call_once
+    /// [`poison::Once::wait_force`]: crate::sync::poison::Once::wait_force
+    #[unstable(feature = "nonpoison_once", issue = "134645")]
+    pub fn wait(&self) {
+        if !self.inner.is_completed() {
+            self.inner.wait(true);
+        }
+    }
+}
+
+#[unstable(feature = "nonpoison_once", issue = "134645")]
+impl fmt::Debug for Once {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Once").finish_non_exhaustive()
+    }
+}

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -106,9 +106,10 @@ use crate::sync::Once;
 /// ```
 #[stable(feature = "once_cell", since = "1.70.0")]
 pub struct OnceLock<T> {
-    // FIXME(nonpoison_once): switch to nonpoison version once it is available
+    /// We use `poison::Once` here to allow us to pseudo-"poison" the `Once` whenever a
+    /// `get_or_try_init` fails, which allows other calls to be run after a failure.
     once: Once,
-    // Whether or not the value is initialized is tracked by `once.is_completed()`.
+    /// Note that `once.is_completed()` tells us if the value is initialized or not.
     value: UnsafeCell<MaybeUninit<T>>,
     /// `PhantomData` to make sure dropck understands we're dropping T in our Drop impl.
     ///

--- a/library/std/tests/sync/lib.rs
+++ b/library/std/tests/sync/lib.rs
@@ -8,6 +8,7 @@
 #![feature(std_internals)]
 #![feature(sync_nonpoison)]
 #![feature(nonpoison_mutex)]
+#![feature(nonpoison_once)]
 #![feature(nonpoison_rwlock)]
 #![allow(internal_features)]
 #![feature(macro_metavar_expr_concat)] // For concatenating identifiers in macros.


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/134645

This PR continues the effort made in https://github.com/rust-lang/rust/pull/144022 by adding the implementation of `nonpoison::once`.

Many of the changes here are similar to the changes made to implement `nonpoison::mutex`.

_Note that even though there were FIXMEs for changing `OnceLock` and `LazyLock` to use the `nonpoison` variant, that is not correct as both rely on poisoning behavior to operate correctly._

### Related PRs

- `nonpoison_rwlock` implementation: https://github.com/rust-lang/rust/pull/144648
- `nonpoison_condvar` implementation: https://github.com/rust-lang/rust/pull/144651