### PR TITLE
E0793: Clarify that it applies to unions as well

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0793.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0793.md
@@ -1,4 +1,9 @@
-An unaligned reference to a field of a [packed] struct got created.
+An unaligned reference to a field of a [packed] `struct` or `union` was created.
+
+The `#[repr(packed)]` attribute removes padding between fields, which can
+cause fields to be stored at unaligned memory addresses. Creating references
+to such fields violates Rust's memory safety guarantees and can lead to
+undefined behavior in optimized code.
 
 Erroneous code example:
 
@@ -45,9 +50,36 @@ unsafe {
     // For formatting, we can create a copy to avoid the direct reference.
     let copy = foo.field1;
     println!("{}", copy);
+
     // Creating a copy can be written in a single line with curly braces.
     // (This is equivalent to the two lines above.)
     println!("{}", { foo.field1 });
+
+    // A reference to a field that will always be sufficiently aligned is safe:
+    println!("{}", foo.field2);
+}
+```
+
+### Unions
+
+Although creating a reference to a `union` field is `unsafe`, this error
+will still be triggered if the referenced field is not sufficiently
+aligned. Use `addr_of!` and raw pointers in the same way as for struct fields.
+
+```compile_fail,E0793
+#[repr(packed)]
+pub union Foo {
+    field1: u64,
+    field2: u8,
+}
+
+unsafe {
+    let foo = Foo { field1: 0 };
+    // Accessing the field directly is fine.
+    let val = foo.field1;
+
+    // A reference to a packed union field causes an error.
+    let val = &foo.field1; // ERROR
 }
 ```
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

pick up inactive PR: https://github.com/rust-lang/rust/pull/131472

Also:
Adjust the language slightly to be more consistent with other similar messages (was created instead of got created).
Add a short section on union.
Add an example line showing referencing a field in a packed struct is safe if the field's type isn't more strictly aligned than the pack.


r? compiler-errors
