### PR TITLE
Gate const trait syntax

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -885,6 +885,9 @@ impl<'a> Parser<'a> {
     /// Parses `unsafe? auto? trait Foo { ... }` or `trait Foo = Bar;`.
     fn parse_item_trait(&mut self, attrs: &mut AttrVec, lo: Span) -> PResult<'a, ItemKind> {
         let constness = self.parse_constness(Case::Sensitive);
+        if let Const::Yes(span) = constness {
+            self.psess.gated_spans.gate(sym::const_trait_impl, span);
+        }
         let safety = self.parse_safety(Case::Sensitive);
         // Parse optional `auto` prefix.
         let is_auto = if self.eat_keyword(exp!(Auto)) {

--- a/tests/ui/traits/const-traits/feature-gate.rs
+++ b/tests/ui/traits/const-traits/feature-gate.rs
@@ -13,6 +13,9 @@ impl const T for S {}
 const fn f<A: [const] T>() {} //[stock]~ ERROR const trait impls are experimental
 fn g<A: const T>() {} //[stock]~ ERROR const trait impls are experimental
 
+const trait Trait {} //[stock]~ ERROR const trait impls are experimental
+#[cfg(false)] const trait Trait {} //[stock]~ ERROR const trait impls are experimental
+
 macro_rules! discard { ($ty:ty) => {} }
 
 discard! { impl [const] T } //[stock]~ ERROR const trait impls are experimental

--- a/tests/ui/traits/const-traits/feature-gate.stock.stderr
+++ b/tests/ui/traits/const-traits/feature-gate.stock.stderr
@@ -29,7 +29,27 @@ LL | fn g<A: const T>() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:18:17
+  --> $DIR/feature-gate.rs:16:1
+   |
+LL | const trait Trait {}
+   | ^^^^^
+   |
+   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: const trait impls are experimental
+  --> $DIR/feature-gate.rs:17:15
+   |
+LL | #[cfg(false)] const trait Trait {}
+   |               ^^^^^
+   |
+   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: const trait impls are experimental
+  --> $DIR/feature-gate.rs:21:17
    |
 LL | discard! { impl [const] T }
    |                 ^^^^^^^
@@ -39,7 +59,7 @@ LL | discard! { impl [const] T }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/feature-gate.rs:19:17
+  --> $DIR/feature-gate.rs:22:17
    |
 LL | discard! { impl const T }
    |                 ^^^^^
@@ -58,6 +78,6 @@ LL | #[const_trait]
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Missed this during my review of rust-lang/rust#143879, huge apologies!
Fixes [after beta backport] https://github.com/rust-lang/rust/issues/144958.

cc @fee1-dead
r? @BoxyUwU or anyone