### PR TITLE
[do not merge] Add a `Move` marker trait

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2241,7 +2241,7 @@ options! {
         "Use WebAssembly error handling for wasm32-unknown-emscripten"),
     enforce_type_length_limit: bool = (false, parse_bool, [TRACKED],
         "enforce the type length limit when monomorphizing instances in codegen"),
-    experimental_default_bounds: bool = (false, parse_bool, [TRACKED],
+    experimental_default_bounds: bool = (true, parse_bool, [TRACKED],
         "enable default bounds for experimental group of auto traits"),
     export_executable_symbols: bool = (false, parse_bool, [TRACKED],
         "export symbols from executables, as if they were dynamic libraries"),

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2025,7 +2025,7 @@ unsafe impl<T: ?Sized, A: Allocator> PinCoerceUnsized for Box<T, A> {}
 // Handling arbitrary custom allocators (which can affect the `Box` layout heavily!)
 // would need a lot of codegen and interpreter adjustments.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T, Global> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized + ?core::marker::Sized> DispatchFromDyn<Box<U>> for Box<T, Global> {}
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
 impl<T: ?Sized, A: Allocator> Borrow<T> for Box<T, A> {

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -191,7 +191,7 @@ use core::error::{self, Error};
 use core::fmt;
 use core::future::Future;
 use core::hash::{Hash, Hasher};
-use core::marker::{Tuple, Unsize};
+use core::marker::{Tuple, Move, Unsize};
 use core::mem::{self, SizedTypeProperties};
 use core::ops::{
     AsyncFn, AsyncFnMut, AsyncFnOnce, CoerceUnsized, Coroutine, CoroutineState, Deref, DerefMut,
@@ -2132,3 +2132,6 @@ impl<E: Error> Error for Box<E> {
         Error::provide(&**self, request);
     }
 }
+
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T: ?Sized> Move for Box<T> {}

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2025,7 +2025,10 @@ unsafe impl<T: ?Sized, A: Allocator> PinCoerceUnsized for Box<T, A> {}
 // Handling arbitrary custom allocators (which can affect the `Box` layout heavily!)
 // would need a lot of codegen and interpreter adjustments.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized + ?core::marker::Sized> DispatchFromDyn<Box<U>> for Box<T, Global> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized + ?core::marker::Sized> DispatchFromDyn<Box<U>>
+    for Box<T, Global>
+{
+}
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
 impl<T: ?Sized, A: Allocator> Borrow<T> for Box<T, A> {

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -191,7 +191,7 @@ use core::error::{self, Error};
 use core::fmt;
 use core::future::Future;
 use core::hash::{Hash, Hasher};
-use core::marker::{Tuple, Move, Unsize};
+use core::marker::{Move, Tuple, Unsize};
 use core::mem::{self, SizedTypeProperties};
 use core::ops::{
     AsyncFn, AsyncFnMut, AsyncFnOnce, CoerceUnsized, Coroutine, CoroutineState, Deref, DerefMut,

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -190,6 +190,9 @@ unsafe impl<#[may_dangle] K, #[may_dangle] V, A: Allocator + Clone> Drop for BTr
     }
 }
 
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<K, V, A: Allocator + Clone> core::marker::Move for BTreeMap<K, V, A> {}
+
 // FIXME: This implementation is "wrong", but changing it would be a breaking change.
 // (The bounds of the automatic `UnwindSafe` implementation have been like this since Rust 1.50.)
 // Maybe we can fix it nonetheless with a crater run, or if the `UnwindSafe`

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -3025,6 +3025,9 @@ impl<T, A: Allocator> IndexMut<usize> for VecDeque<T, A> {
     }
 }
 
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T, A: Allocator> core::marker::Move for VecDeque<T, A> {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> FromIterator<T> for VecDeque<T> {
     #[track_caller]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -132,6 +132,7 @@
 #![feature(local_waker)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array_transpose)]
+#![feature(move_trait)]
 #![feature(panic_internals)]
 #![feature(pattern)]
 #![feature(pin_coerce_unsized_trait)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -251,7 +251,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::{PhantomData, Move, Unsize};
+use core::marker::{Move, PhantomData, Unsize};
 use core::mem::{self, ManuallyDrop, align_of_val_raw};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -251,7 +251,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::{PhantomData, Unsize};
+use core::marker::{PhantomData, Move, Unsize};
 use core::mem::{self, ManuallyDrop, align_of_val_raw};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
@@ -2276,6 +2276,9 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for UniqueRc<T, A> {}
 
 #[unstable(feature = "legacy_receiver_trait", issue = "none")]
 impl<T: ?Sized> LegacyReceiver for Rc<T> {}
+
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T: ?Sized, A: Allocator> Move for Rc<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Rc<T, A> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -17,7 +17,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::{PhantomData, Unsize, Move};
+use core::marker::{Move, PhantomData, Unsize};
 use core::mem::{self, ManuallyDrop, align_of_val_raw};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -17,7 +17,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::{PhantomData, Unsize};
+use core::marker::{PhantomData, Unsize, Move};
 use core::mem::{self, ManuallyDrop, align_of_val_raw};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
@@ -271,6 +271,8 @@ pub struct Arc<
 unsafe impl<T: ?Sized + Sync + Send, A: Allocator + Send> Send for Arc<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send, A: Allocator + Sync> Sync for Arc<T, A> {}
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T: ?Sized, A: Allocator> Move for Arc<T, A> {}
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized, A: Allocator + UnwindSafe> UnwindSafe for Arc<T, A> {}

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -59,7 +59,7 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::{PhantomData, Move};
+use core::marker::{Move, PhantomData};
 use core::mem::{self, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::ops::{self, Index, IndexMut, Range, RangeBounds};
 use core::ptr::{self, NonNull};

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -59,7 +59,7 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
-use core::marker::PhantomData;
+use core::marker::{PhantomData, Move};
 use core::mem::{self, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::ops::{self, Index, IndexMut, Range, RangeBounds};
 use core::ptr::{self, NonNull};
@@ -3907,6 +3907,9 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {
         // RawVec handles deallocation
     }
 }
+
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T> Move for Vec<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -12,6 +12,7 @@
 #![feature(int_format_into)]
 #![feature(linked_list_cursors)]
 #![feature(map_try_insert)]
+#![feature(move_trait)]
 #![feature(pattern)]
 #![feature(trusted_len)]
 #![feature(try_reserve_kind)]

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -250,9 +250,11 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use core::marker::Move;
+
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
-use crate::marker::{PhantomData, Unsize};
+use crate::marker::{Move, PhantomData, Unsize};
 use crate::mem;
 use crate::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn};
 use crate::panic::const_panic;
@@ -309,7 +311,7 @@ pub use once::OnceCell;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
-pub struct Cell<T: ?Sized + ?core::marker::Move> {
+pub struct Cell<T: ?Sized + ?Move> {
     value: UnsafeCell<T>,
 }
 
@@ -322,7 +324,7 @@ unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 // having an explicit negative impl is nice for documentation purposes
 // and results in nicer error messages.
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + ?crate::marker::Move> !Sync for Cell<T> {}
+impl<T: ?Sized + ?Move> !Sync for Cell<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Copy> Clone for Cell<T> {
@@ -668,7 +670,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 // `self: Cell<&Self>` won't work
 // `self: CellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<Cell<U>> for Cell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?Move> DispatchFromDyn<Cell<U>> for Cell<T> {}
 
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
@@ -2090,12 +2092,12 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
-pub struct UnsafeCell<T: ?Sized + ?crate::marker::Move> {
+pub struct UnsafeCell<T: ?Sized + ?Move> {
     value: T,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + ?crate::marker::Move> !Sync for UnsafeCell<T> {}
+impl<T: ?Sized + ?Move> !Sync for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified
@@ -2359,7 +2361,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
 // `self: UnsafeCell<&Self>` won't work
 // `self: UnsafeCellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?Move> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> {}
 
 /// [`UnsafeCell`], but [`Sync`].
 ///
@@ -2377,7 +2379,7 @@ impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<UnsafeCell<
 #[repr(transparent)]
 #[rustc_diagnostic_item = "SyncUnsafeCell"]
 #[rustc_pub_transparent]
-pub struct SyncUnsafeCell<T: ?Sized + ?crate::marker::Move> {
+pub struct SyncUnsafeCell<T: ?Sized + ?Move> {
     value: UnsafeCell<T>,
 }
 
@@ -2466,7 +2468,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<SyncUnsafeCell<U>> for SyncUnsafeCell
 // `self: SyncUnsafeCellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 //#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
-impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?Move> DispatchFromDyn<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
 
 #[allow(unused)]
 fn assert_coerce_unsized(

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -309,7 +309,7 @@ pub use once::OnceCell;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
-pub struct Cell<T: ?Sized> {
+pub struct Cell<T: ?Sized + ?core::marker::Move> {
     value: UnsafeCell<T>,
 }
 
@@ -322,7 +322,7 @@ unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 // having an explicit negative impl is nice for documentation purposes
 // and results in nicer error messages.
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> !Sync for Cell<T> {}
+impl<T: ?Sized + ?crate::marker::Move> !Sync for Cell<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Copy> Clone for Cell<T> {
@@ -668,7 +668,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 // `self: Cell<&Self>` won't work
 // `self: CellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Cell<U>> for Cell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<Cell<U>> for Cell<T> {}
 
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
@@ -2090,12 +2090,12 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
-pub struct UnsafeCell<T: ?Sized> {
+pub struct UnsafeCell<T: ?Sized + ?crate::marker::Move> {
     value: T,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> !Sync for UnsafeCell<T> {}
+impl<T: ?Sized + ?crate::marker::Move> !Sync for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified
@@ -2359,7 +2359,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
 // `self: UnsafeCell<&Self>` won't work
 // `self: UnsafeCellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> {}
 
 /// [`UnsafeCell`], but [`Sync`].
 ///
@@ -2377,7 +2377,7 @@ impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> 
 #[repr(transparent)]
 #[rustc_diagnostic_item = "SyncUnsafeCell"]
 #[rustc_pub_transparent]
-pub struct SyncUnsafeCell<T: ?Sized> {
+pub struct SyncUnsafeCell<T: ?Sized + ?crate::marker::Move> {
     value: UnsafeCell<T>,
 }
 
@@ -2466,7 +2466,7 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<SyncUnsafeCell<U>> for SyncUnsafeCell
 // `self: SyncUnsafeCellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 //#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
-impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
+impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
 
 #[allow(unused)]
 fn assert_coerce_unsized(

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -250,8 +250,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use core::marker::Move;
-
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
 use crate::marker::{Move, PhantomData, Unsize};

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1370,6 +1370,7 @@ pub trait CoercePointeeValidated {
 /// Types that do not require a stable memory address, and so can be freely
 /// `move`d.
 #[lang = "default_trait1"]
+#[rustc_unsafe_specialization_marker]
 #[unstable(feature = "move_trait", issue = "none")]
 pub unsafe auto trait Move {
     // empty.

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -820,7 +820,7 @@ impl<T: PointeeSized> !Sync for *mut T {}
 /// [drop check]: Drop#drop-check
 #[lang = "phantom_data"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct PhantomData<T: PointeeSized>;
+pub struct PhantomData<T: PointeeSized + ?crate::marker::Move>;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PointeeSized> Hash for PhantomData<T> {
@@ -914,7 +914,7 @@ pub trait DiscriminantKind {
 pub unsafe auto trait Freeze {}
 
 #[unstable(feature = "freeze", issue = "121675")]
-impl<T: PointeeSized> !Freeze for UnsafeCell<T> {}
+impl<T: PointeeSized + ?crate::marker::Move> !Freeze for UnsafeCell<T> {}
 marker_impls! {
     #[unstable(feature = "freeze", issue = "121675")]
     unsafe Freeze for
@@ -934,7 +934,7 @@ marker_impls! {
 #[lang = "unsafe_unpin"]
 pub(crate) unsafe auto trait UnsafeUnpin {}
 
-impl<T: ?Sized> !UnsafeUnpin for UnsafePinned<T> {}
+impl<T: ?Sized + ?crate::marker::Move> !UnsafeUnpin for UnsafePinned<T> {}
 unsafe impl<T: ?Sized> UnsafeUnpin for PhantomData<T> {}
 unsafe impl<T: ?Sized> UnsafeUnpin for *const T {}
 unsafe impl<T: ?Sized> UnsafeUnpin for *mut T {}
@@ -1378,7 +1378,6 @@ pub unsafe auto trait Move {
 marker_impls! {
     #[unstable(feature = "move_trait", issue = "none")]
     unsafe Move for
-        {T: ?Sized} PhantomData<T>,
         {T: ?Sized} *const T,
         {T: ?Sized} *mut T,
         {T: ?Sized} &T,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -237,7 +237,7 @@ pub trait PointeeSized {
 #[lang = "unsize"]
 #[rustc_deny_explicit_impl]
 #[rustc_do_not_implement_via_object]
-pub trait Unsize<T: PointeeSized>: PointeeSized {
+pub trait Unsize<T: PointeeSized + ?crate::marker::Move>: PointeeSized {
     // Empty.
 }
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1369,6 +1369,7 @@ pub trait CoercePointeeValidated {
 
 /// Types that do not require a stable memory address, and so can be freely
 /// `move`d.
+#[lang = "default_trait1"]
 #[unstable(feature = "move_trait", issue = "none")]
 pub unsafe auto trait Move {
     // empty.

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1366,3 +1366,19 @@ pub macro CoercePointee($item:item) {
 pub trait CoercePointeeValidated {
     /* compiler built-in */
 }
+
+/// Types that do not require a stable memory address, and so can be freely
+/// `move`d.
+#[unstable(feature = "move_trait", issue = "none")]
+pub unsafe auto trait Move {
+    // empty.
+}
+marker_impls! {
+    #[unstable(feature = "move_trait", issue = "none")]
+    unsafe Move for
+        {T: ?Sized} PhantomData<T>,
+        {T: ?Sized} *const T,
+        {T: ?Sized} *mut T,
+        {T: ?Sized} &T,
+        {T: ?Sized} &mut T,
+}

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -116,7 +116,7 @@ impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *
 /// [^1]: Formerly known as *object safety*.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 #[lang = "dispatch_from_dyn"]
-pub trait DispatchFromDyn<T> {
+pub trait DispatchFromDyn<T: ?Move> {
     // Empty.
 }
 

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -116,7 +116,7 @@ impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *
 /// [^1]: Formerly known as *object safety*.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 #[lang = "dispatch_from_dyn"]
-pub trait DispatchFromDyn<T: ?Move> {
+pub trait DispatchFromDyn<T: ?crate::marker::Move> {
     // Empty.
 }
 

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -39,34 +39,34 @@ pub trait CoerceUnsized<T: PointeeSized> {
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U> for &'a mut T {}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b mut T {}
+impl<'a, 'b: 'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b mut T {}
 // &mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for &'a mut T {}
 // &mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a mut T {}
 
 // &T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, 'b: 'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b T {}
+impl<'a, 'b: 'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b T {}
 // &T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a T {}
 
 // *mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for *mut T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for *mut T {}
 // *mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *mut T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *mut T {}
 
 // *const T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *const T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *const T {}
 
 /// `DispatchFromDyn` is used in the implementation of dyn-compatibility[^1] checks (specifically
 /// allowing arbitrary self types), to guarantee that a method's receiver type can be dispatched on.
@@ -122,13 +122,13 @@ pub trait DispatchFromDyn<T: ?crate::marker::Move> {
 
 // &T -> &U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a U> for &'a T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a U> for &'a T {}
 // &mut T -> &mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a mut U> for &'a mut T {}
 // *const T -> *const U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + Unsize<U>, U: PointeeSized> DispatchFromDyn<*const U> for *const T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<*const U> for *const T {}
 // *mut T -> *mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + Unsize<U>, U: PointeeSized> DispatchFromDyn<*mut U> for *mut T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<*mut U> for *mut T {}

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -122,13 +122,13 @@ pub trait DispatchFromDyn<T: ?crate::marker::Move> {
 
 // &T -> &U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a U> for &'a T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<&'a U> for &'a T {}
 // &mut T -> &mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<&'a mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<&'a mut U> for &'a mut T {}
 // *const T -> *const U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<*const U> for *const T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<*const U> for *const T {}
 // *mut T -> *mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> DispatchFromDyn<*mut U> for *mut T {}
+impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<*mut U> for *mut T {}

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -1,4 +1,4 @@
-use crate::marker::{PointeeSized, Unsize};
+use crate::marker::{Move, PointeeSized, Unsize};
 
 /// Trait that indicates that this is a pointer or a wrapper for one,
 /// where unsizing can be performed on the pointee.
@@ -39,34 +39,46 @@ pub trait CoerceUnsized<T: PointeeSized> {
 
 // &mut T -> &mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a mut U>
+    for &'a mut T
+{
+}
 // &mut T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, 'b: 'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b mut T {}
+impl<'a, 'b: 'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U>
+    for &'b mut T
+{
+}
 // &mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for &'a mut T {}
 // &mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U>
+    for &'a mut T
+{
+}
 
 // &T -> &U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, 'b: 'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U> for &'b T {}
+impl<'a, 'b: 'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<&'a U>
+    for &'b T
+{
+}
 // &T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for &'a T {}
 
 // *mut T -> *mut U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for *mut T {}
+impl<T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*mut U> for *mut T {}
 // *mut T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *mut T {}
+impl<T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *mut T {}
 
 // *const T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "18598")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *const T {}
+impl<T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *const T {}
 
 /// `DispatchFromDyn` is used in the implementation of dyn-compatibility[^1] checks (specifically
 /// allowing arbitrary self types), to guarantee that a method's receiver type can be dispatched on.
@@ -116,19 +128,31 @@ impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized> Coerce
 /// [^1]: Formerly known as *object safety*.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 #[lang = "dispatch_from_dyn"]
-pub trait DispatchFromDyn<T: ?crate::marker::Move> {
+pub trait DispatchFromDyn<T: ?Move> {
     // Empty.
 }
 
 // &T -> &U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<&'a U> for &'a T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized + ?Move> DispatchFromDyn<&'a U>
+    for &'a T
+{
+}
 // &mut T -> &mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<'a, T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<&'a mut U> for &'a mut T {}
+impl<'a, T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized + ?Move> DispatchFromDyn<&'a mut U>
+    for &'a mut T
+{
+}
 // *const T -> *const U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<*const U> for *const T {}
+impl<T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized + ?Move> DispatchFromDyn<*const U>
+    for *const T
+{
+}
 // *mut T -> *mut U
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized + ?crate::marker::Move + Unsize<U>, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<*mut U> for *mut T {}
+impl<T: PointeeSized + ?Move + Unsize<U>, U: PointeeSized + ?Move> DispatchFromDyn<*mut U>
+    for *mut T
+{
+}

--- a/library/core/src/panic/unwind_safe.rs
+++ b/library/core/src/panic/unwind_safe.rs
@@ -197,7 +197,7 @@ impl<T> UnwindSafe for AssertUnwindSafe<T> {}
 // only thing which doesn't implement it (which then transitively applies to
 // everything else).
 #[stable(feature = "catch_unwind", since = "1.9.0")]
-impl<T: ?Sized> !RefUnwindSafe for UnsafeCell<T> {}
+impl<T: ?Sized + ?crate::marker::Move> !RefUnwindSafe for UnsafeCell<T> {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T> RefUnwindSafe for AssertUnwindSafe<T> {}
 

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1091,7 +1091,7 @@ pub use self::unsafe_pinned::UnsafePinned;
 #[repr(transparent)]
 #[rustc_pub_transparent]
 #[derive(Copy, Clone)]
-pub struct Pin<Ptr> {
+pub struct Pin<Ptr: ?crate::marker::Move> {
     pointer: Ptr,
 }
 
@@ -1727,7 +1727,7 @@ where
 impl<Ptr, U> DispatchFromDyn<Pin<U>> for Pin<Ptr>
 where
     Ptr: DispatchFromDyn<U> + PinCoerceUnsized,
-    U: PinCoerceUnsized,
+    U: PinCoerceUnsized + ?crate::marker::Move,
 {
 }
 

--- a/library/core/src/pin/unsafe_pinned.rs
+++ b/library/core/src/pin/unsafe_pinned.rs
@@ -1,5 +1,5 @@
 use crate::cell::UnsafeCell;
-use crate::marker::Unpin;
+use crate::marker::{Move, Unpin};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::pin::Pin;
 use crate::{fmt, ptr};
@@ -24,7 +24,7 @@ use crate::{fmt, ptr};
 #[lang = "unsafe_pinned"]
 #[repr(transparent)]
 #[unstable(feature = "unsafe_pinned", issue = "125735")]
-pub struct UnsafePinned<T: ?Sized + ?crate::marker::Move> {
+pub struct UnsafePinned<T: ?Sized + ?Move> {
     value: UnsafeCell<T>,
 }
 
@@ -36,7 +36,7 @@ unsafe impl<T: ?Sized + Sync> Sync for UnsafePinned<T> {}
 /// aliases from becoming invalidated. Therefore let's mark this as `!Unpin`. You can always opt
 /// back in to `Unpin` with an `impl` block, provided your API is still sound while unpinned.
 #[unstable(feature = "unsafe_pinned", issue = "125735")]
-impl<T: ?Sized + ?crate::marker::Move> !Unpin for UnsafePinned<T> {}
+impl<T: ?Sized + ?Move> !Unpin for UnsafePinned<T> {}
 
 // `Send` and `Sync` are inherited from `T`. This is similar to `SyncUnsafeCell`, since
 // we eventually concluded that `UnsafeCell` implicitly making things `!Sync` is sometimes
@@ -176,6 +176,6 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafePinned<U>> for UnsafePinned<T> 
 // FIXME(unsafe_pinned) this logic is copied from UnsafeCell, is it still sound?
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 // #[unstable(feature = "unsafe_pinned", issue = "125735")]
-impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<UnsafePinned<U>> for UnsafePinned<T> {}
+impl<T: DispatchFromDyn<U>, U: ?Move> DispatchFromDyn<UnsafePinned<U>> for UnsafePinned<T> {}
 
 // FIXME(unsafe_pinned): impl PinCoerceUnsized for UnsafePinned<T>?

--- a/library/core/src/pin/unsafe_pinned.rs
+++ b/library/core/src/pin/unsafe_pinned.rs
@@ -24,7 +24,7 @@ use crate::{fmt, ptr};
 #[lang = "unsafe_pinned"]
 #[repr(transparent)]
 #[unstable(feature = "unsafe_pinned", issue = "125735")]
-pub struct UnsafePinned<T: ?Sized> {
+pub struct UnsafePinned<T: ?Sized + ?crate::marker::Move> {
     value: UnsafeCell<T>,
 }
 
@@ -36,7 +36,7 @@ unsafe impl<T: ?Sized + Sync> Sync for UnsafePinned<T> {}
 /// aliases from becoming invalidated. Therefore let's mark this as `!Unpin`. You can always opt
 /// back in to `Unpin` with an `impl` block, provided your API is still sound while unpinned.
 #[unstable(feature = "unsafe_pinned", issue = "125735")]
-impl<T: ?Sized> !Unpin for UnsafePinned<T> {}
+impl<T: ?Sized + ?crate::marker::Move> !Unpin for UnsafePinned<T> {}
 
 // `Send` and `Sync` are inherited from `T`. This is similar to `SyncUnsafeCell`, since
 // we eventually concluded that `UnsafeCell` implicitly making things `!Sync` is sometimes
@@ -176,6 +176,6 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafePinned<U>> for UnsafePinned<T> 
 // FIXME(unsafe_pinned) this logic is copied from UnsafeCell, is it still sound?
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 // #[unstable(feature = "unsafe_pinned", issue = "125735")]
-impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<UnsafePinned<U>> for UnsafePinned<T> {}
+impl<T: DispatchFromDyn<U>, U: ?crate::marker::Move> DispatchFromDyn<UnsafePinned<U>> for UnsafePinned<T> {}
 
 // FIXME(unsafe_pinned): impl PinCoerceUnsized for UnsafePinned<T>?

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1,3 +1,5 @@
+use core::marker::Move;
+
 use crate::cmp::Ordering;
 use crate::marker::{PointeeSized, Unsize};
 use crate::mem::{MaybeUninit, SizedTypeProperties};
@@ -1624,7 +1626,10 @@ impl<T: PointeeSized> Copy for NonNull<T> {}
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized, U: PointeeSized + ?core::marker::Move> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
+impl<T: PointeeSized, U: PointeeSized + ?Move> DispatchFromDyn<NonNull<U>> for NonNull<T> where
+    T: Unsize<U>
+{
+}
 
 #[stable(feature = "pin", since = "1.33.0")]
 unsafe impl<T: PointeeSized> PinCoerceUnsized for NonNull<T> {}

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -72,7 +72,7 @@ use crate::{fmt, hash, intrinsics, mem, ptr};
 #[rustc_layout_scalar_valid_range_start(1)]
 #[rustc_nonnull_optimization_guaranteed]
 #[rustc_diagnostic_item = "NonNull"]
-pub struct NonNull<T: PointeeSized> {
+pub struct NonNull<T: PointeeSized + ?crate::marker::Move> {
     // Remember to use `.as_ptr()` instead of `.pointer`, as field projecting to
     // this is banned by <https://github.com/rust-lang/compiler-team/issues/807>.
     pointer: *const T,
@@ -81,12 +81,12 @@ pub struct NonNull<T: PointeeSized> {
 /// `NonNull` pointers are not `Send` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
-impl<T: PointeeSized> !Send for NonNull<T> {}
+impl<T: PointeeSized + ?crate::marker::Move> !Send for NonNull<T> {}
 
 /// `NonNull` pointers are not `Sync` because the data they reference may be aliased.
 // N.B., this impl is unnecessary, but should provide better error messages.
 #[stable(feature = "nonnull", since = "1.25.0")]
-impl<T: PointeeSized> !Sync for NonNull<T> {}
+impl<T: PointeeSized + ?crate::marker::Move> !Sync for NonNull<T> {}
 
 impl<T: Sized> NonNull<T> {
     /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
@@ -1624,7 +1624,7 @@ impl<T: PointeeSized> Copy for NonNull<T> {}
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
-impl<T: PointeeSized, U: PointeeSized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
+impl<T: PointeeSized, U: PointeeSized + ?core::marker::Move> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: Unsize<U> {}
 
 #[stable(feature = "pin", since = "1.33.0")]
 unsafe impl<T: PointeeSized> PinCoerceUnsized for NonNull<T> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::marker::{PhantomData, PointeeSized, Unsize};
+use crate::marker::{Move, PhantomData, PointeeSized, Unsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::pin::PinCoerceUnsized;
 use crate::ptr::NonNull;
@@ -32,7 +32,7 @@ use crate::ptr::NonNull;
 )]
 #[doc(hidden)]
 #[repr(transparent)]
-pub struct Unique<T: PointeeSized + ?crate::marker::Move> {
+pub struct Unique<T: PointeeSized + ?Move> {
     pointer: NonNull<T>,
     // NOTE: this marker has no consequences for variance, but is necessary
     // for dropck to understand that we logically own a `T`.
@@ -169,7 +169,10 @@ impl<T: PointeeSized> Copy for Unique<T> {}
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
-impl<T: PointeeSized, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}
+impl<T: PointeeSized, U: PointeeSized + ?Move> DispatchFromDyn<Unique<U>> for Unique<T> where
+    T: Unsize<U>
+{
+}
 
 #[unstable(feature = "pin_coerce_unsized_trait", issue = "123430")]
 unsafe impl<T: PointeeSized> PinCoerceUnsized for Unique<T> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -32,7 +32,7 @@ use crate::ptr::NonNull;
 )]
 #[doc(hidden)]
 #[repr(transparent)]
-pub struct Unique<T: PointeeSized> {
+pub struct Unique<T: PointeeSized + ?crate::marker::Move> {
     pointer: NonNull<T>,
     // NOTE: this marker has no consequences for variance, but is necessary
     // for dropck to understand that we logically own a `T`.
@@ -169,7 +169,7 @@ impl<T: PointeeSized> Copy for Unique<T> {}
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
-impl<T: PointeeSized, U: PointeeSized> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}
+impl<T: PointeeSized, U: PointeeSized + ?crate::marker::Move> DispatchFromDyn<Unique<U>> for Unique<T> where T: Unsize<U> {}
 
 #[unstable(feature = "pin_coerce_unsized_trait", issue = "123430")]
 unsafe impl<T: PointeeSized> PinCoerceUnsized for Unique<T> {}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -74,6 +74,7 @@
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(min_specialization)]
+#![feature(move_trait)]
 #![feature(never_type)]
 #![feature(next_index)]
 #![feature(non_exhaustive_omitted_patterns_lint)]

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1327,6 +1327,15 @@ where
     }
 }
 
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<K, V, S> core::marker::Move for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: Eq,
+    S: BuildHasher,
+{
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K, V, S> Eq for HashMap<K, V, S>
 where

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1046,6 +1046,14 @@ where
 {
 }
 
+#[unstable(feature = "move_trait", issue = "none")]
+unsafe impl<T, S> core::marker::Move for HashSet<T, S>
+where
+    T: Eq + Hash,
+    S: BuildHasher,
+{
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, S> fmt::Debug for HashSet<T, S>
 where

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -349,6 +349,7 @@
 #![feature(lazy_get)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_write_slice)]
+#![feature(move_trait)]
 #![feature(panic_can_unwind)]
 #![feature(panic_internals)]
 #![feature(pin_coerce_unsized_trait)]


### PR DESCRIPTION
This PR implements the `Move` marker trait for the purposes of testing potential performance regressions in combination with https://github.com/rust-lang/rust/pull/120706. For context about this experiment see [this Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/.5Bblog.5D.20Adding.20implicit.20auto-trait.20bounds.20is.20hard.20.3A3/with/531767236).

r? @lcnr