### PR TITLE
rustc_span: mark few methods as must_use

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1992,7 +1992,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn adjust_ident(self, mut ident: Ident, scope: DefId) -> Ident {
-        ident.span.normalize_to_macros_2_0_and_adjust(self.expn_that_defined(scope));
+        let _ = ident.span.normalize_to_macros_2_0_and_adjust(self.expn_that_defined(scope));
         ident
     }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -330,7 +330,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 RibKind::MacroDefinition(def) if def == self.macro_def(ident.span.ctxt()) => {
                     // If an invocation of this macro created `ident`, give up on `ident`
                     // and switch to `ident`'s source from the macro definition.
-                    ident.span.remove_mark();
+                    let _ = ident.span.remove_mark();
                     continue;
                 }
                 _ => continue,
@@ -759,7 +759,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
             }
             ModuleOrUniformRoot::ExternPrelude => {
-                ident.span.normalize_to_macros_2_0_and_adjust(ExpnId::root());
+                let _ = ident.span.normalize_to_macros_2_0_and_adjust(ExpnId::root());
             }
             ModuleOrUniformRoot::ModuleAndExternPrelude(..) | ModuleOrUniformRoot::CurrentScope => {
                 // No adjustments

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2481,7 +2481,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 // and switch to `ident`'s source from the macro definition.
                 && def == self.r.macro_def(label.span.ctxt())
             {
-                label.span.remove_mark();
+                let _ = label.span.remove_mark();
             }
 
             let ident = label.normalize_to_macro_rules();
@@ -3426,7 +3426,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         let Some((module, _)) = self.current_trait_ref else {
             return;
         };
-        ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
+        let _ = ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
         let key = BindingKey::new(ident, ns);
         let mut binding = self.r.resolution(module, key).and_then(|r| r.best_binding());
         debug!(?binding);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2462,7 +2462,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 {
                     // If an invocation of this macro created `ident`, give up on `ident`
                     // and switch to `ident`'s source from the macro definition.
-                    ctxt.remove_mark();
+                    let _ = ctxt.remove_mark();
                     continue;
                 }
 

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -520,6 +520,7 @@ impl HygieneData {
         ret_span
     }
 
+    #[must_use]
     fn adjust(&self, ctxt: &mut SyntaxContext, expn_id: ExpnId) -> Option<ExpnId> {
         let mut scope = None;
         while !self.is_descendant_of(expn_id, self.outer_expn(*ctxt)) {
@@ -754,6 +755,7 @@ impl SyntaxContext {
     /// invocation of f that created g1.
     /// Returns the mark that was removed.
     #[inline]
+    #[must_use]
     pub fn remove_mark(&mut self) -> ExpnId {
         HygieneData::with(|data| data.remove_mark(self).0)
     }
@@ -885,7 +887,7 @@ impl SyntaxContext {
     pub fn hygienic_eq(self, other: SyntaxContext, expn_id: ExpnId) -> bool {
         HygieneData::with(|data| {
             let mut self_normalized = data.normalize_to_macros_2_0(self);
-            data.adjust(&mut self_normalized, expn_id);
+            let _ = data.adjust(&mut self_normalized, expn_id);
             self_normalized == data.normalize_to_macros_2_0(other)
         })
     }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1116,6 +1116,7 @@ impl Span {
     }
 
     #[inline]
+    #[must_use]
     pub fn remove_mark(&mut self) -> ExpnId {
         let mut mark = ExpnId::root();
         *self = self.map_ctxt(|mut ctxt| {
@@ -1136,6 +1137,7 @@ impl Span {
     }
 
     #[inline]
+    #[must_use]
     pub fn normalize_to_macros_2_0_and_adjust(&mut self, expn_id: ExpnId) -> Option<ExpnId> {
         let mut mark = None;
         *self = self.map_ctxt(|mut ctxt| {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -871,7 +871,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut span = obligation.cause.span;
         while span.from_expansion() {
             // Remove all the desugaring and macro contexts.
-            span.remove_mark();
+            let _ = span.remove_mark();
         }
         let mut expr_finder = FindExprBySpan::new(span, self.tcx);
         let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) else {
@@ -1533,7 +1533,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
         while span.desugaring_kind().is_some() {
             // Remove all the hir desugaring contexts while maintaining the macro contexts.
-            span.remove_mark();
+            let _ = span.remove_mark();
         }
         let mut expr_finder = super::FindExprBySpan::new(span, self.tcx);
         let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_id) else {


### PR DESCRIPTION
Marked methods sometimes use returned value, sometimes not. I'm not sure that this is incorrect, so currently silenced warnings.
