### PR TITLE
fix(unicode-table-generator): fix duplicated unique indices

### DIFF
--- a/src/tools/unicode-table-generator/src/raw_emitter.rs
+++ b/src/tools/unicode-table-generator/src/raw_emitter.rs
@@ -341,7 +341,7 @@ impl Canonicalized {
         for &w in unique_words {
             unique_mapping.entry(w).or_insert_with(|| {
                 canonical_words.push(w);
-                UniqueMapping::Canonical(canonical_words.len())
+                UniqueMapping::Canonical(canonical_words.len() - 1)
             });
         }
         assert_eq!(canonicalized_words.len() + canonical_words.len(), unique_words.len());


### PR DESCRIPTION
unicode-table-generator panicked while populating `distinct_indices` because of duplicated indices. This was introduced in rust-lang/rust#144134, where the order of `canonical_words.push(...)` and `canonical_words.len()` was swapped.

Fixes: rust-lang/rust#144134