### PR TITLE
Make mac calls include their semicolons

### DIFF
--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -134,7 +134,7 @@ impl HasTokens for StmtKind {
             StmtKind::Let(local) => local.tokens.as_ref(),
             StmtKind::Item(item) => item.tokens(),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.tokens(),
-            StmtKind::Empty => None,
+            StmtKind::Empty(_) => None,
             StmtKind::MacCall(mac) => mac.tokens.as_ref(),
         }
     }
@@ -143,7 +143,7 @@ impl HasTokens for StmtKind {
             StmtKind::Let(local) => Some(&mut local.tokens),
             StmtKind::Item(item) => item.tokens_mut(),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.tokens_mut(),
-            StmtKind::Empty => None,
+            StmtKind::Empty(_) => None,
             StmtKind::MacCall(mac) => Some(&mut mac.tokens),
         }
     }
@@ -277,7 +277,7 @@ impl HasAttrs for StmtKind {
             StmtKind::Let(local) => &local.attrs,
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.attrs(),
             StmtKind::Item(item) => item.attrs(),
-            StmtKind::Empty => &[],
+            StmtKind::Empty(_) => &[],
             StmtKind::MacCall(mac) => &mac.attrs,
         }
     }
@@ -287,7 +287,7 @@ impl HasAttrs for StmtKind {
             StmtKind::Let(local) => f(&mut local.attrs),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.visit_attrs(f),
             StmtKind::Item(item) => item.visit_attrs(f),
-            StmtKind::Empty => {}
+            StmtKind::Empty(_) => {}
             StmtKind::MacCall(mac) => f(&mut mac.attrs),
         }
     }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -372,7 +372,7 @@ fn walk_flat_map_stmt_kind<T: MutVisitor>(vis: &mut T, kind: StmtKind) -> SmallV
         StmtKind::Item(item) => vis.flat_map_item(item).into_iter().map(StmtKind::Item).collect(),
         StmtKind::Expr(expr) => vis.filter_map_expr(expr).into_iter().map(StmtKind::Expr).collect(),
         StmtKind::Semi(expr) => vis.filter_map_expr(expr).into_iter().map(StmtKind::Semi).collect(),
-        StmtKind::Empty => smallvec![StmtKind::Empty],
+        StmtKind::Empty(from_macro) => smallvec![StmtKind::Empty(from_macro)],
         StmtKind::MacCall(mut mac) => {
             let MacCallStmt { mac: mac_, style: _, attrs, tokens: _ } = mac.deref_mut();
             for attr in attrs {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -428,6 +428,7 @@ macro_rules! common_visitor_and_walkers {
             DelegationMac,
             DelimArgs,
             DelimSpan,
+            EmptyFromMacro,
             EnumDef,
             Extern,
             ForLoopKind,
@@ -1166,7 +1167,7 @@ pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) -> V:
         StmtKind::Let(local) => try_visit!(visitor.visit_local(local)),
         StmtKind::Item(item) => try_visit!(visitor.visit_item(item)),
         StmtKind::Expr(expr) | StmtKind::Semi(expr) => try_visit!(visitor.visit_expr(expr)),
-        StmtKind::Empty => {}
+        StmtKind::Empty(_) => {}
         StmtKind::MacCall(mac) => {
             let MacCallStmt { mac, attrs, style: _, tokens: _ } = &**mac;
             walk_list!(visitor, visit_attribute, attrs);

--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -75,7 +75,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     let span = self.lower_span(s.span);
                     stmts.push(hir::Stmt { hir_id, kind, span });
                 }
-                StmtKind::Empty => {}
+                StmtKind::Empty(_) => {}
                 StmtKind::MacCall(..) => panic!("shouldn't exist here"),
             }
             ast_stmts = tail;

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1446,7 +1446,7 @@ impl<'a> State<'a> {
                 self.print_expr_outer_attr_style(expr, false, FixupContext::new_stmt());
                 self.word(";");
             }
-            ast::StmtKind::Empty => {
+            ast::StmtKind::Empty(_) => {
                 self.space_if_not_bol();
                 self.word(";");
             }
@@ -1454,7 +1454,7 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
                 self.print_outer_attributes(&mac.attrs);
                 self.print_mac(&mac.mac);
-                if mac.style == ast::MacStmtStyle::Semicolon {
+                if matches!(mac.style, ast::MacStmtStyle::Semicolon(_)) {
                     self.word(";");
                 }
             }

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -393,7 +393,7 @@ impl<'cx, 'a> Context<'cx, 'a> {
                 )],
                 self.span,
             ))
