### PR TITLE
Add regression test for a former ICE involving helper attributes containing interpolated tokens

### DIFF
--- a/tests/ui/attributes/auxiliary/derive_macro_with_helper.rs
+++ b/tests/ui/attributes/auxiliary/derive_macro_with_helper.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Derive, attributes(arg))]
+pub fn derive(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/tests/ui/attributes/helper-attr-interpolated-non-lit-arg.rs
+++ b/tests/ui/attributes/helper-attr-interpolated-non-lit-arg.rs
@@ -1,0 +1,20 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/140612>.
+//@ proc-macro: derive_macro_with_helper.rs
+//@ edition: 2018
+//@ check-pass
+
+macro_rules! expand {
+    ($text:expr) => {
+        #[derive(derive_macro_with_helper::Derive)]
+        // This inert attr is completely valid because it follows the grammar
+        // `#` `[` SimplePath DelimitedTokenStream `]`.
+        // However, we used to incorrectly delay a bug here and ICE when trying to parse `$text` as
+        // the inside of a "meta item list" which may only begin with literals or paths.
+        #[arg($text)]
+        pub struct Foo;
+    };
+}
+
+expand!(1 + 1);
+
+fn main() {}


### PR DESCRIPTION
Add regression test for rust-lang/rust#140612 from rust-lang/rust#140601 or rather rust-lang/rust#140859 that only added it to `stable` not `master`.
Supersedes https://github.com/rust-lang/rust/pull/140584.

r? @jdonszelmann or anyone