### PR TITLE
GVN:  Do not flatten derefs with ProjectionElem::Index. 

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -756,7 +756,13 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                 && let Some(v) = self.simplify_place_value(&mut pointee, location)
             {
                 value = v;
-                place_ref = pointee.project_deeper(&place.projection[index..], self.tcx).as_ref();
+                // `pointee` holds a `Place`, so `ProjectionElem::Index` holds a `Local`.
+                // That local is SSA, but we otherwise have no guarantee on that local's value at
+                // the current location compared to its value where `pointee` was borrowed.
+                if pointee.projection.iter().all(|elem| !matches!(elem, ProjectionElem::Index(_))) {
+                    place_ref =
+                        pointee.project_deeper(&place.projection[index..], self.tcx).as_ref();
+                }
             }
             if let Some(local) = self.try_as_local(value, location) {
                 // Both `local` and `Place { local: place.local, projection: projection[..index] }`
@@ -774,7 +780,12 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
             && let Some(v) = self.simplify_place_value(&mut pointee, location)
         {
             value = v;
-            place_ref = pointee.project_deeper(&[], self.tcx).as_ref();
+            // `pointee` holds a `Place`, so `ProjectionElem::Index` holds a `Local`.
+            // That local is SSA, but we otherwise have no guarantee on that local's value at
+            // the current location compared to its value where `pointee` was borrowed.
+            if pointee.projection.iter().all(|elem| !matches!(elem, ProjectionElem::Index(_))) {
+                place_ref = pointee.project_deeper(&[], self.tcx).as_ref();
+            }
         }
         if let Some(new_local) = self.try_as_local(value, location) {
             place_ref = PlaceRef { local: new_local, projection: &[] };

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
@@ -1,0 +1,60 @@
+- // MIR for `dereference_indexing` before GVN
++ // MIR for `dereference_indexing` after GVN
+  
+  fn dereference_indexing(_1: [u8; 2], _2: usize) -> () {
+      debug array => _1;
+      debug index => _2;
+      let mut _0: ();
+      let _3: &u8;
+      let _4: usize;
+      let mut _5: usize;
+      let _6: usize;
+      let mut _7: bool;
+      let _8: ();
+      let mut _9: u8;
+      scope 1 {
+          debug a => _3;
+      }
+      scope 2 {
+          debug i => _4;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+-         StorageLive(_4);
++         nop;
+          StorageLive(_5);
+          _5 = copy _2;
+-         _4 = Add(move _5, const 1_usize);
++         _4 = Add(copy _2, const 1_usize);
+          StorageDead(_5);
+          StorageLive(_6);
+          _6 = copy _4;
+-         _7 = Lt(copy _6, const 2_usize);
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _6) -> [success: bb1, unwind unreachable];
++         _7 = Lt(copy _4, const 2_usize);
++         assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _4) -> [success: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+-         _3 = &_1[_6];
+-         StorageDead(_4);
++         _3 = &_1[_4];
++         nop;
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = copy (*_3);
++         _9 = copy _1[_4];
+          _8 = opaque::<u8>(move _9) -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          _0 = const ();
+          StorageDead(_6);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-abort.diff
@@ -43,8 +43,7 @@
 +         nop;
           StorageLive(_8);
           StorageLive(_9);
--         _9 = copy (*_3);
-+         _9 = copy _1[_4];
+          _9 = copy (*_3);
           _8 = opaque::<u8>(move _9) -> [return: bb2, unwind unreachable];
       }
   

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
@@ -1,0 +1,60 @@
+- // MIR for `dereference_indexing` before GVN
++ // MIR for `dereference_indexing` after GVN
+  
+  fn dereference_indexing(_1: [u8; 2], _2: usize) -> () {
+      debug array => _1;
+      debug index => _2;
+      let mut _0: ();
+      let _3: &u8;
+      let _4: usize;
+      let mut _5: usize;
+      let _6: usize;
+      let mut _7: bool;
+      let _8: ();
+      let mut _9: u8;
+      scope 1 {
+          debug a => _3;
+      }
+      scope 2 {
+          debug i => _4;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+-         StorageLive(_4);
++         nop;
+          StorageLive(_5);
+          _5 = copy _2;
+-         _4 = Add(move _5, const 1_usize);
++         _4 = Add(copy _2, const 1_usize);
+          StorageDead(_5);
+          StorageLive(_6);
+          _6 = copy _4;
+-         _7 = Lt(copy _6, const 2_usize);
+-         assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _6) -> [success: bb1, unwind continue];
++         _7 = Lt(copy _4, const 2_usize);
++         assert(move _7, "index out of bounds: the length is {} but the index is {}", const 2_usize, copy _4) -> [success: bb1, unwind continue];
+      }
+  
+      bb1: {
+-         _3 = &_1[_6];
+-         StorageDead(_4);
++         _3 = &_1[_4];
++         nop;
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = copy (*_3);
++         _9 = copy _1[_4];
+          _8 = opaque::<u8>(move _9) -> [return: bb2, unwind continue];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          _0 = const ();
+          StorageDead(_6);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.dereference_indexing.GVN.panic-unwind.diff
@@ -43,8 +43,7 @@
 +         nop;
           StorageLive(_8);
           StorageLive(_9);
--         _9 = copy (*_3);
-+         _9 = copy _1[_4];
+          _9 = copy (*_3);
           _8 = opaque::<u8>(move _9) -> [return: bb2, unwind continue];
       }
   


### PR DESCRIPTION
r? @saethlin 

This should fix the bug you found with https://github.com/rust-lang/rust/pull/131650

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
