### PR TITLE
Stop using uadd.with.overflow

### DIFF
--- a/tests/codegen-llvm/bigint-helpers.rs
+++ b/tests/codegen-llvm/bigint-helpers.rs
@@ -3,11 +3,20 @@
 #![crate_type = "lib"]
 #![feature(bigint_helper_methods)]
 
+// Note that there's also an assembly test for this, which is what checks for
+// the `ADC` (Add with Carry) instruction on x86 now that the IR we emit uses
+// the preferred instruction phrasing instead of the intrinsic.
+
 // CHECK-LABEL: @u32_carrying_add
 #[no_mangle]
 pub fn u32_carrying_add(a: u32, b: u32, c: bool) -> (u32, bool) {
-    // CHECK: @llvm.uadd.with.overflow.i32
-    // CHECK: @llvm.uadd.with.overflow.i32
-    // CHECK: or disjoint i1
+    // CHECK: %[[AB:.+]] = add i32 {{%a, %b|%b, %a}}
+    // CHECK: %[[O1:.+]] = icmp ult i32 %[[AB]], %a
+    // CHECK: %[[CEXT:.+]] = zext i1 %c to i32
+    // CHECK: %[[ABC:.+]] = add i32 %[[AB]], %[[CEXT]]
+    // CHECK: %[[O2:.+]] = icmp ult i32 %[[ABC]], %[[AB]]
+    // CHECK: %[[O:.+]] = or disjoint i1 %[[O1]], %[[O2]]
+    // CHECK: insertvalue {{.+}}, i32 %[[ABC]], 0
+    // CHECK: insertvalue {{.+}}, i1 %[[O]], 1
     u32::carrying_add(a, b, c)
 }


### PR DESCRIPTION
As discussed in [#t-compiler/llvm > &#96;uadd.with.overflow&#96; (again) @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fllvm/topic/.60uadd.2Ewith.2Eoverflow.60.20.28again.29/near/533041085), stop emitting `uadd.with.overflow` in favour of `add`+`icmp` instead.

r? nikic 
