### PR TITLE
fix(tests/rmake/wasm-unexpected-features): change features from `WASM1` to `MVP`

### DIFF
--- a/tests/run-make/wasm-unexpected-features/rmake.rs
+++ b/tests/run-make/wasm-unexpected-features/rmake.rs
@@ -21,6 +21,6 @@ fn verify_features(path: &Path) {
     eprintln!("verify {path:?}");
     let file = rfs::read(&path);
 
-    let mut validator = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::WASM1);
+    let mut validator = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::MVP);
     validator.validate_all(&file).unwrap();
 }


### PR DESCRIPTION
missed this in rust-lang/rust#145275
since test calls `rustc` with  `-C target-cpu mvp`
try-job: `test-various`
