### PR TITLE
Avoid abbreviating "numerator" as "numer", to allow catching typo "numer" elsewhere

### DIFF
--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -51,17 +51,16 @@ pub trait FromInner<Inner> {
     fn from_inner(inner: Inner) -> Self;
 }
 
-// Computes (value*numer)/denom without overflow, as long as both
-// (numer*denom) and the overall result fit into i64 (which is the case
-// for our time conversions).
+// Computes (value*numerator)/denom without overflow, as long as both (numerator*denom) and the
+// overall result fit into i64 (which is the case for our time conversions).
 #[allow(dead_code)] // not used on all platforms
-pub fn mul_div_u64(value: u64, numer: u64, denom: u64) -> u64 {
+pub fn mul_div_u64(value: u64, numerator: u64, denom: u64) -> u64 {
     let q = value / denom;
     let r = value % denom;
     // Decompose value as (value/denom*denom + value%denom),
-    // substitute into (value*numer)/denom and simplify.
-    // r < denom, so (denom*numer) is the upper bound of (r*numer)
-    q * numer + r * numer / denom
+    // substitute into (value*numerator)/denom and simplify.
+    // r < denom, so (denom*numerator) is the upper bound of (r*numerator)
+    q * numerator + r * numerator / denom
 }
 
 pub fn ignore_notfound<T>(result: crate::io::Result<T>) -> crate::io::Result<()> {

--- a/src/tools/miri/src/shims/time.rs
+++ b/src/tools/miri/src/shims/time.rs
@@ -322,8 +322,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Since our emulated ticks in `mach_absolute_time` *are* nanoseconds,
         // no scaling needs to happen.
-        let (numer, denom) = (1, 1);
-        this.write_int_fields(&[numer.into(), denom.into()], &info)?;
+        let (numerator, denom) = (1, 1);
+        this.write_int_fields(&[numerator.into(), denom.into()], &info)?;
 
         interp_ok(Scalar::from_i32(0)) // KERN_SUCCESS
     }

--- a/typos.toml
+++ b/typos.toml
@@ -52,7 +52,6 @@ ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC = "ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC"
 ERROR_MCA_OCCURED = "ERROR_MCA_OCCURED"
 ERRNO_ACCES = "ERRNO_ACCES"
 tolen = "tolen"
-numer = "numer"
 
 [default]
 extend-ignore-words-re = [


### PR DESCRIPTION
`typos.toml` has an exception for "numer", to avoid flagging its use as an abbreviation for "numerator". Remove the use of that abbrevation, spelling out "numerator" instead, and remove the exception, so that typo checks can find future instances of "numer" as a typo for "number".