### PR TITLE
Remove -Zthinlto

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -673,16 +673,6 @@ impl Session {
             return config::Lto::No;
         }
 
-        // If `-Z thinlto` specified process that, but note that this is mostly
-        // a deprecated option now that `-C lto=thin` exists.
-        if let Some(enabled) = self.opts.unstable_opts.thinlto {
-            if enabled {
-                return config::Lto::ThinLocal;
-            } else {
-                return config::Lto::No;
-            }
-        }
-
         // If there's only one codegen unit and LTO isn't enabled then there's
         // no need for ThinLTO so just return false.
         if self.codegen_units().as_usize() == 1 {

--- a/tests/debuginfo/enum-thinlto.rs
+++ b/tests/debuginfo/enum-thinlto.rs
@@ -1,5 +1,5 @@
 //@ min-lldb-version: 1800
-//@ compile-flags:-g -Z thinlto
+//@ compile-flags:-g -Clto=thin
 
 // === GDB TESTS ===================================================================================
 
@@ -25,7 +25,7 @@
 #[derive(Debug)]
 enum ABC {
     TheA { x: i64, y: i64 },
-    TheB (i64, i32, i32),
+    TheB(i64, i32, i32),
 }
 
 fn main() {
@@ -40,4 +40,6 @@ fn f(abc: &ABC) {
     println!("{:?}", abc);
 }
 
-fn zzz() {()}
+fn zzz() {
+    ()
+}

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -883,7 +883,7 @@ Tests on [AST lowering](https://rustc-dev-guide.rust-lang.org/ast-lowering.html)
 
 ## `tests/ui/lto/`
 
-Exercise *Link-Time Optimization* (LTO), involving the flags `-C lto` or `-Z thinlto`.
+Exercise *Link-Time Optimization* (LTO), involving the `-C lto` flag.
 
 ## `tests/ui/lub-glb/`: LUB/GLB algorithm update
 

--- a/tests/ui/lto/auxiliary/dylib.rs
+++ b/tests/ui/lto/auxiliary/dylib.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z thinlto -C codegen-units=8
+//@ compile-flags: -Clto=thin -C codegen-units=8
 
 #[inline]
 pub fn foo(b: u8) {

--- a/tests/ui/lto/auxiliary/msvc-imp-present.rs
+++ b/tests/ui/lto/auxiliary/msvc-imp-present.rs
@@ -1,5 +1,5 @@
 //@ no-prefer-dynamic
-//@ compile-flags: -Z thinlto -C codegen-units=8 -C prefer-dynamic
+//@ compile-flags: -Clto=thin -C codegen-units=8 -C prefer-dynamic
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/tests/ui/lto/msvc-imp-present.rs
+++ b/tests/ui/lto/msvc-imp-present.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 
 //@ aux-build:msvc-imp-present.rs
-//@ compile-flags: -Z thinlto -C codegen-units=8
+//@ compile-flags: -Clto=thin -C codegen-units=8
 //@ no-prefer-dynamic
 
 // On MSVC we have a "hack" where we emit symbols that look like `_imp_$name`

--- a/tests/ui/lto/thin-lto-global-allocator.rs
+++ b/tests/ui/lto/thin-lto-global-allocator.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ compile-flags: -Z thinlto -C codegen-units=2
+//@ compile-flags: -Clto=thin -C codegen-units=2
 
 #[global_allocator]
 static A: std::alloc::System = std::alloc::System;

--- a/tests/ui/lto/thin-lto-inlines.rs
+++ b/tests/ui/lto/thin-lto-inlines.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-//@ compile-flags: -Z thinlto -C codegen-units=8 -O
+//@ compile-flags: -Clto=thin -C codegen-units=8 -O
 //@ ignore-emscripten can't inspect instructions on emscripten
 
 // We want to assert here that ThinLTO will inline across codegen units. There's

--- a/tests/ui/lto/weak-works.rs
+++ b/tests/ui/lto/weak-works.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-//@ compile-flags: -C codegen-units=8 -Z thinlto
+//@ compile-flags: -C codegen-units=8 -Clto=thin
 //@ ignore-i686-pc-windows-gnu
 //@ ignore-x86_64-pc-windows-gnu
 


### PR DESCRIPTION
This flag enables local ThinLTO, not full ThinLTO. It seems to be a remnant of when ThinLTO was originally introduced before -Clto=thin was supported. Local ThinLTO is already the default in release mode when -Clto is not passed and there is more than 1 codegen units. In debug mode or with 1 codegen unit local ThinLTO doesn't have any benefit, so there is no reason to support enabling it in that case anyway.