### PR TITLE
Dont print arg span in MIR dump for tail call

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -970,11 +970,11 @@ impl<'tcx> TerminatorKind<'tcx> {
             Call { func, args, destination, .. } => {
                 write!(fmt, "{destination:?} = ")?;
                 write!(fmt, "{func:?}(")?;
-                for (index, arg) in args.iter().map(|a| &a.node).enumerate() {
+                for (index, arg) in args.iter().enumerate() {
                     if index > 0 {
                         write!(fmt, ", ")?;
                     }
-                    write!(fmt, "{arg:?}")?;
+                    write!(fmt, "{:?}", arg.node)?;
                 }
                 write!(fmt, ")")
             }
@@ -984,7 +984,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                     if index > 0 {
                         write!(fmt, ", ")?;
                     }
-                    write!(fmt, "{:?}", arg)?;
+                    write!(fmt, "{:?}", arg.node)?;
                 }
                 write!(fmt, ")")
             }

--- a/tests/mir-opt/building/custom/terminators.tail_call.built.after.mir
+++ b/tests/mir-opt/building/custom/terminators.tail_call.built.after.mir
@@ -6,6 +6,6 @@ fn tail_call(_1: i32) -> i32 {
 
     bb0: {
         _2 = Add(copy _1, const 42_i32);
-        tailcall ident::<i32>(Spanned { node: copy _2, span: $DIR/terminators.rs:32:28: 32:29 (#0) });
+        tailcall ident::<i32>(copy _2);
     }
 }

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -93,7 +93,7 @@
       }
   
       bb11: {
-          tailcall g_with_arg(Spanned { node: move _10, span: $DIR/tail_call_drops.rs:36:23: 36:36 (#0) }, Spanned { node: move _11, span: $DIR/tail_call_drops.rs:36:38: 36:51 (#0) });
+          tailcall g_with_arg(move _10, move _11);
       }
   
       bb12 (cleanup): {

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -93,7 +93,7 @@
       }
   
       bb11: {
-          tailcall g_with_arg(Spanned { node: move _10, span: $DIR/tail_call_drops.rs:36:23: 36:36 (#0) }, Spanned { node: move _11, span: $DIR/tail_call_drops.rs:36:38: 36:51 (#0) });
+          tailcall g_with_arg(move _10, move _11);
       }
   
       bb12 (cleanup): {

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
@@ -90,7 +90,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb11: {
-        tailcall g_with_arg(Spanned { node: move _10, span: $DIR/tail_call_drops.rs:36:23: 36:36 (#0) }, Spanned { node: move _11, span: $DIR/tail_call_drops.rs:36:38: 36:51 (#0) });
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb12: {

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
@@ -90,7 +90,7 @@ fn f_with_arg(_1: String, _2: String) -> () {
     }
 
     bb11: {
-        tailcall g_with_arg(Spanned { node: move _10, span: $DIR/tail_call_drops.rs:36:23: 36:36 (#0) }, Spanned { node: move _11, span: $DIR/tail_call_drops.rs:36:38: 36:51 (#0) });
+        tailcall g_with_arg(move _10, move _11);
     }
 
     bb12: {


### PR DESCRIPTION
r? WaffleLapkin

This makes the MIR dump for tail call terminators consistent w/ regular calls.