### PR TITLE
fix: re-enable self-assignment

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -172,7 +172,6 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
         }
     }
 
-    #[allow(dead_code)] // FIXME(81658): should be used + lint reinstated after #83171 relands.
     fn handle_assign(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if self
             .typeck_results()
@@ -189,7 +188,6 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
         }
     }
 
-    #[allow(dead_code)] // FIXME(81658): should be used + lint reinstated after #83171 relands.
     fn check_for_self_assign(&mut self, assign: &'tcx hir::Expr<'tcx>) {
         fn check_for_self_assign_helper<'tcx>(
             typeck_results: &'tcx ty::TypeckResults<'tcx>,
@@ -575,6 +573,10 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
             }
             hir::ExprKind::OffsetOf(..) => {
                 self.handle_offset_of(expr);
+            }
+            hir::ExprKind::Assign(ref lhs, ..) => {
+                self.handle_assign(lhs);
+                self.check_for_self_assign(expr);
             }
             _ => (),
         }

--- a/tests/ui/lint/dead-code/self-assign.rs
+++ b/tests/ui/lint/dead-code/self-assign.rs
@@ -7,12 +7,9 @@
 //! - `dead_code` lint expansion for self-assignments was implemented in #87129.
 //! - Unfortunately implementation components of #87129 had to be disabled as part of reverts
 //!   #86212, #83171 (to revert #81473) to address regressions #81626 and #81658.
-//! - Consequently, none of the following warnings are emitted.
+//! - Re-enabled in current version to properly detect self-assignments.
 
 //@ check-pass
-
-// Implementation of self-assignment `dead_code` lint expansions disabled due to reverts.
-//@ known-bug: #75356
 
 #![allow(unused_assignments)]
 #![warn(dead_code)]
@@ -20,10 +17,10 @@
 fn main() {
     let mut x = 0;
     x = x;
-    // FIXME ~^ WARNING: useless assignment of variable of type `i32` to itself
+    //~^ WARNING: useless assignment of variable of type `i32` to itself
 
     x = (x);
-    // FIXME ~^ WARNING: useless assignment of variable of type `i32` to itself
+    //~^ WARNING: useless assignment of variable of type `i32` to itself
 
     x = {x};
     // block expressions don't count as self-assignments
@@ -32,10 +29,10 @@ fn main() {
     struct S<'a> { f: &'a str }
     let mut s = S { f: "abc" };
     s = s;
-    // FIXME ~^ WARNING: useless assignment of variable of type `S` to itself
+    //~^ WARNING: useless assignment of variable of type `S<'_>` to itself
 
     s.f = s.f;
-    // FIXME ~^ WARNING: useless assignment of field of type `&str` to itself
+    //~^ WARNING: useless assignment of field of type `&str` to itself
 
 
     struct N0 { x: Box<i32> }
@@ -44,11 +41,11 @@ fn main() {
     struct N3 { n: N2 };
     let mut n3 = N3 { n: N2(N1 { n: N0 { x: Box::new(42) } }) };
     n3.n.0.n.x = n3.n.0.n.x;
-    // FIXME ~^ WARNING: useless assignment of field of type `Box<i32>` to itself
+    //~^ WARNING: useless assignment of field of type `Box<i32>` to itself
 
     let mut t = (1, ((2, 3, (4, 5)),));
     t.1.0.2.1 = t.1.0.2.1;
-    // FIXME ~^ WARNING: useless assignment of field of type `i32` to itself
+    //~^ WARNING: useless assignment of field of type `i32` to itself
 
 
     let mut y = 0;

--- a/tests/ui/lint/dead-code/self-assign.stderr
+++ b/tests/ui/lint/dead-code/self-assign.stderr
@@ -1,0 +1,44 @@
+warning: useless assignment of variable of type `i32` to itself
+  --> $DIR/self-assign.rs:19:5
+   |
+LL |     x = x;
+   |     ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/self-assign.rs:15:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: useless assignment of variable of type `i32` to itself
+  --> $DIR/self-assign.rs:22:5
+   |
+LL |     x = (x);
+   |     ^^^^^^^
+
+warning: useless assignment of variable of type `S<'_>` to itself
+  --> $DIR/self-assign.rs:31:5
+   |
+LL |     s = s;
+   |     ^^^^^
+
+warning: useless assignment of field of type `&str` to itself
+  --> $DIR/self-assign.rs:34:5
+   |
+LL |     s.f = s.f;
+   |     ^^^^^^^^^
+
+warning: useless assignment of field of type `Box<i32>` to itself
+  --> $DIR/self-assign.rs:43:5
+   |
+LL |     n3.n.0.n.x = n3.n.0.n.x;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: useless assignment of field of type `i32` to itself
+  --> $DIR/self-assign.rs:47:5
+   |
+LL |     t.1.0.2.1 = t.1.0.2.1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+warning: 6 warnings emitted
+


### PR DESCRIPTION
## Description

Re-enables the self-assignment detection that was previously disabled due to unrelated regressions. The fix detects useless assignments like `x = x` and `foo.field = foo.field`.

## History

The original regressions (rust-lang/rust#81626, rust-lang/rust#81658) were specifically about false positives in write-only field detection, not self-assignment detection. Belows are brief history for the rule that I understand.

- Self-assignment detection was originally implemented in rust-lang/rust#87129 to address rust-lang/rust#75356
- The implementation was disabled alongside the revert of rust-lang/rust#81473's "write-only fields" detection
- rust-lang/rust#81473 was reverted via rust-lang/rust#86212 and rust-lang/rust#83171 due to false positives in write-only field detection (rust-lang/rust#81626, rust-lang/rust#81658)
- The self-assignment detection feature got removed, even though it wasn't the reason for the problems

This PR only re-enables the self-assignment checks, which are orthogonal to the problematic write-only field analysis.

## Changes
- Removed `#[allow(dead_code)]` from `compiler/rustc_passes/src/dead.rs` file
    - `handle_assign` and 
    - `check_for_self_assign`
- Added `ExprKind::Assign` handling in `visit_expr` to call both methods
- Updated test expectations in `tests/ui/lint/dead-code/self-assign.rs`
