### PR TITLE
More `iter().last()` -> `last()`, `iter().next()` -> `first()`

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1741,7 +1741,7 @@ fn deny_equality_constraints(
                         .map(|segment| segment.ident.name)
                         .zip(poly.trait_ref.path.segments.iter().map(|segment| segment.ident.name))
                         .all(|(a, b)| a == b)
-                        && let Some(potential_assoc) = full_path.segments.iter().last()
+                        && let Some(potential_assoc) = full_path.segments.last()
                     {
                         suggest(poly, potential_assoc, predicate);
                     }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -771,7 +771,7 @@ impl<'a> AstValidator<'a> {
         self.dcx().emit_err(errors::ArgsBeforeConstraint {
             arg_spans: arg_spans.clone(),
             constraints: constraint_spans[0],
-            args: *arg_spans.iter().last().unwrap(),
+            args: *arg_spans.last().unwrap(),
             data: data.span,
             constraint_spans: errors::EmptyLabelManySpans(constraint_spans),
             arg_spans2: errors::EmptyLabelManySpans(arg_spans),

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -439,10 +439,10 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                 let discr = discr.load_scalar(fx);
 
                 let use_bool_opt = switch_ty.kind() == fx.tcx.types.bool.kind()
-                    || (targets.iter().count() == 1 && targets.iter().next().unwrap().0 == 0);
+                    || (targets.iter().count() == 1 && targets.iter().first().unwrap().0 == 0);
                 if use_bool_opt {
                     assert_eq!(targets.iter().count(), 1);
-                    let (then_value, then_block) = targets.iter().next().unwrap();
+                    let (then_value, then_block) = targets.iter().first().unwrap();
                     let then_block = fx.get_block(then_block);
                     let else_block = fx.get_block(targets.otherwise());
                     let test_zero = match then_value {

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2497,7 +2497,7 @@ impl HumanEmitter {
                 {
                     let mut buffer = StyledBuffer::new();
                     if !self.short_message {
-                        if let Some(child) = children.iter().next()
+                        if let Some(child) = children.first()
                             && child.span.primary_spans().is_empty()
                         {
                             // We'll continue the vertical bar to point into the next note.

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -146,7 +146,7 @@ impl<'ty> FieldInnerTy<'ty> {
             };
 
             let path = &ty_path.path;
-            let ty = path.segments.iter().last().unwrap();
+            let ty = path.segments.last().unwrap();
             let syn::PathArguments::AngleBracketed(bracketed) = &ty.arguments else {
                 panic!("expected bracketed generic arguments");
             };

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -187,7 +187,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     ty::Adt(_, args) => args,
                     _ => bug!("ReborrowPin with non-Pin type"),
                 };
-                let pin_ty = pin_ty_args.iter().next().unwrap().expect_ty();
+                let pin_ty = pin_ty_args.first().unwrap().expect_ty();
                 let ptr_target_ty = match pin_ty.kind() {
                     ty::Ref(_, ty, _) => *ty,
                     _ => bug!("ReborrowPin with non-Ref type"),

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1671,7 +1671,7 @@ impl<'a> Parser<'a> {
     /// If the user writes `S { ref field: name }` instead of `S { field: ref name }`, we suggest
     /// the correct code.
     fn recover_misplaced_pattern_modifiers(&self, fields: &ThinVec<PatField>, err: &mut Diag<'a>) {
-        if let Some(last) = fields.iter().last()
+        if let Some(last) = fields.last()
             && last.is_shorthand
             && let PatKind::Ident(binding, ident, None) = last.pat.kind
             && binding != BindingMode::NONE

--- a/compiler/rustc_parse/src/parser/tests.rs
+++ b/compiler/rustc_parse/src/parser/tests.rs
@@ -2533,7 +2533,7 @@ fn ttdelim_span() {
         .unwrap();
 
         let ast::ExprKind::MacCall(mac) = &expr.kind else { panic!("not a macro") };
-        let span = mac.args.tokens.iter().last().unwrap().span();
+        let span = mac.args.tokens.last().unwrap().span();
 
         match psess.source_map().span_to_snippet(span) {
             Ok(s) => assert_eq!(&s[..], "{ body }"),

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -770,7 +770,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         let mut diag = struct_span_code_err!(self.dcx(), span, E0432, "{msg}");
 
-        if let Some((_, UnresolvedImportError { note: Some(note), .. })) = errors.iter().last() {
+        if let Some((_, UnresolvedImportError { note: Some(note), .. })) = errors.last() {
             diag.note(note.clone());
         }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3726,7 +3726,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 v.could_be_path = false;
             }
             self.report_error(
-                *v.origin.iter().next().unwrap(),
+                *v.origin.first().unwrap(),
                 ResolutionError::VariableNotBoundInPattern(v, self.parent_scope),
             );
         }
@@ -4369,8 +4369,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         self.resolve_path(&std_path, Some(ns), None, source)
                     {
                         // Check if we wrote `str::from_utf8` instead of `std::str::from_utf8`
-                        let item_span =
-                            path.iter().last().map_or(path_span, |segment| segment.ident.span);
+                        let item_span = path.last().map_or(path_span, |segment| segment.ident.span);
 
                         self.r.confused_type_with_std_module.insert(item_span, path_span);
                         self.r.confused_type_with_std_module.insert(path_span, path_span);


### PR DESCRIPTION
r? @estebank

Follow-up to rust-lang/rust#145401, which was missing some cases. Also change `.iter().next()` -> `.first()` when applicable.