### PR TITLE
[rustdoc] Fix wrong `i` tooltip icon

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1838,6 +1838,10 @@ instead, we check that it's not a "finger" cursor.
 	border-right: 3px solid var(--target-border-color);
 }
 
+a.tooltip {
+	font-family: var(--font-family);
+}
+
 .code-header a.tooltip {
 	color: inherit;
 	margin-right: 15px;

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -8,10 +8,10 @@ define-function: (
     [x, i_x],
     block {
         // Checking they have the same y position.
-        compare-elements-position: (
+        compare-elements-position-near: (
             "//*[@id='method.create_an_iterator_from_read']//a[normalize-space()='NotableStructWithLongName']",
             "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']",
-            ["y"],
+            {"y": 1},
         )
         // Checking they don't have the same x position.
         compare-elements-position-false: (

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -767,3 +767,17 @@ pub mod impls_indent {
         pub fn bar() {}
     }
 }
+
+pub mod tooltips {
+    pub struct X;
+
+    impl X {
+        pub fn bar() -> Vec<u8> {
+            Vec::new()
+        }
+    }
+
+    pub fn bar() -> Vec<u8> {
+        Vec::new()
+    }
+}

--- a/tests/rustdoc-gui/tooltips.goml
+++ b/tests/rustdoc-gui/tooltips.goml
@@ -1,0 +1,15 @@
+// This test checks that the right font is applied to the `i` tooltip element.
+
+define-function: (
+    "check-font",
+    [path],
+    block {
+        go-to: "file://" + |DOC_PATH| + "/test_docs/" + |path|
+        assert-css: (
+            "a.tooltip", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'}, ALL,
+        )
+    }
+)
+
+call-function: ("check-font", {"path": "tooltips/fn.bar.html"})
+call-function: ("check-font", {"path": "tooltips/struct.X.html"})


### PR DESCRIPTION
Current wrong display:

<img width="334" height="37" alt="Screenshot From 2025-08-04 17-42-38" src="https://github.com/user-attachments/assets/57046475-6162-487f-998f-ebb2434c111d" />

With the fix:

<img width="334" height="37" alt="image" src="https://github.com/user-attachments/assets/e761a103-dc39-4e30-8c8e-cfc7fab52fde" />

r? @fmease 