### PR TITLE
Fix [rustdoc] Non-json time diagnostics in stdout when using --format…

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -64,7 +64,8 @@ impl MergedDoctestTimes {
         // If no merged doctest was compiled, then there is nothing to display since the numbers
         // displayed by `libtest` for standalone tests are already accurate (they include both
         // compilation and runtime).
-        if self.added_compilation_times > 0 {
+        // Skip output if JSON format is requested to maintain valid JSON output.
+        if self.added_compilation_times > 0 && !std::env::args().any(|arg| arg == "--format" || arg == "--format=json") {
             println!("{self}");
         }
     }


### PR DESCRIPTION
I've updated the display_times method in doctest.rs to check if JSON output is requested before printing the timing information. Here's what the change does:

Added a check for --format or --format=json in the command-line arguments using std::env::args().any()
The timing information will only be printed if:
There were merged doctests compiled (self.added_compilation_times > 0)
AND JSON format is NOT requested
This change ensures that when running with --format json, the timing information won't be printed to stdout, which would otherwise corrupt the JSON output. The timing information is still available when running in the default format.