### PR TITLE
tests: adapt array-cmp for llvm/llvm-project@f7b65011de51

### DIFF
--- a/tests/codegen-llvm/array-cmp.rs
+++ b/tests/codegen-llvm/array-cmp.rs
@@ -46,7 +46,7 @@ pub fn array_of_tuple_le(a: &[(i16, u16); 2], b: &[(i16, u16); 2]) -> bool {
     // CHECK: %[[B01:.+]] = load i16, ptr %[[PB01]]
     // CHECK-NOT: cmp
     // CHECK: %[[EQ01:.+]] = icmp eq i16 %[[A01]], %[[B01]]
-    // CHECK-NEXT: br i1 %[[EQ01]], label %[[L10:.+]], label %[[EXIT_U:.+]]
+    // CHECK-NEXT: br i1 %[[EQ01]], label %[[L10:.+]], label %[[EXIT_U:.+]]{{(, !llvm.loop ![0-9+])?}}
 
     // CHECK: [[L10]]:
     // CHECK: %[[PA10:.+]] = getelementptr{{.+}}i8, ptr %a, {{i32|i64}} 4


### PR DESCRIPTION
The referenced commit adds a new llvm.loop.estimated_trip_count metadata entry, which shows up in this test. It was being erroneously captured by a too-broad regular expression, which this fixes such that the test passes both before and after the upstream change.

@rustbot label llvm-main

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
