### PR TITLE
Make std use the edition 2024 prelude

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -426,7 +426,7 @@
 // to import the prelude implicitly when building crates that depend on std.
 #[prelude_import]
 #[allow(unused)]
-use prelude::rust_2021::*;
+use prelude::rust_2024::*;
 
 // Access to Bencher, etc.
 #[cfg(test)]


### PR DESCRIPTION
This seem to have been overlooked in <https://github.com/rust-lang/rust/pull/138162>

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
