### PR TITLE
remove FIXME block from `has_significant_drop`, it never encounters inference variables

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1359,6 +1359,7 @@ impl<'tcx> Ty<'tcx> {
     /// 2229 drop reorder migration analysis.
     #[inline]
     pub fn has_significant_drop(self, tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>) -> bool {
+        assert!(!self.has_non_region_infer());
         // Avoid querying in simple cases.
         match needs_drop_components(tcx, self) {
             Err(AlwaysRequiresDrop) => true,
@@ -1370,14 +1371,6 @@ impl<'tcx> Ty<'tcx> {
                     [component_ty] => component_ty,
                     _ => self,
                 };
-
-                // FIXME(#86868): We should be canonicalizing, or else moving this to a method of inference
-                // context, or *something* like that, but for now just avoid passing inference
-                // variables to queries that can't cope with them. Instead, conservatively
-                // return "true" (may change drop order).
-                if query_ty.has_infer() {
-                    return true;
-                }
 
                 // This doesn't depend on regions, so try to minimize distinct
                 // query keys used.

--- a/tests/ui/type-inference/has_sigdrop.rs
+++ b/tests/ui/type-inference/has_sigdrop.rs
@@ -1,0 +1,18 @@
+//@ run-pass
+// Inference, canonicalization, and significant drops should work nicely together.
+// Related issue: #86868
+
+#[clippy::has_significant_drop]
+struct DropGuy {}
+
+fn creator() -> DropGuy {
+    DropGuy {}
+}
+
+fn dropper() {
+    let _ = creator();
+}
+
+fn main() {
+    dropper();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The `FIXME` block in `Ty::has_significant_drop` is outdated as related queries can now handle type inference.

https://github.com/rust-lang/rust/blob/321a89bec57b8ca723d1af8f784490b950458c6a/compiler/rustc_middle/src/ty/util.rs#L1378-L1389

Closes rust-lang/rust#86868 (other places mentioned in the issue have been resolved, or moved to other issues)

r? types