### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -9,6 +9,7 @@ use rustc_middle::bug;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_mir_dataflow::move_paths::{LookupResult, MovePathIndex};
+use rustc_span::def_id::DefId;
 use rustc_span::{BytePos, DUMMY_SP, ExpnKind, MacroKind, Span};
 use rustc_trait_selection::error_reporting::traits::FindExprBySpan;
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -507,38 +508,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 );
 
                 let closure_span = tcx.def_span(def_id);
-                let mut clause_span = DUMMY_SP;
-                let typck_result = self.infcx.tcx.typeck(self.mir_def_id());
-                if let Some(closure_def_id) = def_id.as_local()
-                    && let hir::Node::Expr(expr) = tcx.hir_node_by_def_id(closure_def_id)
-                    && let hir::Node::Expr(parent) = tcx.parent_hir_node(expr.hir_id)
-                    && let hir::ExprKind::Call(callee, _) = parent.kind
-                    && let Some(ty) = typck_result.node_type_opt(callee.hir_id)
-                    && let ty::FnDef(fn_def_id, args) = ty.kind()
-                    && let predicates = tcx.predicates_of(fn_def_id).instantiate(tcx, args)
-                    && let Some((_, span)) =
-                        predicates.predicates.iter().zip(predicates.spans.iter()).find(
-                            |(pred, _)| match pred.as_trait_clause() {
-                                Some(clause)
-                                    if let ty::Closure(clause_closure_def_id, _) =
-                                        clause.self_ty().skip_binder().kind()
-                                        && clause_closure_def_id == def_id
-                                        && (tcx.lang_items().fn_mut_trait()
-                                            == Some(clause.def_id())
-                                            || tcx.lang_items().fn_trait()
-                                                == Some(clause.def_id())) =>
-                                {
-                                    // Found `<TyOfCapturingClosure as FnMut>`
-                                    true
-                                }
-                                _ => false,
-                            },
-                        )
-                {
-                    // We point at the `Fn()` or `FnMut()` bound that coerced the closure, which
-                    // could be changed to `FnOnce()` to avoid the move error.
-                    clause_span = *span;
-                }
 
                 self.cannot_move_out_of(span, &place_description)
                     .with_span_label(upvar_span, "captured outer variable")
@@ -547,7 +516,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         format!("captured by this `{closure_kind}` closure"),
                     )
                     .with_span_help(
-                        clause_span,
+                        self.get_closure_bound_clause_span(*def_id),
                         "`Fn` and `FnMut` closures require captured values to be able to be \
                          consumed multiple times, but an `FnOnce` consume them only once",
                     )
@@ -597,6 +566,45 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             self.explain_captures(&mut err, span, span, use_spans, move_place, msg_opt);
         }
         err
+    }
+
+    fn get_closure_bound_clause_span(&self, def_id: DefId) -> Span {
+        let tcx = self.infcx.tcx;
+        let typeck_result = tcx.typeck(self.mir_def_id());
+        let Some(closure_def_id) = def_id.as_local() else { return DUMMY_SP };
+        let hir::Node::Expr(expr) = tcx.hir_node_by_def_id(closure_def_id) else { return DUMMY_SP };
+        let hir::Node::Expr(parent) = tcx.parent_hir_node(expr.hir_id) else { return DUMMY_SP };
+        let predicates = match parent.kind {
+            hir::ExprKind::Call(callee, _) => {
+                let Some(ty) = typeck_result.node_type_opt(callee.hir_id) else { return DUMMY_SP };
+                let ty::FnDef(fn_def_id, args) = ty.kind() else { return DUMMY_SP };
+                tcx.predicates_of(fn_def_id).instantiate(tcx, args)
+            }
+            hir::ExprKind::MethodCall(..) => {
+                let Some((_, method)) = typeck_result.type_dependent_def(parent.hir_id) else {
+                    return DUMMY_SP;
+                };
+                let args = typeck_result.node_args(parent.hir_id);
+                tcx.predicates_of(method).instantiate(tcx, args)
+            }
+            _ => return DUMMY_SP,
+        };
+        for (pred, span) in predicates.predicates.iter().zip(predicates.spans.iter()) {
+            tracing::info!(?pred);
+            tracing::info!(?span);
+            if let Some(clause) = pred.as_trait_clause()
+                && let ty::Closure(clause_closure_def_id, _) = clause.self_ty().skip_binder().kind()
+                && *clause_closure_def_id == def_id
+                && (tcx.lang_items().fn_mut_trait() == Some(clause.def_id())
+                    || tcx.lang_items().fn_trait() == Some(clause.def_id()))
+            {
+                // Found `<TyOfCapturingClosure as FnMut>`
+                // We point at the `Fn()` or `FnMut()` bound that coerced the closure, which
+                // could be changed to `FnOnce()` to avoid the move error.
+                return *span;
+            }
+        }
+        DUMMY_SP
     }
 
     fn add_move_hints(&self, error: GroupedMoveError<'tcx>, err: &mut Diag<'_>, span: Span) {

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -847,17 +847,18 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         self
     }
 
