### PR TITLE
Better sanitize attr diagnostic

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -171,8 +171,11 @@ codegen_ssa_invalid_monomorphization_unsupported_symbol = invalid monomorphizati
 
 codegen_ssa_invalid_monomorphization_unsupported_symbol_of_size = invalid monomorphization of `{$name}` intrinsic: unsupported {$symbol} from `{$in_ty}` with element `{$in_elem}` of size `{$size}` to `{$ret_ty}`
 
-codegen_ssa_invalid_sanitize = invalid argument for `sanitize`
+codegen_ssa_invalid_sanitizer = invalid argument for `sanitize`
     .note = expected one of: `address`, `kernel_address`, `cfi`, `hwaddress`, `kcfi`, `memory`, `memtag`, `shadow_call_stack`, or `thread`
+
+codegen_ssa_invalid_sanitizer_setting = invalid setting for `{$sanitizer}`
+    .note = expected one of: `on`, or `off`
 
 codegen_ssa_invalid_windows_subsystem = invalid windows subsystem `{$subsystem}`, only `windows` and `console` are allowed
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1121,11 +1121,20 @@ impl IntoDiagArg for ExpectedPointerMutability {
 }
 
 #[derive(Diagnostic)]
-#[diag(codegen_ssa_invalid_sanitize)]
+#[diag(codegen_ssa_invalid_sanitizer)]
 #[note]
-pub(crate) struct InvalidSanitize {
+pub(crate) struct InvalidSanitizer {
     #[primary_span]
     pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_invalid_sanitizer_setting)]
+#[note]
+pub(crate) struct InvalidSanitizerSetting {
+    #[primary_span]
+    pub span: Span,
+    pub sanitizer: Symbol,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/sanitize-attr/invalid-sanitize.rs
+++ b/tests/ui/sanitize-attr/invalid-sanitize.rs
@@ -12,7 +12,7 @@ fn multiple_consistent() {}
 #[sanitize(address = "off")]
 fn multiple_inconsistent() {}
 
-#[sanitize(address = "bogus")] //~ ERROR invalid argument for `sanitize`
+#[sanitize(address = "bogus")] //~ ERROR invalid setting for `address`
 fn wrong_value() {}
 
 #[sanitize = "off"] //~ ERROR malformed `sanitize` attribute input

--- a/tests/ui/sanitize-attr/invalid-sanitize.stderr
+++ b/tests/ui/sanitize-attr/invalid-sanitize.stderr
@@ -70,13 +70,13 @@ LL | #[sanitize(brontosaurus = "off")]
    |
    = note: expected one of: `address`, `kernel_address`, `cfi`, `hwaddress`, `kcfi`, `memory`, `memtag`, `shadow_call_stack`, or `thread`
 
-error: invalid argument for `sanitize`
-  --> $DIR/invalid-sanitize.rs:15:1
+error: invalid setting for `address`
+  --> $DIR/invalid-sanitize.rs:15:12
    |
 LL | #[sanitize(address = "bogus")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^
    |
-   = note: expected one of: `address`, `kernel_address`, `cfi`, `hwaddress`, `kcfi`, `memory`, `memtag`, `shadow_call_stack`, or `thread`
+   = note: expected one of: `on`, or `off`
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
While working on a new sanitizer i noticed that the error messages here could be better.
This now differentiates between a wrong / nonexisting sanitizer and a wrong / nonexisting value for a valid sanitizer.

This is my first time doing a PR to rustc, so i could have missed something.