### PR TITLE
Ping Muscraft when emitter change

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1068,6 +1068,10 @@ cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]
 message = "`rustc_errors::annotate_snippet_emitter_writer` was changed"
 cc = ["@Muscraft"]
 
+[mentions."compiler/rustc_errors/src/emitter.rs"]
+message = "`rustc_errors::emitter` was changed"
+cc = ["@Muscraft"]
+
 [mentions."compiler/rustc_errors/src/translation.rs"]
 message = "`rustc_errors::translation` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1064,6 +1064,10 @@ cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@vakaras"]
 message = "`rustc_error_messages` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]
 
+[mentions."compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs"]
+message = "`rustc_errors::annotate_snippet_emitter_writer` was changed"
+cc = ["@Muscraft"]
+
 [mentions."compiler/rustc_errors/src/translation.rs"]
 message = "`rustc_errors::translation` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]


### PR DESCRIPTION
While I am working towards `annotate-snippets` being the default emitter for `rustc`, it would be helpful if I were pinged when the default emitter is modified so that I can more easily maintain parity in output between `rustc` and `annotate-snippets`.