### PR TITLE
rustdoc: fix caching of intra-doc links on reexports

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1082,7 +1082,12 @@ impl LinkCollector<'_, '_> {
             for md_link in preprocessed_markdown_links(&doc) {
                 let link = self.resolve_link(&doc, item, item_id, module_id, &md_link);
                 if let Some(link) = link {
-                    self.cx.cache.intra_doc_links.entry(item.item_id).or_default().insert(link);
+                    self.cx
+                        .cache
+                        .intra_doc_links
+                        .entry(item.item_or_reexport_id())
+                        .or_default()
+                        .insert(link);
                 }
             }
         }

--- a/tests/rustdoc/intra-doc/macro-caching-144965.rs
+++ b/tests/rustdoc/intra-doc/macro-caching-144965.rs
@@ -1,0 +1,35 @@
+// regression test for https://github.com/rust-lang/rust/issues/144965
+
+#![crate_name = "foo"]
+#![no_std]
+
+#[doc(hidden)]
+pub struct MyStruct;
+
+macro_rules! my_macro {
+    () => {
+        pub fn my_function() {}
+
+        /// Incorrect: [`my_function()`].
+        #[doc(inline)]
+        pub use $crate::MyStruct;
+
+        /// Correct: [`my_function`].
+        pub struct AnotherStruct;
+    };
+}
+
+
+pub mod one {
+    //@ has 'foo/one/index.html'
+    //@ has - '//dl[@class="item-table"]/dd[1]/a[@href="fn.my_function.html"]/code' 'my_function'
+    //@ has - '//dl[@class="item-table"]/dd[2]/a[@href="fn.my_function.html"]/code' 'my_function()'
+    my_macro!();
+}
+
+pub mod two {
+    //@ has 'foo/two/index.html'
+    //@ has - '//dl[@class="item-table"]/dd[1]/a[@href="fn.my_function.html"]/code' 'my_function'
+    //@ has - '//dl[@class="item-table"]/dd[2]/a[@href="fn.my_function.html"]/code' 'my_function()'
+    my_macro!();
+}


### PR DESCRIPTION
previously two reexports of the same item would share a set of intra-doc links, which would cause problems if they had two different links with the same text.  this was fixed by using the reexport defid as the key, if it is available.

fixes https://github.com/rust-lang/rust/issues/144965

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
