### PR TITLE
rust-analyzer: fix parsing of trait bound polarity and for-binders

### DIFF
--- a/src/tools/rust-analyzer/crates/parser/src/grammar/generic_params.rs
+++ b/src/tools/rust-analyzer/crates/parser/src/grammar/generic_params.rs
@@ -182,12 +182,6 @@ fn type_bound(p: &mut Parser<'_>) -> bool {
             );
             m.complete(p, USE_BOUND_GENERIC_ARGS);
         }
-        T![?] if p.nth_at(1, T![for]) => {
-            // test question_for_type_trait_bound
-            // fn f<T>() where T: ?for<> Sized {}
-            p.bump_any();
-            types::for_type(p, false)
-        }
         _ => {
             if path_type_bound(p).is_err() {
                 m.abandon(p);
@@ -219,7 +213,12 @@ fn path_type_bound(p: &mut Parser<'_>) -> Result<(), ()> {
     // test async_trait_bound
     // fn async_foo(_: impl async Fn(&i32)) {}
     p.eat(T![async]);
+    // test question_for_type_trait_bound
+    // fn f<T>() where T: for<> ?Sized {}
     p.eat(T![?]);
+
+    // test_err invalid_question_for_type_trait_bound
+    // fn f<T>() where T: ?for<> Sized {}
 
     if paths::is_use_path_start(p) {
         types::path_type_bounds(p, false);

--- a/src/tools/rust-analyzer/crates/parser/test_data/generated/runner.rs
+++ b/src/tools/rust-analyzer/crates/parser/test_data/generated/runner.rs
@@ -796,6 +796,12 @@ mod err {
     #[test]
     fn impl_type() { run_and_expect_errors("test_data/parser/inline/err/impl_type.rs"); }
     #[test]
+    fn invalid_question_for_type_trait_bound() {
+        run_and_expect_errors(
+            "test_data/parser/inline/err/invalid_question_for_type_trait_bound.rs",
+        );
+    }
+    #[test]
     fn let_else_right_curly_brace() {
         run_and_expect_errors("test_data/parser/inline/err/let_else_right_curly_brace.rs");
     }

--- a/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/err/invalid_question_for_type_trait_bound.rast
+++ b/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/err/invalid_question_for_type_trait_bound.rast
@@ -26,22 +26,24 @@ SOURCE_FILE
         COLON ":"
         WHITESPACE " "
         TYPE_BOUND_LIST
-          TYPE_BOUND
-            FOR_BINDER
-              FOR_KW "for"
-              GENERIC_PARAM_LIST
-                L_ANGLE "<"
-                R_ANGLE ">"
-            WHITESPACE " "
-            QUESTION "?"
-            PATH_TYPE
-              PATH
-                PATH_SEGMENT
-                  NAME_REF
-                    IDENT "Sized"
+          QUESTION "?"
+      WHERE_PRED
+        FOR_BINDER
+          FOR_KW "for"
+          GENERIC_PARAM_LIST
+            L_ANGLE "<"
+            R_ANGLE ">"
+        WHITESPACE " "
+        PATH_TYPE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                IDENT "Sized"
     WHITESPACE " "
     BLOCK_EXPR
       STMT_LIST
         L_CURLY "{"
         R_CURLY "}"
   WHITESPACE "\n"
+error 20: expected comma
+error 31: expected colon

--- a/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/err/invalid_question_for_type_trait_bound.rs
+++ b/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/err/invalid_question_for_type_trait_bound.rs
@@ -1,0 +1,1 @@
+fn f<T>() where T: ?for<> Sized {}

--- a/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/question_for_type_trait_bound.rs
+++ b/src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/question_for_type_trait_bound.rs
@@ -1,1 +1,1 @@
-fn f<T>() where T: ?for<> Sized {}
+fn f<T>() where T: for<> ?Sized {}


### PR DESCRIPTION
The rustc AST allows both `for<>` binders and `?` polarity modifiers in trait bounds, but they are parsed in a specific order and validated for correctness:

    1. `for<>` binder is parsed first.
    2. Polarity modifiers (`?`, `!`) are parsed second.
    3. The parser validates that binders and polarity modifiers do not conflict:

    ```rust
    if let Some(binder_span) = binder_span {
        match modifiers.polarity {
            BoundPolarity::Maybe(polarity_span) => {
                // Error: "for<...> binder not allowed with ? polarity"
            }
        }
    }
    ```

This implies:

- `for<> ?Sized` → Valid syntax. Invalid semantics.
- `?for<> Sized` → Invalid syntax.

However, rust-analyzer incorrectly had special-case logic that allowed `?for<>` as valid syntax. This fix removes that incorrect special case, making rust-analyzer reject `?for<> Sized` as a syntax error, matching rustc behavior.

This has caused confusion in other crates (such as syn) which rely on these files to implement correct syntax evaluation.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
