### PR TITLE
Revert "Preserve the .debug_gdb_scripts section"

### DIFF
--- a/compiler/rustc_codegen_gcc/src/debuginfo.rs
+++ b/compiler/rustc_codegen_gcc/src/debuginfo.rs
@@ -254,8 +254,7 @@ impl<'gcc, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         // TODO(antoyo): implement.
     }
 
-    fn debuginfo_finalize(&mut self) {
-        // TODO: emit section `.debug_gdb_scripts`.
+    fn debuginfo_finalize(&self) {
         self.context.set_debug_info(true)
     }
 

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -109,14 +109,9 @@ pub(crate) fn compile_codegen_unit(
             }
 
             // Finalize code coverage by injecting the coverage map. Note, the coverage map will
-            // also be added to the `llvm.compiler.used` variable, created below.
+            // also be added to the `llvm.compiler.used` variable, created next.
             if cx.sess().instrument_coverage() {
                 cx.coverageinfo_finalize();
-            }
-
-            // Finalize debuginfo. This adds to `llvm.used`, created below.
-            if cx.sess().opts.debuginfo != DebugInfo::None {
-                cx.debuginfo_finalize();
             }
 
             // Create the llvm.used and llvm.compiler.used variables.
@@ -134,6 +129,11 @@ pub(crate) fn compile_codegen_unit(
                     llvm::LLVMReplaceAllUsesWith(old_g, new_g);
                     llvm::LLVMDeleteGlobal(old_g);
                 }
+            }
+
+            // Finalize debuginfo
+            if cx.sess().opts.debuginfo != DebugInfo::None {
+                cx.debuginfo_finalize();
             }
         }
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -1,7 +1,5 @@
 // .debug_gdb_scripts binary section.
 
-use std::ffi::CString;
-
 use rustc_codegen_ssa::base::collect_debugger_visualizers_transitive;
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -33,12 +31,7 @@ pub(crate) fn insert_reference_to_gdb_debug_scripts_section_global(bx: &mut Buil
 pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
     cx: &CodegenCx<'ll, '_>,
 ) -> &'ll Value {
-    let c_section_var_name = CString::new(format!(
-        "__rustc_debug_gdb_scripts_section_{}_{:08x}",
-        cx.tcx.crate_name(LOCAL_CRATE),
-        cx.tcx.stable_crate_id(LOCAL_CRATE),
-    ))
-    .unwrap();
+    let c_section_var_name = c"__rustc_debug_gdb_scripts_section__";
     let section_var_name = c_section_var_name.to_str().unwrap();
 
     let section_var = unsafe { llvm::LLVMGetNamedGlobal(cx.llmod, c_section_var_name.as_ptr()) };
@@ -91,10 +84,17 @@ pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
 }
 
 pub(crate) fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
