### PR TITLE
std: sys: net: uefi: tcp: Initial TcpListener support

### DIFF
--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -18,7 +18,24 @@ impl Tcp {
                 temp.connect(timeout)?;
                 Ok(Tcp::V4(temp))
             }
-            SocketAddr::V6(_) => todo!(),
+            SocketAddr::V6(_) => unsupported(),
+        }
+    }
+
+    pub(crate) fn bind(addr: &SocketAddr) -> io::Result<Self> {
+        match addr {
+            SocketAddr::V4(x) => {
+                let temp = tcp4::Tcp4::new()?;
+                temp.configure(false, None, Some(x))?;
+                Ok(Tcp::V4(temp))
+            }
+            SocketAddr::V6(_) => unsupported(),
+        }
+    }
+
+    pub(crate) fn accept(&self) -> io::Result<Self> {
+        match self {
+            Self::V4(client) => client.accept().map(Tcp::V4),
         }
     }
 

--- a/library/std/src/sys/net/connection/uefi/tcp4.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp4.rs
@@ -3,7 +3,7 @@ use r_efi::protocols::tcp4;
 
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::SocketAddrV4;
-use crate::ptr::NonNull;
+use crate::ptr::{self, NonNull};
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::pal::helpers;
 use crate::time::{Duration, Instant};
@@ -12,9 +12,9 @@ const TYPE_OF_SERVICE: u8 = 8;
 const TIME_TO_LIVE: u8 = 255;
 
 pub(crate) struct Tcp4 {
+    handle: NonNull<crate::ffi::c_void>,
     protocol: NonNull<tcp4::Protocol>,
     flag: AtomicBool,
-    #[expect(dead_code)]
     service_binding: helpers::ServiceProtocol,
 }
 
@@ -22,10 +22,11 @@ const DEFAULT_ADDR: efi::Ipv4Address = efi::Ipv4Address { addr: [0u8; 4] };
 
 impl Tcp4 {
     pub(crate) fn new() -> io::Result<Self> {
-        let service_binding = helpers::ServiceProtocol::open(tcp4::SERVICE_BINDING_PROTOCOL_GUID)?;
-        let protocol = helpers::open_protocol(service_binding.child_handle(), tcp4::PROTOCOL_GUID)?;
+        let (service_binding, handle) =
+            helpers::ServiceProtocol::open(tcp4::SERVICE_BINDING_PROTOCOL_GUID)?;
+        let protocol = helpers::open_protocol(handle, tcp4::PROTOCOL_GUID)?;
 
-        Ok(Self { service_binding, protocol, flag: AtomicBool::new(false) })
+        Ok(Self { service_binding, handle, protocol, flag: AtomicBool::new(false) })
     }
 
     pub(crate) fn configure(
@@ -42,11 +43,14 @@ impl Tcp4 {
             (DEFAULT_ADDR, 0)
         };
 
-        // FIXME: Remove when passive connections with proper subnet handling are added
-        assert!(station_address.is_none());
-        let use_default_address = efi::Boolean::TRUE;
-        let (station_address, station_port) = (DEFAULT_ADDR, 0);
-        let subnet_mask = helpers::ipv4_to_r_efi(crate::net::Ipv4Addr::new(0, 0, 0, 0));
+        let use_default_address: r_efi::efi::Boolean =
+            station_address.is_none_or(|addr| addr.ip().is_unspecified()).into();
+        let (station_address, station_port) = if let Some(x) = station_address {
+            (helpers::ipv4_to_r_efi(*x.ip()), x.port())
+        } else {
+            (DEFAULT_ADDR, 0)
+        };
+        let subnet_mask = helpers::ipv4_to_r_efi(crate::net::Ipv4Addr::new(255, 255, 255, 0));
 
         let mut config_data = tcp4::ConfigData {
             type_of_service: TYPE_OF_SERVICE,
@@ -60,7 +64,7 @@ impl Tcp4 {
                 station_port,
                 subnet_mask,
             },
-            control_option: crate::ptr::null_mut(),
+            control_option: ptr::null_mut(),
         };
 
         let r = unsafe { ((*protocol).configure)(protocol, &mut config_data) };
@@ -74,15 +78,53 @@ impl Tcp4 {
         let r = unsafe {
             ((*protocol).get_mode_data)(
                 protocol,
-                crate::ptr::null_mut(),
+                ptr::null_mut(),
                 &mut config_data,
-                crate::ptr::null_mut(),
-                crate::ptr::null_mut(),
-                crate::ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
             )
         };
 
         if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(config_data) }
+    }
+
+    pub(crate) fn accept(&self) -> io::Result<Self> {
+        let evt = unsafe { self.create_evt() }?;
+        let completion_token =
+            tcp4::CompletionToken { event: evt.as_ptr(), status: Status::SUCCESS };
+        let mut listen_token =
+            tcp4::ListenToken { completion_token, new_child_handle: ptr::null_mut() };
+
+        let protocol = self.protocol.as_ptr();
+        let r = unsafe { ((*protocol).accept)(protocol, &mut listen_token) };
+        if r.is_error() {
+            return Err(io::Error::from_raw_os_error(r.as_usize()));
+        }
+
+        unsafe { self.wait_or_cancel(None, &mut listen_token.completion_token) }?;
+
+        if completion_token.status.is_error() {
+            Err(io::Error::from_raw_os_error(completion_token.status.as_usize()))
+        } else {
+            // EDK2 internals seem to assume a single ServiceBinding Protocol for TCP4 and TCP6, and
+            // thus does not use any service binding protocol data in destroying child sockets. It
+            // does seem to suggest that we need to cleanup even the protocols created by accept. To
+            // be on the safe side with other implementations, we will be using the same service
+            // binding protocol as the parent TCP4 handle.
+            //
+            // https://github.com/tianocore/edk2/blob/f80580f56b267c96f16f985dbf707b2f96947da4/NetworkPkg/TcpDxe/TcpDriver.c#L938
+
+            let handle = NonNull::new(listen_token.new_child_handle).unwrap();
+            let protocol = helpers::open_protocol(handle, tcp4::PROTOCOL_GUID)?;
+
+            Ok(Self {
+                handle,
+                service_binding: self.service_binding,
+                protocol,
+                flag: AtomicBool::new(false),
+            })
+        }
     }
 
     pub(crate) fn connect(&self, timeout: Option<Duration>) -> io::Result<()> {
@@ -349,6 +391,12 @@ impl Tcp4 {
         let r = unsafe { ((*protocol).poll)(protocol) };
 
         if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
+    }
+}
+
+impl Drop for Tcp4 {
+    fn drop(&mut self) {
+        let _ = unsafe { self.service_binding.destroy_child(self.handle) };
     }
 }
 


### PR DESCRIPTION
Add support for binding and accepting TCP4 connections.

While testing, the following network options were used with QEMU + OVMF: -nic user,hostfwd=tcp::12345-:12345

The default localhost address on qemu seems to be 10.0.2.15.

UEFI spec does not seem to state that the TCP Handle returned by the Accept method has a ServiceBinding Protocol. So have made the ServiceBinding Protocol optional.

cc @nicholasbishop 
