### PR TITLE
Ignore coroutine witness type region args in auto trait confirmation

### DIFF
--- a/tests/ui/async-await/recursive-async-auto-trait-overflow.rs
+++ b/tests/ui/async-await/recursive-async-auto-trait-overflow.rs
@@ -1,0 +1,14 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/145151>.
+
+//@ edition: 2024
+//@ check-pass
+
+async fn process<'a>() {
+    Box::pin(process()).await;
+}
+
+fn require_send(_: impl Send) {}
+
+fn main() {
+    require_send(process());
+}


### PR DESCRIPTION
## The problem

Consider code like:

```
async fn process<'a>() {
    Box::pin(process()).await;
}

fn require_send(_: impl Send) {}

fn main() {
    require_send(process());
}
```

When proving that the coroutine `{coroutine@process}::<'?0>: Send`, we end up instantiating a nested goal `{witness@process}::<'?0>: Send` by synthesizing a witness type from the coroutine's args:

Proving a coroutine witness type implements an auto trait requires looking up the coroutine's witness types. The witness types are a binder that look like `for<'r> { Pin<Box<{coroutine@process}::<'r>>> }`. We instantiate this binder with placeholders and prove `Send` on the witness types. This ends up eventually needing to prove something like `{coroutine@process}::<'!1>: Send`. Repeat this process, and we end up in an overflow during fulfillment, since fulfillment does not use freshening.

This can be visualized with a trait stack that ends up looking like:
* `{coroutine@process}::<'?0>: Send`
  * `{witness@process}::<'?0>: Send`
    * `Pin<Box<{coroutine@process}::<'!1>>>: Send`
      * `{coroutine@process}::<'!1>: Send`
        * ...
          * `{coroutine@process}::<'!2>: Send`
            * `{witness@process}::<'!2>: Send`
              * ...
                * overflow!

The problem here specifically comes from the first step: synthesizing a witness type from the coroutine's args. 

## Why wasn't this an issue before?

Specifically, before 63f6845e570305a92eaf855897768617366164d6, this wasn't an issue because we were instead extracting the witness from the coroutine type itself. It turns out that given some `{coroutine@process}::<'?0>`, the witness type was actually something like `{witness@process}::<'erased>`! 

So why do we end up with a witness type with `'erased` in its args? This is due to the fact that opaque type inference erases all regions from the witness. This is actually explicitly part of opaque type inference -- changing this to actually visit the witness types actually replicates this overflow even with 63f6845e570305a92eaf855897768617366164d6 reverted:

https://github.com/rust-lang/rust/blob/ca77504943887037504c7fc0b9bf06dab3910373/compiler/rustc_borrowck/src/type_check/opaque_types.rs#L303-L313

To better understand this difference and how it avoids a cycle, if you look at the trait stack before 63f6845e570305a92eaf855897768617366164d6, we end up with something like:

* `{coroutine@process}::<'?0>: Send`
  * `{witness@process}::<'erased>: Send` **<-- THIS CHANGED**
    * `Pin<Box<{coroutine@process}::<'!1>>>: Send`
      * `{coroutine@process}::<'!1>: Send`
        * ...
          * `{coroutine@process}::<'erased>: Send` **<-- THIS CHANGED**
              * coinductive cycle! :tada:

## So what's the fix?

This hack replicates the behavior in opaque type inference to erase regions from the witness type, but instead erasing the regions during auto trait confirmation. This is kinda a hack, but is sound. It does not need to be replicated in the new trait solver, of course.

---

I hope this explanation makes sense. 

We could beta backport this instead of the revert https://github.com/rust-lang/rust/pull/145193, but then I'd like to un-revert that on master in this PR along with landing this this hack. Thoughts?

r? lcnr