### PR TITLE
[rustdoc] Add support new bang macro kinds

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -46,6 +46,27 @@ pub(crate) fn try_inline(
     attrs: Option<(&[hir::Attribute], Option<LocalDefId>)>,
     visited: &mut DefIdSet,
 ) -> Option<Vec<clean::Item>> {
+    fn try_inline_inner(
+        cx: &mut DocContext<'_>,
+        kind: clean::ItemKind,
+        did: DefId,
+        name: Symbol,
+        import_def_id: Option<LocalDefId>,
+    ) -> clean::Item {
+        cx.inlined.insert(did.into());
+        let mut item = crate::clean::generate_item_with_correct_attrs(
+            cx,
+            kind,
+            did,
+            name,
+            import_def_id.as_slice(),
+            None,
+        );
+        // The visibility needs to reflect the one from the reexport and not from the "source" DefId.
+        item.inner.inline_stmt_id = import_def_id;
+        item
+    }
+
     let did = res.opt_def_id()?;
     if did.is_local() {
         return None;
@@ -138,7 +159,7 @@ pub(crate) fn try_inline(
             })
         }
         Res::Def(DefKind::Macro(kinds), did) => {
-            let mac = build_macro(cx, did, name, kinds);
+            let (mac, others) = build_macro(cx, did, name, kinds);
 
             let type_kind = match kinds {
                 MacroKinds::BANG => ItemType::Macro,
@@ -148,23 +169,21 @@ pub(crate) fn try_inline(
                 _ => panic!("unsupported macro kind {kinds:?}"),
             };
             record_extern_fqn(cx, did, type_kind);
-            mac
+            let first = try_inline_inner(cx, mac, did, name, import_def_id);
+            if let Some(others) = others {
+                for mac_kind in others {
+                    let mut mac = first.clone();
+                    mac.inner.kind = mac_kind;
+                    ret.push(mac);
+                }
+            }
+            ret.push(first);
+            return Some(ret);
         }
         _ => return None,
     };
 
-    cx.inlined.insert(did.into());
-    let mut item = crate::clean::generate_item_with_correct_attrs(
-        cx,
-        kind,
-        did,
-        name,
-        import_def_id.as_slice(),
-        None,
-    );
-    // The visibility needs to reflect the one from the reexport and not from the "source" DefId.
-    item.inner.inline_stmt_id = import_def_id;
-    ret.push(item);
+    ret.push(try_inline_inner(cx, kind, did, name, import_def_id));
     Some(ret)
 }
 
@@ -761,31 +780,51 @@ fn build_macro(
     def_id: DefId,
     name: Symbol,
     macro_kinds: MacroKinds,
-) -> clean::ItemKind {
+) -> (clean::ItemKind, Option<Vec<clean::ItemKind>>) {
     match CStore::from_tcx(cx.tcx).load_macro_untracked(def_id, cx.tcx) {
         LoadedMacro::MacroDef { def, .. } => match macro_kinds {
-            MacroKinds::BANG => clean::MacroItem(
-                clean::Macro {
-                    source: utils::display_macro_source(cx, name, &def),
-                    macro_rules: def.macro_rules,
-                },
+            MacroKinds::BANG => (
+                clean::MacroItem(
+                    clean::Macro {
+                        source: utils::display_macro_source(cx, name, &def),
+                        macro_rules: def.macro_rules,
+                    },
+                    None,
+                ),
                 None,
             ),
-            MacroKinds::DERIVE => clean::ProcMacroItem(clean::ProcMacro {
-                kind: MacroKind::Derive,
-                helpers: Vec::new(),
-            }),
-            MacroKinds::ATTR => clean::ProcMacroItem(clean::ProcMacro {
-                kind: MacroKind::Attr,
-                helpers: Vec::new(),
-            }),
-            _ if macro_kinds == (MacroKinds::BANG | MacroKinds::ATTR) => clean::MacroItem(
-                clean::Macro {
-                    source: utils::display_macro_source(cx, name, &def),
-                    macro_rules: def.macro_rules,
-                },
-                Some(macro_kinds),
+            MacroKinds::DERIVE => (
+                clean::ProcMacroItem(clean::ProcMacro {
+                    kind: MacroKind::Derive,
+                    helpers: Vec::new(),
+                }),
+                None,
             ),
+            MacroKinds::ATTR => (
+                clean::ProcMacroItem(clean::ProcMacro {
+                    kind: MacroKind::Attr,
+                    helpers: Vec::new(),
+                }),
+                None,
+            ),
+            _ if macro_kinds.contains(MacroKinds::BANG) => {
+                let kind = clean::MacroItem(
+                    clean::Macro {
+                        source: utils::display_macro_source(cx, name, &def),
+                        macro_rules: def.macro_rules,
+                    },
+                    Some(macro_kinds),
+                );
+                let mut ret = vec![];
+                for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {
+                    match kind {
+                        MacroKinds::ATTR => ret.push(clean::AttrMacroItem),
+                        MacroKinds::DERIVE => ret.push(clean::DeriveMacroItem),
+                        _ => panic!("unsupported macro kind {kind:?}"),
+                    }
+                }
+                (kind, Some(ret))
+            }
             _ => panic!("unsupported macro kind {macro_kinds:?}"),
         },
         LoadedMacro::ProcMacro(ext) => {
@@ -796,7 +835,7 @@ fn build_macro(
                 MacroKinds::DERIVE => MacroKind::Derive,
                 _ => unreachable!(),
             };
-            clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs })
+            (clean::ProcMacroItem(clean::ProcMacro { kind, helpers: ext.helper_attrs }), None)
         }
     }
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -789,7 +789,7 @@ fn build_macro(
                         source: utils::display_macro_source(cx, name, &def),
                         macro_rules: def.macro_rules,
                     },
-                    None,
+                    MacroKinds::BANG,
                 ),
                 None,
             ),
