### PR TITLE
rustdoc: correct negative-to-implicit discriminant display

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1656,11 +1656,9 @@ fn display_c_like_variant(
         } else if should_show_enum_discriminant {
             let adt_def = cx.tcx().adt_def(enum_def_id);
             let discr = adt_def.discriminant_for_variant(cx.tcx(), index);
-            if discr.ty.is_signed() {
-                write!(w, "{} = {}", name.as_str(), discr.val as i128)?;
-            } else {
-                write!(w, "{} = {}", name.as_str(), discr.val)?;
-            }
+            // Use `discr`'s `Display` impl to render the value with the correct
+            // signedness, including proper sign-extension for signed types.
+            write!(w, "{} = {}", name.as_str(), discr)?;
         } else {
             write!(w, "{name}")?;
         }

--- a/tests/rustdoc/enum/enum-variant-value.rs
+++ b/tests/rustdoc/enum/enum-variant-value.rs
@@ -189,3 +189,25 @@ pub use bar::P;
 //@ has - '//*[@id="variant.A"]/h3' 'A(u32)'
 //@ matches - '//*[@id="variant.B"]/h3' '^B$'
 pub use bar::Q;
+
+// Ensure signed implicit discriminants are rendered correctly after a negative explicit value.
+//@ has 'foo/enum.R.html'
+//@ has - '//*[@class="rust item-decl"]/code' 'A = -2,'
+//@ has - '//*[@class="rust item-decl"]/code' 'B = -1,'
+//@ matches - '//*[@id="variant.A"]/h3' '^A = -2$'
+//@ matches - '//*[@id="variant.B"]/h3' '^B = -1$'
+pub enum R {
+    A = -2,
+    B,
+}
+
+// Also check that incrementing -1 yields 0 for the next implicit variant.
+//@ has 'foo/enum.S.html'
+//@ has - '//*[@class="rust item-decl"]/code' 'A = -1,'
+//@ has - '//*[@class="rust item-decl"]/code' 'B = 0,'
+//@ matches - '//*[@id="variant.A"]/h3' '^A = -1$'
+//@ matches - '//*[@id="variant.B"]/h3' '^B = 0$'
+pub enum S {
+    A = -1,
+    B,
+}


### PR DESCRIPTION
This PR want to fix rust-lang/rust#145125


In:
https://github.com/rust-lang/rust/blob/7f7b8ef27d86c865a7ab20c7c42f50811c6a914d/compiler/rustc_middle/src/ty/util.rs#L33-L38

the `Discr`'s `val` field is `u128`, so we can't use `discr.val as i128` to represent `Discr`'s signed value. 


We should use `Discr`'s `Display` trait to display signed value.


https://github.com/rust-lang/rust/blob/7f7b8ef27d86c865a7ab20c7c42f50811c6a914d/compiler/rustc_middle/src/ty/util.rs#L60-L73