### PR TITLE
Conditionally compile contracts instead of deciding at run-time

### DIFF
--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -17,7 +17,11 @@ impl AttrProcMacro for ExpandRequires {
         annotation: TokenStream,
         annotated: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
-        expand_requires_tts(ecx, span, annotation, annotated)
+        if ecx.sess.contract_checks() {
+            expand_requires_tts(ecx, span, annotation, annotated)
+        } else {
+            Ok(annotated)
+        }
     }
 }
 
@@ -29,7 +33,11 @@ impl AttrProcMacro for ExpandEnsures {
         annotation: TokenStream,
         annotated: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
-        expand_ensures_tts(ecx, span, annotation, annotated)
+        if ecx.sess.contract_checks() {
+            expand_ensures_tts(ecx, span, annotation, annotated)
+        } else {
+            Ok(annotated)
+        }
     }
 }
 

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2557,23 +2557,6 @@ pub const unsafe fn const_make_global(ptr: *mut u8) -> *const u8 {
     ptr
 }
 
-/// Returns whether we should perform contract-checking at runtime.
-///
-/// This is meant to be similar to the ub_checks intrinsic, in terms
-/// of not prematurely committing at compile-time to whether contract
-/// checking is turned on, so that we can specify contracts in libstd
-/// and let an end user opt into turning them on.
-#[rustc_const_unstable(feature = "contracts_internals", issue = "128044" /* compiler-team#759 */)]
-#[unstable(feature = "contracts_internals", issue = "128044" /* compiler-team#759 */)]
-#[inline(always)]
-#[rustc_intrinsic]
-pub const fn contract_checks() -> bool {
-    // FIXME: should this be `false` or `cfg!(contract_checks)`?
-
-    // cfg!(contract_checks)
-    false
-}
-
 /// Check if the pre-condition `cond` has been met.
 ///
 /// By default, if `contract_checks` is enabled, this will panic with no unwind if the condition
