### PR TITLE
Switch Instant to use CLOCK_BOOTTIME on Android.

### DIFF
--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -275,7 +275,9 @@ pub struct Instant {
 impl Instant {
     #[cfg(target_vendor = "apple")]
     pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
-    #[cfg(not(target_vendor = "apple"))]
+    #[cfg(target_os = "android")]
+    pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_BOOTTIME;
+    #[cfg(not(any(target_vendor = "apple", target_os = "android")))]
     pub(crate) const CLOCK_ID: libc::clockid_t = libc::CLOCK_MONOTONIC;
     pub fn now() -> Instant {
         // https://www.manpagez.com/man/3/clock_gettime/
@@ -289,6 +291,9 @@ impl Instant {
         //
         // Instant on macos was historically implemented using mach_absolute_time;
         // we preserve this value domain out of an abundance of caution.
+        //
+        // On Android, we use CLOCK_BOOTTIME because we want the duration between
+        // Instants to not be affected by suspends.
         Instant { t: Timespec::now(Self::CLOCK_ID) }
     }
 


### PR DESCRIPTION
This is a long-term patch we have carried for the Android platform:

https://android.googlesource.com/toolchain/android_rust/+/refs/heads/main/patches/longterm/rustc-0018-Switch-Instant-to-use-CLOCK_BOOTTIME.patch

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
