### PR TITLE
Explicitly disable vector feature on s390x baseline of bad-reg test

### DIFF
--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -1,7 +1,7 @@
 //@ add-core-stubs
 //@ needs-asm-support
 //@ revisions: s390x s390x_vector s390x_vector_stable
-//@[s390x] compile-flags: --target s390x-unknown-linux-gnu
+//@[s390x] compile-flags: --target s390x-unknown-linux-gnu -C target-feature=-vector
 //@[s390x] needs-llvm-components: systemz
 //@[s390x_vector] compile-flags: --target s390x-unknown-linux-gnu -C target-feature=+vector
 //@[s390x_vector] needs-llvm-components: systemz


### PR DESCRIPTION
If the baseline s390x cpu is changed to a newer variant, such as z13, the vector feature may be enabled by default. When rust is packaged on fedora 38 and newer, it is set to z13.

Explicitly disable vector support on the baseline test for consistent results across s390x cpus.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
