### PR TITLE
Allow running tests with GCC

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1771,7 +1771,8 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
 
         if let Some(codegen_backend) = builder.config.codegen_backends(compiler.host).first() {
             cmd.arg("--codegen-backend").arg(codegen_backend);
-        } else if let Some(codegen_backend) = builder.config.default_codegen_backend(compiler.host) {
+        } else if let Some(codegen_backend) = builder.config.default_codegen_backend(compiler.host)
+        {
             cmd.arg("--codegen-backend").arg(&codegen_backend);
         }
 
@@ -1917,6 +1918,11 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         for exclude in &builder.config.skip {
             cmd.arg("--skip");
             cmd.arg(exclude);
+        }
+
+        if builder.config.codegen_backends(target).first().map(|b| b.as_str()) == Some("gcc") {
+            cmd.arg("--extra-library-path");
+            cmd.arg(builder.config.libgccjit_root());
         }
 
         // Get paths from cmd args

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1769,7 +1769,9 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         cmd.arg("--host").arg(&*compiler.host.triple);
         cmd.arg("--llvm-filecheck").arg(builder.llvm_filecheck(builder.config.host_target));
 
-        if let Some(codegen_backend) = builder.config.default_codegen_backend(compiler.host) {
+        if let Some(codegen_backend) = builder.config.codegen_backends(compiler.host).first() {
+            cmd.arg("--codegen-backend").arg(codegen_backend);
+        } else if let Some(codegen_backend) = builder.config.default_codegen_backend(compiler.host) {
             cmd.arg("--codegen-backend").arg(&codegen_backend);
         }
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -563,6 +563,12 @@ impl Builder<'_> {
             println!("using sysroot {sysroot_str}");
         }
 
+        if self.config.codegen_backends(target).first().map(|b| b.as_str()) == Some("gcc") {
+            let gcc_sysroot = self.config.libgccjit_root();
+            let gcc_sysroot = gcc_sysroot.as_os_str().to_str().expect("sysroot should be UTF-8");
+            cargo.env("LD_LIBRARY_PATH", gcc_sysroot);
+        }
+
         let mut rustflags = Rustflags::new(target);
         if build_compiler_stage != 0 {
             if let Ok(s) = env::var("CARGOFLAGS_NOT_BOOTSTRAP") {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1226,6 +1226,13 @@ impl Config {
         self.out.join(self.host_target).join("ci-rustc")
     }
 
+    pub(crate) fn libgccjit_root(&self) -> PathBuf {
+        match self.gcc_ci_mode {
+            GccCiMode::BuildLocally => self.out.join(self.host_target).join("gcc/install/lib"),
+            GccCiMode::DownloadFromCi => self.out.join(self.host_target).join("ci-gcc/lib"),
+        }
+    }
+
     /// Determine whether llvm should be linked dynamically.
     ///
     /// If `false`, llvm should be linked statically.

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -204,11 +204,12 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "only test a specific debugger in debuginfo tests",
             "gdb | lldb | cdb",
         )
+        .optopt("", "codegen-backend", "the codegen backend currently used", "CODEGEN BACKEND NAME")
         .optopt(
             "",
-            "codegen-backend",
-            "the codegen backend currently used",
-            "CODEGEN BACKEND NAME",
+            "extra-library-path",
+            "extra path to be passed into LIBRARY_PATH environment variable",
+            "library path",
         );
 
     let (argv0, args_) = args.split_first().unwrap();
@@ -466,6 +467,10 @@ pub fn parse_config(args: Vec<String>) -> Config {
         minicore_path: opt_path(matches, "minicore-path"),
 
         codegen_backend,
+
+        extra_library_path: matches
+            .opt_str("extra-library-path")
+            .map(|p| make_absolute(Utf8PathBuf::from(p))),
     }
 }
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1556,6 +1556,11 @@ impl<'test> TestCx<'test> {
             // In stage 0, make sure we use `stage0-sysroot` instead of the bootstrap sysroot.
             rustc.arg("--sysroot").arg(&self.config.sysroot_base);
         }
+        // If the provided codegen backend is not LLVM, we need to pass it.
+        if !matches!(self.config.codegen_backend, crate::CodegenBackend::Llvm) {
+            let lib_path = self.config.sysroot_base.join(self.config.codegen_backend.as_str());
+            rustc.arg(format!("-Zcodegen-backend={}", lib_path));
+        }
 
         // Optionally prevent default --target if specified in test compile-flags.
         let custom_target = self.props.compile_flags.iter().any(|x| x.starts_with("--target"));


### PR DESCRIPTION
Part of https://github.com/rust-lang/compiler-team/issues/891.

This PR does two things:

1. Allow to build rustc with GCC (first commit)
2. Allow to run tests with the GCC backend (second commit)

However, if you try it out, compilation will fail, hence why I didn't update the CI yet. We have a sync in progress to fix these bugs. If you want to try it, you can use [this branch](https://github.com/GuillaumeGomez/rust/tree/full-gcc) which includes commits from the current cg_gcc sync.

r? @Kobzol 