+    with_fn! { with_span_help,
     /// Prints the span with some help above it.
     /// This is like [`Diag::help()`], but it gets its own span.
     #[rustc_lint_diagnostics]
-    pub fn span_help<S: Into<MultiSpan>>(
+    pub fn span_help(
         &mut self,
-        sp: S,
+        sp: impl Into<MultiSpan>,
         msg: impl Into<SubdiagMessage>,
     ) -> &mut Self {
         self.sub(Level::Help, msg, sp.into());
         self
-    }
+    } }
 
     /// Disallow attaching suggestions to this diagnostic.
     /// Any suggestions attached e.g. with the `span_suggestion_*` methods

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -395,6 +395,7 @@ provide! { tcx, def_id, other, cdata,
 
     crate_extern_paths => { cdata.source().paths().cloned().collect() }
     expn_that_defined => { cdata.get_expn_that_defined(def_id.index, tcx.sess) }
+    default_field => { cdata.get_default_field(def_id.index) }
     is_doc_hidden => { cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN) }
     doc_link_resolutions => { tcx.arena.alloc(cdata.get_doc_link_resolutions(def_id.index)) }
     doc_link_traits_in_scope => {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1864,6 +1864,13 @@ rustc_queries! {
         feedable
     }
 
+    /// Returns whether the impl or associated function has the `default` keyword.
+    query default_field(def_id: DefId) -> Option<DefId> {
+        desc { |tcx| "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
+        separate_provide_extern
+        feedable
+    }
+
     query check_well_formed(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
         desc { |tcx| "checking that `{}` is well-formed", tcx.def_path_str(key) }
         return_result_from_ensure_ok

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1864,11 +1864,10 @@ rustc_queries! {
         feedable
     }
 
-    /// Returns whether the impl or associated function has the `default` keyword.
+    /// Returns whether the field corresponding to the `DefId` has a default field value.
     query default_field(def_id: DefId) -> Option<DefId> {
         desc { |tcx| "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
-        feedable
     }
 
     query check_well_formed(key: LocalDefId) -> Result<(), ErrorGuaranteed> {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1967,54 +1967,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut err =
             self.dcx().create_err(errors::IsPrivate { span: ident.span, ident_descr, ident });
 
-        if let Some(expr) = source
-            && let ast::ExprKind::Struct(struct_expr) = &expr.kind
-            && let Some(Res::Def(_, def_id)) = self.partial_res_map
-                [&struct_expr.path.segments.iter().last().unwrap().id]
-                .full_res()
-            && let Some(default_fields) = self.field_defaults(def_id)
-            && !struct_expr.fields.is_empty()
-        {
-            let last_span = struct_expr.fields.iter().last().unwrap().span;
-            let mut iter = struct_expr.fields.iter().peekable();
-            let mut prev: Option<Span> = None;
-            while let Some(field) = iter.next() {
-                if field.expr.span.overlaps(ident.span) {
-                    err.span_label(field.ident.span, "while setting this field");
-                    if default_fields.contains(&field.ident.name) {
-                        let sugg = if last_span == field.span {
-                            vec![(field.span, "..".to_string())]
-                        } else {
-                            vec![
-                                (
-                                    // Account for trailing commas and ensure we remove them.
-                                    match (prev, iter.peek()) {
-                                        (_, Some(next)) => field.span.with_hi(next.span.lo()),
-                                        (Some(prev), _) => field.span.with_lo(prev.hi()),
-                                        (None, None) => field.span,
-                                    },
-                                    String::new(),
-                                ),
-                                (last_span.shrink_to_hi(), ", ..".to_string()),
-                            ]
-                        };
-                        err.multipart_suggestion_verbose(
-                            format!(
-                                "the type `{ident}` of field `{}` is private, but you can \
-                                 construct the default value defined for it in `{}` using `..` in \
-                                 the struct initializer expression",
-                                field.ident,
-                                self.tcx.item_name(def_id),
-                            ),
-                            sugg,
-                            Applicability::MachineApplicable,
-                        );
-                        break;
-                    }
-                }
-                prev = Some(field.span);
-            }
-        }
+        self.mention_default_field_values(source, ident, &mut err);
 
         let mut not_publicly_reexported = false;
         if let Some((this_res, outer_ident)) = outermost_res {
@@ -2195,6 +2148,85 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         err.emit();
+    }
+
+    /// When a private field is being set that has a default field value, we suggest using `..` and
+    /// setting the value of that field implicitly with its default.
+    ///
+    /// If we encounter code like
+    /// ```text
+    /// struct Priv;
+    /// pub struct S {
+    ///     pub field: Priv = Priv,
+    /// }
+    /// ```
+    /// which is used from a place where `Priv` isn't accessible
+    /// ```text
+    /// let _ = S { field: m::Priv1 {} };
+    /// //                    ^^^^^ private struct
+    /// ```
+    /// we will suggest instead using the `default_field_values` syntax instead:
+    /// ```text
+    /// let _ = S { .. };
+    /// ```
+    fn mention_default_field_values(
+        &self,
+        source: &Option<ast::Expr>,
+        ident: Ident,
+        err: &mut Diag<'_>,
+    ) {
+        let Some(expr) = source else { return };
+        let ast::ExprKind::Struct(struct_expr) = &expr.kind else { return };
+        // We don't have to handle type-relative paths because they're forbidden in ADT
+        // expressions, but that would change with `#[feature(more_qualified_paths)]`.
+        let Some(Res::Def(_, def_id)) =
+            self.partial_res_map[&struct_expr.path.segments.iter().last().unwrap().id].full_res()
+        else {
+            return;
+        };
+        let Some(default_fields) = self.field_defaults(def_id) else { return };
+        if struct_expr.fields.is_empty() {
+            return;
+        }
+        let last_span = struct_expr.fields.iter().last().unwrap().span;
+        let mut iter = struct_expr.fields.iter().peekable();
+        let mut prev: Option<Span> = None;
+        while let Some(field) = iter.next() {
+            if field.expr.span.overlaps(ident.span) {
+                err.span_label(field.ident.span, "while setting this field");
+                if default_fields.contains(&field.ident.name) {
+                    let sugg = if last_span == field.span {
+                        vec![(field.span, "..".to_string())]
+                    } else {
+                        vec![
+                            (
+                                // Account for trailing commas and ensure we remove them.
+                                match (prev, iter.peek()) {
+                                    (_, Some(next)) => field.span.with_hi(next.span.lo()),
+                                    (Some(prev), _) => field.span.with_lo(prev.hi()),
+                                    (None, None) => field.span,
+                                },
+                                String::new(),
+                            ),
+                            (last_span.shrink_to_hi(), ", ..".to_string()),
+                        ]
+                    };
+                    err.multipart_suggestion_verbose(
+                        format!(
+                            "the type `{ident}` of field `{}` is private, but you can construct \
+                             the default value defined for it in `{}` using `..` in the struct \
+                             initializer expression",
+                            field.ident,
+                            self.tcx.item_name(def_id),
+                        ),
+                        sugg,
+                        Applicability::MachineApplicable,
+                    );
+                    break;
+                }
+            }
+            prev = Some(field.span);
+        }
     }
 
     pub(crate) fn find_similarly_named_module_or_crate(

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -174,7 +174,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         &mut self,
         path: &[Segment],
         span: Span,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
     ) -> BaseError {
         // Make the base error.
@@ -318,7 +318,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 (String::new(), "the crate root".to_string(), Some(CRATE_DEF_ID.to_def_id()), None)
             } else {
                 let mod_path = &path[..path.len() - 1];
-                let mod_res = self.resolve_path(mod_path, Some(TypeNS), None);
+                let mod_res = self.resolve_path(mod_path, Some(TypeNS), None, source);
                 let mod_prefix = match mod_res {
                     PathResult::Module(ModuleOrUniformRoot::Module(module)) => module.res(),
                     _ => None,
@@ -419,7 +419,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
         qself: Option<&QSelf>,
     ) -> (Diag<'tcx>, Vec<ImportSuggestion>) {
@@ -1014,7 +1014,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_typo(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
@@ -1333,7 +1333,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_swapping_misplaced_self_ty_and_trait(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
         span: Span,
     ) {
@@ -1341,7 +1341,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             self.diag_metadata.currently_processing_impl_trait.clone()
             && let TyKind::Path(_, self_ty_path) = &self_ty.kind
             && let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(&Segment::from_path(self_ty_path), Some(TypeNS), None)
+                self.resolve_path(&Segment::from_path(self_ty_path), Some(TypeNS), None, source)
             && let ModuleKind::Def(DefKind::Trait, ..) = module.kind
             && trait_ref.path.span == span
             && let PathSource::Trait(_) = source
@@ -1449,13 +1449,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn get_single_associated_item(
         &mut self,
         path: &[Segment],
-        source: &PathSource<'_, '_, '_>,
+        source: &PathSource<'_, 'ast, 'ra>,
         filter_fn: &impl Fn(Res) -> bool,
     ) -> Option<TypoSuggestion> {
         if let crate::PathSource::TraitItem(_, _) = source {
             let mod_path = &path[..path.len() - 1];
             if let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(mod_path, None, None)
+                self.resolve_path(mod_path, None, None, *source)
             {
                 let targets: Vec<_> = self
                     .r
@@ -1854,7 +1854,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 PathSource::Expr(Some(Expr {
                     kind: ExprKind::Index(..) | ExprKind::Call(..), ..
                 }))
-                | PathSource::Struct,
+                | PathSource::Struct(_),
             ) => {
                 // Don't suggest macro if it's unstable.
                 let suggestable = def_id.is_local()
@@ -2502,7 +2502,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             // Search in module.
             let mod_path = &path[..path.len() - 1];
             if let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(mod_path, Some(TypeNS), None)
+                self.resolve_path(mod_path, Some(TypeNS), None, PathSource::Type)
             {
                 self.r.add_module_candidates(module, &mut names, &filter_fn, None);
             }
@@ -3673,7 +3673,12 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 if let TyKind::Path(None, path) = &ty.kind {
                                     // Check if the path being borrowed is likely to be owned.
                                     let path: Vec<_> = Segment::from_path(path);
-                                    match self.resolve_path(&path, Some(TypeNS), None) {
+                                    match self.resolve_path(
+                                        &path,
+                                        Some(TypeNS),
+                                        None,
+                                        PathSource::Type,
+                                    ) {
                                         PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
                                             match module.res() {
                                                 Some(Res::PrimTy(PrimTy::Str)) => {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -196,7 +196,10 @@ pub(crate) fn detect_llvm_freshness(config: &Config, is_git: bool) -> PathFreshn
 ///
 /// This checks the build triple platform to confirm we're usable at all, and if LLVM
 /// with/without assertions is available.
-pub(crate) fn is_ci_llvm_available_for_target(config: &Config, asserts: bool) -> bool {
+pub(crate) fn is_ci_llvm_available_for_target(
+    host_target: &TargetSelection,
+    asserts: bool,
+) -> bool {
     // This is currently all tier 1 targets and tier 2 targets with host tools
     // (since others may not have CI artifacts)
     // https://doc.rust-lang.org/rustc/platform-support.html#tier-1
@@ -235,8 +238,8 @@ pub(crate) fn is_ci_llvm_available_for_target(config: &Config, asserts: bool) ->
         ("x86_64-unknown-netbsd", false),
     ];
 
-    if !supported_platforms.contains(&(&*config.host_target.triple, asserts))
-        && (asserts || !supported_platforms.contains(&(&*config.host_target.triple, true)))
+    if !supported_platforms.contains(&(&*host_target.triple, asserts))
+        && (asserts || !supported_platforms.contains(&(&*host_target.triple, true)))
     {
         return false;
     }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1278,7 +1278,8 @@ impl Config {
 
         if config.llvm_from_ci {
             let triple = &config.host_target.triple;
-            let ci_llvm_bin = config.ci_llvm_root().join("bin");
+            let ci_llvm_bin =
+                ci_llvm_root(config.llvm_from_ci, &config.out, &config.host_target).join("bin");
             let build_target = config
                 .target_config
                 .entry(config.host_target)
@@ -2735,4 +2736,13 @@ pub fn is_system_llvm(
 
 pub fn is_host_target(host_target: &TargetSelection, target: &TargetSelection) -> bool {
     host_target == target
+}
+
+pub(crate) fn ci_llvm_root(
+    llvm_from_ci: bool,
+    out: &Path,
+    host_target: &TargetSelection,
+) -> PathBuf {
+    assert!(llvm_from_ci);
+    out.join(host_target).join("ci-llvm")
 }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -893,21 +893,25 @@ impl Config {
         let default = config.channel == "dev";
         config.omit_git_hash = rust_omit_git_hash.unwrap_or(default);
 
-        config.rust_info = config.git_info(config.omit_git_hash, &config.src);
+        config.rust_info = git_info(&config.exec_ctx, config.omit_git_hash, &config.src);
         config.cargo_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/cargo"));
-        config.rust_analyzer_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/rust-analyzer"));
+            git_info(&config.exec_ctx, config.omit_git_hash, &config.src.join("src/tools/cargo"));
+        config.rust_analyzer_info = git_info(
+            &config.exec_ctx,
+            config.omit_git_hash,
+            &config.src.join("src/tools/rust-analyzer"),
+        );
         config.clippy_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/clippy"));
+            git_info(&config.exec_ctx, config.omit_git_hash, &config.src.join("src/tools/clippy"));
         config.miri_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/miri"));
+            git_info(&config.exec_ctx, config.omit_git_hash, &config.src.join("src/tools/miri"));
         config.rustfmt_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/rustfmt"));
+            git_info(&config.exec_ctx, config.omit_git_hash, &config.src.join("src/tools/rustfmt"));
         config.enzyme_info =
-            config.git_info(config.omit_git_hash, &config.src.join("src/tools/enzyme"));
-        config.in_tree_llvm_info = config.git_info(false, &config.src.join("src/llvm-project"));
-        config.in_tree_gcc_info = config.git_info(false, &config.src.join("src/gcc"));
+            git_info(&config.exec_ctx, config.omit_git_hash, &config.src.join("src/tools/enzyme"));
+        config.in_tree_llvm_info =
+            git_info(&config.exec_ctx, false, &config.src.join("src/llvm-project"));
+        config.in_tree_gcc_info = git_info(&config.exec_ctx, false, &config.src.join("src/gcc"));
 
         config.vendor = build_vendor.unwrap_or(
             config.rust_info.is_from_tarball()

--- a/tests/ui/borrowck/borrowck-in-static.stderr
+++ b/tests/ui/borrowck/borrowck-in-static.stderr
@@ -10,6 +10,7 @@ LL |     Box::new(|| x)
    |              |
    |              captured by this `Fn` closure
    |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     Box::new(|| x.clone())

--- a/tests/ui/borrowck/borrowck-move-by-capture.stderr
+++ b/tests/ui/borrowck/borrowck-move-by-capture.stderr
@@ -12,6 +12,11 @@ LL |         let _h = to_fn_once(move || -> isize { *bar });
    |                             |
    |                             `bar` is moved here
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/borrowck-move-by-capture.rs:3:37
+   |
+LL | fn to_fn_mut<A:std::marker::Tuple,F:FnMut<A>>(f: F) -> F { f }
+   |                                     ^^^^^^^^
 help: consider cloning the value before moving it into the closure
    |
 LL ~         let value = bar.clone();

--- a/tests/ui/borrowck/issue-103624.stderr
+++ b/tests/ui/borrowck/issue-103624.stderr
@@ -13,6 +13,11 @@ LL |
 LL |             self.b;
    |             ^^^^^^ `self.b` is moved here
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/issue-103624.rs:7:36
+   |
+LL | async fn spawn_blocking<T>(f: impl (Fn() -> T) + Send + Sync + 'static) -> T {
+   |                                    ^^^^^^^^^^^
 note: if `StructB` implemented `Clone`, you could clone the value
   --> $DIR/issue-103624.rs:23:1
    |

--- a/tests/ui/borrowck/issue-87456-point-to-closure.stderr
+++ b/tests/ui/borrowck/issue-87456-point-to-closure.stderr
@@ -10,6 +10,11 @@ LL |
 LL |         let _foo: String = val;
    |                            ^^^ move occurs because `val` has type `String`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/issue-87456-point-to-closure.rs:3:24
+   |
+LL | fn take_mut(_val: impl FnMut()) {}
+   |                        ^^^^^^^
 help: consider borrowing here
    |
 LL |         let _foo: String = &val;

--- a/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -10,6 +10,11 @@ LL |         y.into_iter();
    |         |
    |         move occurs because `y` has type `Vec<String>`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/unboxed-closures-move-upvar-from-non-once-ref-closure.rs:5:28
+   |
+LL | fn call<F>(f: F) where F : Fn() {
+   |                            ^^^^
 note: `into_iter` takes ownership of the receiver `self`, which moves `y`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior

--- a/tests/ui/issues/issue-4335.stderr
+++ b/tests/ui/issues/issue-4335.stderr
@@ -10,6 +10,7 @@ LL |     id(Box::new(|| *v))
    |                 |
    |                 captured by this `FnMut` closure
    |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
 help: if `T` implemented `Clone`, you could clone the value
   --> $DIR/issue-4335.rs:5:10
    |

--- a/tests/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
+++ b/tests/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
@@ -10,6 +10,11 @@ LL |     let _f = to_fn(|| test(i));
    |                    |
    |                    captured by this `Fn` closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/moves-based-on-type-move-out-of-closure-env-issue-1965.rs:3:33
+   |
+LL | fn to_fn<A:std::marker::Tuple,F:Fn<A>>(f: F) -> F { f }
+   |                                 ^^^^^
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _f = to_fn(|| test(i.clone()));

--- a/tests/ui/nll/issue-52663-span-decl-captured-variable.stderr
+++ b/tests/ui/nll/issue-52663-span-decl-captured-variable.stderr
@@ -10,6 +10,11 @@ LL |        expect_fn(|| drop(x.0));
    |                  |
    |                  captured by this `Fn` closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/issue-52663-span-decl-captured-variable.rs:1:33
+   |
+LL | fn expect_fn<F>(f: F) where F : Fn() {
+   |                                 ^^^^
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |        expect_fn(|| drop(x.0.clone()));

--- a/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
+++ b/tests/ui/span/borrowck-call-is-borrow-issue-12224.stderr
@@ -44,6 +44,7 @@ LL |
 LL |         foo(f);
    |             ^ move occurs because `f` has type `{closure@$DIR/borrowck-call-is-borrow-issue-12224.rs:52:17: 52:58}`, which does not implement the `Copy` trait
    |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |         foo(f.clone());

--- a/tests/ui/structs/default-field-values/auxiliary/struct_field_default.rs
+++ b/tests/ui/structs/default-field-values/auxiliary/struct_field_default.rs
@@ -3,3 +3,13 @@
 pub struct A {
     pub a: isize = 42,
 }
+
+struct Priv;
+
+pub struct B {
+    pub a: Priv = Priv,
+}
+
+pub struct C {
+    pub a: Priv,
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.rs
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.rs
@@ -1,0 +1,29 @@
+//@ aux-build:struct_field_default.rs
+#![feature(default_field_values)]
+
+extern crate struct_field_default as xc;
+
+use m::S;
+
+mod m {
+   pub struct S {
+       pub field: () = (),
+       pub field1: Priv1 = Priv1 {},
+       pub field2: Priv2 = Priv2,
+   }
+   struct Priv1 {}
+   struct Priv2;
+}
+
+fn main() {
+    let _ = S { field: (), field1: m::Priv1 {} };
+    //~^ ERROR missing field `field2`
+    //~| ERROR struct `Priv1` is private
+    let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+    //~^ ERROR struct `Priv1` is private
+    //~| ERROR unit struct `Priv2` is private
+    let _ = xc::B { a: xc::Priv };
+    //~^ ERROR unit struct `Priv` is private
+    let _ = xc::C { a: xc::Priv };
+    //~^ ERROR unit struct `Priv` is private
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.stderr
@@ -1,0 +1,105 @@
+error[E0603]: struct `Priv1` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:19:39
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {} };
+   |                            ------     ^^^^^ private struct
+   |                            |
+   |                            while setting this field
+   |
+note: the struct `Priv1` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:14:4
+   |
+LL |    struct Priv1 {}
+   |    ^^^^^^^^^^^^
+help: the type `Priv1` of field `field1` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {} };
+LL +     let _ = S { field: (), .. };
+   |
+
+error[E0603]: struct `Priv1` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:22:39
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+   |                            ------     ^^^^^ private struct
+   |                            |
+   |                            while setting this field
+   |
+note: the struct `Priv1` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:14:4
+   |
+LL |    struct Priv1 {}
+   |    ^^^^^^^^^^^^
+help: the type `Priv1` of field `field1` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+LL +     let _ = S { field: (), field2: m::Priv2, .. };
+   |
+
+error[E0603]: unit struct `Priv2` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:22:60
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+   |                                                 ------     ^^^^^ private unit struct
+   |                                                 |
+   |                                                 while setting this field
+   |
+note: the unit struct `Priv2` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:15:4
+   |
+LL |    struct Priv2;
+   |    ^^^^^^^^^^^^^
+help: the type `Priv2` of field `field2` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+LL +     let _ = S { field: (), field1: m::Priv1 {}, .. };
+   |
+
+error[E0603]: unit struct `Priv` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:25:28
+   |
+LL |     let _ = xc::B { a: xc::Priv };
+   |                     -      ^^^^ private unit struct
+   |                     |
+   |                     while setting this field
+   |
+note: the unit struct `Priv` is defined here
+  --> $DIR/auxiliary/struct_field_default.rs:7:1
+   |
+LL | struct Priv;
+   | ^^^^^^^^^^^
+help: the type `Priv` of field `a` is private, but you can construct the default value defined for it in `B` using `..` in the struct initializer expression
+   |
+LL -     let _ = xc::B { a: xc::Priv };
+LL +     let _ = xc::B { .. };
+   |
+
+error[E0603]: unit struct `Priv` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:27:28
+   |
+LL |     let _ = xc::C { a: xc::Priv };
+   |                     -      ^^^^ private unit struct
+   |                     |
+   |                     while setting this field
+   |
+note: the unit struct `Priv` is defined here
+  --> $DIR/auxiliary/struct_field_default.rs:7:1
+   |
+LL | struct Priv;
+   | ^^^^^^^^^^^
+
+error[E0063]: missing field `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor-2.rs:19:13
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {} };
+   |             ^ missing `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, .. };
+   |                                               ++++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0063, E0603.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/suggestions/dont-suggest-ref/move-into-closure.rs
+++ b/tests/ui/suggestions/dont-suggest-ref/move-into-closure.rs
@@ -35,6 +35,32 @@ fn consume_fnmut<F: FnMut()>(_f: F) { }
 //~| HELP `Fn` and `FnMut` closures
 //~| HELP `Fn` and `FnMut` closures
 
+trait T {
+    fn consume_fn<F: Fn()>(_f: F) { }
+    //~^ HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+    //~^ HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+    //~| HELP `Fn` and `FnMut` closures
+}
+impl T for () {}
+
 pub fn main() { }
 
 fn move_into_fn() {
@@ -46,6 +72,120 @@ fn move_into_fn() {
     // move into Fn
 
     consume_fn(|| {
+        let X(_t) = x;
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        if let Either::One(_t) = e { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        while let Either::One(_t) = e { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        match e {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(_t)
+            | Either::Two(_t) => (),
+        }
+        match e {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(_t) => (),
+            Either::Two(ref _t) => (),
+            // FIXME: should suggest removing `ref` too
+        }
+
+        let X(mut _t) = x;
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        if let Either::One(mut _t) = em { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        while let Either::One(mut _t) = em { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        match em {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(mut _t)
+            | Either::Two(mut _t) => (),
+        }
+        match em {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(mut _t) => (),
+            Either::Two(ref _t) => (),
+            // FIXME: should suggest removing `ref` too
+        }
+    });
+}
+
+fn move_into_assoc_fn() {
+    let e = Either::One(X(Y));
+    let mut em = Either::One(X(Y));
+
+    let x = X(Y);
+
+    // move into Fn
+
+    <() as T>::consume_fn(|| {
+        let X(_t) = x;
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        if let Either::One(_t) = e { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        while let Either::One(_t) = e { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        match e {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(_t)
+            | Either::Two(_t) => (),
+        }
+        match e {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(_t) => (),
+            Either::Two(ref _t) => (),
+            // FIXME: should suggest removing `ref` too
+        }
+
+        let X(mut _t) = x;
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        if let Either::One(mut _t) = em { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        while let Either::One(mut _t) = em { }
+        //~^ ERROR cannot move
+        //~| HELP consider borrowing here
+        match em {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(mut _t)
+            | Either::Two(mut _t) => (),
+        }
+        match em {
+            //~^ ERROR cannot move
+            //~| HELP consider borrowing here
+            Either::One(mut _t) => (),
+            Either::Two(ref _t) => (),
+            // FIXME: should suggest removing `ref` too
+        }
+    });
+}
+
+fn move_into_method() {
+    let e = Either::One(X(Y));
+    let mut em = Either::One(X(Y));
+
+    let x = X(Y);
+
+    // move into Fn
+
+    ().method_consume_fn(|| {
         let X(_t) = x;
         //~^ ERROR cannot move
         //~| HELP consider borrowing here

--- a/tests/ui/suggestions/dont-suggest-ref/move-into-closure.rs
+++ b/tests/ui/suggestions/dont-suggest-ref/move-into-closure.rs
@@ -11,8 +11,29 @@ struct X(Y);
 struct Y;
 
 fn consume_fn<F: Fn()>(_f: F) { }
+//~^ HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
 
 fn consume_fnmut<F: FnMut()>(_f: F) { }
+//~^ HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
+//~| HELP `Fn` and `FnMut` closures
 
 pub fn main() { }
 

--- a/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:49:21
+  --> $DIR/move-into-closure.rs:75:21
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -23,7 +23,7 @@ LL |         let X(_t) = &x;
    |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:52:34
+  --> $DIR/move-into-closure.rs:78:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -48,7 +48,7 @@ LL |         if let Either::One(_t) = &e { }
    |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:55:37
+  --> $DIR/move-into-closure.rs:81:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -73,7 +73,7 @@ LL |         while let Either::One(_t) = &e { }
    |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:58:15
+  --> $DIR/move-into-closure.rs:84:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -101,7 +101,7 @@ LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:64:15
+  --> $DIR/move-into-closure.rs:90:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -129,7 +129,7 @@ LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:72:25
+  --> $DIR/move-into-closure.rs:98:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -154,7 +154,7 @@ LL |         let X(mut _t) = &x;
    |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:75:38
+  --> $DIR/move-into-closure.rs:101:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -179,7 +179,7 @@ LL |         if let Either::One(mut _t) = &em { }
    |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:78:41
+  --> $DIR/move-into-closure.rs:104:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -204,7 +204,7 @@ LL |         while let Either::One(mut _t) = &em { }
    |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:81:15
+  --> $DIR/move-into-closure.rs:107:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -232,7 +232,7 @@ LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:87:15
+  --> $DIR/move-into-closure.rs:113:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -259,8 +259,530 @@ help: consider borrowing here
 LL |         match &em {
    |               +
 
+error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:132:21
+   |
+LL |     let x = X(Y);
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+LL |         let X(_t) = x;
+   |               --    ^
+   |               |
+   |               data moved here
+   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         let X(_t) = &x;
+   |                     +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:135:34
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         if let Either::One(_t) = e { }
+   |                            --    ^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         if let Either::One(_t) = &e { }
+   |                                  +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:138:37
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         while let Either::One(_t) = e { }
+   |                               --    ^
+   |                               |
+   |                               data moved here
+   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         while let Either::One(_t) = &e { }
+   |                                     +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:141:15
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         match e {
+   |               ^
+...
+LL |             Either::One(_t)
+   |                         --
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:147:15
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         match e {
+   |               ^
+...
+LL |             Either::One(_t) => (),
+   |                         --
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
+
+error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:155:25
+   |
+LL |     let x = X(Y);
+   |         - captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         let X(mut _t) = x;
+   |               ------    ^
+   |               |
+   |               data moved here
+   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         let X(mut _t) = &x;
+   |                         +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:158:38
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         if let Either::One(mut _t) = em { }
+   |                            ------    ^^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         if let Either::One(mut _t) = &em { }
+   |                                      +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:161:41
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         while let Either::One(mut _t) = em { }
+   |                               ------    ^^
+   |                               |
+   |                               data moved here
+   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         while let Either::One(mut _t) = &em { }
+   |                                         +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:164:15
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         match em {
+   |               ^^
+...
+LL |             Either::One(mut _t)
+   |                         ------
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:170:15
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     <() as T>::consume_fn(|| {
+   |                           -- captured by this `Fn` closure
+...
+LL |         match em {
+   |               ^^
+...
+LL |             Either::One(mut _t) => (),
+   |                         ------
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:39:22
+   |
+LL |     fn consume_fn<F: Fn()>(_f: F) { }
+   |                      ^^^^
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
+
+error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:189:21
+   |
+LL |     let x = X(Y);
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+LL |         let X(_t) = x;
+   |               --    ^
+   |               |
+   |               data moved here
+   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         let X(_t) = &x;
+   |                     +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:192:34
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         if let Either::One(_t) = e { }
+   |                            --    ^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         if let Either::One(_t) = &e { }
+   |                                  +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:195:37
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         while let Either::One(_t) = e { }
+   |                               --    ^
+   |                               |
+   |                               data moved here
+   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         while let Either::One(_t) = &e { }
+   |                                     +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:198:15
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         match e {
+   |               ^
+...
+LL |             Either::One(_t)
+   |                         --
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
+
+error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:204:15
+   |
+LL |     let e = Either::One(X(Y));
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         match e {
+   |               ^
+...
+LL |             Either::One(_t) => (),
+   |                         --
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         match &e {
+   |               +
+
+error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:212:25
+   |
+LL |     let x = X(Y);
+   |         - captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         let X(mut _t) = x;
+   |               ------    ^
+   |               |
+   |               data moved here
+   |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         let X(mut _t) = &x;
+   |                         +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:215:38
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         if let Either::One(mut _t) = em { }
+   |                            ------    ^^
+   |                            |
+   |                            data moved here
+   |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         if let Either::One(mut _t) = &em { }
+   |                                      +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:218:41
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         while let Either::One(mut _t) = em { }
+   |                               ------    ^^
+   |                               |
+   |                               data moved here
+   |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         while let Either::One(mut _t) = &em { }
+   |                                         +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:221:15
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         match em {
+   |               ^^
+...
+LL |             Either::One(mut _t)
+   |                         ------
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
+
+error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
+  --> $DIR/move-into-closure.rs:227:15
+   |
+LL |     let mut em = Either::One(X(Y));
+   |         ------ captured outer variable
+...
+LL |     ().method_consume_fn(|| {
+   |                          -- captured by this `Fn` closure
+...
+LL |         match em {
+   |               ^^
+...
+LL |             Either::One(mut _t) => (),
+   |                         ------
+   |                         |
+   |                         data moved here
+   |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:50:29
+   |
+LL |     fn method_consume_fn<F: Fn()>(&self, _f: F) { }
+   |                             ^^^^
+help: consider borrowing here
+   |
+LL |         match &em {
+   |               +
+
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:106:21
+  --> $DIR/move-into-closure.rs:246:21
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -284,7 +806,7 @@ LL |         let X(_t) = &x;
    |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:109:34
+  --> $DIR/move-into-closure.rs:249:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -309,7 +831,7 @@ LL |         if let Either::One(_t) = &e { }
    |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:112:37
+  --> $DIR/move-into-closure.rs:252:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -334,7 +856,7 @@ LL |         while let Either::One(_t) = &e { }
    |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:115:15
+  --> $DIR/move-into-closure.rs:255:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -362,7 +884,7 @@ LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:121:15
+  --> $DIR/move-into-closure.rs:261:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -390,7 +912,7 @@ LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:129:25
+  --> $DIR/move-into-closure.rs:269:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -415,7 +937,7 @@ LL |         let X(mut _t) = &x;
    |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:132:38
+  --> $DIR/move-into-closure.rs:272:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -440,7 +962,7 @@ LL |         if let Either::One(mut _t) = &em { }
    |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:135:41
+  --> $DIR/move-into-closure.rs:275:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -465,7 +987,7 @@ LL |         while let Either::One(mut _t) = &em { }
    |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:138:15
+  --> $DIR/move-into-closure.rs:278:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -493,7 +1015,7 @@ LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:144:15
+  --> $DIR/move-into-closure.rs:284:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -521,7 +1043,7 @@ LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:151:15
+  --> $DIR/move-into-closure.rs:291:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -548,6 +1070,6 @@ help: consider borrowing here
 LL |         match &em {
    |               +
 
-error: aborting due to 21 previous errors
+error: aborting due to 41 previous errors
 
 For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/move-into-closure.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:28:21
+  --> $DIR/move-into-closure.rs:49:21
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -12,13 +12,18 @@ LL |         let X(_t) = x;
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         let X(_t) = &x;
    |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:31:34
+  --> $DIR/move-into-closure.rs:52:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -32,13 +37,18 @@ LL |         if let Either::One(_t) = e { }
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         if let Either::One(_t) = &e { }
    |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:34:37
+  --> $DIR/move-into-closure.rs:55:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -52,13 +62,18 @@ LL |         while let Either::One(_t) = e { }
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         while let Either::One(_t) = &e { }
    |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:37:15
+  --> $DIR/move-into-closure.rs:58:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -75,13 +90,18 @@ LL |             Either::One(_t)
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:43:15
+  --> $DIR/move-into-closure.rs:64:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -98,13 +118,18 @@ LL |             Either::One(_t) => (),
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:51:25
+  --> $DIR/move-into-closure.rs:72:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -118,13 +143,18 @@ LL |         let X(mut _t) = x;
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         let X(mut _t) = &x;
    |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:54:38
+  --> $DIR/move-into-closure.rs:75:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -138,13 +168,18 @@ LL |         if let Either::One(mut _t) = em { }
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         if let Either::One(mut _t) = &em { }
    |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:57:41
+  --> $DIR/move-into-closure.rs:78:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -158,13 +193,18 @@ LL |         while let Either::One(mut _t) = em { }
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         while let Either::One(mut _t) = &em { }
    |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:60:15
+  --> $DIR/move-into-closure.rs:81:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -181,13 +221,18 @@ LL |             Either::One(mut _t)
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `Fn` closure
-  --> $DIR/move-into-closure.rs:66:15
+  --> $DIR/move-into-closure.rs:87:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -204,13 +249,18 @@ LL |             Either::One(mut _t) => (),
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:13:18
+   |
+LL | fn consume_fn<F: Fn()>(_f: F) { }
+   |                  ^^^^
 help: consider borrowing here
    |
 LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:85:21
+  --> $DIR/move-into-closure.rs:106:21
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -223,13 +273,18 @@ LL |         let X(_t) = x;
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         let X(_t) = &x;
    |                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:88:34
+  --> $DIR/move-into-closure.rs:109:34
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -243,13 +298,18 @@ LL |         if let Either::One(_t) = e { }
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         if let Either::One(_t) = &e { }
    |                                  +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:91:37
+  --> $DIR/move-into-closure.rs:112:37
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -263,13 +323,18 @@ LL |         while let Either::One(_t) = e { }
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         while let Either::One(_t) = &e { }
    |                                     +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:94:15
+  --> $DIR/move-into-closure.rs:115:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -286,13 +351,18 @@ LL |             Either::One(_t)
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `e.0`, as `e` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:100:15
+  --> $DIR/move-into-closure.rs:121:15
    |
 LL |     let e = Either::One(X(Y));
    |         - captured outer variable
@@ -309,13 +379,18 @@ LL |             Either::One(_t) => (),
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         match &e {
    |               +
 
 error[E0507]: cannot move out of `x.0`, as `x` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:108:25
+  --> $DIR/move-into-closure.rs:129:25
    |
 LL |     let x = X(Y);
    |         - captured outer variable
@@ -329,13 +404,18 @@ LL |         let X(mut _t) = x;
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         let X(mut _t) = &x;
    |                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:111:38
+  --> $DIR/move-into-closure.rs:132:38
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -349,13 +429,18 @@ LL |         if let Either::One(mut _t) = em { }
    |                            data moved here
    |                            move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         if let Either::One(mut _t) = &em { }
    |                                      +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:114:41
+  --> $DIR/move-into-closure.rs:135:41
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -369,13 +454,18 @@ LL |         while let Either::One(mut _t) = em { }
    |                               data moved here
    |                               move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         while let Either::One(mut _t) = &em { }
    |                                         +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:117:15
+  --> $DIR/move-into-closure.rs:138:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -392,13 +482,18 @@ LL |             Either::One(mut _t)
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:123:15
+  --> $DIR/move-into-closure.rs:144:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -415,13 +510,18 @@ LL |             Either::One(mut _t) => (),
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         match &em {
    |               +
 
 error[E0507]: cannot move out of `em.0`, as `em` is a captured variable in an `FnMut` closure
-  --> $DIR/move-into-closure.rs:130:15
+  --> $DIR/move-into-closure.rs:151:15
    |
 LL |     let mut em = Either::One(X(Y));
    |         ------ captured outer variable
@@ -438,6 +538,11 @@ LL |             Either::One(mut _t) => (),
    |                         data moved here
    |                         move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/move-into-closure.rs:25:21
+   |
+LL | fn consume_fnmut<F: FnMut()>(_f: F) { }
+   |                     ^^^^^^^
 help: consider borrowing here
    |
 LL |         match &em {

--- a/tests/ui/suggestions/option-content-move2.stderr
+++ b/tests/ui/suggestions/option-content-move2.stderr
@@ -14,6 +14,11 @@ LL |
 LL |             var = Some(NotCopyable);
    |             --- variable moved due to use in closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/option-content-move2.rs:5:12
+   |
+LL | fn func<F: FnMut() -> H, H: FnMut()>(_: F) {}
+   |            ^^^^^^^^^^^^
 note: if `NotCopyable` implemented `Clone`, you could clone the value
   --> $DIR/option-content-move2.rs:1:1
    |
@@ -38,6 +43,12 @@ LL |         move || {
 LL |
 LL |             var = Some(NotCopyableButCloneable);
    |             --- variable moved due to use in closure
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/option-content-move2.rs:5:12
+   |
+LL | fn func<F: FnMut() -> H, H: FnMut()>(_: F) {}
+   |            ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/option-content-move3.stderr
+++ b/tests/ui/suggestions/option-content-move3.stderr
@@ -9,6 +9,7 @@ LL |         move || {
 LL |             let x = var;
    |                     ^^^ move occurs because `var` has type `NotCopyable`, which does not implement the `Copy` trait
    |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
 note: if `NotCopyable` implemented `Clone`, you could clone the value
   --> $DIR/option-content-move3.rs:2:1
    |
@@ -37,6 +38,11 @@ LL |         move || {
 LL |             let x = var;
    |                     --- variable moved due to use in closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/option-content-move3.rs:6:12
+   |
+LL | fn func<F: FnMut() -> H, H: FnMut()>(_: F) {}
+   |            ^^^^^^^^^^^^
 note: if `NotCopyable` implemented `Clone`, you could clone the value
   --> $DIR/option-content-move3.rs:2:1
    |
@@ -57,6 +63,7 @@ LL |         move || {
 LL |             let x = var;
    |                     ^^^ move occurs because `var` has type `NotCopyableButCloneable`, which does not implement the `Copy` trait
    |
+   = help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
 help: consider borrowing here
    |
 LL |             let x = &var;
@@ -77,6 +84,11 @@ LL |         move || {
 LL |             let x = var;
    |                     --- variable moved due to use in closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/option-content-move3.rs:6:12
+   |
+LL | fn func<F: FnMut() -> H, H: FnMut()>(_: F) {}
+   |            ^^^^^^^^^^^^
 help: consider cloning the value before moving it into the closure
    |
 LL ~         {

--- a/tests/ui/unboxed-closures/unboxed-closure-illegal-move.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-illegal-move.stderr
@@ -10,6 +10,11 @@ LL |         let f = to_fn(|| drop(x));
    |                       |
    |                       captured by this `Fn` closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/unboxed-closure-illegal-move.rs:7:33
+   |
+LL | fn to_fn<A:std::marker::Tuple,F:Fn<A>>(f: F) -> F { f }
+   |                                 ^^^^^
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |         let f = to_fn(|| drop(x.clone()));
@@ -27,6 +32,11 @@ LL |         let f = to_fn_mut(|| drop(x));
    |                           |
    |                           captured by this `FnMut` closure
    |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/unboxed-closure-illegal-move.rs:8:37
+   |
+LL | fn to_fn_mut<A:std::marker::Tuple,F:FnMut<A>>(f: F) -> F { f }
+   |                                     ^^^^^^^^
 help: consider cloning the value if the performance cost is acceptable
    |
 LL |         let f = to_fn_mut(|| drop(x.clone()));
@@ -43,6 +53,12 @@ LL |         let f = to_fn(move || drop(x));
    |                       -------      ^ `x` is moved here
    |                       |
    |                       captured by this `Fn` closure
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/unboxed-closure-illegal-move.rs:7:33
+   |
+LL | fn to_fn<A:std::marker::Tuple,F:Fn<A>>(f: F) -> F { f }
+   |                                 ^^^^^
 
 error[E0507]: cannot move out of `x`, a captured variable in an `FnMut` closure
   --> $DIR/unboxed-closure-illegal-move.rs:32:40
@@ -55,6 +71,12 @@ LL |         let f = to_fn_mut(move || drop(x));
    |                           -------      ^ `x` is moved here
    |                           |
    |                           captured by this `FnMut` closure
+   |
+help: `Fn` and `FnMut` closures require captured values to be able to be consumed multiple times, but an `FnOnce` consume them only once
+  --> $DIR/unboxed-closure-illegal-move.rs:8:37
+   |
+LL | fn to_fn_mut<A:std::marker::Tuple,F:FnMut<A>>(f: F) -> F { f }
+   |                                     ^^^^^^^^
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#135846 (Detect struct construction with private field in field with default)
 - rust-lang/rust#144558 (Point at the `Fn()` or `FnMut()` bound that coerced a closure, which caused a move error)
 - rust-lang/rust#145149 (Make config method invoke inside parse use dwn_ctx)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135846,144558,145149)
<!-- homu-ignore:end -->