### PR TITLE
Enable limit_rdylib_exports on Solaris

### DIFF
--- a/compiler/rustc_target/src/spec/base/solaris.rs
+++ b/compiler/rustc_target/src/spec/base/solaris.rs
@@ -8,7 +8,6 @@ pub(crate) fn opts() -> TargetOptions {
         families: cvs!["unix"],
         is_like_solaris: true,
         linker_flavor: LinkerFlavor::Unix(Cc::Yes),
-        limit_rdylib_exports: false, // Linker doesn't support this
         eh_frame_header: false,
 
         ..Default::default()


### PR DESCRIPTION
This (poorly named) target option controls whether or not cdylibs will export mangled rust symbols rather than just unmangled symbols. Presumably at some point in the past support for this wasn't implemented yet for Solaris, but cg_ssa::back::linker does have handling for this on Solaris now. And one of the Solaris target maintainers confirmed that building Rust with this option enabled works fine for them on Solaris: [#t-compiler > solaris limit_rdylib_exports @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/solaris.20limit_rdylib_exports/near/533480771)