### PR TITLE
Add annotations to the graphviz region graph on region origins

### DIFF
--- a/compiler/rustc_borrowck/src/handle_placeholders.rs
+++ b/compiler/rustc_borrowck/src/handle_placeholders.rs
@@ -157,7 +157,7 @@ fn region_definitions<'tcx>(
     for info in var_infos.iter() {
         let origin = match info.origin {
             RegionVariableOrigin::Nll(origin) => origin,
-            _ => NllRegionVariableOrigin::Existential { from_forall: false },
+            _ => NllRegionVariableOrigin::Existential { from_forall: false, name: None },
         };
 
         let definition = RegionDefinition { origin, universe: info.universe, external_name: None };

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -41,7 +41,21 @@ fn render_region_vid<'tcx>(
         "".to_string()
     };
 
-    format!("{:?}{universe_str}{external_name_str}", rvid)
+    let extra_info = match regioncx.region_definition(rvid).origin {
+        NllRegionVariableOrigin::FreeRegion => "".to_string(),
+        NllRegionVariableOrigin::Placeholder(p) => match p.bound.kind {
+            ty::BoundRegionKind::Named(def_id) => {
+                format!("(p for {})", tcx.item_name(def_id))
+            }
+            ty::BoundRegionKind::ClosureEnv | ty::BoundRegionKind::Anon => "(p)".to_string(),
+            ty::BoundRegionKind::NamedAnon(_) => {
+                bug!("only used for pretty printing")
+            }
+        },
+        NllRegionVariableOrigin::Existential { .. } => "(ex)".to_string(),
+    };
+
+    format!("{:?}{universe_str}{external_name_str}{extra_info}", rvid)
 }
 
 impl<'tcx> RegionInferenceContext<'tcx> {

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -45,14 +45,14 @@ fn render_region_vid<'tcx>(
         NllRegionVariableOrigin::FreeRegion => "".to_string(),
         NllRegionVariableOrigin::Placeholder(p) => match p.bound.kind {
             ty::BoundRegionKind::Named(def_id) => {
-                format!("(p for {})", tcx.item_name(def_id))
+                format!(" (for<{}>)", tcx.item_name(def_id))
             }
-            ty::BoundRegionKind::ClosureEnv | ty::BoundRegionKind::Anon => "(p)".to_string(),
+            ty::BoundRegionKind::ClosureEnv | ty::BoundRegionKind::Anon => " (for<'_>)".to_string(),
             ty::BoundRegionKind::NamedAnon(_) => {
                 bug!("only used for pretty printing")
             }
         },
-        NllRegionVariableOrigin::Existential { .. } => "(ex)".to_string(),
+        NllRegionVariableOrigin::Existential { .. } => " (ex<'?>)".to_string(),
     };
 
     format!("{:?}{universe_str}{external_name_str}{extra_info}", rvid)

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -52,7 +52,8 @@ fn render_region_vid<'tcx>(
                 bug!("only used for pretty printing")
             }
         },
-        NllRegionVariableOrigin::Existential { .. } => " (ex<'?>)".to_string(),
+        NllRegionVariableOrigin::Existential { name: Some(name), .. } => format!(" (ex<{name}>)"),
+        NllRegionVariableOrigin::Existential { .. } => format!(" (ex<'_>)"),
     };
 
     format!("{:?}{universe_str}{external_name_str}{extra_info}", rvid)

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1940,9 +1940,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // and here we prefer to blame the source (the y = x statement).
         let blame_source = match from_region_origin {
             NllRegionVariableOrigin::FreeRegion
-            | NllRegionVariableOrigin::Existential { from_forall: false } => true,
+            | NllRegionVariableOrigin::Existential { from_forall: false, name: _ } => true,
             NllRegionVariableOrigin::Placeholder(_)
-            | NllRegionVariableOrigin::Existential { from_forall: true } => false,
+            | NllRegionVariableOrigin::Existential { from_forall: true, name: _ } => false,
         };
 
         // To pick a constraint to blame, we organize constraints by how interesting we expect them

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx> RegionRenumberer<'a, 'tcx> {
         T: TypeFoldable<TyCtxt<'tcx>>,
         F: Fn() -> RegionCtxt,
     {
-        let origin = NllRegionVariableOrigin::Existential { from_forall: false };
+        let origin = NllRegionVariableOrigin::Existential { from_forall: false, name: None };
         fold_regions(self.infcx.tcx, value, |_region, _depth| {
             self.infcx.next_nll_region_var(origin, || region_ctxt_fn())
         })

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -249,7 +249,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
         from_forall: bool,
         name: Option<Symbol>,
     ) -> ty::Region<'tcx> {
-        let origin = NllRegionVariableOrigin::Existential { from_forall };
+        let origin = NllRegionVariableOrigin::Existential { name, from_forall };
 
         let reg_var =
             self.type_checker.infcx.next_nll_region_var(origin, || RegionCtxt::Existential(name));

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -484,6 +484,7 @@ pub enum NllRegionVariableOrigin {
     Placeholder(ty::PlaceholderRegion),
 
     Existential {
+        name: Option<Symbol>,
         /// If this is true, then this variable was created to represent a lifetime
         /// bound in a `for` binder. For example, it might have been created to
         /// represent the lifetime `'a` in a type like `for<'a> fn(&'a u32)`.


### PR DESCRIPTION
This adds
- `(ex<'e>)` for regions whose origin is existential, with name if one exists,
- `(for<'p>)` for regions whose origin is a placeholder, with name if one exists

For any region whose name we don't know, use `'_`.

This has helped _my_ debugging and it doesn't create too bad clutter, I feel.

The change  ~~is~~was ridiculously small, but I turned it into a separate PR so we can bikeshed the format.

The following snippet:
```rust
struct Co<'a>(&'a ());
struct Contra<'a>(fn(&'a ()));

// `exists<'e> forall<'p> 'p: 'e` -> ERROR
fn p_outlives_e(
    x: for<'e> fn(for<'p> fn(fn(fn(Contra<'e>, Co<'p>)))),
) -> fn(fn(fn(for<'unify> fn(Contra<'unify>, Co<'unify>)))) {
    x
``` 

Gives this graph:
![new-naming](https://github.com/user-attachments/assets/f2c8f17c-d29b-4d42-9da7-4b8e520e76a6)


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
