### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -984,18 +984,17 @@ impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                 // more details: https://github.com/rust-lang/rust/pull/111761
                 return;
             }
-            let entry = self
-                .r
-                .extern_prelude
-                .entry(ident)
-                .or_insert(ExternPreludeEntry { binding: None, introduced_by_item: true });
+            let entry = self.r.extern_prelude.entry(ident).or_insert(ExternPreludeEntry {
+                binding: Cell::new(None),
+                introduced_by_item: true,
+            });
             if orig_name.is_some() {
                 entry.introduced_by_item = true;
             }
             // Binding from `extern crate` item in source code can replace
             // a binding from `--extern` on command line here.
             if !entry.is_import() {
-                entry.binding = Some(imported_binding)
+                entry.binding.set(Some(imported_binding));
             } else if ident.name != kw::Underscore {
                 self.r.dcx().span_delayed_bug(
                     item.span,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3598,6 +3598,7 @@ impl Target {
             ),
             "x86" => (Architecture::I386, None),
             "s390x" => (Architecture::S390x, None),
+            "m68k" => (Architecture::M68k, None),
             "mips" | "mips32r6" => (Architecture::Mips, None),
             "mips64" | "mips64r6" => (
                 // While there are currently no builtin targets

--- a/library/coretests/tests/panic/location.rs
+++ b/library/coretests/tests/panic/location.rs
@@ -3,6 +3,23 @@ use core::panic::Location;
 // Note: Some of the following tests depend on the source location,
 // so please be careful when editing this file.
 
+mod file_a;
+mod file_b;
+mod file_c;
+
+// A small shuffled set of locations for testing, along with their true order.
+const LOCATIONS: [(usize, &'static Location<'_>); 9] = [
+    (7, file_c::two()),
+    (0, file_a::one()),
+    (3, file_b::one()),
+    (5, file_b::three()),
+    (8, file_c::three()),
+    (6, file_c::one()),
+    (2, file_a::three()),
+    (4, file_b::two()),
+    (1, file_a::two()),
+];
+
 #[test]
 fn location_const_caller() {
     const _CALLER_REFERENCE: &Location<'static> = Location::caller();
@@ -20,7 +37,7 @@ fn location_const_file() {
 fn location_const_line() {
     const CALLER: &Location<'static> = Location::caller();
     const LINE: u32 = CALLER.line();
-    assert_eq!(LINE, 21);
+    assert_eq!(LINE, 38);
 }
 
 #[test]
@@ -34,6 +51,28 @@ fn location_const_column() {
 fn location_debug() {
     let f = format!("{:?}", Location::caller());
     assert!(f.contains(&format!("{:?}", file!())));
-    assert!(f.contains("35"));
+    assert!(f.contains("52"));
     assert!(f.contains("29"));
+}
+
+#[test]
+fn location_eq() {
+    for (i, a) in LOCATIONS {
+        for (j, b) in LOCATIONS {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn location_ord() {
+    let mut locations = LOCATIONS.clone();
+    locations.sort_by_key(|(_o, l)| **l);
+    for (correct, (order, _l)) in locations.iter().enumerate() {
+        assert_eq!(correct, *order);
+    }
 }

--- a/library/coretests/tests/panic/location/file_a.rs
+++ b/library/coretests/tests/panic/location/file_a.rs
@@ -1,0 +1,15 @@
+use core::panic::Location;
+
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+pub const fn one() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn two() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn three() -> &'static Location<'static> {
+    Location::caller()
+}

--- a/library/coretests/tests/panic/location/file_b.rs
+++ b/library/coretests/tests/panic/location/file_b.rs
@@ -1,0 +1,15 @@
+use core::panic::Location;
+
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+pub const fn one() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn two() -> &'static Location<'static> {
+    Location::caller()
+}
+
+pub const fn three() -> &'static Location<'static> {
+    Location::caller()
+}

--- a/library/coretests/tests/panic/location/file_c.rs
+++ b/library/coretests/tests/panic/location/file_c.rs
@@ -1,0 +1,11 @@
+// Used for test super::location_{ord, eq}. Must be in a dedicated file.
+
+// This is used for testing column ordering of Location, hence this ugly one-liner.
+// We must fmt skip the entire containing module or else tidy will still complain.
+#[rustfmt::skip]
+mod no_fmt {
+    use core::panic::Location;
+    pub const fn one() -> &'static Location<'static> { Location::caller() }    pub const fn two() -> &'static Location<'static> { Location::caller() }    pub const fn three() -> &'static Location<'static> { Location::caller() }
+}
+
+pub use no_fmt::*;

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -81,9 +81,9 @@ RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/
 RUN /tmp/build-x86_64-fortanix-unknown-sgx-toolchain.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/tmp/wasi-sdk-25.0-x86_64-linux
+ENV WASI_SDK_PATH=/tmp/wasi-sdk-27.0-x86_64-linux
 
 COPY scripts/freebsd-toolchain.sh /tmp/
 RUN /tmp/freebsd-toolchain.sh i686

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -40,9 +40,9 @@ WORKDIR /
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-25.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-27.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -167,7 +167,7 @@ const EXCEPTIONS_RUSTC_PERF: ExceptionList = &[
     ("brotli-decompressor", "BSD-3-Clause/MIT"),
     ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
     ("inferno", "CDDL-1.0"),
-    ("ring", NON_STANDARD_LICENSE), // see EXCEPTIONS_NON_STANDARD_LICENSE_DEPS for more.
+    ("option-ext", "MPL-2.0"),
     ("ryu", "Apache-2.0 OR BSL-1.0"),
     ("snap", "BSD-3-Clause"),
     ("subtle", "BSD-3-Clause"),

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -226,20 +226,6 @@ const EXCEPTIONS_UEFI_QEMU_TEST: ExceptionList = &[
     ("r-efi", "MIT OR Apache-2.0 OR LGPL-2.1-or-later"), // LGPL is not acceptable, but we use it under MIT OR Apache-2.0
 ];
 
-/// Placeholder for non-standard license file.
-const NON_STANDARD_LICENSE: &str = "NON_STANDARD_LICENSE";
-
-/// These dependencies have non-standard licenses but are genenrally permitted.
-const EXCEPTIONS_NON_STANDARD_LICENSE_DEPS: &[&str] = &[
-    // `ring` is included because it is an optional dependency of `hyper`,
-    // which is a training data in rustc-perf for optimized build.
-    // The license of it is generally `ISC AND MIT AND OpenSSL`,
-    // though the `package.license` field is not set.
-    //
-    // See https://github.com/briansmith/ring/issues/902
-    "ring",
-];
-
 const PERMITTED_DEPS_LOCATION: &str = concat!(file!(), ":", line!());
 
 /// Crates rustc is allowed to depend on. Avoid adding to the list if possible.
@@ -751,11 +737,6 @@ fn check_license_exceptions(
         for pkg in metadata.packages.iter().filter(|p| *p.name == *name) {
             match &pkg.license {
                 None => {
-                    if *license == NON_STANDARD_LICENSE
-                        && EXCEPTIONS_NON_STANDARD_LICENSE_DEPS.contains(&pkg.name.as_str())
-                    {
-                        continue;
-                    }
                     tidy_error!(
                         bad,
                         "dependency exception `{}` in workspace `{workspace}` does not declare a license expression",

--- a/tests/assembly-llvm/nvptx-safe-naming.rs
+++ b/tests/assembly-llvm/nvptx-safe-naming.rs
@@ -1,6 +1,9 @@
 //@ assembly-output: ptx-linker
 //@ compile-flags: --crate-type cdylib -Z unstable-options -Clinker-flavor=llbc
 //@ only-nvptx64
+//@ revisions: LLVM20 LLVM21
+//@ [LLVM21] min-llvm-version: 21
+//@ [LLVM20] max-llvm-major-version: 20
 
 #![feature(abi_ptx)]
 #![no_std]
@@ -15,7 +18,8 @@ extern crate breakpoint_panic_handler;
 #[no_mangle]
 pub unsafe extern "ptx-kernel" fn top_kernel(a: *const u32, b: *mut u32) {
     // CHECK:      call.uni (retval0),
-    // CHECK-NEXT: [[IMPL_FN]]
+    // LLVM20-NEXT: [[IMPL_FN]]
+    // LLVM21-SAME: [[IMPL_FN]]
     *b = deep::private::MyStruct::new(*a).square();
 }
 

--- a/tests/assembly-llvm/x86-return-float.rs
+++ b/tests/assembly-llvm/x86-return-float.rs
@@ -334,9 +334,9 @@ pub fn return_f128(x: f128) -> f128 {
     // linux-NEXT: .cfi_offset
     // CHECK-NEXT: movl %esp, %ebp
     // linux-NEXT: .cfi_def_cfa_register
-    // linux-NEXT: movaps 8(%ebp), %xmm0
-    // win-NEXT: movups 8(%ebp), %xmm0
-    // CHECK-NEXT: popl %ebp
+    // linux: movaps 8(%ebp), %xmm0
+    // win: movups 8(%ebp), %xmm0
+    // CHECK: popl %ebp
     // linux-NEXT: .cfi_def_cfa
     // CHECK-NEXT: retl
     x

--- a/tests/codegen-llvm/diverging-function-call-debuginfo.rs
+++ b/tests/codegen-llvm/diverging-function-call-debuginfo.rs
@@ -1,0 +1,38 @@
+/// Make sure that line debuginfo is correct for diverging calls under certain
+/// conditions. In particular we want to ensure that the line number is never
+/// 0, but we check the absence of 0 by looking for the expected exact line
+/// numbers. Regression test for <https://github.com/rust-lang/rust/issues/59558>.
+
+//@ compile-flags: -g -Clto -Copt-level=0
+//@ no-prefer-dynamic
+
+// First find the scope of both diverge() calls, namely this main() function.
+// CHECK-DAG: [[MAIN_SCOPE:![0-9]+]] = distinct !DISubprogram(name: "main", linkageName: {{.*}}diverging_function_call_debuginfo{{.*}}main{{.*}}
+fn main() {
+    if True == False {
+        // unreachable
+        // Then find the DILocation with the correct line number for this call ...
+        // CHECK-DAG: [[UNREACHABLE_CALL_DBG:![0-9]+]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: [[MAIN_SCOPE]]
+        diverge();
+    }
+
+    // ... and this call.
+    // CHECK-DAG: [[LAST_CALL_DBG:![0-9]+]] = !DILocation(line: [[@LINE+1]], {{.*}}scope: [[MAIN_SCOPE]]
+    diverge();
+}
+
+#[derive(PartialEq)]
+pub enum MyBool {
+    True,
+    False,
+}
+
+use MyBool::*;
+
+fn diverge() -> ! {
+    panic!();
+}
+
+// Finally make sure both DILocations belong to each the respective diverge() call.
+// CHECK-DAG: call void {{.*}}diverging_function_call_debuginfo{{.*}}diverge{{.*}} !dbg [[LAST_CALL_DBG]]
+// CHECK-DAG: call void {{.*}}diverging_function_call_debuginfo{{.*}}diverge{{.*}} !dbg [[UNREACHABLE_CALL_DBG]]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -50,6 +50,21 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
+# [backport.*] sections autonominate pull requests for a backport
+# see: https://forge.rust-lang.org/triagebot/backport.html
+
+[backport.t-compiler-beta-backport]
+# The pull request MUST have one of these labels
+required-pr-labels = ["T-compiler"]
+# The regression MUST have this label
+required-issue-label = "regression-from-stable-to-beta"
+# if the above conditions matches, the PR will receive these labels
+add-labels = ["beta-nominated"]
+
+[backport.t-compiler-stable-backport]
+required-pr-labels = ["T-compiler"]
+required-issue-label = "regression-from-stable-to-stable"
+add-labels = ["stable-nominated"]
 
 # ------------------------------------------------------------------------------
 # Ping groups


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#144034 (tests: Test line number in debuginfo for diverging function calls)
 - rust-lang/rust#144510 (Fix Ord, Eq and Hash implementation of panic::Location)
 - rust-lang/rust#144583 (Enable T-compiler backport nomination)
 - rust-lang/rust#144586 (Update wasi-sdk to 27.0 in CI)
 - rust-lang/rust#144605 (Resolve: cachify `ExternPreludeEntry.binding` through a `Cell`)
 - rust-lang/rust#144632 (Update some tests for LLVM 21)
 - rust-lang/rust#144639 (Update rustc-perf submodule)
 - rust-lang/rust#144640 (Add support for the m68k architecture in 'object_architecture')

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=144034,144510,144583,144586,144605,144632,144639,144640)
<!-- homu-ignore:end -->