### PR TITLE
cfg_select: Support unbraced expressions

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -223,13 +223,14 @@ pub macro assert_matches {
 /// }
 /// ```
 ///
-/// The `cfg_select!` macro can also be used in expression position:
+/// The `cfg_select!` macro can also be used in expression position, with or without braces on the
+/// right-hand side:
 ///
 /// ```
 /// #![feature(cfg_select)]
 ///
 /// let _some_string = cfg_select! {
-///     unix => { "With great power comes great electricity bills" }
+///     unix => "With great power comes great electricity bills",
 ///     _ => { "Behind every successful diet is an unwatched pizza" }
 /// };
 /// ```

--- a/tests/ui/macros/cfg_select.rs
+++ b/tests/ui/macros/cfg_select.rs
@@ -8,10 +8,42 @@ fn print() {
     });
 }
 
-fn arm_rhs_must_be_in_braces() -> i32 {
+fn print_2() {
+    println!(cfg_select! {
+        unix => "unix",
+        _ => "not unix",
+    });
+}
+
+fn arm_rhs_expr_1() -> i32 {
     cfg_select! {
         true => 1
-        //~^ ERROR: expected `{`, found `1`
+    }
+}
+
+fn arm_rhs_expr_2() -> i32 {
+    cfg_select! {
+        true => 1,
+        false => 2
+    }
+}
+
+fn arm_rhs_expr_3() -> i32 {
+    cfg_select! {
+        true => 1,
+        false => 2,
+        true => { 42 }
+        false => -1 as i32,
+        true => 2 + 2,
+        false => "",
+        true => if true { 42 } else { 84 }
+        false => if true { 42 } else { 84 },
+        true => return 42,
+        false => loop {}
+        true => (1, 2),
+        false => (1, 2,),
+        true => todo!(),
+        false => println!("hello"),
     }
 }
 

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -1,11 +1,5 @@
-error: expected `{`, found `1`
-  --> $DIR/cfg_select.rs:13:17
-   |
-LL |         true => 1
-   |                 ^ expected `{`
-
 warning: unreachable predicate
-  --> $DIR/cfg_select.rs:20:5
+  --> $DIR/cfg_select.rs:52:5
    |
 LL |     _ => {}
    |     - always matches
@@ -13,7 +7,7 @@ LL |     true => {}
    |     ^^^^ this predicate is never reached
 
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:24:1
+  --> $DIR/cfg_select.rs:56:1
    |
 LL | / cfg_select! {
 LL | |
@@ -22,10 +16,10 @@ LL | | }
    | |_^
 
 error: none of the predicates in this `cfg_select` evaluated to true
-  --> $DIR/cfg_select.rs:29:1
+  --> $DIR/cfg_select.rs:61:1
    |
 LL | cfg_select! {}
    | ^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Tracking issue for `cfg_select`: rust-lang/rust#115585

When operating on expressions, `cfg_select!` can now handle expressions
without braces. (It still requires braces for other things, such as
items.)

Expand the test coverage and documentation accordingly.

---

I'm not sure whether deciding to extend `cfg_select!` in this way is T-lang or T-libs-api. I've labeled for both, with the request that both teams don't block on each other. :)