### PR TITLE
[win][arm64ec] Partial fix for raw-dylib-link-ordinal on Arm64EC

### DIFF
--- a/tests/run-make/raw-dylib-link-ordinal/exporter.def
+++ b/tests/run-make/raw-dylib-link-ordinal/exporter.def
@@ -1,5 +1,5 @@
 LIBRARY exporter
 EXPORTS
     exported_function @13 NONAME
-    exported_variable @5 NONAME
+    exported_variable @5 NONAME DATA
     print_exported_variable @9 NONAME

--- a/tests/run-make/raw-dylib-link-ordinal/rmake.rs
+++ b/tests/run-make/raw-dylib-link-ordinal/rmake.rs
@@ -11,7 +11,7 @@
 
 //@ only-windows
 
-use run_make_support::{cc, diff, is_windows_msvc, run, rustc};
+use run_make_support::{cc, diff, extra_c_flags, is_windows_msvc, run, rustc};
 
 // NOTE: build_native_dynamic lib is not used, as the special `def` files
 // must be passed to the CC compiler.
@@ -24,6 +24,7 @@ fn main() {
         cc().input("exporter.obj")
             .arg("exporter.def")
             .args(&["-link", "-dll", "-noimplib", "-out:exporter.dll"])
+            .args(extra_c_flags())
             .run();
     } else {
         cc().arg("-v").arg("-c").out_exe("exporter.obj").input("exporter.c").run();


### PR DESCRIPTION
These are the test fixes required to get `raw-dylib-link-ordinal` working on Arm64EC.

For the test to completely pass, we also need an updated `ar_archive_writer` with <https://github.com/rust-lang/ar_archive_writer/pull/24> merged in.