### PR TITLE
Recover `for PAT = EXPR {}`

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -642,7 +642,7 @@ parse_missing_for_in_trait_impl = missing `for` in a trait impl
     .suggestion = add `for` here
 
 parse_missing_in_in_for_loop = missing `in` in `for` loop
-    .use_in_not_of = try using `in` here instead
+    .use_in = try using `in` here instead
     .add_in = try adding `in` here
 
 parse_missing_let_before_mut = missing keyword

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -585,14 +585,13 @@ pub(crate) struct MissingInInForLoop {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum MissingInInForLoopSub {
+    // User wrote `for pat of expr {}`
     // Has been misleading, at least in the past (closed Issue #48492), thus maybe-incorrect
-    #[suggestion(
-        parse_use_in_not_of,
-        style = "verbose",
-        applicability = "maybe-incorrect",
-        code = "in"
-    )]
+    #[suggestion(parse_use_in, style = "verbose", applicability = "maybe-incorrect", code = "in")]
     InNotOf(#[primary_span] Span),
+    // User wrote `for pat = expr {}`
+    #[suggestion(parse_use_in, style = "verbose", applicability = "maybe-incorrect", code = "in")]
+    InNotEq(#[primary_span] Span),
     #[suggestion(parse_add_in, style = "verbose", applicability = "maybe-incorrect", code = " in ")]
     AddIn(#[primary_span] Span),
 }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3028,6 +3028,8 @@ impl<'a> Parser<'a> {
             let span = self.token.span;
             self.bump();
             (span, errors::MissingInInForLoopSub::InNotOf)
+        } else if self.eat(exp!(Eq)) {
+            (self.prev_token.span, errors::MissingInInForLoopSub::InNotEq)
         } else {
             (self.prev_token.span.between(self.token.span), errors::MissingInInForLoopSub::AddIn)
         };

--- a/tests/ui/suggestions/for-loop-missing-in.fixed
+++ b/tests/ui/suggestions/for-loop-missing-in.fixed
@@ -1,8 +1,7 @@
 //@ run-rustfix
 
 fn main() {
-    for _i in 0..2 { //~ ERROR missing `in`
-    }
-    for _i in 0..2 { //~ ERROR missing `in`
-    }
+    for _i in 0..2 {} //~ ERROR missing `in`
+    for _i in 0..2 {} //~ ERROR missing `in`
+    for _i in 0..2 {} //~ ERROR missing `in`
 }

--- a/tests/ui/suggestions/for-loop-missing-in.rs
+++ b/tests/ui/suggestions/for-loop-missing-in.rs
@@ -1,8 +1,7 @@
 //@ run-rustfix
 
 fn main() {
-    for _i 0..2 { //~ ERROR missing `in`
-    }
-    for _i of 0..2 { //~ ERROR missing `in`
-    }
+    for _i 0..2 {} //~ ERROR missing `in`
+    for _i of 0..2 {} //~ ERROR missing `in`
+    for _i = 0..2 {} //~ ERROR missing `in`
 }

--- a/tests/ui/suggestions/for-loop-missing-in.stderr
+++ b/tests/ui/suggestions/for-loop-missing-in.stderr
@@ -1,25 +1,37 @@
 error: missing `in` in `for` loop
   --> $DIR/for-loop-missing-in.rs:4:11
    |
-LL |     for _i 0..2 {
+LL |     for _i 0..2 {}
    |           ^
    |
 help: try adding `in` here
    |
-LL |     for _i in 0..2 {
+LL |     for _i in 0..2 {}
    |            ++
 
 error: missing `in` in `for` loop
-  --> $DIR/for-loop-missing-in.rs:6:12
+  --> $DIR/for-loop-missing-in.rs:5:12
    |
-LL |     for _i of 0..2 {
+LL |     for _i of 0..2 {}
    |            ^^
    |
 help: try using `in` here instead
    |
-LL -     for _i of 0..2 {
-LL +     for _i in 0..2 {
+LL -     for _i of 0..2 {}
+LL +     for _i in 0..2 {}
    |
 
-error: aborting due to 2 previous errors
+error: missing `in` in `for` loop
+  --> $DIR/for-loop-missing-in.rs:6:12
+   |
+LL |     for _i = 0..2 {}
+   |            ^
+   |
+help: try using `in` here instead
+   |
+LL -     for _i = 0..2 {}
+LL +     for _i in 0..2 {}
+   |
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
I type this constantly, and the existing suggestion to put `in` before the `=` is misleading.