### PR TITLE
Rewrite`is_ascii` using `slice::as_chunks`

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -45,7 +45,7 @@ mod specialize;
 pub use ascii::EscapeAscii;
 #[unstable(feature = "str_internals", issue = "none")]
 #[doc(hidden)]
-pub use ascii::is_ascii_simple;
+pub use ascii::{is_ascii_simd, is_ascii_swar};
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use index::SliceIndex;
 #[unstable(feature = "slice_range", issue = "76393")]

--- a/library/coretests/benches/ascii/is_ascii.rs
+++ b/library/coretests/benches/ascii/is_ascii.rs
@@ -6,6 +6,7 @@ macro_rules! benches {
     ($( fn $name: ident($arg: ident: &[u8]) $body: block )+) => {
         benches!(mod short SHORT[..] $($name $arg $body)+);
         benches!(mod medium MEDIUM[..] $($name $arg $body)+);
+        benches!(mod medium_15 MEDIUM[..=15] $($name $arg $body)+);
         benches!(mod long LONG[..] $($name $arg $body)+);
         // Ensure we benchmark cases where the functions are called with strings
         // that are not perfectly aligned or have a length which is not a
@@ -37,87 +38,27 @@ macro_rules! benches {
 }
 
 benches! {
-    fn case00_libcore(bytes: &[u8]) {
-        bytes.is_ascii()
+    fn is_ascii_swar_1(bytes: &[u8]) {
+        core::slice::is_ascii_swar::<1>(bytes)
     }
 
-    fn case01_iter_all(bytes: &[u8]) {
-        bytes.iter().all(|b| b.is_ascii())
+    fn is_ascii_swar_2(bytes: &[u8]) {
+        core::slice::is_ascii_swar::<2>(bytes)
     }
 
-    fn case02_align_to(bytes: &[u8]) {
-        is_ascii_align_to(bytes)
+    fn is_ascii_swar_4(bytes: &[u8]) {
+        core::slice::is_ascii_swar::<4>(bytes)
     }
 
-    fn case03_align_to_unrolled(bytes: &[u8]) {
-        is_ascii_align_to_unrolled(bytes)
+    fn is_ascii_simd_08(bytes: &[u8]) {
+        core::slice::is_ascii_simd::<8>(bytes)
     }
 
-    fn case04_while_loop(bytes: &[u8]) {
-        // Process chunks of 32 bytes at a time in the fast path to enable
-        // auto-vectorization and use of `pmovmskb`. Two 128-bit vector registers
-        // can be OR'd together and then the resulting vector can be tested for
-        // non-ASCII bytes.
-        const CHUNK_SIZE: usize = 32;
-
-        let mut i = 0;
-
-        while i + CHUNK_SIZE <= bytes.len() {
-            let chunk_end = i + CHUNK_SIZE;
-
-            // Get LLVM to produce a `pmovmskb` instruction on x86-64 which
-            // creates a mask from the most significant bit of each byte.
-            // ASCII bytes are less than 128 (0x80), so their most significant
-            // bit is unset.
-            let mut count = 0;
-            while i < chunk_end {
-                count += bytes[i].is_ascii() as u8;
-                i += 1;
-            }
-
-            // All bytes should be <= 127 so count is equal to chunk size.
-            if count != CHUNK_SIZE as u8 {
-                return false;
-            }
-        }
-
-        // Process the remaining `bytes.len() % N` bytes.
-        let mut is_ascii = true;
-        while i < bytes.len() {
-            is_ascii &= bytes[i].is_ascii();
-            i += 1;
-        }
-
-        is_ascii
+    fn is_ascii_simd_16(bytes: &[u8]) {
+        core::slice::is_ascii_simd::<16>(bytes)
     }
-}
 
-// These are separate since it's easier to debug errors if they don't go through
-// macro expansion first.
-fn is_ascii_align_to(bytes: &[u8]) -> bool {
-    if bytes.len() < size_of::<usize>() {
-        return bytes.iter().all(|b| b.is_ascii());
+    fn is_ascii_simd_32(bytes: &[u8]) {
+        core::slice::is_ascii_simd::<32>(bytes)
     }
-    // SAFETY: transmuting a sequence of `u8` to `usize` is always fine
-    let (head, body, tail) = unsafe { bytes.align_to::<usize>() };
-    head.iter().all(|b| b.is_ascii())
-        && body.iter().all(|w| !contains_nonascii(*w))
-        && tail.iter().all(|b| b.is_ascii())
-}
-
-fn is_ascii_align_to_unrolled(bytes: &[u8]) -> bool {
-    if bytes.len() < size_of::<usize>() {
-        return bytes.iter().all(|b| b.is_ascii());
-    }
-    // SAFETY: transmuting a sequence of `u8` to `[usize; 2]` is always fine
-    let (head, body, tail) = unsafe { bytes.align_to::<[usize; 2]>() };
-    head.iter().all(|b| b.is_ascii())
-        && body.iter().all(|w| !contains_nonascii(w[0] | w[1]))
-        && tail.iter().all(|b| b.is_ascii())
-}
-
-#[inline]
-fn contains_nonascii(v: usize) -> bool {
-    const NONASCII_MASK: usize = usize::from_ne_bytes([0x80; size_of::<usize>()]);
-    (NONASCII_MASK & v) != 0
 }

--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -8,6 +8,8 @@
 #![feature(iter_array_chunks)]
 #![feature(iter_next_chunk)]
 #![feature(iter_advance_by)]
+#![feature(str_internals)]
+#![allow(internal_features)]
 
 extern crate test;
 


### PR DESCRIPTION
Generalize the x86-64+sse2 version of `is_ascii` to be architecture-neutral, and rewrite it using `slice::as_chunks`. The new version is both shorter (in terms of Rust source code) and smaller (in terms of produced assembly).

Compare the assembly generated before and after:
https://godbolt.org/z/MWKdnaYoK

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
