### PR TITLE
Split codegen backend check step into two and don't run it with `x check compiler`

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1042,7 +1042,8 @@ impl<'a> Builder<'a> {
             Kind::Check | Kind::Fix => describe!(
                 check::Rustc,
                 check::Rustdoc,
-                check::CodegenBackend,
+                check::CraneliftCodegenBackend,
+                check::GccCodegenBackend,
                 check::Clippy,
                 check::Miri,
                 check::CargoMiri,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1514,12 +1514,7 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("check")
                 .path("compiler")
-                .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
-        [check] rustc 0 <host> -> rustc 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
-        ");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
     }
 
     #[test]
@@ -1545,12 +1540,7 @@ mod snapshot {
             ctx.config("check")
                 .path("compiler")
                 .stage(1)
-                .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
-        [check] rustc 0 <host> -> rustc 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
-        ");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
     }
 
     #[test]
@@ -1565,9 +1555,6 @@ mod snapshot {
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [check] rustc 1 <host> -> rustc 2 <host> (73 crates)
-        [check] rustc 1 <host> -> rustc 2 <host>
-        [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <host>
-        [check] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
         ");
     }
 
@@ -1679,12 +1666,7 @@ mod snapshot {
             ctx.config("check")
                 .paths(&["library", "compiler"])
                 .args(&args)
-                .render_steps(), @r"
-        [check] rustc 0 <host> -> rustc 1 <host> (73 crates)
-        [check] rustc 0 <host> -> rustc 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
-        ");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
     }
 
     #[test]
@@ -1768,7 +1750,6 @@ mod snapshot {
                 .render_steps(), @r"
         [check] rustc 0 <host> -> rustc 1 <host>
         [check] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
-        [check] rustc 0 <host> -> rustc_codegen_gcc 1 <host>
         ");
     }
 
@@ -2067,130 +2048,6 @@ mod snapshot {
         [build] rustc 0 <host> -> Rustbook 1 <host>
         [doc] rustc 1 <host> -> reference (book) 2 <host>
         ");
-    }
-
-    #[test]
-    fn clippy_ci() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("ci")
-                .stage(2)
-                .render_steps(), @r"
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] rustc 1 <host> -> bootstrap 2 <host>
-        [clippy] rustc 1 <host> -> std 1 <host>
-        [clippy] rustc 1 <host> -> rustc 2 <host>
-        [check] rustc 1 <host> -> rustc 2 <host>
-        [clippy] rustc 1 <host> -> rustc_codegen_gcc 2 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_compiler_stage1() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("compiler")
-                .render_steps(), @r"
-        [build] llvm <host>
-        [clippy] rustc 0 <host> -> rustc 1 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_compiler_stage2() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("compiler")
-                .stage(2)
-                .render_steps(), @r"
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] rustc 1 <host> -> rustc 2 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_std_stage1() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("std")
-                .render_steps(), @r"
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] rustc 1 <host> -> std 1 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_std_stage2() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("std")
-                .stage(2)
-                .render_steps(), @r"
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [build] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 1 <host> -> clippy-driver 2 <host>
-        [build] rustc 1 <host> -> cargo-clippy 2 <host>
-        [clippy] rustc 2 <host> -> std 2 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_miri_stage1() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("miri")
-                .stage(1)
-                .render_steps(), @r"
-        [build] llvm <host>
-        [check] rustc 0 <host> -> rustc 1 <host>
-        [clippy] rustc 0 <host> -> miri 1 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_miri_stage2() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("miri")
-                .stage(2)
-                .render_steps(), @r"
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
-        [build] rustc 1 <host> -> std 1 <host>
-        [check] rustc 1 <host> -> rustc 2 <host>
-        [build] rustc 0 <host> -> clippy-driver 1 <host>
-        [build] rustc 0 <host> -> cargo-clippy 1 <host>
-        [clippy] rustc 1 <host> -> miri 2 <host>
-        ");
-    }
-
-    #[test]
-    fn clippy_bootstrap() {
-        let ctx = TestCtx::new();
-        insta::assert_snapshot!(
-            ctx.config("clippy")
-                .path("bootstrap")
-                .render_steps(), @"[clippy] rustc 0 <host> -> bootstrap 1 <host>");
     }
 }
 


### PR DESCRIPTION
This reduces the amount of work that is done during `x check compiler`. We still check both backends during `x check` by defaut, even if they are not in `rust.codegen-backends`, as just checking them shouldn't require expensive preparations, like building GCC.

r? @jieyouxu