### PR TITLE
Implement declarative (`macro_rules!`) derive macros (RFC 3698)

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -70,7 +70,7 @@ expand_invalid_fragment_specifier =
     invalid fragment specifier `{$fragment}`
     .help = {$help}
 
-expand_macro_args_bad_delim = macro attribute argument matchers require parentheses
+expand_macro_args_bad_delim = `{$rule_kw}` rule argument matchers require parentheses
 expand_macro_args_bad_delim_sugg = the delimiters should be `(` and `)`
 
 expand_macro_body_stability =

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -490,6 +490,7 @@ pub(crate) struct MacroArgsBadDelim {
     pub span: Span,
     #[subdiagnostic]
     pub sugg: MacroArgsBadDelimSugg,
+    pub rule_kw: Symbol,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -14,14 +14,22 @@ use super::macro_rules::{MacroRule, NoopTracker, parser_from_cx};
 use crate::expand::{AstFragmentKind, parse_ast_fragment};
 use crate::mbe::macro_parser::ParseResult::*;
 use crate::mbe::macro_parser::{MatcherLoc, NamedParseResult, TtParser};
-use crate::mbe::macro_rules::{Tracker, try_match_macro, try_match_macro_attr};
+use crate::mbe::macro_rules::{
+    Tracker, try_match_macro, try_match_macro_attr, try_match_macro_derive,
+};
+
+pub(super) enum FailedMacro<'a> {
+    Func,
+    Attr(&'a TokenStream),
+    Derive,
+}
 
 pub(super) fn failed_to_match_macro(
     psess: &ParseSess,
     sp: Span,
     def_span: Span,
     name: Ident,
-    attr_args: Option<&TokenStream>,
+    args: FailedMacro<'_>,
     body: &TokenStream,
     rules: &[MacroRule],
 ) -> (Span, ErrorGuaranteed) {
@@ -36,10 +44,12 @@ pub(super) fn failed_to_match_macro(
     // diagnostics.
     let mut tracker = CollectTrackerAndEmitter::new(psess.dcx(), sp);
 
-    let try_success_result = if let Some(attr_args) = attr_args {
-        try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
-    } else {
-        try_match_macro(psess, name, body, rules, &mut tracker)
+    let try_success_result = match args {
+        FailedMacro::Func => try_match_macro(psess, name, body, rules, &mut tracker),
+        FailedMacro::Attr(attr_args) => {
+            try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
+        }
+        FailedMacro::Derive => try_match_macro_derive(psess, name, body, rules, &mut tracker),
     };
 
     if try_success_result.is_ok() {
@@ -90,7 +100,7 @@ pub(super) fn failed_to_match_macro(
     }
 
     // Check whether there's a missing comma in this macro call, like `println!("{}" a);`
-    if attr_args.is_none()
+    if let FailedMacro::Func = args
         && let Some((body, comma_span)) = body.add_comma()
     {
         for rule in rules {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -556,6 +556,8 @@ declare_features! (
     (incomplete, loop_match, "1.90.0", Some(132306)),
     /// Allow `macro_rules!` attribute rules
     (unstable, macro_attr, "CURRENT_RUSTC_VERSION", Some(83527)),
+    /// Allow `macro_rules!` derive rules
+    (unstable, macro_derive, "CURRENT_RUSTC_VERSION", Some(143549)),
     /// Give access to additional metadata about declarative macro meta-variables.
     (unstable, macro_metavar_expr, "1.61.0", Some(83527)),
     /// Provides a way to concatenate identifiers using metavariable expressions.

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -249,7 +249,7 @@ resolve_macro_cannot_use_as_attr =
     `{$ident}` exists, but has no `attr` rules
 
 resolve_macro_cannot_use_as_derive =
-     `{$ident}` exists, but a declarative macro cannot be used as a derive macro
+     `{$ident}` exists, but has no `derive` rules
 
 resolve_macro_defined_later =
     a macro with the same name exists, but it appears later

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1315,6 +1315,7 @@ symbols! {
         macro_attr,
         macro_attributes_in_derive_output,
         macro_concat,
+        macro_derive,
         macro_escape,
         macro_export,
         macro_lifetime_matcher,

--- a/tests/ui/feature-gates/feature-gate-macro-derive.rs
+++ b/tests/ui/feature-gates/feature-gate-macro-derive.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+macro_rules! MyDerive { derive() {} => {} }
+//~^ ERROR `macro_rules!` derives are unstable

--- a/tests/ui/feature-gates/feature-gate-macro-derive.stderr
+++ b/tests/ui/feature-gates/feature-gate-macro-derive.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `macro_rules!` derives are unstable
+  --> $DIR/feature-gate-macro-derive.rs:3:1
+   |
+LL | macro_rules! MyDerive { derive() {} => {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_attr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
+++ b/tests/ui/macros/macro-rules-as-derive-or-attr-issue-132928.stderr
@@ -2,7 +2,7 @@ error: cannot find derive macro `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:6:10
    |
 LL | macro_rules! sample { () => {} }
-   |              ------ `sample` exists, but a declarative macro cannot be used as a derive macro
+   |              ------ `sample` exists, but has no `derive` rules
 ...
 LL | #[derive(sample)]
    |          ^^^^^^
@@ -20,7 +20,7 @@ error: cannot find derive macro `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:6:10
    |
 LL | macro_rules! sample { () => {} }
-   |              ------ `sample` exists, but a declarative macro cannot be used as a derive macro
+   |              ------ `sample` exists, but has no `derive` rules
 ...
 LL | #[derive(sample)]
    |          ^^^^^^
@@ -31,7 +31,7 @@ error: cannot find derive macro `sample` in this scope
   --> $DIR/macro-rules-as-derive-or-attr-issue-132928.rs:6:10
    |
 LL | macro_rules! sample { () => {} }
-   |              ------ `sample` exists, but a declarative macro cannot be used as a derive macro
+   |              ------ `sample` exists, but has no `derive` rules
 ...
 LL | #[derive(sample)]
    |          ^^^^^^

--- a/tests/ui/macros/macro-rules-derive-error.rs
+++ b/tests/ui/macros/macro-rules-derive-error.rs
@@ -1,0 +1,51 @@
+#![feature(macro_derive)]
+
+macro_rules! MyDerive {
+    derive() { $($body:tt)* } => {
+        compile_error!(concat!("MyDerive: ", stringify!($($body)*)));
+    };
+    //~^^ ERROR: MyDerive
+}
+
+macro_rules! fn_only {
+//~^ NOTE: `fn_only` exists, but has no `derive` rules
+//~| NOTE: `fn_only` exists, but has no `derive` rules
+    {} => {}
+}
+
+//~v NOTE: `DeriveOnly` exists, but has no rules for function-like invocation
+macro_rules! DeriveOnly {
+    derive() {} => {}
+}
+
+fn main() {
+    //~v NOTE: in this expansion of #[derive(MyDerive)]
+    #[derive(MyDerive)]
+    struct S1;
+
+    //~vv ERROR: cannot find macro `MyDerive` in this scope
+    //~| NOTE: `MyDerive` is in scope, but it is a derive
+    MyDerive!(arg);
+
+    #[derive(fn_only)]
+    struct S2;
+    //~^^ ERROR: cannot find derive macro `fn_only` in this scope
+    //~| ERROR: cannot find derive macro `fn_only` in this scope
+    //~| NOTE: duplicate diagnostic emitted
+
+    DeriveOnly!(); //~ ERROR: cannot find macro `DeriveOnly` in this scope
+}
+
+#[derive(ForwardReferencedDerive)]
+struct S;
+//~^^ ERROR: cannot find derive macro `ForwardReferencedDerive` in this scope
+//~| NOTE: consider moving the definition of `ForwardReferencedDerive` before this call
+//~| ERROR: cannot find derive macro `ForwardReferencedDerive` in this scope
+//~| NOTE: consider moving the definition of `ForwardReferencedDerive` before this call
+//~| NOTE: duplicate diagnostic emitted
+
+macro_rules! ForwardReferencedDerive {
+//~^ NOTE: a macro with the same name exists, but it appears later
+//~| NOTE: a macro with the same name exists, but it appears later
+    derive() {} => {}
+}

--- a/tests/ui/macros/macro-rules-derive-error.stderr
+++ b/tests/ui/macros/macro-rules-derive-error.stderr
@@ -1,0 +1,75 @@
+error: MyDerive: struct S1;
+  --> $DIR/macro-rules-derive-error.rs:5:9
+   |
+LL |         compile_error!(concat!("MyDerive: ", stringify!($($body)*)));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     #[derive(MyDerive)]
+   |              -------- in this derive macro expansion
+   |
+   = note: this error originates in the derive macro `MyDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot find macro `MyDerive` in this scope
+  --> $DIR/macro-rules-derive-error.rs:28:5
+   |
+LL |     MyDerive!(arg);
+   |     ^^^^^^^^
+   |
+   = note: `MyDerive` is in scope, but it is a derive macro: `#[derive(MyDerive)]`
+
+error: cannot find derive macro `fn_only` in this scope
+  --> $DIR/macro-rules-derive-error.rs:30:14
+   |
+LL | macro_rules! fn_only {
+   |              ------- `fn_only` exists, but has no `derive` rules
+...
+LL |     #[derive(fn_only)]
+   |              ^^^^^^^
+
+error: cannot find derive macro `fn_only` in this scope
+  --> $DIR/macro-rules-derive-error.rs:30:14
+   |
+LL | macro_rules! fn_only {
+   |              ------- `fn_only` exists, but has no `derive` rules
+...
+LL |     #[derive(fn_only)]
+   |              ^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: cannot find macro `DeriveOnly` in this scope
+  --> $DIR/macro-rules-derive-error.rs:36:5
+   |
+LL | macro_rules! DeriveOnly {
+   |              ---------- `DeriveOnly` exists, but has no rules for function-like invocation
+...
+LL |     DeriveOnly!();
+   |     ^^^^^^^^^^
+
+error: cannot find derive macro `ForwardReferencedDerive` in this scope
+  --> $DIR/macro-rules-derive-error.rs:39:10
+   |
+LL | #[derive(ForwardReferencedDerive)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ consider moving the definition of `ForwardReferencedDerive` before this call
+   |
+note: a macro with the same name exists, but it appears later
+  --> $DIR/macro-rules-derive-error.rs:47:14
+   |
+LL | macro_rules! ForwardReferencedDerive {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot find derive macro `ForwardReferencedDerive` in this scope
+  --> $DIR/macro-rules-derive-error.rs:39:10
+   |
+LL | #[derive(ForwardReferencedDerive)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ consider moving the definition of `ForwardReferencedDerive` before this call
+   |
+note: a macro with the same name exists, but it appears later
+  --> $DIR/macro-rules-derive-error.rs:47:14
+   |
+LL | macro_rules! ForwardReferencedDerive {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui/macros/macro-rules-derive.rs
+++ b/tests/ui/macros/macro-rules-derive.rs
@@ -1,0 +1,71 @@
+//@ run-pass
+//@ check-run-results
+#![feature(macro_derive)]
+
+#[macro_export]
+macro_rules! MyExportedDerive {
+    derive() { $($body:tt)* } => {
+        println!("MyExportedDerive: body={:?}", stringify!($($body)*));
+    };
+    { $($args:tt)* } => {
+        println!("MyExportedDerive!({:?})", stringify!($($args)*));
+    };
+}
+
+macro_rules! MyLocalDerive {
+    derive() { $($body:tt)* } => {
+        println!("MyLocalDerive: body={:?}", stringify!($($body)*));
+    };
+    { $($args:tt)* } => {
+        println!("MyLocalDerive!({:?})", stringify!($($args)*));
+    };
+}
+
+trait MyTrait {
+    fn name() -> &'static str;
+}
+
+macro_rules! MyTrait {
+    derive() { struct $name:ident; } => {
+        impl MyTrait for $name {
+            fn name() -> &'static str {
+                stringify!($name)
+            }
+        }
+    };
+}
+
+#[derive(MyTrait)]
+struct MyGlobalType;
+
+fn main() {
+    #[derive(crate::MyExportedDerive)]
+    struct _S1;
+    #[derive(crate::MyExportedDerive, crate::MyExportedDerive)]
+    struct _Twice1;
+
+    crate::MyExportedDerive!();
+    crate::MyExportedDerive!(invoked, arguments);
+
+    #[derive(MyExportedDerive)]
+    struct _S2;
+    #[derive(MyExportedDerive, MyExportedDerive)]
+    struct _Twice2;
+
+    MyExportedDerive!();
+    MyExportedDerive!(invoked, arguments);
+
+    #[derive(MyLocalDerive)]
+    struct _S3;
+    #[derive(MyLocalDerive, MyLocalDerive)]
+    struct _Twice3;
+
+    MyLocalDerive!();
+    MyLocalDerive!(invoked, arguments);
+
+    #[derive(MyTrait)]
+    struct MyLocalType;
+
+    println!("MyGlobalType::name(): {}", MyGlobalType::name());
+    println!("MyLocalType::name(): {}", MyLocalType::name());
+}

--- a/tests/ui/macros/macro-rules-derive.run.stdout
+++ b/tests/ui/macros/macro-rules-derive.run.stdout
@@ -1,0 +1,17 @@
+MyExportedDerive: body="struct _S1;"
+MyExportedDerive: body="struct _Twice1;"
+MyExportedDerive: body="struct _Twice1;"
+MyExportedDerive!("")
+MyExportedDerive!("invoked, arguments")
+MyExportedDerive: body="struct _S2;"
+MyExportedDerive: body="struct _Twice2;"
+MyExportedDerive: body="struct _Twice2;"
+MyExportedDerive!("")
+MyExportedDerive!("invoked, arguments")
+MyLocalDerive: body="struct _S3;"
+MyLocalDerive: body="struct _Twice3;"
+MyLocalDerive: body="struct _Twice3;"
+MyLocalDerive!("")
+MyLocalDerive!("invoked, arguments")
+MyGlobalType::name(): MyGlobalType
+MyLocalType::name(): MyLocalType

--- a/tests/ui/parser/macro/macro-attr-bad.rs
+++ b/tests/ui/parser/macro/macro-attr-bad.rs
@@ -14,10 +14,10 @@ macro_rules! attr_incomplete_4 { attr() {} => }
 //~^ ERROR macro definition ended unexpectedly
 
 macro_rules! attr_noparens_1 { attr{} {} => {} }
-//~^ ERROR macro attribute argument matchers require parentheses
+//~^ ERROR `attr` rule argument matchers require parentheses
 
 macro_rules! attr_noparens_2 { attr[] {} => {} }
-//~^ ERROR macro attribute argument matchers require parentheses
+//~^ ERROR `attr` rule argument matchers require parentheses
 
 macro_rules! attr_noparens_3 { attr _ {} => {} }
 //~^ ERROR invalid macro matcher

--- a/tests/ui/parser/macro/macro-attr-bad.stderr
+++ b/tests/ui/parser/macro/macro-attr-bad.stderr
@@ -22,7 +22,7 @@ error: macro definition ended unexpectedly
 LL | macro_rules! attr_incomplete_4 { attr() {} => }
    |                                              ^ expected right-hand side of macro rule
 
-error: macro attribute argument matchers require parentheses
+error: `attr` rule argument matchers require parentheses
   --> $DIR/macro-attr-bad.rs:16:36
    |
 LL | macro_rules! attr_noparens_1 { attr{} {} => {} }
@@ -34,7 +34,7 @@ LL - macro_rules! attr_noparens_1 { attr{} {} => {} }
 LL + macro_rules! attr_noparens_1 { attr() {} => {} }
    |
 
-error: macro attribute argument matchers require parentheses
+error: `attr` rule argument matchers require parentheses
   --> $DIR/macro-attr-bad.rs:19:36
    |
 LL | macro_rules! attr_noparens_2 { attr[] {} => {} }

--- a/tests/ui/parser/macro/macro-attr-recovery.rs
+++ b/tests/ui/parser/macro/macro-attr-recovery.rs
@@ -3,7 +3,7 @@
 
 macro_rules! attr {
     attr[$($args:tt)*] { $($body:tt)* } => {
-        //~^ ERROR: macro attribute argument matchers require parentheses
+        //~^ ERROR: `attr` rule argument matchers require parentheses
         //~v ERROR: attr:
         compile_error!(concat!(
             "attr: args=\"",

--- a/tests/ui/parser/macro/macro-attr-recovery.stderr
+++ b/tests/ui/parser/macro/macro-attr-recovery.stderr
@@ -1,4 +1,4 @@
-error: macro attribute argument matchers require parentheses
+error: `attr` rule argument matchers require parentheses
   --> $DIR/macro-attr-recovery.rs:5:9
    |
 LL |     attr[$($args:tt)*] { $($body:tt)* } => {

--- a/tests/ui/parser/macro/macro-derive-bad.rs
+++ b/tests/ui/parser/macro/macro-derive-bad.rs
@@ -1,0 +1,43 @@
+#![crate_type = "lib"]
+#![feature(macro_derive)]
+
+macro_rules! derive_incomplete_1 { derive }
+//~^ ERROR macro definition ended unexpectedly
+//~| NOTE expected `()` after `derive`
+
+macro_rules! derive_incomplete_2 { derive() }
+//~^ ERROR macro definition ended unexpectedly
+//~| NOTE expected macro derive body
+
+macro_rules! derive_incomplete_3 { derive() {} }
+//~^ ERROR expected `=>`
+//~| NOTE expected `=>`
+
+macro_rules! derive_incomplete_4 { derive() {} => }
+//~^ ERROR macro definition ended unexpectedly
+//~| NOTE expected right-hand side of macro rule
+
+macro_rules! derive_noparens_1 { derive{} {} => {} }
+//~^ ERROR `derive` rule argument matchers require parentheses
+
+macro_rules! derive_noparens_2 { derive[] {} => {} }
+//~^ ERROR `derive` rule argument matchers require parentheses
+
+macro_rules! derive_noparens_3 { derive _ {} => {} }
+//~^ ERROR `derive` must be followed by `()`
+
+macro_rules! derive_args_1 { derive($x:ident) ($y:ident) => {} }
+//~^ ERROR `derive` rules do not accept arguments
+
+macro_rules! derive_args_2 { derive() => {} }
+//~^ ERROR expected macro derive body, got `=>`
+
+macro_rules! derive_args_3 { derive($x:ident) => {} }
+//~^ ERROR `derive` rules do not accept arguments
+//~| ERROR expected macro derive body, got `=>`
+//~| NOTE need `()` after this `derive`
+
+macro_rules! derive_dup_matcher { derive() {$x:ident $x:ident} => {} }
+//~^ ERROR duplicate matcher binding
+//~| NOTE duplicate binding
+//~| NOTE previous binding

--- a/tests/ui/parser/macro/macro-derive-bad.stderr
+++ b/tests/ui/parser/macro/macro-derive-bad.stderr
@@ -1,0 +1,90 @@
+error: macro definition ended unexpectedly
+  --> $DIR/macro-derive-bad.rs:4:42
+   |
+LL | macro_rules! derive_incomplete_1 { derive }
+   |                                          ^ expected `()` after `derive`
+
+error: macro definition ended unexpectedly
+  --> $DIR/macro-derive-bad.rs:8:44
+   |
+LL | macro_rules! derive_incomplete_2 { derive() }
+   |                                            ^ expected macro derive body
+
+error: expected `=>`, found end of macro arguments
+  --> $DIR/macro-derive-bad.rs:12:47
+   |
+LL | macro_rules! derive_incomplete_3 { derive() {} }
+   |                                               ^ expected `=>`
+
+error: macro definition ended unexpectedly
+  --> $DIR/macro-derive-bad.rs:16:50
+   |
+LL | macro_rules! derive_incomplete_4 { derive() {} => }
+   |                                                  ^ expected right-hand side of macro rule
+
+error: `derive` rule argument matchers require parentheses
+  --> $DIR/macro-derive-bad.rs:20:40
+   |
+LL | macro_rules! derive_noparens_1 { derive{} {} => {} }
+   |                                        ^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL - macro_rules! derive_noparens_1 { derive{} {} => {} }
+LL + macro_rules! derive_noparens_1 { derive() {} => {} }
+   |
+
+error: `derive` rule argument matchers require parentheses
+  --> $DIR/macro-derive-bad.rs:23:40
+   |
+LL | macro_rules! derive_noparens_2 { derive[] {} => {} }
+   |                                        ^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL - macro_rules! derive_noparens_2 { derive[] {} => {} }
+LL + macro_rules! derive_noparens_2 { derive() {} => {} }
+   |
+
+error: `derive` rules do not accept arguments; `derive` must be followed by `()`
+  --> $DIR/macro-derive-bad.rs:26:41
+   |
+LL | macro_rules! derive_noparens_3 { derive _ {} => {} }
+   |                                         ^
+
+error: `derive` rules do not accept arguments; `derive` must be followed by `()`
+  --> $DIR/macro-derive-bad.rs:29:36
+   |
+LL | macro_rules! derive_args_1 { derive($x:ident) ($y:ident) => {} }
+   |                                    ^^^^^^^^^^
+
+error: expected macro derive body, got `=>`
+  --> $DIR/macro-derive-bad.rs:32:39
+   |
+LL | macro_rules! derive_args_2 { derive() => {} }
+   |                                       ^^
+
+error: `derive` rules do not accept arguments; `derive` must be followed by `()`
+  --> $DIR/macro-derive-bad.rs:35:36
+   |
+LL | macro_rules! derive_args_3 { derive($x:ident) => {} }
+   |                                    ^^^^^^^^^^
+
+error: expected macro derive body, got `=>`
+  --> $DIR/macro-derive-bad.rs:35:47
+   |
+LL | macro_rules! derive_args_3 { derive($x:ident) => {} }
+   |                              ------           ^^
+   |                              |
+   |                              need `()` after this `derive`
+
+error: duplicate matcher binding
+  --> $DIR/macro-derive-bad.rs:40:54
+   |
+LL | macro_rules! derive_dup_matcher { derive() {$x:ident $x:ident} => {} }
+   |                                             -------- ^^^^^^^^ duplicate binding
+   |                                             |
+   |                                             previous binding
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
This implements RFC 3698, "Declarative (`macro_rules!`) derive macros".
Tracking issue: https://github.com/rust-lang/rust/issues/143549

This has one remaining issue, which I could use some help debugging: in
`tests/ui/macros/macro-rules-derive-error.rs`, the diagnostics for
`derive(fn_only)` (for a `fn_only` with no `derive` rules) and
`derive(ForwardReferencedDerive)` both get emitted twice, as a duplicate
diagnostic.

From what I can tell via adding some debugging code,
`unresolved_macro_suggestions` is getting called twice from
`finalize_macro_resolutions` for each of them, because
`self.single_segment_macro_resolutions` has two entries for the macro, with two
different `parent_scope` values. I'm not clear on why that happened; it doesn't
happen with the equivalent code using attrs.

I'd welcome any suggestions for fixing this.

---

- *See also the related https://github.com/rust-lang/rust/pull/144579*