### PR TITLE
[test][run-make] add needs-llvm-components

### DIFF
--- a/tests/run-make/link-cfg/rmake.rs
+++ b/tests/run-make/link-cfg/rmake.rs
@@ -12,6 +12,7 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+//@ needs-llvm-components: x86
 
 use run_make_support::{bare_rustc, build_native_dynamic_lib, build_native_static_lib, run, rustc};
 

--- a/tests/run-make/mismatching-target-triples/rmake.rs
+++ b/tests/run-make/mismatching-target-triples/rmake.rs
@@ -4,6 +4,7 @@
 // now replaced by a clearer normal error message. This test checks that this aforementioned
 // error message is used.
 // See https://github.com/rust-lang/rust/issues/10814
+//@ needs-llvm-components: x86
 
 use run_make_support::rustc;
 

--- a/tests/run-make/musl-default-linking/rmake.rs
+++ b/tests/run-make/musl-default-linking/rmake.rs
@@ -4,6 +4,7 @@ use run_make_support::{rustc, serde_json};
 // Per https://github.com/rust-lang/compiler-team/issues/422,
 // we should be trying to move these targets to dynamically link
 // musl libc by default.
+//@ needs-llvm-components: aarch64 arm mips powerpc riscv systemz x86
 static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "aarch64-unknown-linux-musl",
     "arm-unknown-linux-musleabi",

--- a/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
+++ b/tests/run-make/rustdoc-target-spec-json-path/rmake.rs
@@ -1,4 +1,5 @@
 // Test that rustdoc will properly canonicalize the target spec json path just like rustc.
+//@ needs-llvm-components: x86
 
 use run_make_support::{cwd, rustc, rustdoc};
 

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -4,6 +4,7 @@
 // with the target flag's bundle of new features to check that compilation either succeeds while
 // using them correctly, or fails with the right error message when using them improperly.
 // See https://github.com/rust-lang/rust/pull/16156
+//@ needs-llvm-components: x86
 
 use run_make_support::{diff, rfs, rustc};
 


### PR DESCRIPTION
Add some constraints to run-make tests that require specific target support and will fail without them.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