-            .add_trailing_semicolon();
+            .add_trailing_semicolon(self.span.shrink_to_hi());
         let local_bind_path = self.cx.expr_path(Path::from_ident(local_bind));
         let rslt = if self.is_consumed {
             let ret = self.cx.stmt_expr(local_bind_path);

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -124,7 +124,7 @@ impl Annotatable {
             Annotatable::AssocItem(node, _) => TokenStream::from_ast(node),
             Annotatable::ForeignItem(node) => TokenStream::from_ast(node),
             Annotatable::Stmt(node) => {
-                assert!(!matches!(node.kind, ast::StmtKind::Empty));
+                assert!(!matches!(node.kind, ast::StmtKind::Empty(_)));
                 TokenStream::from_ast(node)
             }
             Annotatable::Expr(node) => TokenStream::from_ast(node),

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -431,7 +431,7 @@ fn transcribe_metavar<'tx>(
             mk_delimited(block.span, MetaVarKind::Block, TokenStream::from_ast(block))
         }
         MatchedSingle(ParseNtResult::Stmt(stmt)) => {
-            let stream = if let StmtKind::Empty = stmt.kind {
+            let stream = if let StmtKind::Empty(_) = stmt.kind {
                 // FIXME: Properly collect tokens for empty statements.
                 TokenStream::token_alone(token::Semi, stmt.span)
             } else {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -845,7 +845,7 @@ impl EarlyLintPass for UnusedDocComment {
             // Disabled pending discussion in #78306
             ast::StmtKind::Item(..) => return,
             // expressions will be reported by `check_expr`.
-            ast::StmtKind::Empty
+            ast::StmtKind::Empty(_)
             | ast::StmtKind::Semi(_)
             | ast::StmtKind::Expr(_)
             | ast::StmtKind::MacCall(_) => return,

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -1074,30 +1074,6 @@ impl SourceMap {
         let source_file = &self.files()[source_file_index];
         source_file.is_imported()
     }
-
-    /// Gets the span of a statement. If the statement is a macro expansion, the
-    /// span in the context of the block span is found. The trailing semicolon is included
-    /// on a best-effort basis.
-    pub fn stmt_span(&self, stmt_span: Span, block_span: Span) -> Span {
-        if !stmt_span.from_expansion() {
-            return stmt_span;
-        }
-        let mac_call = original_sp(stmt_span, block_span);
-        self.mac_call_stmt_semi_span(mac_call).map_or(mac_call, |s| mac_call.with_hi(s.hi()))
-    }
-
-    /// Tries to find the span of the semicolon of a macro call statement.
-    /// The input must be the *call site* span of a statement from macro expansion.
-    /// ```ignore (illustrative)
-    /// //       v output
-    ///    mac!();
-    /// // ^^^^^^ input
-    /// ```
-    pub fn mac_call_stmt_semi_span(&self, mac_call: Span) -> Option<Span> {
-        let span = self.span_extend_while_whitespace(mac_call);
-        let span = self.next_point(span);
-        if self.span_to_snippet(span).as_deref() == Ok(";") { Some(span) } else { None }
-    }
 }
 
 pub fn get_source_map() -> Option<Arc<SourceMap>> {

--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -591,7 +591,9 @@ fn parse_source(
                         }
                         has_non_items = true;
                     }
-                    StmtKind::Let(_) | StmtKind::Semi(_) | StmtKind::Empty => has_non_items = true,
+                    StmtKind::Let(_) | StmtKind::Semi(_) | StmtKind::Empty(_) => {
+                        has_non_items = true
+                    }
                 }
 
                 // Weirdly enough, the `Stmt` span doesn't include its attributes, so we need to

--- a/src/tools/clippy/clippy_lints/src/semicolon_block.rs
+++ b/src/tools/clippy/clippy_lints/src/semicolon_block.rs
@@ -101,21 +101,8 @@ impl SemicolonBlock {
         );
     }
 
-    fn semicolon_outside_block(&self, cx: &LateContext<'_>, block: &Block<'_>, tail_stmt_expr: &Expr<'_>) {
+    fn semicolon_outside_block(&self, cx: &LateContext<'_>, block: &Block<'_>, remove_span: Span) {
         let insert_span = block.span.with_lo(block.span.hi());
-
-        // For macro call semicolon statements (`mac!();`), the statement's span does not actually
-        // include the semicolon itself, so use `mac_call_stmt_semi_span`, which finds the semicolon
-        // based on a source snippet.
-        // (Does not use `stmt_span` as that requires `.from_expansion()` to return true,
-        // which is not the case for e.g. `line!();` and `asm!();`)
-        let Some(remove_span) = cx
-            .sess()
-            .source_map()
-            .mac_call_stmt_semi_span(tail_stmt_expr.span.source_callsite())
-        else {
-            return;
-        };
 
         if self.semicolon_outside_block_ignore_multiline && get_line(cx, remove_span) != get_line(cx, insert_span) {
             return;
@@ -159,6 +146,14 @@ impl LateLintPass<'_> for SemicolonBlock {
                 else {
                     return;
                 };
+                let expr_span = expr.span.find_ancestor_inside_same_ctxt(stmt.span)?;
+                let remove_span = cx
+                    .tcx
+                    .sess
+                    .source_map()
+                    .span_extend_while_whitespace(expr_span)
+                    .shrink_to_hi()
+                    .with_hi(stmt.span.hi());
                 self.semicolon_outside_block(cx, block, expr);
             },
             StmtKind::Semi(Expr {

--- a/src/tools/rustfmt/src/attr.rs
+++ b/src/tools/rustfmt/src/attr.rs
@@ -31,7 +31,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
         ast::StmtKind::Item(ref item) => item.span,
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,
         ast::StmtKind::MacCall(ref mac_stmt) => mac_stmt.mac.span(),
-        ast::StmtKind::Empty => stmt.span,
+        ast::StmtKind::Empty(_) => stmt.span,
     }
 }
 

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -1248,7 +1248,7 @@ fn block_has_statements(block: &ast::Block) -> bool {
     block
         .stmts
         .iter()
-        .any(|stmt| !matches!(stmt.kind, ast::StmtKind::Empty))
+        .any(|stmt| !matches!(stmt.kind, ast::StmtKind::Empty(_)))
 }
 
 /// Checks whether a block contains no statements, expressions, comments, or

--- a/src/tools/rustfmt/src/spanned.rs
+++ b/src/tools/rustfmt/src/spanned.rs
@@ -75,7 +75,7 @@ impl Spanned for ast::Stmt {
                     mk_sp(mac_stmt.attrs[0].span.lo(), self.span.hi())
                 }
             }
-            ast::StmtKind::Empty => self.span,
+            ast::StmtKind::Empty(_) => self.span,
         }
     }
 }

