### PR TITLE
Fix typo with paren rustc_llvm/build.rs

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -255,7 +255,7 @@ fn main() {
         println!("cargo:rustc-link-lib=kstat");
     }
 
-    if (target.starts_with("arm") && !target.contains("freebsd")) && !target.contains("ohos")
+    if (target.starts_with("arm") && !target.contains("freebsd") && !target.contains("ohos"))
         || target.starts_with("mips-")
         || target.starts_with("mipsel-")
         || target.starts_with("powerpc-")


### PR DESCRIPTION
The current parenthesis looks suspect: it means that OpenHarmony is always excluded whereas it looks like it was intended to only be excluded if the architecture was Arm.

Since Rust doesn't support the other architectures with OpenHarmony, there currently isn't a bug but this cleans up some suspicious code and avoids a potential future annoyance for someone trying to bring up a new triple.

r? @Amanieu 