### PR TITLE
rustc_public: import requried `extern crate`s in run_driver!

### DIFF
--- a/compiler/rustc_public/src/rustc_internal/mod.rs
+++ b/compiler/rustc_public/src/rustc_internal/mod.rs
@@ -184,6 +184,14 @@ macro_rules! optional {
 #[doc(hidden)]
 macro_rules! run_driver {
     ($args:expr, $callback:expr $(, $with_tcx:ident)?) => {{
+        // this way, users don't have to manually import these crates,
+        // but they have to enable #![feature(rustc_private)] manually
+        // because this macro could occur as an expression, which would trigger
+        // the [`stmt_expr_attributes`](https://github.com/rust-lang/rust/issues/15701).
+        extern crate rustc_driver;
+        extern crate rustc_interface;
+        extern crate rustc_middle;
+
         use rustc_driver::{Callbacks, Compilation, run_compiler};
         use rustc_middle::ty::TyCtxt;
         use rustc_interface::interface;

--- a/tests/ui-fulldeps/rustc_public/check_abi.rs
+++ b/tests/ui-fulldeps/rustc_public/check_abi.rs
@@ -9,10 +9,6 @@
 #![feature(assert_matches)]
 #![feature(ascii_char, ascii_char_variants)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_allocation.rs
+++ b/tests/ui-fulldeps/rustc_public/check_allocation.rs
@@ -11,11 +11,6 @@
 #![feature(assert_matches)]
 #![feature(ascii_char, ascii_char_variants)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_assoc_items.rs
+++ b/tests/ui-fulldeps/rustc_public/check_assoc_items.rs
@@ -10,10 +10,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use std::collections::HashSet;

--- a/tests/ui-fulldeps/rustc_public/check_attribute.rs
+++ b/tests/ui-fulldeps/rustc_public/check_attribute.rs
@@ -7,11 +7,6 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_binop.rs
+++ b/tests/ui-fulldeps/rustc_public/check_binop.rs
@@ -7,11 +7,6 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_coroutine_body.rs
+++ b/tests/ui-fulldeps/rustc_public/check_coroutine_body.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_crate_defs.rs
+++ b/tests/ui-fulldeps/rustc_public/check_crate_defs.rs
@@ -8,11 +8,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_def_ty.rs
+++ b/tests/ui-fulldeps/rustc_public/check_def_ty.rs
@@ -10,10 +10,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use rustc_public::ty::{Ty, ForeignItemKind};

--- a/tests/ui-fulldeps/rustc_public/check_defs.rs
+++ b/tests/ui-fulldeps/rustc_public/check_defs.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use std::assert_matches::assert_matches;

--- a/tests/ui-fulldeps/rustc_public/check_foreign.rs
+++ b/tests/ui-fulldeps/rustc_public/check_foreign.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_span;
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_instance.rs
+++ b/tests/ui-fulldeps/rustc_public/check_instance.rs
@@ -9,10 +9,7 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
 
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use std::io::Write;

--- a/tests/ui-fulldeps/rustc_public/check_intrinsics.rs
+++ b/tests/ui-fulldeps/rustc_public/check_intrinsics.rs
@@ -12,11 +12,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-extern crate rustc_hir;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_item_kind.rs
+++ b/tests/ui-fulldeps/rustc_public/check_item_kind.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use rustc_public::*;

--- a/tests/ui-fulldeps/rustc_public/check_normalization.rs
+++ b/tests/ui-fulldeps/rustc_public/check_normalization.rs
@@ -8,10 +8,6 @@
 
 #![feature(rustc_private)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use mir::mono::Instance;

--- a/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
+++ b/tests/ui-fulldeps/rustc_public/check_trait_queries.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_transform.rs
+++ b/tests/ui-fulldeps/rustc_public/check_transform.rs
@@ -9,11 +9,6 @@
 #![feature(assert_matches)]
 #![feature(ascii_char, ascii_char_variants)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_ty_fold.rs
+++ b/tests/ui-fulldeps/rustc_public/check_ty_fold.rs
@@ -10,10 +10,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/check_variant.rs
+++ b/tests/ui-fulldeps/rustc_public/check_variant.rs
@@ -10,10 +10,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/closure-generic-body.rs
+++ b/tests/ui-fulldeps/rustc_public/closure-generic-body.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/closure_body.rs
+++ b/tests/ui-fulldeps/rustc_public/closure_body.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/compilation-result.rs
+++ b/tests/ui-fulldeps/rustc_public/compilation-result.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/crate-info.rs
+++ b/tests/ui-fulldeps/rustc_public/crate-info.rs
@@ -10,10 +10,6 @@
 #![feature(assert_matches)]
 
 extern crate rustc_hir;
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/projections.rs
+++ b/tests/ui-fulldeps/rustc_public/projections.rs
@@ -9,11 +9,7 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_hir;
-extern crate rustc_middle;
 
-extern crate rustc_driver;
-extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 

--- a/tests/ui-fulldeps/rustc_public/smir_internal.rs
+++ b/tests/ui-fulldeps/rustc_public/smir_internal.rs
@@ -10,8 +10,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_middle;
 #[macro_use]
 extern crate rustc_public;

--- a/tests/ui-fulldeps/rustc_public/smir_serde.rs
+++ b/tests/ui-fulldeps/rustc_public/smir_serde.rs
@@ -9,9 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate serde;
 extern crate serde_json;

--- a/tests/ui-fulldeps/rustc_public/smir_visitor.rs
+++ b/tests/ui-fulldeps/rustc_public/smir_visitor.rs
@@ -9,10 +9,6 @@
 #![feature(rustc_private)]
 #![feature(assert_matches)]
 
-extern crate rustc_middle;
-
-extern crate rustc_driver;
-extern crate rustc_interface;
 extern crate rustc_public;
 
 use rustc_public::mir::MirVisitor;


### PR DESCRIPTION
It's unfair to put users to do this work, since they don't know what the code would be after macro expansion and what crates should be imported if they don't take a look at the source code.

However, unfortunately, they have to enable `rustc_private` themselves for now because `run_driver!` could occur as an expression, which would trigger the [`stmt_expr_attributes`](https://github.com/rust-lang/rust/issues/15701) if we enable `rustc_private` in the macro. I think this would be fixed after we have a stable driver.