### PR TITLE
Fix `-Zregparm` for LLVM builtins

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -372,6 +372,15 @@ pub(crate) unsafe fn create_module<'ll>(
         }
     }
 
+    if let Some(regparm_count) = sess.opts.unstable_opts.regparm {
+        llvm::add_module_flag_u32(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Error,
+            "NumRegisterParameters",
+            regparm_count,
+        );
+    }
+
     if let Some(BranchProtection { bti, pac_ret }) = sess.opts.unstable_opts.branch_protection {
         if sess.target.arch == "aarch64" {
             llvm::add_module_flag_u32(

--- a/tests/assembly-llvm/regparm-module-flag.rs
+++ b/tests/assembly-llvm/regparm-module-flag.rs
@@ -1,0 +1,70 @@
+// Test the regparm ABI with builtin and non-builtin calls
+// Issue: https://github.com/rust-lang/rust/issues/145271
+//@ add-core-stubs
+//@ assembly-output: emit-asm
+//@ compile-flags: -O --target=i686-unknown-linux-gnu -Crelocation-model=static
+//@ revisions: REGPARM1 REGPARM2 REGPARM3
+//@[REGPARM1] compile-flags: -Zregparm=1
+//@[REGPARM2] compile-flags: -Zregparm=2
+//@[REGPARM3] compile-flags: -Zregparm=3
+//@ needs-llvm-components: x86
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+
+extern crate minicore;
+use minicore::*;
+
+unsafe extern "C" {
+    fn memset(p: *mut c_void, val: i32, len: usize) -> *mut c_void;
+    fn non_builtin_memset(p: *mut c_void, val: i32, len: usize) -> *mut c_void;
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn entrypoint(len: usize, ptr: *mut c_void, val: i32) -> *mut c_void {
+    // REGPARM1-LABEL: entrypoint
+    // REGPARM1: movl %e{{.*}}, %ecx
+    // REGPARM1: pushl
+    // REGPARM1: pushl
+    // REGPARM1: calll memset
+
+    // REGPARM2-LABEL: entrypoint
+    // REGPARM2: movl 16(%esp), %edx
+    // REGPARM2: movl %e{{.*}}, (%esp)
+    // REGPARM2: movl %e{{.*}}, %eax
+    // REGPARM2: calll memset
+
+    // REGPARM3-LABEL: entrypoint
+    // REGPARM3: movl %e{{.*}}, %esi
+    // REGPARM3: movl %e{{.*}}, %eax
+    // REGPARM3: movl %e{{.*}}, %ecx
+    // REGPARM3: jmp memset
+    unsafe { memset(ptr, val, len) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn non_builtin_entrypoint(
+    len: usize,
+    ptr: *mut c_void,
+    val: i32,
+) -> *mut c_void {
+    // REGPARM1-LABEL: non_builtin_entrypoint
+    // REGPARM1: movl %e{{.*}}, %ecx
+    // REGPARM1: pushl
+    // REGPARM1: pushl
+    // REGPARM1: calll non_builtin_memset
+
+    // REGPARM2-LABEL: non_builtin_entrypoint
+    // REGPARM2: movl 16(%esp), %edx
+    // REGPARM2: movl %e{{.*}}, (%esp)
+    // REGPARM2: movl %e{{.*}}, %eax
+    // REGPARM2: calll non_builtin_memset
+
+    // REGPARM3-LABEL: non_builtin_entrypoint
+    // REGPARM3: movl %e{{.*}}, %esi
+    // REGPARM3: movl %e{{.*}}, %eax
+    // REGPARM3: movl %e{{.*}}, %ecx
+    // REGPARM3: jmp non_builtin_memset
+    unsafe { non_builtin_memset(ptr, val, len) }
+}

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -225,3 +225,10 @@ pub mod mem {
     #[rustc_intrinsic]
     pub unsafe fn transmute<Src, Dst>(src: Src) -> Dst;
 }
+
+#[lang = "c_void"]
+#[repr(u8)]
+pub enum c_void {
+    __variant1,
+    __variant2,
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
    r? @tgross35 
-->
<!-- homu-ignore:end -->
This fixes the issue where `-Zregparm=N` was not working correctly when calling LLVM intrinsics

By default on `x86-32`, arguments are passed on the stack. The `-Zregparm=N` flag allows the first `N` arguments to be passed in registers instead. 

When calling intrinsics like `memset`, LLVM still passes parameters on the stack, which prevents optimizations like tail calls.

As proposed by @tgross35, I fixed this by setting the `NumRegisterParameters` LLVM module flag to `N` when the `-Zregparm=N` is set. 

```rust
// compiler/rust_codegen_llvm/src/context.rs#375-382
if let Some(regparm_count) = sess.opts.unstable_opts.regparm {
    llvm::add_module_flag_u32(
        llmod,
        llvm::ModuleFlagMergeBehavior::Error,
        "NumRegisterParameters",
        regparm_count,
    );
}
```
[Here](https://rust.godbolt.org/z/YMezreo48) is a before/after compiler explorer.

Here is the final result for the code snippet in the original issue:
```asm
entrypoint:
        push    esi
        mov     esi, eax
        mov     eax, ecx
        mov     ecx, esi
        pop     esi
        jmp     memset   ; Tail call parameters in registers
```

Fixes: https://github.com/rust-lang/rust/issues/145271