### PR TITLE
rustdoc-json: Move `#[macro_export]` from `Other` to it's own  variant

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -908,8 +908,12 @@ fn maybe_from_hir_attr(
         hir::Attribute::Parsed(kind) => kind,
 
         hir::Attribute::Unparsed(_) => {
-            // FIXME: We should handle `#[doc(hidden)]`.
-            return Some(other_attr(tcx, attr));
+            return Some(if attr.has_name(sym::macro_export) {
+                Attribute::MacroExport
+                // FIXME: We should handle `#[doc(hidden)]`.
+            } else {
+                other_attr(tcx, attr)
+            });
         }
     };
 

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -37,8 +37,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Structured Attributes
-pub const FORMAT_VERSION: u32 = 54;
+// Latest feature: Add Attribute::MacroUse
+pub const FORMAT_VERSION: u32 = 55;
 
 /// The root of the emitted JSON blob.
 ///
@@ -215,6 +215,9 @@ pub enum Attribute {
 
     /// `#[must_use]`
     MustUse { reason: Option<String> },
+
+    /// `#[macro_export]`
+    MacroExport,
 
     /// `#[export_name = "name"]`
     ExportName(String),

--- a/tests/rustdoc-json/attrs/macro_export.rs
+++ b/tests/rustdoc-json/attrs/macro_export.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --document-private-items
 
 //@ set exported_id = "$.index[?(@.name=='exported')].id"
-//@ is "$.index[?(@.name=='exported')].attrs" '[{"other": "#[macro_export]"}]'
+//@ is "$.index[?(@.name=='exported')].attrs" '["macro_export"]'
 //@ is "$.index[?(@.name=='exported')].visibility" '"public"'
 
 #[macro_export]
@@ -19,7 +19,7 @@ macro_rules! not_exported {
 //@ set module_id = "$.index[?(@.name=='module')].id"
 pub mod module {
     //@ set exported_from_mod_id = "$.index[?(@.name=='exported_from_mod')].id"
-    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '[{"other": "#[macro_export]"}]'
+    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '["macro_export"]'
     //@ is "$.index[?(@.name=='exported_from_mod')].visibility" '"public"'
     #[macro_export]
     macro_rules! exported_from_mod {

--- a/tests/rustdoc-json/attrs/macro_export.rs
+++ b/tests/rustdoc-json/attrs/macro_export.rs
@@ -1,0 +1,40 @@
+//@ compile-flags: --document-private-items
+
+//@ set exported_id = "$.index[?(@.name=='exported')].id"
+//@ is "$.index[?(@.name=='exported')].attrs" '[{"other": "#[macro_export]"}]'
+//@ is "$.index[?(@.name=='exported')].visibility" '"public"'
+
+#[macro_export]
+macro_rules! exported {
+    () => {};
+}
+
+//@ set not_exported_id = "$.index[?(@.name=='not_exported')].id"
+//@ is "$.index[?(@.name=='not_exported')].attrs" []
+//@ is "$.index[?(@.name=='not_exported')].visibility" '"crate"'
+macro_rules! not_exported {
+    () => {};
+}
+
+//@ set module_id = "$.index[?(@.name=='module')].id"
+pub mod module {
+    //@ set exported_from_mod_id = "$.index[?(@.name=='exported_from_mod')].id"
+    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '[{"other": "#[macro_export]"}]'
+    //@ is "$.index[?(@.name=='exported_from_mod')].visibility" '"public"'
+    #[macro_export]
+    macro_rules! exported_from_mod {
+        () => {};
+    }
+
+    //@ set not_exported_from_mod_id = "$.index[?(@.name=='not_exported_from_mod')].id"
+    //@ is "$.index[?(@.name=='not_exported_from_mod')].attrs" []
+    //@ is "$.index[?(@.name=='not_exported_from_mod')].visibility" '"crate"'
+    macro_rules! not_exported_from_mod {
+        () => {};
+    }
+}
+// The non-exported macro's are left in place, but the #[macro_export]'d ones
+// are moved to the crate root.
+
+//@ is "$.index[?(@.name=='module')].inner.module.items[*]" $not_exported_from_mod_id
+//@ ismany "$.index[?(@.name=='macro_export')].inner.module.items[*]" $exported_id $not_exported_id $module_id $exported_from_mod_id


### PR DESCRIPTION
Followup to rust-lang/rust#142936.

cargo-semver-checks [cares about this attribute](https://github.com/obi1kenobi/trustfall-rustdoc-adapter/blob/4a0d1b0ca19b3115bb65d0b6695c388d7f474ac9/src/visibility_tracker.rs#L459-L476), and it wasn't included in the initial PR for structured attributes CC @obi1kenobi.

r? @GuillaumeGomez 
