### PR TITLE
Fix rustdoc scrape examples crash

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -804,8 +804,7 @@ impl Options {
 
         let scrape_examples_options = ScrapeExamplesOptions::new(matches, dcx);
         let with_examples = matches.opt_strs("with-examples");
-        let call_locations =
-            crate::scrape_examples::load_call_locations(with_examples, dcx, &mut loaded_paths);
+        let call_locations = crate::scrape_examples::load_call_locations(with_examples, dcx);
         let doctest_build_args = matches.opt_strs("doctest-build-arg");
 
         let unstable_features =

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -333,11 +333,14 @@ pub(crate) fn run(
 pub(crate) fn load_call_locations(
     with_examples: Vec<String>,
     dcx: DiagCtxtHandle<'_>,
-    loaded_paths: &mut Vec<PathBuf>,
 ) -> AllCallLocations {
     let mut all_calls: AllCallLocations = FxIndexMap::default();
     for path in with_examples {
-        loaded_paths.push(path.clone().into());
+        // FIXME: Figure out why this line is causing this feature to crash in specific contexts.
+        // Full issue backlog is available here: <https://github.com/rust-lang/rust/pull/144600>.
+        //
+        // Can be checked with `tests/run-make/rustdoc-scrape-examples-paths`.
+        // loaded_paths.push(path.clone().into());
         let bytes = match fs::read(&path) {
             Ok(bytes) => bytes,
             Err(e) => dcx.fatal(format!("failed to load examples: {e}")),

--- a/tests/run-make/rustdoc-scrape-examples-paths/foo/Cargo.toml
+++ b/tests/run-make/rustdoc-scrape-examples-paths/foo/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2024"
+
+[[example]]
+name = "complex"
+doc-scrape-examples = true

--- a/tests/run-make/rustdoc-scrape-examples-paths/foo/examples/complex.rs
+++ b/tests/run-make/rustdoc-scrape-examples-paths/foo/examples/complex.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let mut x = foo::X::new();
+}

--- a/tests/run-make/rustdoc-scrape-examples-paths/foo/examples/tester.rs
+++ b/tests/run-make/rustdoc-scrape-examples-paths/foo/examples/tester.rs
@@ -1,0 +1,1 @@
+// This file MUST exist to trigger the original bug.

--- a/tests/run-make/rustdoc-scrape-examples-paths/foo/src/lib.rs
+++ b/tests/run-make/rustdoc-scrape-examples-paths/foo/src/lib.rs
@@ -1,0 +1,7 @@
+pub struct X;
+
+impl X {
+    pub fn new() -> Self {
+        X
+    }
+}

--- a/tests/run-make/rustdoc-scrape-examples-paths/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-paths/rmake.rs
@@ -1,0 +1,16 @@
+//! Test to ensure that the rustdoc `scrape-examples` feature is not panicking.
+//! Regression test for <https://github.com/rust-lang/rust/issues/144752>.
+
+use run_make_support::{cargo, path, rfs};
+
+fn main() {
+    // We copy the crate to be documented "outside" to prevent documenting
+    // the whole compiler.
+    let tmp = std::env::temp_dir();
+    let test_crate = tmp.join("foo");
+    rfs::copy_dir_all(path("foo"), &test_crate);
+
+    // The `scrape-examples` feature is also implemented in `cargo` so instead of reproducing
+    // what `cargo` does, better to just let `cargo` do it.
+    cargo().current_dir(&test_crate).args(["doc", "-p", "foo", "-Zrustdoc-scrape-examples"]).run();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#144752.

The regression was introduced in https://github.com/rust-lang/rust/pull/144600. Although I don't understand why it is an issue currently, this allows to bypass the failure for now until we can figure out what's wrong as it's currently blocking new `bevy`'s release.

cc @alice-i-cecile 
r? @fmease