### PR TITLE
Couple of minor abi handling cleanups

### DIFF
--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -39,7 +39,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             tcx.thread_local_ptr_ty(instance.def_id()),
             false,
             hir::Safety::Safe,
-            rustc_abi::ExternAbi::Unadjusted,
+            rustc_abi::ExternAbi::Rust,
         );
     }
 


### PR DESCRIPTION
These are extracted out of a wip branch I have to get rid of the `extern "unadjusted"` ABI for anything other than LLVM intrinsics.