### PR TITLE
Issue-141806: Remove sizedness_fast_path in fulfill.rs

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -30,10 +30,10 @@ use super::{
 use crate::error_reporting::InferCtxtErrorExt;
 use crate::infer::{InferCtxt, TyOrConstInferVar};
 use crate::solve::StalledOnCoroutines;
+use crate::traits::EvaluateConstErr;
 use crate::traits::normalize::normalize_with_depth_to;
 use crate::traits::project::{PolyProjectionObligation, ProjectionCacheKeyExt as _};
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
-use crate::traits::{EvaluateConstErr, sizedness_fast_path};
 
 pub(crate) type PendingPredicateObligations<'tcx> = ThinVec<PendingPredicateObligation<'tcx>>;
 
@@ -362,10 +362,6 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
         let obligation = &pending_obligation.obligation;
 
         let infcx = self.selcx.infcx;
-
-        if sizedness_fast_path(infcx.tcx, obligation.predicate, obligation.param_env) {
-            return ProcessResult::Changed(thin_vec![]);
-        }
 
         if obligation.predicate.has_aliases() {
             let mut obligations = PredicateObligations::new();

--- a/tests/ui/closures/issue-78720.rs
+++ b/tests/ui/closures/issue-78720.rs
@@ -1,6 +1,5 @@
 fn server() -> impl {
     //~^ ERROR at least one trait must be specified
-    //~^^ ERROR type annotations needed
     ().map2(|| "")
 }
 

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -5,7 +5,7 @@ LL | fn server() -> impl {
    |                ^^^^
 
 error[E0412]: cannot find type `F` in this scope
-  --> $DIR/issue-78720.rs:14:12
+  --> $DIR/issue-78720.rs:13:12
    |
 LL |     _func: F,
    |            ^
@@ -22,14 +22,8 @@ help: you might be missing a type parameter
 LL | struct Map2<Segment2, F> {
    |                     +++
 
-error[E0282]: type annotations needed
-  --> $DIR/issue-78720.rs:1:16
-   |
-LL | fn server() -> impl {
-   |                ^^^^ cannot infer type
-
 error[E0308]: mismatched types
-  --> $DIR/issue-78720.rs:8:39
+  --> $DIR/issue-78720.rs:7:39
    |
 LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                                       ^^ expected `Map2<F>`, found `()`
@@ -38,7 +32,7 @@ LL |     fn map2<F>(self, f: F) -> Map2<F> {}
            found unit type `()`
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-78720.rs:8:16
+  --> $DIR/issue-78720.rs:7:16
    |
 LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                ^^^^ doesn't have a size known at compile-time
@@ -53,7 +47,7 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     fn map2<F>(&self, f: F) -> Map2<F> {}
    |                +
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0282, E0308, E0412.
+Some errors have detailed explanations: E0277, E0308, E0412.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/codegen/overflow-during-mono.rs
+++ b/tests/ui/codegen/overflow-during-mono.rs
@@ -1,4 +1,4 @@
-//~ ERROR overflow evaluating the requirement `for<'a> {closure@$DIR/overflow-during-mono.rs:14:41: 14:44}: FnMut(&'a _)`
+//~ ERROR overflow evaluating the requirement `{closure@$DIR/overflow-during-mono.rs:14:41: 14:44}: Sized`
 //@ build-fail
 //@ compile-flags: -Zwrite-long-types-to-disk=yes
 

--- a/tests/ui/codegen/overflow-during-mono.stderr
+++ b/tests/ui/codegen/overflow-during-mono.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `for<'a> {closure@$DIR/overflow-during-mono.rs:14:41: 14:44}: FnMut(&'a _)`
+error[E0275]: overflow evaluating the requirement `{closure@$DIR/overflow-during-mono.rs:14:41: 14:44}: Sized`
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "64"]` attribute to your crate (`overflow_during_mono`)
    = note: required for `Filter<IntoIter<i32, 11>, {closure@overflow-during-mono.rs:14:41}>` to implement `Iterator`

--- a/tests/ui/layout/unconstrained-param-ice-137308.rs
+++ b/tests/ui/layout/unconstrained-param-ice-137308.rs
@@ -16,4 +16,4 @@ impl<C: ?Sized> A for u8 { //~ ERROR: the type parameter `C` is not constrained
 
 #[rustc_layout(debug)]
 struct S([u8; <u8 as A>::B]);
-//~^ ERROR: the type has an unknown layout
+//~^ ERROR: the type `[u8; <u8 as A>::B]` has an unknown layout

--- a/tests/ui/layout/unconstrained-param-ice-137308.stderr
+++ b/tests/ui/layout/unconstrained-param-ice-137308.stderr
@@ -4,7 +4,7 @@ error[E0207]: the type parameter `C` is not constrained by the impl trait, self 
 LL | impl<C: ?Sized> A for u8 {
    |      ^ unconstrained type parameter
 
-error: the type has an unknown layout
+error: the type `[u8; <u8 as A>::B]` has an unknown layout
   --> $DIR/unconstrained-param-ice-137308.rs:18:1
    |
 LL | struct S([u8; <u8 as A>::B]);

--- a/tests/ui/nll/issue-50716.rs
+++ b/tests/ui/nll/issue-50716.rs
@@ -5,7 +5,7 @@ trait A {
     type X: ?Sized;
 }
 
-fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
+fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>) //~ ERROR: mismatched types
 where
     for<'b> &'b T: A,
     <&'static T as A>::X: Sized

--- a/tests/ui/nll/issue-50716.stderr
+++ b/tests/ui/nll/issue-50716.stderr
@@ -1,3 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-50716.rs:8:27
+   |
+LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
+   |                           ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+   |
+   = note: expected trait `<<&'a T as A>::X as MetaSized>`
+              found trait `<<&'static T as A>::X as MetaSized>`
+note: the lifetime `'a` as defined here...
+  --> $DIR/issue-50716.rs:8:8
+   |
+LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
+   |        ^^
+   = note: ...does not necessarily outlive the static lifetime
+
 error: lifetime may not live long enough
   --> $DIR/issue-50716.rs:13:14
    |
@@ -7,5 +22,6 @@ LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
 LL |     let _x = *s;
    |              ^^ proving this value is `Sized` requires that `'a` must outlive `'static`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/recursion/issue-83150.rs
+++ b/tests/ui/recursion/issue-83150.rs
@@ -1,4 +1,4 @@
-//~ ERROR overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, {closure@$DIR/issue-83150.rs:12:24: 12:27}>: Iterator`
+//~ ERROR overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, {closure@$DIR/issue-83150.rs:12:24: 12:27}>: MetaSized`
 //@ build-fail
 //@ compile-flags: -Copt-level=0 -Zwrite-long-types-to-disk=yes
 

--- a/tests/ui/recursion/issue-83150.stderr
+++ b/tests/ui/recursion/issue-83150.stderr
@@ -10,7 +10,7 @@ LL |     func(&mut iter.map(|x| x + 1))
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, {closure@$DIR/issue-83150.rs:12:24: 12:27}>: Iterator`
+error[E0275]: overflow evaluating the requirement `Map<&mut std::ops::Range<u8>, {closure@$DIR/issue-83150.rs:12:24: 12:27}>: MetaSized`
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_83150`)
    = note: required for `&mut Map<&mut Range<u8>, {closure@issue-83150.rs:12:24}>` to implement `Iterator`

--- a/tests/ui/sized/missing-sized-not-panic.rs
+++ b/tests/ui/sized/missing-sized-not-panic.rs
@@ -1,0 +1,10 @@
+// ICE-141806
+trait Trait<T> {}
+fn func(x: *const dyn Trait<()>)
+where
+    Missing: Sized, //~ ERROR E0412
+{
+    let _x: *const dyn Trait<u8> = x as _;
+}
+
+fn main() {}

--- a/tests/ui/sized/missing-sized-not-panic.stderr
+++ b/tests/ui/sized/missing-sized-not-panic.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/missing-sized-not-panic.rs:5:5
+   |
+LL |     Missing: Sized,
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/where-clauses/ignore-err-clauses.rs
+++ b/tests/ui/where-clauses/ignore-err-clauses.rs
@@ -1,13 +1,13 @@
 use std::ops::Add;
 
 fn dbl<T>(x: T) -> <T as Add>::Output
+//~^ ERROR type annotations needed
 where
     T: Copy + Add,
     UUU: Copy,
     //~^ ERROR cannot find type `UUU` in this scope
 {
     x + x
-    //~^ ERROR use of moved value: `x`
 }
 
 fn main() {

--- a/tests/ui/where-clauses/ignore-err-clauses.stderr
+++ b/tests/ui/where-clauses/ignore-err-clauses.stderr
@@ -1,33 +1,16 @@
 error[E0412]: cannot find type `UUU` in this scope
-  --> $DIR/ignore-err-clauses.rs:6:5
+  --> $DIR/ignore-err-clauses.rs:7:5
    |
 LL |     UUU: Copy,
    |     ^^^ not found in this scope
 
-error[E0382]: use of moved value: `x`
-  --> $DIR/ignore-err-clauses.rs:9:9
+error[E0282]: type annotations needed
+  --> $DIR/ignore-err-clauses.rs:3:14
    |
 LL | fn dbl<T>(x: T) -> <T as Add>::Output
-   |           - move occurs because `x` has type `T`, which does not implement the `Copy` trait
-...
-LL |     x + x
-   |     ----^
-   |     |   |
-   |     |   value used here after move
-   |     `x` moved due to usage in operator
-   |
-help: if `T` implemented `Clone`, you could clone the value
-  --> $DIR/ignore-err-clauses.rs:3:8
-   |
-LL | fn dbl<T>(x: T) -> <T as Add>::Output
-   |        ^ consider constraining this type parameter with `Clone`
-...
-LL |     x + x
-   |     - you could clone this value
-note: calling this operator moves the left-hand side
-  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
+   |              ^ cannot infer type for type parameter `T`
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0382, E0412.
-For more information about an error, try `rustc --explain E0382`.
+Some errors have detailed explanations: E0282, E0412.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
## Context
Fix rust-lang/rust#141806 

If Sized type doesn't exist, the ICE happens. This ICE is from sizedness_fast_path() call in FulfillProcessor.process_abligation.
Originally the function call was added for performance improvement in rust-lang/rust#139577 .

## Change
- Remove the function call
- Add test for the ICE