--- a/src/tools/rustfmt/src/stmt.rs
+++ b/src/tools/rustfmt/src/stmt.rs
@@ -68,7 +68,7 @@ impl<'a> Stmt<'a> {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        matches!(self.inner.kind, ast::StmtKind::Empty)
+        matches!(self.inner.kind, ast::StmtKind::Empty(_))
     }
 
     fn is_last_expr(&self) -> bool {
@@ -137,7 +137,7 @@ fn format_stmt(
                 .max_width_error(shape.width, ex.span())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
-        ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => {
+        ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty(_) => {
             Err(RewriteError::Unknown)
         }
     };

--- a/src/tools/rustfmt/src/visitor.rs
+++ b/src/tools/rustfmt/src/visitor.rs
@@ -176,7 +176,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 }
                 self.format_missing(stmt.span().hi());
             }
-            ast::StmtKind::Empty => (),
+            ast::StmtKind::Empty(_) => (),
         }
     }
 
@@ -908,7 +908,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             let include_next_empty = if stmts.len() > 1 {
                 matches!(
                     (&stmts[0].as_ast_node().kind, &stmts[1].as_ast_node().kind),
-                    (ast::StmtKind::Item(_), ast::StmtKind::Empty)
+                    (ast::StmtKind::Item(_), ast::StmtKind::Empty(_))
                 )
             } else {
                 false

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -156,7 +156,7 @@ LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     naked_asm!("");
-   |     -------------- multiple `naked_asm!` invocations are not allowed in naked functions
+   |     --------------- multiple `naked_asm!` invocations are not allowed in naked functions
 
 error: referencing function parameters is not allowed in naked functions
   --> $DIR/naked-functions.rs:96:11

--- a/tests/ui/asm/x86_64/goto.stderr
+++ b/tests/ui/asm/x86_64/goto.stderr
@@ -10,7 +10,7 @@ LL | |             options(noreturn)
 LL | |         );
    | |_________- any code following this expression is unreachable
 LL |           unreachable!();
