### PR TITLE
Dogfood `-Zno-embed-metadata` in the standard library

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -299,7 +299,8 @@ impl Step for Std {
             if self.is_for_mir_opt_tests {
                 ArtifactKeepMode::OnlyRmeta
             } else {
-                ArtifactKeepMode::OnlyRlib
+                // We use -Zno-embed-metadata for the standard library
+                ArtifactKeepMode::BothRlibAndRmeta
             },
         );
 
@@ -2645,6 +2646,10 @@ pub enum ArtifactKeepMode {
     OnlyRlib,
     /// Only keep .rmeta files, ignore .rlib files
     OnlyRmeta,
+    /// Keep both .rlib and .rmeta files.
+    /// This is essentially only useful when using `-Zno-embed-metadata`, in which case both the
+    /// .rlib and .rmeta files are needed for compilation/linking.
+    BothRlibAndRmeta,
     /// Custom logic for keeping an artifact
     /// It receives the filename of an artifact, and returns true if it should be kept.
     Custom(Box<dyn Fn(&str) -> bool>),
@@ -2701,6 +2706,9 @@ pub fn run_cargo(
                 match &artifact_keep_mode {
                     ArtifactKeepMode::OnlyRlib => filename.ends_with(".rlib"),
                     ArtifactKeepMode::OnlyRmeta => filename.ends_with(".rmeta"),
+                    ArtifactKeepMode::BothRlibAndRmeta => {
+                        filename.ends_with(".rmeta") || filename.ends_with(".rlib")
+                    }
                     ArtifactKeepMode::Custom(func) => func(&filename),
                 }
             };

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1095,6 +1095,10 @@ impl Builder<'_> {
         // Enable usage of unstable features
         cargo.env("RUSTC_BOOTSTRAP", "1");
 
+        if matches!(mode, Mode::Std) {
+            cargo.arg("-Zno-embed-metadata");
+        }
+
         if self.config.dump_bootstrap_shims {
             prepare_behaviour_dump_dir(self.build);
 

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.rs
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.rs
@@ -3,7 +3,7 @@
 //!
 //! Issue: <https://github.com/rust-lang/rust/issues/31788>
 
-//@ normalize-stderr: "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
+//@ normalize-stderr: "loaded from .*libstd-.*.rmeta" -> "loaded from SYSROOT/libstd-*.rmeta"
 //@ dont-require-annotations: NOTE
 
 #![feature(lang_items)]

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
@@ -9,7 +9,7 @@ LL | | }
    | |_^
    |
    = note: the lang item is first defined in crate `std` (which `E0152_duplicate_lang_items` depends on)
-   = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib
+   = note: first definition in `std` loaded from SYSROOT/libstd-*.rmeta
    = note: second definition in the local crate (`E0152_duplicate_lang_items`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/error-codes/E0152.rs
+++ b/tests/ui/error-codes/E0152.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "loaded from .*liballoc-.*.rlib" -> "loaded from SYSROOT/liballoc-*.rlib"
+//@ normalize-stderr: "loaded from .*liballoc-.*.rmeta" -> "loaded from SYSROOT/liballoc-*.rmeta"
 #![feature(lang_items)]
 
 #[lang = "owned_box"]

--- a/tests/ui/error-codes/E0152.stderr
+++ b/tests/ui/error-codes/E0152.stderr
@@ -5,7 +5,7 @@ LL | struct Foo<T>(T);
    | ^^^^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `alloc` (which `std` depends on)
-   = note: first definition in `alloc` loaded from SYSROOT/liballoc-*.rlib
+   = note: first definition in `alloc` loaded from SYSROOT/liballoc-*.rmeta
    = note: second definition in the local crate (`E0152`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/lang-items/duplicate.rs
+++ b/tests/ui/lang-items/duplicate.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "loaded from .*libcore-.*.rlib" -> "loaded from SYSROOT/libcore-*.rlib"
+//@ normalize-stderr: "loaded from .*libcore-.*.rmeta" -> "loaded from SYSROOT/libcore-*.rmeta"
 #![feature(lang_items)]
 
 #[lang = "sized"]

--- a/tests/ui/lang-items/duplicate.stderr
+++ b/tests/ui/lang-items/duplicate.stderr
@@ -5,7 +5,7 @@ LL | trait Sized {}
    | ^^^^^^^^^^^^^^
    |
    = note: the lang item is first defined in crate `core` (which `std` depends on)
-   = note: first definition in `core` loaded from SYSROOT/libcore-*.rlib
+   = note: first definition in `core` loaded from SYSROOT/libcore-*.rmeta
    = note: second definition in the local crate (`duplicate`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/panic-handler/panic-handler-std.rs
+++ b/tests/ui/panic-handler/panic-handler-std.rs
@@ -1,4 +1,4 @@
-//@ normalize-stderr: "loaded from .*libstd-.*.rlib" -> "loaded from SYSROOT/libstd-*.rlib"
+//@ normalize-stderr: "loaded from .*libstd-.*.rmeta" -> "loaded from SYSROOT/libstd-*.rmeta"
 
 extern crate core;
 

--- a/tests/ui/panic-handler/panic-handler-std.stderr
+++ b/tests/ui/panic-handler/panic-handler-std.stderr
@@ -7,7 +7,7 @@ LL | | }
    | |_^
    |
    = note: the lang item is first defined in crate `std` (which `panic_handler_std` depends on)
-   = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib
+   = note: first definition in `std` loaded from SYSROOT/libstd-*.rmeta
    = note: second definition in the local crate (`panic_handler_std`)
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
This PR dogfoods the [`-Zno-embed-metadata`](https://github.com/rust-lang/cargo/issues/15495) flag in the standard library. This removes the .rmeta portion out of the `libstd.so` file, thus reducing its filesize on disk. Notably, this reduces the amount of MiB that we ship to people who download the standard library.

I think that the only way to find out what this breaks is to try to run full CI, and then try to land it on nightly :)

r? @ghost