### PR TITLE
Override custom Cargo `build-dir` in bootstrap

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -433,6 +433,15 @@ impl Builder<'_> {
         let out_dir = self.stage_out(compiler, mode);
         cargo.env("CARGO_TARGET_DIR", &out_dir);
 
+        // Bootstrap makes a lot of assumptions about the artifacts produced in the target
+        // directory. If users override the "build directory" using `build-dir`
+        // (https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-dir), then
+        // bootstrap couldn't find these artifacts. So we forcefully override that option to our
+        // target directory here.
+        // In the future, we could attempt to read the build-dir location from Cargo and actually
+        // respect it.
+        cargo.env("CARGO_BUILD_BUILD_DIR", &out_dir);
+
         // Found with `rg "init_env_logger\("`. If anyone uses `init_env_logger`
         // from out of tree it shouldn't matter, since x.py is only used for
         // building in-tree.


### PR DESCRIPTION
The context for this issue is in https://github.com/rust-lang/rust/issues/145107. The issue is that if people configure `build-dir`, it would break bootstrap. For now, we just hard-code it to our self-contained target directories inside the build directory.

Tested by putting the following:
```toml
[build]
build-dir = "/tmp/foo"

[unstable]
build-dir = true
```

into `<rustc-checkout>/.cargo/config.toml`. `x build` works with this PR, doesn't work without this PR.

Fixes: https://github.com/rust-lang/rust/issues/145107