### PR TITLE
CFI: Fix types that implement Fn, FnMut, or FnOnce

### DIFF
--- a/tests/ui/sanitizer/cfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/cfi/fn-trait-objects.rs
@@ -1,0 +1,32 @@
+// Verifies that types that implement the Fn, FnMut, or FnOnce traits can be
+// called through their trait methods.
+//
+//@ needs-sanitizer-cfi
+//@ only-linux
+//@ ignore-backends: gcc
+//@ compile-flags: -Ctarget-feature=-crt-static -Ccodegen-units=1 -Clto -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=cfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ run-pass
+
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+
+fn foo(_a: u32) {}
+
+#[test]
+fn test_fn_trait() {
+    let f: Box<dyn Fn(u32)> = Box::new(foo);
+    Fn::call(&f, (0,));
+}
+
+#[test]
+fn test_fnmut_trait() {
+    let mut a = 0;
+    let mut f: Box<dyn FnMut(u32)> = Box::new(|x| a += x);
+    FnMut::call_mut(&mut f, (1,));
+}
+
+#[test]
+fn test_fnonce_trait() {
+    let f: Box<dyn FnOnce(u32)> = Box::new(foo);
+    FnOnce::call_once(f, (2,));
+}

--- a/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
+++ b/tests/ui/sanitizer/kcfi/fn-trait-objects.rs
@@ -1,0 +1,32 @@
+// Verifies that types that implement the Fn, FnMut, or FnOnce traits can be
+// called through their trait methods.
+//
+//@ needs-sanitizer-kcfi
+//@ only-linux
+//@ ignore-backends: gcc
+//@ compile-flags: -Ctarget-feature=-crt-static -Zpanic_abort_tests -Cpanic=abort -Cprefer-dynamic=off -Copt-level=0 -Zsanitizer=kcfi -Cunsafe-allow-abi-mismatch=sanitizer --test
+//@ run-pass
+
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+
+fn foo(_a: u32) {}
+
+#[test]
+fn test_fn_trait() {
+    let f: Box<dyn Fn(u32)> = Box::new(foo);
+    Fn::call(&f, (0,));
+}
+
+#[test]
+fn test_fnmut_trait() {
+    let mut a = 0;
+    let mut f: Box<dyn FnMut(u32)> = Box::new(|x| a += x);
+    FnMut::call_mut(&mut f, (1,));
+}
+
+#[test]
+fn test_fnonce_trait() {
+    let f: Box<dyn FnOnce(u32)> = Box::new(foo);
+    FnOnce::call_once(f, (2,));
+}


### PR DESCRIPTION
When looking for instances which could either be dynamically called through a vtable or through a concrete trait method, we missed `FnPtrShim`, instead only looking at `Item` and closure-likes. Fixes rust-lang/rust#144641.

cc @1c3t3a @Jakob-Koschel 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
