### PR TITLE
Add `FnContext` in parser for diagnostic

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use super::{
     AttrWrapper, Capturing, FnParseMode, ForceCollect, Parser, PathStyle, Trailing, UsePreAttrPos,
 };
+use crate::parser::FnContext;
 use crate::{errors, exp, fluent_generated as fluent};
 
 // Public for rustfmt usage
@@ -200,7 +201,7 @@ impl<'a> Parser<'a> {
             AttrWrapper::empty(),
             true,
             false,
-            FnParseMode { req_name: |_| true, req_body: true },
+            FnParseMode { req_name: |_| true, context: FnContext::Free, req_body: true },
             ForceCollect::No,
         ) {
             Ok(Some(item)) => {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -22,7 +22,7 @@ use std::{fmt, mem, slice};
 use attr_wrapper::{AttrWrapper, UsePreAttrPos};
 pub use diagnostics::AttemptLocalParseRecovery;
 pub(crate) use expr::ForbiddenLetReason;
-pub(crate) use item::FnParseMode;
+pub(crate) use item::{FnContext, FnParseMode};
 pub use pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 use path::PathStyle;
 use rustc_ast::token::{

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -19,8 +19,8 @@ use super::diagnostics::AttemptLocalParseRecovery;
 use super::pat::{PatternLocation, RecoverComma};
 use super::path::PathStyle;
 use super::{
-    AttrWrapper, BlockMode, FnParseMode, ForceCollect, Parser, Restrictions, SemiColonMode,
-    Trailing, UsePreAttrPos,
+    AttrWrapper, BlockMode, FnContext, FnParseMode, ForceCollect, Parser, Restrictions,
+    SemiColonMode, Trailing, UsePreAttrPos,
 };
 use crate::errors::{self, MalformedLoopLabel};
 use crate::exp;
@@ -153,7 +153,7 @@ impl<'a> Parser<'a> {
             attrs.clone(), // FIXME: unwanted clone of attrs
             false,
             true,
-            FnParseMode { req_name: |_| true, req_body: true },
+            FnParseMode { req_name: |_| true, context: FnContext::Free, req_body: true },
             force_collect,
         )? {
             self.mk_stmt(lo.to(item.span), StmtKind::Item(Box::new(item)))

--- a/tests/ui/parser/inverted-parameters.rs
+++ b/tests/ui/parser/inverted-parameters.rs
@@ -23,7 +23,6 @@ fn pattern((i32, i32) (a, b)) {}
 fn fizz(i32) {}
 //~^ ERROR expected one of `:`, `@`
 //~| HELP if this is a parameter name, give it a type
-//~| HELP if this is a `self` type, give it a parameter name
 //~| HELP if this is a type, explicitly ignore the parameter name
 
 fn missing_colon(quux S) {}

--- a/tests/ui/parser/inverted-parameters.stderr
+++ b/tests/ui/parser/inverted-parameters.stderr
@@ -34,11 +34,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn fizz(i32) {}
    |            ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn fizz(self: i32) {}
-   |         +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn fizz(i32: TypeName) {}
@@ -49,7 +44,7 @@ LL | fn fizz(_: i32) {}
    |         ++
 
 error: expected one of `:`, `@`, or `|`, found `S`
-  --> $DIR/inverted-parameters.rs:29:23
+  --> $DIR/inverted-parameters.rs:28:23
    |
 LL | fn missing_colon(quux S) {}
    |                  -----^

--- a/tests/ui/parser/lifetime-in-pattern.stderr
+++ b/tests/ui/parser/lifetime-in-pattern.stderr
@@ -16,11 +16,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn test(&'a str) {
    |                ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn test(self: &'a str) {
-   |         +++++
 help: if this is a parameter name, give it a type
    |
 LL - fn test(&'a str) {

--- a/tests/ui/parser/omitted-arg-in-item-fn.stderr
+++ b/tests/ui/parser/omitted-arg-in-item-fn.stderr
@@ -4,11 +4,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn foo(x) {
    |         ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn foo(self: x) {
-   |        +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn foo(x: TypeName) {

--- a/tests/ui/parser/pat-lt-bracket-2.stderr
+++ b/tests/ui/parser/pat-lt-bracket-2.stderr
@@ -4,11 +4,6 @@ error: expected one of `:`, `@`, or `|`, found `<`
 LL | fn a(B<) {}
    |       ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn a(self: B<) {}
-   |      +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn a(_: B<) {}

--- a/tests/ui/parser/suggest-self-in-bare-function.rs
+++ b/tests/ui/parser/suggest-self-in-bare-function.rs
@@ -1,0 +1,25 @@
+// We should not suggest `self` in bare functions.
+// And a note for RFC 1685 should not be shown.
+// See #144968
+
+//@ edition:2018
+
+fn is_even(value) -> bool { //~ ERROR expected one of `:`, `@`, or `|`, found `)`
+    value % 2 == 0
+}
+
+struct S;
+
+impl S {
+    fn is_even(value) -> bool { //~ ERROR expected one of `:`, `@`, or `|`, found `)`
+        value % 2 == 0
+    }
+}
+
+trait T {
+    fn is_even(value) -> bool { //~ ERROR expected one of `:`, `@`, or `|`, found `)`
+        value % 2 == 0
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/suggest-self-in-bare-function.stderr
+++ b/tests/ui/parser/suggest-self-in-bare-function.stderr
@@ -1,0 +1,62 @@
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/suggest-self-in-bare-function.rs:7:17
+   |
+LL | fn is_even(value) -> bool {
+   |                 ^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | fn is_even(self: value) -> bool {
+   |            +++++
+help: if this is a parameter name, give it a type
+   |
+LL | fn is_even(value: TypeName) -> bool {
+   |                 ++++++++++
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn is_even(_: value) -> bool {
+   |            ++
+
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/suggest-self-in-bare-function.rs:14:21
+   |
+LL |     fn is_even(value) -> bool {
+   |                     ^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn is_even(self: value) -> bool {
+   |                +++++
+help: if this is a parameter name, give it a type
+   |
+LL |     fn is_even(value: TypeName) -> bool {
+   |                     ++++++++++
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn is_even(_: value) -> bool {
+   |                ++
+
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/suggest-self-in-bare-function.rs:20:21
+   |
+LL |     fn is_even(value) -> bool {
+   |                     ^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn is_even(self: value) -> bool {
+   |                +++++
+help: if this is a parameter name, give it a type
+   |
+LL |     fn is_even(value: TypeName) -> bool {
+   |                     ++++++++++
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn is_even(_: value) -> bool {
+   |                ++
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/parser/suggest-self-in-bare-function.stderr
+++ b/tests/ui/parser/suggest-self-in-bare-function.stderr
@@ -4,11 +4,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn is_even(value) -> bool {
    |                 ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn is_even(self: value) -> bool {
-   |            +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn is_even(value: TypeName) -> bool {
@@ -24,7 +19,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL |     fn is_even(value) -> bool {
    |                     ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn is_even(self: value) -> bool {

--- a/tests/ui/span/issue-34264.stderr
+++ b/tests/ui/span/issue-34264.stderr
@@ -4,11 +4,6 @@ error: expected one of `:`, `@`, or `|`, found `<`
 LL | fn foo(Option<i32>, String) {}
    |              ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn foo(self: Option<i32>, String) {}
-   |        +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | fn foo(_: Option<i32>, String) {}
@@ -20,7 +15,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn foo(Option<i32>, String) {}
    |                           ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 help: if this is a parameter name, give it a type
    |
 LL | fn foo(Option<i32>, String: TypeName) {}
@@ -36,11 +30,6 @@ error: expected one of `:`, `@`, or `|`, found `,`
 LL | fn bar(x, y: usize) {}
    |         ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | fn bar(self: x, y: usize) {}
-   |        +++++
 help: if this is a parameter name, give it a type
    |
 LL | fn bar(x: TypeName, y: usize) {}

--- a/tests/ui/suggestions/issue-64252-self-type.stderr
+++ b/tests/ui/suggestions/issue-64252-self-type.stderr
@@ -4,11 +4,6 @@ error: expected one of `:`, `@`, or `|`, found `<`
 LL | pub fn foo(Box<Self>) { }
    |               ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
-help: if this is a `self` type, give it a parameter name
-   |
-LL | pub fn foo(self: Box<Self>) { }
-   |            +++++
 help: if this is a type, explicitly ignore the parameter name
    |
 LL | pub fn foo(_: Box<Self>) { }
@@ -20,7 +15,6 @@ error: expected one of `:`, `@`, or `|`, found `<`
 LL |     fn bar(Box<Self>) { }
    |               ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 help: if this is a `self` type, give it a parameter name
    |
 LL |     fn bar(self: Box<Self>) { }

--- a/tests/ui/type/issue-102598.stderr
+++ b/tests/ui/type/issue-102598.stderr
@@ -15,7 +15,6 @@ error: expected one of `:`, `@`, or `|`, found `)`
 LL | fn foo<'a>(_: impl 'a Sized) {}
    |                            ^ expected one of `:`, `@`, or `|`
    |
-   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
 help: if this is a parameter name, give it a type
    |
 LL | fn foo<'a>(_: impl 'a Sized: TypeName) {}


### PR DESCRIPTION
Fixes rust-lang/rust#144968

Inspired by https://github.com/rust-lang/rust/issues/144968#issuecomment-3156094581, I implemented `FnContext` to indicate whether a function should have a self parameter, for example, whether the function is a trait method, whether it is in an impl block. And I removed the outdated note.

I made two commits to show the difference.

cc @estebank @djc 

r? compiler