### PR TITLE
coverage: Don't consume `CoverageInfoBuilder` when building

### DIFF
--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -147,11 +147,15 @@ impl CoverageInfoBuilder {
         });
     }
 
-    pub(crate) fn into_done(self) -> Box<CoverageInfoHi> {
-        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info } = self;
+    pub(crate) fn build(&self) -> Box<CoverageInfoHi> {
+        let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
+            self;
 
-        let branch_spans =
-            branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
+        let branch_spans = branch_info
+            .as_ref()
+            .map(|branch_info| branch_info.branch_spans.as_slice())
+            .unwrap_or_default()
+            .to_owned();
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -802,7 +802,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.coroutine,
             None,
         );
-        body.coverage_info_hi = self.coverage_info.map(|b| b.into_done());
+        body.coverage_info_hi = self.coverage_info.as_ref().map(|b| b.build());
 
         for (index, block) in body.basic_blocks.iter().enumerate() {
             if block.terminator.is_none() {


### PR DESCRIPTION
This change isn't needed for any coverage-related reason, but is intended to make rust-lang/rust#144780 easier by not requiring the whole builder to be cloned.

r? ghost