### PR TITLE
Stabilize `btree_entry_insert` feature

### DIFF
--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -275,7 +275,6 @@ impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(btree_entry_insert)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut map: BTreeMap<&str, String> = BTreeMap::new();
@@ -284,7 +283,7 @@ impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
     /// assert_eq!(entry.key(), &"poneyland");
     /// ```
     #[inline]
-    #[unstable(feature = "btree_entry_insert", issue = "65225")]
+    #[stable(feature = "btree_entry_insert", since = "CURRENT_RUSTC_VERSION")]
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, A> {
         match self {
             Occupied(mut entry) => {
@@ -383,7 +382,6 @@ impl<'a, K: Ord, V, A: Allocator + Clone> VacantEntry<'a, K, V, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(btree_entry_insert)]
     /// use std::collections::BTreeMap;
     /// use std::collections::btree_map::Entry;
     ///
@@ -395,7 +393,7 @@ impl<'a, K: Ord, V, A: Allocator + Clone> VacantEntry<'a, K, V, A> {
     /// }
     /// assert_eq!(map["poneyland"], 37);
     /// ```
-    #[unstable(feature = "btree_entry_insert", issue = "65225")]
+    #[stable(feature = "btree_entry_insert", since = "CURRENT_RUSTC_VERSION")]
     pub fn insert_entry(mut self, value: V) -> OccupiedEntry<'a, K, V, A> {
         let handle = match self.handle {
             None => {


### PR DESCRIPTION
This stabilises `btree_map::VacantEntry::insert_entry` and `btree_map::Entry::insert_entry`, following the FCP in [tracking issue](https://github.com/rust-lang/rust/issues/65225).

New stable API:

```rust
impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, A>;
}

impl<'a, K: Ord, V, A: Allocator + Clone> VacantEntry<'a, K, V, A> {
    pub fn insert_entry(mut self, value: V) -> OccupiedEntry<'a, K, V, A>;
}
```

(FCP ended almost a year ago, so if it's needed for process we could rerun it)

Closes: https://github.com/rust-lang/rust/issues/65225