### PR TITLE
Reject tail calls of `#[track_caller]` functions

### DIFF
--- a/tests/ui/explicit-tail-calls/callee_is_track_caller.rs
+++ b/tests/ui/explicit-tail-calls/callee_is_track_caller.rs
@@ -1,15 +1,11 @@
-//@ check-pass
-// FIXME(explicit_tail_calls): make this run-pass, once tail calls are properly implemented
 #![expect(incomplete_features)]
 #![feature(explicit_tail_calls)]
 
-fn a(x: u32) -> u32 {
-    become b(x);
+fn a() {
+    become b(); //~ error: a function marked with `#[track_caller]` cannot be tail-called
 }
 
 #[track_caller]
-fn b(x: u32) -> u32 { x + 42 }
+fn b() {}
 
-fn main() {
-    assert_eq!(a(12), 54);
-}
+fn main() {}

--- a/tests/ui/explicit-tail-calls/callee_is_track_caller.stderr
+++ b/tests/ui/explicit-tail-calls/callee_is_track_caller.stderr
@@ -1,0 +1,8 @@
+error: a function marked with `#[track_caller]` cannot be tail-called
+  --> $DIR/callee_is_track_caller.rs:5:5
+   |
+LL |     become b();
+   |     ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/explicit-tail-calls/callee_is_track_caller_polymorphic.rs
+++ b/tests/ui/explicit-tail-calls/callee_is_track_caller_polymorphic.rs
@@ -1,0 +1,21 @@
+//@ build-fail
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+fn c<T: Trait>() {
+    // `T::f` is not known when checking tail calls,
+    // so this has to be checked by the backend.
+    become T::f();
+}
+
+trait Trait {
+    #[track_caller]
+    // FIXME(explicit_tail_calls): make error point to the tail call, not callee definition
+    fn f() {} //~ error: a function marked with `#[track_caller]` cannot be tail-called
+}
+
+impl Trait for () {}
+
+fn main() {
+    c::<()>();
+}

--- a/tests/ui/explicit-tail-calls/callee_is_track_caller_polymorphic.stderr
+++ b/tests/ui/explicit-tail-calls/callee_is_track_caller_polymorphic.stderr
@@ -1,0 +1,8 @@
+error: a function marked with `#[track_caller]` cannot be tail-called (llvm)
+  --> $DIR/callee_is_track_caller_polymorphic.rs:14:5
+   |
+LL |     fn f() {}
+   |     ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/explicit-tail-calls/caller_is_track_caller.rs
+++ b/tests/ui/explicit-tail-calls/caller_is_track_caller.rs
@@ -3,14 +3,17 @@
 
 #[track_caller]
 fn a() {
-    become b(); //~ error: a function marked with `#[track_caller]` cannot perform a tail-call
+    become b();
+    //~^ error: a function marked with `#[track_caller]` cannot perform a tail-call
 }
 
 fn b() {}
 
 #[track_caller]
 fn c() {
-    become a(); //~ error: a function marked with `#[track_caller]` cannot perform a tail-call
+    become a();
+    //~^ error: a function marked with `#[track_caller]` cannot perform a tail-call
+    //~| error: a function marked with `#[track_caller]` cannot be tail-called
 }
 
 fn main() {}

--- a/tests/ui/explicit-tail-calls/caller_is_track_caller.stderr
+++ b/tests/ui/explicit-tail-calls/caller_is_track_caller.stderr
@@ -5,10 +5,16 @@ LL |     become b();
    |     ^^^^^^^^^^
 
 error: a function marked with `#[track_caller]` cannot perform a tail-call
-  --> $DIR/caller_is_track_caller.rs:13:5
+  --> $DIR/caller_is_track_caller.rs:14:5
    |
 LL |     become a();
    |     ^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: a function marked with `#[track_caller]` cannot be tail-called
+  --> $DIR/caller_is_track_caller.rs:14:5
+   |
+LL |     become a();
+   |     ^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

To make tail calls possible either both functions need to be `#[track_caller]`, or neither can. For simplicity I propose to just disallow using tail calling `#[track_caller]` functions / tail calling from `#[track_caller]` functions. I don't think `#[track_caller]` is useful with tail calls anyway.

However, we do need to have a quite late check, after monopolization (as otherwise you don't necessarily know if the callee has `#[track_caller]`).

I'm not very happy with this implementation -- error'ing in the backend seems like a hack and will probably lead to disagreements between backends. Ideally we'd have a mir specific check (that would also probably make getting the span easier...).

Fixes rust-lang/rust#144755