### PR TITLE
Don't emit `rustdoc::broken_intra_doc_links` for GitHub-flavored Markdown admonitions like `[!NOTE]`

### DIFF
--- a/tests/rustdoc-ui/intra-doc/github-flavored-admonitions.rs
+++ b/tests/rustdoc-ui/intra-doc/github-flavored-admonitions.rs
@@ -1,0 +1,6 @@
+// regression test for https://github.com/rust-lang/rust/issues/141866
+//@ check-pass
+#![deny(rustdoc::broken_intra_doc_links)]
+
+//! > [!NOTE]
+//! > This should not cause any warnings


### PR DESCRIPTION
fixes rust-lang/rust#141866

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
