### PR TITLE
Do not materialise X in [X; 0] when X is unsizing a const

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -661,8 +661,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// operations that can be const-folded today.
     fn check_constness(&self, mut kind: &'a ExprKind<'tcx>) -> bool {
         loop {
+            debug!(?kind, "check_constness");
             match kind {
-                &ExprKind::PointerCoercion {
+                &ExprKind::ValueTypeAscription { source: eid, user_ty: _, user_ty_span: _ }
+                | &ExprKind::Use { source: eid }
+                | &ExprKind::PointerCoercion {
                     cast: PointerCoercion::Unsize,
                     source: eid,
                     is_from_as_cast: _,

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -8,6 +8,7 @@ use rustc_middle::middle::region;
 use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::*;
 use rustc_middle::thir::*;
+use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::{CastTy, mir_cast_kind};
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, UpvarArgs};
@@ -656,6 +657,24 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         block.and(rvalue)
     }
 
+    /// Recursively inspect a THIR expression and probe through unsizing
+    /// operations that can be const-folded today.
+    fn check_constness(&self, mut kind: &'a ExprKind<'tcx>) -> bool {
+        loop {
+            match kind {
+                &ExprKind::PointerCoercion {
+                    cast: PointerCoercion::Unsize,
+                    source: eid,
+                    is_from_as_cast: _,
+                }
+                | &ExprKind::Scope { region_scope: _, lint_level: _, value: eid } => {
+                    kind = &self.thir[eid].kind
+                }
+                _ => return matches!(Category::of(&kind), Some(Category::Constant)),
+            }
+        }
+    }
+
     fn build_zero_repeat(
         &mut self,
         mut block: BasicBlock,
@@ -666,7 +685,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let this = self;
         let value_expr = &this.thir[value];
         let elem_ty = value_expr.ty;
-        if let Some(Category::Constant) = Category::of(&value_expr.kind) {
+        if this.check_constness(&value_expr.kind) {
             // Repeating a const does nothing
         } else {
             // For a non-const, we may need to generate an appropriate `Drop`

--- a/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
+++ b/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
@@ -1,0 +1,30 @@
+//@ run-pass
+
+#![feature(unsize)]
+#![feature(coerce_unsized)]
+
+use std::fmt::Display;
+use std::marker::Unsize;
+use std::ops::CoerceUnsized;
+
+#[repr(transparent)]
+struct X<'a, T: ?Sized> {
+    f: &'a T,
+}
+
+impl<'a, T: ?Sized> Drop for X<'a, T> {
+    fn drop(&mut self) {
+        panic!()
+    }
+}
+
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<X<'a, U>> for X<'a, T> where
+    &'a T: CoerceUnsized<&'a U>
+{
+}
+
+const Y: X<'static, i32> = X { f: &0 };
+
+fn main() {
+    let _: [X<'static, dyn Display>; 0] = [Y; 0];
+}

--- a/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
+++ b/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
@@ -29,10 +29,18 @@ const Y: X<'static, i32> = X { f: &0 };
 fn main() {
     let _: [X<'static, dyn Display>; 0] = [Y; 0];
     coercion_on_weak_in_const();
+    coercion_on_weak_as_cast();
 }
 
 fn coercion_on_weak_in_const() {
     const X: Weak<i32> = Weak::new();
     const Y: [Weak<dyn Send>; 0] = [X; 0];
     let _ = Y;
+}
+
+fn coercion_on_weak_as_cast() {
+    const Y: X<'static, i32> = X { f: &0 };
+    // What happens in the following code is that
+    // a constant is explicitly coerced into
+    let _a: [X<'static, dyn Display>; 0] = [Y as X<'static, dyn Display>; 0];
 }

--- a/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
+++ b/tests/ui/coercion/no_local_for_coerced_const-issue-143671.rs
@@ -6,6 +6,7 @@
 use std::fmt::Display;
 use std::marker::Unsize;
 use std::ops::CoerceUnsized;
+use std::rc::Weak;
 
 #[repr(transparent)]
 struct X<'a, T: ?Sized> {
@@ -27,4 +28,11 @@ const Y: X<'static, i32> = X { f: &0 };
 
 fn main() {
     let _: [X<'static, dyn Display>; 0] = [Y; 0];
+    coercion_on_weak_in_const();
+}
+
+fn coercion_on_weak_in_const() {
+    const X: Weak<i32> = Weak::new();
+    const Y: [Weak<dyn Send>; 0] = [X; 0];
+    let _ = Y;
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix rust-lang/rust#143671

It turns out that MIR builder materialise `X` in `[X; 0]` into a temporary local when `X` is unsizing a `const`. This led to a confusing call to destructor of `X` when such a destructor is declared. [Playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=8dfc933af89efeb89c881bc77498ba63)

This patch may miss out other cases that we should avoid materialisation in case of `[X; 0]`. Suggestions to include is most welcome!