### PR TITLE
`File::set_times`: Update documentation and example to support setting timestamps on directories

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1111,6 +1111,10 @@ impl File {
     /// `futimes` on macOS before 10.13) and the `SetFileTime` function on Windows. Note that this
     /// [may change in the future][changes].
     ///
+    /// On most platforms, including UNIX and Windows platforms, this function can also change the
+    /// timestamps of a directory. To do so, open the directory with `File::open`, without
+    /// attempting to obtain write permission.
+    ///
     /// [changes]: io#platform-specific-behavior
     ///
     /// # Errors

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1112,8 +1112,9 @@ impl File {
     /// [may change in the future][changes].
     ///
     /// On most platforms, including UNIX and Windows platforms, this function can also change the
-    /// timestamps of a directory. To do so, open the directory with `File::open`, without
-    /// attempting to obtain write permission.
+    /// timestamps of a directory. To get a `File` representing a directory in order to call
+    /// `set_times`, open the directory with `File::open` without attempting to obtain write
+    /// permission.
     ///
     /// [changes]: io#platform-specific-behavior
     ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1128,7 +1128,7 @@ impl File {
     ///     use std::fs::{self, File, FileTimes};
     ///
     ///     let src = fs::metadata("src")?;
-    ///     let dest = File::options().write(true).open("dest")?;
+    ///     let dest = File::open("dest")?;
     ///     let times = FileTimes::new()
     ///         .set_accessed(src.accessed()?)
     ///         .set_modified(src.modified()?);


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust/issues/123883 .
