### PR TITLE
update enzyme submodule to handle llvm 21

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -986,6 +986,7 @@ impl Step for Enzyme {
             .env("LLVM_CONFIG_REAL", &llvm_config)
             .define("LLVM_ENABLE_ASSERTIONS", "ON")
             .define("ENZYME_EXTERNAL_SHARED_LIB", "ON")
+            .define("ENZYME_BC_LOADER", "OFF")
             .define("LLVM_DIR", builder.llvm_out(target));
 
         cfg.build();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This currently has a fix / workaround in our local rust-lang/Enzyme fork, which is needed to unblock a few people contributing to std::autodiff. It also permanently disables a component (BCLoader) which we shouldn't need on the rust side, hence saving a bit of compile time and disk space.

Once upstream Enzyme (EnzymeAD/Enzyme) fixed llvm-21 support I'll probably make another pr to drop our local patch.