### PR TITLE
rustc_target: Add the `32s` target feature for LoongArch

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -277,6 +277,7 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
         {
             None
         }
+        ("loongarch32" | "loongarch64", "32s") if get_version().0 < 21 => None,
         // Filter out features that are not supported by the current LLVM version
         ("riscv32" | "riscv64", "zacas") if get_version().0 < 20 => None,
         (

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -763,6 +763,7 @@ static CSKY_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
 
 static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
+    ("32s", Unstable(sym::loongarch_target_feature), &[]),
     ("d", Stable, &["f"]),
     ("div32", Unstable(sym::loongarch_target_feature), &[]),
     ("f", Stable, &[]),

--- a/library/std_detect/src/detect/arch/loongarch.rs
+++ b/library/std_detect/src/detect/arch/loongarch.rs
@@ -8,6 +8,7 @@ features! {
     /// Checks if `loongarch` feature is enabled.
     /// Supported arguments are:
     ///
+    /// * `"32s"`
     /// * `"f"`
     /// * `"d"`
     /// * `"frecipe"`
@@ -22,6 +23,8 @@ features! {
     /// * `"lvz"`
     /// * `"ual"`
     #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")]
+    @FEATURE: #[unstable(feature = "stdarch_loongarch_feature_detection", issue = "117425")] _32s: "32s";
+    /// 32S
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] f: "f";
     /// F
     @FEATURE: #[stable(feature = "stdarch_loongarch_feature", since = "1.89.0")] d: "d";

--- a/library/std_detect/src/detect/os/linux/loongarch.rs
+++ b/library/std_detect/src/detect/os/linux/loongarch.rs
@@ -17,22 +17,21 @@ pub(crate) fn detect_features() -> cache::Initializer {
     // The values are part of the platform-specific [cpucfg]
     //
     // [cpucfg]: LoongArch Reference Manual Volume 1: Basic Architecture v1.1
+    let cpucfg1: usize;
     let cpucfg2: usize;
-    unsafe {
-        asm!(
-            "cpucfg {}, {}",
-            out(reg) cpucfg2, in(reg) 2,
-            options(pure, nomem, preserves_flags, nostack)
-        );
-    }
     let cpucfg3: usize;
     unsafe {
         asm!(
             "cpucfg {}, {}",
+            "cpucfg {}, {}",
+            "cpucfg {}, {}",
+            out(reg) cpucfg1, in(reg) 1,
+            out(reg) cpucfg2, in(reg) 2,
             out(reg) cpucfg3, in(reg) 3,
             options(pure, nomem, preserves_flags, nostack)
         );
     }
+    enable_feature(&mut value, Feature::_32s, bit::test(cpucfg1, 0) || bit::test(cpucfg1, 1));
     enable_feature(&mut value, Feature::frecipe, bit::test(cpucfg2, 25));
     enable_feature(&mut value, Feature::div32, bit::test(cpucfg2, 26));
     enable_feature(&mut value, Feature::lam_bh, bit::test(cpucfg2, 27));

--- a/library/std_detect/tests/macro_trailing_commas.rs
+++ b/library/std_detect/tests/macro_trailing_commas.rs
@@ -69,6 +69,8 @@ fn aarch64() {
 #[test]
 #[cfg(any(target_arch = "loongarch32", target_arch = "loongarch64"))]
 fn loongarch() {
+    let _ = is_loongarch_feature_detected!("32s");
+    let _ = is_loongarch_feature_detected!("32s",);
     let _ = is_loongarch_feature_detected!("lsx");
     let _ = is_loongarch_feature_detected!("lsx",);
 }

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -6,6 +6,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
    |
    = note: expected values for `target_feature` are: `10e60`
 `2e3`
+`32s`
 `3e3r1`
 `3e3r2`
 `3e3r3`


### PR DESCRIPTION
LLVM: https://github.com/llvm/llvm-project/pull/139695