### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -493,7 +493,7 @@ fn suggestion_signature<'tcx>(
     let args = ty::GenericArgs::identity_for_item(tcx, assoc.def_id).rebase_onto(
         tcx,
         assoc.container_id(tcx),
-        impl_trait_ref.with_self_ty(tcx, tcx.types.self_param).args,
+        impl_trait_ref.with_replaced_self_ty(tcx, tcx.types.self_param).args,
     );
 
     match assoc.kind {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -888,8 +888,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 ty::PredicateKind::Clause(ty::ClauseKind::Projection(pred)) => {
                     // `<Foo as Iterator>::Item = String`.
                     let projection_term = pred.projection_term;
-                    let quiet_projection_term =
-                        projection_term.with_self_ty(tcx, Ty::new_var(tcx, ty::TyVid::ZERO));
+                    let quiet_projection_term = projection_term
+                        .with_replaced_self_ty(tcx, Ty::new_var(tcx, ty::TyVid::ZERO));
 
                     let term = pred.term;
                     let obligation = format!("{projection_term} = {term}");

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1800,11 +1800,13 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                             .kind()
                             .map_bound(|clause| match clause {
                                 ty::ClauseKind::Trait(trait_pred) => Some(ty::ClauseKind::Trait(
-                                    trait_pred.with_self_ty(fcx.tcx, ty),
+                                    trait_pred.with_replaced_self_ty(fcx.tcx, ty),
                                 )),
-                                ty::ClauseKind::Projection(proj_pred) => Some(
-                                    ty::ClauseKind::Projection(proj_pred.with_self_ty(fcx.tcx, ty)),
-                                ),
+                                ty::ClauseKind::Projection(proj_pred) => {
+                                    Some(ty::ClauseKind::Projection(
+                                        proj_pred.with_replaced_self_ty(fcx.tcx, ty),
+                                    ))
+                                }
                                 _ => None,
                             })
                             .transpose()?;

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1053,8 +1053,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let pred = bound_predicate.rebind(pred);
                         // `<Foo as Iterator>::Item = String`.
                         let projection_term = pred.skip_binder().projection_term;
-                        let quiet_projection_term =
-                            projection_term.with_self_ty(tcx, Ty::new_var(tcx, ty::TyVid::ZERO));
+                        let quiet_projection_term = projection_term
+                            .with_replaced_self_ty(tcx, Ty::new_var(tcx, ty::TyVid::ZERO));
 
                         let term = pred.skip_binder().term;
 
@@ -2157,7 +2157,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     self.tcx,
                                     self.fresh_args_for_item(sugg_span, impl_did),
                                 )
-                                .with_self_ty(self.tcx, rcvr_ty),
+                                .with_replaced_self_ty(self.tcx, rcvr_ty),
                             idx,
                             sugg_span,
                             item,
@@ -2196,7 +2196,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 trait_did,
                                 self.fresh_args_for_item(sugg_span, trait_did),
                             )
-                            .with_self_ty(self.tcx, rcvr_ty),
+                            .with_replaced_self_ty(self.tcx, rcvr_ty),
                             idx,
                             sugg_span,
                             item,

--- a/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
+++ b/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
@@ -151,7 +151,7 @@ impl<'tcx> TypeckRootCtxt<'tcx> {
                 obligation.predicate.kind().rebind(
                     // (*) binder moved here
                     ty::PredicateKind::Clause(ty::ClauseKind::Trait(
-                        tpred.with_self_ty(self.tcx, new_self_ty),
+                        tpred.with_replaced_self_ty(self.tcx, new_self_ty),
                     )),
                 ),
             );

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -50,7 +50,7 @@ where
 
     fn trait_ref(self, cx: I) -> ty::TraitRef<I>;
 
-    fn with_self_ty(self, cx: I, self_ty: I::Ty) -> Self;
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self;
 
     fn trait_def_id(self, cx: I) -> I::DefId;
 
