### PR TITLE
Correct some grammar in integer documentation

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2512,8 +2512,7 @@ macro_rules! int_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `i32` is used here.
+        /// Please note that this example is shared among integer types, which is why `i32` is used.
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]
@@ -2543,8 +2542,7 @@ macro_rules! int_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `i32` is used here.
+        /// Please note that this example is shared among integer types, which is why `i32` is used.
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]
@@ -2581,8 +2579,7 @@ macro_rules! int_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `i32` is used here.
+        /// Please note that this example is shared among integer types, which is why `i32` is used.
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -660,8 +660,8 @@ macro_rules! saturating_int_impl {
             ///
             /// # Examples
             ///
-            /// Please note that this example is shared between integer types.
-            /// Which explains why `i16` is used here.
+            /// Please note that this example is shared among integer types, which is why `i16`
+            /// is used.
             ///
             /// ```
             /// use std::num::Saturating;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2136,8 +2136,7 @@ macro_rules! uint_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `u8` is used here.
+        /// Please note that this example is shared among integer types, which is why `u8` is used.
         ///
         /// ```
         /// assert_eq!(10u8.wrapping_mul(12), 120);
@@ -2627,8 +2626,8 @@ macro_rules! uint_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `u32` is used here.
+        /// Please note that this example is shared among integer types, which is why why `u32`
+        /// is used.
         ///
         /// ```
         /// assert_eq!(5u32.overflowing_mul(2), (10, false));
@@ -2654,8 +2653,7 @@ macro_rules! uint_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `u32` is used here.
+        /// Please note that this example is shared among integer types, which is why `u32` is used.
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]
@@ -2685,8 +2683,7 @@ macro_rules! uint_impl {
         ///
         /// # Examples
         ///
-        /// Please note that this example is shared between integer types.
-        /// Which explains why `u32` is used here.
+        /// Please note that this example is shared among integer types, which is why `u32` is used.
         ///
         /// ```
         /// #![feature(bigint_helper_methods)]

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -677,8 +677,8 @@ macro_rules! wrapping_int_impl {
             ///
             /// # Examples
             ///
-            /// Please note that this example is shared between integer types.
-            /// Which explains why `i16` is used here.
+            /// Please note that this example is shared among integer types, which is why `i16`
+            /// is used.
             ///
             /// Basic usage:
             ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
Some minor fixes that didn't read very well.
<!-- homu-ignore:end -->

Update "between" to "among" (more than two items), connect the "which" dependent clause to the independent part, and remove the redundant "here".