### PR TITLE
Disable hashing on `effective_visibilities`

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1387,7 +1387,7 @@ rustc_queries! {
 
     /// Performs part of the privacy check and computes effective visibilities.
     query effective_visibilities(_: ()) -> &'tcx EffectiveVisibilities {
-        eval_always
+        no_hash
         desc { "checking effective visibilities" }
     }
     query check_private_in_public(module_def_id: LocalModDefId) {


### PR DESCRIPTION
Make `effective_visibilities` no_hash. We were wasting too much time on hashing the `FxIndexMap` (15 million instructions on `tokio` just for the hashing) so it was not worth it.