### PR TITLE
Enable new `[range-diff]` feature in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1589,3 +1589,8 @@ days-threshold = 28
 # Documentation at: https://forge.rust-lang.org/triagebot/concern.html
 [concern]
 labels = ["S-waiting-on-concerns"]
+
+# Enable comments linking to triagebot range-diff when a PR is rebased
+# onto a different base commit
+# Documentation at: https://forge.rust-lang.org/triagebot/range-diff.html
+[range-diff]


### PR DESCRIPTION
This new feature adds a comment to triagebot range-diff feature when a PR is rebased  onto a different base/master commit.

Related to [#t-compiler > Experimental range-diff for force-push @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Experimental.20range-diff.20for.20force-push/near/534649322)

r? Kobzol