### PR TITLE
Change days-threshold to 28 in [behind-upstream]

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1572,7 +1572,7 @@ changelog-branch = "master"
 [note]
 
 [behind-upstream]
-days-threshold = 14
+days-threshold = 28
 
 # Canonicalize issue numbers to avoid closing the wrong issue
 # when commits are included in subtrees, as well as warning links in commits.


### PR DESCRIPTION
Make the days-threshold to 28 to reduce false positives.

[#triagebot > Outdated commit message](https://rust-lang.zulipchat.com/#narrow/channel/224082-triagebot/topic/Outdated.20commit.20message)

r? @Urgau 

cc @jieyouxu 