### PR TITLE
Properly recover from parenthesized use-bounds (precise capturing lists) plus small cleanups

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -748,9 +748,6 @@ parse_parentheses_with_struct_fields = invalid `struct` delimiters or `fn` call 
     .suggestion_braces_for_struct = if `{$type}` is a struct, use braces as delimiters
     .suggestion_no_fields_for_fn = if `{$type}` is a function, use the arguments directly
 
-parse_parenthesized_lifetime = parenthesized lifetime bounds are not supported
-parse_parenthesized_lifetime_suggestion = remove the parentheses
-
 parse_path_double_colon = path separator must be a double colon
     .suggestion = use a double colon instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -3136,27 +3136,6 @@ pub(crate) struct ModifierLifetime {
     pub modifier: &'static str,
 }
 
-#[derive(Subdiagnostic)]
-#[multipart_suggestion(
-    parse_parenthesized_lifetime_suggestion,
-    applicability = "machine-applicable"
-)]
-pub(crate) struct RemoveParens {
-    #[suggestion_part(code = "")]
-    pub lo: Span,
-    #[suggestion_part(code = "")]
-    pub hi: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(parse_parenthesized_lifetime)]
-pub(crate) struct ParenthesizedLifetime {
-    #[primary_span]
-    pub span: Span,
-    #[subdiagnostic]
-    pub sugg: RemoveParens,
-}
-
 #[derive(Diagnostic)]
 #[diag(parse_underscore_literal_suffix)]
 pub(crate) struct UnderscoreLiteralSuffix {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2397,12 +2397,12 @@ impl<'a> Parser<'a> {
         let before = self.prev_token;
         let binder = if self.check_keyword(exp!(For)) {
             let lo = self.token.span;
-            let (lifetime_defs, _) = self.parse_late_bound_lifetime_defs()?;
+            let (bound_vars, _) = self.parse_higher_ranked_binder()?;
             let span = lo.to(self.prev_token.span);
 
             self.psess.gated_spans.gate(sym::closure_lifetime_binder, span);
 
-            ClosureBinder::For { span, generic_params: lifetime_defs }
+            ClosureBinder::For { span, generic_params: bound_vars }
         } else {
             ClosureBinder::NotPresent
         };

--- a/tests/ui/impl-trait/precise-capturing/parenthesized.rs
+++ b/tests/ui/impl-trait/precise-capturing/parenthesized.rs
@@ -1,0 +1,8 @@
+// Ensure that we forbid parenthesized use-bounds. In the future we might want
+// to lift this restriction but for now they bear no use whatsoever.
+
+fn f() -> impl Sized + (use<>) {}
+//~^ ERROR precise capturing lists may not be parenthesized
+//~| HELP remove the parentheses
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/parenthesized.stderr
+++ b/tests/ui/impl-trait/precise-capturing/parenthesized.stderr
@@ -1,0 +1,14 @@
+error: precise capturing lists may not be parenthesized
+  --> $DIR/parenthesized.rs:4:24
+   |
+LL | fn f() -> impl Sized + (use<>) {}
+   |                        ^^^^^^^
+   |
+help: remove the parentheses
+   |
+LL - fn f() -> impl Sized + (use<>) {}
+LL + fn f() -> impl Sized + use<> {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/trait-object-lifetime-parens.e2015.stderr
+++ b/tests/ui/parser/trait-object-lifetime-parens.e2015.stderr
@@ -1,4 +1,4 @@
-error: parenthesized lifetime bounds are not supported
+error: lifetime bounds may not be parenthesized
   --> $DIR/trait-object-lifetime-parens.rs:9:21
    |
 LL | fn f<'a, T: Trait + ('a)>() {}
@@ -10,7 +10,7 @@ LL - fn f<'a, T: Trait + ('a)>() {}
 LL + fn f<'a, T: Trait + 'a>() {}
    |
 
-error: parenthesized lifetime bounds are not supported
+error: lifetime bounds may not be parenthesized
   --> $DIR/trait-object-lifetime-parens.rs:12:24
    |
 LL |     let _: Box<Trait + ('a)>;

--- a/tests/ui/parser/trait-object-lifetime-parens.e2021.stderr
+++ b/tests/ui/parser/trait-object-lifetime-parens.e2021.stderr
@@ -1,4 +1,4 @@
-error: parenthesized lifetime bounds are not supported
+error: lifetime bounds may not be parenthesized
   --> $DIR/trait-object-lifetime-parens.rs:9:21
    |
 LL | fn f<'a, T: Trait + ('a)>() {}
@@ -10,7 +10,7 @@ LL - fn f<'a, T: Trait + ('a)>() {}
 LL + fn f<'a, T: Trait + 'a>() {}
    |
 
-error: parenthesized lifetime bounds are not supported
+error: lifetime bounds may not be parenthesized
   --> $DIR/trait-object-lifetime-parens.rs:12:24
    |
 LL |     let _: Box<Trait + ('a)>;

--- a/tests/ui/parser/trait-object-lifetime-parens.rs
+++ b/tests/ui/parser/trait-object-lifetime-parens.rs
@@ -6,10 +6,10 @@
 
 trait Trait {}
 
-fn f<'a, T: Trait + ('a)>() {} //~ ERROR parenthesized lifetime bounds are not supported
+fn f<'a, T: Trait + ('a)>() {} //~ ERROR lifetime bounds may not be parenthesized
 
 fn check<'a>() {
-    let _: Box<Trait + ('a)>; //~ ERROR parenthesized lifetime bounds are not supported
+    let _: Box<Trait + ('a)>; //~ ERROR lifetime bounds may not be parenthesized
     //[e2021]~^ ERROR expected a type, found a trait
     // FIXME: It'd be great if we could suggest removing the parentheses here too.
     //[e2015]~v ERROR lifetimes must be followed by `+` to form a trait object type


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145470.

First commit fixes the issue, second one performs some desperately needed cleanups.

The fix shouldn't be a breaking change because IINM the parser always ensures that all brackets are balanced (via a buffer of brackets). Meaning even though we used to accept `(use<>` as a valid precise capturing list, it was guaranteed that we would fail in the end.