### PR TITLE
compiletest: assert that debugger provided for debuginfo tests and any tests actually collected for run

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -587,6 +587,11 @@ pub fn run_tests(config: Arc<Config>) {
                 }
             }
         }
+        // FIXME: not really true, few tests in tests/debuginfo do not require any debugger
+        assert!(
+            !configs.is_empty(),
+            "no debuggers found, debuginfo tests can't run without debugger"
+        );
     } else {
         configs.push(config.clone());
     };
@@ -597,7 +602,7 @@ pub fn run_tests(config: Arc<Config>) {
     for c in configs {
         tests.extend(collect_and_make_tests(c));
     }
-
+    assert!(!tests.is_empty(), "no test found for run, verify configuration");
     tests.sort_by(|a, b| Ord::cmp(&a.desc.name, &b.desc.name));
 
     // Delegate to the executor to filter and run the big list of test structures


### PR DESCRIPTION
I've run tests on some machine which for some reason missed any debuggers, and `x.py test tests/debuginfo` happily reported that it successfully run 0 of 0 test. That is bad.

Added two asserts: that for debuginfo suite there actually found any debugger; and that for current config *any* (non zero) number of tests collected.

Feel free to suggest better wording for errors.