### PR TITLE
Drop `rust-version` from `rustc_thread_pool`

### DIFF
--- a/compiler/rustc_thread_pool/Cargo.toml
+++ b/compiler/rustc_thread_pool/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 description = "Core APIs for Rayon - fork for rustc"
 license = "MIT OR Apache-2.0"
-rust-version = "1.63"
 edition = "2021"
 readme = "README.md"
 keywords = ["parallel", "thread", "concurrency", "join", "performance"]


### PR DESCRIPTION
The current `rust-version = "1.63"` was inherited from rayon, but it
doesn't make sense to limit this in the compiler workspace. Having any
setting at all has effects on tools like `cargo info` that try to infer
the MSRV when the workspace itself doesn't specify it. Since we are the
compiler, our only MSRV is whatever bootstrapping requires.
