### PR TITLE
aarch64: Make `outline-atomics` a known target feature

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -248,6 +248,10 @@ static AARCH64_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("mte", Stable, &[]),
     // FEAT_AdvSimd & FEAT_FP
     ("neon", Stable, &[]),
+    // Backend option to turn atomic operations into an intrinsic call when `lse` is not known to be
+    // available, so the intrinsic can do runtime LSE feature detection rather than unconditionally
+    // using slower non-LSE operations. Unstable since it doesn't need to user-togglable.
+    ("outline-atomics", Unstable(sym::aarch64_unstable_target_feature), &[]),
     // FEAT_PAUTH (address authentication)
     ("paca", Stable, &[]),
     // FEAT_PAUTH (generic authentication)

--- a/tests/assembly-llvm/asm/aarch64-outline-atomics.rs
+++ b/tests/assembly-llvm/asm/aarch64-outline-atomics.rs
@@ -8,6 +8,10 @@
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering::*;
 
+// Verify config on outline-atomics works (it is always enabled on aarch64-linux).
+#[cfg(not(target_feature = "outline-atomics"))]
+compile_error!("outline-atomics is not enabled");
+
 pub fn compare_exchange(a: &AtomicI32) {
     // On AArch64 LLVM should outline atomic operations.
     // CHECK: __aarch64_cas4_relax

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -183,6 +183,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `nnp-assist`
 `nontrapping-fptoint`
 `nvic`
+`outline-atomics`
 `paca`
 `pacg`
 `pan`


### PR DESCRIPTION
This is a feature used by LLVM that is enabled for our `aarch64-linux` targets, which we would like to configure on in `std`. Thus, mark `outline-atomics` a known feature. It is left unstable for now.