### PR TITLE
[win][arm64ec] Fix msvc-wholearchive for Arm64EC

### DIFF
--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::external_deps::c_build::{
 };
 // Re-exports of external dependencies.
 pub use crate::external_deps::c_cxx_compiler::{
-    Cc, Gcc, cc, cxx, extra_c_flags, extra_cxx_flags, gcc,
+    Cc, Gcc, cc, cxx, extra_c_flags, extra_cxx_flags, extra_linker_flags, gcc,
 };
 pub use crate::external_deps::cargo::cargo;
 pub use crate::external_deps::clang::{Clang, clang};
@@ -84,6 +84,6 @@ pub use crate::string::{
 };
 // Helpers for checking target information.
 pub use crate::targets::{
-    apple_os, is_aix, is_darwin, is_win7, is_windows, is_windows_gnu, is_windows_msvc,
+    apple_os, is_aix, is_arm64ec, is_darwin, is_win7, is_windows, is_windows_gnu, is_windows_msvc,
     llvm_components_contain, target, uname,
 };

--- a/src/tools/run-make-support/src/targets.rs
+++ b/src/tools/run-make-support/src/targets.rs
@@ -46,6 +46,12 @@ pub fn is_aix() -> bool {
     target().contains("aix")
 }
 
+/// Check if target is arm64ec.
+#[must_use]
+pub fn is_arm64ec() -> bool {
+    target().starts_with("arm64ec")
+}
+
 /// Get the target OS on Apple operating systems.
 #[must_use]
 pub fn apple_os() -> &'static str {

--- a/tests/run-make/msvc-wholearchive/rmake.rs
+++ b/tests/run-make/msvc-wholearchive/rmake.rs
@@ -7,7 +7,7 @@
 
 use std::path::PathBuf;
 
-use run_make_support::{cc, cmd, env_var, extra_c_flags, rustc};
+use run_make_support::{cc, cmd, env_var, extra_linker_flags, rustc};
 
 fn main() {
     // Build the staticlib
@@ -31,7 +31,7 @@ fn main() {
     // Otherwise the actual test failure may be caused by something else.
     cmd(&linker)
         .args(["c.obj", "./static.lib", "-dll", "-def:dll.def", "-out:dll.dll"])
-        .args(extra_c_flags())
+        .args(extra_linker_flags())
         .run();
 
     // FIXME(@ChrisDenton): this doesn't currently work with llvm's lld-link for other reasons.
@@ -46,7 +46,7 @@ fn main() {
                 "-def:dll.def",
                 "-out:dll_whole_archive.dll",
             ])
-            .args(extra_c_flags())
+            .args(extra_linker_flags())
             .run();
     }
 }


### PR DESCRIPTION
`msvc-wholearchive` was failing on Arm64EC Windows as it requires the `/MACHINE:ARM64EC` flag to be passed to the MSVC linker.

This required splitting the `extra_c_flags` function into a new `extra_linker_flags` function as `/MACHINE:ARM64EC` is not a valid argument to be passed to the MSVC Compiler (instead, `/arm64EC` should be used).