### PR TITLE
[test][AIX] ignore extern_weak linkage test

### DIFF
--- a/tests/ui/linkage-attr/propagate-generic-issue-18804/main.rs
+++ b/tests/ui/linkage-attr/propagate-generic-issue-18804/main.rs
@@ -4,6 +4,7 @@
 
 //@ ignore-emscripten no weak symbol support
 //@ ignore-apple no extern_weak linkage
+//@ ignore-aix no extern_weak linkage
 
 //@ aux-build:lib.rs
 


### PR DESCRIPTION
The AIX linkage model doesn't support ELF-style extern_weak semantics, so just skip this test, like other platforms that don't have it.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
