### PR TITLE
Update rustfmt's dependency on annotate-snippets to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,16 +60,6 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
-dependencies = [
- "unicode-width 0.1.14",
- "yansi-term",
-]
-
-[[package]]
-name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
@@ -3790,7 +3780,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.11.5",
+ "annotate-snippets",
  "derive_setters",
  "rustc_abi",
  "rustc_ast",
@@ -3858,7 +3848,7 @@ dependencies = [
 name = "rustc_fluent_macro"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.11.5",
+ "annotate-snippets",
  "fluent-bundle",
  "fluent-syntax",
  "proc-macro2",
@@ -4878,7 +4868,7 @@ dependencies = [
 name = "rustfmt-nightly"
 version = "1.8.0"
 dependencies = [
- "annotate-snippets 0.9.2",
+ "annotate-snippets",
  "anyhow",
  "bytecount",
  "cargo_metadata 0.18.1",
@@ -5744,7 +5734,7 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b56a6897cc4bb6f8daf1939b0b39cd9645856997f46f4d0b3e3cb7122dfe9251"
 dependencies = [
- "annotate-snippets 0.11.5",
+ "annotate-snippets",
  "anyhow",
  "bstr",
  "cargo-platform 0.1.9",
@@ -6728,15 +6718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/src/tools/rustfmt/Cargo.toml
+++ b/src/tools/rustfmt/Cargo.toml
@@ -33,7 +33,7 @@ rustfmt-format-diff = []
 generic-simd = ["bytecount/generic-simd"]
 
 [dependencies]
-annotate-snippets = { version = "0.9", features = ["color"] }
+annotate-snippets = "0.11"
 anyhow = "1.0"
 bytecount = "0.6.8"
 cargo_metadata = "0.18"

--- a/src/tools/rustfmt/src/config/file_lines.rs
+++ b/src/tools/rustfmt/src/config/file_lines.rs
@@ -1,6 +1,7 @@
 //! This module contains types and functions to support formatting specific line ranges.
 
 use itertools::Itertools;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -23,6 +24,15 @@ pub struct LineRange {
 pub enum FileName {
     Real(PathBuf),
     Stdin,
+}
+
+impl FileName {
+    pub fn to_string_lossy(&self) -> Cow<'_, str> {
+        match self {
+            FileName::Real(path) => path.to_string_lossy(),
+            FileName::Stdin => "<stdin>".into(),
+        }
+    }
 }
 
 impl From<rustc_span::FileName> for FileName {

--- a/src/tools/rustfmt/src/format_report_formatter.rs
+++ b/src/tools/rustfmt/src/format_report_formatter.rs
@@ -1,7 +1,6 @@
 use crate::formatting::FormattingError;
 use crate::{ErrorKind, FormatReport};
-use annotate_snippets::display_list::{DisplayList, FormatOptions};
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Annotation, Level, Renderer, Snippet};
 use std::fmt::{self, Display};
 
 /// A builder for [`FormatReportFormatter`].
@@ -49,51 +48,41 @@ impl<'a> Display for FormatReportFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let errors_by_file = &self.report.internal.borrow().0;
 
-        let opt = FormatOptions {
-            color: self.enable_colors,
-            ..Default::default()
+        let renderer = if self.enable_colors {
+            Renderer::styled()
+        } else {
+            Renderer::plain()
         };
 
         for (file, errors) in errors_by_file {
+            let file = file.to_string_lossy();
             for error in errors {
                 let error_kind = error.kind.to_string();
-                let title = Some(Annotation {
-                    id: if error.is_internal() {
-                        Some("internal")
-                    } else {
-                        None
-                    },
-                    label: Some(&error_kind),
-                    annotation_type: error_kind_to_snippet_annotation_type(&error.kind),
-                });
+                let message = error_kind_to_snippet_level(&error.kind).title(&error_kind);
+                let message = if error.is_internal() {
+                    message.id("internal")
+                } else {
+                    message
+                };
 
                 let message_suffix = error.msg_suffix();
-                let footer = if !message_suffix.is_empty() {
-                    Some(Annotation {
-                        id: None,
-                        label: Some(message_suffix),
-                        annotation_type: AnnotationType::Note,
-                    })
+                let message = if !message_suffix.is_empty() {
+                    message.footer(Level::Note.title(message_suffix))
                 } else {
-                    None
+                    message
                 };
 
-                let origin = format!("{}:{}", file, error.line);
-                let slice = Slice {
-                    source: &error.line_buffer.clone(),
-                    line_start: error.line,
-                    origin: Some(origin.as_str()),
-                    fold: false,
-                    annotations: slice_annotation(error).into_iter().collect(),
+                let snippet = Snippet::source(&error.line_buffer)
+                    .line_start(error.line)
+                    .origin(file.as_ref());
+                let snippet = if let Some(annotation) = slice_annotation(error) {
+                    snippet.annotation(annotation)
+                } else {
+                    snippet
                 };
 
-                let snippet = Snippet {
-                    title,
-                    footer: footer.into_iter().collect(),
-                    slices: vec![slice],
-                    opt,
-                };
-                writeln!(f, "{}\n", DisplayList::from(snippet))?;
+                let message = message.snippet(snippet);
+                writeln!(f, "{}\n", renderer.render(message))?;
             }
         }
 
@@ -102,39 +91,26 @@ impl<'a> Display for FormatReportFormatter<'a> {
                 "rustfmt has failed to format. See previous {} errors.",
                 self.report.warning_count()
             );
-            let snippet = Snippet {
-                title: Some(Annotation {
-                    id: None,
-                    label: Some(&label),
-                    annotation_type: AnnotationType::Warning,
-                }),
-                footer: Vec::new(),
-                slices: Vec::new(),
-                opt,
-            };
-            writeln!(f, "{}", DisplayList::from(snippet))?;
+            let message = Level::Warning.title(&label);
+            writeln!(f, "{}", renderer.render(message))?;
         }
 
         Ok(())
     }
 }
 
-fn slice_annotation(error: &FormattingError) -> Option<SourceAnnotation<'_>> {
+fn slice_annotation(error: &FormattingError) -> Option<Annotation<'_>> {
     let (range_start, range_length) = error.format_len();
     let range_end = range_start + range_length;
 
     if range_length > 0 {
-        Some(SourceAnnotation {
-            annotation_type: AnnotationType::Error,
-            range: (range_start, range_end),
-            label: "",
-        })
+        Some(Level::Error.span(range_start..range_end))
     } else {
         None
     }
 }
 
-fn error_kind_to_snippet_annotation_type(error_kind: &ErrorKind) -> AnnotationType {
+fn error_kind_to_snippet_level(error_kind: &ErrorKind) -> Level {
     match error_kind {
         ErrorKind::LineOverflow(..)
         | ErrorKind::TrailingWhitespace
@@ -144,7 +120,7 @@ fn error_kind_to_snippet_annotation_type(error_kind: &ErrorKind) -> AnnotationTy
         | ErrorKind::LostComment
         | ErrorKind::BadAttr
         | ErrorKind::InvalidGlobPattern(_)
-        | ErrorKind::VersionMismatch => AnnotationType::Error,
-        ErrorKind::DeprecatedAttr => AnnotationType::Warning,
+        | ErrorKind::VersionMismatch => Level::Error,
+        ErrorKind::DeprecatedAttr => Level::Warning,
     }
 }


### PR DESCRIPTION
`annotate-snippets` 0.9 indirectly depends on `winapi`, which is an old, unsupported crate for Windows bindings and (for my purposes) doesn't fully support Arm64EC.

This change updates `annotate-snippets` to 0.11 (which Rust already depends on) and removes the indirect dependency on `winapi`.