### PR TITLE
Introduce `TypingMode::Codegen` to avoid layout cycles on coroutines

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -369,33 +369,49 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToAllocationRawResult<'tcx> {
+    let ty::PseudoCanonicalInput { typing_env, value } = key;
+
     // This shouldn't be used for statics, since statics are conceptually places,
     // not values -- so what we do here could break pointer identity.
     assert!(key.value.promoted.is_some() || !tcx.is_static(key.value.instance.def_id()));
 
-    if cfg!(debug_assertions) {
-        match key.typing_env.typing_mode().assert_not_erased() {
-            ty::TypingMode::PostAnalysis => {}
-            ty::TypingMode::Coherence
-            | ty::TypingMode::Analysis { .. }
-            | ty::TypingMode::Borrowck { .. }
-            | ty::TypingMode::PostBorrowckAnalysis { .. } => {
+    match key.typing_env.typing_mode().assert_not_erased() {
+        ty::TypingMode::PostAnalysis => {}
+        // We are in codegen. It's very likely this constant has been evaluated in PostAnalysis before.
+        // Try to reuse this evaluation, and only re-run if we hit a `TooGeneric` error.
+        ty::TypingMode::Codegen => {
+            let with_postanalysis =
+                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
+            let with_postanalysis =
+                tcx.eval_to_allocation_raw(with_postanalysis.as_query_input(value));
+            match with_postanalysis {
+                Ok(_) | Err(ErrorHandled::Reported(..)) => return with_postanalysis,
+                Err(ErrorHandled::TooGeneric(_)) => {}
+            }
+        }
+        ty::TypingMode::Coherence
+        | ty::TypingMode::Analysis { .. }
+        | ty::TypingMode::Borrowck { .. }
+        | ty::TypingMode::PostBorrowckAnalysis { .. } => {
+            if cfg!(debug_assertions) {
                 bug!(
-                    "Const eval should always happens in PostAnalysis mode. See the comment in `InterpCx::new` for more details."
+                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
                 )
             }
         }
+    }
 
+    if cfg!(debug_assertions) {
         // Make sure we format the instance even if we do not print it.
         // This serves as a regression test against an ICE on printing.
         // The next two lines concatenated contain some discussion:
         // https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/
         // subject/anon_const_instance_printing/near/135980032
-        let instance = with_no_trimmed_paths!(key.value.instance.to_string());
-        trace!("const eval: {:?} ({})", key, instance);
+        let instance = with_no_trimmed_paths!(value.instance.to_string());
+        trace!("const eval: {:?} ({}) inside {:?}", value, instance, typing_env);
     }
 
-    eval_in_interpreter(tcx, key.value, key.typing_env)
+    eval_in_interpreter(tcx, value, typing_env)
 }
 
 fn eval_in_interpreter<'tcx, R: InterpretationResult<'tcx>>(

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -327,9 +327,40 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToConstValueResult<'tcx> {
-    if let Some((value, _ty)) = tcx.trivial_const(key.value.instance.def_id()) {
+    let ty::PseudoCanonicalInput { typing_env, value } = key;
+
+    if let Some((value, _ty)) = tcx.trivial_const(value.instance.def_id()) {
         return Ok(value);
     }
+
+    match typing_env.typing_mode().assert_not_erased() {
+        ty::TypingMode::PostAnalysis => {}
+        // We are in codegen. It's very likely this constant has been evaluated in PostAnalysis before.
+        // Try to reuse this evaluation, and only re-run if we hit a `TooGeneric` error.
+        ty::TypingMode::Codegen => {
+            let with_postanalysis =
+                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
+            let with_postanalysis =
+                tcx.eval_to_const_value_raw(with_postanalysis.as_query_input(value));
+            match with_postanalysis {
+                Ok(_) | Err(ErrorHandled::Reported(..)) => return with_postanalysis,
+                Err(ErrorHandled::TooGeneric(_)) => {}
+            }
+        }
+        // Const eval always happens in PostAnalysis or Codegen mode. See the comment in
+        // `InterpCx::new` for more details.
+        ty::TypingMode::Coherence
+        | ty::TypingMode::Analysis { .. }
+        | ty::TypingMode::Borrowck { .. }
+        | ty::TypingMode::PostBorrowckAnalysis { .. } => {
+            if cfg!(debug_assertions) {
+                bug!(
+                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
+                )
+            }
+        }
+    }
+
     tcx.eval_to_allocation_raw(key).map(|val| turn_into_const_value(tcx, val, key))
 }
 

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -8,7 +8,7 @@ use rustc_middle::mir::{self, ConstAlloc, ConstValue};
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::{HasTypingEnv, TyAndLayout};
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitable};
 use rustc_middle::{bug, throw_inval};
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
@@ -22,6 +22,33 @@ use crate::interpret::{
     intern_const_alloc_recursive, interp_ok, throw_exhaust,
 };
 use crate::{CTRL_C_RECEIVED, errors};
+
+fn retry_codegen_mode_with_postanalysis<'tcx, K: TypeVisitable<TyCtxt<'tcx>>, V>(
+    key: ty::PseudoCanonicalInput<'tcx, K>,
+    f: impl FnOnce(ty::PseudoCanonicalInput<'tcx, K>) -> Result<V, ErrorHandled>,
+) -> Option<Result<V, ErrorHandled>> {
+    let ty::PseudoCanonicalInput { typing_env, value } = key;
+    match typing_env.typing_mode().assert_not_erased() {
+        // We are in codegen. It's very likely this constant has been evaluated in PostAnalysis
+        // before. Try to reuse this evaluation, and only re-run if we hit a `TooGeneric` error.
+        ty::TypingMode::Codegen => {
+            let with_postanalysis =
+                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
+            let with_postanalysis = f(with_postanalysis.as_query_input(value));
+            match with_postanalysis {
+                Ok(_) | Err(ErrorHandled::Reported(..)) => return Some(with_postanalysis),
+                Err(ErrorHandled::TooGeneric(_)) => {}
+            }
+        }
+        ty::TypingMode::Coherence
+        | ty::TypingMode::Analysis { .. }
+        | ty::TypingMode::Borrowck { .. }
+        | ty::TypingMode::PostBorrowckAnalysis { .. }
+        | ty::TypingMode::PostAnalysis => {}
+    }
+
+    None
+}
 
 fn setup_for_eval<'tcx>(
     ecx: &mut CompileTimeInterpCx<'tcx>,
@@ -327,38 +354,16 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToConstValueResult<'tcx> {
-    let ty::PseudoCanonicalInput { typing_env, value } = key;
+    crate::assert_typing_mode(key.typing_env.typing_mode());
 
-    if let Some((value, _ty)) = tcx.trivial_const(value.instance.def_id()) {
+    if let Some((value, _ty)) = tcx.trivial_const(key.value.instance.def_id()) {
         return Ok(value);
     }
 
-    match typing_env.typing_mode().assert_not_erased() {
-        ty::TypingMode::PostAnalysis => {}
-        // We are in codegen. It's very likely this constant has been evaluated in PostAnalysis before.
-        // Try to reuse this evaluation, and only re-run if we hit a `TooGeneric` error.
-        ty::TypingMode::Codegen => {
-            let with_postanalysis =
-                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
-            let with_postanalysis =
-                tcx.eval_to_const_value_raw(with_postanalysis.as_query_input(value));
-            match with_postanalysis {
-                Ok(_) | Err(ErrorHandled::Reported(..)) => return with_postanalysis,
-                Err(ErrorHandled::TooGeneric(_)) => {}
-            }
-        }
-        // Const eval always happens in PostAnalysis or Codegen mode. See the comment in
-        // `InterpCx::new` for more details.
-        ty::TypingMode::Coherence
-        | ty::TypingMode::Analysis { .. }
-        | ty::TypingMode::Borrowck { .. }
-        | ty::TypingMode::PostBorrowckAnalysis { .. } => {
-            if cfg!(debug_assertions) {
-                bug!(
-                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
-                )
-            }
-        }
+    if let Some(retry) =
+        retry_codegen_mode_with_postanalysis(key, |key| tcx.eval_to_const_value_raw(key))
+    {
+        return retry;
     }
 
     tcx.eval_to_allocation_raw(key).map(|val| turn_into_const_value(tcx, val, key))
@@ -400,37 +405,16 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::PseudoCanonicalInput<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToAllocationRawResult<'tcx> {
-    let ty::PseudoCanonicalInput { typing_env, value } = key;
+    crate::assert_typing_mode(key.typing_env.typing_mode());
+    if let Some(retry) =
+        retry_codegen_mode_with_postanalysis(key, |key| tcx.eval_to_allocation_raw(key))
+    {
+        return retry;
+    }
 
     // This shouldn't be used for statics, since statics are conceptually places,
     // not values -- so what we do here could break pointer identity.
     assert!(key.value.promoted.is_some() || !tcx.is_static(key.value.instance.def_id()));
-
-    match key.typing_env.typing_mode().assert_not_erased() {
-        ty::TypingMode::PostAnalysis => {}
-        // We are in codegen. It's very likely this constant has been evaluated in PostAnalysis before.
-        // Try to reuse this evaluation, and only re-run if we hit a `TooGeneric` error.
-        ty::TypingMode::Codegen => {
-            let with_postanalysis =
-                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
-            let with_postanalysis =
-                tcx.eval_to_allocation_raw(with_postanalysis.as_query_input(value));
-            match with_postanalysis {
-                Ok(_) | Err(ErrorHandled::Reported(..)) => return with_postanalysis,
-                Err(ErrorHandled::TooGeneric(_)) => {}
-            }
-        }
-        ty::TypingMode::Coherence
-        | ty::TypingMode::Analysis { .. }
-        | ty::TypingMode::Borrowck { .. }
-        | ty::TypingMode::PostBorrowckAnalysis { .. } => {
-            if cfg!(debug_assertions) {
-                bug!(
-                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
-                )
-            }
-        }
-    }
 
     if cfg!(debug_assertions) {
         // Make sure we format the instance even if we do not print it.
@@ -438,11 +422,11 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
         // The next two lines concatenated contain some discussion:
         // https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/
         // subject/anon_const_instance_printing/near/135980032
-        let instance = with_no_trimmed_paths!(value.instance.to_string());
-        trace!("const eval: {:?} ({}) inside {:?}", value, instance, typing_env);
+        let instance = with_no_trimmed_paths!(key.value.instance.to_string());
+        trace!("const eval: {:?} ({})", key, instance);
     }
 
-    eval_in_interpreter(tcx, value, typing_env)
+    eval_in_interpreter(tcx, key.value, key.typing_env)
 }
 
 fn eval_in_interpreter<'tcx, R: InterpretationResult<'tcx>>(

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -243,13 +243,13 @@ pub(crate) fn eval_to_valtree<'tcx>(
 ) -> EvalToValTreeResult<'tcx> {
     if cfg!(debug_assertions) {
         match typing_env.typing_mode().assert_not_erased() {
-            ty::TypingMode::PostAnalysis => {}
+            ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {}
             ty::TypingMode::Coherence
             | ty::TypingMode::Analysis { .. }
             | ty::TypingMode::Borrowck { .. }
             | ty::TypingMode::PostBorrowckAnalysis { .. } => {
                 bug!(
-                    "Const eval should always happens in PostAnalysis mode. See the comment in `InterpCx::new` for more details."
+                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
                 )
             }
         }

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -241,19 +241,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
     typing_env: ty::TypingEnv<'tcx>,
     cid: GlobalId<'tcx>,
 ) -> EvalToValTreeResult<'tcx> {
-    if cfg!(debug_assertions) {
-        match typing_env.typing_mode().assert_not_erased() {
-            ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {}
-            ty::TypingMode::Coherence
-            | ty::TypingMode::Analysis { .. }
-            | ty::TypingMode::Borrowck { .. }
-            | ty::TypingMode::PostBorrowckAnalysis { .. } => {
-                bug!(
-                    "Const eval should always happens in PostAnalysis or Codegen mode. See the comment in `InterpCx::new` for more details."
-                )
-            }
-        }
-    }
+    crate::assert_typing_mode(typing_env.typing_mode());
     let const_alloc = tcx.eval_to_allocation_raw(typing_env.as_query_input(cid))?;
 
     // FIXME Need to provide a span to `eval_to_valtree`

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -9,10 +9,9 @@ use rustc_middle::ty::layout::{
     LayoutOfHelpers, TyAndLayout,
 };
 use rustc_middle::ty::{
-    self, GenericArgsRef, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingEnv, TypingMode,
-    Variance,
+    self, GenericArgsRef, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingEnv, Variance,
 };
-use rustc_middle::{bug, mir, span_bug};
+use rustc_middle::{mir, span_bug};
 use rustc_span::Span;
 use rustc_target::callconv::FnAbi;
 use tracing::{debug, trace};
@@ -238,21 +237,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         typing_env: ty::TypingEnv<'tcx>,
         machine: M,
     ) -> Self {
-        // Const eval always happens in post analysis mode in order to be able to use the hidden types of
-        // opaque types. This is needed for trivial things like `size_of`, but also for using associated
-        // types that are not specified in the opaque type. We also use MIR bodies whose opaque types have
-        // already been revealed, so we'd be able to at least partially observe the hidden types anyways.
-        if cfg!(debug_assertions) {
-            match typing_env.typing_mode().assert_not_erased() {
-                TypingMode::PostAnalysis | TypingMode::Codegen => {}
-                TypingMode::Coherence
-                | TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. } => {
-                    bug!("Const eval should always happens in PostAnalysis or Codegen mode.");
-                }
-            }
-        }
+        crate::assert_typing_mode(typing_env.typing_mode());
 
         InterpCx {
             machine,

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -244,12 +244,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // already been revealed, so we'd be able to at least partially observe the hidden types anyways.
         if cfg!(debug_assertions) {
             match typing_env.typing_mode().assert_not_erased() {
-                TypingMode::PostAnalysis => {}
+                TypingMode::PostAnalysis | TypingMode::Codegen => {}
                 TypingMode::Coherence
                 | TypingMode::Analysis { .. }
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. } => {
-                    bug!("Const eval should always happens in PostAnalysis mode.");
+                    bug!("Const eval should always happens in PostAnalysis or Codegen mode.");
                 }
             }
         }

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -18,8 +18,28 @@ pub mod util;
 
 use std::sync::atomic::AtomicBool;
 
-use rustc_middle::ty;
 use rustc_middle::util::Providers;
+use rustc_middle::{bug, ty};
+
+/// Const eval always happens in post analysis mode in order to be able to use the hidden types of
+/// opaque types. This is needed for trivial things like `size_of`, but also for using associated
+/// types that are not specified in the opaque type. We also use MIR bodies whose opaque types have
+/// already been revealed, so we'd be able to at least partially observe the hidden types anyways.
+fn assert_typing_mode(typing_mode: ty::TypingMode<'_>) {
+    if cfg!(debug_assertions) {
+        match typing_mode.assert_not_erased() {
+            ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {}
+            // Const eval always happens in PostAnalysis or Codegen mode. See the comment in
+            // `InterpCx::new` for more details.
+            ty::TypingMode::Coherence
+            | ty::TypingMode::Analysis { .. }
+            | ty::TypingMode::Borrowck { .. }
+            | ty::TypingMode::PostBorrowckAnalysis { .. } => bug!(
+                "Const eval should always happens in PostAnalysis or Codegen mode. See the comment on `assert_typing_mode` for more details."
+            ),
+        }
+    }
+}
 
 pub fn provide(providers: &mut Providers) {
     const_eval::provide(&mut providers.queries);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -663,7 +663,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty::TypingMode::Coherence
             | ty::TypingMode::Borrowck { .. }
             | ty::TypingMode::PostBorrowckAnalysis { .. }
-            | ty::TypingMode::PostAnalysis => {
+            | ty::TypingMode::PostAnalysis
+            | ty::TypingMode::Codegen => {
                 bug!()
             }
         };

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -147,7 +147,7 @@ pub(crate) fn check_transmutes(tcx: TyCtxt<'_>, owner: LocalDefId) -> Result<(),
         return Err(e);
     };
 
-    let typing_env = ty::TypingEnv::post_analysis(tcx, owner);
+    let typing_env = ty::TypingEnv::codegen(tcx, owner);
     let mut result = Ok(());
     for &(from, to, hir_id) in &typeck_results.transmutes_to_check {
         result = result.and(check_transmute(tcx, typing_env, from, to, hir_id));

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -105,7 +105,8 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             ty::TypingMode::Coherence
             | ty::TypingMode::Borrowck { .. }
             | ty::TypingMode::PostBorrowckAnalysis { .. }
-            | ty::TypingMode::PostAnalysis => {
+            | ty::TypingMode::PostAnalysis
+            | ty::TypingMode::Codegen => {
                 bug!()
             }
         };

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -350,7 +350,8 @@ impl<'tcx> Drop for InferCtxt<'tcx> {
             TypingMode::Coherence
             | TypingMode::Analysis { .. }
             | TypingMode::PostBorrowckAnalysis { .. }
-            | TypingMode::PostAnalysis => {}
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => {}
             // In erased mode, the opaque type storage is always empty
             TypingMode::ErasedNotCoherence(..) => {}
             TypingMode::Borrowck { .. } => {
@@ -1156,7 +1157,8 @@ impl<'tcx> InferCtxt<'tcx> {
             // to support PostBorrowckAnalysis in the old solver as well.
             TypingMode::Coherence
             | TypingMode::PostBorrowckAnalysis { .. }
-            | TypingMode::PostAnalysis => false,
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => false,
         }
     }
 
@@ -1486,7 +1488,8 @@ impl<'tcx> InferCtxt<'tcx> {
             }
             mode @ (ty::TypingMode::Coherence
             | ty::TypingMode::PostBorrowckAnalysis { .. }
-            | ty::TypingMode::PostAnalysis) => mode,
+            | ty::TypingMode::PostAnalysis
+            | ty::TypingMode::Codegen) => mode,
             ty::TypingMode::ErasedNotCoherence(MayBeErased) => unreachable!(),
         };
         ty::TypingEnv::new(param_env, typing_mode)

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -283,7 +283,9 @@ impl<'tcx> InferCtxt<'tcx> {
                         .map(|obligation| obligation.as_goal()),
                 );
             }
-            mode @ (ty::TypingMode::PostBorrowckAnalysis { .. } | ty::TypingMode::PostAnalysis) => {
+            mode @ (ty::TypingMode::PostBorrowckAnalysis { .. }
+            | ty::TypingMode::PostAnalysis
+            | ty::TypingMode::Codegen) => {
                 bug!("insert hidden type in {mode:?}")
             }
         }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1180,10 +1180,10 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
                 && (!tcx.is_async_drop_in_place_coroutine(def_id.to_def_id()))
             {
                 // Eagerly check the unsubstituted layout for cycles.
-                tcx.ensure_ok().layout_of(
-                    ty::TypingEnv::post_analysis(tcx, def_id.to_def_id())
-                        .as_query_input(tcx.type_of(def_id).instantiate_identity().skip_norm_wip()),
-                );
+                tcx.ensure_ok()
+                    .layout_of(ty::TypingEnv::codegen(tcx, def_id.to_def_id()).as_query_input(
+                        tcx.type_of(def_id).instantiate_identity().skip_norm_wip(),
+                    ));
             }
         });
     });

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1627,7 +1627,7 @@ rustc_queries! {
     /// Like `param_env`, but returns the `ParamEnv` after all opaque types have been
     /// replaced with their hidden type. This is used in the old trait solver
     /// when in `PostAnalysis` mode and should not be called directly.
-    query typing_env_normalized_for_post_analysis(def_id: DefId) -> ty::TypingEnv<'tcx> {
+    query param_env_normalized_for_post_analysis(def_id: DefId) -> ty::ParamEnv<'tcx> {
         desc { "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1040,6 +1040,17 @@ impl<'tcx> ParamEnv<'tcx> {
     pub fn and<T: TypeVisitable<TyCtxt<'tcx>>>(self, value: T) -> ParamEnvAnd<'tcx, T> {
         ParamEnvAnd { param_env: self, value }
     }
+
+    /// Eagerly reveal all opaque types in the `param_env`.
+    pub fn with_normalized(self, tcx: TyCtxt<'tcx>) -> ParamEnv<'tcx> {
+        // No need to reveal opaques with the new solver enabled,
+        // since we have lazy norm.
+        if tcx.next_trait_solver_globally() {
+            self
+        } else {
+            ParamEnv::new(tcx.reveal_opaque_types_in_bounds(self.caller_bounds))
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TypeFoldable, TypeVisitable)]
@@ -1102,31 +1113,44 @@ impl<'tcx> TypingEnv<'tcx> {
     }
 
     pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryKey<DefId>) -> TypingEnv<'tcx> {
-        let def_id = def_id.into_query_key();
-        tcx.typing_env_normalized_for_post_analysis(def_id)
+        TypingEnv::new(tcx.param_env_normalized_for_post_analysis(def_id), TypingMode::PostAnalysis)
+    }
+
+    pub fn codegen(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryKey<DefId>) -> TypingEnv<'tcx> {
+        TypingEnv::new(tcx.param_env_normalized_for_post_analysis(def_id), TypingMode::Codegen)
     }
 
     /// Modify the `typing_mode` to `PostAnalysis` or `Codegen` and eagerly reveal all opaque types
     /// in the `param_env`.
     pub fn with_post_analysis_normalized(self, tcx: TyCtxt<'tcx>) -> TypingEnv<'tcx> {
         let TypingEnv { typing_mode, param_env } = self;
+        match typing_mode.0.assert_not_erased() {
+            TypingMode::Coherence
+            | TypingMode::Analysis { .. }
+            | TypingMode::Borrowck { .. }
+            | TypingMode::PostBorrowckAnalysis { .. } => {}
+            TypingMode::PostAnalysis | TypingMode::Codegen => return self,
+        }
 
-        // No need to reveal opaques with the new solver enabled,
-        // since we have lazy norm.
-        let param_env = if tcx.next_trait_solver_globally() {
-            param_env
-        } else {
-            match typing_mode.0.assert_not_erased() {
-                TypingMode::Coherence
-                | TypingMode::Analysis { .. }
-                | TypingMode::Borrowck { .. }
-                | TypingMode::PostBorrowckAnalysis { .. } => {}
-                TypingMode::PostAnalysis | TypingMode::Codegen => return self,
-            }
+        let param_env = param_env.with_normalized(tcx);
+        TypingEnv::new(param_env, TypingMode::PostAnalysis)
+    }
 
-            ParamEnv::new(tcx.reveal_opaque_types_in_bounds(param_env.caller_bounds()))
-        };
-        TypingEnv { typing_mode: TypingModeEqWrapper(TypingMode::PostAnalysis), param_env }
+    /// Modify the `typing_mode` to `PostAnalysis` or `Codegen` and eagerly reveal all opaque types
+    /// in the `param_env`.
+    pub fn with_codegen_normalized(self, tcx: TyCtxt<'tcx>) -> TypingEnv<'tcx> {
+        let TypingEnv { typing_mode, param_env } = self;
+        match typing_mode.0.assert_not_erased() {
+            TypingMode::Coherence
+            | TypingMode::Analysis { .. }
+            | TypingMode::Borrowck { .. }
+            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::PostAnalysis => {}
+            TypingMode::Codegen => return self,
+        }
+
+        let param_env = param_env.with_normalized(tcx);
+        TypingEnv::new(param_env, TypingMode::Codegen)
     }
 
     /// Combine this typing environment with the given `value` to be used by

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1085,7 +1085,7 @@ impl<'tcx> TypingEnv<'tcx> {
     /// use `TypingMode::PostAnalysis`, they may still have where-clauses
     /// in scope.
     pub fn fully_monomorphized() -> TypingEnv<'tcx> {
-        Self::new(ParamEnv::empty(), TypingMode::PostAnalysis)
+        Self::new(ParamEnv::empty(), TypingMode::Codegen)
     }
 
     /// Create a typing environment for use during analysis outside of a body.
@@ -1106,8 +1106,8 @@ impl<'tcx> TypingEnv<'tcx> {
         tcx.typing_env_normalized_for_post_analysis(def_id)
     }
 
-    /// Modify the `typing_mode` to `PostAnalysis` and eagerly reveal all
-    /// opaque types in the `param_env`.
+    /// Modify the `typing_mode` to `PostAnalysis` or `Codegen` and eagerly reveal all opaque types
+    /// in the `param_env`.
     pub fn with_post_analysis_normalized(self, tcx: TyCtxt<'tcx>) -> TypingEnv<'tcx> {
         let TypingEnv { typing_mode, param_env } = self;
 
@@ -1121,7 +1121,7 @@ impl<'tcx> TypingEnv<'tcx> {
                 | TypingMode::Analysis { .. }
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. } => {}
-                TypingMode::PostAnalysis => return self,
+                TypingMode::PostAnalysis | TypingMode::Codegen => return self,
             }
 
             ParamEnv::new(tcx.reveal_opaque_types_in_bounds(param_env.caller_bounds()))

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -102,10 +102,8 @@ impl<'tcx> ConstToPat<'tcx> {
         //
         // FIXME: `const_eval_resolve_for_typeck` should probably just modify the env itself
         // instead of having this logic here
-        let typing_env = self
-            .tcx
-            .erase_and_anonymize_regions(self.typing_env)
-            .with_post_analysis_normalized(self.tcx);
+        let typing_env =
+            self.tcx.erase_and_anonymize_regions(self.typing_env).with_codegen_normalized(self.tcx);
         let uv = self.tcx.erase_and_anonymize_regions(uv);
 
         // try to resolve e.g. associated constants to their definition on an impl, and then

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -780,7 +780,7 @@ where
                 let tcx = self.tcx();
 
                 match self.elaborator.typing_env().typing_mode().assert_not_erased() {
-                    ty::TypingMode::PostAnalysis => {}
+                    ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {}
                     ty::TypingMode::Coherence
                     | ty::TypingMode::Analysis { .. }
                     | ty::TypingMode::Borrowck { .. }

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -484,6 +484,7 @@ where
                     | TypingMode::Borrowck { .. }
                     | TypingMode::PostBorrowckAnalysis { .. }
                     | TypingMode::PostAnalysis
+                    | TypingMode::Codegen
                     | TypingMode::ErasedNotCoherence(MayBeErased) => !candidates.iter().any(|c| {
                         matches!(
                             c.source,
@@ -1056,7 +1057,8 @@ where
             TypingMode::Coherence
             | TypingMode::Borrowck { .. }
             | TypingMode::PostBorrowckAnalysis { .. }
-            | TypingMode::PostAnalysis => vec![],
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => vec![],
             TypingMode::ErasedNotCoherence(MayBeErased) => {
                 self.opaque_accesses
                     .rerun_if_any_opaque_has_infer_as_hidden_type(RerunReason::SelfTyInfer)?;

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -771,7 +771,10 @@ where
             // =============================
             (RerunCondition::Always, _) => RerunDecision::Yes,
             // =============================
-            (RerunCondition::OpaqueInStorage(..), TypingMode::PostAnalysis) => RerunDecision::Yes,
+            (
+                RerunCondition::OpaqueInStorage(..),
+                TypingMode::PostAnalysis | TypingMode::Codegen,
+            ) => RerunDecision::Yes,
             (
                 RerunCondition::OpaqueInStorage(defids),
                 TypingMode::PostBorrowckAnalysis { defined_opaque_types: opaques }
@@ -786,12 +789,13 @@ where
                 RerunCondition::AnyOpaqueHasInferAsHidden,
                 TypingMode::PostBorrowckAnalysis { .. }
                 | TypingMode::PostAnalysis
+                | TypingMode::Codegen
                 | TypingMode::Borrowck { .. },
             ) => RerunDecision::No,
             // =============================
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(_),
-                TypingMode::PostAnalysis,
+                TypingMode::PostAnalysis | TypingMode::Codegen,
             ) => RerunDecision::No,
             (
                 RerunCondition::OpaqueInStorageOrAnyOpaqueHasInferAsHidden(defids),

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -396,7 +396,7 @@ where
             .assert_not_erased()
         {
             // Opaques are never rigid outside of analysis mode.
-            TypingMode::Coherence | TypingMode::PostAnalysis => false,
+            TypingMode::Coherence | TypingMode::PostAnalysis | TypingMode::Codegen => false,
             // During analysis, opaques are rigid unless they may be defined by
             // the current body.
             TypingMode::Analysis { defining_opaque_types_and_generators: non_rigid_opaques }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -325,7 +325,8 @@ where
                         ty::TypingMode::Analysis { .. }
                         | ty::TypingMode::Borrowck { .. }
                         | ty::TypingMode::PostBorrowckAnalysis { .. }
-                        | ty::TypingMode::PostAnalysis => {
+                        | ty::TypingMode::PostAnalysis
+                        | ty::TypingMode::Codegen => {
                             ecx.structurally_instantiate_normalizes_to_term(
                                 goal,
                                 goal.predicate.alias,

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
@@ -100,7 +100,8 @@ where
                         }
                         TypingMode::Coherence
                         | TypingMode::PostBorrowckAnalysis { .. }
-                        | TypingMode::PostAnalysis => unreachable!(),
+                        | TypingMode::PostAnalysis
+                        | TypingMode::Codegen => unreachable!(),
                     }
                 }
 
@@ -138,7 +139,7 @@ where
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                     .map_err(Into::into)
             }
-            TypingMode::PostAnalysis => {
+            TypingMode::PostAnalysis | TypingMode::Codegen => {
                 // FIXME: Add an assertion that opaque type storage is empty.
                 let actual =
                     cx.type_of(def_id.into()).instantiate(cx, opaque_ty.args).skip_norm_wip();

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -72,6 +72,7 @@ where
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. }
                 | TypingMode::PostAnalysis
+                | TypingMode::Codegen
                 | TypingMode::ErasedNotCoherence(MayBeErased) => {
                     (Err(NoSolution), AccessedOpaques::default())
                 }

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1611,6 +1611,7 @@ where
                 }
                 TypingMode::Coherence
                 | TypingMode::PostAnalysis
+                | TypingMode::Codegen
                 | TypingMode::Borrowck { defining_opaque_types: _ }
                 | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ } => {}
             }

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -338,7 +338,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 | TypingMode::Analysis { .. }
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. } => false,
-                TypingMode::PostAnalysis => {
+                TypingMode::PostAnalysis | TypingMode::Codegen => {
                     let poly_trait_ref = self.resolve_vars_if_possible(goal_trait_ref);
                     !poly_trait_ref.still_further_specializable()
                 }

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -283,7 +283,8 @@ where
             TypingMode::Coherence
             | TypingMode::Borrowck { defining_opaque_types: _ }
             | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ }
-            | TypingMode::PostAnalysis => return Default::default(),
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => return Default::default(),
         };
 
         if stalled_coroutines.is_empty() {

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -178,7 +178,8 @@ where
             TypingMode::Coherence
             | TypingMode::Borrowck { defining_opaque_types: _ }
             | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ }
-            | TypingMode::PostAnalysis => return Default::default(),
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => return Default::default(),
         };
 
         if stalled_coroutines.is_empty() {

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -143,7 +143,7 @@ pub(super) fn needs_normalization<'tcx, T: TypeVisitable<TyCtxt<'tcx>>>(
         | TypingMode::Analysis { .. }
         | TypingMode::Borrowck { .. }
         | TypingMode::PostBorrowckAnalysis { .. } => flags.remove(ty::TypeFlags::HAS_TY_OPAQUE),
-        TypingMode::PostAnalysis => {}
+        TypingMode::PostAnalysis | TypingMode::Codegen => {}
     }
 
     value.has_type_flags(flags)
@@ -415,7 +415,7 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
                     | TypingMode::Analysis { .. }
                     | TypingMode::Borrowck { .. }
                     | TypingMode::PostBorrowckAnalysis { .. } => ty.super_fold_with(self),
-                    TypingMode::PostAnalysis => {
+                    TypingMode::PostAnalysis | TypingMode::Codegen => {
                         let recursion_limit = self.cx().recursion_limit();
                         if !recursion_limit.value_within_limit(self.depth) {
                             self.selcx.infcx.err_ctxt().report_overflow_error(

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -962,7 +962,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                                     );
                                     false
                                 }
-                                TypingMode::PostAnalysis => {
+                                TypingMode::PostAnalysis | TypingMode::Codegen => {
                                     // NOTE(eddyb) inference variables can resolve to parameters, so
                                     // assume `poly_trait_ref` isn't monomorphic, if it contains any.
                                     let poly_trait_ref =

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -220,7 +220,7 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'a, 'tcx> {
                     | TypingMode::Borrowck { .. }
                     | TypingMode::PostBorrowckAnalysis { .. } => ty.try_super_fold_with(self)?,
 
-                    TypingMode::PostAnalysis => {
+                    TypingMode::PostAnalysis | TypingMode::Codegen => {
                         let args = data.args.try_fold_with(self)?;
                         let recursion_limit = self.cx().recursion_limit();
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1488,7 +1488,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             TypingMode::Analysis { .. }
             | TypingMode::Borrowck { .. }
             | TypingMode::PostBorrowckAnalysis { .. }
-            | TypingMode::PostAnalysis => return Ok(()),
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => return Ok(()),
         }
 
         debug!("is_knowable()");
@@ -1547,7 +1548,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             //
             // FIXME(#132279): This is still incorrect as we treat opaque types
             // and default associated items differently between these two modes.
-            TypingMode::PostAnalysis => true,
+            TypingMode::PostAnalysis | TypingMode::Codegen => true,
         }
     }
 
@@ -2914,6 +2915,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             }
             TypingMode::Coherence
             | TypingMode::PostAnalysis
+            | TypingMode::Codegen
             | TypingMode::Borrowck { defining_opaque_types: _ }
             | TypingMode::PostBorrowckAnalysis { defined_opaque_types: _ } => false,
         }

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -160,7 +160,9 @@ fn resolve_associated_item<'tcx>(
                     | ty::TypingMode::Analysis { .. }
                     | ty::TypingMode::Borrowck { .. }
                     | ty::TypingMode::PostBorrowckAnalysis { .. } => false,
-                    ty::TypingMode::PostAnalysis => !trait_ref.still_further_specializable(),
+                    ty::TypingMode::PostAnalysis | ty::TypingMode::Codegen => {
+                        !trait_ref.still_further_specializable()
+                    }
                 }
             };
             if !eligible {

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -537,6 +537,18 @@ fn layout_of_uncached<'tcx>(
         }
 
         ty::Coroutine(def_id, args) => {
+            match cx.typing_env.typing_mode() {
+                ty::TypingMode::Codegen => {}
+                ty::TypingMode::Coherence
+                | ty::TypingMode::Analysis { .. }
+                | ty::TypingMode::Borrowck { .. }
+                | ty::TypingMode::PostBorrowckAnalysis { .. }
+                | ty::TypingMode::ErasedNotCoherence(_)
+                | ty::TypingMode::PostAnalysis => {
+                    return Err(error(cx, LayoutError::TooGeneric(ty)));
+                }
+            }
+
             use rustc_middle::ty::layout::PrimitiveExt as _;
 
             let info = tcx.coroutine_layout(def_id, args)?;
@@ -704,7 +716,10 @@ fn layout_of_uncached<'tcx>(
 
             let maybe_unsized = def.is_struct()
                 && def.non_enum_variant().tail_opt().is_some_and(|last_field| {
-                    let typing_env = ty::TypingEnv::post_analysis(tcx, def.did());
+                    let typing_env = ty::TypingEnv::new(
+                        tcx.param_env_normalized_for_post_analysis(def.did()),
+                        cx.typing_env.typing_mode(),
+                    );
                     !tcx.type_of(last_field.did)
                         .instantiate_identity()
                         .skip_norm_wip()

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -66,6 +66,24 @@ fn layout_of<'tcx>(
         return tcx.layout_of(typing_env.as_query_input(ty));
     }
 
+    match typing_env.typing_mode() {
+        ty::TypingMode::Codegen => {
+            let with_postanalysis =
+                ty::TypingEnv::new(typing_env.param_env, ty::TypingMode::PostAnalysis);
+            let res = tcx.layout_of(with_postanalysis.as_query_input(ty));
+            match res {
+                Err(LayoutError::TooGeneric(_)) => {}
+                _ => return res,
+            };
+        }
+        ty::TypingMode::Coherence
+        | ty::TypingMode::Analysis { .. }
+        | ty::TypingMode::Borrowck { .. }
+        | ty::TypingMode::PostBorrowckAnalysis { .. }
+        | ty::TypingMode::ErasedNotCoherence(_)
+        | ty::TypingMode::PostAnalysis => {}
+    }
+
     let cx = LayoutCx::new(tcx, typing_env);
 
     let layout = layout_of_uncached(&cx, ty)?;

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -292,8 +292,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitFinder<'_, 'tcx> {
     }
 }
 
-fn typing_env_normalized_for_post_analysis(tcx: TyCtxt<'_>, def_id: DefId) -> ty::TypingEnv<'_> {
-    ty::TypingEnv::non_body_analysis(tcx, def_id).with_post_analysis_normalized(tcx)
+fn param_env_normalized_for_post_analysis(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
+    tcx.param_env(def_id).with_normalized(tcx)
 }
 
 /// Check if a function is async.
@@ -405,7 +405,7 @@ pub(crate) fn provide(providers: &mut Providers) {
         asyncness,
         adt_sizedness_constraint,
         param_env,
-        typing_env_normalized_for_post_analysis,
+        param_env_normalized_for_post_analysis,
         defaultness,
         unsizing_params_for_adt,
         impl_self_is_guaranteed_unsized,

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -120,15 +120,18 @@ pub enum TypingMode<I: Interner, S: TypingModeErasedStatus = MayBeErased> {
     /// This is currently only used by the new solver, but should be implemented in
     /// the old solver as well.
     PostBorrowckAnalysis { defined_opaque_types: I::LocalDefIds },
-    /// After analysis, mostly during codegen and MIR optimizations, we're able to
+    /// After analysis, mostly during MIR optimizations, we're able to
     /// reveal all opaque types. As the hidden type should *never* be observable
     /// directly by the user, this should not be used by checks which may expose
     /// such details to the user.
     ///
-    /// There are some exceptions to this as for example `layout_of` and const-evaluation
-    /// always run in `PostAnalysis` mode, even when used during analysis. This exposes
-    /// some information about the underlying type to users, but not the type itself.
+    /// However, we restrict `layout_of` and const-evaluation from exposing some information like
+    /// coroutine layout which requires optimized MIR.
     PostAnalysis,
+
+    /// During codegen and MIR optimizations, we're able to reveal all opaque types and compute all
+    /// layouts.
+    Codegen,
 
     /// The typing modes above (except coherence) only differ in how they handle
     ///
@@ -180,6 +183,7 @@ impl<I: Interner> PartialEq for TypingModeEqWrapper<I> {
                 TypingMode::PostBorrowckAnalysis { defined_opaque_types: r },
             ) => l == r,
             (TypingMode::PostAnalysis, TypingMode::PostAnalysis) => true,
+            (TypingMode::Codegen, TypingMode::Codegen) => true,
             (
                 TypingMode::ErasedNotCoherence(MayBeErased),
                 TypingMode::ErasedNotCoherence(MayBeErased),
@@ -190,6 +194,7 @@ impl<I: Interner> PartialEq for TypingModeEqWrapper<I> {
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. }
                 | TypingMode::PostAnalysis
+                | TypingMode::Codegen
                 | TypingMode::ErasedNotCoherence(MayBeErased),
                 _,
             ) => false,
@@ -212,6 +217,7 @@ impl<I: Interner, S: TypingModeErasedStatus> TypingMode<I, S> {
             | TypingMode::Borrowck { .. }
             | TypingMode::PostBorrowckAnalysis { .. }
             | TypingMode::PostAnalysis
+            | TypingMode::Codegen
             | TypingMode::ErasedNotCoherence(_) => false,
         }
     }
@@ -228,7 +234,8 @@ impl<I: Interner, S: TypingModeErasedStatus> TypingMode<I, S> {
             | TypingMode::Analysis { .. }
             | TypingMode::Borrowck { .. }
             | TypingMode::PostBorrowckAnalysis { .. }
-            | TypingMode::PostAnalysis => false,
+            | TypingMode::PostAnalysis
+            | TypingMode::Codegen => false,
         }
     }
 }
@@ -251,6 +258,7 @@ impl<I: Interner> TypingMode<I, MayBeErased> {
                 TypingMode::PostBorrowckAnalysis { defined_opaque_types }
             }
             TypingMode::PostAnalysis => TypingMode::PostAnalysis,
+            TypingMode::Codegen => TypingMode::Codegen,
             TypingMode::ErasedNotCoherence(MayBeErased) => panic!(
                 "Called `assert_not_erased` from a place that can be called by the trait solver in `TypingMode::ErasedNotCoherence`. `TypingMode` is `ErasedNotCoherence` in a place where that should be impossible"
             ),
@@ -315,6 +323,7 @@ impl<I: Interner> From<TypingMode<I, CantBeErased>> for TypingMode<I, MayBeErase
                 TypingMode::PostBorrowckAnalysis { defined_opaque_types }
             }
             TypingMode::PostAnalysis => TypingMode::PostAnalysis,
+            TypingMode::Codegen => TypingMode::Codegen,
         }
     }
 }
@@ -536,9 +545,8 @@ where
         TypingMode::Coherence
         | TypingMode::Analysis { .. }
         | TypingMode::Borrowck { .. }
-        | TypingMode::PostBorrowckAnalysis { .. } => {
-            infcx.cx().features().feature_bound_holds_in_crate(symbol)
-        }
-        TypingMode::PostAnalysis => true,
+        | TypingMode::PostBorrowckAnalysis { .. }
+        | TypingMode::PostAnalysis => infcx.cx().features().feature_bound_holds_in_crate(symbol),
+        TypingMode::Codegen => true,
     }
 }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -902,7 +902,8 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                 | TypingMode::ErasedNotCoherence { .. }
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. }
-                | TypingMode::PostAnalysis => (),
+                | TypingMode::PostAnalysis
+                | TypingMode::Codegen => (),
             };
 
             RegionConstraint::Or(candidates.into_boxed_slice())

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -143,7 +143,8 @@ where
                 TypingMode::Analysis { .. }
                 | TypingMode::Borrowck { .. }
                 | TypingMode::PostBorrowckAnalysis { .. }
