### PR TITLE
Allocate arguments from topmost frame into temporary storage before popping stack frame in `init_fn_tail_call`

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -205,6 +205,16 @@ impl<'tcx, Prov: Provenance> LocalState<'tcx, Prov> {
             LocalValue::Live(val) => interp_ok(val),
         }
     }
+
+    pub(super) fn is_allocation(&self) -> bool {
+        match self.value {
+            LocalValue::Dead => false,
+            LocalValue::Live(val) => match val {
+                Operand::Immediate(_) => false,
+                Operand::Indirect(_) => true,
+            },
+        }
+    }
 }
 
 /// What we store about a frame in an interpreter backtrace.

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -544,7 +544,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let EvaluatedCalleeAndArgs { callee, args, fn_sig, fn_abi, with_caller_location } =
                     self.eval_callee_and_args(terminator, func, args)?;
 
-                self.init_fn_tail_call(callee, (fn_sig.abi, fn_abi), &args, with_caller_location)?;
+                self.init_fn_tail_call(callee, (fn_sig.abi, fn_abi), args, with_caller_location)?;
 
                 if self.frame_idx() != old_frame_idx {
                     span_bug!(

--- a/src/tools/miri/tests/pass/tail_call_temp.rs
+++ b/src/tools/miri/tests/pass/tail_call_temp.rs
@@ -1,0 +1,12 @@
+#![feature(explicit_tail_calls)]
+#![expect(incomplete_features)]
+
+struct Wrapper(#[expect(unused)] usize);
+
+fn f(t: bool, x: Wrapper) {
+    if t { become f(false, x); }
+}
+
+fn main() {
+    f(true, Wrapper(5));
+}


### PR DESCRIPTION
When doing a tail call, we pop the topmost frame and then push a new frame to replace it. If we have an argument that is being passed indirectly from an mplace of a local from that *old* stack frame, then it will be invalidated before we can copy them into the locals of the new stack frame.

THis PR detects arguments that are being indirectly via pointers which point into the allocations of the topmost stack frame's locals. If we find an argument, we copy it into new temporary memory for constructing the new stack frame, and then we deallocate that old memory.

Not totally sure who should review this, since I'm not totally sure if I'm using CTFE correctly 😎  Specifically I don't know if I am implementing the right logic for "does this argument come from an allocation that corresponds to a local in the top stack frame".

r? @wafflelapkin @ralfjung @oli-obk 

Fix https://github.com/rust-lang/rust/issues/144820