### PR TITLE
Forbid tail calling intrinsics

### DIFF
--- a/tests/ui/explicit-tail-calls/intrinsics.rs
+++ b/tests/ui/explicit-tail-calls/intrinsics.rs
@@ -1,0 +1,13 @@
+#![feature(explicit_tail_calls, core_intrinsics)]
+#![expect(incomplete_features, internal_features)]
+
+fn trans((): ()) {
+    unsafe { become std::mem::transmute(()) } //~ error: tail calling intrinsics is not allowed
+
+}
+
+fn cats(x: u64) -> u32 {
+    become std::intrinsics::ctlz(x) //~ error: tail calling intrinsics is not allowed
+}
+
+fn main() {}

--- a/tests/ui/explicit-tail-calls/intrinsics.stderr
+++ b/tests/ui/explicit-tail-calls/intrinsics.stderr
@@ -1,0 +1,14 @@
+error: tail calling intrinsics is not allowed
+  --> $DIR/intrinsics.rs:5:14
+   |
+LL |     unsafe { become std::mem::transmute(()) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: tail calling intrinsics is not allowed
+  --> $DIR/intrinsics.rs:10:5
+   |
+LL |     become std::intrinsics::ctlz(x)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

There is only one intrinsic that can be called on stable, as far as I can find, (`transmute`). And in general tail calling intrinsics doesn't make much sense.

Alternative to rust-lang/rust#144815 (and thus closes rust-lang/rust#144815)
Fixes https://github.com/rust-lang/rust/issues/144806

r? @scottmcm 