### PR TITLE
Fix bug where `rustdoc-js` tester would not pick the right `search.js` file if there is more than one

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -437,7 +437,7 @@ async function loadSearchJS(doc_folder, resource_suffix) {
     const staticFiles = path.join(doc_folder, "static.files");
     const stringdexJs = mostRecentMatch(staticFiles, /stringdex.*\.js$/);
     const stringdexModule = require(path.join(staticFiles, stringdexJs));
-    const searchJs = mostRecentMatch(staticFiles, /search.*\.js$/);
+    const searchJs = mostRecentMatch(staticFiles, /search-[0-9a-f]{8}.*\.js$/);
     const searchModule = require(path.join(staticFiles, searchJs));
     globalThis.nonnull = (x, msg) => {
         if (x === null) {

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -405,6 +405,24 @@ async function runChecks(testFile, doSearch, parseQuery) {
     return res;
 }
 
+function mostRecentMatch(staticFiles, regex) {
+    const matchingEntries = fs.readdirSync(staticFiles)
+        .filter(f => f.match(regex))
+        .map(f => {
+            const stats = fs.statSync(path.join(staticFiles, f));
+            return {
+                path: f,
+                time: stats.mtimeMs,
+            };
+        });
+    if (matchingEntries.length === 0) {
+        throw "No static file matching regex";
+    }
+    // We sort entries in descending order.
+    matchingEntries.sort((a, b) => b.time - a.time);
+    return matchingEntries[0].path;
+}
+
 /**
  * Load searchNNN.js and search-indexNNN.js.
  *
@@ -417,9 +435,9 @@ async function runChecks(testFile, doSearch, parseQuery) {
  */
 async function loadSearchJS(doc_folder, resource_suffix) {
     const staticFiles = path.join(doc_folder, "static.files");
-    const stringdexJs = fs.readdirSync(staticFiles).find(f => f.match(/stringdex.*\.js$/));
+    const stringdexJs = mostRecentMatch(staticFiles, /stringdex.*\.js$/);
     const stringdexModule = require(path.join(staticFiles, stringdexJs));
-    const searchJs = fs.readdirSync(staticFiles).find(f => f.match(/search.*\.js$/));
+    const searchJs = mostRecentMatch(staticFiles, /search.*\.js$/);
     const searchModule = require(path.join(staticFiles, searchJs));
     globalThis.nonnull = (x, msg) => {
         if (x === null) {


### PR DESCRIPTION
It happened to me quite a few times recently when I worked on the search index:
1. I make a change in search.js
2. I run `rustdoc-js` tests
3. nothing changes

So my solution was to simply remove the folder, but it's really suboptimal. With this PR, it now picks the most recently modified file.

cc @lolbinarycat 