### PR TITLE
Autolabel `src/tools/{rustfmt,rust-analyzer}` changes with `T-{rustfmt,rust-analyzer}`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -628,6 +628,16 @@ trigger_files = [
     "src/ci",
 ]
 
+[autolabel."T-rust-analyzer"]
+trigger_files = [
+    "src/tools/rust-analyzer",
+]
+
+[autolabel."T-rustfmt"]
+trigger_files = [
+    "src/tools/rustfmt",
+]
+
 # ------------------------------------------------------------------------------
 # Prioritization and team nominations
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Make e.g. rust-lang/rust#144323 more obvious who should be reviewing it and easier to filter.