### PR TITLE
refactor(parse): separate self parameter parsing from general parameter parsing

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2961,9 +2961,9 @@ impl<'a> Parser<'a> {
         let mut params = ThinVec::new();
 
         // Parse the self parameter as first parameter
+        let attrs = self.parse_outer_attributes()?;
         if let Some(mut self_param) = self.parse_self_param()? {
-            let self_attrs = self.parse_outer_attributes()?;
-            self_param.attrs = self.attrs;
+            self_param.attrs = attrs;
             params.push(self_param);
         }    
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2961,7 +2961,7 @@ impl<'a> Parser<'a> {
         let mut params = ThinVec::new();
 
         // Parse the self parameter as first parameter
-        if let Some(mut self_param) = self.parse_self_param()?{
+        if let Some(mut self_param) = self.parse_self_param()? {
             let self_attrs = self.parse_outer_attributes()?;
             self_param.attrs = self.attrs;
             params.push(self_param);

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2960,7 +2960,7 @@ impl<'a> Parser<'a> {
         
         let mut params = ThinVec::new();
 
-        //Parse the self parameter as first parameter
+        // Parse the self parameter as first parameter
         if let Some(mut self_param) = self.parse_self_param()?{
             let self_attrs = self.parse_outer_attributes()?;
             self_param.attrs = self.attrs;

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -400,7 +400,7 @@ impl<'a> Parser<'a> {
 
                     let dcx = self.dcx();
                     let parse_params_result = self.parse_paren_comma_seq(|p| {
-                        let param = p.parse_param_general(|_| false, false, false);
+                        let param = p.parse_param_general(|_| false, false);
                         param.map(move |param| {
                             if !matches!(param.pat.kind, PatKind::Missing) {
                                 dcx.emit_err(FnPathFoundNamedParams {


### PR DESCRIPTION
Fixes rust-lang/rust#144206

The changes-:
Moves self parameter parsing out of parse_param_general and into parse_fn_params
for better separation of concerns. This removes the first_param boolean and its
branching logic while maintaining identical behavior.

Benefits:
- Cleaner separation of concerns
- Improved readability and testability
- More maintainable code structure

No behavioral changes introduced.