### PR TITLE
Fix Cargo cross-compilation (take two)

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -857,7 +857,9 @@ impl Step for Cargo {
     fn run(self, builder: &Builder<'_>) -> ToolBuildResult {
         builder.build.require_submodule("src/tools/cargo", None);
 
+        builder.std(self.build_compiler, builder.host_target);
         builder.std(self.build_compiler, self.target);
+
         builder.ensure(ToolBuild {
             build_compiler: self.build_compiler,
             target: self.target,


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/145083, I fixed the case of manually invoking `x dist cargo`, but I realized that `x install` creates the `tool::Cargo` step through the `from_build_frompiler` constructor, which doesn't go through `get_tool_target_compiler`. So we just prepare both the host and target stdlibs directly before building Cargo. Ideally we would get rid of `from_build_compiler`, but that will require refactoring the dist and test steps, which is upcoming.

Hopefully fixes https://github.com/rust-lang/rust/issues/145059 for good.