### PR TITLE
`suggest_borrow_generic_arg`: use the correct generic args

### DIFF
--- a/tests/ui/moves/use-correct-generic-args-in-borrow-suggest.rs
+++ b/tests/ui/moves/use-correct-generic-args-in-borrow-suggest.rs
@@ -1,0 +1,13 @@
+//! Regression test for #145164: For normal calls, make sure the suggestion to borrow generic inputs
+//! uses the generic args from the callee's type rather than those attached to the callee's HIR
+//! node. In cases where the callee isn't an identifier expression, its HIR node won't have its
+//! generic arguments attached, which could lead to ICE when it had other generic args. In this
+//! case, the callee expression is `run.clone()`, to which `clone`'s generic arguments are attached.
+
+fn main() {
+    let value = String::new();
+    run.clone()(value, ());
+    run(value, ());
+    //~^ ERROR use of moved value: `value`
+}
+fn run<F, T: Clone>(value: T, f: F) {}

--- a/tests/ui/moves/use-correct-generic-args-in-borrow-suggest.stderr
+++ b/tests/ui/moves/use-correct-generic-args-in-borrow-suggest.stderr
@@ -1,0 +1,18 @@
+error[E0382]: use of moved value: `value`
+  --> $DIR/use-correct-generic-args-in-borrow-suggest.rs:10:9
+   |
+LL |     let value = String::new();
+   |         ----- move occurs because `value` has type `String`, which does not implement the `Copy` trait
+LL |     run.clone()(value, ());
+   |                 ----- value moved here
+LL |     run(value, ());
+   |         ^^^^^ value used here after move
+   |
+help: consider borrowing `value`
+   |
+LL |     run.clone()(&value, ());
+   |                 +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
The suggestion now gets calls' generic arguments from the callee's type to handle cases where the callee isn't an identifier expression. Fixes rust-lang/rust#145164.