### PR TITLE
Anonymize binders in tail call sig

### DIFF
--- a/tests/ui/explicit-tail-calls/higher-ranked-arg.rs
+++ b/tests/ui/explicit-tail-calls/higher-ranked-arg.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144826>.
+//@ check-pass
+
+#![feature(explicit_tail_calls)]
+#![expect(incomplete_features)]
+
+fn foo(x: fn(&i32)) {
+    become bar(x);
+}
+
+fn bar(_: fn(&i32)) {}
+
+fn main() {}


### PR DESCRIPTION
See the comment for explanation

Fixes rust-lang/rust#144826 

r? WaffleLapkin