### PR TITLE
Fix typos in bootstrap.example.toml

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -9,7 +9,7 @@
 # a custom configuration file can also be specified with `--config` to the build
 # system.
 #
-# Note that the following are equivelent, for more details see <https://toml.io/en/v1.0.0>.
+# Note that the following are equivalent, for more details see <https://toml.io/en/v1.0.0>.
 #
 #     build.verbose = 1
 #
@@ -482,7 +482,7 @@
 # Use `--extra-checks=''` to temporarily disable all extra checks.
 #
 # Automatically enabled in the "tools" profile.
-# Set to the empty string to force disable (recommeded for hdd systems).
+# Set to the empty string to force disable (recommended for hdd systems).
 #build.tidy-extra-checks = ""
 
 # Indicates whether ccache is used when building certain artifacts (e.g. LLVM).


### PR DESCRIPTION
Founds these small typos while looking around.

`equivelent` -> `equivalent`
`recommeded` -> `recommended`

cheers :)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
