### PR TITLE
Fix example from_utf8_lossy to match the behavior of the real one.

### DIFF
--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -167,7 +167,7 @@ impl fmt::Debug for Debug<'_> {
 ///     for chunk in input.utf8_chunks() {
 ///         push(chunk.valid());
 ///
-///         if !chunk.invalid().is_empty() {
+///         for _byte in chunk.invalid() {
 ///             push("\u{FFFD}");
 ///         }
 ///     }


### PR DESCRIPTION
String::from_utf8_lossy("\xF0\xF0") will return `"��"`, but the example would only push a single `"�"`. I think that's a bit too easy for readers to miss, and the bug is easy to miss in unit tests. (In fact, I'm here right out of a code review where the same mistake existed, possibly inspired by these docs!)

Note that the documentation for utf8_chunks does not have this issue, and does the for loop: https://doc.rust-lang.org/std/primitive.slice.html#method.utf8_chunks
