### PR TITLE
Fix tail calling intrinsics

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -982,6 +982,14 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
                                 return if let Some(target) = target {
                                     helper.funclet_br(self, bx, target, mergeable_succ)
+                                } else if kind == CallKind::Tail {
+                                    let res = bx.load(
+                                        bx.backend_type(result.layout),
+                                        result.val.llval,
+                                        result.val.align,
+                                    );
+                                    bx.ret(res);
+                                    MergingSucc::False
                                 } else {
                                     bx.unreachable();
                                     MergingSucc::False

--- a/tests/ui/explicit-tail-calls/intrinsics.rs
+++ b/tests/ui/explicit-tail-calls/intrinsics.rs
@@ -1,0 +1,13 @@
+//@ run-pass
+#![feature(explicit_tail_calls, core_intrinsics)]
+#![expect(incomplete_features, internal_features)]
+
+fn trans((): ()) {
+    // transmute is lowered in a mir pass
+    unsafe { become std::mem::transmute(()) }
+}
+
+fn main() {
+    trans(());
+}
+

--- a/tests/ui/explicit-tail-calls/intrinsics.rs
+++ b/tests/ui/explicit-tail-calls/intrinsics.rs
@@ -7,7 +7,12 @@ fn trans((): ()) {
     unsafe { become std::mem::transmute(()) }
 }
 
+fn cats(x: u64) -> u32 {
+    become std::intrinsics::ctlz(x)
+}
+
 fn main() {
     trans(());
+    assert_eq!(cats(17), 59);
 }
 


### PR DESCRIPTION
Tail-calling intrinsics used to ICE/miscompile, this PR fixes that.

The reason I think we should explicitly support calling intrinsics, rather than banning it, is that I don't think we want to expose to users if a function is an intrinsic or not. This is especially relevant with something like `std::mem::transmute` which is a direct export of the intrinsic, rather than a wrapper function.

The fix has two parts:
1. For intrinsics which are lowered in mir I've added code to lower them even if they are tail called
2. For `cg_ssa` I added code which transforms a tail call to an intrinsic into intrinsic desugaring+ret. This feels like a hack, but I don't really see a better way. (cc @scottmcm, maybe you have an opinion?)

Fixes rust-lang/rust#144806
