### PR TITLE
 Improve suggestion for "missing function argument" on multiline call

### DIFF
--- a/tests/ui/argument-suggestions/issue-100478.stderr
+++ b/tests/ui/argument-suggestions/issue-100478.stderr
@@ -75,12 +75,16 @@ LL | fn foo(p1: T1, p2: Arc<T2>, p3: T3, p4: Arc<T4>, p5: T5, p6: T6, p7: T7, p8
    |    ^^^         -----------
 help: provide the argument
    |
-LL -     foo(
-LL -
-LL -         p1, //p2,
-LL -         p3, p4, p5, p6, p7, p8,
-LL -     );
-LL +     foo(p1, /* Arc<T2> */, p3, p4, p5, p6, p7, p8);
+LL ~     foo(
+LL +         p1,
+LL +         /* Arc<T2> */,
+LL +         p3,
+LL +         p4,
+LL +         p5,
+LL +         p6,
+LL +         p7,
+LL +         p8,
+LL ~     );
    |
 
 error: aborting due to 4 previous errors

--- a/tests/ui/fn/fn-arg-count-mismatch-diagnostics.rs
+++ b/tests/ui/fn/fn-arg-count-mismatch-diagnostics.rs
@@ -46,9 +46,21 @@ impl Bar {
     }
 }
 
+fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+
 fn main() {
     foo(1, 2, 3);
     //~^ ERROR function takes 4 arguments but 3
     bar(1, 2, 3);
     //~^ ERROR function takes 6 arguments but 3
+
+    let variable_name = 42;
+    function_with_lots_of_arguments(
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+        variable_name,
+    );
+    //~^^^^^^^ ERROR this function takes 6 arguments but 5 arguments were supplied [E0061]
 }

--- a/tests/ui/fn/fn-arg-count-mismatch-diagnostics.stderr
+++ b/tests/ui/fn/fn-arg-count-mismatch-diagnostics.stderr
@@ -52,7 +52,7 @@ LL |         <$from>::$method(8, /* u8 */)
    |                           ++++++++++
 
 error[E0061]: this function takes 4 arguments but 3 arguments were supplied
-  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:50:5
+  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:52:5
    |
 LL |     foo(1, 2, 3);
    |     ^^^--------- argument #4 of type `isize` is missing
@@ -68,7 +68,7 @@ LL |     foo(1, 2, 3, /* isize */);
    |                +++++++++++++
 
 error[E0061]: this function takes 6 arguments but 3 arguments were supplied
-  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:52:5
+  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:54:5
    |
 LL |     bar(1, 2, 3);
    |     ^^^--------- three arguments of type `i32`, `i32`, and `i32` are missing
@@ -83,6 +83,32 @@ help: provide the arguments
 LL |     bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
    |                +++++++++++++++++++++++++++++++++
 
-error: aborting due to 5 previous errors
+error[E0061]: this function takes 6 arguments but 5 arguments were supplied
+  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:58:5
+   |
+LL |     function_with_lots_of_arguments(
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         variable_name,
+LL |         variable_name,
+   |         ------------- argument #2 of type `char` is missing
+   |
+note: function defined here
+  --> $DIR/fn-arg-count-mismatch-diagnostics.rs:49:4
+   |
+LL | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32, f: i32) {}
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
+help: provide the argument
+   |
+LL -     function_with_lots_of_arguments(
+LL -         variable_name,
+LL -         variable_name,
+LL -         variable_name,
+LL -         variable_name,
+LL -         variable_name,
+LL -     );
+LL +     function_with_lots_of_arguments(variable_name, /* char */, variable_name, variable_name, variable_name, variable_name);
+   |
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/fn/fn-arg-count-mismatch-diagnostics.stderr
+++ b/tests/ui/fn/fn-arg-count-mismatch-diagnostics.stderr
@@ -99,14 +99,10 @@ LL | fn function_with_lots_of_arguments(a: i32, b: char, c: i32, d: i32, e: i32,
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -------
 help: provide the argument
    |
-LL -     function_with_lots_of_arguments(
-LL -         variable_name,
-LL -         variable_name,
-LL -         variable_name,
-LL -         variable_name,
-LL -         variable_name,
-LL -     );
-LL +     function_with_lots_of_arguments(variable_name, /* char */, variable_name, variable_name, variable_name, variable_name);
+LL |     function_with_lots_of_arguments(
+LL |         variable_name,
+LL ~         /* char */,
+LL ~         variable_name,
    |
 
 error: aborting due to 6 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`rustc` has a very neat suggestion when the argument count does not match, with a nice placeholder that shows where an argument may be missing. Unfortunately the suggestion is always single-line, even when the function call spans across multiple lines. With this PR, `rustc` tries to guess if the function call is multiline or not, and emits a multiline suggestion when required.

r? @jdonszelmann 