### PR TITLE
rustdoc: turn is_unnamable into a compiler query

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -879,6 +879,7 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     providers.resolutions = |tcx, ()| tcx.resolver_for_lowering_raw(()).1;
     providers.early_lint_checks = early_lint_checks;
     providers.env_var_os = env_var_os;
+    providers.is_unnamable = crate::queries::is_unnamable;
     limits::provide(providers);
     proc_macro_decls::provide(providers);
     rustc_const_eval::provide(providers);

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -5,7 +5,8 @@ use rustc_codegen_ssa::CodegenResults;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_data_structures::svh::Svh;
 use rustc_errors::timings::TimingSection;
-use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_metadata::EncodedMetadata;
 use rustc_middle::dep_graph::DepGraph;
 use rustc_middle::ty::TyCtxt;
@@ -106,4 +107,33 @@ impl Linker {
         let _timing = sess.timings.section_guard(sess.dcx(), TimingSection::Linking);
         codegen_backend.link(sess, codegen_results, self.metadata, &self.output_filenames)
     }
+}
+
+/// Checks if the given `DefId` refers to an item that is unnamable, such as one defined in a const block.
+///
+/// # Example
+///
+/// ```
+/// pub fn f() {
+///     // In here, `X` is not reachable outside of `f`, making it unnamable.
+///     pub struct X;
+/// }
+/// ```
+pub(crate) fn is_unnamable(tcx: TyCtxt<'_>, did: DefId) -> bool {
+    let mut cur_did = did;
+    while let Some(parent) = tcx.opt_parent(cur_did) {
+        match tcx.def_kind(parent) {
+            // items defined in these can be linked to, as long as they are visible
+            DefKind::Mod | DefKind::ForeignMod => cur_did = parent,
+            // items in impls can be linked to,
+            // as long as we can link to the item the impl is on.
+            // since associated traits are not yet a thing,
+            // it should not be possible to refer to an impl item if
+            // the base type is not namable.
+            DefKind::Impl { .. } => return false,
+            // everything else does not have docs generated for it
+            _ => return true,
+        }
+    }
+    return false;
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1547,6 +1547,22 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    /// Checks if the given `DefId` refers to an item that is unnamable, such as one defined in a const block.
+    ///
+    /// Used by rustdoc.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// pub fn f() {
+    ///     // In here, `X` is not reachable outside of `f`, making it unnamable.
+    ///     pub struct X;
+    /// }
+    /// ```
+    query is_unnamable(def_id: DefId) -> bool {
+        desc { |tcx| "checking if `{}` is unnamable", tcx.def_path_str(def_id) }
+    }
+
     query impl_parent(def_id: DefId) -> Option<DefId> {
         desc { |tcx| "computing specialization parent impl of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -481,26 +481,6 @@ fn generate_item_def_id_path(
     Ok((url_parts, shortty, fqp))
 }
 
-/// Checks if the given defid refers to an item that is unnamable, such as one defined in a const block.
-fn is_unnamable(tcx: TyCtxt<'_>, did: DefId) -> bool {
-    let mut cur_did = did;
-    while let Some(parent) = tcx.opt_parent(cur_did) {
-        match tcx.def_kind(parent) {
-            // items defined in these can be linked to, as long as they are visible
-            DefKind::Mod | DefKind::ForeignMod => cur_did = parent,
-            // items in impls can be linked to,
-            // as long as we can link to the item the impl is on.
-            // since associated traits are not a thing,
-            // it should not be possible to refer to an impl item if
-            // the base type is not namable.
-            DefKind::Impl { .. } => return false,
-            // everything else does not have docs generated for it
-            _ => return true,
-        }
-    }
-    return false;
-}
-
 fn to_module_fqp(shortty: ItemType, fqp: &[Symbol]) -> &[Symbol] {
     if shortty == ItemType::Module { fqp } else { &fqp[..fqp.len() - 1] }
 }
@@ -574,7 +554,7 @@ pub(crate) fn href_with_root_path(
         }
         _ => original_did,
     };
-    if is_unnamable(cx.tcx(), did) {
+    if cx.tcx().is_unnamable(did) {
         return Err(HrefError::UnnamableItem);
     }
     let cache = cx.cache();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

as discussed in https://github.com/rust-lang/rust/pull/143849#issuecomment-3151638381

first time adding a compiler query, so i'm not sure if i have all the options and caching strategies configured right.

need someone to run a perf job for me on this.

once this is merged i may send a followup to also use this query to inhibit normalization into unnamable types.

as discussed in https://github.com/rust-lang/rust/pull/143849#issuecomment-3151638381

r? @GuillaumeGomez 