### PR TITLE
improve "Documentation problem" issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,5 +1,5 @@
 name: Documentation problem
-description: Create a report for a documentation problem.
+description: Report an issue with documentation content.
 labels: ["A-docs"]
 body:
   - type: markdown
@@ -19,20 +19,20 @@ body:
         - [The Rustonomicon](https://github.com/rust-lang/nomicon/issues)
         - [The Embedded Book](https://github.com/rust-embedded/book/issues)
 
-        All other documentation issues should be filed here.
+        Or, if you find an issue related to rustdoc (e.g. doctest, rustdoc UI), please use the rustdoc issue template instead.
 
-        Or, if you find an issue related to rustdoc (e.g. doctest, rustdoc UI), please use the bug report or blank issue template instead.
+        All other documentation issues should be filed here.
 
   - type: textarea
     id: location
     attributes:
-      label: Location
+      label: Location (URL)
     validations:
-      required: true 
+      required: true
 
   - type: textarea
     id: summary
     attributes:
       label: Summary
     validations:
-      required: true 
+      required: true


### PR DESCRIPTION
rustdoc has its own issue template now, mention that.

swap the order of the last two sentances so it reads more like a typical if/else chain (base case listed last).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
