### PR TITLE
Escape diff strings in MIR dataflow graphviz

### DIFF
--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -800,6 +800,7 @@ where
     let re = regex!("\t?\u{001f}([+-])");
 
     let raw_diff = format!("{:#?}", DebugDiffWithAdapter { new, old, ctxt });
+    let raw_diff = dot::escape_html(&raw_diff);
 
     // Replace newlines in the `Debug` output with `<br/>`
     let raw_diff = raw_diff.replace('\n', r#"<br align="left"/>"#);


### PR DESCRIPTION
This uses `dot::escape_html` on diff strings so that `<` and `>` are properly escaped in MIR dataflow graphviz.

Previously the output could be malformed. For example, the graphviz for borrow check `MaybeInitializedPlaces` for the example in rust-lang/rust#145032 contained an unescaped `Fork<'_>`.