### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -40,7 +40,7 @@ ast_passes_auto_generic = auto traits cannot have generic parameters
 
 ast_passes_auto_items = auto traits cannot have associated items
     .label = {ast_passes_auto_items}
-    .suggestion = remove these associated items
+    .suggestion = remove the associated items
 
 ast_passes_auto_super_lifetime = auto traits cannot have super traits or lifetime bounds
     .label = {ast_passes_auto_super_lifetime}

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -699,19 +699,23 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn deny_super_traits(&self, bounds: &GenericBounds, ident_span: Span) {
+    fn deny_super_traits(&self, bounds: &GenericBounds, ident: Span) {
         if let [.., last] = &bounds[..] {
-            let span = ident_span.shrink_to_hi().to(last.span());
-            self.dcx().emit_err(errors::AutoTraitBounds { span, ident: ident_span });
+            let span = bounds.iter().map(|b| b.span()).collect();
+            let removal = ident.shrink_to_hi().to(last.span());
+            self.dcx().emit_err(errors::AutoTraitBounds { span, removal, ident });
         }
     }
 
-    fn deny_where_clause(&self, where_clause: &WhereClause, ident_span: Span) {
+    fn deny_where_clause(&self, where_clause: &WhereClause, ident: Span) {
         if !where_clause.predicates.is_empty() {
             // FIXME: The current diagnostic is misleading since it only talks about
             // super trait and lifetime bounds while we should just say “bounds”.
-            self.dcx()
-                .emit_err(errors::AutoTraitBounds { span: where_clause.span, ident: ident_span });
+            self.dcx().emit_err(errors::AutoTraitBounds {
+                span: vec![where_clause.span],
+                removal: where_clause.span,
+                ident,
+            });
         }
     }
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -344,7 +344,7 @@ pub(crate) struct ModuleNonAscii {
 #[diag(ast_passes_auto_generic, code = E0567)]
 pub(crate) struct AutoTraitGeneric {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub span: Span,
     #[label]
     pub ident: Span,
@@ -354,8 +354,9 @@ pub(crate) struct AutoTraitGeneric {
 #[diag(ast_passes_auto_super_lifetime, code = E0568)]
 pub(crate) struct AutoTraitBounds {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
-    pub span: Span,
+    pub span: Vec<Span>,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
+    pub removal: Span,
     #[label]
     pub ident: Span,
 }
@@ -365,7 +366,7 @@ pub(crate) struct AutoTraitBounds {
 pub(crate) struct AutoTraitItems {
     #[primary_span]
     pub spans: Vec<Span>,
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub total: Span,
     #[label]
     pub ident: Span,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2156,6 +2156,7 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
+        report_in_deps: true,
     };
     crate_level_only
 }
@@ -2887,11 +2888,12 @@ declare_lint! {
     /// struct S { /* fields */ }
     /// ```
     pub LEGACY_DERIVE_HELPERS,
-    Warn,
+    Deny,
     "detects derive helper attributes that are used before they are introduced",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #79202 <https://github.com/rust-lang/rust/issues/79202>",
+        report_in_deps: true,
     };
 }
 
@@ -4624,11 +4626,12 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub PRIVATE_MACRO_USE,
-    Warn,
+    Deny,
     "detects certain macro bindings that should not be re-exported",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #120192 <https://github.com/rust-lang/rust/issues/120192>",
+        report_in_deps: true,
     };
 }
 
@@ -4828,7 +4831,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// #![doc = in_root!()]
     ///
     /// macro_rules! in_root { () => { "" } }
@@ -4853,11 +4856,12 @@ declare_lint! {
     ///
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub OUT_OF_SCOPE_MACRO_CALLS,
-    Warn,
+    Deny,
     "detects out of scope calls to `macro_rules` in key-value attributes",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseError,
         reference: "issue #124535 <https://github.com/rust-lang/rust/issues/124535>",
+        report_in_deps: true,
     };
 }
 

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -725,7 +725,7 @@ unsafe impl Send for TypeId {}
 unsafe impl Sync for TypeId {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+#[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 impl const PartialEq for TypeId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -773,7 +773,7 @@ impl TypeId {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[rustc_const_stable(feature = "const_type_id", since = "CURRENT_RUSTC_VERSION")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         const { intrinsics::type_id::<T>() }
     }

--- a/tests/ui/attributes/key-value-expansion-scope.rs
+++ b/tests/ui/attributes/key-value-expansion-scope.rs
@@ -1,7 +1,7 @@
-#![doc = in_root!()] //~ WARN cannot find macro `in_root`
+#![doc = in_root!()] //~ ERROR cannot find macro `in_root`
                      //~| WARN this was previously accepted by the compiler
 #![doc = in_mod!()] //~ ERROR cannot find macro `in_mod` in this scope
-#![doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+#![doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                            //~| WARN this was previously accepted by the compiler
 #![doc = in_block!()] //~ ERROR cannot find macro `in_block` in this scope
 
@@ -18,10 +18,10 @@ fn before() {
 
 macro_rules! in_root { () => { "" } }
 
-#[doc = in_mod!()] //~ WARN cannot find macro `in_mod`
+#[doc = in_mod!()] //~ ERROR cannot find macro `in_mod`
                    //~| WARN this was previously accepted by the compiler
 mod macros_stay {
-    #![doc = in_mod!()] //~ WARN cannot find macro `in_mod`
+    #![doc = in_mod!()] //~ ERROR cannot find macro `in_mod`
                         //~| WARN this was previously accepted by the compiler
 
     macro_rules! in_mod { () => { "" } }
@@ -33,10 +33,10 @@ mod macros_stay {
 }
 
 #[macro_use]
-#[doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+#[doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                           //~| WARN this was previously accepted by the compiler
 mod macros_escape {
-    #![doc = in_mod_escape!()] //~ WARN cannot find macro `in_mod_escape`
+    #![doc = in_mod_escape!()] //~ ERROR cannot find macro `in_mod_escape`
                                //~| WARN this was previously accepted by the compiler
 
     macro_rules! in_mod_escape { () => { "" } }

--- a/tests/ui/attributes/key-value-expansion-scope.stderr
+++ b/tests/ui/attributes/key-value-expansion-scope.stderr
@@ -126,7 +126,7 @@ LL |     #![doc = in_block!()]
    |
    = help: have you added the `#[macro_use]` on the module/import?
 
-warning: cannot find macro `in_root` in the current scope when looking from the crate root
+error: cannot find macro `in_root` in the current scope when looking from the crate root
   --> $DIR/key-value-expansion-scope.rs:1:10
    |
 LL | #![doc = in_root!()]
@@ -135,9 +135,9 @@ LL | #![doc = in_root!()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
-   = note: `#[warn(out_of_scope_macro_calls)]` on by default
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
+error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
   --> $DIR/key-value-expansion-scope.rs:4:10
    |
 LL | #![doc = in_mod_escape!()]
@@ -147,7 +147,7 @@ LL | #![doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:21:9
    |
 LL | #[doc = in_mod!()]
@@ -157,7 +157,7 @@ LL | #[doc = in_mod!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
   --> $DIR/key-value-expansion-scope.rs:24:14
    |
 LL |     #![doc = in_mod!()]
@@ -167,7 +167,7 @@ LL |     #![doc = in_mod!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:36:9
    |
 LL | #[doc = in_mod_escape!()]
@@ -177,7 +177,7 @@ LL | #[doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-warning: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
   --> $DIR/key-value-expansion-scope.rs:39:14
    |
 LL |     #![doc = in_mod_escape!()]
@@ -187,5 +187,77 @@ LL |     #![doc = in_mod_escape!()]
    = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
    = help: import `macro_rules` with `use` to make it callable above its definition
 
-error: aborting due to 16 previous errors; 6 warnings emitted
+error: aborting due to 22 previous errors
+
+Future incompatibility report: Future breakage diagnostic:
+error: cannot find macro `in_root` in the current scope when looking from the crate root
+  --> $DIR/key-value-expansion-scope.rs:1:10
+   |
+LL | #![doc = in_root!()]
+   |          ^^^^^^^ not found from the crate root
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from the crate root
+  --> $DIR/key-value-expansion-scope.rs:4:10
+   |
+LL | #![doc = in_mod_escape!()]
+   |          ^^^^^^^^^^^^^ not found from the crate root
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+  --> $DIR/key-value-expansion-scope.rs:21:9
+   |
+LL | #[doc = in_mod!()]
+   |         ^^^^^^ not found from module `macros_stay`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod` in the current scope when looking from module `macros_stay`
+  --> $DIR/key-value-expansion-scope.rs:24:14
+   |
+LL |     #![doc = in_mod!()]
+   |              ^^^^^^ not found from module `macros_stay`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+  --> $DIR/key-value-expansion-scope.rs:36:9
+   |
+LL | #[doc = in_mod_escape!()]
+   |         ^^^^^^^^^^^^^ not found from module `macros_escape`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
+
+Future breakage diagnostic:
+error: cannot find macro `in_mod_escape` in the current scope when looking from module `macros_escape`
+  --> $DIR/key-value-expansion-scope.rs:39:14
+   |
+LL |     #![doc = in_mod_escape!()]
+   |              ^^^^^^^^^^^^^ not found from module `macros_escape`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124535 <https://github.com/rust-lang/rust/issues/124535>
+   = help: import `macro_rules` with `use` to make it callable above its definition
+   = note: `#[deny(out_of_scope_macro_calls)]` on by default
 

--- a/tests/ui/auto-traits/assoc-ty.current.stderr
+++ b/tests/ui/auto-traits/assoc-ty.current.stderr
@@ -5,7 +5,7 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/assoc-ty.next.stderr
+++ b/tests/ui/auto-traits/assoc-ty.next.stderr
@@ -5,7 +5,7 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/auto-trait-validation.fixed
+++ b/tests/ui/auto-traits/auto-trait-validation.fixed
@@ -11,4 +11,15 @@ auto trait LifetimeBound {}
 //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait {  }
 //~^ ERROR auto traits cannot have associated items [E0380]
+auto trait AssocTy {  }
+//~^ ERROR auto traits cannot have associated items [E0380]
+auto trait All {
+    //~^ ERROR auto traits cannot have generic parameters [E0567]
+    
+}
+// We can't test both generic params and super-traits because the suggestion span overlaps.
+auto trait All2 {
+    //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
+    
+}
 fn main() {}

--- a/tests/ui/auto-traits/auto-trait-validation.rs
+++ b/tests/ui/auto-traits/auto-trait-validation.rs
@@ -11,4 +11,19 @@ auto trait LifetimeBound : 'static {}
 //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait { fn foo() {} }
 //~^ ERROR auto traits cannot have associated items [E0380]
+auto trait AssocTy { type Bar; }
+//~^ ERROR auto traits cannot have associated items [E0380]
+auto trait All<'a, T> {
+    //~^ ERROR auto traits cannot have generic parameters [E0567]
+    type Bar;
+    //~^ ERROR auto traits cannot have associated items [E0380]
+    fn foo() {}
+}
+// We can't test both generic params and super-traits because the suggestion span overlaps.
+auto trait All2: Copy + 'static {
+    //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
+    type Bar;
+    //~^ ERROR auto traits cannot have associated items [E0380]
+    fn foo() {}
+}
 fn main() {}

--- a/tests/ui/auto-traits/auto-trait-validation.stderr
+++ b/tests/ui/auto-traits/auto-trait-validation.stderr
@@ -2,23 +2,23 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/auto-trait-validation.rs:6:19
    |
 LL | auto trait Generic<T> {}
-   |            -------^^^ help: remove the parameters
+   |            -------^^^
    |            |
    |            auto trait cannot have generic parameters
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:8:17
+  --> $DIR/auto-trait-validation.rs:8:20
    |
 LL | auto trait Bound : Copy {}
-   |            -----^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----   ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:10:25
+  --> $DIR/auto-trait-validation.rs:10:28
    |
 LL | auto trait LifetimeBound : 'static {}
-   |            -------------^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -------------   ^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
@@ -26,12 +26,59 @@ error[E0380]: auto traits cannot have associated items
   --> $DIR/auto-trait-validation.rs:12:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   |            -------   ---^^^-----
-   |            |         |
-   |            |         help: remove these associated items
+   |            -------      ^^^
+   |            |
    |            auto traits cannot have associated items
 
-error: aborting due to 4 previous errors
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:14:27
+   |
+LL | auto trait AssocTy { type Bar; }
+   |            -------        ^^^
+   |            |
+   |            auto traits cannot have associated items
+
+error[E0567]: auto traits cannot have generic parameters
+  --> $DIR/auto-trait-validation.rs:16:15
+   |
+LL | auto trait All<'a, T> {
+   |            ---^^^^^^^
+   |            |
+   |            auto trait cannot have generic parameters
+
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:18:10
+   |
+LL | auto trait All<'a, T> {
+   |            --- auto traits cannot have associated items
+LL |
+LL |     type Bar;
+   |          ^^^
+LL |
+LL |     fn foo() {}
+   |        ^^^
+
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/auto-trait-validation.rs:23:18
+   |
+LL | auto trait All2: Copy + 'static {
+   |            ----  ^^^^   ^^^^^^^
+   |            |
+   |            auto traits cannot have super traits or lifetime bounds
+
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:25:10
+   |
+LL | auto trait All2: Copy + 'static {
+   |            ---- auto traits cannot have associated items
+LL |
+LL |     type Bar;
+   |          ^^^
+LL |
+LL |     fn foo() {}
+   |        ^^^
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0380, E0567, E0568.
 For more information about an error, try `rustc --explain E0380`.

--- a/tests/ui/auto-traits/bad-generics-on-dyn.stderr
+++ b/tests/ui/auto-traits/bad-generics-on-dyn.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/bad-generics-on-dyn.rs:3:18
    |
 LL | auto trait Trait1<'a> {}
-   |            ------^^^^ help: remove the parameters
+   |            ------^^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/has-arguments.stderr
+++ b/tests/ui/auto-traits/has-arguments.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/has-arguments.rs:3:18
    |
 LL | auto trait Trait1<'outer> {}
-   |            ------^^^^^^^^ help: remove the parameters
+   |            ------^^^^^^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/issue-117789.stderr
+++ b/tests/ui/auto-traits/issue-117789.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/issue-117789.rs:1:17
    |
 LL | auto trait Trait<P> {}
-   |            -----^^^ help: remove the parameters
+   |            -----^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/issue-23080-2.current.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.current.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080-2.next.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.next.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080.stderr
+++ b/tests/ui/auto-traits/issue-23080.stderr
@@ -1,13 +1,10 @@
 error[E0380]: auto traits cannot have associated items
   --> $DIR/issue-23080.rs:5:8
    |
-LL |   unsafe auto trait Trait {
-   |                     ----- auto traits cannot have associated items
-LL |       fn method(&self) {
-   |  _____-  ^^^^^^
-LL | |         println!("Hello");
-LL | |     }
-   | |_____- help: remove these associated items
+LL | unsafe auto trait Trait {
+   |                   ----- auto traits cannot have associated items
+LL |     fn method(&self) {
+   |        ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-84075.stderr
+++ b/tests/ui/auto-traits/issue-84075.stderr
@@ -2,7 +2,7 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/issue-84075.rs:5:18
    |
 LL | auto trait Magic where Self: Copy {}
-   |            ----- ^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            ----- ^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:17
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----   ^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
@@ -10,7 +10,7 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:26
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/typeck-auto-trait-no-supertraits.rs:28:17
+  --> $DIR/typeck-auto-trait-no-supertraits.rs:28:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----  ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -1,4 +1,3 @@
-#![feature(const_type_id)]
 #![feature(generic_const_exprs)]
 #![feature(const_trait_impl, const_cmp)]
 #![feature(core_intrinsics)]

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -1,5 +1,5 @@
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:15:8
+  --> $DIR/issue-90318.rs:14:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = note: this operation may be supported in the future
 
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:22:8
+  --> $DIR/issue-90318.rs:21:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-typeid-of-rpass.rs
+++ b/tests/ui/consts/const-typeid-of-rpass.rs
@@ -1,6 +1,4 @@
 //@ run-pass
-#![feature(const_type_id)]
-#![feature(core_intrinsics)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_cmp_type_id.rs
+++ b/tests/ui/consts/const_cmp_type_id.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Znext-solver
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id.rs
+++ b/tests/ui/consts/const_transmute_type_id.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id2.rs
+++ b/tests/ui/consts/const_transmute_type_id2.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "0x(ff)+" -> "<u128::MAX>"
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature( const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id3.rs
+++ b/tests/ui/consts/const_transmute_type_id3.rs
@@ -1,7 +1,7 @@
 //! Test that all bytes of a TypeId must have the
 //! TypeId marker provenance.
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature( const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id4.rs
+++ b/tests/ui/consts/const_transmute_type_id4.rs
@@ -1,4 +1,4 @@
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/const_transmute_type_id5.rs
+++ b/tests/ui/consts/const_transmute_type_id5.rs
@@ -1,7 +1,7 @@
 //! Test that we require an equal TypeId to have an integer part that properly
 //! reflects the type id hash.
 
-#![feature(const_type_id, const_trait_impl, const_cmp)]
+#![feature(const_trait_impl, const_cmp)]
 
 use std::any::TypeId;
 

--- a/tests/ui/consts/issue-102117.rs
+++ b/tests/ui/consts/issue-102117.rs
@@ -1,5 +1,3 @@
-#![feature(const_type_id)]
-
 use std::alloc::Layout;
 use std::any::TypeId;
 use std::mem::transmute;

--- a/tests/ui/consts/issue-102117.stderr
+++ b/tests/ui/consts/issue-102117.stderr
@@ -1,5 +1,5 @@
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/issue-102117.rs:19:26
+  --> $DIR/issue-102117.rs:17:26
    |
 LL |                 type_id: TypeId::of::<T>(),
    |                          ^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     pub fn new<T: 'static>() -> &'static Self {
    |                 +++++++++
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/issue-102117.rs:19:26
+  --> $DIR/issue-102117.rs:17:26
    |
 LL |                 type_id: TypeId::of::<T>(),
    |                          ^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/issue-73976-monomorphic.rs
+++ b/tests/ui/consts/issue-73976-monomorphic.rs
@@ -5,7 +5,6 @@
 // will be properly rejected. This test will ensure that monomorphic use of these
 // would not be wrongly rejected in patterns.
 
-#![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_trait_impl)]
 #![feature(const_cmp)]

--- a/tests/ui/consts/issue-73976-polymorphic.rs
+++ b/tests/ui/consts/issue-73976-polymorphic.rs
@@ -5,7 +5,6 @@
 // This test case should either run-pass or be rejected at compile time.
 // Currently we just disallow this usage and require pattern is monomorphic.
 
-#![feature(const_type_id)]
 #![feature(const_type_name)]
 
 use std::any::{self, TypeId};

--- a/tests/ui/consts/issue-73976-polymorphic.stderr
+++ b/tests/ui/consts/issue-73976-polymorphic.stderr
@@ -1,5 +1,5 @@
 error[E0158]: constant pattern cannot depend on generic parameters
-  --> $DIR/issue-73976-polymorphic.rs:20:37
+  --> $DIR/issue-73976-polymorphic.rs:19:37
    |
 LL | impl<T: 'static> GetTypeId<T> {
    | -----------------------------
@@ -12,7 +12,7 @@ LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<T>::VALUE)
    |                                     ^^^^^^^^^^^^^^^^^^^^^ `const` depends on a generic parameter
 
 error[E0158]: constant pattern cannot depend on generic parameters
-  --> $DIR/issue-73976-polymorphic.rs:31:42
+  --> $DIR/issue-73976-polymorphic.rs:30:42
    |
 LL | impl<T: 'static> GetTypeNameLen<T> {
    | ----------------------------------

--- a/tests/ui/extern/issue-80074.rs
+++ b/tests/ui/extern/issue-80074.rs
@@ -11,7 +11,7 @@ extern crate issue_80074_2;
 
 fn main() {
     foo!();
-    //~^ WARN: macro `foo` is private
+    //~^ ERROR: macro `foo` is private
     //~| WARN: it will become a hard error in a future release!
     bar!();
     //~^ ERROR: cannot find macro `bar` in this scope

--- a/tests/ui/extern/issue-80074.stderr
+++ b/tests/ui/extern/issue-80074.stderr
@@ -16,7 +16,7 @@ error: cannot find macro `m` in this scope
 LL |     m!();
    |     ^
 
-warning: macro `foo` is private
+error: macro `foo` is private
   --> $DIR/issue-80074.rs:13:5
    |
 LL |     foo!();
@@ -24,8 +24,19 @@ LL |     foo!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #120192 <https://github.com/rust-lang/rust/issues/120192>
-   = note: `#[warn(private_macro_use)]` on by default
+   = note: `#[deny(private_macro_use)]` on by default
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0469`.
+Future incompatibility report: Future breakage diagnostic:
+error: macro `foo` is private
+  --> $DIR/issue-80074.rs:13:5
+   |
+LL |     foo!();
+   |     ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #120192 <https://github.com/rust-lang/rust/issues/120192>
+   = note: `#[deny(private_macro_use)]` on by default
+

--- a/tests/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -41,3 +41,47 @@ LL |   define_exported!();
 
 error: aborting due to 2 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-2.rs:13:9
+   |
+LL |     use crate::exported;
+   |         ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-2.rs:5:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------ in this macro invocation
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+  --> $DIR/local-modularized-tricky-fail-2.rs:19:5
+   |
+LL |     crate::exported!();
+   |     ^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+note: the macro is defined here
+  --> $DIR/local-modularized-tricky-fail-2.rs:5:5
+   |
+LL | /     macro_rules! exported {
+LL | |         () => ()
+LL | |     }
+   | |_____^
+...
+LL |   define_exported!();
+   |   ------------------ in this macro invocation
+   = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/tests/ui/methods/issues/issue-105732.stderr
+++ b/tests/ui/methods/issues/issue-105732.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | auto trait Foo {
    |            --- auto traits cannot have associated items
 LL |     fn g(&self);
-   |     ---^-------- help: remove these associated items
+   |        ^
 
 error[E0599]: no method named `g` found for reference `&Self` in the current scope
   --> $DIR/issue-105732.rs:10:14

--- a/tests/ui/proc-macro/derive-helper-shadowing.rs
+++ b/tests/ui/proc-macro/derive-helper-shadowing.rs
@@ -17,7 +17,7 @@ macro_rules! gen_helper_use {
 }
 
 #[empty_helper] //~ ERROR `empty_helper` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[derive(Empty)]
 struct S {

--- a/tests/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/tests/ui/proc-macro/derive-helper-shadowing.stderr
@@ -58,7 +58,7 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/derive-helper-shadowing.rs:19:3
    |
 LL | #[empty_helper]
@@ -69,8 +69,22 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/derive-helper-shadowing.rs:19:3
+   |
+LL | #[empty_helper]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Empty)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.rs
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.rs
@@ -5,7 +5,7 @@ extern crate test_macros;
 use test_macros::empty_attr as empty_helper;
 
 #[empty_helper] //~ ERROR `empty_helper` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[derive(Empty)]
 struct S;

--- a/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
+++ b/tests/ui/proc-macro/helper-attr-blocked-by-import-ambig.stderr
@@ -17,7 +17,7 @@ LL | use test_macros::empty_attr as empty_helper;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: use `crate::empty_helper` to refer to this attribute macro unambiguously
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:3
    |
 LL | #[empty_helper]
@@ -28,8 +28,22 @@ LL | #[derive(Empty)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/helper-attr-blocked-by-import-ambig.rs:7:3
+   |
+LL | #[empty_helper]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Empty)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.rs
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.rs
@@ -6,7 +6,7 @@
 // Tests that we cfg-strip all targets before invoking
 // a derive macro
 // FIXME: We currently lose spans here (see issue #43081)
-
+#![warn(legacy_derive_helpers)]
 #![no_std] // Don't load unnecessary hygiene information from std
 extern crate std;
 

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -9,7 +9,11 @@ LL | #[derive(Print)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 
 warning: derive helper attribute is used before it is introduced
   --> $DIR/issue-75930-derive-cfg.rs:46:3
@@ -25,4 +29,40 @@ LL | #[derive(Print)]
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: 2 warnings emitted
+
+Future incompatibility report: Future breakage diagnostic:
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:46:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+Future breakage diagnostic:
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:46:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+note: the lint level is defined here
+  --> $DIR/issue-75930-derive-cfg.rs:9:9
+   |
+LL | #![warn(legacy_derive_helpers)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/proc-macro/proc-macro-attributes.rs
+++ b/tests/ui/proc-macro/proc-macro-attributes.rs
@@ -4,17 +4,17 @@
 extern crate derive_b;
 
 #[B] //~ ERROR `B` is ambiguous
-     //~| WARN derive helper attribute is used before it is introduced
+     //~| ERROR derive helper attribute is used before it is introduced
      //~| WARN this was previously accepted
 #[C] //~ ERROR cannot find attribute `C` in this scope
 #[B(D)] //~ ERROR `B` is ambiguous
-        //~| WARN derive helper attribute is used before it is introduced
+        //~| ERROR derive helper attribute is used before it is introduced
         //~| WARN this was previously accepted
 #[B(E = "foo")] //~ ERROR `B` is ambiguous
-                //~| WARN derive helper attribute is used before it is introduced
+                //~| ERROR derive helper attribute is used before it is introduced
                 //~| WARN this was previously accepted
 #[B(arbitrary tokens)] //~ ERROR `B` is ambiguous
-                       //~| WARN derive helper attribute is used before it is introduced
+                       //~| ERROR derive helper attribute is used before it is introduced
                        //~| WARN this was previously accepted
 #[derive(B)]
 struct B;

--- a/tests/ui/proc-macro/proc-macro-attributes.stderr
+++ b/tests/ui/proc-macro/proc-macro-attributes.stderr
@@ -76,7 +76,7 @@ note: `B` could also refer to the derive macro imported here
 LL | #[macro_use]
    | ^^^^^^^^^^^^
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:6:3
    |
 LL | #[B]
@@ -87,9 +87,9 @@ LL | #[derive(B)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
-   = note: `#[warn(legacy_derive_helpers)]` on by default
+   = note: `#[deny(legacy_derive_helpers)]` on by default
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:10:3
    |
 LL | #[B(D)]
@@ -101,7 +101,7 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:13:3
    |
 LL | #[B(E = "foo")]
@@ -113,7 +113,7 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: derive helper attribute is used before it is introduced
+error: derive helper attribute is used before it is introduced
   --> $DIR/proc-macro-attributes.rs:16:3
    |
 LL | #[B(arbitrary tokens)]
@@ -125,6 +125,62 @@ LL | #[derive(B)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-error: aborting due to 5 previous errors; 4 warnings emitted
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0659`.
+Future incompatibility report: Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:6:3
+   |
+LL | #[B]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:10:3
+   |
+LL | #[B(D)]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:13:3
+   |
+LL | #[B(E = "foo")]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+
+Future breakage diagnostic:
+error: derive helper attribute is used before it is introduced
+  --> $DIR/proc-macro-attributes.rs:16:3
+   |
+LL | #[B(arbitrary tokens)]
+   |   ^
+...
+LL | #[derive(B)]
+   |          - the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+   = note: `#[deny(legacy_derive_helpers)]` on by default
+

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/supertrait-auto-trait.rs:8:17
+  --> $DIR/supertrait-auto-trait.rs:8:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----  ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#137831 (Tweak auto trait errors)
 - rust-lang/rust#143929 (Mark all deprecation lints in name resolution as deny-by-default and report-in-deps)
 - rust-lang/rust#144133 (Stabilize const TypeId::of)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137831,143929,144133)
<!-- homu-ignore:end -->