@@ -376,8 +376,8 @@ where
             return self.forced_ambiguity(MaybeCause::Ambiguity).into_iter().collect();
         }
 
-        let goal: Goal<I, G> =
-            goal.with(self.cx(), goal.predicate.with_self_ty(self.cx(), normalized_self_ty));
+        let goal: Goal<I, G> = goal
+            .with(self.cx(), goal.predicate.with_replaced_self_ty(self.cx(), normalized_self_ty));
         // Vars that show up in the rest of the goal substs may have been constrained by
         // normalizing the self type as well, since type variables are not uniquified.
         let goal = self.resolve_vars_if_possible(goal);

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -29,8 +29,8 @@ where
         self.trait_ref
     }
 
-    fn with_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
-        self.with_self_ty(cx, self_ty)
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
+        self.with_replaced_self_ty(cx, self_ty)
     }
 
     fn trait_def_id(self, _: I) -> I::DefId {

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -99,8 +99,8 @@ where
         self.alias.trait_ref(cx)
     }
 
-    fn with_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
-        self.with_self_ty(cx, self_ty)
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
+        self.with_replaced_self_ty(cx, self_ty)
     }
 
     fn trait_def_id(self, cx: I) -> I::DefId {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -33,8 +33,8 @@ where
         self.trait_ref
     }
 
