### PR TITLE
Add a method to dump MIR in the middle of MIR building

### DIFF
--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -157,6 +157,21 @@ impl CoverageInfoBuilder {
         // if there's nothing interesting in it.
         Box::new(CoverageInfoHi { num_block_markers, branch_spans })
     }
+
+    pub(crate) fn as_done(&self) -> Box<CoverageInfoHi> {
+        let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
+            self;
+
+        let branch_spans = branch_info
+            .as_ref()
+            .map(|branch_info| branch_info.branch_spans.as_slice())
+            .unwrap_or_default()
+            .to_owned();
+
+        // For simplicity, always return an info struct (without Option), even
+        // if there's nothing interesting in it.
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+    }
 }
 
 impl<'tcx> Builder<'_, 'tcx> {

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -791,7 +791,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     #[allow(dead_code)]
     fn dump_for_debugging(&self) {
-        let body = Body::new(
+        let mut body = Body::new(
             MirSource::item(self.def_id.to_def_id()),
             self.cfg.basic_blocks.clone(),
             self.source_scopes.clone(),
@@ -803,7 +803,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.coroutine.clone(),
             None,
         );
-        //body.coverage_info_hi = self.coverage_info.clone().map(|b| b.into_done());
+        body.coverage_info_hi = self.coverage_info.as_ref().map(|b| b.as_done());
 
         use rustc_middle::mir::pretty;
         let options = pretty::PrettyPrintMirOptions::from_cli(self.tcx);

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -789,6 +789,28 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         builder
     }
 
+    #[allow(dead_code)]
+    fn dump_for_debugging(&self) {
+        let body = Body::new(
+            MirSource::item(self.def_id.to_def_id()),
+            self.cfg.basic_blocks.clone(),
+            self.source_scopes.clone(),
+            self.local_decls.clone(),
+            self.canonical_user_type_annotations.clone(),
+            self.arg_count.clone(),
+            self.var_debug_info.clone(),
+            self.fn_span.clone(),
+            self.coroutine.clone(),
+            None,
+        );
+        //body.coverage_info_hi = self.coverage_info.clone().map(|b| b.into_done());
+
+        use rustc_middle::mir::pretty;
+        let options = pretty::PrettyPrintMirOptions::from_cli(self.tcx);
+        pretty::write_mir_fn(self.tcx, &body, &mut |_, _| Ok(()), &mut std::io::stdout(), options)
+            .unwrap();
+    }
+
     fn finish(self) -> Body<'tcx> {
         let mut body = Body::new(
             MirSource::item(self.def_id.to_def_id()),


### PR DESCRIPTION
This makes it easier to debug issues with MIR building by inserting dump_for_debugging calls around the suspected code responsible for the bad MIR.