### PR TITLE
Update `rustc_codegen_gcc` rotate operation document

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -493,9 +493,10 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                         }
                         sym::bitreverse => self.bit_reverse(width, args[0].immediate()),
                         sym::rotate_left | sym::rotate_right => {
-                            // TODO(antoyo): implement using algorithm from:
+                            // Using optimized branchless algorithm from:
                             // https://blog.regehr.org/archives/1063
-                            // for other platforms.
+                            // This implementation uses the pattern (x<<n) | (x>>(-n&(width-1)))
+                            // which generates efficient code for other platforms.
                             let is_left = name == sym::rotate_left;
                             let val = args[0].immediate();
                             let raw_shift = args[1].immediate();


### PR DESCRIPTION
## Description

This PR resolves a TODO comment in the `rustc_codegen_gcc` backend by documenting that the rotate operations (`rotate_left` and `rotate_right`) already implement the optimized branchless algorithm from comment.

The existing implementation already uses the optimal branchless rotation pattern:
- For left rotation: `(x << n) | (x >> (-n & (width-1)))`
- For right rotation: `(x >> n) | (x << (-n & (width-1)))`

This pattern avoids branches and generates efficient machine code across different platforms, which was the goal mentioned in the original TODO.

## Changes

- Removed the TODO comment that suggested implementing the algorithm from https://blog.regehr.org/archives/1063