### PR TITLE
`{BTree,Hash}Map`: add "`Entry` API" section heading

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -135,6 +135,8 @@ pub(super) const MIN_LEN: usize = node::MIN_LEN_AFTER_SPLIT;
 /// ]);
 /// ```
 ///
+/// ## `Entry` API
+///
 /// `BTreeMap` implements an [`Entry API`], which allows for complex
 /// methods of getting, setting, updating and removing keys and their values:
 ///

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -169,6 +169,8 @@ use crate::ops::Index;
 /// player_stats.entry("mana").and_modify(|mana| *mana += 200).or_insert(100);
 /// ```
 ///
+/// ## Usage with custom key types
+///
 /// The easiest way to use `HashMap` with a custom key type is to derive [`Eq`] and [`Hash`].
 /// We must also derive [`PartialEq`].
 ///

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -135,6 +135,8 @@ use crate::ops::Index;
 /// ]);
 /// ```
 ///
+/// ## `Entry` API
+///
 /// `HashMap` implements an [`Entry` API](#method.entry), which allows
 /// for complex methods of getting, setting, updating and removing keys and
 /// their values:


### PR DESCRIPTION
I wanted to link to an introduction of the `Entry` API to the help message of `clippy::map_entry` (see https://github.com/rust-lang/rust-clippy/issues/11598 for motivation), but I found the documentation on the `Entry` enum itself a bit short. On the other hand, `{BTree,Hash}Map` both have sections in their docs introducing the whole API and giving usage examples, and so I would like to link to that instead. For that, I introduce the "`Entry` API" section heading to both of them.

Do let me know whether you think this is the right approach.