### PR TITLE
Properly pass path to staged `rustc` to `compiletest` self-tests

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -749,6 +749,12 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
             SourceType::InTree,
             &[],
         );
+
+        // Used for `compiletest` self-tests to have the path to the *staged* compiler. Getting this
+        // right is important, as `compiletest` is intended to only support one target spec JSON
+        // format, namely that of the staged compiler.
+        cargo.env("TEST_RUSTC", builder.rustc(compiler));
+
         cargo.allow_features(COMPILETEST_ALLOW_FEATURES);
         run_cargo_test(cargo, &[], &[], "compiletest self test", host, builder);
     }

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -203,22 +203,8 @@ impl ConfigBuilder {
         }
 
         args.push("--rustc-path".to_string());
-        // This is a subtle/fragile thing. On rust-lang CI, there is no global
-        // `rustc`, and Cargo doesn't offer a convenient way to get the path to
-        // `rustc`. Fortunately bootstrap sets `RUSTC` for us, which is pointing
-        // to the stage0 compiler.
-        //
-        // Otherwise, if you are running compiletests's tests manually, you
-        // probably don't have `RUSTC` set, in which case this falls back to the
-        // global rustc. If your global rustc is too far out of sync with stage0,
-        // then this may cause confusing errors. Or if for some reason you don't
-        // have rustc in PATH, that would also fail.
-        args.push(std::env::var("RUSTC").unwrap_or_else(|_| {
-            eprintln!(
-                "warning: RUSTC not set, using global rustc (are you not running via bootstrap?)"
-            );
-            "rustc".to_string()
-        }));
+        args.push(std::env::var("TEST_RUSTC").expect("must be configured by bootstrap"));
+
         crate::parse_config(args)
     }
 }


### PR DESCRIPTION
Otherwise, this can do weird things like use a global rustc, or try to use stage 0 rustc. This must be properly configured, because `compiletest` is intended to only support one compiler target spec JSON format (of the in-tree compiler).

Historically, this was probably done so before `bootstrap` was really its own thing, and `compiletest` had to be runnable as a much more "self-standing" tool.

Follow-up to rust-lang/rust#144675, as I didn't realize this until Zalathar pointed it out in [#t-infra/bootstrap > Building vs testing &#96;compiletest&#96; @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Building.20vs.20testing.20.60compiletest.60/near/532040838).

r? @Kobzol
