### PR TITLE
Fix macro infinite recursion test to not trigger warning about semicolon in expr

### DIFF
--- a/tests/ui/infinite/issue-41731-infinite-macro-print.rs
+++ b/tests/ui/infinite/issue-41731-infinite-macro-print.rs
@@ -5,7 +5,7 @@
 fn main() {
     macro_rules! stack {
         ($overflow:expr) => {
-            print!(stack!($overflow));
+            print!(stack!($overflow))
             //~^ ERROR recursion limit reached while expanding
             //~| ERROR format argument must be a string literal
         };

--- a/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-print.stderr
@@ -14,11 +14,11 @@ LL |     stack!("overflow");
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `stack! { "overflow" }`
-   = note: to `print! (stack! ("overflow"));`
+   = note: to `print! (stack! ("overflow"))`
    = note: expanding `print! { stack! ("overflow") }`
    = note: to `{ $crate :: io :: _print($crate :: format_args! (stack! ("overflow"))); }`
    = note: expanding `stack! { "overflow" }`
-   = note: to `print! (stack! ("overflow"));`
+   = note: to `print! (stack! ("overflow"))`
    = note: expanding `print! { stack! ("overflow") }`
    = note: to `{ $crate :: io :: _print($crate :: format_args! (stack! ("overflow"))); }`
 
@@ -31,7 +31,7 @@ LL |     stack!("overflow");
    = note: this error originates in the macro `print` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a string literal to format with
    |
-LL |             print!("{}", stack!($overflow));
+LL |             print!("{}", stack!($overflow))
    |                    +++++
 
 error: aborting due to 2 previous errors

--- a/tests/ui/infinite/issue-41731-infinite-macro-println.rs
+++ b/tests/ui/infinite/issue-41731-infinite-macro-println.rs
@@ -5,7 +5,7 @@
 fn main() {
     macro_rules! stack {
         ($overflow:expr) => {
-            println!(stack!($overflow));
+            println!(stack!($overflow))
             //~^ ERROR recursion limit reached while expanding
             //~| ERROR format argument must be a string literal
         };

--- a/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
+++ b/tests/ui/infinite/issue-41731-infinite-macro-println.stderr
@@ -14,11 +14,11 @@ LL |     stack!("overflow");
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `stack! { "overflow" }`
-   = note: to `println! (stack! ("overflow"));`
+   = note: to `println! (stack! ("overflow"))`
    = note: expanding `println! { stack! ("overflow") }`
    = note: to `{ $crate :: io :: _print($crate :: format_args_nl! (stack! ("overflow"))); }`
    = note: expanding `stack! { "overflow" }`
-   = note: to `println! (stack! ("overflow"));`
+   = note: to `println! (stack! ("overflow"))`
    = note: expanding `println! { stack! ("overflow") }`
    = note: to `{ $crate :: io :: _print($crate :: format_args_nl! (stack! ("overflow"))); }`
 
@@ -31,7 +31,7 @@ LL |     stack!("overflow");
    = note: this error originates in the macro `println` which comes from the expansion of the macro `stack` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a string literal to format with
    |
-LL |             println!("{}", stack!($overflow));
+LL |             println!("{}", stack!($overflow))
    |                      +++++
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
The test cases for rust-lang/rust#41731 are about infinite macro recursion that
incorporates `print!` and `println!`. However, they also included
trailing semicolons despite expanding to expressions; that isn't what
these particular test cases are designed to test.

Eliminate the trailing semicolons, to simplify future work on removing
this special case. Every *other* macro that expands to a semicolon in an
expression is a test case for that specifically.
