### PR TITLE
[win][arm64ec] Add `/machine:arm64ec` when linking LLVM as Arm64EC

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -421,6 +421,13 @@ impl Step for Llvm {
             ldflags.shared.push(" -latomic");
         }
 
+        if target.starts_with("arm64ec") {
+            // MSVC linker requires the -machine:arm64ec flag to be passed to
+            // know it's linking as Arm64EC (vs Arm64X).
+            ldflags.exe.push(" -machine:arm64ec");
+            ldflags.shared.push(" -machine:arm64ec");
+        }
+
         if target.is_msvc() {
             cfg.define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreaded");
             cfg.static_crt(true);


### PR DESCRIPTION
When the MSVC linker sees an Arm64EC object file, it needs to know if it's linking the final executable as Arm64EC or Arm64X.

This change adds the `/machine:arm64ec` flag to the linker when building LLVM as Arm64EC to avoid that ambiguity (and resulting linker error).