### PR TITLE
Tweak spans providing type context on errors when involving macros

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -698,7 +698,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         match (self.tcx.parent_hir_node(expr.hir_id), error) {
             (hir::Node::LetStmt(hir::LetStmt { ty: Some(ty), init: Some(init), .. }), _)
-                if init.hir_id == expr.hir_id =>
+                if init.hir_id == expr.hir_id && !ty.span.source_equal(init.span) =>
             {
                 // Point at `let` assignment type.
                 err.span_label(ty.span, "expected due to this");

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -459,7 +459,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             span,
                             format!("this is an iterator with items of type `{}`", args.type_at(0)),
                         );
-                    } else {
+                    } else if !span.overlaps(cause.span) {
                         let expected_ty = self.tcx.short_string(expected_ty, err.long_ty_path());
                         err.span_label(span, format!("this expression has type `{expected_ty}`"));
                     }

--- a/tests/ui/proc-macro/auxiliary/match-expander.rs
+++ b/tests/ui/proc-macro/auxiliary/match-expander.rs
@@ -1,0 +1,15 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn matcher(input: TokenStream) -> TokenStream {
+"
+struct S(());
+let s = S(());
+match s {
+    true => {}
+    _ => {}
+}
+".parse().unwrap()
+}

--- a/tests/ui/proc-macro/match-expander.rs
+++ b/tests/ui/proc-macro/match-expander.rs
@@ -1,0 +1,13 @@
+//@ proc-macro: match-expander.rs
+// Ensure that we don't point at macro invocation when providing inference contexts.
+
+#[macro_use]
+extern crate match_expander;
+
+fn main() {
+    match_expander::matcher!();
+    //~^ ERROR: mismatched types
+    //~| NOTE: expected `S`, found `bool`
+    //~| NOTE: this expression has type `S`
+    //~| NOTE: in this expansion of match_expander::matcher!
+}

--- a/tests/ui/proc-macro/match-expander.rs
+++ b/tests/ui/proc-macro/match-expander.rs
@@ -8,6 +8,5 @@ fn main() {
     match_expander::matcher!();
     //~^ ERROR: mismatched types
     //~| NOTE: expected `S`, found `bool`
-    //~| NOTE: this expression has type `S`
     //~| NOTE: in this expansion of match_expander::matcher!
 }

--- a/tests/ui/proc-macro/match-expander.stderr
+++ b/tests/ui/proc-macro/match-expander.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/match-expander.rs:8:5
+   |
+LL |     match_expander::matcher!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `S`, found `bool`
+   |     this expression has type `S`
+   |
+   = note: this error originates in the macro `match_expander::matcher` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/proc-macro/match-expander.stderr
+++ b/tests/ui/proc-macro/match-expander.stderr
@@ -2,10 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/match-expander.rs:8:5
    |
 LL |     match_expander::matcher!();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected `S`, found `bool`
-   |     this expression has type `S`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `S`, found `bool`
    |
    = note: this error originates in the macro `match_expander::matcher` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/proc-macro/quote/does-not-have-iter-interpolated-dup.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter-interpolated-dup.stderr
@@ -5,7 +5,6 @@ LL |     quote!($($nonrep $nonrep)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     expected due to this
    |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error

--- a/tests/ui/proc-macro/quote/does-not-have-iter-interpolated.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter-interpolated.stderr
@@ -5,7 +5,6 @@ LL |     quote!($($nonrep)*);
    |     ^^^^^^^^^^^^^^^^^^^
    |     |
    |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     expected due to this
    |     here the type of `has_iter` is inferred to be `ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error

--- a/tests/ui/proc-macro/quote/does-not-have-iter-separated.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter-separated.stderr
@@ -2,10 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/does-not-have-iter-separated.rs:8:5
    |
 LL |     quote!($(a b),*);
-   |     ^^^^^^^^^^^^^^^^
-   |     |
-   |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     expected due to this
+   |     ^^^^^^^^^^^^^^^^ expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/quote/does-not-have-iter.stderr
+++ b/tests/ui/proc-macro/quote/does-not-have-iter.stderr
@@ -2,10 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/does-not-have-iter.rs:8:5
    |
 LL |     quote!($(a b)*);
-   |     ^^^^^^^^^^^^^^^
-   |     |
-   |     expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
-   |     expected due to this
+   |     ^^^^^^^^^^^^^^^ expected `HasIterator`, found `ThereIsNoIteratorInRepetition`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Do not point at macro invocation multiple times when we try to add span labels mentioning what type each expression has, which is unnecessary when the error is at a macro invocation.