### PR TITLE
Remove duplicated tracing span in bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2494,9 +2494,6 @@ pub fn stream_cargo(
 ) -> bool {
     let mut cmd = cargo.into_cmd();
 
-    #[cfg(feature = "tracing")]
-    let _run_span = crate::utils::tracing::trace_cmd(&cmd);
-
     // Instruct Cargo to give us json messages on stdout, critically leaving
     // stderr as piped so we can get those pretty colors.
     let mut message_format = if builder.config.json_output {


### PR DESCRIPTION
`trace_cmd` is now called also in the `stream` method, so including it also here was duplicating command spans.

r? @jieyouxu
