### PR TITLE
compiletest: Require explicit `--filecheck-prefixes`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2071,25 +2071,6 @@ impl<'test> TestCx<'test> {
         let mut filecheck = Command::new(self.config.llvm_filecheck.as_ref().unwrap());
         filecheck.arg("--input-file").arg(output).arg(&self.testpaths.file);
 
-        // Because we use custom prefixes, we also have to register the default prefix.
-        filecheck.arg("--check-prefix=CHECK");
-
-        // FIXME(#134510): auto-registering revision names as check prefix is a bit sketchy, and
-        // that having to pass `--allow-unused-prefix` is an unfortunate side-effect of not knowing
-        // whether the test author actually wanted revision-specific check prefixes or not.
-        //
-        // TL;DR We may not want to conflate `compiletest` revisions and `FileCheck` prefixes.
-
-        // HACK: tests are allowed to use a revision name as a check prefix.
-        if let Some(rev) = self.revision {
-            filecheck.arg("--check-prefix").arg(rev);
-        }
-
-        // HACK: the filecheck tool normally fails if a prefix is defined but not used. However,
-        // sometimes revisions are used to specify *compiletest* directives which are not FileCheck
-        // concerns.
-        filecheck.arg("--allow-unused-prefixes");
-
         // Provide more context on failures.
         filecheck.args(&["--dump-input-context", "100"]);
 

--- a/tests/assembly-llvm/aarch64-pointer-auth.rs
+++ b/tests/assembly-llvm/aarch64-pointer-auth.rs
@@ -6,8 +6,11 @@
 //@ needs-llvm-components: aarch64
 //@ compile-flags: --target aarch64-unknown-linux-gnu
 //@ [PACRET] compile-flags: -Z branch-protection=pac-ret,leaf
+//@ [PACRET] filecheck-flags: --check-prefixes=PACRET
 //@ [PAUTHLR_NOP] compile-flags: -Z branch-protection=pac-ret,pc,leaf
+//@ [PAUTHLR_NOP] filecheck-flags: --check-prefixes=PAUTHLR_NOP
 //@ [PAUTHLR] compile-flags: -C target-feature=+pauth-lr -Z branch-protection=pac-ret,pc,leaf
+//@ [PAUTHLR] filecheck-flags: --check-prefixes=PAUTHLR
 
 #![feature(no_core, lang_items)]
 #![no_std]

--- a/tests/assembly-llvm/asm/arm-types.rs
+++ b/tests/assembly-llvm/asm/arm-types.rs
@@ -7,6 +7,8 @@
 //@[d32] compile-flags: -C target-feature=+d32
 //@[neon] compile-flags: -C target-feature=+neon --cfg d32
 //@[neon] filecheck-flags: --check-prefix d32
+//@[d32] filecheck-flags: --check-prefixes=CHECK,d32
+//@[neon] filecheck-flags: --check-prefixes=CHECK,neon
 //@ needs-llvm-components: arm
 
 #![feature(no_core, repr_simd, f16)]

--- a/tests/assembly-llvm/asm/loongarch-type.rs
+++ b/tests/assembly-llvm/asm/loongarch-type.rs
@@ -8,6 +8,7 @@
 
 //@[loongarch64] compile-flags: --target loongarch64-unknown-none
 //@[loongarch64] needs-llvm-components: loongarch
+//@[loongarch64] filecheck-flags: --check-prefixes=CHECK,loongarch64
 
 //@ compile-flags: -Zmerge-functions=disabled
 

--- a/tests/assembly-llvm/asm/mips-types.rs
+++ b/tests/assembly-llvm/asm/mips-types.rs
@@ -5,6 +5,8 @@
 //@[mips32] needs-llvm-components: mips
 //@[mips64] compile-flags: --target mips64-unknown-linux-gnuabi64
 //@[mips64] needs-llvm-components: mips
+//@[mips32] filecheck-flags: --check-prefixes=CHECK,mips32
+//@[mips64] filecheck-flags: --check-prefixes=CHECK,mips64
 //@ compile-flags: -Zmerge-functions=disabled
 
 #![feature(no_core, asm_experimental_arch)]

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -4,12 +4,16 @@
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
 //@[powerpc_altivec] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec --cfg altivec
+//@[powerpc_altivec] filecheck-flags: --check-prefixes=CHECK,powerpc_altivec
 //@[powerpc_altivec] needs-llvm-components: powerpc
 //@[powerpc_vsx] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx --cfg altivec --cfg vsx
+//@[powerpc_vsx] filecheck-flags: --check-prefixes=CHECK,powerpc_vsx
 //@[powerpc_vsx] needs-llvm-components: powerpc
 //@[powerpc64] compile-flags: --target powerpc64-unknown-linux-gnu --cfg altivec
+//@[powerpc64] filecheck-flags: --check-prefixes=CHECK,powerpc64
 //@[powerpc64] needs-llvm-components: powerpc
 //@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg altivec --cfg vsx
+//@[powerpc64_vsx] filecheck-flags: --check-prefixes=CHECK,powerpc64_vsx
 //@[powerpc64_vsx] needs-llvm-components: powerpc
 //@ compile-flags: -Zmerge-functions=disabled
 

--- a/tests/assembly-llvm/asm/riscv-types.rs
+++ b/tests/assembly-llvm/asm/riscv-types.rs
@@ -4,6 +4,7 @@
 
 //@[riscv64] compile-flags: --target riscv64imac-unknown-none-elf
 //@[riscv64] needs-llvm-components: riscv
+//@[riscv64] filecheck-flags: --check-prefixes=CHECK,riscv64
 
 //@[riscv32] compile-flags: --target riscv32imac-unknown-none-elf
 //@[riscv32] needs-llvm-components: riscv
@@ -11,21 +12,22 @@
 //@[riscv64-zfhmin] compile-flags: --target riscv64imac-unknown-none-elf --cfg riscv64
 //@[riscv64-zfhmin] needs-llvm-components: riscv
 //@[riscv64-zfhmin] compile-flags: -C target-feature=+zfhmin
-//@[riscv64-zfhmin] filecheck-flags: --check-prefix riscv64
+//@[riscv64-zfhmin] filecheck-flags: --check-prefixes=CHECK,riscv64
 
 //@[riscv32-zfhmin] compile-flags: --target riscv32imac-unknown-none-elf
 //@[riscv32-zfhmin] needs-llvm-components: riscv
 //@[riscv32-zfhmin] compile-flags: -C target-feature=+zfhmin
+//@[riscv32-zfhmin] filecheck-flags: --check-prefixes=CHECK,zfhmin
 
 //@[riscv64-zfh] compile-flags: --target riscv64imac-unknown-none-elf --cfg riscv64
 //@[riscv64-zfh] needs-llvm-components: riscv
 //@[riscv64-zfh] compile-flags: -C target-feature=+zfh
-//@[riscv64-zfh] filecheck-flags: --check-prefix riscv64 --check-prefix zfhmin
+//@[riscv64-zfh] filecheck-flags: --check-prefixes=CHECK,riscv64 --check-prefix zfhmin
 
 //@[riscv32-zfh] compile-flags: --target riscv32imac-unknown-none-elf
 //@[riscv32-zfh] needs-llvm-components: riscv
 //@[riscv32-zfh] compile-flags: -C target-feature=+zfh
-//@[riscv32-zfh] filecheck-flags: --check-prefix zfhmin
+//@[riscv32-zfh] filecheck-flags: --check-prefixes=CHECK,zfhmin
 
 //@ compile-flags: -C target-feature=+d
 //@ compile-flags: -Zmerge-functions=disabled

--- a/tests/assembly-llvm/asm/s390x-types.rs
+++ b/tests/assembly-llvm/asm/s390x-types.rs
@@ -5,6 +5,7 @@
 //@[s390x] needs-llvm-components: systemz
 //@[s390x_vector] compile-flags: --target s390x-unknown-linux-gnu -C target-feature=+vector
 //@[s390x_vector] needs-llvm-components: systemz
+//@[s390x_vector] filecheck-flags: --check-prefixes=CHECK,s390x_vector
 //@ compile-flags: -Zmerge-functions=disabled
 
 #![feature(no_core, repr_simd, f128)]

--- a/tests/assembly-llvm/asm/sparc-types.rs
+++ b/tests/assembly-llvm/asm/sparc-types.rs
@@ -7,6 +7,7 @@
 //@[sparcv8plus] needs-llvm-components: sparc
 //@[sparc64] compile-flags: --target sparc64-unknown-linux-gnu
 //@[sparc64] needs-llvm-components: sparc
+//@[sparc64] filecheck-flags: --check-prefixes=CHECK,sparc64
 //@ compile-flags: -Zmerge-functions=disabled
 
 #![feature(no_core, asm_experimental_arch)]

--- a/tests/assembly-llvm/asm/x86-modifiers.rs
+++ b/tests/assembly-llvm/asm/x86-modifiers.rs
@@ -6,6 +6,8 @@
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-gnu
 //@[i686] needs-llvm-components: x86
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
+//@[i686] filecheck-flags: --check-prefixes=CHECK,i686
 //@ compile-flags: -C llvm-args=--x86-asm-syntax=intel
 //@ compile-flags: -C target-feature=+avx512bw
 //@ compile-flags: -Zmerge-functions=disabled

--- a/tests/assembly-llvm/asm/x86-types.rs
+++ b/tests/assembly-llvm/asm/x86-types.rs
@@ -5,6 +5,8 @@
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-gnu
 //@[i686] needs-llvm-components: x86
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
+//@[i686] filecheck-flags: --check-prefixes=CHECK,i686
 //@ compile-flags: -C llvm-args=--x86-asm-syntax=intel
 //@ compile-flags: -C target-feature=+avx512bw
 //@ compile-flags: -Zmerge-functions=disabled

--- a/tests/assembly-llvm/nvptx-safe-naming.rs
+++ b/tests/assembly-llvm/nvptx-safe-naming.rs
@@ -4,6 +4,8 @@
 //@ revisions: LLVM20 LLVM21
 //@ [LLVM21] min-llvm-version: 21
 //@ [LLVM20] max-llvm-major-version: 20
+//@ [LLVM21] filecheck-flags: --check-prefixes=CHECK,LLVM21
+//@ [LLVM20] filecheck-flags: --check-prefixes=CHECK,LLVM20
 
 #![feature(abi_ptx)]
 #![no_std]

--- a/tests/assembly-llvm/powerpc64-struct-abi.rs
+++ b/tests/assembly-llvm/powerpc64-struct-abi.rs
@@ -3,18 +3,17 @@
 //@ assembly-output: emit-asm
 //@ compile-flags: -Copt-level=3
 //@[elfv1-be] compile-flags: --target powerpc64-unknown-linux-gnu
+//@[elfv1-be] filecheck-flags: --check-prefixes=CHECK,elfv1-be,be,elf
 //@[elfv1-be] needs-llvm-components: powerpc
 //@[elfv2-be] compile-flags: --target powerpc64-unknown-linux-musl
+//@[elfv2-be] filecheck-flags: --check-prefixes=CHECK,elfv2-be,be,elf
 //@[elfv2-be] needs-llvm-components: powerpc
 //@[elfv2-le] compile-flags: --target powerpc64le-unknown-linux-gnu -C target-cpu=pwr8
+//@[elfv2-le] filecheck-flags: --check-prefixes=CHECK,elfv2-le,elf
 //@[elfv2-le] needs-llvm-components: powerpc
 //@[aix] compile-flags: --target powerpc64-ibm-aix
+//@[aix] filecheck-flags: --check-prefixes=CHECK,aix
 //@[aix] needs-llvm-components: powerpc
-//@[elfv1-be] filecheck-flags: --check-prefix be
-//@[elfv2-be] filecheck-flags: --check-prefix be
-//@[elfv1-be] filecheck-flags: --check-prefix elf
-//@[elfv2-be] filecheck-flags: --check-prefix elf
-//@[elfv2-le] filecheck-flags: --check-prefix elf
 
 #![feature(no_core, lang_items)]
 #![no_std]

--- a/tests/assembly-llvm/riscv-soft-abi-with-float-features.rs
+++ b/tests/assembly-llvm/riscv-soft-abi-with-float-features.rs
@@ -5,6 +5,8 @@
 //@ revisions: LLVM-PRE-20 LLVM-POST-20
 //@ [LLVM-PRE-20] max-llvm-major-version: 19
 //@ [LLVM-POST-20] min-llvm-version: 20
+//@ [LLVM-PRE-20] filecheck-flags: --check-prefixes=CHECK,LLVM-PRE-20
+//@ [LLVM-POST-20] filecheck-flags: --check-prefixes=CHECK,LLVM-POST-20
 
 #![feature(no_core, lang_items, f16)]
 #![crate_type = "lib"]

--- a/tests/assembly-llvm/rust-abi-arg-attr.rs
+++ b/tests/assembly-llvm/rust-abi-arg-attr.rs
@@ -8,6 +8,9 @@
 //@ [riscv64-zbb] needs-llvm-components: riscv
 //@ [loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@ [loongarch64] needs-llvm-components: loongarch
+//@ [riscv64] filecheck-flags: --check-prefixes=CHECK,riscv64
+//@ [riscv64-zbb] filecheck-flags: --check-prefixes=CHECK,riscv64-zbb
+//@ [loongarch64] filecheck-flags: --check-prefixes=CHECK,loongarch64
 
 #![feature(no_core, lang_items, intrinsics, rustc_attrs)]
 #![crate_type = "lib"]

--- a/tests/assembly-llvm/s390x-backchain-toggle.rs
+++ b/tests/assembly-llvm/s390x-backchain-toggle.rs
@@ -5,6 +5,9 @@
 //@ needs-llvm-components: systemz
 //@[enable-backchain] compile-flags: -Ctarget-feature=+backchain
 //@[disable-backchain] compile-flags: -Ctarget-feature=-backchain
+//@[enable-backchain] filecheck-flags: --check-prefixes=CHECK,enable-backchain
+//@[disable-backchain] filecheck-flags: --check-prefixes=CHECK,disable-backchain
+
 #![feature(no_core, lang_items)]
 #![no_std]
 #![no_core]

--- a/tests/assembly-llvm/s390x-vector-abi.rs
+++ b/tests/assembly-llvm/s390x-vector-abi.rs
@@ -3,10 +3,12 @@
 //@ assembly-output: emit-asm
 //@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 //@[z10] compile-flags: --target s390x-unknown-linux-gnu  -C target-cpu=z10 --cfg no_vector
+//@[z10] filecheck-flags: --check-prefixes=CHECK,z10
 //@[z10] needs-llvm-components: systemz
 //@[z10_vector] compile-flags: --target s390x-unknown-linux-gnu -C target-cpu=z10 -C target-feature=+vector
 //@[z10_vector] needs-llvm-components: systemz
 //@[z13] compile-flags: --target s390x-unknown-linux-gnu -C target-cpu=z13
+//@[z13] filecheck-flags: --check-prefixes=CHECK,z13
 //@[z13] needs-llvm-components: systemz
 //@[z13_no_vector] compile-flags: --target s390x-unknown-linux-gnu -C target-cpu=z13 -C target-feature=-vector --cfg no_vector
 //@[z13_no_vector] needs-llvm-components: systemz

--- a/tests/assembly-llvm/simd-bitmask.rs
+++ b/tests/assembly-llvm/simd-bitmask.rs
@@ -1,14 +1,18 @@
 //@ add-core-stubs
 //@ revisions: x86 x86-avx2 x86-avx512 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
+//@ [x86] filecheck-flags: --check-prefixes=CHECK,x86
 //@ [x86] needs-llvm-components: x86
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
+//@ [x86-avx2] filecheck-flags: --check-prefixes=CHECK,x86-avx2
 //@ [x86-avx2] needs-llvm-components: x86
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
 //@ [x86-avx512] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
+//@ [aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort

--- a/tests/assembly-llvm/simd-intrinsic-gather.rs
+++ b/tests/assembly-llvm/simd-intrinsic-gather.rs
@@ -3,6 +3,7 @@
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 

--- a/tests/assembly-llvm/simd-intrinsic-mask-load.rs
+++ b/tests/assembly-llvm/simd-intrinsic-mask-load.rs
@@ -2,9 +2,11 @@
 //@ revisions: x86-avx2 x86-avx512
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
+//@ [x86-avx2] filecheck-flags: --check-prefixes=CHECK,x86-avx2
 //@ [x86-avx2] needs-llvm-components: x86
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
 //@ [x86-avx512] needs-llvm-components: x86
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort

--- a/tests/assembly-llvm/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly-llvm/simd-intrinsic-mask-reduce.rs
@@ -4,8 +4,10 @@
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 // Set the base cpu explicitly, in case the default has been changed.
 //@ [x86] compile-flags: -C target-cpu=x86-64
+//@ [x86] filecheck-flags: --check-prefixes=CHECK,x86
 //@ [x86] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
+//@ [aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort

--- a/tests/assembly-llvm/simd-intrinsic-mask-store.rs
+++ b/tests/assembly-llvm/simd-intrinsic-mask-store.rs
@@ -3,9 +3,11 @@
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
 //@ [x86-avx2] needs-llvm-components: x86
+//@ [x86-avx2] filecheck-flags: --check-prefixes=CHECK,x86-avx2
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 

--- a/tests/assembly-llvm/simd-intrinsic-scatter.rs
+++ b/tests/assembly-llvm/simd-intrinsic-scatter.rs
@@ -3,6 +3,7 @@
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 

--- a/tests/assembly-llvm/simd-intrinsic-select.rs
+++ b/tests/assembly-llvm/simd-intrinsic-select.rs
@@ -8,6 +8,9 @@
 //@ [x86-avx512] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
+//@ [x86-avx2] filecheck-flags: --check-prefixes=CHECK,x86-avx2
+//@ [x86-avx512] filecheck-flags: --check-prefixes=CHECK,x86-avx512
+//@ [aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 

--- a/tests/assembly-llvm/simd/reduce-fadd-unordered.rs
+++ b/tests/assembly-llvm/simd/reduce-fadd-unordered.rs
@@ -5,7 +5,10 @@
 //@[aarch64] only-aarch64
 //@[x86_64] only-x86_64
 //@[x86_64] compile-flags: -Ctarget-feature=+sse3
+//@[aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
 //@ ignore-sgx Test incompatible with LVI mitigations
+
 #![feature(portable_simd)]
 #![feature(core_intrinsics)]
 use std::intrinsics::simd as intrinsics;

--- a/tests/assembly-llvm/static-relocation-model.rs
+++ b/tests/assembly-llvm/static-relocation-model.rs
@@ -7,6 +7,9 @@
 //@ [A64] needs-llvm-components: aarch64
 //@ [ppc64le] compile-flags: --target powerpc64le-unknown-linux-gnu -Crelocation-model=static
 //@ [ppc64le] needs-llvm-components: powerpc
+//@ [x64] filecheck-flags: --check-prefixes=CHECK,x64
+//@ [A64] filecheck-flags: --check-prefixes=CHECK,A64
+//@ [ppc64le] filecheck-flags: --check-prefixes=CHECK,ppc64le
 
 #![feature(no_core, lang_items)]
 #![no_core]

--- a/tests/assembly-llvm/x86-return-float.rs
+++ b/tests/assembly-llvm/x86-return-float.rs
@@ -15,6 +15,8 @@
 //@[win] needs-llvm-components: x86
 //@[linux] compile-flags: --target i686-unknown-linux-gnu
 //@[win] compile-flags: --target i686-pc-windows-msvc
+//@[linux] filecheck-flags: --check-prefixes=CHECK,linux
+//@[win] filecheck-flags: --check-prefixes=CHECK,win
 
 #![crate_type = "lib"]
 #![feature(f16, f128)]

--- a/tests/assembly-llvm/x86_64-windows-i128-abi.rs
+++ b/tests/assembly-llvm/x86_64-windows-i128-abi.rs
@@ -6,6 +6,8 @@
 //@[msvc] needs-llvm-components: x86
 //@[softfloat] compile-flags: --target x86_64-unknown-uefi
 //@[softfloat] needs-llvm-components: x86
+//@[msvc] filecheck-flags: --check-prefixes=CHECK,msvc
+//@[softfloat] filecheck-flags: --check-prefixes=CHECK,softfloat
 
 #![feature(no_core)]
 #![no_core]

--- a/tests/codegen-llvm/README.md
+++ b/tests/codegen-llvm/README.md
@@ -1,14 +1,15 @@
 The files here use the LLVM FileCheck framework, documented at
 <https://llvm.org/docs/CommandGuide/FileCheck.html>.
 
-One extension worth noting is the use of revisions as custom prefixes for
-FileCheck. If your codegen test has different behavior based on the chosen
-target or different compiler flags that you want to exercise, you can use a
-revisions annotation, like so:
+If your codegen test has different behavior based on the chosen target or
+different compiler flags that you want to exercise, you can set different
+filecheck prefixes for each revision:
 
 ```rust
 // revisions: aaa bbb
 // [bbb] compile-flags: --flags-for-bbb
+// [aaa] filecheck-flags: --check-prefixes=ALL,AAA
+// [bbb] filecheck-flags: --check-prefixes=ALL,BBB
 ```
 
 After specifying those variations, you can write different expected, or
@@ -16,9 +17,9 @@ explicitly *unexpected* output by using `<prefix>-SAME:` and `<prefix>-NOT:`,
 like so:
 
 ```rust
-// CHECK: expected code
-// aaa-SAME: emitted-only-for-aaa
-// aaa-NOT:                        emitted-only-for-bbb
-// bbb-NOT:  emitted-only-for-aaa
-// bbb-SAME:                       emitted-only-for-bbb
+// ALL: expected code
+// AAA-SAME: emitted-only-for-aaa
+// AAA-NOT:                        emitted-only-for-bbb
+// BBB-NOT:  emitted-only-for-aaa
+// BBB-SAME:                       emitted-only-for-bbb
 ```

--- a/tests/codegen-llvm/aarch64-struct-align-128.rs
+++ b/tests/codegen-llvm/aarch64-struct-align-128.rs
@@ -5,6 +5,9 @@
 //@[linux] compile-flags: --target aarch64-unknown-linux-gnu
 //@[darwin] compile-flags: --target aarch64-apple-darwin
 //@[win] compile-flags: --target aarch64-pc-windows-msvc
+//@[linux] filecheck-flags: --check-prefixes=linux
+//@[darwin] filecheck-flags: --check-prefixes=darwin
+//@[win] filecheck-flags: --check-prefixes=win
 //@[linux] needs-llvm-components: aarch64
 //@[darwin] needs-llvm-components: aarch64
 //@[win] needs-llvm-components: aarch64

--- a/tests/codegen-llvm/abi-efiapi.rs
+++ b/tests/codegen-llvm/abi-efiapi.rs
@@ -3,14 +3,19 @@
 //@ add-core-stubs
 //@ revisions:x86_64 i686 aarch64 arm riscv
 //@[x86_64] compile-flags: --target x86_64-unknown-uefi
+//@[x86_64] filecheck-flags: --check-prefixes=x86_64
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-musl
+//@[i686] filecheck-flags: --check-prefixes=i686
 //@[i686] needs-llvm-components: x86
 //@[aarch64] compile-flags: --target aarch64-unknown-none
+//@[aarch64] filecheck-flags: --check-prefixes=aarch64
 //@[aarch64] needs-llvm-components: aarch64
 //@[arm] compile-flags: --target armv7r-none-eabi
+//@[arm] filecheck-flags: --check-prefixes=arm
 //@[arm] needs-llvm-components: arm
 //@[riscv] compile-flags: --target riscv64gc-unknown-none-elf
+//@[riscv] filecheck-flags: --check-prefixes=riscv
 //@[riscv] needs-llvm-components: riscv
 //@ compile-flags: -C no-prepopulate-passes
 

--- a/tests/codegen-llvm/abi-repr-ext.rs
+++ b/tests/codegen-llvm/abi-repr-ext.rs
@@ -4,18 +4,24 @@
 //@ revisions:x86_64 i686 aarch64-apple aarch64-windows aarch64-linux arm riscv
 
 //@[x86_64] compile-flags: --target x86_64-unknown-uefi
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-musl
 //@[i686] needs-llvm-components: x86
 //@[aarch64-windows] compile-flags: --target aarch64-pc-windows-msvc
+//@[aarch64-windows] filecheck-flags: --check-prefixes=CHECK,aarch64-windows
 //@[aarch64-windows] needs-llvm-components: aarch64
 //@[aarch64-linux] compile-flags: --target aarch64-unknown-linux-gnu
+//@[aarch64-linux] filecheck-flags: --check-prefixes=CHECK,aarch64-linux
 //@[aarch64-linux] needs-llvm-components: aarch64
 //@[aarch64-apple] compile-flags: --target aarch64-apple-darwin
+//@[aarch64-apple] filecheck-flags: --check-prefixes=CHECK,aarch64-apple
 //@[aarch64-apple] needs-llvm-components: aarch64
 //@[arm] compile-flags: --target armv7r-none-eabi
+//@[arm] filecheck-flags: --check-prefixes=CHECK,arm
 //@[arm] needs-llvm-components: arm
 //@[riscv] compile-flags: --target riscv64gc-unknown-none-elf
+//@[riscv] filecheck-flags: --check-prefixes=CHECK,riscv
 //@[riscv] needs-llvm-components: riscv
 
 // See bottom of file for a corresponding C source file that is meant to yield

--- a/tests/codegen-llvm/abi-x86-sse.rs
+++ b/tests/codegen-llvm/abi-x86-sse.rs
@@ -2,14 +2,17 @@
 
 //@ revisions: x86-64
 //@[x86-64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[x86-64] filecheck-flags: --check-prefixes=x86-64
 //@[x86-64] needs-llvm-components: x86
 
 //@ revisions: x86-32
 //@[x86-32] compile-flags: --target i686-unknown-linux-gnu
+//@[x86-32] filecheck-flags: --check-prefixes=x86-32
 //@[x86-32] needs-llvm-components: x86
 
 //@ revisions: x86-32-nosse
 //@[x86-32-nosse] compile-flags: --target i586-unknown-linux-gnu
+//@[x86-32-nosse] filecheck-flags: --check-prefixes=x86-32-nosse
 //@[x86-32-nosse] needs-llvm-components: x86
 
 #![feature(no_core, lang_items, rustc_attrs, repr_simd)]

--- a/tests/codegen-llvm/align-byval-alignment-mismatch.rs
+++ b/tests/codegen-llvm/align-byval-alignment-mismatch.rs
@@ -5,8 +5,10 @@
 //@ compile-flags: -Cno-prepopulate-passes -Copt-level=1 -Cpanic=abort
 //@[i686-linux] compile-flags: --target i686-unknown-linux-gnu
 //@[i686-linux] needs-llvm-components: x86
+//@[i686-linux] filecheck-flags: --check-prefixes=CHECK,i686-linux
 //@[x86_64-linux] compile-flags: --target x86_64-unknown-linux-gnu
 //@[x86_64-linux] needs-llvm-components: x86
+//@[x86_64-linux] filecheck-flags: --check-prefixes=CHECK,x86_64-linux
 
 // Tests that we correctly copy arguments into allocas when the alignment of the byval argument
 // is different from the alignment of the Rust type.

--- a/tests/codegen-llvm/align-byval-vector.rs
+++ b/tests/codegen-llvm/align-byval-vector.rs
@@ -2,8 +2,10 @@
 //@ revisions:x86-linux x86-darwin
 
 //@[x86-linux] compile-flags: --target i686-unknown-linux-gnu
+//@[x86-linux] filecheck-flags: --check-prefix=x86-linux
 //@[x86-linux] needs-llvm-components: x86
 //@[x86-darwin] compile-flags: --target i686-apple-darwin
+//@[x86-darwin] filecheck-flags: --check-prefix=x86-darwin
 //@[x86-darwin] needs-llvm-components: x86
 
 // Tests that aggregates containing vector types get their alignment increased to 16 on Darwin.

--- a/tests/codegen-llvm/align-byval.rs
+++ b/tests/codegen-llvm/align-byval.rs
@@ -3,14 +3,19 @@
 //@ revisions:m68k x86_64-linux x86_64-windows i686-linux i686-windows
 
 //@[m68k] compile-flags: --target m68k-unknown-linux-gnu
+//@[m68k] filecheck-flags: --check-prefixes=CHECK,m68k
 //@[m68k] needs-llvm-components: m68k
 //@[x86_64-linux] compile-flags: --target x86_64-unknown-linux-gnu
+//@[x86_64-linux] filecheck-flags: --check-prefixes=CHECK,x86_64-linux
 //@[x86_64-linux] needs-llvm-components: x86
 //@[x86_64-windows] compile-flags: --target x86_64-pc-windows-msvc
+//@[x86_64-windows] filecheck-flags: --check-prefixes=CHECK,x86_64-windows
 //@[x86_64-windows] needs-llvm-components: x86
 //@[i686-linux] compile-flags: --target i686-unknown-linux-gnu
+//@[i686-linux] filecheck-flags: --check-prefixes=CHECK,i686-linux
 //@[i686-linux] needs-llvm-components: x86
 //@[i686-windows] compile-flags: --target i686-pc-windows-msvc
+//@[i686-windows] filecheck-flags: --check-prefixes=CHECK,i686-windows
 //@[i686-windows] needs-llvm-components: x86
 
 // Tests that `byval` alignment is properly specified (#80127).

--- a/tests/codegen-llvm/array-from_fn.rs
+++ b/tests/codegen-llvm/array-from_fn.rs
@@ -1,6 +1,8 @@
 //@ revisions: NORMAL OPT
 //@ [NORMAL] compile-flags: -C opt-level=0 -C debuginfo=2
+//@ [NORMAL] filecheck-flags: --check-prefix=NORMAL
 //@ [OPT] compile-flags: -C opt-level=s -C debuginfo=0
+//@ [OPT] filecheck-flags: --check-prefix=OPT
 
 #![crate_type = "lib"]
 #![feature(array_from_fn)]

--- a/tests/codegen-llvm/async-fn-debug-awaitee-field.rs
+++ b/tests/codegen-llvm/async-fn-debug-awaitee-field.rs
@@ -5,7 +5,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=CHECK,MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=CHECK,NONMSVC
 
 //@ compile-flags: -C debuginfo=2 -Copt-level=0
 //@ edition: 2018

--- a/tests/codegen-llvm/branch-protection.rs
+++ b/tests/codegen-llvm/branch-protection.rs
@@ -4,13 +4,21 @@
 //@ revisions: BTI PACRET LEAF BKEY PAUTHLR PAUTHLR_BKEY PAUTHLR_LEAF PAUTHLR_BTI NONE
 //@ needs-llvm-components: aarch64
 //@ [BTI] compile-flags: -Z branch-protection=bti
+//@ [BTI] filecheck-flags: --check-prefixes=CHECK,BTI
 //@ [PACRET] compile-flags: -Z branch-protection=pac-ret
+//@ [PACRET] filecheck-flags: --check-prefixes=CHECK,PACRET
 //@ [LEAF] compile-flags: -Z branch-protection=pac-ret,leaf
+//@ [LEAF] filecheck-flags: --check-prefixes=CHECK,LEAF
 //@ [BKEY] compile-flags: -Z branch-protection=pac-ret,b-key
+//@ [BKEY] filecheck-flags: --check-prefixes=CHECK,BKEY
 //@ [PAUTHLR] compile-flags: -Z branch-protection=pac-ret,pc
+//@ [PAUTHLR] filecheck-flags: --check-prefixes=CHECK,PAUTHLR
 //@ [PAUTHLR_BKEY] compile-flags: -Z branch-protection=pac-ret,pc,b-key
+//@ [PAUTHLR_BKEY] filecheck-flags: --check-prefixes=CHECK,PAUTHLR_BKEY
 //@ [PAUTHLR_LEAF] compile-flags: -Z branch-protection=pac-ret,pc,leaf
+//@ [PAUTHLR_LEAF] filecheck-flags: --check-prefixes=CHECK,PAUTHLR_LEAF
 //@ [PAUTHLR_BTI] compile-flags: -Z branch-protection=bti,pac-ret,pc
+//@ [PAUTHLR_BTI] filecheck-flags: --check-prefixes=CHECK,PAUTHLR_BTI
 //@ compile-flags: --target aarch64-unknown-linux-gnu
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/cast-target-abi.rs
+++ b/tests/codegen-llvm/cast-target-abi.rs
@@ -4,14 +4,19 @@
 //@ compile-flags: -Copt-level=3 -Cno-prepopulate-passes -Zlint-llvm-ir
 
 //@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
+//@[aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
 //@[aarch64] needs-llvm-components: aarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
+//@[loongarch64] filecheck-flags: --check-prefixes=CHECK,loongarch64
 //@[loongarch64] needs-llvm-components: loongarch
 //@[powerpc64] compile-flags: --target powerpc64-unknown-linux-gnu
+//@[powerpc64] filecheck-flags: --check-prefixes=CHECK,powerpc64
 //@[powerpc64] needs-llvm-components: powerpc
 //@[sparc64] compile-flags: --target sparc64-unknown-linux-gnu
+//@[sparc64] filecheck-flags: --check-prefixes=CHECK,sparc64
 //@[sparc64] needs-llvm-components: sparc
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
 //@[x86_64] needs-llvm-components: x86
 
 // Tests that arguments with `PassMode::Cast` are handled correctly.

--- a/tests/codegen-llvm/cf-protection.rs
+++ b/tests/codegen-llvm/cf-protection.rs
@@ -4,10 +4,15 @@
 //@ revisions: undefined none branch return full
 //@ needs-llvm-components: x86
 // [undefined] no extra compile-flags
+//@ [undefined] filecheck-flags: --check-prefix=undefined
 //@ [none] compile-flags: -Z cf-protection=none
+//@ [none] filecheck-flags: --check-prefix=none
 //@ [branch] compile-flags: -Z cf-protection=branch
+//@ [branch] filecheck-flags: --check-prefix=branch
 //@ [return] compile-flags: -Z cf-protection=return
+//@ [return] filecheck-flags: --check-prefix=return
 //@ [full] compile-flags: -Z cf-protection=full
+//@ [full] filecheck-flags: --check-prefix=full
 //@ compile-flags: --target x86_64-unknown-linux-gnu
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/cffi/c-variadic-ffi.rs
+++ b/tests/codegen-llvm/cffi/c-variadic-ffi.rs
@@ -3,15 +3,21 @@
 //@ compile-flags: -Z merge-functions=disabled
 //@ revisions: x86_32 x86_32_win x86_64 aarch64 arm32
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[x86_64] filecheck-flags: --check-prefixes=CHECK,x86_64
 //@[x86_64] needs-llvm-components: x86
 //@[x86_32_win] compile-flags: --target i686-pc-windows-msvc
+//@[x86_32_win] filecheck-flags: --check-prefixes=CHECK,x86_32_win
 //@[x86_32_win] needs-llvm-components: x86
 //@[x86_32] compile-flags: --target i686-unknown-linux-gnu
+//@[x86_32] filecheck-flags: --check-prefixes=CHECK,x86_32
 //@[x86_32] needs-llvm-components: x86
 //@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
+//@[aarch64] filecheck-flags: --check-prefixes=CHECK,aarch64
 //@[aarch64] needs-llvm-components: aarch64
 //@[arm32] compile-flags: --target armv7-unknown-linux-gnueabihf
+//@[arm32] filecheck-flags: --check-prefixes=CHECK,arm32
 //@[arm32] needs-llvm-components: arm
+
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![feature(extended_varargs_abi_support, extern_system_varargs)]

--- a/tests/codegen-llvm/cold-call-declare-and-call.rs
+++ b/tests/codegen-llvm/cold-call-declare-and-call.rs
@@ -3,6 +3,8 @@
 //@[NORMAL] ignore-windows
 //@[WIN] only-windows
 //@[WIN] only-x86_64
+//@[NORMAL] filecheck-flags: --check-prefixes=NORMAL
+//@[WIN] filecheck-flags: --check-prefixes=WIN
 
 #![crate_type = "lib"]
 #![feature(rust_cold_cc)]

--- a/tests/codegen-llvm/debug-accessibility/crate-enum.rs
+++ b/tests/codegen-llvm/debug-accessibility/crate-enum.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefix=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefix=NONMSVC
 
 //@ compile-flags: -C debuginfo=2
 

--- a/tests/codegen-llvm/debug-accessibility/private-enum.rs
+++ b/tests/codegen-llvm/debug-accessibility/private-enum.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefix=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefix=NONMSVC
 //@ compile-flags: -C debuginfo=2
 
 use std::hint::black_box;

--- a/tests/codegen-llvm/debug-accessibility/public-enum.rs
+++ b/tests/codegen-llvm/debug-accessibility/public-enum.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=NONMSVC
 
 //@ compile-flags: -C debuginfo=2
 

--- a/tests/codegen-llvm/debug-accessibility/super-enum.rs
+++ b/tests/codegen-llvm/debug-accessibility/super-enum.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefix=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefix=NONMSVC
 //@ compile-flags: -C debuginfo=2
 
 mod module {

--- a/tests/codegen-llvm/debug-vtable.rs
+++ b/tests/codegen-llvm/debug-vtable.rs
@@ -4,7 +4,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=CHECK,MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=CHECK,NONMSVC
 
 // Use the v0 symbol mangling scheme to codegen order independent of rustc version.
 // Unnamed items like shims are generated in lexicographical order of their symbol name and in the

--- a/tests/codegen-llvm/debuginfo-generic-closure-env-names.rs
+++ b/tests/codegen-llvm/debuginfo-generic-closure-env-names.rs
@@ -11,7 +11,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=CHECK,MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=CHECK,NONMSVC
 
 // Use the v0 symbol mangling scheme to codegen order independent of rustc version.
 // Unnamed items like shims are generated in lexicographical order of their symbol name and in the

--- a/tests/codegen-llvm/enum/enum-discriminant-eq.rs
+++ b/tests/codegen-llvm/enum/enum-discriminant-eq.rs
@@ -3,7 +3,9 @@
 //@ only-64bit
 //@ revisions: LLVM20 LLVM21
 //@ [LLVM21] min-llvm-version: 21
+//@ [LLVM21] filecheck-flags: --check-prefixes=CHECK,LLVM21
 //@ [LLVM20] max-llvm-major-version: 20
+//@ [LLVM20] filecheck-flags: --check-prefixes=CHECK,LLVM20
 
 // The `derive(PartialEq)` on enums with field-less variants compares discriminants,
 // so make sure we emit that in some reasonable way.

--- a/tests/codegen-llvm/fewer-names.rs
+++ b/tests/codegen-llvm/fewer-names.rs
@@ -1,7 +1,9 @@
 //@ compile-flags: -Coverflow-checks=no -Copt-level=3
 //@ revisions: YES NO
-//@ [YES]compile-flags: -Zfewer-names=yes
+//@ [YES] compile-flags: -Zfewer-names=yes
+//@ [YES] filecheck-flags: --check-prefixes=YES
 //@ [NO] compile-flags: -Zfewer-names=no
+//@ [NO] filecheck-flags: --check-prefixes=NO
 #![crate_type = "lib"]
 
 #[no_mangle]

--- a/tests/codegen-llvm/float/f128.rs
+++ b/tests/codegen-llvm/float/f128.rs
@@ -4,14 +4,18 @@
 //@ revisions: x86-sse x86-nosse bit32 bit64 emscripten
 //@[x86-sse] only-x86
 //@[x86-sse] only-rustc_abi-x86-sse2
+//@[x86-sse] filecheck-flags: --check-prefixes=CHECK,x86-sse
 //@[x86-nosse] only-x86
 //@[x86-nosse] ignore-rustc_abi-x86-sse2
+//@[x86-nosse] filecheck-flags: --check-prefixes=CHECK,x86-nosse
 //@[bit32] ignore-x86
 //@[bit32] ignore-emscripten
 //@[bit32] only-32bit
+//@[bit32] filecheck-flags: --check-prefixes=CHECK,bit32
 //@[bit64] ignore-x86
 //@[bit64] ignore-emscripten
 //@[bit64] only-64bit
+//@[bit64] filecheck-flags: --check-prefixes=CHECK,bit64
 //@[emscripten] only-emscripten
 
 // Verify that our intrinsics generate the correct LLVM calls for f128

--- a/tests/codegen-llvm/float/f16.rs
+++ b/tests/codegen-llvm/float/f16.rs
@@ -3,12 +3,16 @@
 //@ revisions: x86-sse x86-nosse bit32 bit64
 //@[x86-sse] only-x86
 //@[x86-sse] only-rustc_abi-x86-sse2
+//@[x86-sse] filecheck-flags: --check-prefixes=CHECK,x86-sse
 //@[x86-nosse] only-x86
 //@[x86-nosse] ignore-rustc_abi-x86-sse2
+//@[x86-nosse] filecheck-flags: --check-prefixes=CHECK,x86-nosse
 //@[bit32] ignore-x86
 //@[bit32] only-32bit
+//@[bit32] filecheck-flags: --check-prefixes=CHECK,bit32
 //@[bit64] ignore-x86
 //@[bit64] only-64bit
+//@[bit64] filecheck-flags: --check-prefixes=CHECK,bit64
 
 // Verify that our intrinsics generate the correct LLVM calls for f16
 

--- a/tests/codegen-llvm/force-frame-pointers.rs
+++ b/tests/codegen-llvm/force-frame-pointers.rs
@@ -1,6 +1,8 @@
 //@ revisions: Always NonLeaf
 //@ [Always] compile-flags: -Cforce-frame-pointers=yes
+//@ [Always] filecheck-flags: --check-prefix=Always
 //@ [NonLeaf] compile-flags: -Cforce-frame-pointers=non-leaf
+//@ [NonLeaf] filecheck-flags: --check-prefix=NonLeaf
 //@ compile-flags: -Zunstable-options
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //@ [NonLeaf] ignore-illumos

--- a/tests/codegen-llvm/frame-pointer-cli-control.rs
+++ b/tests/codegen-llvm/frame-pointer-cli-control.rs
@@ -2,12 +2,16 @@
 //@ compile-flags: --crate-type=rlib -Copt-level=0
 //@ revisions: force-on aarch64-apple aarch64-apple-on aarch64-apple-off
 //@ [force-on] compile-flags: -Cforce-frame-pointers=on
+//@ [force-on] filecheck-flags: --check-prefixes=CHECK,force-on
 //@ [aarch64-apple] needs-llvm-components: aarch64
 //@ [aarch64-apple] compile-flags: --target=aarch64-apple-darwin
+//@ [aarch64-apple] filecheck-flags: --check-prefixes=CHECK,aarch64-apple
 //@ [aarch64-apple-on] needs-llvm-components: aarch64
 //@ [aarch64-apple-on] compile-flags: --target=aarch64-apple-darwin -Cforce-frame-pointers=on
+//@ [aarch64-apple-on] filecheck-flags: --check-prefixes=CHECK,aarch64-apple-on
 //@ [aarch64-apple-off] needs-llvm-components: aarch64
 //@ [aarch64-apple-off] compile-flags: --target=aarch64-apple-darwin -Cforce-frame-pointers=off
+//@ [aarch64-apple-off] filecheck-flags: --check-prefixes=CHECK,aarch64-apple-off
 /*!
 
 Tests the extent to which frame pointers can be controlled by the CLI.

--- a/tests/codegen-llvm/frame-pointer.rs
+++ b/tests/codegen-llvm/frame-pointer.rs
@@ -3,14 +3,19 @@
 //@ revisions: aarch64-apple aarch64-linux force x64-apple x64-linux
 //@ [aarch64-apple] needs-llvm-components: aarch64
 //@ [aarch64-apple] compile-flags: --target=aarch64-apple-darwin
+//@ [aarch64-apple] filecheck-flags: --check-prefixes=CHECK,aarch64-apple
 //@ [aarch64-linux] needs-llvm-components: aarch64
 //@ [aarch64-linux] compile-flags: --target=aarch64-unknown-linux-gnu
+//@ [aarch64-linux] filecheck-flags: --check-prefixes=CHECK,aarch64-linux
 //@ [force] needs-llvm-components: x86
 //@ [force] compile-flags: --target=x86_64-unknown-linux-gnu -Cforce-frame-pointers=yes
+//@ [force] filecheck-flags: --check-prefixes=CHECK,force
 //@ [x64-apple] needs-llvm-components: x86
 //@ [x64-apple] compile-flags: --target=x86_64-apple-darwin
+//@ [x64-apple] filecheck-flags: --check-prefixes=CHECK,x64-apple
 //@ [x64-linux] needs-llvm-components: x86
 //@ [x64-linux] compile-flags: --target=x86_64-unknown-linux-gnu
+//@ [x64-linux] filecheck-flags: --check-prefixes=CHECK,x64-linux
 
 #![feature(no_core, lang_items)]
 #![no_core]

--- a/tests/codegen-llvm/gpu-kernel-abi.rs
+++ b/tests/codegen-llvm/gpu-kernel-abi.rs
@@ -10,6 +10,6 @@
 extern crate minicore;
 use minicore::*;
 
-// nvptx: define ptx_kernel void @fun(i32
+// CHECK: define ptx_kernel void @fun(i32
 #[no_mangle]
 pub extern "gpu-kernel" fn fun(_: i32) {}

--- a/tests/codegen-llvm/i128-x86-callconv.rs
+++ b/tests/codegen-llvm/i128-x86-callconv.rs
@@ -8,14 +8,15 @@
 //@ [MSVC] needs-llvm-components: x86
 //@ [MSVC] compile-flags: --target x86_64-pc-windows-msvc
 // Use `WIN` as a common prefix for MSVC and MINGW but *not* the softfloat test.
-//@ [MSVC] filecheck-flags: --check-prefix=WIN
+//@ [MSVC] filecheck-flags: --check-prefixes=CHECK,WIN
 //@ [MINGW] needs-llvm-components: x86
 //@ [MINGW] compile-flags: --target x86_64-pc-windows-gnu
-//@ [MINGW] filecheck-flags: --check-prefix=WIN
+//@ [MINGW] filecheck-flags: --check-prefixes=CHECK,WIN
 // The `x86_64-unknown-uefi` target also uses the Windows calling convention,
 // but does not have SSE registers available.
 //@ [softfloat] needs-llvm-components: x86
 //@ [softfloat] compile-flags: --target x86_64-unknown-uefi
+//@ [softfloat] filecheck-flags: --check-prefixes=CHECK,softfloat
 
 #![crate_type = "lib"]
 #![no_std]

--- a/tests/codegen-llvm/instrument-coverage/testprog.rs
+++ b/tests/codegen-llvm/instrument-coverage/testprog.rs
@@ -26,6 +26,7 @@
 //@ [WIN] filecheck-flags: -DINSTR_PROF_COVMAP=.lcovmap$M
 //@ [WIN] filecheck-flags: -DINSTR_PROF_COVFUN=.lcovfun$M
 //@ [WIN] filecheck-flags: '-DCOMDAT_IF_SUPPORTED=, comdat'
+//@ [WIN] filecheck-flags: --check-prefixes=CHECK,WIN
 
 // ignore-tidy-linelength
 

--- a/tests/codegen-llvm/integer-cmp.rs
+++ b/tests/codegen-llvm/integer-cmp.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: llvm-pre-20 llvm-20
 //@ [llvm-20] min-llvm-version: 20
+//@ [llvm-20] filecheck-flags: --check-prefixes=CHECK,llvm-20
 //@ [llvm-pre-20] max-llvm-major-version: 19
+//@ [llvm-pre-20] filecheck-flags: --check-prefixes=CHECK,llvm-pre-20
 //@ compile-flags: -C opt-level=3 -Zmerge-functions=disabled
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/intrinsics/carrying_mul_add.rs
+++ b/tests/codegen-llvm/intrinsics/carrying_mul_add.rs
@@ -1,6 +1,8 @@
 //@ revisions: RAW OPT
 //@ compile-flags: -C opt-level=1
 //@[RAW] compile-flags: -C no-prepopulate-passes
+//@[RAW] filecheck-flags: --check-prefixes=CHECK,RAW
+//@[OPT] filecheck-flags: --check-prefixes=CHECK,OPT
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]

--- a/tests/codegen-llvm/intrinsics/transmute-niched.rs
+++ b/tests/codegen-llvm/intrinsics/transmute-niched.rs
@@ -1,6 +1,8 @@
 //@ revisions: OPT DBG
 //@ [OPT] compile-flags: -C opt-level=3 -C no-prepopulate-passes
+//@ [OPT] filecheck-flags: --check-prefixes=CHECK,OPT
 //@ [DBG] compile-flags: -C opt-level=0 -C no-prepopulate-passes
+//@ [DBG] filecheck-flags: --check-prefixes=CHECK
 //@ only-64bit (so I don't need to worry about usize)
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/intrinsics/typed_swap.rs
+++ b/tests/codegen-llvm/intrinsics/typed_swap.rs
@@ -1,6 +1,8 @@
 //@ revisions: OPT0 OPT3
 //@ [OPT0] compile-flags: -Copt-level=0
+//@ [OPT0] filecheck-flags: --check-prefixes=CHECK,OPT0
 //@ [OPT3] compile-flags: -Copt-level=3
+//@ [OPT3] filecheck-flags: --check-prefixes=CHECK,OPT3
 //@ compile-flags: -C no-prepopulate-passes
 //@ only-64bit (so I don't need to worry about usize)
 // ignore-tidy-linelength (the memcpy calls get long)

--- a/tests/codegen-llvm/issues/issue-32031.rs
+++ b/tests/codegen-llvm/issues/issue-32031.rs
@@ -2,7 +2,9 @@
 // 32-bit x86 returns `f32` and `f64` differently to avoid the x87 stack.
 //@ revisions: x86 other
 //@[x86] only-rustc_abi-x86-sse2
+//@[x86] filecheck-flags: --check-prefix=x86
 //@[other] ignore-x86
+//@[other] filecheck-flags: --check-prefix=other
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/issues/issue-98678-async.rs
+++ b/tests/codegen-llvm/issues/issue-98678-async.rs
@@ -4,7 +4,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=NONMSVC
 //@ edition:2021
 //@ compile-flags: --crate-type=lib -Copt-level=0 -Cdebuginfo=2 -Zdebug-info-type-line-numbers=true
 

--- a/tests/codegen-llvm/issues/issue-98678-closure-coroutine.rs
+++ b/tests/codegen-llvm/issues/issue-98678-closure-coroutine.rs
@@ -6,7 +6,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=NONMSVC
 //@ compile-flags: --crate-type=lib -Copt-level=0 -Cdebuginfo=2 -Zdebug-info-type-line-numbers=true
 
 // NONMSVC-DAG: ![[#FILE:]] = !DIFile({{.*}}filename:{{.*[/\\]}}issue-98678-closure-coroutine.rs{{".*}})

--- a/tests/codegen-llvm/issues/issue-98678-enum.rs
+++ b/tests/codegen-llvm/issues/issue-98678-enum.rs
@@ -3,7 +3,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=CHECK,MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=CHECK,NONMSVC
 //@ compile-flags: --crate-type=lib -Copt-level=0 -Cdebuginfo=2 -Zdebug-info-type-line-numbers=true
 
 // NONMSVC: ![[#FILE:]] = !DIFile({{.*}}filename:{{.*[/\\]}}issue-98678-enum.rs{{".*}})

--- a/tests/codegen-llvm/issues/issue-98678-struct-union.rs
+++ b/tests/codegen-llvm/issues/issue-98678-struct-union.rs
@@ -4,7 +4,9 @@
 
 //@ revisions: MSVC NONMSVC
 //@[MSVC] only-msvc
+//@[MSVC] filecheck-flags: --check-prefixes=CHECK,MSVC
 //@[NONMSVC] ignore-msvc
+//@[NONMSVC] filecheck-flags: --check-prefixes=CHECK,NONMSVC
 //@ compile-flags: --crate-type=lib -Copt-level=0 -Cdebuginfo=2 -Zdebug-info-type-line-numbers=true
 
 // NONMSVC: ![[#FILE:]] = !DIFile({{.*}}filename:{{.*[/\\]}}issue-98678-struct-union.rs{{".*}})

--- a/tests/codegen-llvm/meta-filecheck/revision-prefix.rs
+++ b/tests/codegen-llvm/meta-filecheck/revision-prefix.rs
@@ -1,8 +1,9 @@
-// The current revision name is registered as a filecheck prefix.
+// The default filecheck prefix is `CHECK`, others need to be specified
 
 //@ revisions: GOOD BAD
 //@ [BAD] should-fail
+//@ [BAD] filecheck-flags: --check-prefixes=BAD
 
-// GOOD: main
+// CHECK: main
 // BAD: text that should not match
 fn main() {}

--- a/tests/codegen-llvm/mir-aggregate-no-alloca.rs
+++ b/tests/codegen-llvm/mir-aggregate-no-alloca.rs
@@ -1,7 +1,9 @@
 // 32-bit systems will return 128bit values using a return area pointer.
 //@ revisions: bit32 bit64
 //@[bit32] only-32bit
+//@[bit32] filecheck-flags: --check-prefixes=CHECK,bit32
 //@[bit64] only-64bit
+//@[bit64] filecheck-flags: --check-prefixes=CHECK,bit64
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Z randomize-layout=no
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/naked-fn/naked-functions.rs
+++ b/tests/codegen-llvm/naked-fn/naked-functions.rs
@@ -2,14 +2,19 @@
 //@ revisions: linux win_x86 win_i686 macos thumb
 //
 //@[linux] compile-flags: --target x86_64-unknown-linux-gnu
+//@[linux] filecheck-flags: --check-prefixes=CHECK,linux
 //@[linux] needs-llvm-components: x86
 //@[win_x86] compile-flags: --target x86_64-pc-windows-gnu
+//@[win_x86] filecheck-flags: --check-prefixes=CHECK,win_x86
 //@[win_x86] needs-llvm-components: x86
 //@[win_i686] compile-flags: --target i686-pc-windows-gnu
+//@[win_i686] filecheck-flags: --check-prefixes=CHECK,win_i686
 //@[win_i686] needs-llvm-components: x86
 //@[macos] compile-flags: --target aarch64-apple-darwin
+//@[macos] filecheck-flags: --check-prefixes=CHECK,macos
 //@[macos] needs-llvm-components: aarch64
 //@[thumb] compile-flags: --target thumbv7em-none-eabi
+//@[thumb] filecheck-flags: --check-prefixes=CHECK,thumb
 //@[thumb] needs-llvm-components: arm
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/optimize-attr-1.rs
+++ b/tests/codegen-llvm/optimize-attr-1.rs
@@ -1,7 +1,10 @@
 //@ revisions: NO-OPT SIZE-OPT SPEED-OPT
 //@[NO-OPT] compile-flags: -Copt-level=0 -Ccodegen-units=1
+//@[NO-OPT] filecheck-flags: --check-prefixes=CHECK,NO-OPT
 //@[SIZE-OPT] compile-flags: -Copt-level=s -Ccodegen-units=1
+//@[SIZE-OPT] filecheck-flags: --check-prefixes=CHECK,SIZE-OPT
 //@[SPEED-OPT] compile-flags: -Copt-level=3 -Ccodegen-units=1
+//@[SPEED-OPT] filecheck-flags: --check-prefixes=CHECK,SPEED-OPT
 
 #![feature(optimize_attribute)]
 #![crate_type = "rlib"]

--- a/tests/codegen-llvm/option-niche-eq.rs
+++ b/tests/codegen-llvm/option-niche-eq.rs
@@ -2,6 +2,7 @@
 //@ min-llvm-version: 20
 //@ compile-flags: -Copt-level=3 -Zmerge-functions=disabled
 //@ [LLVM21] min-llvm-version: 21
+//@ [LLVM21] filecheck-flags: --check-prefixes=CHECK,LLVM21
 #![crate_type = "lib"]
 
 extern crate core;

--- a/tests/codegen-llvm/range-attribute.rs
+++ b/tests/codegen-llvm/range-attribute.rs
@@ -4,7 +4,9 @@
 // 32-bit systems will return 128bit values using a return area pointer.
 //@ revisions: bit32 bit64
 //@[bit32] only-32bit
+//@[bit32] filecheck-flags: --check-prefixes=CHECK,bit32
 //@[bit64] only-64bit
+//@[bit64] filecheck-flags: --check-prefixes=CHECK,bit64
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/regparm-inreg.rs
+++ b/tests/codegen-llvm/regparm-inreg.rs
@@ -8,9 +8,13 @@
 
 //@ revisions:regparm0 regparm1 regparm2 regparm3
 //@[regparm0] compile-flags: -Zregparm=0
+//@[regparm0] filecheck-flags: --check-prefixes=CHECK,regparm0
 //@[regparm1] compile-flags: -Zregparm=1
+//@[regparm1] filecheck-flags: --check-prefixes=CHECK,regparm1
 //@[regparm2] compile-flags: -Zregparm=2
+//@[regparm2] filecheck-flags: --check-prefixes=CHECK,regparm2
 //@[regparm3] compile-flags: -Zregparm=3
+//@[regparm3] filecheck-flags: --check-prefixes=CHECK,regparm3
 
 #![crate_type = "lib"]
 #![no_core]

--- a/tests/codegen-llvm/riscv-target-abi.rs
+++ b/tests/codegen-llvm/riscv-target-abi.rs
@@ -2,14 +2,17 @@
 //@ revisions:riscv64gc riscv32gc riscv32imac
 
 //@[riscv64gc] compile-flags: --target=riscv64gc-unknown-linux-gnu
+//@[riscv64gc] filecheck-flags: --check-prefixes=riscv64gc
 //@[riscv64gc] needs-llvm-components: riscv
 // riscv64gc: !{i32 1, !"target-abi", !"lp64d"}
 
 //@[riscv32gc] compile-flags: --target=riscv32gc-unknown-linux-musl
+//@[riscv32gc] filecheck-flags: --check-prefixes=riscv32gc
 //@[riscv32gc] needs-llvm-components: riscv
 // riscv32gc: !{i32 1, !"target-abi", !"ilp32d"}
 
 //@[riscv32imac] compile-flags: --target=riscv32imac-unknown-none-elf
+//@[riscv32imac] filecheck-flags: --check-prefixes=riscv32imac
 //@[riscv32imac] needs-llvm-components: riscv
 // riscv32imac: !{i32 1, !"target-abi", !"ilp32"}
 

--- a/tests/codegen-llvm/sanitizer/memory-track-origins.rs
+++ b/tests/codegen-llvm/sanitizer/memory-track-origins.rs
@@ -6,10 +6,15 @@
 //
 //@ compile-flags: -Zsanitizer=memory -Ctarget-feature=-crt-static
 // [MSAN-0] no extra compile-flags
+//@[MSAN-0] filecheck-flags: --check-prefixes=MSAN-0
 //@[MSAN-1] compile-flags: -Zsanitizer-memory-track-origins=1
+//@[MSAN-1] filecheck-flags: --check-prefixes=MSAN-1
 //@[MSAN-2] compile-flags: -Zsanitizer-memory-track-origins
+//@[MSAN-2] filecheck-flags: --check-prefixes=MSAN-2
 //@[MSAN-1-LTO] compile-flags: -Zsanitizer-memory-track-origins=1 -C lto=fat
+//@[MSAN-1-LTO] filecheck-flags: --check-prefixes=MSAN-1-LTO
 //@[MSAN-2-LTO] compile-flags: -Zsanitizer-memory-track-origins -C lto=fat
+//@[MSAN-2-LTO] filecheck-flags: --check-prefixes=MSAN-2-LTO
 
 #![crate_type = "lib"]
 

--- a/tests/codegen-llvm/sanitizer/no-sanitize-inlining.rs
+++ b/tests/codegen-llvm/sanitizer/no-sanitize-inlining.rs
@@ -6,7 +6,9 @@
 //@ revisions: ASAN LSAN
 //@       compile-flags: -Copt-level=3 -Zmir-opt-level=4 -Ctarget-feature=-crt-static
 //@[ASAN] compile-flags: -Zsanitizer=address
+//@[ASAN] filecheck-flags: --check-prefixes=ASAN
 //@[LSAN] compile-flags: -Zsanitizer=leak
+//@[LSAN] filecheck-flags: --check-prefixes=LSAN
 
 #![crate_type = "lib"]
 #![feature(no_sanitize)]

--- a/tests/codegen-llvm/sanitizer/sanitizer-recover.rs
+++ b/tests/codegen-llvm/sanitizer/sanitizer-recover.rs
@@ -8,10 +8,15 @@
 //
 //@                   compile-flags: -Ctarget-feature=-crt-static
 //@[ASAN]             compile-flags: -Zsanitizer=address -Copt-level=0
+//@[ASAN]             filecheck-flags: --check-prefixes=ASAN
 //@[ASAN-RECOVER]     compile-flags: -Zsanitizer=address -Zsanitizer-recover=address -Copt-level=0
+//@[ASAN-RECOVER]     filecheck-flags: --check-prefixes=ASAN-RECOVER
 //@[MSAN]             compile-flags: -Zsanitizer=memory
+//@[MSAN]             filecheck-flags: --check-prefixes=MSAN
 //@[MSAN-RECOVER]     compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory
+//@[MSAN-RECOVER]     filecheck-flags: --check-prefixes=MSAN-RECOVER
 //@[MSAN-RECOVER-LTO] compile-flags: -Zsanitizer=memory  -Zsanitizer-recover=memory -C lto=fat
+//@[MSAN-RECOVER-LTO] filecheck-flags: --check-prefixes=MSAN-RECOVER-LTO
 //
 // MSAN-NOT:         @__msan_keep_going
 // MSAN-RECOVER:     @__msan_keep_going = weak_odr {{.*}}constant i32 1

--- a/tests/codegen-llvm/simd/packed-simd.rs
+++ b/tests/codegen-llvm/simd/packed-simd.rs
@@ -1,7 +1,9 @@
 //@ revisions:opt3 noopt
 //@ only-x86_64
 //@[opt3] compile-flags: -Copt-level=3
+//@[opt3] filecheck-flags: --check-prefixes=CHECK,opt3
 //@[noopt] compile-flags: -Cno-prepopulate-passes
+//@[noopt] filecheck-flags: --check-prefixes=CHECK,noopt
 
 #![crate_type = "lib"]
 #![no_std]

--- a/tests/codegen-llvm/some-abis-do-extend-params-to-32-bits.rs
+++ b/tests/codegen-llvm/some-abis-do-extend-params-to-32-bits.rs
@@ -4,18 +4,25 @@
 //@ revisions:x86_64 i686 aarch64-apple aarch64-windows aarch64-linux arm riscv
 
 //@[x86_64] compile-flags: --target x86_64-unknown-uefi
+//@[x86_64] filecheck-flags: --check-prefixes=x86_64
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-musl
+//@[i686] filecheck-flags: --check-prefixes=i686
 //@[i686] needs-llvm-components: x86
 //@[aarch64-windows] compile-flags: --target aarch64-pc-windows-msvc
+//@[aarch64-windows] filecheck-flags: --check-prefixes=aarch64-windows
 //@[aarch64-windows] needs-llvm-components: aarch64
 //@[aarch64-linux] compile-flags: --target aarch64-unknown-linux-gnu
+//@[aarch64-linux] filecheck-flags: --check-prefixes=aarch64-linux
 //@[aarch64-linux] needs-llvm-components: aarch64
 //@[aarch64-apple] compile-flags: --target aarch64-apple-darwin
+//@[aarch64-apple] filecheck-flags: --check-prefixes=aarch64-apple
 //@[aarch64-apple] needs-llvm-components: aarch64
 //@[arm] compile-flags: --target armv7r-none-eabi
+//@[arm] filecheck-flags: --check-prefixes=arm
 //@[arm] needs-llvm-components: arm
 //@[riscv] compile-flags: --target riscv64gc-unknown-none-elf
+//@[riscv] filecheck-flags: --check-prefixes=riscv
 //@[riscv] needs-llvm-components: riscv
 
 // See bottom of file for a corresponding C source file that is meant to yield

--- a/tests/codegen-llvm/target-feature-overrides.rs
+++ b/tests/codegen-llvm/target-feature-overrides.rs
@@ -4,7 +4,9 @@
 //@ needs-llvm-components: x86
 //@ compile-flags: --target=x86_64-unknown-linux-gnu -Copt-level=3
 //@ [COMPAT] compile-flags: -Ctarget-feature=+avx2
+//@ [COMPAT] filecheck-flags: --check-prefixes=CHECK,COMPAT
 //@ [INCOMPAT] compile-flags: -Ctarget-feature=-avx2,-avx
+//@ [INCOMPAT] filecheck-flags: --check-prefixes=CHECK,INCOMPAT
 
 // See also tests/assembly-llvm/target-feature-multiple.rs
 #![feature(no_core, lang_items)]

--- a/tests/codegen-llvm/terminating-catchpad.rs
+++ b/tests/codegen-llvm/terminating-catchpad.rs
@@ -2,6 +2,9 @@
 //@[emscripten] compile-flags: --target wasm32-unknown-emscripten -Z emscripten-wasm-eh
 //@[wasi] compile-flags: --target wasm32-wasip1 -C panic=unwind
 //@[seh] compile-flags: --target x86_64-pc-windows-msvc
+//@[emscripten] filecheck-flags: --check-prefix=emscripten
+//@[wasi] filecheck-flags: --check-prefix=wasi
+//@[seh] filecheck-flags: --check-prefix=seh
 //@[emscripten] needs-llvm-components: webassembly
 //@[wasi] needs-llvm-components: webassembly
 //@[seh] needs-llvm-components: x86

--- a/tests/codegen-llvm/tied-features-strength.rs
+++ b/tests/codegen-llvm/tied-features-strength.rs
@@ -1,6 +1,10 @@
 // ignore-tidy-linelength
 //@ add-core-stubs
 //@ revisions: ENABLE_SVE DISABLE_SVE DISABLE_NEON ENABLE_NEON
+//@ [ENABLE_SVE] filecheck-flags: --check-prefixes=ENABLE_SVE
+//@ [DISABLE_SVE] filecheck-flags: --check-prefixes=DISABLE_SVE
+//@ [ENABLE_NEON] filecheck-flags: --check-prefixes=ENABLE_NEON
+//@ [DISABLE_NEON] filecheck-flags: --check-prefixes=DISABLE_NEON
 //@ compile-flags: --crate-type=rlib --target=aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 

--- a/tests/codegen-llvm/try_question_mark_nop.rs
+++ b/tests/codegen-llvm/try_question_mark_nop.rs
@@ -3,7 +3,9 @@
 //@ only-x86_64
 //@ revisions: NINETEEN TWENTY
 //@[NINETEEN] exact-llvm-major-version: 19
+//@[NINETEEN] filecheck-flags: --check-prefixes=CHECK,NINETEEN
 //@[TWENTY] min-llvm-version: 20
+//@[TWENTY] filecheck-flags: --check-prefixes=CHECK,TWENTY
 
 #![crate_type = "lib"]
 #![feature(try_blocks)]


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/rust/issues/134510

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->

try-job: aarch64-apple
try-job: i686-gnu-*
try-job: test-various
try-job: x86_64-msvc-1
try-job: x86_64-msvc-2