### PR TITLE
Fix wrong spans with external macros in the `dropping_copy_types` lint

### DIFF
--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -151,7 +151,7 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     && let Node::Stmt(stmt) = node
                     && let StmtKind::Semi(e) = stmt.kind
                     && e.hir_id == expr.hir_id
-                    && let Some(arg_span) = arg.span.find_ancestor_inside(expr.span)
+                    && let Some(arg_span) = arg.span.find_ancestor_inside_same_ctxt(expr.span)
                 {
                     UseLetUnderscoreIgnoreSuggestion::Suggestion {
                         start_span: expr.span.shrink_to_lo().until(arg_span),

--- a/tests/ui/lint/dropping_copy_types-macros.fixed
+++ b/tests/ui/lint/dropping_copy_types-macros.fixed
@@ -9,4 +9,7 @@ fn main() {
     let mut msg = String::new();
     let _ = writeln!(&mut msg, "test");
     //~^ ERROR calls to `std::mem::drop`
+
+    let _ = format_args!("a");
+    //~^ ERROR calls to `std::mem::drop`
 }

--- a/tests/ui/lint/dropping_copy_types-macros.rs
+++ b/tests/ui/lint/dropping_copy_types-macros.rs
@@ -9,4 +9,7 @@ fn main() {
     let mut msg = String::new();
     drop(writeln!(&mut msg, "test"));
     //~^ ERROR calls to `std::mem::drop`
+
+    drop(format_args!("a"));
+    //~^ ERROR calls to `std::mem::drop`
 }

--- a/tests/ui/lint/dropping_copy_types-macros.stderr
+++ b/tests/ui/lint/dropping_copy_types-macros.stderr
@@ -17,5 +17,19 @@ LL -     drop(writeln!(&mut msg, "test"));
 LL +     let _ = writeln!(&mut msg, "test");
    |
 
-error: aborting due to 1 previous error
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-macros.rs:13:5
+   |
+LL |     drop(format_args!("a"));
+   |     ^^^^^-----------------^
+   |          |
+   |          argument has type `Arguments<'_>`
+   |
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(format_args!("a"));
+LL +     let _ = format_args!("a");
+   |
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR fixes some wrong spans manipulations when external macros are involved.

Specifically we didn't make sure the spans had the same context, which kind-of make our spans manipulations go wrong and produce weird spans. We fix that by making sure they have the same context.

Fixes https://github.com/rust-lang/rust/issues/145427