### PR TITLE
Add new `test::print_merged_doctests_times` used by rustdoc to display more detailed time information

### DIFF
--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -215,6 +215,17 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
 
         Ok(state.failed == 0)
     }
+
+    fn write_merged_doctests_times(
+        &mut self,
+        total_time: f64,
+        compilation_time: f64,
+    ) -> io::Result<()> {
+        let newline = "\n";
+        self.writeln_message(&format!(
+            r#"{{ "type": "report", "total_time": {total_time}, "compilation_time": {compilation_time} }}{newline}"#,
+        ))
+    }
 }
 
 /// A formatting utility used to print strings with characters in need of escaping.

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -182,6 +182,16 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
 
         Ok(state.failed == 0)
     }
+
+    fn write_merged_doctests_times(
+        &mut self,
+        total_time: f64,
+        compilation_time: f64,
+    ) -> io::Result<()> {
+        self.write_message(&format!(
+            "<report total_time=\"{total_time}\" compilation_time=\"{compilation_time}\"></report>\n",
+        ))
+    }
 }
 
 fn parse_class_name(desc: &TestDesc) -> (String, String) {

--- a/library/test/src/formatters/mod.rs
+++ b/library/test/src/formatters/mod.rs
@@ -33,6 +33,11 @@ pub(crate) trait OutputFormatter {
         state: &ConsoleTestState,
     ) -> io::Result<()>;
     fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool>;
+    fn write_merged_doctests_times(
+        &mut self,
+        total_time: f64,
+        compilation_time: f64,
+    ) -> io::Result<()>;
 }
 
 pub(crate) fn write_stderr_delimiter(test_output: &mut Vec<u8>, test_name: &TestName) {

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -303,4 +303,14 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
 
         Ok(success)
     }
+
+    fn write_merged_doctests_times(
+        &mut self,
+        total_time: f64,
+        compilation_time: f64,
+    ) -> io::Result<()> {
+        self.write_plain(format!(
+            "all doctests ran in {total_time:.2}s; merged doctests compilation took {compilation_time:.2}s\n",
+        ))
+    }
 }

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -295,4 +295,14 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
 
         Ok(success)
     }
+
+    fn write_merged_doctests_times(
+        &mut self,
+        total_time: f64,
+        compilation_time: f64,
+    ) -> io::Result<()> {
+        self.write_plain(format!(
+            "all doctests ran in {total_time:.2}s; merged doctests compilation took {compilation_time:.2}s\n",
+        ))
+    }
 }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -244,6 +244,21 @@ fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {
     }
 }
 
+/// Public API used by rustdoc to display the `total` and `compilation` times in the expected
+/// format.
+pub fn print_merged_doctests_times(args: &[String], total_time: f64, compilation_time: f64) {
+    let opts = match cli::parse_opts(args) {
+        Some(Ok(o)) => o,
+        Some(Err(msg)) => {
+            eprintln!("error: {msg}");
+            process::exit(ERROR_EXIT_CODE);
+        }
+        None => return,
+    };
+    let mut formatter = console::get_formatter(&opts, 0);
+    formatter.write_merged_doctests_times(total_time, compilation_time).unwrap();
+}
+
 /// Invoked when unit tests terminate. Returns `Result::Err` if the test is
 /// considered a failure. By default, invokes `report()` and checks for a `0`
 /// result.


### PR DESCRIPTION
This PR is the first commit of https://github.com/rust-lang/rust/pull/144908. Sadly, it seems like we can't do all of it at once...

r? @Amanieu 