### PR TITLE
bootstrap: Fix jemalloc 64K page support for aarch64 tools

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1391,6 +1391,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
 
     // Build jemalloc on AArch64 with support for page sizes up to 64K
     // See: https://github.com/rust-lang/rust/pull/135081
+    // See also the "JEMALLOC_SYS_WITH_LG_PAGE" setting in the tool build step.
     if builder.config.jemalloc(target)
         && target.starts_with("aarch64")
         && env::var_os("JEMALLOC_SYS_WITH_LG_PAGE").is_none()

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -257,6 +257,14 @@ pub fn prepare_tool_cargo(
     // own copy
     cargo.env("LZMA_API_STATIC", "1");
 
+    // Build jemalloc on AArch64 with support for page sizes up to 64K
+    // See: https://github.com/rust-lang/rust/pull/135081
+    // Note that `miri` always uses jemalloc. As such, there is no checking of the jemalloc build flag.
+    // See also the "JEMALLOC_SYS_WITH_LG_PAGE" setting in the compile build step.
+    if target.starts_with("aarch64") && env::var_os("JEMALLOC_SYS_WITH_LG_PAGE").is_none() {
+        cargo.env("JEMALLOC_SYS_WITH_LG_PAGE", "16");
+    }
+
     // CFG_RELEASE is needed by rustfmt (and possibly other tools) which
     // import rustc-ap-rustc_attr which requires this to be set for the
     // `#[cfg(version(...))]` attribute.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Resolves rust-lang/rust#133748 

The prior page size fix only targeted the compile build step, not the tools step: https://github.com/rust-lang/rust/pull/135081

Also note that since `miri` always uses jemalloc, I didn't copy the `builder.config.jemalloc(target)` check to the tools section.

Tested by running `strings` on the compiled `miri` binary to see the LG_PAGE value. 

Before: 

```
> strings miri | grep '^LG_PAGE'
LG_PAGE 14
```

After:

```
> strings miri | grep '^LG_PAGE'
LG_PAGE 16
```

May also need a separate fix for the standalone miri repository: https://github.com/rust-lang/miri/issues/4514 (likely a change needed in miri-script?)