### PR TITLE
llvm-wrapper cleanup

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -173,7 +173,7 @@ fn build_pointer_or_reference_di_node<'ll, 'tcx>(
             );
 
             let di_node = unsafe {
-                llvm::LLVMRustDIBuilderCreatePointerType(
+                llvm::LLVMDIBuilderCreatePointerType(
                     DIB(cx),
                     pointee_type_di_node,
                     pointer_size.bits(),
@@ -231,7 +231,7 @@ fn build_pointer_or_reference_di_node<'ll, 'tcx>(
                     // The data pointer type is a regular, thin pointer, regardless of whether this
                     // is a slice or a trait object.
                     let data_ptr_type_di_node = unsafe {
-                        llvm::LLVMRustDIBuilderCreatePointerType(
+                        llvm::LLVMDIBuilderCreatePointerType(
                             DIB(cx),
                             pointee_type_di_node,
                             addr_field.size.bits(),
@@ -327,7 +327,7 @@ fn build_subroutine_type_di_node<'ll, 'tcx>(
         _ => unreachable!(),
     };
     let di_node = unsafe {
-        llvm::LLVMRustDIBuilderCreatePointerType(
+        llvm::LLVMDIBuilderCreatePointerType(
             DIB(cx),
             fn_di_node,
             size.bits(),

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{iter, ptr};
 
-use libc::{c_longlong, c_uint};
+use libc::c_uint;
 use rustc_abi::{Align, Size};
 use rustc_codegen_ssa::debuginfo::type_names::{VTableNameKind, cpp_like_debuginfo};
 use rustc_codegen_ssa::traits::*;
@@ -112,12 +112,10 @@ fn build_fixed_size_array_di_node<'ll, 'tcx>(
 
     let (size, align) = cx.size_and_align_of(array_type);
 
-    let upper_bound = len
-        .try_to_target_usize(cx.tcx)
-        .expect("expected monomorphic const in codegen") as c_longlong;
+    let count =
+        len.try_to_target_usize(cx.tcx).expect("expected monomorphic const in codegen") as i64;
 
-    let subrange =
-        unsafe { Some(llvm::LLVMRustDIBuilderGetOrCreateSubrange(DIB(cx), 0, upper_bound)) };
+    let subrange = unsafe { Some(llvm::LLVMDIBuilderGetOrCreateSubrange(DIB(cx), 0, count)) };
 
     let subscripts = create_DIArray(DIB(cx), &[subrange]);
     let di_node = unsafe {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
@@ -567,38 +567,36 @@ fn build_variant_struct_wrapper_type_di_node<'ll, 'tcx>(
                 None,
             ));
 
-            let build_assoc_const = |name: &str,
-                                     type_di_node_: &'ll DIType,
-                                     value: u64,
-                                     align: Align| unsafe {
-                // FIXME: Currently we force all DISCR_* values to be u64's as LLDB seems to have
-                // problems inspecting other value types. Since DISCR_* is typically only going to be
-                // directly inspected via the debugger visualizer - which compares it to the `tag` value
-                // (whose type is not modified at all) it shouldn't cause any real problems.
-                let (t_di, align) = if name == ASSOC_CONST_DISCR_NAME {
-                    (type_di_node_, align.bits() as u32)
-                } else {
-                    let ty_u64 = Ty::new_uint(cx.tcx, ty::UintTy::U64);
-                    (type_di_node(cx, ty_u64), Align::EIGHT.bits() as u32)
+            let build_assoc_const =
+                |name: &str, type_di_node_: &'ll DIType, value: u64, align: Align| unsafe {
+                    // FIXME: Currently we force all DISCR_* values to be u64's as LLDB seems to have
+                    // problems inspecting other value types. Since DISCR_* is typically only going to be
+                    // directly inspected via the debugger visualizer - which compares it to the `tag` value
+                    // (whose type is not modified at all) it shouldn't cause any real problems.
+                    let (t_di, align) = if name == ASSOC_CONST_DISCR_NAME {
+                        (type_di_node_, align.bits() as u32)
+                    } else {
+                        let ty_u64 = Ty::new_uint(cx.tcx, ty::UintTy::U64);
+                        (type_di_node(cx, ty_u64), Align::EIGHT.bits() as u32)
+                    };
+
+                    // must wrap type in a `const` modifier for LLDB to be able to inspect the value of the member
+                    let field_type =
+                        llvm::LLVMDIBuilderCreateQualifiedType(DIB(cx), DW_TAG_const_type, t_di);
+
+                    llvm::LLVMRustDIBuilderCreateStaticMemberType(
+                        DIB(cx),
+                        wrapper_struct_type_di_node,
+                        name.as_c_char_ptr(),
+                        name.len(),
+                        unknown_file_metadata(cx),
+                        UNKNOWN_LINE_NUMBER,
+                        field_type,
+                        DIFlags::FlagZero,
+                        Some(cx.const_u64(value)),
+                        align,
+                    )
                 };
-
-                // must wrap type in a `const` modifier for LLDB to be able to inspect the value of the member
-                let field_type =
-                    llvm::LLVMRustDIBuilderCreateQualifiedType(DIB(cx), DW_TAG_const_type, t_di);
-
-                llvm::LLVMRustDIBuilderCreateStaticMemberType(
-                    DIB(cx),
-                    wrapper_struct_type_di_node,
-                    name.as_c_char_ptr(),
-                    name.len(),
-                    unknown_file_metadata(cx),
-                    UNKNOWN_LINE_NUMBER,
-                    field_type,
-                    DIFlags::FlagZero,
-                    Some(cx.const_u64(value)),
-                    align,
-                )
-            };
 
             // We also always have an associated constant for the discriminant value
             // of the variant.

--- a/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
@@ -1,5 +1,6 @@
 // Utility Functions.
 
+use libc::size_t;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::layout::{HasTypingEnv, LayoutOf};
 use rustc_middle::ty::{self, Ty};
@@ -28,7 +29,7 @@ pub(crate) fn create_DIArray<'ll>(
     builder: &DIBuilder<'ll>,
     arr: &[Option<&'ll DIDescriptor>],
 ) -> &'ll DIArray {
-    unsafe { llvm::LLVMRustDIBuilderGetOrCreateArray(builder, arr.as_ptr(), arr.len() as u32) }
+    unsafe { llvm::LLVMDIBuilderGetOrCreateTypeArray(builder, arr.as_ptr(), arr.len() as size_t) }
 }
 
 #[inline]

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1852,6 +1852,12 @@ unsafe extern "C" {
         Data: *const Option<&'ll DIDescriptor>, //FIXME: is it really const?
         Length: size_t,
     ) -> &'ll DIArray;
+
+    pub(crate) fn LLVMDIBuilderGetOrCreateSubrange<'ll>(
+        Builder: &DIBuilder<'ll>,
+        Lo: i64,
+        Count: i64,
+    ) -> &'ll DISubrange;
 }
 
 #[link(name = "llvm-wrapper", kind = "static")]
@@ -2309,12 +2315,6 @@ unsafe extern "C" {
         Ty: &'a DIType,
         Subscripts: &'a DIArray,
     ) -> &'a DIType;
-
-    pub(crate) fn LLVMRustDIBuilderGetOrCreateSubrange<'a>(
-        Builder: &DIBuilder<'a>,
-        Lo: i64,
-        Count: i64,
-    ) -> &'a DISubrange;
 
     pub(crate) fn LLVMRustDIBuilderInsertDeclareAtEnd<'a>(
         Builder: &DIBuilder<'a>,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1830,6 +1830,12 @@ unsafe extern "C" {
         Scope: &'ll Metadata,
         InlinedAt: Option<&'ll Metadata>,
     ) -> &'ll Metadata;
+
+    pub(crate) fn LLVMDIBuilderCreateQualifiedType<'ll>(
+        Builder: &DIBuilder<'ll>,
+        Tag: c_uint,
+        Type: &'ll DIType,
+    ) -> &'ll DIDerivedType;
 }
 
 #[link(name = "llvm-wrapper", kind = "static")]
@@ -2257,12 +2263,6 @@ unsafe extern "C" {
         Flags: DIFlags,
         val: Option<&'a Value>,
         AlignInBits: u32,
-    ) -> &'a DIDerivedType;
-
-    pub(crate) fn LLVMRustDIBuilderCreateQualifiedType<'a>(
-        Builder: &DIBuilder<'a>,
-        Tag: c_uint,
-        Type: &'a DIType,
     ) -> &'a DIDerivedType;
 
     pub(crate) fn LLVMRustDIBuilderCreateStaticVariable<'a>(

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1846,6 +1846,12 @@ unsafe extern "C" {
         Name: *const c_char,
         NameLen: size_t,
     ) -> &'ll DIDerivedType;
+
+    pub(crate) fn LLVMDIBuilderGetOrCreateTypeArray<'ll>(
+        Builder: &DIBuilder<'ll>,
+        Data: *const Option<&'ll DIDescriptor>, //FIXME: is it really const?
+        Length: size_t,
+    ) -> &'ll DIArray;
 }
 
 #[link(name = "llvm-wrapper", kind = "static")]
@@ -2309,12 +2315,6 @@ unsafe extern "C" {
         Lo: i64,
         Count: i64,
     ) -> &'a DISubrange;
-
-    pub(crate) fn LLVMRustDIBuilderGetOrCreateArray<'a>(
-        Builder: &DIBuilder<'a>,
-        Ptr: *const Option<&'a DIDescriptor>,
-        Count: c_uint,
-    ) -> &'a DIArray;
 
     pub(crate) fn LLVMRustDIBuilderInsertDeclareAtEnd<'a>(
         Builder: &DIBuilder<'a>,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1836,6 +1836,16 @@ unsafe extern "C" {
         Tag: c_uint,
         Type: &'ll DIType,
     ) -> &'ll DIDerivedType;
