### PR TITLE
Regression test for LLVM error with unsupported expression in static initializer for const pointer in array on macOS.

### DIFF
--- a/tests/ui/codegen/unsupported-static-initializer-in-const-array.rs
+++ b/tests/ui/codegen/unsupported-static-initializer-in-const-array.rs
@@ -1,0 +1,18 @@
+//! LLVM error with unsupported expression in static
+//! initializer for const pointer in array on macOS.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/89225>.
+
+//@ build-pass
+//@ compile-flags: -C opt-level=3
+
+const fn make() -> (i32, i32, *const i32) {
+    const V: i32 = 123;
+    &V as *const i32;
+    (0, 0, &V)
+}
+
+fn main() {
+    let arr = [make(); 32];
+    println!("{}", arr[0].0);
+}


### PR DESCRIPTION
Regression test for rust-lang/rust#89225, I have shortened the original example as much as i could, while still generating the error.

here is my output on MacOs:
```
rustup run 1.60 cargo build --release
   Compiling rug_int v0.1.0 (/Users/luca/dev/rug_int)
LLVM ERROR: Unsupported expression in static initializer: zext (i64 ptrtoint (<{ [4 x i8] }>* @anon.fad58de7366495db4650cfefac2fcd61.0 to i64) to i128)
error: could not compile `rug_int`

rustup run 1.61 cargo build --release
   Compiling rug_int v0.1.0 (/Users/luca/dev/rug_int)
    Finished release [optimized] target(s) in 0.60s
```
