### PR TITLE
Print CGU reuse statistics in `-Zprint-mono-items`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
+++ b/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
@@ -69,6 +69,15 @@ pub fn assert_module_sources(tcx: TyCtxt<'_>, set_reuse: &dyn Fn(&mut CguReuseTr
 
         set_reuse(&mut ams.cgu_reuse_tracker);
 
+        if tcx.sess.opts.unstable_opts.print_mono_items
+            && let Some(data) = &ams.cgu_reuse_tracker.data
+        {
+            data.actual_reuse.items().all(|(cgu, reuse)| {
+                println!("CGU_REUSE {cgu} {reuse}");
+                true
+            });
+        }
+
         ams.cgu_reuse_tracker.check_expected_reuse(tcx.sess);
     });
 }


### PR DESCRIPTION
I'm trying to expose more information about incremental profiling from rustc (https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Profiling.2Fanalysis.20of.20incremental.20builds/with/531383501). One of the things that would be quite useful to expose is the CGU reuse state, so that when you do a rebuild, you can see all the CGUs (and all the functions) that had to be recompiled.

Currently, we have (AFAIK) two ways of outputting monomorphization statistics:
1) `-Zdump-mono-stats` outputs statistics about number of instantiations and expected compilation cost of individual functions in the local crate being compiled. It can be outputted either as Markdown or JSON.
2) `-Zprint-mono-items` outputs a pair (item, CGU) for each monomorphized item.

I was thinking about recording CGU statistics in the self-profile output, but I realized that as a simpler step, we could just add CGU reuse data to `-Zprint-mono-items`, as an additional output. That is what this PR does.