### PR TITLE
Enforce in bootstrap that clippy must have stage at least 1

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -232,7 +232,13 @@ impl Step for Rustc {
     }
 
     fn metadata(&self) -> Option<StepMetadata> {
-        Some(StepMetadata::check("rustc", self.target).built_by(self.build_compiler))
+        let metadata = StepMetadata::check("rustc", self.target).built_by(self.build_compiler);
+        let metadata = if self.crates.is_empty() {
+            metadata
+        } else {
+            metadata.with_metadata(format!("({} crates)", self.crates.len()))
+        };
+        Some(metadata)
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -168,12 +168,8 @@ pub struct Rustc {
 }
 
 impl Rustc {
-    pub fn new(builder: &Builder<'_>, build_compiler: Compiler, target: TargetSelection) -> Self {
-        let crates = builder
-            .in_tree_crates("rustc-main", Some(target))
-            .into_iter()
-            .map(|krate| krate.name.to_string())
-            .collect();
+    pub fn new(builder: &Builder<'_>, target: TargetSelection, crates: Vec<String>) -> Self {
+        let build_compiler = prepare_compiler_for_check(builder, target, Mode::Rustc);
         Self { build_compiler, target, crates }
     }
 }
@@ -189,11 +185,7 @@ impl Step for Rustc {
 
     fn make_run(run: RunConfig<'_>) {
         let crates = run.make_run_crates(Alias::Compiler);
-        run.builder.ensure(Rustc {
-            target: run.target,
-            build_compiler: prepare_compiler_for_check(run.builder, run.target, Mode::Rustc),
-            crates,
-        });
+        run.builder.ensure(Rustc::new(run.builder, run.target, crates));
     }
 
     /// Check the compiler.
@@ -206,15 +198,6 @@ impl Step for Rustc {
     fn run(self, builder: &Builder<'_>) {
         let build_compiler = self.build_compiler;
         let target = self.target;
-
-        // Build host std for compiling build scripts
-        builder.std(build_compiler, build_compiler.host);
-
-        // Build target std so that the checked rustc can link to it during the check
-        // FIXME: maybe we can a way to only do a check of std here?
-        // But for that we would have to copy the stdlib rmetas to the sysroot of the build
-        // compiler, which conflicts with std rlibs, if we also build std.
-        builder.std(build_compiler, target);
 
         let mut cargo = builder::Cargo::new(
             builder,
@@ -289,11 +272,13 @@ fn prepare_compiler_for_check(
             build_compiler
         }
         Mode::ToolRustc | Mode::Codegen => {
-            // FIXME: this is a hack, see description of Mode::Rustc below
-            let stage = if host == target { builder.top_stage - 1 } else { builder.top_stage };
-            // When checking tool stage N, we check it with compiler stage N-1
-            let build_compiler = builder.compiler(stage, host);
-            builder.ensure(Rustc::new(builder, build_compiler, target));
+            // Check Rustc to produce the required rmeta artifacts for rustc_private, and then
+            // return the build compiler that was used to check rustc.
+            // We do not need to check examples/tests/etc. of Rustc for rustc_private, so we pass
+            // an empty set of crates, which will avoid using `cargo -p`.
+            let check = Rustc::new(builder, target, vec![]);
+            let build_compiler = check.build_compiler;
+            builder.ensure(check);
             build_compiler
         }
         Mode::Rustc => {
@@ -305,7 +290,18 @@ fn prepare_compiler_for_check(
             // FIXME: remove this and either fix cross-compilation check on stage 2 (which has a
             // myriad of other problems) or disable cross-checking on stage 1.
             let stage = if host == target { builder.top_stage - 1 } else { builder.top_stage };
-            builder.compiler(stage, host)
+            let build_compiler = builder.compiler(stage, host);
+
+            // Build host std for compiling build scripts
+            builder.std(build_compiler, build_compiler.host);
+
+            // Build target std so that the checked rustc can link to it during the check
+            // FIXME: maybe we can a way to only do a check of std here?
+            // But for that we would have to copy the stdlib rmetas to the sysroot of the build
+            // compiler, which conflicts with std rlibs, if we also build std.
+            builder.std(build_compiler, target);
+
+            build_compiler
         }
         Mode::Std => {
             // When checking std stage N, we want to do it with the stage N compiler

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -30,10 +30,6 @@ pub struct Std {
 
 impl Std {
     const CRATE_OR_DEPS: &[&str] = &["sysroot", "coretests", "alloctests"];
-
-    pub fn new(build_compiler: Compiler, target: TargetSelection) -> Self {
-        Self { build_compiler, target, crates: vec![] }
-    }
 }
 
 impl Step for Std {
@@ -241,7 +237,7 @@ impl Step for Rustc {
 }
 
 /// Prepares a compiler that will check something with the given `mode`.
-fn prepare_compiler_for_check(
+pub fn prepare_compiler_for_check(
     builder: &Builder<'_>,
     target: TargetSelection,
     mode: Mode,

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -298,7 +298,7 @@ macro_rules! lint_any {
                 let target = self.target;
 
                 if !builder.download_rustc() {
-                    builder.ensure(check::Rustc::new(builder, build_compiler, target));
+                    builder.ensure(check::Rustc::new(builder, target, vec![]));
                 };
 
                 let cargo = prepare_tool_cargo(

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -178,6 +178,10 @@ impl Step for Std {
             false,
         );
     }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(StepMetadata::clippy("std", self.target))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -260,6 +264,10 @@ impl Step for Rustc {
             true,
             false,
         );
+    }
+
+    fn metadata(&self) -> Option<StepMetadata> {
+        Some(StepMetadata::clippy("rustc", self.target))
     }
 }
 
@@ -403,6 +411,10 @@ macro_rules! lint_any {
                     true,
                     false,
                 );
+            }
+
+            fn metadata(&self) -> Option<StepMetadata> {
+                Some(StepMetadata::clippy($readable_name, self.target))
             }
         }
         )+

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -6,7 +6,8 @@
 //!   which is performed by the `x clippy ci` command.
 //!
 //! In order to prepare a build compiler for running clippy, use the
-//! [check::prepare_compiler_for_check] function. That prepares a compiler and a standard library
+//! [prepare_compiler_for_check] function. That prepares a
+//! compiler and a standard library
 //! for running Clippy. The second part (actually building Clippy) is performed inside
 //! [Builder::cargo_clippy_cmd]. It would be nice if this was more explicit, and we actually had
 //! to pass a prebuilt Clippy from the outside when running `cargo clippy`, but that would be

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -447,7 +447,7 @@ macro_rules! lint_any {
             }
 
             fn metadata(&self) -> Option<StepMetadata> {
-                Some(StepMetadata::clippy($readable_name, self.target))
+                Some(StepMetadata::clippy($readable_name, self.target).built_by(self.build_compiler))
             }
         }
         )+

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -160,6 +160,10 @@ impl StepMetadata {
         Self::new(name, target, Kind::Check)
     }
 
+    pub fn clippy(name: &str, target: TargetSelection) -> Self {
+        Self::new(name, target, Kind::Clippy)
+    }
+
     pub fn doc(name: &str, target: TargetSelection) -> Self {
         Self::new(name, target, Kind::Doc)
     }

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1556,38 +1556,6 @@ You have to build a stage1 compiler for `{}` first, and then use it to build a s
         self.ensure(tool::Rustdoc { target_compiler })
     }
 
-    /// Create a Cargo command for running Clippy.
-    /// The used Clippy is (or in the case of stage 0, already was) built using `build_compiler`.
-    pub fn cargo_clippy_cmd(&self, build_compiler: Compiler) -> BootstrapCommand {
-        if build_compiler.stage == 0 {
-            let cargo_clippy = self
-                .config
-                .initial_cargo_clippy
-                .clone()
-                .unwrap_or_else(|| self.build.config.download_clippy());
-
-            let mut cmd = command(cargo_clippy);
-            cmd.env("CARGO", &self.initial_cargo);
-            return cmd;
-        }
-
-        let compilers = RustcPrivateCompilers::from_build_compiler(
-            self,
-            build_compiler,
-            self.build.host_target,
-        );
-
-        let _ = self.ensure(tool::Clippy::from_compilers(compilers));
-        let cargo_clippy = self.ensure(tool::CargoClippy::from_compilers(compilers));
-        let mut dylib_path = helpers::dylib_path();
-        dylib_path.insert(0, self.sysroot(build_compiler).join("lib"));
-
-        let mut cmd = command(cargo_clippy.tool_path);
-        cmd.env(helpers::dylib_path_var(), env::join_paths(&dylib_path).unwrap());
-        cmd.env("CARGO", &self.initial_cargo);
-        cmd
-    }
-
     pub fn cargo_miri_cmd(&self, run_compiler: Compiler) -> BootstrapCommand {
         assert!(run_compiler.stage > 0, "miri can not be invoked at stage 0");
 
@@ -1611,6 +1579,37 @@ You have to build a stage1 compiler for `{}` first, and then use it to build a s
         // added to the PATH due to the stage mismatch.
         // Also see https://github.com/rust-lang/rust/pull/123192#issuecomment-2028901503.
         add_dylib_path(self.rustc_lib_paths(run_compiler), &mut cmd);
+        cmd
+    }
+
+    /// Create a Cargo command for running Clippy.
+    /// The used Clippy is (or in the case of stage 0, already was) built using `build_compiler`.
+    pub fn cargo_clippy_cmd(&self, build_compiler: Compiler) -> BootstrapCommand {
+        if build_compiler.stage == 0 {
+            let cargo_clippy = self
+                .config
+                .initial_cargo_clippy
+                .clone()
+                .unwrap_or_else(|| self.build.config.download_clippy());
+
+            let mut cmd = command(cargo_clippy);
+            cmd.env("CARGO", &self.initial_cargo);
+            return cmd;
+        }
+
+        // If we're linting something with build_compiler stage N, we want to build Clippy stage N
+        // and use that to lint it. That is why we use the `build_compiler` as the target compiler
+        // for RustcPrivateCompilers. We will use build compiler stage N-1 to build Clippy stage N.
+        let compilers = RustcPrivateCompilers::from_target_compiler(self, build_compiler);
+
+        let _ = self.ensure(tool::Clippy::from_compilers(compilers));
+        let cargo_clippy = self.ensure(tool::CargoClippy::from_compilers(compilers));
+        let mut dylib_path = helpers::dylib_path();
+        dylib_path.insert(0, self.sysroot(build_compiler).join("lib"));
+
+        let mut cmd = command(cargo_clippy.tool_path);
+        cmd.env(helpers::dylib_path_var(), env::join_paths(&dylib_path).unwrap());
+        cmd.env("CARGO", &self.initial_cargo);
         cmd
     }
 

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1515,7 +1515,7 @@ mod snapshot {
             ctx.config("check")
                 .path("compiler")
                 .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
         [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
@@ -1528,9 +1528,7 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("check")
                 .path("rustc")
-                .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host>
-        ");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (1 crates)");
     }
 
     #[test]
@@ -1548,7 +1546,7 @@ mod snapshot {
                 .path("compiler")
                 .stage(1)
                 .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
         [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
@@ -1566,7 +1564,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
-        [check] rustc 1 <host> -> rustc 2 <host>
+        [check] rustc 1 <host> -> rustc 2 <host> (73 crates)
         [check] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <host>
         [check] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
@@ -1585,7 +1583,7 @@ mod snapshot {
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
-        [check] rustc 1 <host> -> rustc 2 <target1>
+        [check] rustc 1 <host> -> rustc 2 <target1> (73 crates)
         [check] rustc 1 <host> -> rustc 2 <target1>
         [check] rustc 1 <host> -> Rustdoc 2 <target1>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <target1>
@@ -1682,7 +1680,7 @@ mod snapshot {
                 .paths(&["library", "compiler"])
                 .args(&args)
                 .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
         [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2073,12 +2073,11 @@ mod snapshot {
             ctx.config("clippy")
                 .path("ci")
                 .render_steps(), @r"
+        [clippy] rustc 0 <host> -> bootstrap 1 <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
-        [check] rustc 1 <host> -> rustc 2 <host>
         [build] rustc 0 <host> -> clippy-driver 1 <host>
         [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] bootstrap <host>
         [clippy] rustc 1 <host> -> std 1 <host>
         [clippy] rustc 0 <host> -> rustc 1 <host>
         [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
@@ -2096,21 +2095,20 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 1 <host> -> rustc 2 <host>
-        [check] rustc 2 <host> -> rustc 3 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
-        [clippy] bootstrap <host>
-        [clippy] rustc 2 <host> -> std 2 <host>
         [build] rustc 0 <host> -> clippy-driver 1 <host>
         [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] rustc 1 <host> -> bootstrap 2 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] rustc 2 <host> -> std 2 <host>
         [clippy] rustc 1 <host> -> rustc 2 <host>
         [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
         ");
     }
 
     #[test]
-    fn clippy_compiler() {
+    fn clippy_compiler_stage1() {
         let ctx = TestCtx::new();
         insta::assert_snapshot!(
             ctx.config("clippy")
@@ -2122,7 +2120,24 @@ mod snapshot {
     }
 
     #[test]
-    fn clippy_std() {
+    fn clippy_compiler_stage2() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("compiler")
+                .stage(2)
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] rustc 1 <host> -> rustc 2 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_std_stage1() {
         let ctx = TestCtx::new();
         insta::assert_snapshot!(
             ctx.config("clippy")
@@ -2134,6 +2149,65 @@ mod snapshot {
         [build] rustc 0 <host> -> cargo-clippy 1 <host>
         [clippy] rustc 1 <host> -> std 1 <host>
         ");
+    }
+
+    #[test]
+    fn clippy_std_stage2() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("std")
+                .stage(2)
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] rustc 2 <host> -> std 2 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_miri_stage1() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("miri")
+                .stage(1)
+                .render_steps(), @r"
+        [build] llvm <host>
+        [check] rustc 0 <host> -> rustc 1 <host>
+        [clippy] rustc 0 <host> -> miri 1 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_miri_stage2() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("miri")
+                .stage(2)
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [check] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] rustc 1 <host> -> miri 2 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_bootstrap() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("bootstrap")
+                .render_steps(), @"[clippy] rustc 0 <host> -> bootstrap 1 <host>");
     }
 }
 

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2072,25 +2072,6 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("clippy")
                 .path("ci")
-                .render_steps(), @r"
-        [clippy] rustc 0 <host> -> bootstrap 1 <host>
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] rustc 1 <host> -> std 1 <host>
-        [clippy] rustc 0 <host> -> rustc 1 <host>
-        [check] rustc 0 <host> -> rustc 1 <host>
-        [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_ci_stage_2() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("ci")
                 .stage(2)
                 .render_steps(), @r"
         [build] llvm <host>
@@ -2099,10 +2080,7 @@ mod snapshot {
         [build] rustc 0 <host> -> clippy-driver 1 <host>
         [build] rustc 0 <host> -> cargo-clippy 1 <host>
         [clippy] rustc 1 <host> -> bootstrap 2 <host>
-        [build] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
-        [clippy] rustc 2 <host> -> std 2 <host>
+        [clippy] rustc 1 <host> -> std 1 <host>
         [clippy] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 1 <host> -> rustc 2 <host>
         [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2080,6 +2080,7 @@ mod snapshot {
         [build] rustc 0 <host> -> cargo-clippy 1 <host>
         [clippy] rustc 1 <host> -> std 1 <host>
         [clippy] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host>
         [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
     }
@@ -2103,6 +2104,7 @@ mod snapshot {
         [build] rustc 1 <host> -> cargo-clippy 2 <host>
         [clippy] rustc 2 <host> -> std 2 <host>
         [clippy] rustc 1 <host> -> rustc 2 <host>
+        [check] rustc 1 <host> -> rustc 2 <host>
         [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
         ");
     }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1516,6 +1516,7 @@ mod snapshot {
                 .path("compiler")
                 .render_steps(), @r"
         [check] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
@@ -1548,6 +1549,7 @@ mod snapshot {
                 .stage(1)
                 .render_steps(), @r"
         [check] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
@@ -1564,6 +1566,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [check] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <host>
         [check] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
@@ -1582,6 +1585,7 @@ mod snapshot {
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
+        [check] rustc 1 <host> -> rustc 2 <target1>
         [check] rustc 1 <host> -> rustc 2 <target1>
         [check] rustc 1 <host> -> Rustdoc 2 <target1>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <target1>
@@ -1678,6 +1682,7 @@ mod snapshot {
                 .paths(&["library", "compiler"])
                 .args(&args)
                 .render_steps(), @r"
+        [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2124,6 +2124,23 @@ mod snapshot {
         [clippy] rustc 0 <host> -> rustc 1 <host>
         ");
     }
+
+    #[test]
+    fn clippy_std() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("std")
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] std <host>
+        ");
+    }
 }
 
 struct ExecutedSteps {

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2076,12 +2076,10 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
         [clippy] bootstrap <host>
-        [clippy] std <host>
+        [clippy] rustc 1 <host> -> std 1 <host>
         [clippy] rustc 0 <host> -> rustc 1 <host>
         [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
@@ -2100,14 +2098,12 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 2 <host> -> rustc 3 <host>
-        [build] rustc 2 <host> -> std 2 <host>
-        [build] rustc 2 <host> -> rustc 3 <host>
-        [build] rustc 2 <host> -> clippy-driver 3 <host>
-        [build] rustc 2 <host> -> cargo-clippy 3 <host>
-        [clippy] bootstrap <host>
-        [clippy] std <host>
         [build] rustc 1 <host> -> clippy-driver 2 <host>
         [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] bootstrap <host>
+        [clippy] rustc 2 <host> -> std 2 <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
         [clippy] rustc 1 <host> -> rustc 2 <host>
         [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
         ");
@@ -2134,11 +2130,9 @@ mod snapshot {
                 .render_steps(), @r"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
-        [clippy] std <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] rustc 1 <host> -> std 1 <host>
         ");
     }
 }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2076,12 +2076,13 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
         [clippy] bootstrap <host>
         [clippy] std <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [clippy] rustc <host>
+        [clippy] rustc 0 <host> -> rustc 1 <host>
         [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
     }
@@ -2099,15 +2100,28 @@ mod snapshot {
         [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 1 <host> -> rustc 2 <host>
         [check] rustc 2 <host> -> rustc 3 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [build] rustc 2 <host> -> std 2 <host>
+        [build] rustc 2 <host> -> rustc 3 <host>
+        [build] rustc 2 <host> -> clippy-driver 3 <host>
+        [build] rustc 2 <host> -> cargo-clippy 3 <host>
         [clippy] bootstrap <host>
         [clippy] std <host>
-        [build] rustc 2 <host> -> std 2 <host>
-        [clippy] rustc <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] rustc 1 <host> -> rustc 2 <host>
         [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_compiler() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("compiler")
+                .render_steps(), @r"
+        [build] llvm <host>
+        [clippy] rustc 0 <host> -> rustc 1 <host>
         ");
     }
 }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2065,6 +2065,51 @@ mod snapshot {
         [doc] rustc 1 <host> -> reference (book) 2 <host>
         ");
     }
+
+    #[test]
+    fn clippy_ci() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("ci")
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [check] rustc 1 <host> -> rustc 2 <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] bootstrap <host>
+        [clippy] std <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [clippy] rustc <host>
+        [clippy] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
+        ");
+    }
+
+    #[test]
+    fn clippy_ci_stage_2() {
+        let ctx = TestCtx::new();
+        insta::assert_snapshot!(
+            ctx.config("clippy")
+                .path("ci")
+                .stage(2)
+                .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
+        [check] rustc 2 <host> -> rustc 3 <host>
+        [build] rustc 1 <host> -> clippy-driver 2 <host>
+        [build] rustc 1 <host> -> cargo-clippy 2 <host>
+        [clippy] bootstrap <host>
+        [clippy] std <host>
+        [build] rustc 2 <host> -> std 2 <host>
+        [clippy] rustc <host>
+        [build] rustc 0 <host> -> clippy-driver 1 <host>
+        [build] rustc 0 <host> -> cargo-clippy 1 <host>
+        [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
+        ");
+    }
 }
 
 struct ExecutedSteps {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1375,6 +1375,10 @@ impl Config {
                 eprintln!("ERROR: cannot document anything on stage 0. Use at least stage 1.");
                 exit!(1);
             }
+            (0, Subcommand::Clippy { .. }) => {
+                eprintln!("ERROR: cannot run clippy on stage 0. Use at least stage 1.");
+                exit!(1);
+            }
             _ => {}
         }
 

--- a/src/bootstrap/src/utils/build_stamp.rs
+++ b/src/bootstrap/src/utils/build_stamp.rs
@@ -146,13 +146,13 @@ pub fn libstd_stamp(
 }
 
 /// Cargo's output path for librustc in a given stage, compiled by a particular
-/// compiler for the specified target.
+/// `build_compiler` for the specified target.
 pub fn librustc_stamp(
     builder: &Builder<'_>,
-    compiler: Compiler,
+    build_compiler: Compiler,
     target: TargetSelection,
 ) -> BuildStamp {
-    BuildStamp::new(&builder.cargo_out(compiler, Mode::Rustc, target)).with_prefix("librustc")
+    BuildStamp::new(&builder.cargo_out(build_compiler, Mode::Rustc, target)).with_prefix("librustc")
 }
 
 /// Computes a hash representing the state of a repository/submodule and additional input.

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -501,4 +501,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "The names of stageN directories in the build directory have been consolidated with the new (post-stage-0-redesign) staging scheme. Some tools and binaries might be located in a different build directory than before.",
     },
+    ChangeInfo {
+        change_id: 145131,
+        severity: ChangeSeverity::Warning,
+        summary: "It is no longer possible to `x clippy` with stage 0. All clippy commands have to be on stage 1+.",
+    },
 ];

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -28,7 +28,7 @@ RUN sh /scripts/sccache.sh
 
 ENV SCRIPT \
         python3 ../x.py check && \
-        python3 ../x.py clippy ci && \
+        python3 ../x.py clippy ci --stage 2 && \
         python3 ../x.py test --stage 1 core alloc std test proc_macro && \
         python3 ../x.py test --stage 1 src/tools/compiletest && \
         python3 ../x.py doc bootstrap && \


### PR DESCRIPTION
This mostly piggybacks on the previous `x check` [rework](https://github.com/rust-lang/rust/pull/143048).

The new "rules" follow the new staging logic. So `x clippy <foo>` lints `foo` using stage0 Clippy. `x clippy --stage 2 <foo>` lints `foo` using stage1 Clippy (which is built from in-tree sources).

I had to fix some latent issues with `prepare_compiler_for_check` along the way.

Checking `rustc_private` tools should now check less compiler crates (or rather not check compiler examples/tests/etc.), potentially speeding it up slightly.

I also had to make some manual adjustments to `x clippy ci` so that it doesn't do needless work.

r? @jieyouxu