+
+    pub(crate) fn LLVMDIBuilderCreatePointerType<'ll>(
+        Builder: &DIBuilder<'ll>,
+        PointeeTy: &'ll DIType,
+        SizeInBits: u64,
+        AlignInBits: u32,
+        AddressSpace: c_uint,
+        Name: *const c_char,
+        NameLen: size_t,
+    ) -> &'ll DIDerivedType;
 }
 
 #[link(name = "llvm-wrapper", kind = "static")]
@@ -2193,16 +2203,6 @@ unsafe extern "C" {
         File: &'a DIFile,
         LineNo: c_uint,
         Scope: Option<&'a DIScope>,
-    ) -> &'a DIDerivedType;
-
-    pub(crate) fn LLVMRustDIBuilderCreatePointerType<'a>(
-        Builder: &DIBuilder<'a>,
-        PointeeTy: &'a DIType,
-        SizeInBits: u64,
-        AlignInBits: u32,
-        AddressSpace: c_uint,
-        Name: *const c_char,
-        NameLen: size_t,
     ) -> &'a DIDerivedType;
 
     pub(crate) fn LLVMRustDIBuilderCreateStructType<'a>(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -340,14 +340,6 @@ static FloatABI::ABIType fromRust(LLVMRustFloatABI RustFloatAbi) {
   report_fatal_error("Bad FloatABI.");
 }
 
