### PR TITLE
dec2flt: Provide more valid inputs examples

### DIFF
--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -124,8 +124,8 @@ macro_rules! from_str_float_impl {
             /// * '2.5E-10'
             /// * '5.'
             /// * '.5', or, equivalently, '0.5'
-            /// * '5'
-            /// * '005'
+            /// * '7'
+            /// * '007'
             /// * 'inf', '-inf', '+infinity', 'NaN'
             ///
             /// Note that alphabetical characters are not case-sensitive.

--- a/library/core/src/num/dec2flt/mod.rs
+++ b/library/core/src/num/dec2flt/mod.rs
@@ -124,6 +124,8 @@ macro_rules! from_str_float_impl {
             /// * '2.5E-10'
             /// * '5.'
             /// * '.5', or, equivalently, '0.5'
+            /// * '5'
+            /// * '005'
             /// * 'inf', '-inf', '+infinity', 'NaN'
             ///
             /// Note that alphabetical characters are not case-sensitive.


### PR DESCRIPTION
I was just looking at the specifics of how the parsing is handled here and I wasn't sure if the examples were incomplete or the grammar below was misleading.

The grammar was correct so I figured I'd add these examples to clarify.