### PR TITLE
`Interner` arg to `EarlyBinder` does not affect auto traits

### DIFF
--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -357,7 +357,7 @@ impl<I: Interner> TypeVisitor<I> for ValidateBoundVars<I> {
 pub struct EarlyBinder<I: Interner, T> {
     value: T,
     #[derive_where(skip(Debug))]
-    _tcx: PhantomData<I>,
+    _tcx: PhantomData<fn() -> I>,
 }
 
 /// For early binders, you should first call `instantiate` before using any visitors.


### PR DESCRIPTION
Conceptually `EarlyBinder` does not contain an `Interner` so it shouldn't tell Rust it does via `PhantomData`. This is necessary for rust-analyzer as it stores `EarlyBinder`s in query results which require `Sync`, placing restrictions on our interner setup.

r? compiler-errors 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
