### PR TITLE
fix: Only "close the window" when its the last annotated file

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1597,8 +1597,9 @@ impl HumanEmitter {
             annotated_files.swap(0, pos);
         }
 
+        let annotated_files_len = annotated_files.len();
         // Print out the annotate source lines that correspond with the error
-        for annotated_file in annotated_files {
+        for (file_idx, annotated_file) in annotated_files.into_iter().enumerate() {
             // we can't annotate anything if the source is unavailable.
             if !should_show_source_code(
                 &self.ignored_directories_in_source_blocks,
@@ -1855,7 +1856,9 @@ impl HumanEmitter {
                         width_offset,
                         code_offset,
                         margin,
-                        !is_cont && line_idx + 1 == annotated_file.lines.len(),
+                        !is_cont
+                            && file_idx + 1 == annotated_files_len
+                            && line_idx + 1 == annotated_file.lines.len(),
                     );
 
                     let mut to_add = FxHashMap::default();

--- a/tests/ui/error-emitter/auxiliary/close_window.rs
+++ b/tests/ui/error-emitter/auxiliary/close_window.rs
@@ -1,0 +1,4 @@
+pub struct S;
+impl S {
+    fn method(&self) {}
+}

--- a/tests/ui/error-emitter/close_window.ascii.stderr
+++ b/tests/ui/error-emitter/close_window.ascii.stderr
@@ -1,0 +1,14 @@
+error[E0624]: method `method` is private
+  --> $DIR/close_window.rs:9:7
+   |
+LL |     s.method();
+   |       ^^^^^^ private method
+   |
+  ::: $DIR/auxiliary/close_window.rs:3:5
+   |
+LL |     fn method(&self) {}
+   |     ---------------- private method defined here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0624`.

--- a/tests/ui/error-emitter/close_window.rs
+++ b/tests/ui/error-emitter/close_window.rs
@@ -1,0 +1,11 @@
+//@ aux-build:close_window.rs
+//@ revisions: ascii unicode
+//@[unicode] compile-flags: -Zunstable-options --error-format=human-unicode
+
+extern crate close_window;
+
+fn main() {
+   let s = close_window::S;
+    s.method();
+   //[ascii]~^ ERROR method `method` is private
+}

--- a/tests/ui/error-emitter/close_window.unicode.stderr
+++ b/tests/ui/error-emitter/close_window.unicode.stderr
@@ -2,7 +2,7 @@ error[E0624]: method `method` is private
    ╭▸ $DIR/close_window.rs:9:7
    │
 LL │     s.method();
-   ╰╴      ━━━━━━ private method
+   │       ━━━━━━ private method
    │
    ⸬ $DIR/auxiliary/close_window.rs:3:5
    │

--- a/tests/ui/error-emitter/close_window.unicode.stderr
+++ b/tests/ui/error-emitter/close_window.unicode.stderr
@@ -1,0 +1,14 @@
+error[E0624]: method `method` is private
+   ╭▸ $DIR/close_window.rs:9:7
+   │
+LL │     s.method();
+   ╰╴      ━━━━━━ private method
+   │
+   ⸬ $DIR/auxiliary/close_window.rs:3:5
+   │
+LL │     fn method(&self) {}
+   ╰╴    ──────────────── private method defined here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0624`.


### PR DESCRIPTION
While comparing the Unicode theme output of `rustc` and `annotate-snippets`, I found that `rustc` would ["close the window"](https://github.com/rust-lang/rust/blob/686bc1c5f9c06762b18082434c04d514acf6707e/compiler/rustc_errors/src/emitter.rs#L1025-L1027) (draw a `╰╴`), even though there were other annotated files that followed the current one. This PR makes it so the emitter will only "close the window" on the last annotated file.


Before:
```
error[E0624]: method `method` is private
   ╭▸ $DIR/close_window.rs:9:7
   │
LL │     s.method();
   ╰╴      ━━━━━━ private method
   │
   ⸬ $DIR/auxiliary/close_window.rs:3:5
   │
LL │     fn method(&self) {}
   ╰╴    ──────────────── private method defined here
```

After:
```
error[E0624]: method `method` is private
   ╭▸ $DIR/close_window.rs:9:7
   │
LL │     s.method();
   │       ━━━━━━ private method
   │
   ⸬ $DIR/auxiliary/close_window.rs:3:5
   │
LL │     fn method(&self) {}
   ╰╴    ──────────────── private method defined here
```