### PR TITLE
Improve "rustdoc.md" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rustdoc.md
+++ b/.github/ISSUE_TEMPLATE/rustdoc.md
@@ -1,5 +1,5 @@
 ---
-name: Problem with rustdoc
+name: Problem with rustdoc tool
 about: Report an issue with how docs get generated.
 labels: C-bug, T-rustdoc
 ---


### PR DESCRIPTION
I rename the title of `rustdoc.md` to `Problem with rustdoc tool`, which is clearer.