### PR TITLE
Add reproducible build verification to bootstrap

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -353,6 +353,16 @@
 # This is only useful for verifying that rustc generates reproducible builds.
 #build.full-bootstrap = false
 
+# Set to `true` to verify build reproducibility by compiling the compiler twice
+# in separate directories and comparing outputs. This only takes effect when
+# running `x.py build` (not other commands) and requires significant time/disk space.
+# Can also be enabled via `--reproducible` CLI flag.
+#
+# Optionally, you can generate a detailed HTML report using the CLI:
+#   ./x.py build --reproducible --html report.html
+# The report is saved to the specified path, and a copy is placed in the Rust source directory.
+#build.reproducible = false
+
 # Set the bootstrap/download cache path. It is useful when building rust
 # repeatedly in a CI environment.
 #build.bootstrap-cache-path = /path/to/shared/cache

--- a/src/bootstrap/README.md
+++ b/src/bootstrap/README.md
@@ -35,7 +35,13 @@ compiler. What actually happens when you invoke bootstrap is:
    and the compiler, and then these binaries are then copied to the `stage1`
    directory. That compiler is then used to generate the stage1 artifacts which
    are then copied to the stage2 directory, and then finally, the stage2
-   artifacts are generated using that compiler.
+   artifacts are generated using that compiler. A full stage 2 build (producing
+   a complete, self-contained compiler) can be executed with:
+
+   ```bash
+   ./x.py build --stage 2 compiler/rustc
+   ```
+   This builds the compiler through all bootstrap stages.
 
 The goal of each stage is to (a) leverage Cargo as much as possible and failing
 that (b) leverage Rust as much as possible!
@@ -154,6 +160,32 @@ build/
     stage2/
     stage3/
 ```
+## Verifying Build Reproducibility
+
+To ensure the compiler produces identical output across builds (important for
+security and deterministic builds), you can verify build reproducibility:
+
+```bash
+./x.py build --reproducible
+```
+Or set in `bootstrap.toml`:
+```toml
+[build]
+build.reproducible = true
+```
+
+This will:
+1. Build the compiler in two separate directories
+2. Compare critical artifacts (binaries, libraries)
+3. Report any differences
+Note: Requires significant time and disk space as it performs two complete builds.
+Verification compares:
+- Rustc binaries (`bin/`)
+- Standard library (`lib/*.so`)
+- Compiler RLIBs (`lib/rustlib/`)
+
+For a detailed HTML report, use the --html flag:
+./x.py build --reproducible --html report.html
 
 ## Extending bootstrap
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -320,6 +320,7 @@ o(
     "build three compilers instead of two (not recommended except for testing reproducible builds)",
 )
 o("extended", "build.extended", "build an extended rust tool set")
+o("reproducible", "build.reproducible", "perform a reproducibility check by building the compiler twice")
 
 v("bootstrap-cache-path", None, "use provided path for the bootstrap cache")
 v("tools", None, "List of extended tools will be installed")

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -99,6 +99,7 @@ pub struct Config {
     pub vendor: bool,
     pub target_config: HashMap<TargetSelection, Target>,
     pub full_bootstrap: bool,
+    pub reproducible: bool,
     pub bootstrap_cache_path: Option<PathBuf>,
     pub extended: bool,
     pub tools: Option<HashSet<String>>,
@@ -722,6 +723,7 @@ impl Config {
             locked_deps,
             vendor,
             full_bootstrap,
+            reproducible,
             bootstrap_cache_path,
             extended,
             tools,
@@ -879,6 +881,7 @@ impl Config {
         set(&mut config.docs, docs);
         set(&mut config.locked_deps, locked_deps);
         set(&mut config.full_bootstrap, full_bootstrap);
+        set(&mut config.reproducible, reproducible);
         set(&mut config.extended, extended);
         config.tools = tools;
         set(&mut config.tool, tool);

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -41,6 +41,7 @@ define_config! {
         locked_deps: Option<bool> = "locked-deps",
         vendor: Option<bool> = "vendor",
         full_bootstrap: Option<bool> = "full-bootstrap",
+        reproducible: Option<bool> = "reproducible",
         bootstrap_cache_path: Option<PathBuf> = "bootstrap-cache-path",
         extended: Option<bool> = "extended",
         tools: Option<HashSet<String>> = "tools",


### PR DESCRIPTION
This change introduces a new `--reproducible` flag and `build.reproducible` config option that performs a verification of build reproducibility by:

1. Building the compiler twice in separate directories
2. Comparing critical artifacts (binaries, shared libraries, RLIBs)
3. Reporting any differences found

Key features:
- Can be enabled via CLI flag or config file
- Generates a detailed HTML report with `--html` flag
- Only runs for actual build commands (not help/other commands)
- Focuses on comparing critical compiler artifacts
- Provides clear success/failure output

The verification helps ensure the compiler produces identical outputs across builds, which is important for security and deterministic builds.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
