### PR TITLE
add block kind during name resolution

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -327,6 +327,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
             module = match rib.kind {
                 RibKind::Module(module) => module,
+                RibKind::Block { module } if let Some(module) = module => module,
                 RibKind::MacroDefinition(def) if def == self.macro_def(ident.span.ctxt()) => {
                     // If an invocation of this macro created `ident`, give up on `ident`
                     // and switch to `ident`'s source from the macro definition.
@@ -1149,6 +1150,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         RibKind::Normal
                         | RibKind::FnOrCoroutine
                         | RibKind::Module(..)
+                        | RibKind::Block { .. }
                         | RibKind::MacroDefinition(..)
                         | RibKind::ForwardGenericParamBan(_) => {
                             // Nothing to do. Continue.
@@ -1241,6 +1243,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         RibKind::Normal
                         | RibKind::FnOrCoroutine
                         | RibKind::Module(..)
+                        | RibKind::Block { .. }
                         | RibKind::MacroDefinition(..)
                         | RibKind::InlineAsmSym
                         | RibKind::AssocItem
@@ -1334,6 +1337,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         RibKind::Normal
                         | RibKind::FnOrCoroutine
                         | RibKind::Module(..)
+                        | RibKind::Block { .. }
                         | RibKind::MacroDefinition(..)
                         | RibKind::InlineAsmSym
                         | RibKind::AssocItem

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -852,7 +852,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         // Try to find in last block rib
         if let Some(rib) = &self.last_block_rib
-            && let RibKind::Normal = rib.kind
+            && let RibKind::Block { module: None } = rib.kind
         {
             for (ident, &res) in &rib.bindings {
                 if let Res::Local(_) = res
@@ -2467,7 +2467,8 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 }
 
                 // Items in scope
-                if let RibKind::Module(module) = rib.kind {
+                if let RibKind::Module(module) | RibKind::Block { module: Some(module) } = rib.kind
+                {
                     // Items from this module
                     self.r.add_module_candidates(module, &mut names, &filter_fn, Some(ctxt));
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/143141#discussion_r2260643817

I've discovered we cannot completely remove `RibKind::Module` as it's still required for module scope operations and is more semantically appropriate, such as:

https://github.com/rust-lang/rust/blob/cd434309efcf5dc68b253e5ef6ba40c1c43711c9/compiler/rustc_resolve/src/late.rs#L1529-L1540

r? @petrochenkov 

