### PR TITLE
Stylize `*-lynxos178-*` target maintainer handle to make it easier to copy/paste

### DIFF
--- a/src/doc/rustc/src/platform-support/lynxos178.md
+++ b/src/doc/rustc/src/platform-support/lynxos178.md
@@ -15,7 +15,7 @@ Target triples available:
 
 ## Target maintainers
 
-- Renat Fatykhov, https://github.com/rfatykhov-lynx
+[@rfatykhov-lynx](https://github.com/rfatykhov-lynx)
 
 ## Requirements
 


### PR DESCRIPTION
Apparently I forgot to submit this branch I had lying around.

Noticed while reviewing Tier 3 target platform support pages. In the same style as rust-lang/rust#139028.