### PR TITLE
Experiment: Add `where T: Default` to `Default for [T; 0]` impl.

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -484,7 +484,7 @@ macro_rules! array_impl_default {
     };
     {$n:expr,} => {
         #[stable(since = "1.4.0", feature = "array_default")]
-        impl<T> Default for [T; $n] {
+        impl<T> Default for [T; $n] where T: Default {
             fn default() -> [T; $n] { [] }
         }
     };

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -293,13 +293,6 @@ fn array_default_impl_avoids_leaks_on_panic() {
 }
 
 #[test]
-fn empty_array_is_always_default() {
-    struct DoesNotImplDefault;
-
-    let _arr = <[DoesNotImplDefault; 0]>::default();
-}
-
-#[test]
 fn array_map() {
     let a = [1, 2, 3];
     let b = a.map(|v| v + 1);


### PR DESCRIPTION
*Not to be merged; just an experiment.*

I'm curious how many crates rely on the `Default for [T; 0]` implementation not having a `T: Default` bound. Let's do a crater check run to find out. :)