### PR TITLE
Remove impl `PinCoerceUnsized` for `Pin`

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1759,9 +1759,6 @@ unsafe impl<'a, T: ?Sized> PinCoerceUnsized for &'a T {}
 unsafe impl<'a, T: ?Sized> PinCoerceUnsized for &'a mut T {}
 
 #[stable(feature = "pin", since = "1.33.0")]
-unsafe impl<T: PinCoerceUnsized> PinCoerceUnsized for Pin<T> {}
-
-#[stable(feature = "pin", since = "1.33.0")]
 unsafe impl<T: ?Sized> PinCoerceUnsized for *const T {}
 
 #[stable(feature = "pin", since = "1.33.0")]

--- a/library/coretests/tests/pin.rs
+++ b/library/coretests/tests/pin.rs
@@ -77,7 +77,4 @@ mod pin_coerce_unsized {
     pub fn pin_non_null(arg: Pin<NonNull<String>>) -> Pin<NonNull<dyn MyTrait>> {
         arg
     }
-    pub fn nesting_pins(arg: Pin<Pin<&String>>) -> Pin<Pin<&dyn MyTrait>> {
-        arg
-    }
 }

--- a/tests/ui/self/arbitrary_self_types_stdlib_pointers.rs
+++ b/tests/ui/self/arbitrary_self_types_stdlib_pointers.rs
@@ -13,7 +13,6 @@ trait Trait {
     fn by_arc(self: Arc<Self>) -> i64;
     fn by_pin_mut(self: Pin<&mut Self>) -> i64;
     fn by_pin_box(self: Pin<Box<Self>>) -> i64;
-    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64;
 }
 
 impl Trait for i64 {
@@ -27,9 +26,6 @@ impl Trait for i64 {
         *self
     }
     fn by_pin_box(self: Pin<Box<Self>>) -> i64 {
-        *self
-    }
-    fn by_pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> i64 {
         *self
     }
 }
@@ -47,8 +43,4 @@ fn main() {
 
     let pin_box = Into::<Pin<Box<i64>>>::into(Box::new(4i64)) as Pin<Box<dyn Trait>>;
     assert_eq!(4, pin_box.by_pin_box());
-
-    let value = 5i64;
-    let pin_pin_pin_ref = Pin::new(Pin::new(Pin::new(&value))) as Pin<Pin<Pin<&dyn Trait>>>;
-    assert_eq!(5, pin_pin_pin_ref.by_pin_pin_pin_ref());
 }

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
@@ -1,5 +1,4 @@
-//@ check-pass
-//@ known-bug: #85099
+//@ check-fail
 
 // Should fail. Can coerce `Pin<T>` into `Pin<U>` where
 // `T: Deref<Target: Unpin>` and `U: Deref<Target: !Unpin>`, using the
@@ -59,6 +58,8 @@ pub fn unsound_pin<Fut: Future<Output = ()>>(
     let s: &SomeLocalStruct<'_, Fut> = &SomeLocalStruct(&cell);
     let p: Pin<Pin<&SomeLocalStruct<'_, Fut>>> = Pin::new(Pin::new(s));
     let mut p: Pin<Pin<&dyn SomeTrait<'_, Fut>>> = p;
+    //~^ ERROR: the trait bound `Pin<&SomeLocalStruct<'_, Fut>>: PinCoerceUnsized` is not satisfied [E0277]
+    //~| ERROR: the trait bound `Pin<&dyn SomeTrait<'_, Fut>>: PinCoerceUnsized` is not satisfied [E0277]
     let r: Pin<&mut dyn SomeTrait<'_, Fut>> = p.as_mut();
     let f: Pin<&mut Fut> = r.downcast();
     callback(f);

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `Pin<&SomeLocalStruct<'_, Fut>>: PinCoerceUnsized` is not satisfied
+  --> $DIR/pin-unsound-issue-85099-derefmut.rs:60:52
+   |
+LL |     let mut p: Pin<Pin<&dyn SomeTrait<'_, Fut>>> = p;
+   |                                                    ^ the trait `PinCoerceUnsized` is not implemented for `Pin<&SomeLocalStruct<'_, Fut>>`
+   |
+   = help: the following other types implement trait `PinCoerceUnsized`:
+             &'a T
+             &'a mut T
+             *const T
+             *mut T
+             Arc<T, A>
+             Box<T, A>
+             Cell<T>
+             NonNull<T>
+           and 11 others
+   = note: required for the cast from `Pin<Pin<&SomeLocalStruct<'_, Fut>>>` to `Pin<Pin<&dyn SomeTrait<'_, Fut>>>`
+
+error[E0277]: the trait bound `Pin<&dyn SomeTrait<'_, Fut>>: PinCoerceUnsized` is not satisfied
+  --> $DIR/pin-unsound-issue-85099-derefmut.rs:60:52
+   |
+LL |     let mut p: Pin<Pin<&dyn SomeTrait<'_, Fut>>> = p;
+   |                                                    ^ the trait `PinCoerceUnsized` is not implemented for `Pin<&dyn SomeTrait<'_, Fut>>`
+   |
+   = help: the following other types implement trait `PinCoerceUnsized`:
+             &'a T
+             &'a mut T
+             *const T
+             *mut T
+             Arc<T, A>
+             Box<T, A>
+             Cell<T>
+             NonNull<T>
+           and 11 others
+   = note: required for the cast from `Pin<Pin<&SomeLocalStruct<'_, Fut>>>` to `Pin<Pin<&dyn SomeTrait<'_, Fut>>>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
The safety requirements for [`PinCoerceUnsized`](https://doc.rust-lang.org/stable/std/pin/trait.PinCoerceUnsized.html) are essentially that the type does not have a malicious `Deref` or `DerefMut` impl. However, the `Pin` type is fundamental, so the end-user can provide their own implementation of `DerefMut` for `Pin<&SomeLocalType>`, so it's possible for `Pin` to have a malicious `DerefMut` impl.

Thus, remove the unsound implementation of `PinCoerceUnsized` for the `Pin` type.

This PR is a breaking change, but it fixes rust-lang/rust#85099.
