### PR TITLE
`std_detect`: Linux 6.16 support for RISC-V

### DIFF
--- a/library/std_detect/src/detect/arch/riscv.rs
+++ b/library/std_detect/src/detect/arch/riscv.rs
@@ -73,6 +73,7 @@ features! {
     /// * Zihintpause: `"zihintpause"`
     /// * Zihpm: `"zihpm"`
     /// * Zimop: `"zimop"`
+    /// * Zabha: `"zabha"`
     /// * Zacas: `"zacas"`
     /// * Zawrs: `"zawrs"`
     /// * Zfa: `"zfa"`
@@ -195,6 +196,8 @@ features! {
     /// "Zaamo" Extension for Atomic Memory Operations
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zawrs: "zawrs";
     /// "Zawrs" Extension for Wait-on-Reservation-Set Instructions
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zabha: "zabha";
+    /// "Zabha" Extension for Byte and Halfword Atomic Memory Operations
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zacas: "zacas";
     /// "Zacas" Extension for Atomic Compare-and-Swap (CAS) Instructions
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zam: "zam";

--- a/library/std_detect/src/detect/os/linux/riscv.rs
+++ b/library/std_detect/src/detect/os/linux/riscv.rs
@@ -10,13 +10,13 @@ use super::super::riscv::imply_features;
 use super::auxvec;
 use crate::detect::{Feature, bit, cache};
 
-// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/prctl.h?h=v6.15>
+// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/prctl.h?h=v6.16>
 // for runtime status query constants.
 const PR_RISCV_V_GET_CONTROL: libc::c_int = 70;
 const PR_RISCV_V_VSTATE_CTRL_ON: libc::c_int = 2;
 const PR_RISCV_V_VSTATE_CTRL_CUR_MASK: libc::c_int = 3;
 
-// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwprobe.h?h=v6.15>
+// See <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwprobe.h?h=v6.16>
 // for riscv_hwprobe struct and hardware probing constants.
 
 #[repr(C)]
@@ -98,6 +98,7 @@ const RISCV_HWPROBE_EXT_ZVFBFWMA: u64 = 1 << 54;
 const RISCV_HWPROBE_EXT_ZICBOM: u64 = 1 << 55;
 const RISCV_HWPROBE_EXT_ZAAMO: u64 = 1 << 56;
 const RISCV_HWPROBE_EXT_ZALRSC: u64 = 1 << 57;
+const RISCV_HWPROBE_EXT_ZABHA: u64 = 1 << 58;
 
 const RISCV_HWPROBE_KEY_CPUPERF_0: i64 = 5;
 const RISCV_HWPROBE_MISALIGNED_FAST: u64 = 3;
@@ -138,7 +139,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // Use auxiliary vector to enable single-letter ISA extensions.
     // The values are part of the platform-specific [asm/hwcap.h][hwcap]
     //
-    // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.15
+    // [hwcap]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/riscv/include/uapi/asm/hwcap.h?h=v6.16
     let auxv = auxvec::auxv().expect("read auxvec"); // should not fail on RISC-V platform
     let mut has_i = bit::test(auxv.hwcap, (b'i' - b'a').into());
     #[allow(clippy::eq_op)]
@@ -233,6 +234,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
         enable_feature(Feature::zalrsc, test(RISCV_HWPROBE_EXT_ZALRSC));
         enable_feature(Feature::zaamo, test(RISCV_HWPROBE_EXT_ZAAMO));
         enable_feature(Feature::zawrs, test(RISCV_HWPROBE_EXT_ZAWRS));
+        enable_feature(Feature::zabha, test(RISCV_HWPROBE_EXT_ZABHA));
         enable_feature(Feature::zacas, test(RISCV_HWPROBE_EXT_ZACAS));
         enable_feature(Feature::ztso, test(RISCV_HWPROBE_EXT_ZTSO));
 

--- a/library/std_detect/src/detect/os/riscv.rs
+++ b/library/std_detect/src/detect/os/riscv.rs
@@ -90,7 +90,7 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
         group!(zks == zbkb & zbkc & zbkx & zksed & zksh);
         group!(zk == zkn & zkr & zkt);
 
-        imply!(zacas => zaamo);
+        imply!(zabha | zacas => zaamo);
         group!(a == zalrsc & zaamo);
 
         group!(b == zba & zbb & zbs);

--- a/library/std_detect/tests/cpu-detection.rs
+++ b/library/std_detect/tests/cpu-detection.rs
@@ -242,6 +242,7 @@ fn riscv_linux() {
     println!("zalrsc: {}", is_riscv_feature_detected!("zalrsc"));
     println!("zaamo: {}", is_riscv_feature_detected!("zaamo"));
     println!("zawrs: {}", is_riscv_feature_detected!("zawrs"));
+    println!("zabha: {}", is_riscv_feature_detected!("zabha"));
     println!("zacas: {}", is_riscv_feature_detected!("zacas"));
     println!("zam: {}", is_riscv_feature_detected!("zam"));
     println!("ztso: {}", is_riscv_feature_detected!("ztso"));


### PR DESCRIPTION
It adds feature detection of 1 extension (new in `std_detect`).

New RISC-V Extension:

1.  "Zabha"

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
