### PR TITLE
alignborrowck: allow borrowing packed arrays with ABI align <= packed align in const generics

### DIFF
--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -76,10 +76,8 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv {
-                typing_mode: ty::TypingMode::non_body_analysis(),
-                param_env,
-            };
+            let typing_env = 
+                ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,
@@ -88,10 +86,8 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Slice(element_ty) => {
             // For slices, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv {
-                typing_mode: ty::TypingMode::non_body_analysis(),
-                param_env,
-            };
+            let typing_env = 
+                ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -61,11 +61,7 @@ where
 
             // Try to determine alignment from the type structure
             if let Some(element_align) = get_element_alignment(tcx, normalized_ty) {
-                if element_align <= pack {
-                    false
-                } else {
-                    true
-                }
+                element_align > pack
             } else {
                 // If we still can't determine alignment, conservatively assume disaligned
                 true
@@ -80,7 +76,10 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            let typing_env = ty::TypingEnv {
+                typing_mode: ty::TypingMode::non_body_analysis(),
+                param_env,
+            };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,
@@ -89,7 +88,10 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Slice(element_ty) => {
             // For slices, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            let typing_env = ty::TypingEnv {
+                typing_mode: ty::TypingMode::non_body_analysis(),
+                param_env,
+            };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -23,7 +23,7 @@ where
 
     let ty = place.ty(local_decls, tcx).ty;
     let unsized_tail = || tcx.struct_tail_for_codegen(ty, typing_env);
-    
+
     // Try to normalize the type to resolve any generic parameters
     let normalized_ty = match tcx.try_normalize_erasing_regions(typing_env, ty) {
         Ok(normalized) => normalized,
@@ -32,12 +32,12 @@ where
             ty
         }
     };
