### PR TITLE
chore: fix typos in comment

### DIFF
--- a/tests/ui/wf/ice-wf-missing-span-in-error-130012.rs
+++ b/tests/ui/wf/ice-wf-missing-span-in-error-130012.rs
@@ -1,6 +1,6 @@
 // Regression test for ICE #130012
 // Checks that we do not ICE while reporting
-// lifetime mistmatch error
+// lifetime mismatch error
 
 trait Fun {
     type Assoc;

--- a/tests/ui/wf/unnormalized-projection-guides-inference.rs
+++ b/tests/ui/wf/unnormalized-projection-guides-inference.rs
@@ -18,7 +18,7 @@ impl<T, U: EqualTo<Ty = T>> MyTrait<U> for T {
 
 fn main() {
     let _: <_ as MyTrait<u8>>::Out;
-    // We shoud be able to infer a value for the inference variable above.
+    // We should be able to infer a value for the inference variable above.
     // The WF of the unnormalized projection requires `u8: EqualTo<Ty = _>`,
     // which is sufficient to guide inference.
 }


### PR DESCRIPTION
This PR addresses several typos in the Rust standard library's documentation comments:

 - Corrected "mistmatch" to "mismatch"
 - Corrected "shoud" to "should"

These changes improve documentation readability and consistency without affecting any functional code.