### PR TITLE
Add `PeekableIterator` trait

### DIFF
--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -1,7 +1,7 @@
 //! Defines the `IntoIter` owned iterator for arrays.
 
 use crate::intrinsics::transmute_unchecked;
-use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccessNoCoerce};
+use crate::iter::{FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccessNoCoerce};
 use crate::mem::{ManuallyDrop, MaybeUninit};
 use crate::num::NonZero;
 use crate::ops::{Deref as _, DerefMut as _, IndexRange, Range, Try};
@@ -358,6 +358,13 @@ impl<T, const N: usize> FusedIterator for IntoIter<T, N> {}
 // always decremented by 1 in those methods, but only if `Some(_)` is returned.
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 unsafe impl<T, const N: usize> TrustedLen for IntoIter<T, N> {}
+
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+impl<T, const N: usize> PeekableIterator for IntoIter<T, N> {
+    fn peek_with<U>(&mut self, func: impl for<'b> FnOnce(Option<&'b Self::Item>) -> U) -> U {
+        self.unsize_mut().peek_with(func)
+    }
+}
 
 #[doc(hidden)]
 #[unstable(issue = "none", feature = "std_internals")]

--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -176,6 +176,14 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
     }
 
     #[inline]
+    pub(super) fn peek_with<U>(&self, func: impl for<'b> FnOnce(Option<&'b T>) -> U) -> U {
+        func(self.alive.clone().next().map(|idx| {
+            // SAFETY: `idx` is in self.alive range
+            unsafe { self.data.get_unchecked(idx).assume_init_ref() }
+        }))
+    }
+
+    #[inline]
     pub(super) fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))

--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -1,5 +1,5 @@
 use crate::iter::adapters::SourceIter;
-use crate::iter::{FusedIterator, TrustedLen};
+use crate::iter::{FusedIterator, PeekableIterator, TrustedLen};
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator with a `peek()` that returns an optional reference to the next
@@ -460,6 +460,14 @@ impl<I: Iterator> Peekable<I> {
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<I> TrustedLen for Peekable<I> where I: TrustedLen {}
+
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+impl<I: Iterator> PeekableIterator for Peekable<I> {
+    fn peek_with<T>(&mut self, func: impl for<'a> FnOnce(Option<&'a Self::Item>) -> T) -> T {
+        let tmp = self.peek();
+        func(tmp)
+    }
+}
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 unsafe impl<I: Iterator> SourceIter for Peekable<I>

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -452,6 +452,8 @@ pub use self::traits::FusedIterator;
 pub use self::traits::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::Iterator;
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+pub use self::traits::PeekableIterator;
 #[unstable(issue = "none", feature = "trusted_fused")]
 pub use self::traits::TrustedFused;
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -4,6 +4,11 @@ mod double_ended;
 mod exact_size;
 mod iterator;
 mod marker;