@@ -813,7 +813,7 @@ fn build_macro(
                         source: utils::display_macro_source(cx, name, &def),
                         macro_rules: def.macro_rules,
                     },
-                    Some(macro_kinds),
+                    macro_kinds,
                 );
                 let mut ret = vec![];
                 for kind in macro_kinds.iter().filter(|kind| *kind != MacroKinds::BANG) {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2847,7 +2847,7 @@ fn clean_maybe_renamed_item<'tcx>(
                         source: display_macro_source(cx, name, macro_def),
                         macro_rules: macro_def.macro_rules,
                     },
-                    None,
+                    MacroKinds::BANG,
                 ),
                 MacroKinds::ATTR => clean_proc_macro(item, &mut name, MacroKind::Attr, cx),
                 MacroKinds::DERIVE => clean_proc_macro(item, &mut name, MacroKind::Derive, cx),
@@ -2857,7 +2857,7 @@ fn clean_maybe_renamed_item<'tcx>(
                             source: display_macro_source(cx, name, macro_def),
                             macro_rules: macro_def.macro_rules,
                         },
-                        Some(kinds),
+                        kinds,
                     );
                     let mac = generate_item_with_correct_attrs(
                         cx,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -846,8 +846,12 @@ pub(crate) enum ItemKind {
     ForeignStaticItem(Static, hir::Safety),
     /// `type`s from an extern block
     ForeignTypeItem,
-    MacroItem(Macro, Option<MacroKinds>),
+    MacroItem(Macro, MacroKinds),
+    /// This is NOT an attribute proc-macro but a bang macro with support for being used as an
+    /// attribute macro.
     AttrMacroItem,
+    /// This is NOT an attribute proc-macro but a bang macro with support for being used as a
+    /// derive macro.
     DeriveMacroItem,
     ProcMacroItem(ProcMacro),
     PrimitiveItem(PrimitiveType),

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -89,6 +89,8 @@ pub(crate) trait DocFolder: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
+            | AttrMacroItem
+            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -88,7 +88,7 @@ pub(crate) trait DocFolder: Sized {
             | ForeignFunctionItem(..)
             | ForeignStaticItem(..)
             | ForeignTypeItem
-            | MacroItem(_)
+            | MacroItem(..)
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -378,8 +378,10 @@ impl DocFolder for CacheBuilder<'_, '_> {
             | clean::RequiredAssocTypeItem(..)
             | clean::AssocTypeItem(..)
             | clean::StrippedItem(..)
-            | clean::KeywordItem
-            | clean::AttributeItem => {
+            | clean::AttributeItem
+            | clean::AttrMacroItem
+            | clean::DeriveMacroItem
+            | clean::KeywordItem => {
                 // FIXME: Do these need handling?
                 // The person writing this comment doesn't know.
                 // So would rather leave them to an expert,

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -99,6 +99,8 @@ item_type! {
     // This number is reserved for use in JavaScript
     // Generic = 26,
     Attribute = 27,
+    BangMacroAttribute = 28,
+    BangMacroDerive = 29,
 }
 
 impl<'a> From<&'a clean::Item> for ItemType {
@@ -128,10 +130,8 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::ForeignFunctionItem(..) => ItemType::Function, // no ForeignFunction
             clean::ForeignStaticItem(..) => ItemType::Static,     // no ForeignStatic
             clean::MacroItem(..) => ItemType::Macro,
-            // Is this a good idea?
-            clean::AttrMacroItem => ItemType::ProcAttribute,
-            // Is this a good idea?
-            clean::DeriveMacroItem => ItemType::ProcDerive,
+            clean::AttrMacroItem => ItemType::BangMacroAttribute,
+            clean::DeriveMacroItem => ItemType::BangMacroDerive,
             clean::PrimitiveItem(..) => ItemType::Primitive,
             clean::RequiredAssocConstItem(..)
             | clean::ProvidedAssocConstItem(..)
@@ -225,8 +225,8 @@ impl ItemType {
             ItemType::AssocConst => "associatedconstant",
             ItemType::ForeignType => "foreigntype",
             ItemType::Keyword => "keyword",
-            ItemType::ProcAttribute => "attr",
-            ItemType::ProcDerive => "derive",
+            ItemType::ProcAttribute | ItemType::BangMacroAttribute => "attr",
+            ItemType::ProcDerive | ItemType::BangMacroDerive => "derive",
             ItemType::TraitAlias => "traitalias",
             ItemType::Attribute => "attribute",
         }

--- a/src/librustdoc/formats/item_type.rs
+++ b/src/librustdoc/formats/item_type.rs
@@ -128,6 +128,10 @@ impl<'a> From<&'a clean::Item> for ItemType {
             clean::ForeignFunctionItem(..) => ItemType::Function, // no ForeignFunction
             clean::ForeignStaticItem(..) => ItemType::Static,     // no ForeignStatic
             clean::MacroItem(..) => ItemType::Macro,
+            // Is this a good idea?
+            clean::AttrMacroItem => ItemType::ProcAttribute,
+            // Is this a good idea?
+            clean::DeriveMacroItem => ItemType::ProcDerive,
             clean::PrimitiveItem(..) => ItemType::Primitive,
             clean::RequiredAssocConstItem(..)
             | clean::ProvidedAssocConstItem(..)

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -2038,7 +2038,7 @@ fn is_default_id(id: &str) -> bool {
         | "crate-search"
         | "crate-search-div"
         // This is the list of IDs used in HTML generated in Rust (including the ones
-        // used in tera template files).
+        // used in askama template files).
         | "themeStyle"
         | "settings-menu"
         | "help-button"
@@ -2077,7 +2077,7 @@ fn is_default_id(id: &str) -> bool {
         | "blanket-implementations-list"
         | "deref-methods"
         | "layout"
-        | "aliased-type"
+        | "aliased-type",
     )
 }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -169,7 +169,10 @@ impl SharedContext<'_> {
 
 struct SidebarItem {
     name: String,
-    is_actually_macro: bool,
+    /// Bang macros can now be used as attribute/derive macros, making it tricky to correctly
+    /// handle all their cases at once, which means that even if they are categorized as
+    /// derive/attribute macros, they should still link to a "macro_rules" URL.
+    is_macro_rules: bool,
 }
 
 impl serde::Serialize for SidebarItem {
@@ -177,7 +180,7 @@ impl serde::Serialize for SidebarItem {
     where
         S: serde::Serializer,
     {
-        if self.is_actually_macro {
+        if self.is_macro_rules {
             let mut seq = serializer.serialize_seq(Some(2))?;
             seq.serialize_element(&self.name)?;
             seq.serialize_element(&1)?;
@@ -349,7 +352,7 @@ impl<'tcx> Context<'tcx> {
                 let name = name.to_string();
                 map.entry(type_)
                     .or_default()
-                    .push(SidebarItem { name, is_actually_macro: item.is_macro_placeholder() });
+                    .push(SidebarItem { name, is_macro_rules: item.is_macro_placeholder() });
             }
         }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -505,44 +505,32 @@ impl AllTypes {
         }
     }
 
-    fn append(
-        &mut self,
-        item_name: String,
-        item_type: &ItemType,
-        extra_types: Option<Vec<ItemType>>,
-    ) {
+    fn append(&mut self, item_name: String, item: &clean::Item) {
         let mut url: Vec<_> = item_name.split("::").skip(1).collect();
         if let Some(name) = url.pop() {
-            let new_url = format!("{}/{item_type}.{name}.html", url.join("/"));
+            let new_url = format!("{}/{}", url.join("/"), item.html_filename());
             url.push(name);
+            let item_type = item.type_();
             let name = url.join("::");
-            if let Some(extra_types) = extra_types {
-                for extra_type in extra_types {
-                    self.append_with_url(name.clone(), &extra_type, new_url.clone());
+            match item_type {
+                ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
+                ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
+                ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
+                ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
+                ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
+                ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
+                ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
+                ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
+                ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
+                ItemType::ProcAttribute => {
+                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
                 }
-            } else {
-                self.append_with_url(name, item_type, new_url);
-            }
+                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
+                _ => true,
+            };
         }
-    }
-
-    fn append_with_url(&mut self, name: String, item_type: &ItemType, url: String) {
-        match *item_type {
-            ItemType::Struct => self.structs.insert(ItemEntry::new(url, name)),
-            ItemType::Enum => self.enums.insert(ItemEntry::new(url, name)),
-            ItemType::Union => self.unions.insert(ItemEntry::new(url, name)),
-            ItemType::Primitive => self.primitives.insert(ItemEntry::new(url, name)),
-            ItemType::Trait => self.traits.insert(ItemEntry::new(url, name)),
-            ItemType::Macro => self.macros.insert(ItemEntry::new(url, name)),
-            ItemType::Function => self.functions.insert(ItemEntry::new(url, name)),
-            ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(url, name)),
-            ItemType::Static => self.statics.insert(ItemEntry::new(url, name)),
-            ItemType::Constant => self.constants.insert(ItemEntry::new(url, name)),
-            ItemType::ProcAttribute => self.attribute_macros.insert(ItemEntry::new(url, name)),
-            ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(url, name)),
-            ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(url, name)),
-            _ => true,
-        };
     }
 
     fn item_sections(&self) -> FxHashSet<ItemSection> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -505,31 +505,44 @@ impl AllTypes {
         }
     }
 
-    fn append(&mut self, item_name: String, item_type: &ItemType) {
+    fn append(
+        &mut self,
+        item_name: String,
+        item_type: &ItemType,
+        extra_types: Option<Vec<ItemType>>,
+    ) {
         let mut url: Vec<_> = item_name.split("::").skip(1).collect();
         if let Some(name) = url.pop() {
             let new_url = format!("{}/{item_type}.{name}.html", url.join("/"));
             url.push(name);
             let name = url.join("::");
-            match *item_type {
-                ItemType::Struct => self.structs.insert(ItemEntry::new(new_url, name)),
-                ItemType::Enum => self.enums.insert(ItemEntry::new(new_url, name)),
-                ItemType::Union => self.unions.insert(ItemEntry::new(new_url, name)),
-                ItemType::Primitive => self.primitives.insert(ItemEntry::new(new_url, name)),
-                ItemType::Trait => self.traits.insert(ItemEntry::new(new_url, name)),
-                ItemType::Macro => self.macros.insert(ItemEntry::new(new_url, name)),
-                ItemType::Function => self.functions.insert(ItemEntry::new(new_url, name)),
-                ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
-                ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
-                ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute => {
-                    self.attribute_macros.insert(ItemEntry::new(new_url, name))
+            if let Some(extra_types) = extra_types {
+                for extra_type in extra_types {
+                    self.append_with_url(name.clone(), &extra_type, new_url.clone());
                 }
-                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
-                ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
-                _ => true,
-            };
+            } else {
+                self.append_with_url(name, item_type, new_url);
+            }
         }
+    }
+
+    fn append_with_url(&mut self, name: String, item_type: &ItemType, url: String) {
+        match *item_type {
+            ItemType::Struct => self.structs.insert(ItemEntry::new(url, name)),
+            ItemType::Enum => self.enums.insert(ItemEntry::new(url, name)),
+            ItemType::Union => self.unions.insert(ItemEntry::new(url, name)),
+            ItemType::Primitive => self.primitives.insert(ItemEntry::new(url, name)),
+            ItemType::Trait => self.traits.insert(ItemEntry::new(url, name)),
+            ItemType::Macro => self.macros.insert(ItemEntry::new(url, name)),
+            ItemType::Function => self.functions.insert(ItemEntry::new(url, name)),
+            ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(url, name)),
+            ItemType::Static => self.statics.insert(ItemEntry::new(url, name)),
+            ItemType::Constant => self.constants.insert(ItemEntry::new(url, name)),
+            ItemType::ProcAttribute => self.attribute_macros.insert(ItemEntry::new(url, name)),
+            ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(url, name)),
+            ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(url, name)),
+            _ => true,
+        };
     }
 
     fn item_sections(&self) -> FxHashSet<ItemSection> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -523,10 +523,12 @@ impl AllTypes {
                 ItemType::TypeAlias => self.type_aliases.insert(ItemEntry::new(new_url, name)),
                 ItemType::Static => self.statics.insert(ItemEntry::new(new_url, name)),
                 ItemType::Constant => self.constants.insert(ItemEntry::new(new_url, name)),
-                ItemType::ProcAttribute => {
+                ItemType::ProcAttribute | ItemType::BangMacroAttribute => {
                     self.attribute_macros.insert(ItemEntry::new(new_url, name))
                 }
-                ItemType::ProcDerive => self.derive_macros.insert(ItemEntry::new(new_url, name)),
+                ItemType::ProcDerive | ItemType::BangMacroDerive => {
+                    self.derive_macros.insert(ItemEntry::new(new_url, name))
+                }
                 ItemType::TraitAlias => self.trait_aliases.insert(ItemEntry::new(new_url, name)),
                 _ => true,
             };
@@ -2610,8 +2612,8 @@ fn item_ty_to_section(ty: ItemType) -> ItemSection {
         ItemType::ForeignType => ItemSection::ForeignTypes,
         ItemType::Keyword => ItemSection::Keywords,
         ItemType::Attribute => ItemSection::Attributes,
-        ItemType::ProcAttribute => ItemSection::AttributeMacros,
-        ItemType::ProcDerive => ItemSection::DeriveMacros,
+        ItemType::ProcAttribute | ItemType::BangMacroAttribute => ItemSection::AttributeMacros,
+        ItemType::ProcDerive | ItemType::BangMacroDerive => ItemSection::DeriveMacros,
         ItemType::TraitAlias => ItemSection::TraitAliases,
     }
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2549,7 +2549,7 @@ impl ItemSection {
             Self::ForeignTypes => "foreign-types",
             Self::Keywords => "keywords",
             Self::Attributes => "attributes",
-            Self::AttributeMacros => "attributes",
+            Self::AttributeMacros => "attribute-macros",
             Self::DeriveMacros => "derives",
             Self::TraitAliases => "trait-aliases",
         }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -314,7 +314,14 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
             FxHashMap::default();
 
         for (index, item) in items.iter().filter(|i| !i.is_stripped()).enumerate() {
-            not_stripped_items.entry(item.type_()).or_default().push((index, item));
+            // To prevent having new "bang macro attribute/derive" sections in the module,
+            // we cheat by turning them into their "proc-macro equivalent".
+            let type_ = match item.type_() {
+                ItemType::BangMacroAttribute => ItemType::ProcAttribute,
+                ItemType::BangMacroDerive => ItemType::ProcDerive,
+                type_ => type_,
+            };
+            not_stripped_items.entry(type_).or_default().push((index, item));
         }
 
         // the order of item types in the listing

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -406,13 +406,15 @@ fn item_module(cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) -> i
 
         for type_ in types {
             let my_section = item_ty_to_section(type_);
-            let section_id = my_section.id();
-            let tag =
-                if section_id == "reexports" { REEXPORTS_TABLE_OPEN } else { ITEM_TABLE_OPEN };
+            let tag = if my_section == super::ItemSection::Reexports {
+                REEXPORTS_TABLE_OPEN
+            } else {
+                ITEM_TABLE_OPEN
+            };
             write!(
                 w,
                 "{}",
-                write_section_heading(my_section.name(), &cx.derive_id(section_id), None, tag)
+                write_section_heading(my_section.name(), &cx.derive_id(my_section.id()), None, tag)
             )?;
 
             for (_, myitem) in &not_stripped_items[&type_] {
@@ -1889,7 +1891,7 @@ fn item_macro(
     cx: &Context<'_>,
     it: &clean::Item,
     t: &clean::Macro,
-    kinds: Option<MacroKinds>,
+    kinds: MacroKinds,
 ) -> impl fmt::Display {
     fmt::from_fn(move |w| {
         wrap_item(w, |w| {
@@ -1900,7 +1902,7 @@ fn item_macro(
             }
             write!(w, "{}", Escape(&t.source))
         })?;
-        if let Some(kinds) = kinds {
+        if kinds != MacroKinds::BANG {
             write!(
                 w,
                 "<h3 class='macro-info'>ⓘ This is {} {}</h3>",

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -653,7 +653,13 @@ fn sidebar_module(
                     })
                     .is_some()
         })
-        .map(|it| item_ty_to_section(it.type_()))
+        .flat_map(|it| {
+            if let Some(types) = it.bang_macro_types() {
+                types.into_iter().map(|type_| item_ty_to_section(type_)).collect::<Vec<_>>()
+            } else {
+                vec![item_ty_to_section(it.type_())]
+            }
+        })
         .collect();
 
     sidebar_module_like(item_sections_in_use, ids, module_like)

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -653,13 +653,7 @@ fn sidebar_module(
                     })
                     .is_some()
         })
-        .flat_map(|it| {
-            if let Some(types) = it.bang_macro_types() {
-                types.into_iter().map(|type_| item_ty_to_section(type_)).collect::<Vec<_>>()
-            } else {
-                vec![item_ty_to_section(it.type_())]
-            }
-        })
+        .map(|it| item_ty_to_section(it.type_()))
         .collect();
 
     sidebar_module_like(item_sections_in_use, ids, module_like)

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -799,7 +799,7 @@ function preLoadCss(cssUrl) {
             block("foreigntype", "foreign-types", "Foreign Types");
             block("keyword", "keywords", "Keywords");
             block("attribute", "attributes", "Attributes");
-            block("attr", "attributes", "Attribute Macros");
+            block("attr", "attribute-macros", "Attribute Macros");
             block("derive", "derives", "Derive Macros");
             block("traitalias", "trait-aliases", "Trait Aliases");
         }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -736,12 +736,20 @@ function preLoadCss(cssUrl) {
             const ul = document.createElement("ul");
             ul.className = "block " + shortty;
 
-            for (const name of filtered) {
+            for (const item of filtered) {
+                let name = item;
+                let isMacro = false;
+                if (Array.isArray(item)) {
+                    name = item[0];
+                    isMacro = true;
+                }
                 let path;
                 if (shortty === "mod") {
                     path = `${modpath}${name}/index.html`;
-                } else {
+                } else if (!isMacro) {
                     path = `${modpath}${shortty}.${name}.html`;
+                } else {
+                    path = `${modpath}macro.${name}.html`;
                 }
                 let current_page = document.location.href.toString();
                 if (current_page.endsWith("/")) {

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -244,6 +244,27 @@ declare namespace rustdoc {
         traitParent: number?,
         deprecated: boolean,
         associatedItemDisambiguator: string?,
+        /**
+         * If `true`, this item is a `macro_rules!` macro that supports
+         * multiple usage syntaxes, as described in RFC 3697 and 3698.
+         * The syntax for such a macro looks like this:
+         *
+         * ```rust
+         * /// Doc Comment.
+         * macro_rules! NAME {
+         *     attr(key = $value:literal) ($attached:item) => { ... };
+         *     derive() ($attached:item) => { ... };
+         *     ($bang:tt) => { ... };
+         *  }
+         * ```
+         *
+         * Each usage syntax gets a separate EntryData---one for the attr,
+         * one for the derive, and one for the bang syntax---with a corresponding
+         * `ty` field that can be used for filtering and presenting results.
+         * But the documentation lives in a single `macro.NAME.html` page, and
+         * this boolean flag is used for generating that HREF.
+         */
+        isBangMacro: boolean,
     }
 
     /**
@@ -300,7 +321,7 @@ declare namespace rustdoc {
 
     type ItemType = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
         11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 |
-        21 | 22 | 23 | 24 | 25 | 26;
+        21 | 22 | 23 | 24 | 25 | 26 | 28 | 29;
 
     /**
      * The viewmodel for the search engine results page.

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -308,7 +308,7 @@ fn from_clean_item(item: &clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum 
             type_: ci.type_.into_json(renderer),
             const_: ci.kind.into_json(renderer),
         },
-        MacroItem(m) => ItemEnum::Macro(m.source.clone()),
+        MacroItem(m, _) => ItemEnum::Macro(m.source.clone()),
         ProcMacroItem(m) => ItemEnum::ProcMacro(m.into_json(renderer)),
         PrimitiveItem(p) => {
             ItemEnum::Primitive(Primitive {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -898,8 +898,8 @@ impl FromClean<ItemType> for ItemKind {
             Keyword => ItemKind::Keyword,
             Attribute => ItemKind::Attribute,
             TraitAlias => ItemKind::TraitAlias,
-            ProcAttribute => ItemKind::ProcAttribute,
-            ProcDerive => ItemKind::ProcDerive,
+            ProcAttribute | BangMacroAttribute => ItemKind::ProcAttribute,
+            ProcDerive | BangMacroDerive => ItemKind::ProcDerive,
         }
     }
 }

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -88,6 +88,8 @@ impl DocFolder for StabilityPropagator<'_, '_> {
                     | ItemKind::ForeignStaticItem(..)
                     | ItemKind::ForeignTypeItem
                     | ItemKind::MacroItem(..)
+                    | ItemKind::AttrMacroItem
+                    | ItemKind::DeriveMacroItem
                     | ItemKind::ProcMacroItem(..)
                     | ItemKind::ConstantItem(..) => {
                         // If any of the item's parents was stabilized later or is still unstable,

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -64,6 +64,8 @@ impl DocFolder for Stripper<'_, '_> {
             | clean::UnionItem(..)
             | clean::TraitAliasItem(..)
             | clean::MacroItem(..)
+            | clean::AttrMacroItem
+            | clean::DeriveMacroItem
             | clean::ForeignTypeItem => {
                 let item_id = i.item_id;
                 if item_id.is_local()

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -41,7 +41,7 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | ForeignFunctionItem(..)
             | ForeignStaticItem(..)
             | ForeignTypeItem
-            | MacroItem(_)
+            | MacroItem(..)
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -42,6 +42,8 @@ pub(crate) trait DocVisitor<'a>: Sized {
             | ForeignStaticItem(..)
             | ForeignTypeItem
             | MacroItem(..)
+            | AttrMacroItem
+            | DeriveMacroItem
             | ProcMacroItem(_)
             | PrimitiveItem(_)
             | RequiredAssocConstItem(..)

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -1,0 +1,39 @@
+// This test ensures that a bang macro which is also an attribute macro is listed correctly in
+// the sidebar and in the module.
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/macro.b.html"
+// It should be present twice in the sidebar.
+assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
+assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
+// We check that the current item in the sidebar is the correct one.
+assert-text: ("#rustdoc-modnav .block.macro .current", "b")
+
+// We now go to the attribute macro page.
+click: "#rustdoc-modnav a[href='macro.attr_macro.html']"
+// It should be present twice in the sidebar.
+assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
+assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
+// We check that the current item is the "attr_macro".
+assert-text: ("#rustdoc-modnav .block.macro .current", "attr_macro")
+// Since the item is present twice in the sidebar, we should have two "current" items.
+assert-count: ("#rustdoc-modnav .current", 2)
+// We check it has the expected information.
+assert-text: ("h3.macro-info", "ⓘ This is an attribute/function macro")
+
+// Now we check it's correctly listed in the crate page.
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+// It should be only present twice.
+assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
+// First in the "Macros" section.
+assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+// Then in the "Attribute Macros" section.
+assert-text: ("#attributes + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+
+// And finally we check it's correctly listed in the "all items" page.
+go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
+// It should be only present twice.
+assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
+// First in the "Macros" section.
+assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+// Then in the "Attribute Macros" section.
+assert-text: ("#attributes + .all-items a[href='macro.attr_macro.html']", "attr_macro")

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -27,7 +27,7 @@ assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
 // First in the "Macros" section.
 assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
 // Then in the "Attribute Macros" section.
-assert-text: ("#attributes + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+assert-text: ("#attribute-macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
 
 // And finally we check it's correctly listed in the "all items" page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
@@ -36,4 +36,4 @@ assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
 // First in the "Macros" section.
 assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
 // Then in the "Attribute Macros" section.
-assert-text: ("#attributes + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+assert-text: ("#attribute-macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")

--- a/tests/rustdoc-gui/attr-macros.goml
+++ b/tests/rustdoc-gui/attr-macros.goml
@@ -2,38 +2,75 @@
 // the sidebar and in the module.
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/macro.b.html"
-// It should be present twice in the sidebar.
-assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
-assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
 // We check that the current item in the sidebar is the correct one.
 assert-text: ("#rustdoc-modnav .block.macro .current", "b")
 
-// We now go to the attribute macro page.
-click: "#rustdoc-modnav a[href='macro.attr_macro.html']"
-// It should be present twice in the sidebar.
-assert-count: ("#rustdoc-modnav a[href='macro.attr_macro.html']", 2)
-assert-count: ("//*[@id='rustdoc-modnav']//a[text()='attr_macro']", 2)
-// We check that the current item is the "attr_macro".
-assert-text: ("#rustdoc-modnav .block.macro .current", "attr_macro")
-// Since the item is present twice in the sidebar, we should have two "current" items.
-assert-count: ("#rustdoc-modnav .current", 2)
-// We check it has the expected information.
-assert-text: ("h3.macro-info", "ⓘ This is an attribute/function macro")
+define-function: (
+    "check_macro",
+    [name, info],
+    block {
+        // It should be present twice in the sidebar.
+        assert-count: ("#rustdoc-modnav a[href='macro." + |name| + ".html']", 2)
+        assert-count: ("//*[@id='rustdoc-modnav']//a[text()='" + |name| + "']", 2)
+
+        // We now go to the macro page.
+        click: "#rustdoc-modnav a[href='macro." + |name| + ".html']"
+        // It should be present twice in the sidebar.
+        assert-count: ("#rustdoc-modnav a[href='macro." + |name| + ".html']", 2)
+        assert-count: ("//*[@id='rustdoc-modnav']//a[text()='" + |name| + "']", 2)
+        // We check that the current item is the macro.
+        assert-text: ("#rustdoc-modnav .block.macro .current", |name|)
+        // Since the item is present twice in the sidebar, we should have two "current" items.
+        assert-count: ("#rustdoc-modnav .current", 2)
+        // We check it has the expected information.
+        assert-text: ("h3.macro-info", "ⓘ This is " + |info| + "/function macro")
+    }
+)
+
+call-function: ("check_macro", {"name": "attr_macro", "info": "an attribute"})
+call-function: ("check_macro", {"name": "derive_macro", "info": "a derive"})
+
+define-function: (
+    "crate_page",
+    [name, section_id],
+    block {
+        // It should be only present twice.
+        assert-count: ("#main-content a[href='macro." + |name| + ".html']", 2)
+        // First in the "Macros" section.
+        assert-text: ("#macros + .item-table a[href='macro." + |name| + ".html']", |name|)
+        // Then in the other macro section.
+        assert-text: (
+            "#" + |section_id| + " + .item-table a[href='macro." + |name| + ".html']",
+            |name|,
+        )
+    }
+)
 
 // Now we check it's correctly listed in the crate page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-// It should be only present twice.
-assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
-// First in the "Macros" section.
-assert-text: ("#macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
-// Then in the "Attribute Macros" section.
-assert-text: ("#attribute-macros + .item-table a[href='macro.attr_macro.html']", "attr_macro")
+call-function: ("crate_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("crate_page", {"name": "derive_macro", "section_id": "derives"})
+// We also check we don't have duplicated sections.
+assert-count: ("//*[@id='main-content']/h2[text()='Attribute Macros']", 1)
+assert-count: ("//*[@id='main-content']/h2[text()='Derive Macros']", 1)
+
+define-function: (
+    "all_items_page",
+    [name, section_id],
+    block {
+        // It should be only present twice.
+        assert-count: ("#main-content a[href='macro." + |name| + ".html']", 2)
+        // First in the "Macros" section.
+        assert-text: ("#macros + .all-items a[href='macro." + |name| + ".html']", |name|)
+        // Then in the "Attribute Macros" section.
+        assert-text: (
+            "#" + |section_id| + " + .all-items a[href='macro." + |name| + ".html']",
+            |name|,
+        )
+    }
+)
 
 // And finally we check it's correctly listed in the "all items" page.
 go-to: "file://" + |DOC_PATH| + "/test_docs/all.html"
-// It should be only present twice.
-assert-count: ("#main-content a[href='macro.attr_macro.html']", 2)
-// First in the "Macros" section.
-assert-text: ("#macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
-// Then in the "Attribute Macros" section.
-assert-text: ("#attribute-macros + .all-items a[href='macro.attr_macro.html']", "attr_macro")
+call-function: ("all_items_page", {"name": "attr_macro", "section_id": "attribute-macros"})
+call-function: ("all_items_page", {"name": "derive_macro", "section_id": "derives"})

--- a/tests/rustdoc-gui/module-items-font.goml
+++ b/tests/rustdoc-gui/module-items-font.goml
@@ -74,3 +74,12 @@ assert-css: (
     "#attributes + .item-table dd",
     {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
 )
+// attribute macros
+assert-css: (
+    "#attribute-macros + .item-table dt a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#attribute-macros + .item-table dd",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -8,6 +8,7 @@
 #![feature(rustdoc_internals)]
 #![feature(doc_cfg)]
 #![feature(associated_type_defaults)]
+#![feature(macro_attr)]
 
 /*!
 Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -9,6 +9,7 @@
 #![feature(doc_cfg)]
 #![feature(associated_type_defaults)]
 #![feature(macro_attr)]
+#![feature(macro_derive)]
 
 /*!
 Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -2,3 +2,10 @@
 macro_rules! a{ () => {}}
 #[macro_export]
 macro_rules! b{ () => {}}
+
+// An attribute bang macro.
+#[macro_export]
+macro_rules! attr_macro {
+    attr() () => {};
+    () => {};
+}

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -3,7 +3,7 @@ macro_rules! a{ () => {}}
 #[macro_export]
 macro_rules! b{ () => {}}
 
-// An attribute bang macro.
+/// An attribute bang macro.
 #[macro_export]
 macro_rules! attr_macro {
     attr() () => {};

--- a/tests/rustdoc-gui/src/test_docs/macros.rs
+++ b/tests/rustdoc-gui/src/test_docs/macros.rs
@@ -9,3 +9,17 @@ macro_rules! attr_macro {
     attr() () => {};
     () => {};
 }
+
+/// An attribute bang macro.
+#[macro_export]
+macro_rules! derive_macro {
+    derive() () => {};
+    () => {};
+}
+
+#[macro_export]
+macro_rules! one_for_all_macro {
+    attr() () => {};
+    derive() () => {};
+    () => {};
+}

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -1,0 +1,18 @@
+// exact-check
+
+const EXPECTED = [
+    {
+        'query': 'macro:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1' },
+            { 'path': 'macro_kinds', 'name': 'macro3' },
+        ],
+    },
+    {
+        'query': 'attr:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1' },
+            { 'path': 'macro_kinds', 'name': 'macro2' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/macro-kinds.js
+++ b/tests/rustdoc-js/macro-kinds.js
@@ -4,15 +4,24 @@ const EXPECTED = [
     {
         'query': 'macro:macro',
         'others': [
-            { 'path': 'macro_kinds', 'name': 'macro1' },
-            { 'path': 'macro_kinds', 'name': 'macro3' },
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            { 'path': 'macro_kinds', 'name': 'macro3', 'href': '../macro_kinds/macro.macro3.html' },
         ],
     },
     {
         'query': 'attr:macro',
         'others': [
-            { 'path': 'macro_kinds', 'name': 'macro1' },
-            { 'path': 'macro_kinds', 'name': 'macro2' },
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            { 'path': 'macro_kinds', 'name': 'macro2', 'href': '../macro_kinds/attr.macro2.html' },
+        ],
+    },
+    {
+        'query': 'derive:macro',
+        'others': [
+            { 'path': 'macro_kinds', 'name': 'macro1', 'href': '../macro_kinds/macro.macro1.html' },
+            {
+                'path': 'macro_kinds', 'name': 'macro4', 'href': '../macro_kinds/derive.macro4.html'
+            },
         ],
     },
 ];

--- a/tests/rustdoc-js/macro-kinds.rs
+++ b/tests/rustdoc-js/macro-kinds.rs
@@ -3,10 +3,12 @@
 // `macro2` and `macro3` should only appear in `attr` or `macro` filters respectively.
 
 #![feature(macro_attr)]
+#![feature(macro_derive)]
 
 #[macro_export]
 macro_rules! macro1 {
     attr() () => {};
+    derive() () => {};
     () => {};
 }
 
@@ -18,4 +20,9 @@ macro_rules! macro2 {
 #[macro_export]
 macro_rules! macro3 {
     () => {};
+}
+
+#[macro_export]
+macro_rules! macro4 {
+    derive() () => {};
 }

--- a/tests/rustdoc-js/macro-kinds.rs
+++ b/tests/rustdoc-js/macro-kinds.rs
@@ -1,0 +1,21 @@
+// Test which ensures that attribute macros are correctly handled by the search.
+// For example: `macro1` should appear in both `attr` and `macro` filters whereas
+// `macro2` and `macro3` should only appear in `attr` or `macro` filters respectively.
+
+#![feature(macro_attr)]
+
+#[macro_export]
+macro_rules! macro1 {
+    attr() () => {};
+    () => {};
+}
+
+#[macro_export]
+macro_rules! macro2 {
+    attr() () => {};
+}
+
+#[macro_export]
+macro_rules! macro3 {
+    () => {};
+}


### PR DESCRIPTION
This implements rust-lang/rust#145153 in rustdoc. This PR voluntarily doesn't touch anything related to intra-doc links, I'll send a follow-up if needed.

So now about the implementation itself: this is a weird case where a macro can be different things at once but still only gets one file generated. I saw two ways to implement this:
1. Handle `ItemKind::Macro` differently and iter through its `MacroKinds` values.
2. Add new placeholder variants in the `ItemKind` enum, which means that when we encounter them in rendering, we need to ignore them. It also makes the `ItemKind` enum bigger (and also needs more code to be handled). Another downside is that it needs to be handled in the JSON output.

~~I implemented 1. in the first commit and 2. in the third commit so if we don't to keep 2., I can simply remove it. I personally have no preference for one or the other since the first is "simpler" but it's easy to forget to go through the macro kinds whereas the second needs a lot more code.~~

Now there was an interesting improvement that came with this PR in the `html::render::print_item::item_module` function: I simplified its implementation and split the different parts in a `HashMap` where the key is the item type. So then, we can just iterate through the keys and open/close the section at each iteration instead of keeping an `Option<section>` around. 

cc @joshtriplett 