### PR TITLE
print raw lifetime idents with r#

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -7,6 +7,7 @@ pub use NtPatKind::*;
 pub use TokenKind::*;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::edition::Edition;
+use rustc_span::symbol::IdentPrintMode;
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, kw, sym};
 #[allow(clippy::useless_attribute)] // FIXME: following use of `hidden_glob_reexports` incorrectly triggers `useless_attribute` lint.
 #[allow(hidden_glob_reexports)]
@@ -344,15 +345,24 @@ pub enum IdentIsRaw {
     Yes,
 }
 
-impl From<bool> for IdentIsRaw {
-    fn from(b: bool) -> Self {
-        if b { Self::Yes } else { Self::No }
+impl IdentIsRaw {
+    pub fn to_print_mode_ident(self) -> IdentPrintMode {
+        match self {
+            IdentIsRaw::No => IdentPrintMode::Normal,
+            IdentIsRaw::Yes => IdentPrintMode::RawIdent,
+        }
+    }
+    pub fn to_print_mode_lifetime(self) -> IdentPrintMode {
+        match self {
+            IdentIsRaw::No => IdentPrintMode::Normal,
+            IdentIsRaw::Yes => IdentPrintMode::RawLifetime,
+        }
     }
 }
 
-impl From<IdentIsRaw> for bool {
-    fn from(is_raw: IdentIsRaw) -> bool {
-        matches!(is_raw, IdentIsRaw::Yes)
+impl From<bool> for IdentIsRaw {
+    fn from(b: bool) -> Self {
+        if b { Self::Yes } else { Self::No }
     }
 }
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -250,12 +250,14 @@ impl FromInternal<(TokenStream, &mut Rustc<'_, '_>)> for Vec<TokenTree<TokenStre
                 Question => op("?"),
                 SingleQuote => op("'"),
 
-                Ident(sym, is_raw) => {
-                    trees.push(TokenTree::Ident(Ident { sym, is_raw: is_raw.into(), span }))
-                }
+                Ident(sym, is_raw) => trees.push(TokenTree::Ident(Ident {
+                    sym,
+                    is_raw: matches!(is_raw, IdentIsRaw::Yes),
+                    span,
+                })),
                 NtIdent(ident, is_raw) => trees.push(TokenTree::Ident(Ident {
                     sym: ident.name,
-                    is_raw: is_raw.into(),
+                    is_raw: matches!(is_raw, IdentIsRaw::Yes),
                     span: ident.span,
                 })),
 
@@ -263,7 +265,11 @@ impl FromInternal<(TokenStream, &mut Rustc<'_, '_>)> for Vec<TokenTree<TokenStre
                     let ident = rustc_span::Ident::new(name, span).without_first_quote();
                     trees.extend([
                         TokenTree::Punct(Punct { ch: b'\'', joint: true, span }),
-                        TokenTree::Ident(Ident { sym: ident.name, is_raw: is_raw.into(), span }),
+                        TokenTree::Ident(Ident {
+                            sym: ident.name,
+                            is_raw: matches!(is_raw, IdentIsRaw::Yes),
+                            span,
+                        }),
                     ]);
                 }
                 NtLifetime(ident, is_raw) => {

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -468,9 +468,6 @@ parse_invalid_dyn_keyword = invalid `dyn` keyword
 parse_invalid_expression_in_let_else = a `{$operator}` expression cannot be directly assigned in `let...else`
 parse_invalid_identifier_with_leading_number = identifiers cannot start with a number
 
-parse_invalid_label =
-    invalid label name `{$name}`
-
 parse_invalid_literal_suffix_on_tuple_index = suffixes on a tuple index are invalid
     .label = invalid suffix `{$suffix}`
     .tuple_exception_line_1 = `{$suffix}` is *temporarily* accepted on tuple index fields as it was incorrectly accepted on stable for a few releases
@@ -499,6 +496,8 @@ parse_invalid_unicode_escape = invalid unicode character escape
 
 parse_invalid_variable_declaration =
     invalid variable declaration
+
+parse_keyword_label = labels cannot use keyword names
 
 parse_keyword_lifetime =
     lifetimes cannot use keyword names

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2228,11 +2228,10 @@ pub(crate) struct KeywordLifetime {
 }
 
 #[derive(Diagnostic)]
-#[diag(parse_invalid_label)]
-pub(crate) struct InvalidLabel {
+#[diag(parse_keyword_label)]
+pub(crate) struct KeywordLabel {
     #[primary_span]
     pub span: Span,
-    pub name: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2232,7 +2232,7 @@ pub(crate) struct KeywordLifetime {
 pub(crate) struct InvalidLabel {
     #[primary_span]
     pub span: Span,
-    pub name: Symbol,
+    pub name: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3094,13 +3094,7 @@ impl<'a> Parser<'a> {
         if let Some((ident, is_raw)) = self.token.lifetime() {
             // Disallow `'fn`, but with a better error message than `expect_lifetime`.
             if matches!(is_raw, IdentIsRaw::No) && ident.without_first_quote().is_reserved() {
-                self.dcx().emit_err(errors::InvalidLabel {
-                    span: ident.span,
-                    // `IntoDiagArg` prints the symbol as if it was an ident,
-                    // so `'break` is printed as `r#break`. We don't want that
-                    // here so convert to string eagerly.
-                    name: ident.without_first_quote().name.to_string(),
-                });
+                self.dcx().emit_err(errors::KeywordLabel { span: ident.span });
             }
 
             self.bump();

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3094,7 +3094,13 @@ impl<'a> Parser<'a> {
         if let Some((ident, is_raw)) = self.token.lifetime() {
             // Disallow `'fn`, but with a better error message than `expect_lifetime`.
             if matches!(is_raw, IdentIsRaw::No) && ident.without_first_quote().is_reserved() {
-                self.dcx().emit_err(errors::InvalidLabel { span: ident.span, name: ident.name });
+                self.dcx().emit_err(errors::InvalidLabel {
+                    span: ident.span,
+                    // `IntoDiagArg` prints the symbol as if it was an ident,
+                    // so `'break` is printed as `r#break`. We don't want that
+                    // here so convert to string eagerly.
+                    name: ident.without_first_quote().name.to_string(),
+                });
             }
 
             self.bump();

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -1479,8 +1479,7 @@ impl<'a> Parser<'a> {
     pub(super) fn expect_lifetime(&mut self) -> Lifetime {
         if let Some((ident, is_raw)) = self.token.lifetime() {
             if matches!(is_raw, IdentIsRaw::No)
-                && ident.without_first_quote().is_reserved()
-                && ![kw::UnderscoreLifetime, kw::StaticLifetime].contains(&ident.name)
+                && ident.without_first_quote().is_reserved_lifetime()
             {
                 self.dcx().emit_err(errors::KeywordLifetime { span: ident.span });
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -3045,13 +3045,17 @@ impl Ident {
         self.name.can_be_raw() && self.is_reserved()
     }
 
+    /// Given the name of a lifetime without the first quote (`'`),
+    /// returns whether the lifetime name is reserved (therefore invalid)
+    pub fn is_reserved_lifetime(self) -> bool {
+        self.is_reserved() && ![kw::Underscore, kw::Static].contains(&self.name)
+    }
+
     pub fn is_raw_lifetime_guess(self) -> bool {
-        // this should be kept consistent with `Parser::expect_lifetime` found under
-        // compiler/rustc_parse/src/parser/ty.rs
         let name_without_apostrophe = self.without_first_quote();
         name_without_apostrophe.name != self.name
-            && ![kw::UnderscoreLifetime, kw::StaticLifetime].contains(&self.name)
-            && name_without_apostrophe.is_raw_guess()
+            && name_without_apostrophe.name.can_be_raw()
+            && name_without_apostrophe.is_reserved_lifetime()
     }
 
     pub fn guess_print_mode(self) -> IdentPrintMode {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2533,8 +2533,14 @@ impl fmt::Debug for Ident {
 /// except that AST identifiers don't keep the rawness flag, so we have to guess it.
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&IdentPrinter::new(self.name, self.is_raw_guess(), None), f)
+        fmt::Display::fmt(&IdentPrinter::new(self.name, self.guess_print_mode(), None), f)
     }
+}
+
+pub enum IdentPrintMode {
+    Normal,
+    RawIdent,
+    RawLifetime,
 }
 
 /// The most general type to print identifiers.
@@ -2552,7 +2558,7 @@ impl fmt::Display for Ident {
 /// done for a token stream or a single token.
 pub struct IdentPrinter {
     symbol: Symbol,
-    is_raw: bool,
+    mode: IdentPrintMode,
     /// Span used for retrieving the crate name to which `$crate` refers to,
     /// if this field is `None` then the `$crate` conversion doesn't happen.
     convert_dollar_crate: Option<Span>,
@@ -2560,32 +2566,51 @@ pub struct IdentPrinter {
 
 impl IdentPrinter {
     /// The most general `IdentPrinter` constructor. Do not use this.
-    pub fn new(symbol: Symbol, is_raw: bool, convert_dollar_crate: Option<Span>) -> IdentPrinter {
-        IdentPrinter { symbol, is_raw, convert_dollar_crate }
+    pub fn new(
+        symbol: Symbol,
+        mode: IdentPrintMode,
+        convert_dollar_crate: Option<Span>,
+    ) -> IdentPrinter {
+        IdentPrinter { symbol, mode, convert_dollar_crate }
     }
 
     /// This implementation is supposed to be used when printing identifiers
     /// as a part of pretty-printing for larger AST pieces.
     /// Do not use this either.
-    pub fn for_ast_ident(ident: Ident, is_raw: bool) -> IdentPrinter {
-        IdentPrinter::new(ident.name, is_raw, Some(ident.span))
+    pub fn for_ast_ident(ident: Ident, mode: IdentPrintMode) -> IdentPrinter {
+        IdentPrinter::new(ident.name, mode, Some(ident.span))
     }
 }
 
 impl fmt::Display for IdentPrinter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_raw {
-            f.write_str("r#")?;
-        } else if self.symbol == kw::DollarCrate {
-            if let Some(span) = self.convert_dollar_crate {
+        let s = match self.mode {
+            IdentPrintMode::Normal
+                if self.symbol == kw::DollarCrate
+                    && let Some(span) = self.convert_dollar_crate =>
+            {
                 let converted = span.ctxt().dollar_crate_name();
                 if !converted.is_path_segment_keyword() {
                     f.write_str("::")?;
                 }
-                return fmt::Display::fmt(&converted, f);
+                converted
             }
-        }
-        fmt::Display::fmt(&self.symbol, f)
+            IdentPrintMode::Normal => self.symbol,
+            IdentPrintMode::RawIdent => {
+                f.write_str("r#")?;
+                self.symbol
+            }
+            IdentPrintMode::RawLifetime => {
+                f.write_str("'r#")?;
+                let s = self
+                    .symbol
+                    .as_str()
+                    .strip_prefix("'")
+                    .expect("only lifetime idents should be passed with RawLifetime mode");
+                Symbol::intern(s)
+            }
+        };
+        s.fmt(f)
     }
 }
 
@@ -3018,6 +3043,25 @@ impl Ident {
     /// How was it written originally? Did it use the raw form? Let's try to guess.
     pub fn is_raw_guess(self) -> bool {
         self.name.can_be_raw() && self.is_reserved()
+    }
+
+    pub fn is_raw_lifetime_guess(self) -> bool {
+        // this should be kept consistent with `Parser::expect_lifetime` found under
+        // compiler/rustc_parse/src/parser/ty.rs
+        let name_without_apostrophe = self.without_first_quote();
+        name_without_apostrophe.name != self.name
+            && ![kw::UnderscoreLifetime, kw::StaticLifetime].contains(&self.name)
+            && name_without_apostrophe.is_raw_guess()
+    }
+
+    pub fn guess_print_mode(self) -> IdentPrintMode {
+        if self.is_raw_lifetime_guess() {
+            IdentPrintMode::RawLifetime
+        } else if self.is_raw_guess() {
+            IdentPrintMode::RawIdent
+        } else {
+            IdentPrintMode::Normal
+        }
     }
 
     /// Whether this would be the identifier for a tuple field like `self.0`, as

--- a/tests/ui/closures/issue-52437.rs
+++ b/tests/ui/closures/issue-52437.rs
@@ -1,5 +1,5 @@
 fn main() {
     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]
-    //~^ ERROR: invalid label name `'static`
+    //~^ ERROR: invalid label name `static`
     //~| ERROR: type annotations needed
 }

--- a/tests/ui/closures/issue-52437.rs
+++ b/tests/ui/closures/issue-52437.rs
@@ -1,5 +1,5 @@
 fn main() {
     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]
-    //~^ ERROR: invalid label name `static`
+    //~^ ERROR: labels cannot use keyword names
     //~| ERROR: type annotations needed
 }

--- a/tests/ui/closures/issue-52437.stderr
+++ b/tests/ui/closures/issue-52437.stderr
@@ -1,4 +1,4 @@
-error: invalid label name `static`
+error: labels cannot use keyword names
   --> $DIR/issue-52437.rs:2:13
    |
 LL |     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]

--- a/tests/ui/closures/issue-52437.stderr
+++ b/tests/ui/closures/issue-52437.stderr
@@ -1,4 +1,4 @@
-error: invalid label name `'static`
+error: invalid label name `static`
   --> $DIR/issue-52437.rs:2:13
    |
 LL |     [(); &(&'static: loop { |x| {}; }) as *const _ as usize]

--- a/tests/ui/issues/issue-46311.rs
+++ b/tests/ui/issues/issue-46311.rs
@@ -1,4 +1,4 @@
 fn main() {
-    'break: loop { //~ ERROR invalid label name `break`
+    'break: loop { //~ ERROR labels cannot use keyword names
     }
 }

--- a/tests/ui/issues/issue-46311.rs
+++ b/tests/ui/issues/issue-46311.rs
@@ -1,4 +1,4 @@
 fn main() {
-    'break: loop { //~ ERROR invalid label name `'break`
+    'break: loop { //~ ERROR invalid label name `break`
     }
 }

--- a/tests/ui/issues/issue-46311.stderr
+++ b/tests/ui/issues/issue-46311.stderr
@@ -1,4 +1,4 @@
-error: invalid label name `'break`
+error: invalid label name `break`
   --> $DIR/issue-46311.rs:2:5
    |
 LL |     'break: loop {

--- a/tests/ui/issues/issue-46311.stderr
+++ b/tests/ui/issues/issue-46311.stderr
@@ -1,4 +1,4 @@
-error: invalid label name `break`
+error: labels cannot use keyword names
   --> $DIR/issue-46311.rs:2:5
    |
 LL |     'break: loop {

--- a/tests/ui/label/label-static.rs
+++ b/tests/ui/label/label-static.rs
@@ -1,5 +1,5 @@
 fn main() {
-    'static: loop { //~ ERROR invalid label name `static`
-        break 'static //~ ERROR invalid label name `static`
+    'static: loop { //~ ERROR labels cannot use keyword names
+        break 'static //~ ERROR labels cannot use keyword names
     }
 }

--- a/tests/ui/label/label-static.rs
+++ b/tests/ui/label/label-static.rs
@@ -1,5 +1,5 @@
 fn main() {
-    'static: loop { //~ ERROR invalid label name `'static`
-        break 'static //~ ERROR invalid label name `'static`
+    'static: loop { //~ ERROR invalid label name `static`
+        break 'static //~ ERROR invalid label name `static`
     }
 }

--- a/tests/ui/label/label-static.stderr
+++ b/tests/ui/label/label-static.stderr
@@ -1,10 +1,10 @@
-error: invalid label name `'static`
+error: invalid label name `static`
   --> $DIR/label-static.rs:2:5
    |
 LL |     'static: loop {
    |     ^^^^^^^
 
-error: invalid label name `'static`
+error: invalid label name `static`
   --> $DIR/label-static.rs:3:15
    |
 LL |         break 'static

--- a/tests/ui/label/label-static.stderr
+++ b/tests/ui/label/label-static.stderr
@@ -1,10 +1,10 @@
-error: invalid label name `static`
+error: labels cannot use keyword names
   --> $DIR/label-static.rs:2:5
    |
 LL |     'static: loop {
    |     ^^^^^^^
 
-error: invalid label name `static`
+error: labels cannot use keyword names
   --> $DIR/label-static.rs:3:15
    |
 LL |         break 'static

--- a/tests/ui/label/label-underscore.rs
+++ b/tests/ui/label/label-underscore.rs
@@ -1,5 +1,5 @@
 fn main() {
-    '_: loop { //~ ERROR invalid label name `_`
-        break '_ //~ ERROR invalid label name `_`
+    '_: loop { //~ ERROR labels cannot use keyword names
+        break '_ //~ ERROR labels cannot use keyword names
     }
 }

--- a/tests/ui/label/label-underscore.rs
+++ b/tests/ui/label/label-underscore.rs
@@ -1,5 +1,5 @@
 fn main() {
-    '_: loop { //~ ERROR invalid label name `'_`
-        break '_ //~ ERROR invalid label name `'_`
+    '_: loop { //~ ERROR invalid label name `_`
+        break '_ //~ ERROR invalid label name `_`
     }
 }

--- a/tests/ui/label/label-underscore.stderr
+++ b/tests/ui/label/label-underscore.stderr
@@ -1,10 +1,10 @@
-error: invalid label name `'_`
+error: invalid label name `_`
   --> $DIR/label-underscore.rs:2:5
    |
 LL |     '_: loop {
    |     ^^
 
-error: invalid label name `'_`
+error: invalid label name `_`
   --> $DIR/label-underscore.rs:3:15
    |
 LL |         break '_

--- a/tests/ui/label/label-underscore.stderr
+++ b/tests/ui/label/label-underscore.stderr
@@ -1,10 +1,10 @@
-error: invalid label name `_`
+error: labels cannot use keyword names
   --> $DIR/label-underscore.rs:2:5
    |
 LL |     '_: loop {
    |     ^^
 
-error: invalid label name `_`
+error: labels cannot use keyword names
   --> $DIR/label-underscore.rs:3:15
    |
 LL |         break '_

--- a/tests/ui/lifetimes/raw/use-of-undeclared-raw-lifetimes.rs
+++ b/tests/ui/lifetimes/raw/use-of-undeclared-raw-lifetimes.rs
@@ -1,0 +1,21 @@
+// Check that we properly suggest `r#fn` if we use it undeclared.
+// https://github.com/rust-lang/rust/issues/143150
+//
+//@ edition: 2021
+
+fn a(_: dyn Trait + 'r#fn) {
+    //~^ ERROR use of undeclared lifetime name `'r#fn` [E0261]
+}
+
+trait Trait {}
+
+struct Test {
+    a: &'r#fn str,
+    //~^ ERROR use of undeclared lifetime name `'r#fn` [E0261]
+}
+
+trait Trait1<T>
+  where T: for<'a> Trait1<T> + 'r#fn { }
+//~^ ERROR use of undeclared lifetime name `'r#fn` [E0261]
+
+fn main() {}

--- a/tests/ui/lifetimes/raw/use-of-undeclared-raw-lifetimes.stderr
+++ b/tests/ui/lifetimes/raw/use-of-undeclared-raw-lifetimes.stderr
@@ -1,0 +1,42 @@
+error[E0261]: use of undeclared lifetime name `'r#fn`
+  --> $DIR/use-of-undeclared-raw-lifetimes.rs:6:21
+   |
+LL | fn a(_: dyn Trait + 'r#fn) {
+   |                     ^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'r#fn` here
+   |
+LL | fn a<'r#fn>(_: dyn Trait + 'r#fn) {
+   |     +++++++
+
+error[E0261]: use of undeclared lifetime name `'r#fn`
+  --> $DIR/use-of-undeclared-raw-lifetimes.rs:13:9
+   |
+LL |     a: &'r#fn str,
+   |         ^^^^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'r#fn` here
+   |
+LL | struct Test<'r#fn> {
+   |            +++++++
+
+error[E0261]: use of undeclared lifetime name `'r#fn`
+  --> $DIR/use-of-undeclared-raw-lifetimes.rs:18:32
+   |
+LL |   where T: for<'a> Trait1<T> + 'r#fn { }
+   |                                ^^^^^ undeclared lifetime
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'r#fn` lifetime
+   |
+LL -   where T: for<'a> Trait1<T> + 'r#fn { }
+LL +   where for<'r#fn, 'a> T: Trait1<T> + 'r#fn { }
+   |
+help: consider introducing lifetime `'r#fn` here
+   |
+LL | trait Trait1<'r#fn, T>
+   |              ++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/parser/require-parens-for-chained-comparison.rs
+++ b/tests/ui/parser/require-parens-for-chained-comparison.rs
@@ -24,14 +24,14 @@ fn main() {
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     //~| ERROR expected
     //~| HELP add `'` to close the char literal
-    //~| ERROR invalid label name
+    //~| ERROR labels cannot use keyword names
 
     f<'_>();
     //~^ ERROR comparison operators cannot be chained
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     //~| ERROR expected
     //~| HELP add `'` to close the char literal
-    //~| ERROR invalid label name
+    //~| ERROR labels cannot use keyword names
 
     let _ = f<u8>;
     //~^ ERROR comparison operators cannot be chained

--- a/tests/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/tests/ui/parser/require-parens-for-chained-comparison.stderr
@@ -53,7 +53,7 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<u8, i8>();
    |              ++
 
-error: invalid label name `_`
+error: labels cannot use keyword names
   --> $DIR/require-parens-for-chained-comparison.rs:22:15
    |
 LL |     let _ = f<'_, i8>();
@@ -81,7 +81,7 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<'_, i8>();
    |              ++
 
-error: invalid label name `_`
+error: labels cannot use keyword names
   --> $DIR/require-parens-for-chained-comparison.rs:29:7
    |
 LL |     f<'_>();

--- a/tests/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/tests/ui/parser/require-parens-for-chained-comparison.stderr
@@ -53,7 +53,7 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<u8, i8>();
    |              ++
 
-error: invalid label name `'_`
+error: invalid label name `_`
   --> $DIR/require-parens-for-chained-comparison.rs:22:15
    |
 LL |     let _ = f<'_, i8>();
@@ -81,7 +81,7 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<'_, i8>();
    |              ++
 
-error: invalid label name `'_`
+error: invalid label name `_`
   --> $DIR/require-parens-for-chained-comparison.rs:29:7
    |
 LL |     f<'_>();


### PR DESCRIPTION
This replaces rust-lang/rust#143185 and fixes rust-lang/rust#143150

cc @fmease 