+<<<<<<< HEAD
+=======
+mod peekable;
+mod unchecked_iterator;
+>>>>>>> 3b7f4abc23a (Add peekable_iterator)
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::marker::InPlaceIterable;
@@ -11,6 +16,8 @@ pub use self::marker::InPlaceIterable;
 pub use self::marker::TrustedFused;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::marker::TrustedStep;
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+pub use self::peekable::PeekableIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::{
     accum::{Product, Sum},

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -4,11 +4,7 @@ mod double_ended;
 mod exact_size;
 mod iterator;
 mod marker;
-<<<<<<< HEAD
-=======
 mod peekable;
-mod unchecked_iterator;
->>>>>>> 3b7f4abc23a (Add peekable_iterator)
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
 pub use self::marker::InPlaceIterable;

--- a/library/core/src/iter/traits/peekable.rs
+++ b/library/core/src/iter/traits/peekable.rs
@@ -1,0 +1,82 @@
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+/// Iterators which inherently support peeking without needing to be wrapped by a `Peekable`.
+pub trait PeekableIterator: Iterator {
+    /// Executes the closure with a reference to the `next()` value without advancing the iterator.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// use std::iter::PeekableIterator;
+    ///
+    /// let mut vals = [0, 1, 2].into_iter();
+    ///
+    /// assert_eq!(vals.peek_with(|x| x.copied()), Some(0));
+    /// // element is not consumed
+    /// assert_eq!(vals.next(), Some(0));
+    ///
+    /// // examine the pending element
+    /// assert_eq!(vals.peek_with(|x| x.copied()), Some(1));
+    /// assert_eq!(vals.next(), Some(1));
+    ///
+    /// // determine if the iterator has an element without advancing
+    /// assert_eq!(vals.peek_with(|x| x.is_some()), false);
+    /// assert_eq!(vals.next(), Some(2));
+    ///
+    /// // exhausted iterator
+    /// assert_eq!(vals.next(), None);
+    /// assert_eq!(vals.peek_with(|x| x.copied()), None);
+    /// ```
+    fn peek_with<T>(&mut self, func: impl for<'a> FnOnce(Option<&'a Self::Item>) -> T) -> T;
+
+    /// Returns the `next()` element if the given predicate holds true.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// use std::iter::PeekableIterator;
+    /// fn parse_number(s: &str) -> u32 {
+    ///     if s == "0" {
+    ///         return 0
+    ///     }
+    ///
+    ///     let mut c = s.chars();
+    ///
+    ///     let base = if c.next_if_eq(&'0').is_some() {
+    ///         match c.next_if(|c| "oxb".contains(*c)) {
+    ///             Some('x') => 16,
+    ///             Some('b') => 2,
+    ///             _ => 8
+    ///         }
+    ///     } else {
+    ///       10
+    ///     };
+    ///
+    ///     u32::from_str_radix(c.as_str(), base).unwrap()
+    /// }
+    ///
+    /// assert_eq!(parse_number("055"), 45);
+    /// assert_eq!(parse_number("0o42"), 34);
+    /// assert_eq!(parse_number("0x11"), 17);
+    /// assert_eq!(parse_number("0"), 0);
+    /// ```
+    ///
+    fn next_if(&mut self, func: impl FnOnce(&Self::Item) -> bool) -> Option<Self::Item> {
+        match self.peek_with(|x| x.map(|y| func(y))) {
+            Some(true) => self.next(),
+            _ => None,
+        }
+    }
+
+    /// Moves forward and return the `next()` item if it is equal to the expected value.
+    fn next_if_eq<T>(&mut self, expected: &T) -> Option<Self::Item>
+    where
+        Self::Item: PartialEq<T>,
+        T: ?Sized,
+    {
+        self.next_if(|x| x == expected)
+    }
+}