-    fn with_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
-        self.with_self_ty(cx, self_ty)
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
+        self.with_replaced_self_ty(cx, self_ty)
     }
 
     fn trait_def_id(self, _: I) -> I::DefId {
@@ -1263,7 +1263,9 @@ where
             let goals =
                 ecx.enter_forall(constituent_tys(ecx, goal.predicate.self_ty())?, |ecx, tys| {
                     tys.into_iter()
-                        .map(|ty| goal.with(ecx.cx(), goal.predicate.with_self_ty(ecx.cx(), ty)))
+                        .map(|ty| {
+                            goal.with(ecx.cx(), goal.predicate.with_replaced_self_ty(ecx.cx(), ty))
+                        })
                         .collect::<Vec<_>>()
                 });
             ecx.add_goals(GoalSource::ImplWhereBound, goals);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -581,7 +581,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let trait_args = trait_ref
             .instantiate_identity()
             // Replace the explicit self type with `Self` for better suggestion rendering
-            .with_self_ty(self.tcx, Ty::new_param(self.tcx, 0, kw::SelfUpper))
+            .with_replaced_self_ty(self.tcx, Ty::new_param(self.tcx, 0, kw::SelfUpper))
             .args;
         let trait_item_args = ty::GenericArgs::identity_for_item(self.tcx, impl_item_def_id)
             .rebase_onto(self.tcx, impl_def_id, trait_args);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -512,7 +512,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             && self.fallback_has_occurred
                         {
                             let predicate = leaf_trait_predicate.map_bound(|trait_pred| {
-                                trait_pred.with_self_ty(self.tcx, tcx.types.unit)
+                                trait_pred.with_replaced_self_ty(self.tcx, tcx.types.unit)
                             });
                             let unit_obligation = obligation.with(tcx, predicate);
                             if self.predicate_may_hold(&unit_obligation) {
@@ -2364,8 +2364,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         trait_ref_and_ty: ty::Binder<'tcx, (ty::TraitPredicate<'tcx>, Ty<'tcx>)>,
     ) -> PredicateObligation<'tcx> {
-        let trait_pred =
-            trait_ref_and_ty.map_bound(|(tr, new_self_ty)| tr.with_self_ty(self.tcx, new_self_ty));
+        let trait_pred = trait_ref_and_ty
+            .map_bound(|(tr, new_self_ty)| tr.with_replaced_self_ty(self.tcx, new_self_ty));
 
         Obligation::new(self.tcx, ObligationCause::dummy(), param_env, trait_pred)
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3942,7 +3942,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             if let hir::Expr { kind: hir::ExprKind::MethodCall(_, rcvr, _, _), .. } = expr
                 && let Some(ty) = typeck_results.node_type_opt(rcvr.hir_id)
                 && let Some(failed_pred) = failed_pred.as_trait_clause()
-                && let pred = failed_pred.map_bound(|pred| pred.with_self_ty(tcx, ty))
+                && let pred = failed_pred.map_bound(|pred| pred.with_replaced_self_ty(tcx, ty))
                 && self.predicate_must_hold_modulo_regions(&Obligation::misc(
                     tcx, expr.span, body_id, param_env, pred,
                 ))
@@ -4624,9 +4624,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let Some(root_pred) = root_obligation.predicate.as_trait_clause() else { return };
 
         let trait_ref = root_pred.map_bound(|root_pred| {
-            root_pred
-                .trait_ref
-                .with_self_ty(self.tcx, Ty::new_tup(self.tcx, &[root_pred.trait_ref.self_ty()]))
+            root_pred.trait_ref.with_replaced_self_ty(
+                self.tcx,
+                Ty::new_tup(self.tcx, &[root_pred.trait_ref.self_ty()]),
+            )
         });
 
         let obligation =

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -97,7 +97,7 @@ impl<I: Interner> TraitRef<I> {
         )
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         TraitRef::new(
             interner,
             self.def_id,
@@ -146,8 +146,11 @@ pub struct TraitPredicate<I: Interner> {
 }
 
 impl<I: Interner> TraitPredicate<I> {
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
-        Self { trait_ref: self.trait_ref.with_self_ty(interner, self_ty), polarity: self.polarity }
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
+        Self {
+            trait_ref: self.trait_ref.with_replaced_self_ty(interner, self_ty),
+            polarity: self.polarity,
+        }
     }
 
     pub fn def_id(self) -> I::DefId {
@@ -645,7 +648,7 @@ impl<I: Interner> AliasTerm<I> {
         self.args.type_at(0)
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         AliasTerm::new(
             interner,
             self.def_id,
@@ -756,8 +759,11 @@ impl<I: Interner> ProjectionPredicate<I> {
         self.projection_term.self_ty()
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
-        Self { projection_term: self.projection_term.with_self_ty(interner, self_ty), ..self }
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
+        Self {
+            projection_term: self.projection_term.with_replaced_self_ty(interner, self_ty),
+            ..self
+        }
     }
 
     pub fn trait_def_id(self, interner: I) -> I::DefId {
@@ -814,8 +820,8 @@ impl<I: Interner> NormalizesTo<I> {
         self.alias.self_ty()
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> NormalizesTo<I> {
-        Self { alias: self.alias.with_self_ty(interner, self_ty), ..self }
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> NormalizesTo<I> {
+        Self { alias: self.alias.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
     pub fn trait_def_id(self, interner: I) -> I::DefId {
@@ -849,8 +855,8 @@ impl<I: Interner> HostEffectPredicate<I> {
         self.trait_ref.self_ty()
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
-        Self { trait_ref: self.trait_ref.with_self_ty(interner, self_ty), ..self }
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
+        Self { trait_ref: self.trait_ref.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
     pub fn def_id(self) -> I::DefId {

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -475,7 +475,7 @@ impl<I: Interner> AliasTy<I> {
         self.args.type_at(0)
     }
 
-    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         AliasTy::new(
             interner,
             self.def_id,

--- a/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -417,7 +417,7 @@ fn replace_types<'tcx>(
                 {
                     let projection = projection_predicate
                         .projection_term
-                        .with_self_ty(cx.tcx, new_ty)
+                        .with_replaced_self_ty(cx.tcx, new_ty)
                         .expect_ty(cx.tcx)
                         .to_ty(cx.tcx);
 

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.rs
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: -Copt-level=0 -Zmir-opt-level=1 -Cdebuginfo=limited
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+
+#[derive(PartialOrd, Ord, PartialEq, Eq)]
+pub struct MultiField(char, i16);
+
+// EMIT_MIR derived_ord_debug.{impl#0}-partial_cmp.PreCodegen.after.mir
+// EMIT_MIR derived_ord_debug.{impl#1}-cmp.PreCodegen.after.mir
+
+// CHECK-LABEL: partial_cmp(_1: &MultiField, _2: &MultiField) -> Option<std::cmp::Ordering>
+// CHECK: = <char as PartialOrd>::partial_cmp(
+// CHECK: = <i16 as PartialOrd>::partial_cmp(
+
+// CHECK-LABEL: cmp(_1: &MultiField, _2: &MultiField) -> std::cmp::Ordering
+// CHECK: = <char as Ord>::cmp(
+// CHECK: = <i16 as Ord>::cmp(

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#0}-partial_cmp.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#0}-partial_cmp.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,52 @@
+// MIR for `<impl at $DIR/derived_ord_debug.rs:6:10: 6:20>::partial_cmp` after PreCodegen
+
+fn <impl at $DIR/derived_ord_debug.rs:6:10: 6:20>::partial_cmp(_1: &MultiField, _2: &MultiField) -> Option<std::cmp::Ordering> {
+    debug self => _1;
+    debug other => _2;
+    let mut _0: std::option::Option<std::cmp::Ordering>;
+    let _3: &char;
+    let _4: &char;
+    let mut _5: std::option::Option<std::cmp::Ordering>;
+    let mut _6: isize;
+    let mut _7: i8;
+    let _8: &i16;
+    let _9: &i16;
+    scope 1 {
+        debug cmp => _5;
+    }
+
+    bb0: {
+        _3 = &((*_1).0: char);
+        _4 = &((*_2).0: char);
+        _5 = <char as PartialOrd>::partial_cmp(copy _3, copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [1: bb2, 0: bb4, otherwise: bb6];
+    }
+
+    bb2: {
+        _7 = discriminant(((_5 as Some).0: std::cmp::Ordering));
+        switchInt(move _7) -> [0: bb3, otherwise: bb4];
+    }
+
+    bb3: {
+        _8 = &((*_1).1: i16);
+        _9 = &((*_2).1: i16);
+        _0 = <i16 as PartialOrd>::partial_cmp(copy _8, copy _9) -> [return: bb5, unwind unreachable];
+    }
+
+    bb4: {
+        _0 = copy _5;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+
+    bb6: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#0}-partial_cmp.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#0}-partial_cmp.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,52 @@
+// MIR for `<impl at $DIR/derived_ord_debug.rs:6:10: 6:20>::partial_cmp` after PreCodegen
+
+fn <impl at $DIR/derived_ord_debug.rs:6:10: 6:20>::partial_cmp(_1: &MultiField, _2: &MultiField) -> Option<std::cmp::Ordering> {
+    debug self => _1;
+    debug other => _2;
+    let mut _0: std::option::Option<std::cmp::Ordering>;
+    let _3: &char;
+    let _4: &char;
+    let mut _5: std::option::Option<std::cmp::Ordering>;
+    let mut _6: isize;
+    let mut _7: i8;
+    let _8: &i16;
+    let _9: &i16;
+    scope 1 {
+        debug cmp => _5;
+    }
+
+    bb0: {
+        _3 = &((*_1).0: char);
+        _4 = &((*_2).0: char);
+        _5 = <char as PartialOrd>::partial_cmp(copy _3, copy _4) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [1: bb2, 0: bb4, otherwise: bb6];
+    }
+
+    bb2: {
+        _7 = discriminant(((_5 as Some).0: std::cmp::Ordering));
+        switchInt(move _7) -> [0: bb3, otherwise: bb4];
+    }
+
+    bb3: {
+        _8 = &((*_1).1: i16);
+        _9 = &((*_2).1: i16);
+        _0 = <i16 as PartialOrd>::partial_cmp(copy _8, copy _9) -> [return: bb5, unwind continue];
+    }
+
+    bb4: {
+        _0 = copy _5;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+
+    bb6: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#1}-cmp.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#1}-cmp.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,42 @@
+// MIR for `<impl at $DIR/derived_ord_debug.rs:6:22: 6:25>::cmp` after PreCodegen
+
+fn <impl at $DIR/derived_ord_debug.rs:6:22: 6:25>::cmp(_1: &MultiField, _2: &MultiField) -> std::cmp::Ordering {
+    debug self => _1;
+    debug other => _2;
+    let mut _0: std::cmp::Ordering;
+    let _3: &char;
+    let _4: &char;
+    let mut _5: std::cmp::Ordering;
+    let mut _6: i8;
+    let _7: &i16;
+    let _8: &i16;
+    scope 1 {
+        debug cmp => _5;
+    }
+
+    bb0: {
+        _3 = &((*_1).0: char);
+        _4 = &((*_2).0: char);
+        _5 = <char as Ord>::cmp(copy _3, copy _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _7 = &((*_1).1: i16);
+        _8 = &((*_2).1: i16);
+        _0 = <i16 as Ord>::cmp(copy _7, copy _8) -> [return: bb4, unwind unreachable];
+    }
+
+    bb3: {
+        _0 = copy _5;
+        goto -> bb4;
+    }
+
+    bb4: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#1}-cmp.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/derived_ord_debug.{impl#1}-cmp.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,42 @@
+// MIR for `<impl at $DIR/derived_ord_debug.rs:6:22: 6:25>::cmp` after PreCodegen
+
+fn <impl at $DIR/derived_ord_debug.rs:6:22: 6:25>::cmp(_1: &MultiField, _2: &MultiField) -> std::cmp::Ordering {
+    debug self => _1;
+    debug other => _2;
+    let mut _0: std::cmp::Ordering;
+    let _3: &char;
+    let _4: &char;
+    let mut _5: std::cmp::Ordering;
+    let mut _6: i8;
+    let _7: &i16;
+    let _8: &i16;
+    scope 1 {
+        debug cmp => _5;
+    }
+
+    bb0: {
+        _3 = &((*_1).0: char);
+        _4 = &((*_2).0: char);
+        _5 = <char as Ord>::cmp(copy _3, copy _4) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(move _6) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _7 = &((*_1).1: i16);
+        _8 = &((*_2).1: i16);
+        _0 = <i16 as Ord>::cmp(copy _7, copy _8) -> [return: bb4, unwind continue];
+    }
+
+    bb3: {
+        _0 = copy _5;
+        goto -> bb4;
+    }
+
+    bb4: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_direct.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_direct.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,37 @@
+// MIR for `option_direct` after PreCodegen
+
+fn option_direct(_1: Option<u32>) -> Option<u32> {
+    debug x => _1;
+    let mut _0: std::option::Option<u32>;
+    let mut _2: isize;
+    let _3: u32;
+    let mut _4: u32;
+    scope 1 {
+        debug x => _3;
+    }
+
+    bb0: {
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+    }
+
+    bb1: {
+        _0 = Option::<u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        _3 = copy ((_1 as Some).0: u32);
+        _4 = Not(copy _3);
+        _0 = Option::<u32>::Some(move _4);
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+
+    bb4: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_direct.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_direct.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,37 @@
+// MIR for `option_direct` after PreCodegen
+
+fn option_direct(_1: Option<u32>) -> Option<u32> {
+    debug x => _1;
+    let mut _0: std::option::Option<u32>;
+    let mut _2: isize;
+    let _3: u32;
+    let mut _4: u32;
+    scope 1 {
+        debug x => _3;
+    }
+
+    bb0: {
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+    }
+
+    bb1: {
+        _0 = Option::<u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        _3 = copy ((_1 as Some).0: u32);
+        _4 = Not(copy _3);
+        _0 = Option::<u32>::Some(move _4);
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+
+    bb4: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,47 @@
+// MIR for `option_traits` after PreCodegen
+
+fn option_traits(_1: Option<u32>) -> Option<u32> {
+    debug x => _1;
+    let mut _0: std::option::Option<u32>;
+    let mut _2: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>;
+    let mut _3: isize;
+    let _4: u32;
+    let mut _5: u32;
+    scope 1 {
+        debug residual => const Option::<Infallible>::None;
+        scope 2 {
+        }
+    }
+    scope 3 {
+        debug val => _4;
+        scope 4 {
+        }
+    }
+
+    bb0: {
+        _2 = <Option<u32> as Try>::branch(copy _1) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _3 = discriminant(_2);
+        switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb5];
+    }
+
+    bb2: {
+        _4 = copy ((_2 as Continue).0: u32);
+        _5 = Not(copy _4);
+        _0 = <Option<u32> as Try>::from_output(move _5) -> [return: bb4, unwind unreachable];
+    }
+
+    bb3: {
+        _0 = <Option<u32> as FromResidual<Option<Infallible>>>::from_residual(const Option::<Infallible>::None) -> [return: bb4, unwind unreachable];
+    }
+
+    bb4: {
+        return;
+    }
+
+    bb5: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,47 @@
+// MIR for `option_traits` after PreCodegen
+
+fn option_traits(_1: Option<u32>) -> Option<u32> {
+    debug x => _1;
+    let mut _0: std::option::Option<u32>;
+    let mut _2: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, u32>;
+    let mut _3: isize;
+    let _4: u32;
+    let mut _5: u32;
+    scope 1 {
+        debug residual => const Option::<Infallible>::None;
+        scope 2 {
+        }
+    }
+    scope 3 {
+        debug val => _4;
+        scope 4 {
+        }
+    }
+
+    bb0: {
+        _2 = <Option<u32> as Try>::branch(copy _1) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        _3 = discriminant(_2);
+        switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb5];
+    }
+
+    bb2: {
+        _4 = copy ((_2 as Continue).0: u32);
+        _5 = Not(copy _4);
+        _0 = <Option<u32> as Try>::from_output(move _5) -> [return: bb4, unwind continue];
+    }
+
+    bb3: {
+        _0 = <Option<u32> as FromResidual<Option<Infallible>>>::from_residual(const Option::<Infallible>::None) -> [return: bb4, unwind continue];
+    }
+
+    bb4: {
+        return;
+    }
+
+    bb5: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.rs
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.rs
@@ -1,0 +1,29 @@
+//@ compile-flags: -Copt-level=0 -Zmir-opt-level=1 -Cdebuginfo=limited
+//@ edition: 2024
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+#![feature(try_blocks)]
+
+// EMIT_MIR option_bubble_debug.option_direct.PreCodegen.after.mir
+pub fn option_direct(x: Option<u32>) -> Option<u32> {
+    // CHECK-LABEL: fn option_direct(_1: Option<u32>) -> Option<u32>
+    // CHECK: = discriminant(_1);
+    // CHECK: [[TEMP:_.+]] = Not({{.+}});
+    // CHECK: _0 = Option::<u32>::Some(move [[TEMP]]);
+
+    match x {
+        Some(x) => Some(!x),
+        None => None,
+    }
+}
+
+// EMIT_MIR option_bubble_debug.option_traits.PreCodegen.after.mir
+pub fn option_traits(x: Option<u32>) -> Option<u32> {
+    // CHECK-LABEL: fn option_traits(_1: Option<u32>) -> Option<u32>
+    // CHECK: = <Option<u32> as Try>::branch(copy _1)
+    // CHECK: [[TEMP:_.+]] = Not({{.+}});
+    // CHECK: _0 = <Option<u32> as Try>::from_output(move [[TEMP]])
+
+    try { !(x?) }
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#144694 (Distinguish prepending and replacing self ty in predicates)
 - rust-lang/rust#144875 (Add some pre-codegen MIR tests for debug mode)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=144694,144875)
<!-- homu-ignore:end -->