### PR TITLE
Fix tracing debug representation of steps without arguments in bootstrap

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1839,9 +1839,14 @@ pub fn pretty_step_name<S: Step>() -> String {
 /// Renders `step` using its `Debug` implementation and extract the field arguments out of it.
 fn step_debug_args<S: Step>(step: &S) -> String {
     let step_dbg_repr = format!("{step:?}");
-    let brace_start = step_dbg_repr.find('{').unwrap_or(0);
-    let brace_end = step_dbg_repr.rfind('}').unwrap_or(step_dbg_repr.len());
-    step_dbg_repr[brace_start + 1..brace_end - 1].trim().to_string()
+
+    // Some steps do not have any arguments, so they do not have the braces
+    match (step_dbg_repr.find('{'), step_dbg_repr.rfind('}')) {
+        (Some(brace_start), Some(brace_end)) => {
+            step_dbg_repr[brace_start + 1..brace_end - 1].trim().to_string()
+        }
+        _ => String::new(),
+    }
 }
 
 fn pretty_print_step<S: Step>(step: &S) -> String {


### PR DESCRIPTION
I was wondering why I see `lainSourceTarbal` in tracing logs...

r? @jieyouxu