-/// getLongestEntryLength - Return the length of the longest entry in the table.
-template <typename KV> static size_t getLongestEntryLength(ArrayRef<KV> Table) {
-  size_t MaxLen = 0;
-  for (auto &I : Table)
-    MaxLen = std::max(MaxLen, std::strlen(I.Key));
-  return MaxLen;
-}
-
 extern "C" void LLVMRustPrintTargetCPUs(LLVMTargetMachineRef TM,
                                         RustStringRef OutStr) {
   ArrayRef<SubtargetSubTypeKV> CPUTable =

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1204,15 +1204,6 @@ LLVMRustDIBuilderGetOrCreateSubrange(LLVMDIBuilderRef Builder, int64_t Lo,
   return wrap(unwrap(Builder)->getOrCreateSubrange(Lo, Count));
 }
 
-extern "C" LLVMMetadataRef
-LLVMRustDIBuilderGetOrCreateArray(LLVMDIBuilderRef Builder,
-                                  LLVMMetadataRef *Ptr, unsigned Count) {
-  Metadata **DataValue = unwrap(Ptr);
-  return wrap(unwrap(Builder)
-                  ->getOrCreateArray(ArrayRef<Metadata *>(DataValue, Count))
-                  .get());
-}
-
 extern "C" void
 LLVMRustDIBuilderInsertDeclareAtEnd(LLVMDIBuilderRef Builder, LLVMValueRef V,
                                     LLVMMetadataRef VarInfo, uint64_t *AddrOps,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1076,15 +1076,6 @@ LLVMRustDIBuilderCreateTypedef(LLVMDIBuilderRef Builder, LLVMMetadataRef Type,
       LineNo, unwrapDIPtr<DIScope>(Scope)));
 }
 
