### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -262,19 +262,11 @@ pub trait Emitter {
                     format!("help: {msg}")
                 } else {
                     // Show the default suggestion text with the substitution
-                    format!(
-                        "help: {}{}: `{}`",
-                        msg,
-                        if self
-                            .source_map()
-                            .is_some_and(|sm| is_case_difference(sm, snippet, part.span,))
-                        {
-                            " (notice the capitalization)"
-                        } else {
-                            ""
-                        },
-                        snippet,
-                    )
+                    let confusion_type = self
+                        .source_map()
+                        .map(|sm| detect_confusion_type(sm, snippet, part.span))
+                        .unwrap_or(ConfusionType::None);
+                    format!("help: {}{}: `{}`", msg, confusion_type.label_text(), snippet,)
                 };
                 primary_span.push_span_label(part.span, msg);
 
@@ -2028,12 +2020,12 @@ impl HumanEmitter {
         buffer.append(0, ": ", Style::HeaderMsg);
 
         let mut msg = vec![(suggestion.msg.to_owned(), Style::NoStyle)];
-        if suggestions
-            .iter()
-            .take(MAX_SUGGESTIONS)
-            .any(|(_, _, _, only_capitalization)| *only_capitalization)
+        if let Some(confusion_type) =
+            suggestions.iter().take(MAX_SUGGESTIONS).find_map(|(_, _, _, confusion_type)| {
+                if confusion_type.has_confusion() { Some(*confusion_type) } else { None }
+            })
         {
-            msg.push((" (notice the capitalization difference)".into(), Style::NoStyle));
+            msg.push((confusion_type.label_text().into(), Style::NoStyle));
         }
         self.msgs_to_buffer(
             &mut buffer,
@@ -3528,24 +3520,107 @@ pub fn is_different(sm: &SourceMap, suggested: &str, sp: Span) -> bool {
 }
 
 /// Whether the original and suggested code are visually similar enough to warrant extra wording.
-pub fn is_case_difference(sm: &SourceMap, suggested: &str, sp: Span) -> bool {
-    // FIXME: this should probably be extended to also account for `FO0` → `FOO` and unicode.
+pub fn detect_confusion_type(sm: &SourceMap, suggested: &str, sp: Span) -> ConfusionType {
     let found = match sm.span_to_snippet(sp) {
         Ok(snippet) => snippet,
         Err(e) => {
             warn!(error = ?e, "Invalid span {:?}", sp);
-            return false;
+            return ConfusionType::None;
         }
     };
-    let ascii_confusables = &['c', 'f', 'i', 'k', 'o', 's', 'u', 'v', 'w', 'x', 'y', 'z'];
-    // All the chars that differ in capitalization are confusable (above):
-    let confusable = iter::zip(found.chars(), suggested.chars())
-        .filter(|(f, s)| f != s)
-        .all(|(f, s)| ascii_confusables.contains(&f) || ascii_confusables.contains(&s));
-    confusable && found.to_lowercase() == suggested.to_lowercase()
-            // FIXME: We sometimes suggest the same thing we already have, which is a
-            //        bug, but be defensive against that here.
-            && found != suggested
+
+    let mut has_case_confusion = false;
+    let mut has_digit_letter_confusion = false;
+
+    if found.len() == suggested.len() {
+        let mut has_case_diff = false;
+        let mut has_digit_letter_confusable = false;
+        let mut has_other_diff = false;
+
+        let ascii_confusables = &['c', 'f', 'i', 'k', 'o', 's', 'u', 'v', 'w', 'x', 'y', 'z'];
+
+        let digit_letter_confusables = [('0', 'O'), ('1', 'l'), ('5', 'S'), ('8', 'B'), ('9', 'g')];
+
+        for (f, s) in iter::zip(found.chars(), suggested.chars()) {
+            if f != s {
+                if f.to_lowercase().to_string() == s.to_lowercase().to_string() {
+                    // Check for case differences (any character that differs only in case)
+                    if ascii_confusables.contains(&f) || ascii_confusables.contains(&s) {
+                        has_case_diff = true;
+                    } else {
+                        has_other_diff = true;
+                    }
+                } else if digit_letter_confusables.contains(&(f, s))
+                    || digit_letter_confusables.contains(&(s, f))
+                {
+                    // Check for digit-letter confusables (like 0 vs O, 1 vs l, etc.)
+                    has_digit_letter_confusable = true;
+                } else {
+                    has_other_diff = true;
+                }
+            }
+        }
+
+        // If we have case differences and no other differences
+        if has_case_diff && !has_other_diff && found != suggested {
+            has_case_confusion = true;
+        }
+        if has_digit_letter_confusable && !has_other_diff && found != suggested {
+            has_digit_letter_confusion = true;
+        }
+    }
+
+    match (has_case_confusion, has_digit_letter_confusion) {
+        (true, true) => ConfusionType::Both,
+        (true, false) => ConfusionType::Case,
+        (false, true) => ConfusionType::DigitLetter,
+        (false, false) => ConfusionType::None,
+    }
+}
+
+/// Represents the type of confusion detected between original and suggested code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfusionType {
+    /// No confusion detected
+    None,
+    /// Only case differences (e.g., "hello" vs "Hello")
+    Case,
+    /// Only digit-letter confusion (e.g., "0" vs "O", "1" vs "l")
+    DigitLetter,
+    /// Both case and digit-letter confusion
+    Both,
+}
+
+impl ConfusionType {
+    /// Returns the appropriate label text for this confusion type.
+    pub fn label_text(&self) -> &'static str {
+        match self {
+            ConfusionType::None => "",
+            ConfusionType::Case => " (notice the capitalization)",
+            ConfusionType::DigitLetter => " (notice the digit/letter confusion)",
+            ConfusionType::Both => " (notice the capitalization and digit/letter confusion)",
+        }
+    }
+
+    /// Combines two confusion types. If either is `Both`, the result is `Both`.
+    /// If one is `Case` and the other is `DigitLetter`, the result is `Both`.
+    /// Otherwise, returns the non-`None` type, or `None` if both are `None`.
+    pub fn combine(self, other: ConfusionType) -> ConfusionType {
+        match (self, other) {
+            (ConfusionType::None, other) => other,
+            (this, ConfusionType::None) => this,
+            (ConfusionType::Both, _) | (_, ConfusionType::Both) => ConfusionType::Both,
+            (ConfusionType::Case, ConfusionType::DigitLetter)
+            | (ConfusionType::DigitLetter, ConfusionType::Case) => ConfusionType::Both,
+            (ConfusionType::Case, ConfusionType::Case) => ConfusionType::Case,
+            (ConfusionType::DigitLetter, ConfusionType::DigitLetter) => ConfusionType::DigitLetter,
+        }
+    }
+
+    /// Returns true if this confusion type represents any kind of confusion.
+    pub fn has_confusion(&self) -> bool {
+        *self != ConfusionType::None
+    }
 }
 
 pub(crate) fn should_show_source_code(

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -311,7 +311,6 @@ dependencies = [
  "addr2line",
  "alloc",
  "cfg-if",
- "compiler_builtins",
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -183,9 +183,8 @@ name = "panic_abort"
 version = "0.0.0"
 dependencies = [
  "alloc",
- "compiler_builtins",
- "core",
  "libc",
+ "rustc-std-workspace-core",
 ]
 
 [[package]]
@@ -194,9 +193,8 @@ version = "0.0.0"
 dependencies = [
  "alloc",
  "cfg-if",
- "compiler_builtins",
- "core",
  "libc",
+ "rustc-std-workspace-core",
  "unwind",
 ]
 
@@ -380,9 +378,8 @@ name = "unwind"
 version = "0.0.0"
 dependencies = [
  "cfg-if",
- "compiler_builtins",
- "core",
  "libc",
+ "rustc-std-workspace-core",
  "unwinding",
 ]
 

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -12,8 +12,7 @@ bench = false
 doc = false
 
 [dependencies]
-core = { path = "../core" }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins" }
+core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -13,10 +13,9 @@ doc = false
 
 [dependencies]
 alloc = { path = "../alloc" }
-core = { path = "../core" }
-unwind = { path = "../unwind" }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins" }
 cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
+core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
+unwind = { path = "../unwind" }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2", default-features = false }

--- a/library/rustc-std-workspace-core/README.md
+++ b/library/rustc-std-workspace-core/README.md
@@ -11,6 +11,12 @@ on crates.io will draw a dependency edge to `libcore`, the version defined in
 this repository. That should draw all the dependency edges to ensure Cargo
 builds crates successfully!
 
+`rustc-std-workspace-core` also ensures `compiler-builtins` is in the crate
+graph. This crate is used by other crates in `library/`, other than `std` and
+`alloc`, so the `compiler-builtins` setup only needs to be configured in a
+single place. (Otherwise these crates would just need to depend on `core` and
+`compiler-builtins` separately.)
+
 Note that crates on crates.io need to depend on this crate with the name `core`
 for everything to work correctly. To do that they can use:
 

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,6 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -14,9 +14,8 @@ bench = false
 doc = false
 
 [dependencies]
-core = { path = "../core" }
-compiler_builtins = { path = "../compiler-builtins/compiler-builtins" }
 cfg-if = "1.0"
+core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.140", features = ['rustc-dep-of-std'], default-features = false }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -999,7 +999,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
-        [doc] std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         ");
     }
 
@@ -1048,7 +1048,7 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> LintDocs 1 <host>
         [build] rustc 0 <host> -> RustInstaller 1 <host>
@@ -1090,7 +1090,7 @@ mod snapshot {
         [build] rustc 1 <host> -> WasmComponentLd 2 <host>
         [build] rustc 1 <host> -> LlvmBitcodeLinker 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> LintDocs 1 <host>
         [build] rustc 0 <host> -> RustInstaller 1 <host>
@@ -1126,8 +1126,8 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
-        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> LintDocs 1 <host>
         [build] rustc 0 <host> -> RustInstaller 1 <host>
@@ -1163,7 +1163,7 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> LintDocs 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
@@ -1200,8 +1200,8 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
-        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> LintDocs 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
@@ -1242,7 +1242,7 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> RustInstaller 1 <host>
         [dist] docs <target1>
@@ -1274,7 +1274,7 @@ mod snapshot {
         [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustc 1 <host> -> WasmComponentLd 2 <host>
         [build] rustdoc 1 <host>
-        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 2 <target1> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 2 <host> -> std 2 <host>
         [build] rustc 1 <host> -> std 1 <target1>
         [build] rustc 2 <host> -> std 2 <target1>
@@ -1620,7 +1620,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
-        [doc] std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,std,std_detect,sysroot,test,unwind]
+        [doc] std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         ");
     }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -486,8 +486,14 @@ fn is_unnamable(tcx: TyCtxt<'_>, did: DefId) -> bool {
     let mut cur_did = did;
     while let Some(parent) = tcx.opt_parent(cur_did) {
         match tcx.def_kind(parent) {
-            // items defined in these can be linked to
-            DefKind::Mod | DefKind::Impl { .. } | DefKind::ForeignMod => cur_did = parent,
+            // items defined in these can be linked to, as long as they are visible
+            DefKind::Mod | DefKind::ForeignMod => cur_did = parent,
+            // items in impls can be linked to,
+            // as long as we can link to the item the impl is on.
+            // since associated traits are not a thing,
+            // it should not be possible to refer to an impl item if
+            // the base type is not namable.
+            DefKind::Impl { .. } => return false,
             // everything else does not have docs generated for it
             _ => return true,
         }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -908,8 +908,12 @@ fn maybe_from_hir_attr(
         hir::Attribute::Parsed(kind) => kind,
 
         hir::Attribute::Unparsed(_) => {
-            // FIXME: We should handle `#[doc(hidden)]`.
-            return Some(other_attr(tcx, attr));
+            return Some(if attr.has_name(sym::macro_export) {
+                Attribute::MacroExport
+                // FIXME: We should handle `#[doc(hidden)]`.
+            } else {
+                other_attr(tcx, attr)
+            });
         }
     };
 

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -37,8 +37,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Structured Attributes
-pub const FORMAT_VERSION: u32 = 54;
+// Latest feature: Add Attribute::MacroUse
+pub const FORMAT_VERSION: u32 = 55;
 
 /// The root of the emitted JSON blob.
 ///
@@ -215,6 +215,9 @@ pub enum Attribute {
 
     /// `#[must_use]`
     MustUse { reason: Option<String> },
+
+    /// `#[macro_export]`
+    MacroExport,
 
     /// `#[export_name = "name"]`
     ExportName(String),

--- a/src/tools/clippy/tests/ui/match_str_case_mismatch.stderr
+++ b/src/tools/clippy/tests/ui/match_str_case_mismatch.stderr
@@ -18,7 +18,7 @@ error: this `match` arm has a differing case than its expression
 LL |         "~!@#$%^&*()-_=+Foo" => {},
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-help: consider changing the case of this arm to respect `to_ascii_lowercase` (notice the capitalization difference)
+help: consider changing the case of this arm to respect `to_ascii_lowercase` (notice the capitalization)
    |
 LL -         "~!@#$%^&*()-_=+Foo" => {},
 LL +         "~!@#$%^&*()-_=+foo" => {},

--- a/src/tools/run-make-support/src/artifact_names.rs
+++ b/src/tools/run-make-support/src/artifact_names.rs
@@ -35,6 +35,8 @@ pub fn dynamic_lib_extension() -> &'static str {
         "dylib"
     } else if target.contains("windows") {
         "dll"
+    } else if target.contains("aix") {
+        "a"
     } else {
         "so"
     }

--- a/tests/rustdoc-json/attrs/macro_export.rs
+++ b/tests/rustdoc-json/attrs/macro_export.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: --document-private-items
 
 //@ set exported_id = "$.index[?(@.name=='exported')].id"
-//@ is "$.index[?(@.name=='exported')].attrs" '[{"other": "#[macro_export]"}]'
+//@ is "$.index[?(@.name=='exported')].attrs" '["macro_export"]'
 //@ is "$.index[?(@.name=='exported')].visibility" '"public"'
 
 #[macro_export]
@@ -19,7 +19,7 @@ macro_rules! not_exported {
 //@ set module_id = "$.index[?(@.name=='module')].id"
 pub mod module {
     //@ set exported_from_mod_id = "$.index[?(@.name=='exported_from_mod')].id"
-    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '[{"other": "#[macro_export]"}]'
+    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '["macro_export"]'
     //@ is "$.index[?(@.name=='exported_from_mod')].visibility" '"public"'
     #[macro_export]
     macro_rules! exported_from_mod {

--- a/tests/rustdoc-json/attrs/macro_export.rs
+++ b/tests/rustdoc-json/attrs/macro_export.rs
@@ -1,0 +1,40 @@
+//@ compile-flags: --document-private-items
+
+//@ set exported_id = "$.index[?(@.name=='exported')].id"
+//@ is "$.index[?(@.name=='exported')].attrs" '[{"other": "#[macro_export]"}]'
+//@ is "$.index[?(@.name=='exported')].visibility" '"public"'
+
+#[macro_export]
+macro_rules! exported {
+    () => {};
+}
+
+//@ set not_exported_id = "$.index[?(@.name=='not_exported')].id"
+//@ is "$.index[?(@.name=='not_exported')].attrs" []
+//@ is "$.index[?(@.name=='not_exported')].visibility" '"crate"'
+macro_rules! not_exported {
+    () => {};
+}
+
+//@ set module_id = "$.index[?(@.name=='module')].id"
+pub mod module {
+    //@ set exported_from_mod_id = "$.index[?(@.name=='exported_from_mod')].id"
+    //@ is "$.index[?(@.name=='exported_from_mod')].attrs" '[{"other": "#[macro_export]"}]'
+    //@ is "$.index[?(@.name=='exported_from_mod')].visibility" '"public"'
+    #[macro_export]
+    macro_rules! exported_from_mod {
+        () => {};
+    }
+
+    //@ set not_exported_from_mod_id = "$.index[?(@.name=='not_exported_from_mod')].id"
+    //@ is "$.index[?(@.name=='not_exported_from_mod')].attrs" []
+    //@ is "$.index[?(@.name=='not_exported_from_mod')].visibility" '"crate"'
+    macro_rules! not_exported_from_mod {
+        () => {};
+    }
+}
+// The non-exported macro's are left in place, but the #[macro_export]'d ones
+// are moved to the crate root.
+
+//@ is "$.index[?(@.name=='module')].inner.module.items[*]" $not_exported_from_mod_id
+//@ ismany "$.index[?(@.name=='macro_export')].inner.module.items[*]" $exported_id $not_exported_id $module_id $exported_from_mod_id

--- a/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
+++ b/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
@@ -4,7 +4,7 @@ pub trait Assoc {
 
 pub struct Foo(<Foo as crate::Assoc>::Ty);
 
-const _: () = {
+const _X: () = {
     impl crate::Assoc for Foo {
         type Ty = Bar;
     }

--- a/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
+++ b/tests/rustdoc/reexport/auxiliary/wrap-unnamable-type.rs
@@ -1,0 +1,12 @@
+pub trait Assoc {
+    type Ty;
+}
+
+pub struct Foo(<Foo as crate::Assoc>::Ty);
+
+const _: () = {
+    impl crate::Assoc for Foo {
+        type Ty = Bar;
+    }
+    pub struct Bar;
+};

--- a/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
+++ b/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Z normalize-docs --document-private-items -Zunstable-options --show-type-layout
+//@ aux-build:wrap-unnamable-type.rs
+//@ build-aux-docs
+
+#![crate_name = "foo"]
+
+extern crate wrap_unnamable_type as helper;
+//extern crate helper;
+//@ has 'foo/struct.Foo.html'
+//@ !hasraw - '_/struct.Bar.html'
+#[doc(inline)]
+pub use helper::Foo;

--- a/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
+++ b/tests/rustdoc/reexport/wrapped-unnamble-type-143222.rs
@@ -2,11 +2,15 @@
 //@ aux-build:wrap-unnamable-type.rs
 //@ build-aux-docs
 
+// regression test for https://github.com/rust-lang/rust/issues/143222
+// makes sure normalizing docs does not cause us to link to unnamable types
+// in cross-crate reexports.
+
 #![crate_name = "foo"]
 
 extern crate wrap_unnamable_type as helper;
-//extern crate helper;
+
 //@ has 'foo/struct.Foo.html'
-//@ !hasraw - '_/struct.Bar.html'
+//@ !hasraw - 'struct.Bar.html'
 #[doc(inline)]
 pub use helper::Foo;

--- a/tests/ui/error-codes/E0423.stderr
+++ b/tests/ui/error-codes/E0423.stderr
@@ -54,7 +54,7 @@ help: use struct literal syntax instead
 LL -     let f = Foo();
 LL +     let f = Foo { a: val };
    |
-help: a function with a similar name exists (notice the capitalization difference)
+help: a function with a similar name exists (notice the capitalization)
    |
 LL -     let f = Foo();
 LL +     let f = foo();

--- a/tests/ui/lint/lint-non-uppercase-usages.stderr
+++ b/tests/ui/lint/lint-non-uppercase-usages.stderr
@@ -29,7 +29,7 @@ warning: const parameter `foo` should have an upper case name
 LL | fn foo<const foo: u32>() {
    |              ^^^
    |
-help: convert the identifier to upper case (notice the capitalization difference)
+help: convert the identifier to upper case (notice the capitalization)
    |
 LL - fn foo<const foo: u32>() {
 LL + fn foo<const FOO: u32>() {

--- a/tests/ui/parser/item-kw-case-mismatch.stderr
+++ b/tests/ui/parser/item-kw-case-mismatch.stderr
@@ -4,7 +4,7 @@ error: keyword `use` is written in the wrong case
 LL | Use std::ptr::read;
    | ^^^
    |
-help: write it in the correct case (notice the capitalization difference)
+help: write it in the correct case (notice the capitalization)
    |
 LL - Use std::ptr::read;
 LL + use std::ptr::read;
@@ -28,7 +28,7 @@ error: keyword `fn` is written in the wrong case
 LL | async Fn _a() {}
    |       ^^
    |
-help: write it in the correct case (notice the capitalization difference)
+help: write it in the correct case (notice the capitalization)
    |
 LL - async Fn _a() {}
 LL + async fn _a() {}
@@ -40,7 +40,7 @@ error: keyword `fn` is written in the wrong case
 LL | Fn _b() {}
    | ^^
    |
-help: write it in the correct case (notice the capitalization difference)
+help: write it in the correct case (notice the capitalization)
    |
 LL - Fn _b() {}
 LL + fn _b() {}

--- a/tests/ui/parser/kw-in-trait-bounds.stderr
+++ b/tests/ui/parser/kw-in-trait-bounds.stderr
@@ -4,7 +4,7 @@ error: expected identifier, found keyword `fn`
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
    |          ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
 LL + fn _f<F: Fn(), G>(_: impl fn(), _: &dyn fn())
@@ -16,7 +16,7 @@ error: expected identifier, found keyword `fn`
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
    |                           ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
 LL + fn _f<F: fn(), G>(_: impl Fn(), _: &dyn fn())
@@ -28,7 +28,7 @@ error: expected identifier, found keyword `fn`
 LL | fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
    |                                         ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - fn _f<F: fn(), G>(_: impl fn(), _: &dyn fn())
 LL + fn _f<F: fn(), G>(_: impl fn(), _: &dyn Fn())
@@ -40,7 +40,7 @@ error: expected identifier, found keyword `fn`
 LL | G: fn(),
    |    ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - G: fn(),
 LL + G: Fn(),

--- a/tests/ui/parser/misspelled-keywords/hrdt.stderr
+++ b/tests/ui/parser/misspelled-keywords/hrdt.stderr
@@ -4,7 +4,7 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found keyword 
 LL |     Where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
    |           ^^^ expected one of 7 possible tokens
    |
-help: write keyword `where` in lowercase (notice the capitalization difference)
+help: write keyword `where` in lowercase (notice the capitalization)
    |
 LL -     Where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
 LL +     where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,

--- a/tests/ui/parser/misspelled-keywords/impl-return.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-return.stderr
@@ -4,7 +4,7 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `Display
 LL | fn code() -> Impl Display {}
    |                   ^^^^^^^ expected one of 7 possible tokens
    |
-help: write keyword `impl` in lowercase (notice the capitalization difference)
+help: write keyword `impl` in lowercase (notice the capitalization)
    |
 LL - fn code() -> Impl Display {}
 LL + fn code() -> impl Display {}

--- a/tests/ui/parser/misspelled-keywords/static.stderr
+++ b/tests/ui/parser/misspelled-keywords/static.stderr
@@ -4,7 +4,7 @@ error: expected one of `!` or `::`, found `a`
 LL | Static a = 0;
    |        ^ expected one of `!` or `::`
    |
-help: write keyword `static` in lowercase (notice the capitalization difference)
+help: write keyword `static` in lowercase (notice the capitalization)
    |
 LL - Static a = 0;
 LL + static a = 0;

--- a/tests/ui/parser/misspelled-keywords/struct.stderr
+++ b/tests/ui/parser/misspelled-keywords/struct.stderr
@@ -4,7 +4,7 @@ error: expected one of `!` or `::`, found `Foor`
 LL | Struct Foor {
    |        ^^^^ expected one of `!` or `::`
    |
-help: write keyword `struct` in lowercase (notice the capitalization difference)
+help: write keyword `struct` in lowercase (notice the capitalization)
    |
 LL - Struct Foor {
 LL + struct Foor {

--- a/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.stderr
+++ b/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.stderr
@@ -4,7 +4,7 @@ error: expected identifier, found keyword `fn`
 LL | fn foo(_: impl fn() -> i32) {}
    |                ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - fn foo(_: impl fn() -> i32) {}
 LL + fn foo(_: impl Fn() -> i32) {}
@@ -16,7 +16,7 @@ error: expected identifier, found keyword `fn`
 LL | fn foo2<T: fn(i32)>(_: T) {}
    |            ^^
    |
-help: use `Fn` to refer to the trait (notice the capitalization difference)
+help: use `Fn` to refer to the trait (notice the capitalization)
    |
 LL - fn foo2<T: fn(i32)>(_: T) {}
 LL + fn foo2<T: Fn(i32)>(_: T) {}

--- a/tests/ui/parser/typod-const-in-const-param-def.stderr
+++ b/tests/ui/parser/typod-const-in-const-param-def.stderr
@@ -4,7 +4,7 @@ error: `const` keyword was mistyped as `Const`
 LL | pub fn foo<Const N: u8>() {}
    |            ^^^^^
    |
-help: use the `const` keyword (notice the capitalization difference)
+help: use the `const` keyword (notice the capitalization)
    |
 LL - pub fn foo<Const N: u8>() {}
 LL + pub fn foo<const N: u8>() {}
@@ -16,7 +16,7 @@ error: `const` keyword was mistyped as `Const`
 LL | pub fn baz<Const N: u8, T>() {}
    |            ^^^^^
    |
-help: use the `const` keyword (notice the capitalization difference)
+help: use the `const` keyword (notice the capitalization)
    |
 LL - pub fn baz<Const N: u8, T>() {}
 LL + pub fn baz<const N: u8, T>() {}
@@ -28,7 +28,7 @@ error: `const` keyword was mistyped as `Const`
 LL | pub fn qux<T, Const N: u8>() {}
    |               ^^^^^
    |
-help: use the `const` keyword (notice the capitalization difference)
+help: use the `const` keyword (notice the capitalization)
    |
 LL - pub fn qux<T, Const N: u8>() {}
 LL + pub fn qux<T, const N: u8>() {}
@@ -40,7 +40,7 @@ error: `const` keyword was mistyped as `Const`
 LL | pub fn quux<T, Const N: u8, U>() {}
    |                ^^^^^
    |
-help: use the `const` keyword (notice the capitalization difference)
+help: use the `const` keyword (notice the capitalization)
    |
 LL - pub fn quux<T, Const N: u8, U>() {}
 LL + pub fn quux<T, const N: u8, U>() {}

--- a/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
+++ b/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
@@ -8,7 +8,7 @@ LL |     let x: i32 = MyS::foo;
    |
    = note: expected type `i32`
            found fn item `fn() -> MyS {MyS::foo}`
-help: try referring to the associated const `FOO` instead (notice the capitalization difference)
+help: try referring to the associated const `FOO` instead (notice the capitalization)
    |
 LL -     let x: i32 = MyS::foo;
 LL +     let x: i32 = MyS::FOO;

--- a/tests/ui/suggestions/bool_typo_err_suggest.stderr
+++ b/tests/ui/suggestions/bool_typo_err_suggest.stderr
@@ -16,7 +16,7 @@ error[E0425]: cannot find value `False` in this scope
 LL |     let y = False;
    |             ^^^^^ not found in this scope
    |
-help: you may want to use a bool value instead (notice the capitalization difference)
+help: you may want to use a bool value instead (notice the capitalization)
    |
 LL -     let y = False;
 LL +     let y = false;

--- a/tests/ui/suggestions/case-difference-suggestions.rs
+++ b/tests/ui/suggestions/case-difference-suggestions.rs
@@ -1,0 +1,57 @@
+fn main() {
+
+    // Simple case difference, no hit
+    let hello = "hello";
+    println!("{}", Hello); //~ ERROR cannot find value `Hello` in this scope
+
+    // Multiple case differences, hit
+    let myVariable = 10;
+    println!("{}", myvariable); //~ ERROR cannot find value `myvariable` in this scope
+
+    // Case difference with special characters, hit
+    let user_name = "john";
+    println!("{}", User_Name); //~ ERROR cannot find value `User_Name` in this scope
+
+    // All uppercase vs all lowercase, hit
+    let FOO = 42;
+    println!("{}", foo); //~ ERROR cannot find value `foo` in this scope
+
+
+    // 0 vs O
+    let FFO0 = 100;
+    println!("{}", FFOO); //~ ERROR cannot find value `FFOO` in this scope
+
+    let l1st = vec![1, 2, 3];
+    println!("{}", list); //~ ERROR cannot find value `list` in this scope
+
+    let S5 = "test";
+    println!("{}", SS); //~ ERROR cannot find value `SS` in this scope
+
+    let aS5 = "test";
+    println!("{}", a55); //~ ERROR cannot find value `a55` in this scope
+
+    let B8 = 8;
+    println!("{}", BB); //~ ERROR cannot find value `BB` in this scope
+
+    let g9 = 9;
+    println!("{}", gg); //~ ERROR cannot find value `gg` in this scope
+
+    let o1d = "old";
+    println!("{}", old); //~ ERROR cannot find value `old` in this scope
+
+    let new1 = "new";
+    println!("{}", newl); //~ ERROR cannot find value `newl` in this scope
+
+    let apple = "apple";
+    println!("{}", app1e); //~ ERROR cannot find value `app1e` in this scope
+
+    let a = 1;
+    println!("{}", A); //~ ERROR cannot find value `A` in this scope
+
+    let worldlu = "world";
+    println!("{}", world1U); //~ ERROR cannot find value `world1U` in this scope
+
+    let myV4rlable = 42;
+    println!("{}", myv4r1able); //~ ERROR cannot find value `myv4r1able` in this scope
+
+}

--- a/tests/ui/suggestions/case-difference-suggestions.stderr
+++ b/tests/ui/suggestions/case-difference-suggestions.stderr
@@ -1,0 +1,99 @@
+error[E0425]: cannot find value `Hello` in this scope
+  --> $DIR/case-difference-suggestions.rs:5:20
+   |
+LL |     println!("{}", Hello);
+   |                    ^^^^^ help: a local variable with a similar name exists: `hello`
+
+error[E0425]: cannot find value `myvariable` in this scope
+  --> $DIR/case-difference-suggestions.rs:9:20
+   |
+LL |     println!("{}", myvariable);
+   |                    ^^^^^^^^^^ help: a local variable with a similar name exists (notice the capitalization): `myVariable`
+
+error[E0425]: cannot find value `User_Name` in this scope
+  --> $DIR/case-difference-suggestions.rs:13:20
+   |
+LL |     println!("{}", User_Name);
+   |                    ^^^^^^^^^ help: a local variable with a similar name exists: `user_name`
+
+error[E0425]: cannot find value `foo` in this scope
+  --> $DIR/case-difference-suggestions.rs:17:20
+   |
+LL |     println!("{}", foo);
+   |                    ^^^ help: a local variable with a similar name exists (notice the capitalization): `FOO`
+
+error[E0425]: cannot find value `FFOO` in this scope
+  --> $DIR/case-difference-suggestions.rs:22:20
+   |
+LL |     println!("{}", FFOO);
+   |                    ^^^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `FFO0`
+
+error[E0425]: cannot find value `list` in this scope
+  --> $DIR/case-difference-suggestions.rs:25:20
+   |
+LL |     println!("{}", list);
+   |                    ^^^^ help: a local variable with a similar name exists: `l1st`
+
+error[E0425]: cannot find value `SS` in this scope
+  --> $DIR/case-difference-suggestions.rs:28:20
+   |
+LL |     println!("{}", SS);
+   |                    ^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `S5`
+
+error[E0425]: cannot find value `a55` in this scope
+  --> $DIR/case-difference-suggestions.rs:31:20
+   |
+LL |     println!("{}", a55);
+   |                    ^^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `aS5`
+
+error[E0425]: cannot find value `BB` in this scope
+  --> $DIR/case-difference-suggestions.rs:34:20
+   |
+LL |     println!("{}", BB);
+   |                    ^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `B8`
+
+error[E0425]: cannot find value `gg` in this scope
+  --> $DIR/case-difference-suggestions.rs:37:20
+   |
+LL |     println!("{}", gg);
+   |                    ^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `g9`
+
+error[E0425]: cannot find value `old` in this scope
+  --> $DIR/case-difference-suggestions.rs:40:20
+   |
+LL |     println!("{}", old);
+   |                    ^^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `o1d`
+
+error[E0425]: cannot find value `newl` in this scope
+  --> $DIR/case-difference-suggestions.rs:43:20
+   |
+LL |     println!("{}", newl);
+   |                    ^^^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `new1`
+
+error[E0425]: cannot find value `app1e` in this scope
+  --> $DIR/case-difference-suggestions.rs:46:20
+   |
+LL |     println!("{}", app1e);
+   |                    ^^^^^ help: a local variable with a similar name exists (notice the digit/letter confusion): `apple`
+
+error[E0425]: cannot find value `A` in this scope
+  --> $DIR/case-difference-suggestions.rs:49:20
+   |
+LL |     println!("{}", A);
+   |                    ^ help: a local variable with a similar name exists: `a`
+
+error[E0425]: cannot find value `world1U` in this scope
+  --> $DIR/case-difference-suggestions.rs:52:20
+   |
+LL |     println!("{}", world1U);
+   |                    ^^^^^^^ help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion): `worldlu`
+
+error[E0425]: cannot find value `myv4r1able` in this scope
+  --> $DIR/case-difference-suggestions.rs:55:20
+   |
+LL |     println!("{}", myv4r1able);
+   |                    ^^^^^^^^^^ help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion): `myV4rlable`
+
+error: aborting due to 16 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -455,7 +455,7 @@
 </tspan>
     <tspan x="10px" y="3916px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3934px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name (notice the capitalization difference)</tspan>
+    <tspan x="10px" y="3934px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name (notice the capitalization)</tspan>
 </tspan>
     <tspan x="10px" y="3952px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -355,6 +355,7 @@ trigger_labels = [
 [autolabel."T-libs"]
 trigger_files = [
     "library/alloc",
+    "library/compiler-builtins",
     "library/core",
     "library/panic_abort",
     "library/panic_unwind",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1068,6 +1068,10 @@ cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]
 message = "`rustc_errors::annotate_snippet_emitter_writer` was changed"
 cc = ["@Muscraft"]
 
+[mentions."compiler/rustc_errors/src/emitter.rs"]
+message = "`rustc_errors::emitter` was changed"
+cc = ["@Muscraft"]
+
 [mentions."compiler/rustc_errors/src/translation.rs"]
 message = "`rustc_errors::translation` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1064,6 +1064,10 @@ cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@vakaras"]
 message = "`rustc_error_messages` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]
 
+[mentions."compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs"]
+message = "`rustc_errors::annotate_snippet_emitter_writer` was changed"
+cc = ["@Muscraft"]
+
 [mentions."compiler/rustc_errors/src/translation.rs"]
 message = "`rustc_errors::translation` was changed"
 cc = ["@davidtwco", "@compiler-errors", "@TaKO8Ki"]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#143849 (rustdoc: never link to unnamable items)
 - rust-lang/rust#144683 (Simplify library dependencies on `compiler-builtins`)
 - rust-lang/rust#144691 (Extend `is_case_difference` to handle digit-letter confusables)
 - rust-lang/rust#144700 (rustdoc-json: Move `#[macro_export]` from `Other` to it's own  variant)
 - rust-lang/rust#144751 (Add correct dynamic_lib_extension for aix)
 - rust-lang/rust#144757 (Ping Muscraft when emitter change)
 - rust-lang/rust#144759 (triagebot: Label `compiler-builtins` T-libs)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=143849,144683,144691,144700,144751,144757,144759)
<!-- homu-ignore:end -->