### PR TITLE
Add correct dynamic_lib_extension for aix

### DIFF
--- a/src/tools/run-make-support/src/artifact_names.rs
+++ b/src/tools/run-make-support/src/artifact_names.rs
@@ -35,6 +35,8 @@ pub fn dynamic_lib_extension() -> &'static str {
         "dylib"
     } else if target.contains("windows") {
         "dll"
+    } else if target.contains("aix") {
+        "a"
     } else {
         "so"
     }


### PR DESCRIPTION
AIX uses `.a` for static and shared libraries, this fixes a number of `run-make` tests on AIX
