### PR TITLE
Stabilise `const_array_each_ref`.

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -621,7 +621,7 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(strings.len(), 3);
     /// ```
     #[stable(feature = "array_methods", since = "1.77.0")]
-    #[rustc_const_unstable(feature = "const_array_each_ref", issue = "133289")]
+    #[rustc_const_stable(feature = "const_array_each_ref", since = "CURRENT_RUSTC_VERSION")]
     pub const fn each_ref(&self) -> [&T; N] {
         let mut buf = [null::<T>(); N];
 
@@ -652,7 +652,7 @@ impl<T, const N: usize> [T; N] {
     /// assert_eq!(floats, [0.0, 2.7, -1.0]);
     /// ```
     #[stable(feature = "array_methods", since = "1.77.0")]
-    #[rustc_const_unstable(feature = "const_array_each_ref", issue = "133289")]
+    #[rustc_const_stable(feature = "const_array_each_ref", since = "CURRENT_RUSTC_VERSION")]
     pub const fn each_mut(&mut self) -> [&mut T; N] {
         let mut buf = [null_mut::<T>(); N];
 


### PR DESCRIPTION
Tracking issue: rust-lang/rust#133289

This PR stabilises the items locked behind the `const_array_each_ref` feature gate:

```rust
impl<T, const N: usize> [T; N] {
    pub const fn each_ref(&self) -> [&T; N];

    pub const fn each_mut(&mut self) -> [&mut T; N];
}
```

As of writing, FCP is still pending for the feature.

@rustbot label +T-libs-api -T-libs

r? libs-api