-    // We collect pretty printers transitively for all crates, so we make sure
-    // that the section is only emitted for leaf crates.
+    // To ensure the section `__rustc_debug_gdb_scripts_section__` will not create
+    // ODR violations at link time, this section will not be emitted for rlibs since
+    // each rlib could produce a different set of visualizers that would be embedded
+    // in the `.debug_gdb_scripts` section. For that reason, we make sure that the
+    // section is only emitted for leaf crates.
     let embed_visualizers = cx.tcx.crate_types().iter().any(|&crate_type| match crate_type {
-        CrateType::Executable | CrateType::Cdylib | CrateType::Staticlib | CrateType::Sdylib => {
+        CrateType::Executable
+        | CrateType::Dylib
+        | CrateType::Cdylib
+        | CrateType::Staticlib
+        | CrateType::Sdylib => {
             // These are crate types for which we will embed pretty printers since they
             // are treated as leaf crates.
             true
@@ -105,11 +105,9 @@ pub(crate) fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
             // want to slow down the common case.
             false
         }
-        CrateType::Rlib | CrateType::Dylib => {
-            // Don't embed pretty printers for these crate types; the compiler
-            // can see the `#[debug_visualizer]` attributes when using the
-            // library, and emitting `.debug_gdb_scripts` regardless would
-            // break `#![omit_gdb_pretty_printer_section]`.
+        CrateType::Rlib => {
+            // As per the above description, embedding pretty printers for rlibs could
+            // lead to ODR violations so we skip this crate type as well.
             false
         }
     });

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -1,13 +1,13 @@
 // .debug_gdb_scripts binary section.
 
-use std::collections::BTreeSet;
 use std::ffi::CString;
 
+use rustc_codegen_ssa::base::collect_debugger_visualizers_transitive;
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::bug;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerType;
-use rustc_session::config::DebugInfo;
+use rustc_session::config::{CrateType, DebugInfo};
 
 use crate::builder::Builder;
 use crate::common::CodegenCx;
@@ -51,14 +51,10 @@ pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
 
         // Next, add the pretty printers that were specified via the `#[debugger_visualizer]`
         // attribute.
-        let visualizers = cx
-            .tcx
-            .debugger_visualizers(LOCAL_CRATE)
-            .iter()
-            .filter(|visualizer| {
-                visualizer.visualizer_type == DebuggerVisualizerType::GdbPrettyPrinter
-            })
-            .collect::<BTreeSet<_>>();
+        let visualizers = collect_debugger_visualizers_transitive(
+            cx.tcx,
+            DebuggerVisualizerType::GdbPrettyPrinter,
+        );
         let crate_name = cx.tcx.crate_name(LOCAL_CRATE);
         for (index, visualizer) in visualizers.iter().enumerate() {
             // The initial byte `4` instructs GDB that the following pretty printer
@@ -95,5 +91,30 @@ pub(crate) fn get_or_insert_gdb_debug_scripts_section_global<'ll>(
 }
 
 pub(crate) fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
-    cx.sess().opts.debuginfo != DebugInfo::None && cx.sess().target.emit_debug_gdb_scripts
+    // We collect pretty printers transitively for all crates, so we make sure
+    // that the section is only emitted for leaf crates.
+    let embed_visualizers = cx.tcx.crate_types().iter().any(|&crate_type| match crate_type {
+        CrateType::Executable | CrateType::Cdylib | CrateType::Staticlib | CrateType::Sdylib => {
+            // These are crate types for which we will embed pretty printers since they
+            // are treated as leaf crates.
+            true
+        }
+        CrateType::ProcMacro => {
+            // We could embed pretty printers for proc macro crates too but it does not
+            // seem like a good default, since this is a rare use case and we don't
+            // want to slow down the common case.
+            false
+        }
+        CrateType::Rlib | CrateType::Dylib => {
+            // Don't embed pretty printers for these crate types; the compiler
+            // can see the `#[debug_visualizer]` attributes when using the
+            // library, and emitting `.debug_gdb_scripts` regardless would
+            // break `#![omit_gdb_pretty_printer_section]`.
+            false
+        }
+    });
+
+    cx.sess().opts.debuginfo != DebugInfo::None
+        && cx.sess().target.emit_debug_gdb_scripts
+        && embed_visualizers
 }

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -609,7 +609,15 @@ pub fn collect_debugger_visualizers_transitive(
 ) -> BTreeSet<DebuggerVisualizerFile> {
     tcx.debugger_visualizers(LOCAL_CRATE)
         .iter()
-        .chain(tcx.crates(()).iter().flat_map(|&cnum| tcx.debugger_visualizers(cnum)))
+        .chain(
+            tcx.crates(())
+                .iter()
+                .filter(|&cnum| {
+                    let used_crate_source = tcx.used_crate_source(*cnum);
+                    used_crate_source.rlib.is_some() || used_crate_source.rmeta.is_some()
+                })
+                .flat_map(|&cnum| tcx.debugger_visualizers(cnum)),
+        )
         .filter(|visualizer| visualizer.visualizer_type == visualizer_type)
         .cloned()
         .collect::<BTreeSet<_>>()

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -609,15 +609,7 @@ pub fn collect_debugger_visualizers_transitive(
 ) -> BTreeSet<DebuggerVisualizerFile> {
     tcx.debugger_visualizers(LOCAL_CRATE)
         .iter()
-        .chain(
-            tcx.crates(())
-                .iter()
-                .filter(|&cnum| {
-                    let used_crate_source = tcx.used_crate_source(*cnum);
-                    used_crate_source.rlib.is_some() || used_crate_source.rmeta.is_some()
-                })
-                .flat_map(|&cnum| tcx.debugger_visualizers(cnum)),
-        )
+        .chain(tcx.crates(()).iter().flat_map(|&cnum| tcx.debugger_visualizers(cnum)))
         .filter(|visualizer| visualizer.visualizer_type == visualizer_type)
         .cloned()
         .collect::<BTreeSet<_>>()

--- a/compiler/rustc_codegen_ssa/src/traits/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/debuginfo.rs
@@ -50,7 +50,7 @@ pub trait DebugInfoCodegenMethods<'tcx>: BackendTypes {
         scope_metadata: Self::DIScope,
         file: &SourceFile,
     ) -> Self::DIScope;
-    fn debuginfo_finalize(&mut self);
+    fn debuginfo_finalize(&self);
 
     // FIXME(eddyb) find a common convention for all of the debuginfo-related
     // names (choose between `dbg`, `debug`, `debuginfo`, `debug_info` etc.).

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -68,7 +68,6 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-gnu",
     "ignore-haiku",
     "ignore-horizon",
-    "ignore-i586-unknown-linux-gnu",
     "ignore-i686-pc-windows-gnu",
     "ignore-i686-pc-windows-msvc",
     "ignore-illumos",

--- a/tests/codegen-llvm/gdb_debug_script_load.rs
+++ b/tests/codegen-llvm/gdb_debug_script_load.rs
@@ -9,8 +9,6 @@
 #![feature(lang_items)]
 #![no_std]
 
-// CHECK: @llvm.used = {{.+}} @__rustc_debug_gdb_scripts_section
-
 #[panic_handler]
 fn panic_handler(_: &core::panic::PanicInfo) -> ! {
     loop {}
@@ -24,7 +22,7 @@ extern "C" fn rust_eh_personality() {
 // Needs rustc to generate `main` as that's where the magic load is inserted.
 // IOW, we cannot write this test with `#![no_main]`.
 // CHECK-LABEL: @main
-// CHECK: load volatile i8, {{.+}} @__rustc_debug_gdb_scripts_section
+// CHECK: load volatile i8, {{.+}} @__rustc_debug_gdb_scripts_section__
 
 #[lang = "start"]
 fn lang_start<T: 'static>(

--- a/tests/debuginfo/embedded-visualizer.rs
+++ b/tests/debuginfo/embedded-visualizer.rs
@@ -1,8 +1,6 @@
 //@ compile-flags:-g
 //@ ignore-lldb
 //@ ignore-windows-gnu: #128981
-//@ ignore-musl: linker too old in CI
-//@ ignore-i586-unknown-linux-gnu: linker too old in CI
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -35,7 +35,13 @@ fn symbols_check_archive(path: &str) {
             continue; // All compiler-builtins symbols must remain unmangled
         }
 
-        if symbol_ok_everywhere(name) {
+        if name.contains("rust_eh_personality") {
+            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
+        }
+
+        if name.contains(".llvm.") {
+            // Starting in LLVM 21 we get various implementation-detail functions which
+            // contain .llvm. that are not a problem.
             continue;
         }
 
@@ -65,7 +71,13 @@ fn symbols_check(path: &str) {
             continue;
         }
 
-        if symbol_ok_everywhere(name) {
+        if name.contains("rust_eh_personality") {
+            continue; // Unfortunately LLVM doesn't allow us to mangle this symbol
+        }
+
+        if name.contains(".llvm.") {
+            // Starting in LLVM 21 we get various implementation-detail functions which
+            // contain .llvm. that are not a problem.
             continue;
         }
 
@@ -75,23 +87,4 @@ fn symbols_check(path: &str) {
 
 fn strip_underscore_if_apple(symbol: &str) -> &str {
     if cfg!(target_vendor = "apple") { symbol.strip_prefix("_").unwrap() } else { symbol }
-}
-
-fn symbol_ok_everywhere(name: &str) -> bool {
-    if name.contains("rust_eh_personality") {
-        return true; // Unfortunately LLVM doesn't allow us to mangle this symbol
-    }
-
-    if name.contains(".llvm.") {
-        // Starting in LLVM 21 we get various implementation-detail functions which
-        // contain .llvm. that are not a problem.
-        return true;
-    }
-
-    if name.starts_with("__rustc_debug_gdb_scripts_section") {
-        // These symbols are fine; they're made unique by the crate ID.
-        return true;
-    }
-
-    return false;
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/143679 introduces a significant build time perf regression for ripgrep. Let's revert it such that we can investigate it without pressure.