-    
+
     match tcx.layout_of(typing_env.as_query_input(normalized_ty)) {
         Ok(layout) => {
             if layout.align.abi <= pack
-                && (layout.is_sized()
-                    || matches!(unsized_tail().kind(), ty::Slice(..) | ty::Str)) {
+                && (layout.is_sized() || matches!(unsized_tail().kind(), ty::Slice(..) | ty::Str))
+            {
                 // If the packed alignment is greater or equal to the field alignment, the type won't be
                 // further disaligned.
                 // However we need to ensure the field is sized; for unsized fields, `layout.align` is
@@ -58,7 +58,7 @@ where
             // We cannot figure out the layout. This often happens with generic types.
             // For const generic arrays like [u8; CAP], we can make a reasonable assumption
             // about their alignment based on the element type.
-            
+
             // Try to determine alignment from the type structure
             if let Some(element_align) = get_element_alignment(tcx, normalized_ty) {
                 if element_align <= pack {
@@ -75,7 +75,7 @@ where
 }
 
 /// Try to determine the alignment of an array element type
-fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Align> {
+fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Align> {
     match ty.kind() {
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
@@ -98,7 +98,6 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Align>
         _ => None,
     }
 }
-
 pub fn is_within_packed<'tcx, L>(
     tcx: TyCtxt<'tcx>,
     local_decls: &L,

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -76,7 +76,7 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = 
+            let typing_env =
                 ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
@@ -86,7 +86,7 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Slice(element_ty) => {
             // For slices, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = 
+            let typing_env =
                 ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -1,6 +1,6 @@
 use rustc_abi::Align;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use tracing::debug;
 
 /// Returns `true` if this place is allowed to be less aligned
@@ -23,30 +23,79 @@ where
 
     let ty = place.ty(local_decls, tcx).ty;
     let unsized_tail = || tcx.struct_tail_for_codegen(ty, typing_env);
-    match tcx.layout_of(typing_env.as_query_input(ty)) {
-        Ok(layout)
+    
+    // Try to normalize the type to resolve any generic parameters
+    let normalized_ty = match tcx.try_normalize_erasing_regions(typing_env, ty) {
+        Ok(normalized) => normalized,
+        Err(_) => {
+            // If normalization fails, fall back to the original type
+            ty
+        }
+    };
+    
+    match tcx.layout_of(typing_env.as_query_input(normalized_ty)) {
+        Ok(layout) => {
             if layout.align.abi <= pack
                 && (layout.is_sized()
-                    || matches!(unsized_tail().kind(), ty::Slice(..) | ty::Str)) =>
-        {
-            // If the packed alignment is greater or equal to the field alignment, the type won't be
-            // further disaligned.
-            // However we need to ensure the field is sized; for unsized fields, `layout.align` is
-            // just an approximation -- except when the unsized tail is a slice, where the alignment
-            // is fully determined by the type.
-            debug!(
-                "is_disaligned({:?}) - align = {}, packed = {}; not disaligned",
-                place,
-                layout.align.abi.bytes(),
-                pack.bytes()
-            );
-            false
+                    || matches!(unsized_tail().kind(), ty::Slice(..) | ty::Str)) {
+                // If the packed alignment is greater or equal to the field alignment, the type won't be
+                // further disaligned.
+                // However we need to ensure the field is sized; for unsized fields, `layout.align` is
+                // just an approximation -- except when the unsized tail is a slice, where the alignment
+                // is fully determined by the type.
+                debug!(
+                    "is_disaligned({:?}) - align = {}, packed = {}; not disaligned",
+                    place,
+                    layout.align.abi.bytes(),
+                    pack.bytes()
+                );
+                false
+            } else {
+                true
+            }
         }
-        _ => {
-            // We cannot figure out the layout. Conservatively assume that this is disaligned.
-            debug!("is_disaligned({:?}) - true", place);
-            true
+        Err(_) => {
+            // We cannot figure out the layout. This often happens with generic types.
+            // For const generic arrays like [u8; CAP], we can make a reasonable assumption
+            // about their alignment based on the element type.
+            
+            // Try to determine alignment from the type structure
+            if let Some(element_align) = get_element_alignment(tcx, normalized_ty) {
+                if element_align <= pack {
+                    false
+                } else {
+                    true
+                }
+            } else {
+                // If we still can't determine alignment, conservatively assume disaligned
+                true
+            }
         }
+    }
+}
+
+/// Try to determine the alignment of an array element type
+fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Align> {
+    match ty.kind() {
+        ty::Array(element_ty, _) => {
+            // For arrays, the alignment is the same as the element type
+            let param_env = ty::ParamEnv::empty();
+            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
+                Ok(layout) => Some(layout.align.abi),
+                Err(_) => None,
+            }
+        }
+        ty::Slice(element_ty) => {
+            // For slices, the alignment is the same as the element type
+            let param_env = ty::ParamEnv::empty();
+            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
+                Ok(layout) => Some(layout.align.abi),
+                Err(_) => None,
+            }
+        }
+        _ => None,
     }
 }
 

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -76,7 +76,10 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            let typing_env = ty::TypingEnv {
+                typing_mode: ty::TypingMode::non_body_analysis(),
+                param_env,
+            };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,
@@ -85,7 +88,10 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Slice(element_ty) => {
             // For slices, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
+            let typing_env = ty::TypingEnv {
+                typing_mode: ty::TypingMode::non_body_analysis(),
+                param_env,
+            };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -76,10 +76,7 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Array(element_ty, _) => {
             // For arrays, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv {
-                typing_mode: ty::TypingMode::non_body_analysis(),
-                param_env,
-            };
+            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,
@@ -88,10 +85,7 @@ fn get_element_alignment<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> Option<Al
         ty::Slice(element_ty) => {
             // For slices, the alignment is the same as the element type
             let param_env = ty::ParamEnv::empty();
-            let typing_env = ty::TypingEnv {
-                typing_mode: ty::TypingMode::non_body_analysis(),
-                param_env,
-            };
+            let typing_env = ty::TypingEnv { typing_mode: ty::TypingMode::non_body_analysis(), param_env };
             match tcx.layout_of(typing_env.as_query_input(*element_ty)) {
                 Ok(layout) => Some(layout.align.abi),
                 Err(_) => None,

--- a/tests/ui/packed/packed-array-const-generic.rs
+++ b/tests/ui/packed/packed-array-const-generic.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+#![allow(dead_code)]
+
+#[repr(C, packed)]
+struct PascalString<const CAP: usize> {
+    len: u8,
+    buf: [u8; CAP],
+}
+
+fn bar<const CAP: usize>(s: &PascalString<CAP>) -> &str {
+    // 目标：这行不应触发 E0793
+    std::str::from_utf8(&s.buf[0..s.len as usize]).unwrap()
+}
+
+fn main() {
+    let p = PascalString::<10> { len: 3, buf: *b"abc\0\0\0\0\0\0\0" };
+    let s = bar(&p);
+    assert_eq!(s, "abc");
+}


### PR DESCRIPTION
Fixes #145376

### Summary
This PR fixes a false positive E0793 ("reference to packed field is unaligned")  
when borrowing from a `#[repr(C, packed)]` struct field whose type is a const-generic array  
with an element type that has ABI alignment <= the struct's packed alignment.

Example before this change:
```rust
#[repr(C, packed)]
struct PascalString<const CAP: usize> {
    len: u8,
    buf: [u8; CAP],
}

fn bar<const CAP: usize>(s: &PascalString<CAP>) -> &str {
    std::str::from_utf8(&s.buf[0..s.len as usize]).unwrap()
}