-   |           ^^^^^^^^^^^^^^ unreachable statement
+   |           ^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/goto.rs:133:8

--- a/tests/ui/async-await/unreachable-lint-2.stderr
+++ b/tests/ui/async-await/unreachable-lint-2.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |     endless().await;
    |               ----- any code following this expression is unreachable
 LL |     println!("this is unreachable!");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/unreachable-lint-2.rs:3:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/block-result/issue-13428.stderr
+++ b/tests/ui/block-result/issue-13428.stderr
@@ -1,10 +1,15 @@
 error[E0308]: mismatched types
   --> $DIR/issue-13428.rs:3:13
    |
-LL | fn foo() -> String {
-   |    ---      ^^^^^^ expected `String`, found `()`
-   |    |
-   |    implicitly returns `()` as its body has no tail or `return` expression
+LL |   fn foo() -> String {
+   |      ---      ^^^^^^ expected `String`, found `()`
+   |      |
+   |      implicitly returns `()` as its body has no tail or `return` expression
+...
+LL | /     // Put the trailing semicolon on its own line to test that the
+LL | |     // note message gets the offending semicolon exactly
+LL | |     ;
+   | |_____- help: remove this semicolon to return this value
 
 error[E0308]: mismatched types
   --> $DIR/issue-13428.rs:11:13

--- a/tests/ui/lint/dead-code/closure-bang.stderr
+++ b/tests/ui/lint/dead-code/closure-bang.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |     x();
    |     --- any code following this expression is unreachable
 LL |     println!("Foo bar");
-   |     ^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/closure-bang.rs:1:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.rs
+++ b/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.rs
@@ -3,9 +3,9 @@
 #![deny(redundant_semicolons)]
 
 macro_rules! m {
-    ($stmt:stmt) => { #[allow(bad_style)] $stmt } //~ ERROR unnecessary trailing semicolon [redundant_semicolons]
+    ($stmt:stmt) => { #[allow(bad_style)] $stmt }
 }
 
 fn main() {
-    m!(;);
+    m!(;); //~ ERROR unnecessary trailing semicolon [redundant_semicolons]
 }

--- a/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
+++ b/tests/ui/lint/redundant-semicolon/suggest-remove-semi-in-macro-expansion-issue-142143.stderr
@@ -1,18 +1,14 @@
 error: unnecessary trailing semicolon
-  --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:6:43
+  --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:10:5
    |
-LL |     ($stmt:stmt) => { #[allow(bad_style)] $stmt }
-   |                                           ^^^^^
-...
 LL |     m!(;);
-   |     ----- in this macro invocation
+   |     ^^^^^^ help: remove this semicolon
    |
 note: the lint level is defined here
   --> $DIR/suggest-remove-semi-in-macro-expansion-issue-142143.rs:3:9
    |
 LL | #![deny(redundant_semicolons)]
    |         ^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/tests/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -28,8 +28,9 @@ error[E0308]: mismatched types
   --> $DIR/liveness-return-last-stmt-semi.rs:3:41
    |
 LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
-   |                                ---      ^^^ expected `i32`, found `()`
-   |                                |
+   |                                ---      ^^^    - help: remove this semicolon to return this value
+   |                                |        |
+   |                                |        expected `i32`, found `()`
    |                                implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();

--- a/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
+++ b/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
@@ -4,7 +4,7 @@ error[E0271]: expected `{closure@fallback-closure-wrap.rs:18:40}` to return `()`
 LL |     let error = Closure::wrap(Box::new(move || {
    |                                        ------- this closure
 LL |         panic!("Can't connect to server.");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `!`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `!`
    |
    = note: expected unit type `()`
                    found type `!`

--- a/tests/ui/reachable/expr_again.stderr
+++ b/tests/ui/reachable/expr_again.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |         continue;
    |         -------- any code following this expression is unreachable
 LL |         println!("hi");
-   |         ^^^^^^^^^^^^^^ unreachable statement
+   |         ^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_again.rs:3:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/reachable/expr_block.stderr
+++ b/tests/ui/reachable/expr_block.stderr
@@ -18,9 +18,7 @@ error: unreachable statement
 LL |         return;
    |         ------ any code following this expression is unreachable
 LL |         println!("foo");
-   |         ^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |         ^^^^^^^^^^^^^^^^ unreachable statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reachable/expr_if.stderr
+++ b/tests/ui/reachable/expr_if.stderr
@@ -22,9 +22,7 @@ LL |         return;
    |         ------ any code following this expression is unreachable
 ...
 LL |     println!("But I am.");
-   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/reachable/expr_loop.stderr
+++ b/tests/ui/reachable/expr_loop.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |     loop { return; }
    |            ------ any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_loop.rs:4:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:21:5
@@ -19,9 +18,7 @@ error: unreachable statement
 LL |     loop { return; }
    |            ------ any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:32:5
@@ -29,9 +26,7 @@ error: unreachable statement
 LL |     loop { 'middle: loop { loop { break 'middle; } } }
    |     -------------------------------------------------- any code following this expression is unreachable
 LL |     println!("I am dead.");
-   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/reachable/expr_match.stderr
+++ b/tests/ui/reachable/expr_match.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |     match () { () => return }
    |     ------------------------- any code following this `match` expression is unreachable, as all arms diverge
 LL |     println!("I am dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/expr_match.rs:4:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_match.rs:19:5
@@ -19,9 +18,7 @@ error: unreachable statement
 LL |     match () { () if false => return, () => return }
    |     ------------------------------------------------ any code following this `match` expression is unreachable, as all arms diverge
 LL |     println!("I am dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
 
 error: unreachable expression
   --> $DIR/expr_match.rs:25:25
@@ -41,9 +38,7 @@ LL | |         () => return,
 LL | |     }
    | |_____- any code following this `match` expression is unreachable, as all arms diverge
 LL |       println!("I am dead");
-   |       ^^^^^^^^^^^^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |       ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/reachable/unreachable-code-ret.stderr
+++ b/tests/ui/reachable/unreachable-code-ret.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL |     return;
    |     ------ any code following this expression is unreachable
 LL |     println!("Paul is dead");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/unreachable-code-ret.rs:1:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/diverge-causes-unreachable-code.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/diverge-causes-unreachable-code.stderr
@@ -4,14 +4,13 @@ error: unreachable statement
 LL | fn never_arg(!: Void) -> u32 {
    |              - any code following a never pattern is unreachable
 LL |     println!();
-   |     ^^^^^^^^^^ unreachable statement
+   |     ^^^^^^^^^^^ unreachable statement
    |
 note: the lint level is defined here
   --> $DIR/diverge-causes-unreachable-code.rs:4:9
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:16:5
@@ -19,9 +18,7 @@ error: unreachable statement
 LL | fn ref_never_arg(&!: &Void) -> u32 {
    |                  -- any code following a never pattern is unreachable
 LL |     println!();
-   |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^ unreachable statement
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:25:5
@@ -30,9 +27,7 @@ LL |         let ! = *ptr;
    |             - any code following a never pattern is unreachable
 LL |     }
 LL |     println!();
-   |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^ unreachable statement
 
 error: unreachable statement
   --> $DIR/diverge-causes-unreachable-code.rs:34:5
@@ -41,9 +36,7 @@ LL |         match *ptr { ! };
    |         ---------------- any code following this `match` expression is unreachable, as all arms diverge
 LL |     }
 LL |     println!();
-   |     ^^^^^^^^^^ unreachable statement
-   |
-   = note: this error originates in the macro `$crate::print` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |     ^^^^^^^^^^^ unreachable statement
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unpretty/interpolation-expanded.stdout
+++ b/tests/ui/unpretty/interpolation-expanded.stdout
@@ -61,20 +61,16 @@ fn local() {
     macro_rules! let_expr_else_return {
         ($pat:pat, $expr:expr) => { let $pat = $expr else { return; }; };
     }
-    let 
 
-            no_paren = void() else { return; };
+    let no_paren = void() else { return; };
 }
 
 fn match_arm() {
     macro_rules! match_arm {
         ($pat:pat, $expr:expr) => { match () { $pat => $expr } };
     }
-    match () {
 
-
-            no_paren => 1 - 1,
-    };
+    match () { no_paren => 1 - 1, };
     match () { paren_around_brace => ({ 1 }) - 1, };
 }
 
@@ -99,6 +95,6 @@ fn vis_inherited() {
     macro_rules! vis_inherited {
         ($vis:vis struct) => { $vis struct Struct; };
     }
-    struct Struct;
 
+    struct Struct;
 }


### PR DESCRIPTION
This needs a bit of cleanup, but it fixes a strange inconsistency where `macro_call!();` as a `StmtKind::Semi` would not actually include the span of the semicolon at the end of the mac call. This led to some hacks to actually make this so.