-extern "C" LLVMMetadataRef LLVMRustDIBuilderCreatePointerType(
-    LLVMDIBuilderRef Builder, LLVMMetadataRef PointeeTy, uint64_t SizeInBits,
-    uint32_t AlignInBits, unsigned AddressSpace, const char *Name,
-    size_t NameLen) {
-  return wrap(unwrap(Builder)->createPointerType(
-      unwrapDI<DIType>(PointeeTy), SizeInBits, AlignInBits, AddressSpace,
-      StringRef(Name, NameLen)));
-}
-
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStructType(
     LLVMDIBuilderRef Builder, LLVMMetadataRef Scope, const char *Name,
     size_t NameLen, LLVMMetadataRef File, unsigned LineNumber,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1149,13 +1149,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStaticMemberType(
       unwrap<llvm::ConstantInt>(val), llvm::dwarf::DW_TAG_member, AlignInBits));
 }
 
-extern "C" LLVMMetadataRef
-LLVMRustDIBuilderCreateQualifiedType(LLVMDIBuilderRef Builder, unsigned Tag,
-                                     LLVMMetadataRef Type) {
-  return wrap(
-      unwrap(Builder)->createQualifiedType(Tag, unwrapDI<DIType>(Type)));
-}
-
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStaticVariable(
     LLVMDIBuilderRef Builder, LLVMMetadataRef Context, const char *Name,
     size_t NameLen, const char *LinkageName, size_t LinkageNameLen,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1198,12 +1198,6 @@ LLVMRustDIBuilderCreateArrayType(LLVMDIBuilderRef Builder, uint64_t Size,
       DINodeArray(unwrapDI<MDTuple>(Subscripts))));
 }
 
-extern "C" LLVMMetadataRef
-LLVMRustDIBuilderGetOrCreateSubrange(LLVMDIBuilderRef Builder, int64_t Lo,
-                                     int64_t Count) {
-  return wrap(unwrap(Builder)->getOrCreateSubrange(Lo, Count));
-}
-
 extern "C" void
 LLVMRustDIBuilderInsertDeclareAtEnd(LLVMDIBuilderRef Builder, LLVMValueRef V,
                                     LLVMMetadataRef VarInfo, uint64_t *AddrOps,


### PR DESCRIPTION
Removes dead code and replaces few LLVMRust* with LLVM* c api, see commits with whitespace collapsed. Partially intersects with rust-lang/rust#136632.

See https://github.com/llvm/llvm-project/blob/release/19.x/llvm/lib/IR/DebugInfo.cpp