### PR TITLE
add code example showing that file_prefix treats dotfiles as the name of a file, not an extension

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2683,6 +2683,8 @@ impl Path {
     ///
     /// assert_eq!("foo", Path::new("foo.rs").file_prefix().unwrap());
     /// assert_eq!("foo", Path::new("foo.tar.gz").file_prefix().unwrap());
+    /// assert_eq!(".config", Path::new(".config").file_prefix().unwrap());
+    /// assert_eq!(".config", Path::new(".config.toml").file_prefix().unwrap());
     /// ```
     ///
     /// # See Also


### PR DESCRIPTION
This came up in a libs-api meeting while we were reviewing rust-lang/rust#144870