### PR TITLE
Remove unneeded `stage` parameter when setting up stdlib Cargo

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -84,7 +84,7 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, stage, &mut cargo);
+        std_cargo(builder, target, &mut cargo);
         if matches!(builder.config.cmd, Subcommand::Fix) {
             // By default, cargo tries to fix all targets. Tell it not to fix tests until we've added `test` to the sysroot.
             cargo.arg("--lib");
@@ -125,7 +125,7 @@ impl Step for Std {
             Kind::Check,
         );
 
-        std_cargo(builder, target, build_compiler.stage, &mut cargo);
+        std_cargo(builder, target, &mut cargo);
 
         // Explicitly pass -p for all dependencies krates -- this will force cargo
         // to also check the tests/benches/examples for these crates, rather

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -154,7 +154,7 @@ impl Step for Std {
             Kind::Clippy,
         );
 
-        std_cargo(builder, target, compiler.stage, &mut cargo);
+        std_cargo(builder, target, &mut cargo);
 
         for krate in &*self.crates {
             cargo.arg("-p").arg(krate);

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -269,7 +269,7 @@ impl Step for Std {
                 target,
                 Kind::Build,
             );
-            std_cargo(builder, target, compiler.stage, &mut cargo);
+            std_cargo(builder, target, &mut cargo);
             for krate in &*self.crates {
                 cargo.arg("-p").arg(krate);
             }
@@ -497,7 +497,7 @@ fn compiler_rt_for_profiler(builder: &Builder<'_>) -> PathBuf {
 
 /// Configure cargo to compile the standard library, adding appropriate env vars
 /// and such.
-pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, cargo: &mut Cargo) {
+pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, cargo: &mut Cargo) {
     // rustc already ensures that it builds with the minimum deployment
     // target, so ideally we shouldn't need to do anything here.
     //
@@ -645,12 +645,8 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
     // built with bitcode so that the produced rlibs can be used for both LTO
     // builds (which use bitcode) and non-LTO builds (which use object code).
     // So we override the override here!
-    //
-    // But we don't bother for the stage 0 compiler because it's never used
-    // with LTO.
-    if stage >= 1 {
-        cargo.rustflag("-Cembed-bitcode=yes");
-    }
+    cargo.rustflag("-Cembed-bitcode=yes");
+
     if builder.config.rust_lto == RustcLto::Off {
         cargo.rustflag("-Clto=off");
     }

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -722,7 +722,7 @@ fn doc_std(
     let mut cargo =
         builder::Cargo::new(builder, compiler, Mode::Std, SourceType::InTree, target, Kind::Doc);
 
-    compile::std_cargo(builder, target, compiler.stage, &mut cargo);
+    compile::std_cargo(builder, target, &mut cargo);
     cargo
         .arg("--no-deps")
         .arg("--target-dir")

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2858,7 +2858,7 @@ impl Step for Crate {
                         .arg("--manifest-path")
                         .arg(builder.src.join("library/sysroot/Cargo.toml"));
                 } else {
-                    compile::std_cargo(builder, target, compiler.stage, &mut cargo);
+                    compile::std_cargo(builder, target, &mut cargo);
                 }
             }
             Mode::Rustc => {


### PR DESCRIPTION
The standard library can't be built using a compiler that has a lower stage than 1 anymore, so the condition was useless (you can test that with e.g. `x doc std --stage 0`, which is broken - I aim to forbid doing that soon).

Found this while doing an unrelated cleanup.

r? @jieyouxu