### PR TITLE
Suppress wrapper suggestion when expected and actual ty are the same adt and the variant is unresolved

### DIFF
--- a/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.rs
+++ b/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.rs
@@ -1,0 +1,26 @@
+// Suppress the suggestion that adding a wrapper.
+// When expected_ty and expr_ty are the same ADT,
+// we prefer to compare their internal generic params,
+// so when the current variant corresponds to an unresolved infer,
+// the suggestion is rejected.
+// e.g. `Ok(Some("hi"))` is type of `Result<Option<&str>, _>`,
+// where `E` is still an unresolved inference variable.
+
+fn foo() -> Result<Option<String>, ()> {
+    todo!()
+}
+
+#[derive(PartialEq, Debug)]
+enum Bar<T, E> {
+    A(T),
+    B(E),
+}
+
+fn bar() -> Bar<String, ()> {
+    todo!()
+}
+
+fn main() {
+    assert_eq!(Ok(Some("hi")), foo()); //~ ERROR mismatched types [E0308]
+    assert_eq!(Bar::A("hi"), bar()); //~ ERROR mismatched types [E0308]
+}

--- a/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.stderr
+++ b/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-add-wrapper-issue-145294.rs:24:32
+   |
+LL |     assert_eq!(Ok(Some("hi")), foo());
+   |                                ^^^^^ expected `Result<Option<&str>, _>`, found `Result<Option<String>, ()>`
+   |
+   = note: expected enum `Result<Option<&str>, _>`
+              found enum `Result<Option<String>, ()>`
+help: try wrapping the expression in `Err`
+   |
+LL |     assert_eq!(Ok(Some("hi")), Err(foo()));
+   |                                ++++     +
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-add-wrapper-issue-145294.rs:25:30
+   |
+LL |     assert_eq!(Bar::A("hi"), bar());
+   |                              ^^^^^ expected `Bar<&str, _>`, found `Bar<String, ()>`
+   |
+   = note: expected enum `Bar<&str, _>`
+              found enum `Bar<String, ()>`
+help: try wrapping the expression in `Bar::B`
+   |
+LL |     assert_eq!(Bar::A("hi"), Bar::B(bar()));
+   |                              +++++++     +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.stderr
+++ b/tests/ui/typeck/suggestions/suggest-add-wrapper-issue-145294.stderr
@@ -6,10 +6,6 @@ LL |     assert_eq!(Ok(Some("hi")), foo());
    |
    = note: expected enum `Result<Option<&str>, _>`
               found enum `Result<Option<String>, ()>`
-help: try wrapping the expression in `Err`
-   |
-LL |     assert_eq!(Ok(Some("hi")), Err(foo()));
-   |                                ++++     +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-add-wrapper-issue-145294.rs:25:30
@@ -19,10 +15,6 @@ LL |     assert_eq!(Bar::A("hi"), bar());
    |
    = note: expected enum `Bar<&str, _>`
               found enum `Bar<String, ()>`
-help: try wrapping the expression in `Bar::B`
-   |
-LL |     assert_eq!(Bar::A("hi"), Bar::B(bar()));
-   |                              +++++++     +
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#145294

I initially tried the desired suggestion in this issue, but since that suggestion occurs in the expected type, it is inappropriate to suggest for expected expressions (see other suggest methods in the same file). I believe that suppressing the incorrect suggestion is the more appropriate choice here.

I opted for a slightly more general approach: when the expected type and actual type are the same ADT (e.g., both are Result in this example), we assume that code tend to compare the internal generic parameters(i.e. `Option<&str>` vs `Option<String>`, instead of `E = _` vs `Result<Option<String>>>`). When `E` is an unresolved infer type in the expected type (`_` in this example), we should not wrapp the actual type.

Two commits show the difference.

r? compiler