--- a/library/core/src/iter/traits/peekable.rs
+++ b/library/core/src/iter/traits/peekable.rs
@@ -21,7 +21,7 @@ pub trait PeekableIterator: Iterator {
     /// assert_eq!(vals.next(), Some(1));
     ///
     /// // determine if the iterator has an element without advancing
-    /// assert_eq!(vals.peek_with(|x| x.is_some()), false);
+    /// assert_eq!(vals.peek_with(|x| x.is_some()), true);
     /// assert_eq!(vals.next(), Some(2));
     ///
     /// // exhausted iterator

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -6,7 +6,7 @@ mod macros;
 use super::{from_raw_parts, from_raw_parts_mut};
 use crate::hint::assert_unchecked;
 use crate::iter::{
-    FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce
+    FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
 use crate::marker::PhantomData;
 use crate::mem::{self, SizedTypeProperties};

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -5,7 +5,9 @@ mod macros;
 
 use super::{from_raw_parts, from_raw_parts_mut};
 use crate::hint::assert_unchecked;
-use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use crate::iter::{
+    FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce
+};
 use crate::marker::PhantomData;
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZero;

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -481,6 +481,21 @@ macro_rules! iterator {
         #[unstable(feature = "trusted_len", issue = "37572")]
         unsafe impl<T> TrustedLen for $name<'_, T> {}
 
+        #[unstable(feature = "peekable_iterator", issue = "132973")]
+        impl<'a, T> PeekableIterator for $name<'a, T> {
+            fn peek_with<U>(&mut self, func: impl for<'b> FnOnce(Option<&'b Self::Item>) -> U) -> U {
+
+                if len!(self) == 0 {
+                    func(None)
+                } else {
+                    // SAFETY: Element within bounds as len > 0.
+                    // The reference is dropped after the closure completes
+                    // and can not outlive the mutable borrow of self.
+                    let tmp = unsafe { & $( $mut_ )? *self.ptr.as_ptr() };
+                    func(Some(tmp).as_ref())
+                }
+            }
+        }
         #[stable(feature = "default_iters", since = "1.70.0")]
         impl<T> Default for $name<'_, T> {
             /// Creates an empty slice iterator.

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -8,8 +8,8 @@ use super::{
 };
 use crate::fmt::{self, Write};
 use crate::iter::{
-    Chain, Copied, Filter, FlatMap, Flatten, FusedIterator, Map, TrustedLen, TrustedRandomAccess,
-    TrustedRandomAccessNoCoerce,
+    Chain, Copied, Filter, FlatMap, Flatten, FusedIterator, Map, PeekableIterator, TrustedLen,
+    TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
 use crate::num::NonZero;
 use crate::ops::Try;
@@ -126,6 +126,14 @@ impl<'a> DoubleEndedIterator for Chars<'a> {
         // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and
         // the resulting `ch` is a valid Unicode Scalar Value.
         unsafe { next_code_point_reverse(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }
+    }
+}
+
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+impl<'a> PeekableIterator for Chars<'a> {
+    fn peek_with<T>(&mut self, func: impl for<'b> FnOnce(Option<&'b Self::Item>) -> T) -> T {
+        let tmp = self.clone().next();
+        func(tmp.as_ref())
     }
 }
 

--- a/library/coretests/tests/iter/traits/iterator.rs
+++ b/library/coretests/tests/iter/traits/iterator.rs
@@ -1,5 +1,5 @@
 use core::cell::RefCell;
-use core::iter::zip;
+use core::iter::{PeekableIterator, zip};
 use core::num::NonZero;
 
 /// A wrapper struct that implements `Eq` and `Ord` based on the wrapped
@@ -679,6 +679,32 @@ fn test_extend_for_tuple_side_effects_order() {
     p.extend(zip([(1, 2), (3, 4)], [(), ()]));
     let effects = effects.into_inner();
     assert_eq!(effects, [("l", vec![1]), ("r", vec![2]), ("l", vec![3]), ("r", vec![4])]);
+}
+
+#[test]
+fn test_peekable_slice_into() {
+    let mut b = [3, 1, 4, 1, 5].into_iter();
+
+    assert!(b.peek_with(|x| x == Some(&3)));
+    assert_eq!(b.next_if_eq(&3), Some(3));
+
+    assert_eq!(b.next_if_eq(&1), Some(1));
+    assert_eq!(b.next_if(|x| x == &4), Some(4));
+
+    // iterator shouldn't move forward
+    b.next_if(|_| false);
+    assert_eq!(b.next(), Some(1));
+}
+
+#[test]
+fn test_peekable_chars() {
+    let mut a = "hello world!".chars();
+
+    assert!(a.peek_with(|x| x == Some(&'h')));
+    // element not consumed
+    assert_eq!(a.next_if_eq(&'h'), Some('h'));
+    // moves only if condition holds
+    assert_eq!(a.next_if(|x| x == &'l'), None)
 }
 
 // just tests by whether or not this compiles

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -93,6 +93,7 @@
 #![feature(one_sided_range)]
 #![feature(panic_internals)]
 #![feature(pattern)]
+#![feature(peekable_iterator)]
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/144935)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#132973

Implementation
```rust
pub trait PeekableIterator: Iterator {
  // required method
  fn peek_with<T>(&mut self, func: impl for<'a> FnOnce(Option<&'a Self::Item>) -> T) -> T

  // provided methods
  fn peek_map<T>(&mut self, func: impl for<'a> FnOnce(&'a Self::Item) -> T) -> Option<T>
  fn next_if(&mut self, func: impl FnOnce(&Self::Item) -> bool) -> Option<Self::Item>
  fn next_if_eq<T>(&mut self, expected: &T) -> Option<Self::Item>
  where
    Self::Item: PartialEq<T>,
    T: ?Sized,
}
```

Todo: Determine which structures need to implement `PeekableIterator`:
* `slice::iter`
* `str::Chars`
* `vec::IntoIter`
* `Peekable<T>`

Unresolved Issues:
* Add another trait for iterators that can `peek()` without mutating?
