### PR TITLE
doc test: fix mpsc.rs try_send doc test

### DIFF
--- a/library/std/src/sync/mpsc.rs
+++ b/library/std/src/sync/mpsc.rs
@@ -697,14 +697,14 @@ impl<T> SyncSender<T> {
     /// let sync_sender2 = sync_sender.clone();
     ///
     /// // First thread owns sync_sender
-    /// thread::spawn(move || {
+    /// let handle1 = thread::spawn(move || {
     ///     sync_sender.send(1).unwrap();
     ///     sync_sender.send(2).unwrap();
     ///     // Thread blocked
     /// });
     ///
     /// // Second thread owns sync_sender2
-    /// thread::spawn(move || {
+    /// let handle2 = thread::spawn(move || {
     ///     // This will return an error and send
     ///     // no message if the buffer is full
     ///     let _ = sync_sender2.try_send(3);
@@ -722,6 +722,10 @@ impl<T> SyncSender<T> {
     ///     Ok(msg) => println!("message {msg} received"),
     ///     Err(_) => println!("the third message was never sent"),
     /// }
+    ///
+    /// // Wait for threads to complete
+    /// handle1.join().unwrap();
+    /// handle2.join().unwrap();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {


### PR DESCRIPTION
This Pr want to fix the doctest, to make https://github.com/rust-lang/rust/pull/145293 's CI pass:

r? @Zalathar

https://github.com/rust-lang/rust/actions/runs/16903356990/job/47887354221

```bash
2025-08-12T10:19:32.3873237Z test library/std/src/thread/scoped.rs - thread::scoped::ScopedJoinHandle<'scope,T>::join (line 302) ... ok
2025-08-12T10:19:32.4370250Z test library/std/src/time.rs - time::SystemTimeError::duration (line 688) ... ok
2025-08-12T10:19:32.5121966Z test library/std/src/time.rs - time::UNIX_EPOCH (line 664) ... ok
2025-08-12T10:19:32.5122586Z 
2025-08-12T10:19:32.5122738Z failures:
2025-08-12T10:19:32.5122973Z 
2025-08-12T10:19:32.5123482Z ---- library/std/src/sync/mpsc.rs - sync::mpsc::SyncSender<T>::try_send (line 691) stdout ----
2025-08-12T10:19:32.5124286Z Test executable failed (exit status: 1).
2025-08-12T10:19:32.5124518Z 
2025-08-12T10:19:32.5124605Z stdout:
2025-08-12T10:19:32.5124810Z message 3 received
2025-08-12T10:19:32.5125043Z message 1 received
2025-08-12T10:19:32.5125288Z the third message was never sent
2025-08-12T10:19:32.5125497Z 
2025-08-12T10:19:32.5125581Z stderr:
2025-08-12T10:19:32.5125701Z 
2025-08-12T10:19:32.5125935Z thread '<unnamed>' (203874) panicked at library/std/src/sync/mpsc.rs:14:25:
2025-08-12T10:19:32.5126459Z called `Result::unwrap()` on an `Err` value: SendError { .. }
2025-08-12T10:19:32.5126836Z stack backtrace:
2025-08-12T10:19:32.5127568Z ␛[0m␛[1m␛[38;5;9merror␛[0m␛[0m␛[1m: the main thread terminated without waiting for all remaining threads␛[0m
2025-08-12T10:19:32.5127971Z 
2025-08-12T10:19:32.5128335Z ␛[0m␛[1m␛[38;5;10mnote␛[0m␛[0m␛[1m: set `MIRIFLAGS=-Zmiri-ignore-leaks` to disable this check␛[0m
2025-08-12T10:19:32.5128694Z 
2025-08-12T10:19:32.5128943Z ␛[0m␛[1m␛[38;5;9merror␛[0m␛[0m␛[1m: aborting due to 1 previous error␛[0m
2025-08-12T10:19:32.5129519Z 
2025-08-12T10:19:32.5129527Z 
2025-08-12T10:19:32.5129532Z 
2025-08-12T10:19:32.5129537Z 
2025-08-12T10:19:32.5129631Z failures:
2025-08-12T10:19:32.5130018Z     library/std/src/sync/mpsc.rs - sync::mpsc::SyncSender<T>::try_send (line 691)
2025-08-12T10:19:32.5130396Z 
2025-08-12T10:19:32.5130713Z test result: FAILED. 999 passed; 1 failed; 16 ignored; 0 measured; 344 filtered out; finished in 105.92s
```
