### PR TITLE
cleanup: use run_in_tmpdir in run-make/rustdoc-scrape-examples-paths

### DIFF
--- a/tests/run-make/rustdoc-scrape-examples-paths/rmake.rs
+++ b/tests/run-make/rustdoc-scrape-examples-paths/rmake.rs
@@ -1,16 +1,16 @@
 //! Test to ensure that the rustdoc `scrape-examples` feature is not panicking.
 //! Regression test for <https://github.com/rust-lang/rust/issues/144752>.
 
-use run_make_support::{cargo, path, rfs};
+use run_make_support::cargo;
+use run_make_support::scoped_run::run_in_tmpdir;
 
 fn main() {
     // We copy the crate to be documented "outside" to prevent documenting
     // the whole compiler.
-    let tmp = std::env::temp_dir();
-    let test_crate = tmp.join("foo");
-    rfs::copy_dir_all(path("foo"), &test_crate);
-
-    // The `scrape-examples` feature is also implemented in `cargo` so instead of reproducing
-    // what `cargo` does, better to just let `cargo` do it.
-    cargo().current_dir(&test_crate).args(["doc", "-p", "foo", "-Zrustdoc-scrape-examples"]).run();
+    std::env::set_current_dir("foo").unwrap();
+    run_in_tmpdir(|| {
+        // The `scrape-examples` feature is also implemented in `cargo` so instead of reproducing
+        // what `cargo` does, better to just let `cargo` do it.
+        cargo().args(["doc", "-p", "foo", "-Zrustdoc-scrape-examples"]).run();
+    })
 }


### PR DESCRIPTION
We had an issue on our LLVM-head Rust builder where it got stuck with this test failing because it was reusing the tmpdir between runs and something broke the incremental compile. Everything seems to work fine with run_in_tmpdir in this test. tests/run-make/uefi-qemu also uses the same tmpdir across runs, but I don't have the right environment to test that so I didn't try fixing it. That is the only use of std::env::temp_dir left in run-make tests after this fix.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