@@ -2594,7 +2577,7 @@ pub const fn contract_check_requires<C: Fn() -> bool + Copy>(cond: C) {
         if const {
                 // Do nothing
         } else {
-            if contract_checks() && !cond() {
+            if !cond() {
                 // Emit no unwind panic in case this was a safety requirement.
                 crate::panicking::panic_nounwind("failed requires check");
             }
@@ -2622,7 +2605,7 @@ pub const fn contract_check_ensures<C: Fn(&Ret) -> bool + Copy, Ret>(cond: C, re
             // Do nothing
             ret
         } else {
-            if contract_checks() && !cond(&ret) {
+            if !cond(&ret) {
                 // Emit no unwind panic in case this was a safety requirement.
                 crate::panicking::panic_nounwind("failed ensures check");
             }

--- a/tests/ui/contracts/associated-item-disabled.rs
+++ b/tests/ui/contracts/associated-item-disabled.rs
@@ -1,7 +1,7 @@
-// Ensure we don't ICE when lowering contracts on an associated item.
+// Ensure we don't ICE when contract present on an associated item but
+// contract-checks are disabled.
 
 //@ compile-flags: --crate-type=lib
-//@ compile-flags: -Zcontract-checks=yes
 //@ check-pass
 
 #![feature(contracts)]

--- a/tests/ui/contracts/associated-item-disabled.stderr
+++ b/tests/ui/contracts/associated-item-disabled.stderr
@@ -1,7 +1,7 @@
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/contract-lang-items.rs:15:12
+  --> $DIR/associated-item-disabled.rs:7:12
    |
-LL | #![feature(contracts)] // to access core::contracts
+LL | #![feature(contracts)]
    |            ^^^^^^^^^
    |
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information

--- a/tests/ui/contracts/contract-annotation-limitations.rs
+++ b/tests/ui/contracts/contract-annotation-limitations.rs
@@ -1,6 +1,8 @@
 //! Test for some of the existing limitations and the current error messages.
 //! Some of these limitations may be removed in the future.
 
+//@ compile-flags: -Zcontract-checks=yes
+
 #![feature(contracts)]
 //~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
 #![allow(dead_code)]

--- a/tests/ui/contracts/contract-annotation-limitations.stderr
+++ b/tests/ui/contracts/contract-annotation-limitations.stderr
@@ -1,17 +1,17 @@
 error: contract annotations is only supported in functions with bodies
-  --> $DIR/contract-annotation-limitations.rs:18:5
+  --> $DIR/contract-annotation-limitations.rs:20:5
    |
 LL |     #[core::contracts::ensures(|ret| ret.is_none_or(Stars::is_valid))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations is only supported in functions with bodies
-  --> $DIR/contract-annotation-limitations.rs:22:5
+  --> $DIR/contract-annotation-limitations.rs:24:5
    |
 LL |     #[core::contracts::ensures(|ret| ret.is_none_or(Stars::is_valid))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/contract-annotation-limitations.rs:4:12
+  --> $DIR/contract-annotation-limitations.rs:6:12
    |
 LL | #![feature(contracts)]
    |            ^^^^^^^^^

--- a/tests/ui/contracts/contracts-disabled-side-effect-ensures.rs
+++ b/tests/ui/contracts/contracts-disabled-side-effect-ensures.rs
@@ -1,0 +1,17 @@
+//@ run-pass
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::ensures;
+
+#[ensures({*x = 0; |_ret| true})]
+fn buggy_add(x: &mut u32, y: u32) {
+    *x = *x + y;
+}
+
+fn main() {
+    let mut x = 10;
+    buggy_add(&mut x, 100);
+    assert_eq!(x, 110);
+}

--- a/tests/ui/contracts/contracts-disabled-side-effect-ensures.stderr
+++ b/tests/ui/contracts/contracts-disabled-side-effect-ensures.stderr
@@ -1,7 +1,7 @@
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/contract-lang-items.rs:15:12
+  --> $DIR/contracts-disabled-side-effect-ensures.rs:2:12
    |
-LL | #![feature(contracts)] // to access core::contracts
+LL | #![feature(contracts)]
    |            ^^^^^^^^^
    |
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information

--- a/tests/ui/contracts/disallow-contract-annotation-on-non-fn.rs
+++ b/tests/ui/contracts/disallow-contract-annotation-on-non-fn.rs
@@ -1,4 +1,5 @@
 //! Checks for compilation errors related to adding contracts to non-function items.
+//@ compile-flags: -Zcontract-checks=yes
 
 #![feature(contracts)]
 //~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]

--- a/tests/ui/contracts/disallow-contract-annotation-on-non-fn.stderr
+++ b/tests/ui/contracts/disallow-contract-annotation-on-non-fn.stderr
@@ -1,47 +1,47 @@
 error: contract annotations can only be used on functions
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:7:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:8:1
    |
 LL | #[core::contracts::requires(true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations can only be used on functions
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:11:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:12:1
    |
 LL | #[core::contracts::ensures(|v| v == 100)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations is only supported in functions with bodies
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:16:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:17:1
    |
 LL | #[core::contracts::ensures(|v| v == 100)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations is only supported in functions with bodies
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:20:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:21:1
    |
 LL | #[core::contracts::ensures(|v| v == 100)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations can only be used on functions
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:24:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:25:1
    |
 LL | #[core::contracts::requires(true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations can only be used on functions
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:35:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:36:1
    |
 LL | #[core::contracts::ensures(|dummy| dummy.0 > 0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: contract annotations can only be used on functions
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:46:1
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:47:1
    |
 LL | #[core::contracts::requires(true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/disallow-contract-annotation-on-non-fn.rs:3:12
+  --> $DIR/disallow-contract-annotation-on-non-fn.rs:4:12
    |
 LL | #![feature(contracts)]
    |            ^^^^^^^^^

--- a/tests/ui/contracts/empty-ensures.rs
+++ b/tests/ui/contracts/empty-ensures.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::ensures;
+
+#[ensures()]
+//~^ ERROR expected a `Fn(&_)` closure, found `()` [E0277]
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/empty-ensures.stderr
+++ b/tests/ui/contracts/empty-ensures.stderr
@@ -1,0 +1,25 @@
+warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/empty-ensures.rs:2:12
+   |
+LL | #![feature(contracts)]
+   |            ^^^^^^^^^
+   |
+   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: expected a `Fn(&_)` closure, found `()`
+  --> $DIR/empty-ensures.rs:8:1
+   |
+LL | #[ensures()]
+   | ^^^^^^^^^^^^
+   | |
+   | expected an `Fn(&_)` closure, found `()`
+   | required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> Fn(&'a _)` is not implemented for `()`
+note: required by a bound in `build_check_ensures`
+  --> $SRC_DIR/core/src/contracts.rs:LL:COL
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/contracts/empty-requires.rs
+++ b/tests/ui/contracts/empty-requires.rs
@@ -1,0 +1,18 @@
+//@ dont-require-annotations: NOTE
+//@ compile-flags: -Zcontract-checks=yes
+#![feature(contracts)]
+//~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
+
+extern crate core;
+use core::contracts::requires;
+
+#[requires()]
+//~^ ERROR mismatched types [E0308]
+//~| NOTE expected `bool`, found `()`
+fn foo(x: u32) -> u32 {
+    x * 2
+}
+
+fn main() {
+    foo(1);
+}

--- a/tests/ui/contracts/empty-requires.stderr
+++ b/tests/ui/contracts/empty-requires.stderr
@@ -1,5 +1,5 @@
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/associated-item.rs:7:12
+  --> $DIR/empty-requires.rs:3:12
    |
 LL | #![feature(contracts)]
    |            ^^^^^^^^^
@@ -7,5 +7,12 @@ LL | #![feature(contracts)]
    = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-warning: 1 warning emitted
+error[E0308]: mismatched types
+  --> $DIR/empty-requires.rs:9:1
+   |
+LL | #[requires()]
+   | ^^^^^^^^^^^^^ expected `bool`, found `()`
 
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/contracts/internal_machinery/contract-ast-extensions-nest.rs
+++ b/tests/ui/contracts/internal_machinery/contract-ast-extensions-nest.rs
@@ -1,20 +1,9 @@
-//@ revisions: unchk_pass unchk_fail_pre unchk_fail_post chk_pass chk_fail_pre chk_fail_post
+//@ revisions: chk_pass chk_fail_pre chk_fail_post
 //
-//@ [unchk_pass] run-pass
-//@ [unchk_fail_pre] run-pass
-//@ [unchk_fail_post] run-pass
 //@ [chk_pass] run-pass
 //
 //@ [chk_fail_pre] run-crash
 //@ [chk_fail_post] run-crash
-//
-//@ [unchk_pass] compile-flags: -Zcontract-checks=no
-//@ [unchk_fail_pre] compile-flags: -Zcontract-checks=no
-//@ [unchk_fail_post] compile-flags: -Zcontract-checks=no
-//
-//@ [chk_pass] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_pre] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_post] compile-flags: -Zcontract-checks=yes
 
 #![feature(contracts_internals)]
 
@@ -30,15 +19,15 @@ fn nest(x: Baz) -> i32
 struct Baz { baz: i32 }
 
 const BAZ_PASS_PRE_POST: Baz = Baz { baz: 100 };
-#[cfg(any(unchk_fail_post, chk_fail_post))]
+#[cfg(chk_fail_post)]
 const BAZ_FAIL_POST: Baz = Baz { baz: 10 };
-#[cfg(any(unchk_fail_pre, chk_fail_pre))]
+#[cfg(chk_fail_pre)]
 const BAZ_FAIL_PRE: Baz = Baz { baz: -10 };
 
 fn main() {
     assert_eq!(nest(BAZ_PASS_PRE_POST), 150);
-    #[cfg(any(unchk_fail_pre, chk_fail_pre))]
+    #[cfg(chk_fail_pre)]
     nest(BAZ_FAIL_PRE);
-    #[cfg(any(unchk_fail_post, chk_fail_post))]
+    #[cfg(chk_fail_post)]
     nest(BAZ_FAIL_POST);
 }

--- a/tests/ui/contracts/internal_machinery/contract-ast-extensions-tail.rs
+++ b/tests/ui/contracts/internal_machinery/contract-ast-extensions-tail.rs
@@ -1,20 +1,9 @@
-//@ revisions: unchk_pass unchk_fail_pre unchk_fail_post chk_pass chk_fail_pre chk_fail_post
+//@ revisions: chk_pass chk_fail_pre chk_fail_post
 //
-//@ [unchk_pass] run-pass
-//@ [unchk_fail_pre] run-pass
-//@ [unchk_fail_post] run-pass
 //@ [chk_pass] run-pass
 //
 //@ [chk_fail_pre] run-crash
 //@ [chk_fail_post] run-crash
-//
-//@ [unchk_pass] compile-flags: -Zcontract-checks=no
-//@ [unchk_fail_pre] compile-flags: -Zcontract-checks=no
-//@ [unchk_fail_post] compile-flags: -Zcontract-checks=no
-//
-//@ [chk_pass] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_pre] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_post] compile-flags: -Zcontract-checks=yes
 
 #![feature(contracts_internals)]
 
@@ -28,15 +17,15 @@ fn tail(x: Baz) -> i32
 struct Baz { baz: i32 }
 
 const BAZ_PASS_PRE_POST: Baz = Baz { baz: 100 };
-#[cfg(any(unchk_fail_post, chk_fail_post))]
+#[cfg(chk_fail_post)]
 const BAZ_FAIL_POST: Baz = Baz { baz: 10 };
-#[cfg(any(unchk_fail_pre, chk_fail_pre))]
+#[cfg(chk_fail_pre)]
 const BAZ_FAIL_PRE: Baz = Baz { baz: -10 };
 
 fn main() {
     assert_eq!(tail(BAZ_PASS_PRE_POST), 150);
-    #[cfg(any(unchk_fail_pre, chk_fail_pre))]
+    #[cfg(chk_fail_pre)]
     tail(BAZ_FAIL_PRE);
-    #[cfg(any(unchk_fail_post, chk_fail_post))]
+    #[cfg(chk_fail_post)]
     tail(BAZ_FAIL_POST);
 }

--- a/tests/ui/contracts/internal_machinery/contract-intrinsics.rs
+++ b/tests/ui/contracts/internal_machinery/contract-intrinsics.rs
@@ -1,36 +1,23 @@
-//@ revisions: default unchk_pass chk_pass chk_fail_ensures chk_fail_requires
+//@ revisions: chk_pass chk_fail_ensures chk_fail_requires
 //
-//@ [default] run-pass
-//@ [unchk_pass] run-pass
 //@ [chk_pass] run-pass
 //@ [chk_fail_requires] run-crash
 //@ [chk_fail_ensures] run-crash
-//
-//@ [unchk_pass] compile-flags: -Zcontract-checks=no
-//@ [chk_pass] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_requires] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_ensures] compile-flags: -Zcontract-checks=yes
 #![feature(cfg_contract_checks, contracts_internals, core_intrinsics)]
 
 fn main() {
-    #[cfg(any(default, unchk_pass))] // default: disabled
-    assert_eq!(core::intrinsics::contract_checks(), false);
-
-    #[cfg(chk_pass)] // explicitly enabled
-    assert_eq!(core::intrinsics::contract_checks(), true);
-
     // always pass
     core::intrinsics::contract_check_requires(|| true);
 
-    // fail if enabled
-    #[cfg(any(default, unchk_pass, chk_fail_requires))]
+    // always fail
+    #[cfg(chk_fail_requires)]
     core::intrinsics::contract_check_requires(|| false);
 
     let doubles_to_two = { let old = 2; move |ret: &u32 | ret + ret == old };
     // Always pass
     core::intrinsics::contract_check_ensures(doubles_to_two, 1);
 
-    // Fail if enabled
-    #[cfg(any(default, unchk_pass, chk_fail_ensures))]
+    // always fail
+    #[cfg(chk_fail_ensures)]
     core::intrinsics::contract_check_ensures(doubles_to_two, 2);
 }

--- a/tests/ui/contracts/internal_machinery/contract-lang-items.chk_fail_post.stderr
+++ b/tests/ui/contracts/internal_machinery/contract-lang-items.chk_fail_post.stderr
@@ -1,5 +1,5 @@
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/contract-lang-items.rs:15:12
+  --> $DIR/contract-lang-items.rs:7:12
    |
 LL | #![feature(contracts)] // to access core::contracts
    |            ^^^^^^^^^

--- a/tests/ui/contracts/internal_machinery/contract-lang-items.chk_pass.stderr
+++ b/tests/ui/contracts/internal_machinery/contract-lang-items.chk_pass.stderr
@@ -1,5 +1,5 @@
 warning: the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/contract-lang-items.rs:15:12
+  --> $DIR/contract-lang-items.rs:7:12
    |
 LL | #![feature(contracts)] // to access core::contracts
    |            ^^^^^^^^^

--- a/tests/ui/contracts/internal_machinery/contract-lang-items.rs
+++ b/tests/ui/contracts/internal_machinery/contract-lang-items.rs
@@ -1,16 +1,8 @@
-//@ revisions: unchk_pass unchk_fail_post chk_pass chk_fail_post
+//@ revisions: chk_pass chk_fail_post
 //
-//@ [unchk_pass] run-pass
-//@ [unchk_fail_post] run-pass
 //@ [chk_pass] run-pass
 //
 //@ [chk_fail_post] run-crash
-//
-//@ [unchk_pass] compile-flags: -Zcontract-checks=no
-//@ [unchk_fail_post] compile-flags: -Zcontract-checks=no
-//
-//@ [chk_pass] compile-flags: -Zcontract-checks=yes
-//@ [chk_fail_post] compile-flags: -Zcontract-checks=yes
 
 #![feature(contracts)] // to access core::contracts
 //~^ WARN the feature `contracts` is incomplete and may not be safe to use and/or cause compiler crashes [incomplete_features]
@@ -29,11 +21,11 @@ struct Baz { baz: i32 }
 
 
 const BAZ_PASS_PRE_POST: Baz = Baz { baz: 100 };
-#[cfg(any(unchk_fail_post, chk_fail_post))]
+#[cfg(chk_fail_post)]
 const BAZ_FAIL_POST: Baz = Baz { baz: 10 };
 
 fn main() {
     assert_eq!(foo(BAZ_PASS_PRE_POST), 150);
-    #[cfg(any(unchk_fail_post, chk_fail_post))]
+    #[cfg(chk_fail_post)]
     foo(BAZ_FAIL_POST);
 }

--- a/tests/ui/contracts/internal_machinery/contracts-lowering-ensures-is-not-inherited-when-nesting.rs
+++ b/tests/ui/contracts/internal_machinery/contracts-lowering-ensures-is-not-inherited-when-nesting.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ compile-flags: -Zcontract-checks=yes
 #![feature(contracts_internals)]
 
 fn outer() -> i32

--- a/tests/ui/contracts/internal_machinery/contracts-lowering-requires-is-not-inherited-when-nesting.rs
+++ b/tests/ui/contracts/internal_machinery/contracts-lowering-requires-is-not-inherited-when-nesting.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ compile-flags: -Zcontract-checks=yes
 #![feature(contracts_internals)]
 
 struct Outer { outer: std::cell::Cell<i32> }

--- a/tests/ui/contracts/internal_machinery/internal-feature-gating.rs
+++ b/tests/ui/contracts/internal_machinery/internal-feature-gating.rs
@@ -1,9 +1,6 @@
 // gate-test-contracts_internals
 
 fn main() {
-    // intrinsics are guarded by contracts_internals feature gate.
-    core::intrinsics::contract_checks();
-    //~^ ERROR use of unstable library feature `contracts_internals`
     core::intrinsics::contract_check_requires(|| true);
     //~^ ERROR use of unstable library feature `contracts_internals`
     core::intrinsics::contract_check_ensures( |_|true, &1);

--- a/tests/ui/contracts/internal_machinery/internal-feature-gating.stderr
+++ b/tests/ui/contracts/internal_machinery/internal-feature-gating.stderr
@@ -1,5 +1,5 @@
 error[E0658]: contract internal machinery is for internal use only
-  --> $DIR/internal-feature-gating.rs:16:28
+  --> $DIR/internal-feature-gating.rs:13:28
    |
 LL |     fn identity_1() -> i32 contract_requires(|| true) { 10 }
    |                            ^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     fn identity_1() -> i32 contract_requires(|| true) { 10 }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: contract internal machinery is for internal use only
-  --> $DIR/internal-feature-gating.rs:18:28
+  --> $DIR/internal-feature-gating.rs:15:28
    |
 LL |     fn identity_2() -> i32 contract_ensures(|_| true) { 10 }
    |                            ^^^^^^^^^^^^^^^^
@@ -19,17 +19,7 @@ LL |     fn identity_2() -> i32 contract_ensures(|_| true) { 10 }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `contracts_internals`
-  --> $DIR/internal-feature-gating.rs:5:5
-   |
-LL |     core::intrinsics::contract_checks();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #128044 <https://github.com/rust-lang/rust/issues/128044> for more information
-   = help: add `#![feature(contracts_internals)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `contracts_internals`
-  --> $DIR/internal-feature-gating.rs:7:5
+  --> $DIR/internal-feature-gating.rs:4:5
    |
 LL |     core::intrinsics::contract_check_requires(|| true);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +29,7 @@ LL |     core::intrinsics::contract_check_requires(|| true);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `contracts_internals`
-  --> $DIR/internal-feature-gating.rs:9:5
+  --> $DIR/internal-feature-gating.rs:6:5
    |
 LL |     core::intrinsics::contract_check_ensures( |_|true, &1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +39,7 @@ LL |     core::intrinsics::contract_check_ensures( |_|true, &1);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `contracts_internals`
-  --> $DIR/internal-feature-gating.rs:12:5
+  --> $DIR/internal-feature-gating.rs:9:5
    |
 LL |     core::contracts::build_check_ensures(|_: &()| true);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,6 +48,6 @@ LL |     core::contracts::build_check_ensures(|_: &()| true);
    = help: add `#![feature(contracts_internals)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.rs
+++ b/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Zcontract-checks=yes
+
 #![feature(contracts)]
 #![allow(incomplete_features)]
 

--- a/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.stderr
+++ b/tests/ui/macros/ice-in-tokenstream-for-contracts-issue-140683.stderr
@@ -1,5 +1,5 @@
 error: expected `{`, found `)`
-  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:8:18
+  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:10:18
    |
 LL |     fn b() {(loop)}
    |              ----^ expected `{`
@@ -7,7 +7,7 @@ LL |     fn b() {(loop)}
    |              while parsing this `loop` expression
 
 error: expected `{`, found `)`
-  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:8:18
+  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:10:18
    |
 LL |     fn b() {(loop)}
    |              ----^ expected `{`
@@ -17,7 +17,7 @@ LL |     fn b() {(loop)}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: expected a `Fn(&_)` closure, found `()`
-  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:7:5
+  --> $DIR/ice-in-tokenstream-for-contracts-issue-140683.rs:9:5
    |
 LL |     #[core::contracts::ensures]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The initial implementation of contracts, despite requiring a compiler flag to enable runtime checking of contracts, still compiled contracts into function definitions, even when the compiler flag was disabled. This meant that contracts could not be safely added to functions without breaking optimisations, or even without potentially changing the behaviour of the function. This was blocking the addition of contracts to standard library functions in rust-lang/rust#136578.

This change guards macro expansion of the built-in contract macros with the `contract-checks` compiler flag. Additionally, it removes the `contract_checks` compiler intrinsic that was used to determine whether contract checks should be executed at runtime. Now, when contracts checks are compiled into the body of a function, they will always be executed.

The change is motivated by the following discussion: https://github.com/rust-lang/rust/pull/144438#issuecomment-3120044986

Contracts tracking issue: https://github.com/rust-lang/rust/issues/128044

**Known limitations**:

- When `contract-checks` are disabled, contracts will not be parsed or type checked, meaning that they are susceptible to becoming out of sync with the rest of the codebase.