### PR TITLE
[EXPERIMENT] Avoid tracking span to compute `end_point`.

### DIFF
--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -911,7 +911,8 @@ impl SourceMap {
 
     /// Returns a new span representing just the last character of this span.
     pub fn end_point(&self, sp: Span) -> Span {
-        let sp = sp.data();
+        // We restrict the current span, so we cannot look around. Using the untracked data is ok.
+        let sp = sp.data_untracked();
         let pos = sp.hi.0;
 
         let width = self.find_width_of_character_at_span(sp, false);


### PR DESCRIPTION
This is probably unsound.

r? @ghost

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
