### PR TITLE
triagebot: Label `compiler-builtins` T-libs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -355,6 +355,7 @@ trigger_labels = [
 [autolabel."T-libs"]
 trigger_files = [
     "library/alloc",
+    "library/compiler-builtins",
     "library/core",
     "library/panic_abort",
     "library/panic_unwind",


### PR DESCRIPTION
Changes to `compiler-builtins` don't currently get a `T-` label, but it is mostly managed by libs. Add the autolabel here.