### PR TITLE
Enable RUST_BACKTRACE=1 on CI

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -205,6 +205,9 @@ if [ "$ENABLE_GCC_CODEGEN" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-new-symbol-mangling"
 fi
 
+# If bootstrap fails, we want to see its backtrace
+export RUST_BACKTRACE=1
+
 # Print the date from the local machine and the date from an external source to
 # check for clock drifts. An HTTP URL is used instead of HTTPS since on Azure
 # Pipelines it happened that the certificates were marked as expired.


### PR DESCRIPTION
We should really see the backtrace if something in bootstrap fails on CI. https://github.com/rust-lang/rust/pull/145011#issuecomment-3172664934 doesn't show many details.