-                | TypingMode::PostAnalysis => structurally_relate_tys(relation, a, b),
+                | TypingMode::PostAnalysis
+                | TypingMode::Codegen => structurally_relate_tys(relation, a, b),
             }
         }
 

--- a/src/tools/clippy/clippy_lints/src/large_futures.rs
+++ b/src/tools/clippy/clippy_lints/src/large_futures.rs
@@ -64,7 +64,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeFuture {
             && let ty = cx.typeck_results().expr_ty(arg)
             && let Some(future_trait_def_id) = cx.tcx.lang_items().future_trait()
             && implements_trait(cx, ty, future_trait_def_id, &[])
-            && let Ok(layout) = cx.tcx.layout_of(cx.typing_env().as_query_input(ty))
+            && let Ok(layout) = cx.tcx.layout_of(cx.typing_env().with_codegen_normalized(cx.tcx).as_query_input(ty))
             && let size = layout.layout.size()
             && size >= Size::from_bytes(self.future_size_threshold)
         {

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -1,9 +1,14 @@
-error[E0391]: cycle detected when const-evaluating + checking `TRAIT_REF_BAR`
+error[E0391]: cycle detected when simplifying constant for the type system `TRAIT_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:28
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    |                            ^^^^^^^^^^^^^^^^^^^^^
-   |
 note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |
@@ -24,13 +29,8 @@ note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-c
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |                      ^^^^^^^^^^^^^
-note: ...which requires simplifying constant for the type system `TRAIT_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
-   |
-LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires const-evaluating + checking `TRAIT_REF_BAR`, completing the cycle
-note: cycle used when const-evaluating + checking `TRAIT_REF_BAR`
+   = note: ...which again requires simplifying constant for the type system `TRAIT_REF_BAR`, completing the cycle
+note: cycle used when simplifying constant for the type system `TRAIT_REF_BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -1,14 +1,9 @@
-error[E0391]: cycle detected when simplifying constant for the type system `TRAIT_REF_BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
-   |
-LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
+error[E0391]: cycle detected when const-evaluating + checking `TRAIT_REF_BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:28
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    |                            ^^^^^^^^^^^^^^^^^^^^^
+   |
 note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |
@@ -29,8 +24,17 @@ note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-c
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |                      ^^^^^^^^^^^^^
-   = note: ...which again requires simplifying constant for the type system `TRAIT_REF_BAR`, completing the cycle
-   = note: cycle used when running analysis passes on crate `issue_24949_assoc_const_static_recursion_trait`
+note: ...which requires simplifying constant for the type system `TRAIT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating + checking `TRAIT_REF_BAR`, completing the cycle
+note: cycle used when const-evaluating + checking `TRAIT_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -9,7 +9,7 @@ note: please make sure that you have updated to the latest nightly
 
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `X`
-#1 [eval_to_allocation_raw] const-evaluating + checking `X`
+#1 [eval_to_const_value_raw] simplifying constant for the type system `X`
 #2 [eval_to_const_value_raw] simplifying constant for the type system `X`
 #3 [analysis] running analysis passes on crate `const_eval_query_stack`
 end of query stack

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -9,6 +9,7 @@ note: please make sure that you have updated to the latest nightly
 
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `X`
-#1 [eval_to_const_value_raw] simplifying constant for the type system `X`
-#2 [analysis] running analysis passes on crate `const_eval_query_stack`
+#1 [eval_to_allocation_raw] const-evaluating + checking `X`
+#2 [eval_to_const_value_raw] simplifying constant for the type system `X`
+#3 [analysis] running analysis passes on crate `const_eval_query_stack`
 end of query stack

--- a/tests/ui/consts/const-size_of-cycle.stderr
+++ b/tests/ui/consts/const-size_of-cycle.stderr
@@ -5,6 +5,11 @@ LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/const-size_of-cycle.rs:2:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 note: ...which requires simplifying constant for the type system `core::mem::SizedTypeProperties::SIZE`...
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL

--- a/tests/ui/consts/issue-44415.stderr
+++ b/tests/ui/consts/issue-44415.stderr
@@ -9,6 +9,11 @@ note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`..
    |
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires computing layout of `Foo`...
   --> $DIR/issue-44415.rs:5:1
    |

--- a/tests/ui/consts/recursive-block.stderr
+++ b/tests/ui/consts/recursive-block.stderr
@@ -5,7 +5,7 @@ LL |     const { foo::<&T>() }
    |           ^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_block`)
-   = note: query depth increased by 1 when computing layout of `foo<&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&i32>`
+   = note: query depth increased by 1 when computing layout of `foo<&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&i32>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/recursion_limit/zero-overflow.rs
+++ b/tests/ui/recursion/recursion_limit/zero-overflow.rs
@@ -1,4 +1,4 @@
-//~ ERROR overflow evaluating the requirement `&mut Self: DispatchFromDyn<&mut RustaceansAreAwesome>
+//~ ERROR queries overflow the depth limit!
 //~| HELP consider increasing the recursion limit
 //@ build-fail
 

--- a/tests/ui/recursion/recursion_limit/zero-overflow.stderr
+++ b/tests/ui/recursion/recursion_limit/zero-overflow.stderr
@@ -1,7 +1,7 @@
-error[E0275]: overflow evaluating the requirement `&mut Self: DispatchFromDyn<&mut RustaceansAreAwesome>`
+error: queries overflow the depth limit!
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2"]` attribute to your crate (`zero_overflow`)
+   = note: query depth increased by 2 when computing layout of `isize`
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/145477)*
<!-- homu-ignore:end -->

Computing layout of coroutines depends on their `optimized_mir`. At the same time, MIR opts can require using layouts to work. For instance to evaluate constants. This leads to cycles and clumsy workarounds.

This PR creates a new typing mode for layout computations:
- when a coroutine's layout is requested with `TypingMode::PostAnalysis` or earlier, return `LayourError::TooGeneric`;
- when a coroutine's layout is requested with `TypingMode::Codegen`, actually compute it.

`TypingMode::Codegen` is meant be be used by codegen code, and analyses that require coroutine layout, like transmute check and coroutine recursion check.

With this PR, we can remove all `is_coroutine` checks from `rustc_mir_transform` and unlock simplifying coroutine MIR.

Perf is not terrific. This PR causes recomputation of a few queries, and I had to insert workarounds.