### PR TITLE
Change visibility of Args new function

### DIFF
--- a/library/std/src/sys/args/common.rs
+++ b/library/std/src/sys/args/common.rs
@@ -12,7 +12,7 @@ impl !Sync for Args {}
 
 impl Args {
     #[inline]
-    pub(super) fn new(args: Vec<OsString>) -> Self {
+    pub fn new(args: Vec<OsString>) -> Self {
         Args { iter: args.into_iter() }
     }
 }


### PR DESCRIPTION
Currently the Args new function is constrained to pub(super) but this stops me from being able to construct Args structs in unit tests.

This pull request is to change this to pub.