### PR TITLE
Stabilize `core::iter::chain`

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -45,8 +45,6 @@ impl<A, B> Chain<A, B> {
 /// # Examples
 ///
 /// ```
-/// #![feature(iter_chain)]
-///
 /// use std::iter::chain;
 ///
 /// let a = [1, 2, 3];
@@ -62,7 +60,7 @@ impl<A, B> Chain<A, B> {
 /// assert_eq!(iter.next(), Some(6));
 /// assert_eq!(iter.next(), None);
 /// ```
-#[unstable(feature = "iter_chain", reason = "recently added", issue = "125964")]
+#[stable(feature = "iter_chain", since = "CURRENT_RUSTC_VERSION")]
 pub fn chain<A, B>(a: A, b: B) -> Chain<A::IntoIter, B::IntoIter>
 where
     A: IntoIterator,

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -32,7 +32,7 @@ mod zip;
 pub use self::array_chunks::ArrayChunks;
 #[unstable(feature = "std_internals", issue = "none")]
 pub use self::by_ref_sized::ByRefSized;
-#[unstable(feature = "iter_chain", reason = "recently added", issue = "125964")]
+#[stable(feature = "iter_chain", since = "CURRENT_RUSTC_VERSION")]
 pub use self::chain::chain;
 #[stable(feature = "iter_cloned", since = "1.1.0")]
 pub use self::cloned::Cloned;

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -404,7 +404,7 @@ pub use self::adapters::StepBy;
 pub use self::adapters::TrustedRandomAccess;
 #[unstable(feature = "trusted_random_access", issue = "none")]
 pub use self::adapters::TrustedRandomAccessNoCoerce;
-#[unstable(feature = "iter_chain", reason = "recently added", issue = "125964")]
+#[stable(feature = "iter_chain", since = "CURRENT_RUSTC_VERSION")]
 pub use self::adapters::chain;
 pub(crate) use self::adapters::try_process;
 #[stable(feature = "iter_zip", since = "1.59.0")]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -59,7 +59,6 @@
 #![feature(isolate_most_least_significant_one)]
 #![feature(iter_advance_by)]
 #![feature(iter_array_chunks)]
-#![feature(iter_chain)]
 #![feature(iter_collect_into)]
 #![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]


### PR DESCRIPTION
Closes rust-lang/rust#125964
