### PR TITLE
fix: Match width of ascii and unicode secondary file start

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2988,7 +2988,7 @@ impl HumanEmitter {
     fn secondary_file_start(&self) -> &'static str {
         match self.theme {
             OutputTheme::Ascii => "::: ",
-            OutputTheme::Unicode => " ⸬ ",
+            OutputTheme::Unicode => " ⸬  ",
         }
     }
 

--- a/tests/ui/error-emitter/close_window.unicode.stderr
+++ b/tests/ui/error-emitter/close_window.unicode.stderr
@@ -4,7 +4,7 @@ error[E0624]: method `method` is private
 LL │     s.method();
    │       ━━━━━━ private method
    │
-   ⸬ $DIR/auxiliary/close_window.rs:3:5
+   ⸬  $DIR/auxiliary/close_window.rs:3:5
    │
 LL │     fn method(&self) {}
    ╰╴    ──────────────── private method defined here


### PR DESCRIPTION
The current [unicode secondary file start](https://github.com/rust-lang/rust/blob/64ca23b6235732fa61c0a2b957c5d7e591e7c972/compiler/rustc_errors/src/emitter.rs#L2991) is only three characters, whereas the ASCII variant and normal [file start](https://github.com/rust-lang/rust/blob/64ca23b6235732fa61c0a2b957c5d7e591e7c972/compiler/rustc_errors/src/emitter.rs#L2983-L2984) are four characters. This slight difference caused the paths following a Unicode secondary file start to not align with other structured elements.