### PR TITLE
Port must_use to the new target checking

### DIFF
--- a/compiler/rustc_attr_parsing/messages.ftl
+++ b/compiler/rustc_attr_parsing/messages.ftl
@@ -12,9 +12,11 @@ attr_parsing_empty_attribute =
 
 attr_parsing_invalid_target = `#[{$name}]` attribute cannot be used on {$target}
     .help = `#[{$name}]` can {$only}be applied to {$applied}
+    .suggestion = remove the attribute
 attr_parsing_invalid_target_lint = `#[{$name}]` attribute cannot be used on {$target}
     .warn = {-attr_parsing_previously_accepted}
     .help = `#[{$name}]` can {$only}be applied to {$applied}
+    .suggestion = remove the attribute
 
 attr_parsing_empty_confusables =
     expected at least one confusable name

--- a/compiler/rustc_attr_parsing/src/lints.rs
+++ b/compiler/rustc_attr_parsing/src/lints.rs
@@ -53,6 +53,7 @@ pub fn emit_attribute_lint<L: LintEmitter>(lint: &AttributeLint<HirId>, lint_emi
                     target: target.plural_name(),
                     applied: applied.clone(),
                     only,
+                    attr_span: *span,
                 },
             ),
     }

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -489,6 +489,8 @@ pub(crate) struct InvalidTargetLint {
     pub target: &'static str,
     pub applied: String,
     pub only: &'static str,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
+    pub attr_span: Span,
 }
 
 #[derive(Diagnostic)]
@@ -496,6 +498,7 @@ pub(crate) struct InvalidTargetLint {
 #[diag(attr_parsing_invalid_target)]
 pub(crate) struct InvalidTarget {
     #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub span: Span,
     pub name: Symbol,
     pub target: &'static str,

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -432,10 +432,6 @@ passes_must_not_suspend =
     `must_not_suspend` attribute should be applied to a struct, enum, union, or trait
     .label = is not a struct, enum, union, or trait
 
-passes_must_use_no_effect =
-    `#[must_use]` has no effect when applied to {$target}
-    .suggestion = remove the attribute
-
 passes_no_link =
     attribute should be applied to an `extern crate` item
     .label = not an `extern crate` item

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -194,9 +194,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 Attribute::Parsed(AttributeKind::MayDangle(attr_span)) => {
                     self.check_may_dangle(hir_id, *attr_span)
                 }
-                Attribute::Parsed(AttributeKind::MustUse { span, .. }) => {
-                    self.check_must_use(hir_id, *span, target)
-                }
                 &Attribute::Parsed(AttributeKind::CustomMir(dialect, phase, attr_span)) => {
                     self.check_custom_mir(dialect, phase, attr_span)
                 }
@@ -249,7 +246,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::Coverage (..)
                     | AttributeKind::ShouldPanic { .. }
                     | AttributeKind::Coroutine(..)
-                    | AttributeKind::Linkage(..),
+                    | AttributeKind::Linkage(..)
+                    | AttributeKind::MustUse { .. },
                 ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {
                     style = Some(attr_item.style);
@@ -1258,41 +1256,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             // `#[ffi_const]` functions cannot be `#[ffi_pure]`
             self.dcx().emit_err(errors::BothFfiConstAndPure { attr_span });
         }
-    }
-
-    /// Warns against some misuses of `#[must_use]`
-    fn check_must_use(&self, hir_id: HirId, attr_span: Span, target: Target) {
-        if matches!(
-            target,
-            Target::Fn
-                | Target::Enum
-                | Target::Struct
-                | Target::Union
-                | Target::Method(MethodKind::Trait { body: false } | MethodKind::Inherent)
-                | Target::ForeignFn
-                // `impl Trait` in return position can trip
-                // `unused_must_use` if `Trait` is marked as
-                // `#[must_use]`
-                | Target::Trait
-        ) {
-            return;
-        }
-
-        // `#[must_use]` can be applied to a trait method definition with a default body
-        if let Target::Method(MethodKind::Trait { body: true }) = target
-            && let parent_def_id = self.tcx.hir_get_parent_item(hir_id).def_id
-            && let containing_item = self.tcx.hir_expect_item(parent_def_id)
-            && let hir::ItemKind::Trait(..) = containing_item.kind
-        {
-            return;
-        }
-
-        self.tcx.emit_node_span_lint(
-            UNUSED_ATTRIBUTES,
-            hir_id,
-            attr_span,
-            errors::MustUseNoEffect { target: target.plural_name(), attr_span },
-        );
     }
 
     /// Checks if `#[must_not_suspend]` is applied to a struct, enum, union, or trait.

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -358,14 +358,6 @@ pub(crate) struct BothFfiConstAndPure {
     pub attr_span: Span,
 }
 
-#[derive(LintDiagnostic)]
-#[diag(passes_must_use_no_effect)]
-pub(crate) struct MustUseNoEffect {
-    pub target: &'static str,
-    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
-    pub attr_span: Span,
-}
-
 #[derive(Diagnostic)]
 #[diag(passes_must_not_suspend)]
 pub(crate) struct MustNotSuspend {

--- a/tests/ui/attributes/rustc_confusables.rs
+++ b/tests/ui/attributes/rustc_confusables.rs
@@ -45,4 +45,5 @@ impl Bar {
 #[rustc_confusables("blah")]
 //~^ ERROR attribute cannot be used on
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 fn not_inherent_impl_method() {}

--- a/tests/ui/extern/issue-47725.rs
+++ b/tests/ui/extern/issue-47725.rs
@@ -4,12 +4,14 @@
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 struct Foo;
 
 #[link_name = "foobar"]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 extern "C" {
     fn foo() -> u32;
 }
@@ -19,6 +21,7 @@ extern "C" {
 //~| HELP must be of the form
 //~| WARN attribute cannot be used on
 //~| WARN previously accepted
+//~| HELP remove the attribute
 //~| HELP can be applied to
 //~| NOTE for more information, visit
 extern "C" {

--- a/tests/ui/extern/issue-47725.stderr
+++ b/tests/ui/extern/issue-47725.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/issue-47725.rs:17:1
+  --> $DIR/issue-47725.rs:19:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^ help: must be of the form: `#[link_name = "name"]`
@@ -21,7 +21,7 @@ LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-47725.rs:9:1
+  --> $DIR/issue-47725.rs:10:1
    |
 LL | #[link_name = "foobar"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL | #[link_name = "foobar"]
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-47725.rs:17:1
+  --> $DIR/issue-47725.rs:19:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -50,9 +50,11 @@
 #![should_panic] //~ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 #![ignore] //~ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 #![no_implicit_prelude]
 #![reexport_test_harness_main = "2900"]
 // see gated-link-args.rs
@@ -61,22 +63,28 @@
 #![proc_macro_derive(Test)] //~ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 #![doc = "2400"]
 #![cold] //~ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 #![link()] //~ WARN attribute should be applied to an `extern` block
 //~^ WARN this was previously accepted
 #![link_name = "1900"]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 #![link_section = "1800"]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 #![must_use]
-//~^ WARN `#[must_use]` has no effect
+//~^ WARN attribute cannot be used on
+//~| WARN previously accepted
+//~| HELP can be applied to
 //~| HELP remove the attribute
 // see issue-43106-gating-of-stable.rs
 // see issue-43106-gating-of-unstable.rs
@@ -184,21 +192,25 @@ mod macro_use {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_use] struct S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_use] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_use] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 #[macro_export]
@@ -260,57 +272,68 @@ mod path {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[path = "3800"]  struct S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[path = "3800"] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[path = "3800"] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 }
 
 #[automatically_derived]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 mod automatically_derived {
     mod inner { #![automatically_derived] }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] fn f() { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] struct S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] trait W { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[automatically_derived] impl W for S { }
 }
@@ -319,11 +342,13 @@ mod automatically_derived {
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 mod no_mangle {
     mod inner { #![no_mangle] }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_mangle] fn f() { }
 
@@ -331,27 +356,32 @@ mod no_mangle {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_mangle] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_mangle] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     trait Tr {
         #[no_mangle] fn foo();
         //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
         //~| HELP can be applied to
+        //~| HELP remove the attribute
 
         #[no_mangle] fn bar() {}
         //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
         //~| HELP can be applied to
+        //~| HELP remove the attribute
     }
 }
 
@@ -359,11 +389,13 @@ mod no_mangle {
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 mod should_panic {
     mod inner { #![should_panic] }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[should_panic] fn f() { }
 
@@ -371,27 +403,32 @@ mod should_panic {
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[should_panic] type T = S;
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[should_panic] impl S { }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 }
 
 #[ignore]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 mod ignore {
     mod inner { #![ignore] }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[ignore] fn f() { }
 
@@ -399,16 +436,19 @@ mod ignore {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[ignore] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[ignore] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 }
 
 #[no_implicit_prelude]
@@ -419,21 +459,25 @@ mod no_implicit_prelude {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_implicit_prelude] struct S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_implicit_prelude] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[no_implicit_prelude] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 #[reexport_test_harness_main = "2900"]
@@ -467,21 +511,25 @@ mod macro_escape {
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_escape] struct S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_escape] type T = S;
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[macro_escape] impl S { }
     //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 #[no_std]
@@ -524,12 +572,14 @@ mod doc {
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can only be applied to
+//~| HELP remove the attribute
 mod cold {
 
     mod inner { #![cold] }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[cold] fn f() { }
 
@@ -537,64 +587,76 @@ mod cold {
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[cold] type T = S;
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 
     #[cold] impl S { }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can only be applied to
+    //~| HELP remove the attribute
 }
 
 #[link_name = "1900"]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 mod link_name {
     #[link_name = "1900"]
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
     extern "C" { }
 
     mod inner { #![link_name="1900"] }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_name = "1900"] fn f() { }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_name = "1900"] struct S;
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_name = "1900"] type T = S;
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_name = "1900"] impl S { }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 #[link_section = "1800"]
 //~^ WARN attribute cannot be used on
 //~| WARN previously accepted
 //~| HELP can be applied to
+//~| HELP remove the attribute
 mod link_section {
     mod inner { #![link_section="1800"] }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_section = "1800"] fn f() { }
 
@@ -602,16 +664,19 @@ mod link_section {
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_section = "1800"] type T = S;
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[link_section = "1800"] impl S { }
     //~^ WARN attribute cannot be used on
     //~| WARN previously accepted
     //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 
@@ -668,21 +733,29 @@ mod deprecated {
     #[deprecated] impl super::StructForDeprecated { }
 }
 
-#[must_use] //~ WARN `#[must_use]` has no effect
-//~^ HELP remove the attribute
+#[must_use] //~ WARN attribute cannot be used on
+//~| WARN previously accepted
+//~| HELP can be applied to
+//~| HELP remove the attribute
 mod must_use {
-    mod inner { #![must_use] } //~ WARN `#[must_use]` has no effect
-    //~^ HELP remove the attribute
+    mod inner { #![must_use] } //~ WARN attribute cannot be used on
+    //~| WARN previously accepted
+    //~| HELP can be applied to
+    //~| HELP remove the attribute
 
     #[must_use] fn f() { }
 
     #[must_use] struct S;
 
-    #[must_use] type T = S; //~ WARN `#[must_use]` has no effect
-    //~^ HELP remove the attribute
+    #[must_use] type T = S; //~ WARN attribute cannot be used on
+    //~| WARN previously accepted
+    //~| HELP can be applied to
+    //~| HELP remove the attribute
 
-    #[must_use] impl S { } //~ WARN `#[must_use]` has no effect
-    //~^ HELP remove the attribute
+    #[must_use] impl S { } //~ WARN attribute cannot be used on
+    //~| WARN previously accepted
+    //~| HELP can be applied to
+    //~| HELP remove the attribute
 }
 
 #[windows_subsystem = "windows"]

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:462:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:506:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     mod inner { #![macro_escape] }
    = help: try an outer attribute: `#[macro_use]`
 
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:459:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:503:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
@@ -43,151 +43,151 @@ LL | #![deny(x5100)]
    |         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:103:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:111:8
    |
 LL | #[warn(x5400)]
    |        ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:106:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:114:25
    |
 LL |     mod inner { #![warn(x5400)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:109:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:117:12
    |
 LL |     #[warn(x5400)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:112:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:120:12
    |
 LL |     #[warn(x5400)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:115:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:123:12
    |
 LL |     #[warn(x5400)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:118:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:126:12
    |
 LL |     #[warn(x5400)] impl S { }
    |            ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:122:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:130:9
    |
 LL | #[allow(x5300)]
    |         ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:125:26
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:133:26
    |
 LL |     mod inner { #![allow(x5300)] }
    |                          ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:128:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:136:13
    |
 LL |     #[allow(x5300)] fn f() { }
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:131:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:139:13
    |
 LL |     #[allow(x5300)] struct S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:134:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:142:13
    |
 LL |     #[allow(x5300)] type T = S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:137:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:145:13
    |
 LL |     #[allow(x5300)] impl S { }
    |             ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:141:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:149:10
    |
 LL | #[forbid(x5200)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:144:27
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:152:27
    |
 LL |     mod inner { #![forbid(x5200)] }
    |                           ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:147:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:155:14
    |
 LL |     #[forbid(x5200)] fn f() { }
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:150:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:158:14
    |
 LL |     #[forbid(x5200)] struct S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:153:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:161:14
    |
 LL |     #[forbid(x5200)] type T = S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:156:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:164:14
    |
 LL |     #[forbid(x5200)] impl S { }
    |              ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:160:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:168:8
    |
 LL | #[deny(x5100)]
    |        ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:163:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:171:25
    |
 LL |     mod inner { #![deny(x5100)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:166:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:174:12
    |
 LL |     #[deny(x5100)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:169:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:177:12
    |
 LL |     #[deny(x5100)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:172:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:180:12
    |
 LL |     #[deny(x5100)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:175:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:183:12
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:204:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
    |
 LL | #[macro_export]
    | ^^^^^^^^^^^^^^^
@@ -199,19 +199,19 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:439:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:1
    |
 LL | #[reexport_test_harness_main = "2900"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:535:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:620:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:1
    |
 LL |   #[link()]
    |   ^^^^^^^^^
@@ -226,76 +226,64 @@ LL | | }
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` has no effect when applied to modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:1
-   |
-LL | #[must_use]
-   | ^^^^^^^^^^^
-
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:1
    |
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:709:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:728:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:747:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:820:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:767:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:840:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:859:1
    |
 LL | #[no_builtins]
    | ^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:805:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:878:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:824:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:897:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
    |
 LL | #![link()]
    | ^^^^^^^^^^ not an `extern` block
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` has no effect when applied to modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:78:1
-   |
-LL | #![must_use]
-   | ^^^^^^^^^^^^
-
 warning: the feature `rust1` has been stable since 1.0.0 and no longer requires an attribute to enable
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:92:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:100:12
    |
 LL | #![feature(rust1)]
    |            ^^^^^
@@ -303,97 +291,97 @@ LL | #![feature(rust1)]
    = note: `#[warn(stable_features)]` on by default
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:207:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
    |
 LL |     mod inner { #![macro_export] }
    |                 ^^^^^^^^^^^^^^^^
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:210:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:222:5
    |
 LL |     #[macro_export] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:213:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:225:5
    |
 LL |     #[macro_export] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:228:5
    |
 LL |     #[macro_export] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: `#[macro_export]` only has an effect on macro definitions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:231:5
    |
 LL |     #[macro_export] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:442:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:486:17
    |
 LL |     mod inner { #![reexport_test_harness_main="2900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:445:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:489:5
    |
 LL |     #[reexport_test_harness_main = "2900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:448:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:492:5
    |
 LL |     #[reexport_test_harness_main = "2900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:451:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
    |
 LL |     #[reexport_test_harness_main = "2900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:454:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:498:5
    |
 LL |     #[reexport_test_harness_main = "2900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:490:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:538:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:493:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:541:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:544:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:499:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:547:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:502:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:550:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:626:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:691:17
    |
 LL |     mod inner { #![link()] }
    |     ------------^^^^^^^^^^-- not an `extern` block
@@ -401,7 +389,7 @@ LL |     mod inner { #![link()] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:631:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
    |
 LL |     #[link()] fn f() { }
    |     ^^^^^^^^^ ---------- not an `extern` block
@@ -409,7 +397,7 @@ LL |     #[link()] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:636:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:5
    |
 LL |     #[link()] struct S;
    |     ^^^^^^^^^ --------- not an `extern` block
@@ -417,7 +405,7 @@ LL |     #[link()] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:641:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
    |
 LL |     #[link()] type T = S;
    |     ^^^^^^^^^ ----------- not an `extern` block
@@ -425,7 +413,7 @@ LL |     #[link()] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:711:5
    |
 LL |     #[link()] impl S { }
    |     ^^^^^^^^^ ---------- not an `extern` block
@@ -433,273 +421,255 @@ LL |     #[link()] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:651:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:5
    |
 LL |     #[link()] extern "Rust" {}
    |     ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: `#[must_use]` has no effect when applied to modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:674:17
-   |
-LL |     mod inner { #![must_use] }
-   |                 ^^^^^^^^^^^^
-
-warning: `#[must_use]` has no effect when applied to type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:681:5
-   |
-LL |     #[must_use] type T = S;
-   |     ^^^^^^^^^^^
-
-warning: `#[must_use]` has no effect when applied to inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:684:5
-   |
-LL |     #[must_use] impl S { }
-   |     ^^^^^^^^^^^
-
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:691:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:17
    |
 LL |     mod inner { #![windows_subsystem="windows"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:694:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:767:5
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:697:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:5
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:5
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:703:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:776:5
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:712:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:715:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:788:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:791:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:721:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:794:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:724:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:731:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:734:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:807:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:737:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:810:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:740:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:813:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:743:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:816:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:750:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:823:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:753:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:826:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:829:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:759:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:832:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:762:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:835:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:776:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:849:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:779:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:855:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:862:17
    |
 LL |     mod inner { #![no_builtins] }
    |                 ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:792:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:865:5
    |
 LL |     #[no_builtins] fn f() { }
    |     ^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:868:5
    |
 LL |     #[no_builtins] struct S;
    |     ^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:798:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:5
    |
 LL |     #[no_builtins] type T = S;
    |     ^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:801:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:874:5
    |
 LL |     #[no_builtins] impl S { }
    |     ^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:881:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:811:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:884:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:814:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:887:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:817:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:890:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:820:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:893:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:830:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:903:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:833:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:906:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:836:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:909:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:183:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:191:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
@@ -708,7 +678,7 @@ LL |     #[macro_use] fn f() { }
    = help: `#[macro_use]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:188:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:5
    |
 LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
@@ -717,7 +687,7 @@ LL |     #[macro_use] struct S;
    = help: `#[macro_use]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
@@ -726,7 +696,7 @@ LL |     #[macro_use] type T = S;
    = help: `#[macro_use]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:198:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
@@ -735,7 +705,7 @@ LL |     #[macro_use] impl S { }
    = help: `#[macro_use]` can be applied to modules, extern crates, crates
 
 warning: `#[path]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:259:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:271:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
@@ -744,7 +714,7 @@ LL |     #[path = "3800"] fn f() { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:264:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:277:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
@@ -753,7 +723,7 @@ LL |     #[path = "3800"]  struct S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:269:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:283:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
@@ -762,7 +732,7 @@ LL |     #[path = "3800"] type T = S;
    = help: `#[path]` can only be applied to modules
 
 warning: `#[path]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:274:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:289:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
@@ -771,7 +741,7 @@ LL |     #[path = "3800"] impl S { }
    = help: `#[path]` can only be applied to modules
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:280:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:296:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -780,7 +750,7 @@ LL | #[automatically_derived]
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:285:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:302:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -789,7 +759,7 @@ LL |     mod inner { #![automatically_derived] }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:290:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:308:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -798,7 +768,7 @@ LL |     #[automatically_derived] fn f() { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:295:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:314:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -807,7 +777,7 @@ LL |     #[automatically_derived] struct S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:300:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:320:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -816,7 +786,7 @@ LL |     #[automatically_derived] type T = S;
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:305:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:326:5
    |
 LL |     #[automatically_derived] trait W { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -825,7 +795,7 @@ LL |     #[automatically_derived] trait W { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:310:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -834,7 +804,7 @@ LL |     #[automatically_derived] impl S { }
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:318:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:1
    |
 LL | #[no_mangle]
    | ^^^^^^^^^^^^
@@ -843,7 +813,7 @@ LL | #[no_mangle]
    = help: `#[no_mangle]` can be applied to functions, statics
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:323:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:347:17
    |
 LL |     mod inner { #![no_mangle] }
    |                 ^^^^^^^^^^^^^
@@ -852,7 +822,7 @@ LL |     mod inner { #![no_mangle] }
    = help: `#[no_mangle]` can be applied to functions, statics
 
 warning: `#[no_mangle]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:330:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:355:5
    |
 LL |     #[no_mangle] struct S;
    |     ^^^^^^^^^^^^
@@ -861,7 +831,7 @@ LL |     #[no_mangle] struct S;
    = help: `#[no_mangle]` can be applied to functions, statics
 
 warning: `#[no_mangle]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:335:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:361:5
    |
 LL |     #[no_mangle] type T = S;
    |     ^^^^^^^^^^^^
@@ -870,7 +840,7 @@ LL |     #[no_mangle] type T = S;
    = help: `#[no_mangle]` can be applied to functions, statics
 
 warning: `#[no_mangle]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:340:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:5
    |
 LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
@@ -879,7 +849,7 @@ LL |     #[no_mangle] impl S { }
    = help: `#[no_mangle]` can be applied to functions, statics
 
 warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:346:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:374:9
    |
 LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
@@ -888,7 +858,7 @@ LL |         #[no_mangle] fn foo();
    = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, trait methods in impl blocks
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:351:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:380:9
    |
 LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
@@ -897,7 +867,7 @@ LL |         #[no_mangle] fn bar() {}
    = help: `#[no_mangle]` can be applied to functions, statics, inherent methods, trait methods in impl blocks
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:358:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:388:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
@@ -906,7 +876,7 @@ LL | #[should_panic]
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:363:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:394:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
@@ -915,7 +885,7 @@ LL |     mod inner { #![should_panic] }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:370:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -924,7 +894,7 @@ LL |     #[should_panic] struct S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:375:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -933,7 +903,7 @@ LL |     #[should_panic] type T = S;
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[should_panic]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:380:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -942,7 +912,7 @@ LL |     #[should_panic] impl S { }
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:386:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:421:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
@@ -951,7 +921,7 @@ LL | #[ignore]
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:391:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
@@ -960,7 +930,7 @@ LL |     mod inner { #![ignore] }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:435:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
@@ -969,7 +939,7 @@ LL |     #[ignore] struct S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:403:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:441:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
@@ -978,7 +948,7 @@ LL |     #[ignore] type T = S;
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:447:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
@@ -987,7 +957,7 @@ LL |     #[ignore] impl S { }
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:418:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:458:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -996,7 +966,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    = help: `#[no_implicit_prelude]` can be applied to modules, crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:423:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:464:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -1005,7 +975,7 @@ LL |     #[no_implicit_prelude] struct S;
    = help: `#[no_implicit_prelude]` can be applied to modules, crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:428:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:470:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -1014,7 +984,7 @@ LL |     #[no_implicit_prelude] type T = S;
    = help: `#[no_implicit_prelude]` can be applied to modules, crates
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:433:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -1023,7 +993,7 @@ LL |     #[no_implicit_prelude] impl S { }
    = help: `#[no_implicit_prelude]` can be applied to modules, crates
 
 warning: `#[macro_escape]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:510:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
@@ -1032,7 +1002,7 @@ LL |     #[macro_escape] fn f() { }
    = help: `#[macro_escape]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_escape]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:471:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:516:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -1041,7 +1011,7 @@ LL |     #[macro_escape] struct S;
    = help: `#[macro_escape]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:522:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -1050,7 +1020,7 @@ LL |     #[macro_escape] type T = S;
    = help: `#[macro_escape]` can be applied to modules, extern crates, crates
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:481:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:528:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -1059,7 +1029,7 @@ LL |     #[macro_escape] impl S { }
    = help: `#[macro_escape]` can be applied to modules, extern crates, crates
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:523:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:571:1
    |
 LL | #[cold]
    | ^^^^^^^
@@ -1068,7 +1038,7 @@ LL | #[cold]
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:529:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:578:17
    |
 LL |     mod inner { #![cold] }
    |                 ^^^^^^^^
@@ -1077,7 +1047,7 @@ LL |     mod inner { #![cold] }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:536:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:586:5
    |
 LL |     #[cold] struct S;
    |     ^^^^^^^
@@ -1086,7 +1056,7 @@ LL |     #[cold] struct S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:541:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:592:5
    |
 LL |     #[cold] type T = S;
    |     ^^^^^^^
@@ -1095,7 +1065,7 @@ LL |     #[cold] type T = S;
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:546:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:598:5
    |
 LL |     #[cold] impl S { }
    |     ^^^^^^^
@@ -1104,7 +1074,7 @@ LL |     #[cold] impl S { }
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:552:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:605:1
    |
 LL | #[link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -1113,7 +1083,7 @@ LL | #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:557:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:611:5
    |
 LL |     #[link_name = "1900"]
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1122,7 +1092,7 @@ LL |     #[link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:563:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:618:17
    |
 LL |     mod inner { #![link_name="1900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -1131,7 +1101,7 @@ LL |     mod inner { #![link_name="1900"] }
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:568:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:624:5
    |
 LL |     #[link_name = "1900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1140,7 +1110,7 @@ LL |     #[link_name = "1900"] fn f() { }
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:573:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:630:5
    |
 LL |     #[link_name = "1900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1149,7 +1119,7 @@ LL |     #[link_name = "1900"] struct S;
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:578:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:636:5
    |
 LL |     #[link_name = "1900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1158,7 +1128,7 @@ LL |     #[link_name = "1900"] type T = S;
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:583:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
    |
 LL |     #[link_name = "1900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -1167,7 +1137,7 @@ LL |     #[link_name = "1900"] impl S { }
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:589:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:649:1
    |
 LL | #[link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1176,7 +1146,7 @@ LL | #[link_section = "1800"]
    = help: `#[link_section]` can be applied to statics, functions
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:594:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:655:17
    |
 LL |     mod inner { #![link_section="1800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -1185,7 +1155,7 @@ LL |     mod inner { #![link_section="1800"] }
    = help: `#[link_section]` can be applied to statics, functions
 
 warning: `#[link_section]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:601:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:5
    |
 LL |     #[link_section = "1800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1194,7 +1164,7 @@ LL |     #[link_section = "1800"] struct S;
    = help: `#[link_section]` can be applied to statics, functions
 
 warning: `#[link_section]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:606:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:669:5
    |
 LL |     #[link_section = "1800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1203,13 +1173,49 @@ LL |     #[link_section = "1800"] type T = S;
    = help: `#[link_section]` can be applied to statics, functions
 
 warning: `#[link_section]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:611:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
    |
 LL |     #[link_section = "1800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[link_section]` can be applied to statics, functions
+
+warning: `#[must_use]` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:736:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+warning: `#[must_use]` attribute cannot be used on modules
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:741:17
+   |
+LL |     mod inner { #![must_use] }
+   |                 ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+warning: `#[must_use]` attribute cannot be used on type aliases
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:750:5
+   |
+LL |     #[must_use] type T = S;
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+warning: `#[must_use]` attribute cannot be used on inherent impl blocks
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:755:5
+   |
+LL |     #[must_use] impl S { }
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
 warning: `#[should_panic]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:50:1
@@ -1221,7 +1227,7 @@ LL | #![should_panic]
    = help: `#[should_panic]` can only be applied to functions
 
 warning: `#[ignore]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:53:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:54:1
    |
 LL | #![ignore]
    | ^^^^^^^^^^
@@ -1230,7 +1236,7 @@ LL | #![ignore]
    = help: `#[ignore]` can only be applied to functions
 
 warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:61:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
    |
 LL | #![proc_macro_derive(Test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1239,7 +1245,7 @@ LL | #![proc_macro_derive(Test)]
    = help: `#[proc_macro_derive]` can only be applied to functions
 
 warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:65:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
    |
 LL | #![cold]
    | ^^^^^^^^
@@ -1248,7 +1254,7 @@ LL | #![cold]
    = help: `#[cold]` can only be applied to functions
 
 warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:70:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:74:1
    |
 LL | #![link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -1257,13 +1263,22 @@ LL | #![link_name = "1900"]
    = help: `#[link_name]` can be applied to foreign functions, foreign statics
 
 warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:74:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:79:1
    |
 LL | #![link_section = "1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[link_section]` can be applied to statics, functions
+
+warning: `#[must_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:84:1
+   |
+LL | #![must_use]
+   | ^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
 warning: 173 warnings emitted
 

--- a/tests/ui/lint/unused/unused_attributes-must_use.fixed
+++ b/tests/ui/lint/unused/unused_attributes-must_use.fixed
@@ -4,18 +4,23 @@
 #![deny(unused_attributes, unused_must_use)]
 #![feature(asm_experimental_arch, stmt_expr_attributes, trait_alias)]
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 extern crate std as std2;
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 mod test_mod {}
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 use std::arch::global_asm;
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 const CONST: usize = 4;
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 #[no_mangle]
 static STATIC: usize = 4;
 
@@ -32,7 +37,8 @@ union U {
     unit: (),
 }
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 impl U {
     #[must_use]
     fn method() -> i32 {
@@ -46,10 +52,12 @@ fn foo() -> i64 {
     4
 }
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 extern "Rust" {
     #[link_name = "STATIC"]
-     //~ ERROR `#[must_use]` has no effect
+     //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     static FOREIGN_STATIC: usize;
 
     #[link_name = "foo"]
@@ -60,16 +68,20 @@ extern "Rust" {
  //~ ERROR unused attribute
 global_asm!("");
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 type UseMe = ();
 
-fn qux< T>(_: T) {} //~ ERROR `#[must_use]` has no effect
+fn qux< T>(_: T) {} //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 
 #[must_use]
 trait Use {
-     //~ ERROR `#[must_use]` has no effect
+     //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     const ASSOC_CONST: usize = 4;
-     //~ ERROR `#[must_use]` has no effect
+     //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     type AssocTy;
 
     #[must_use]
@@ -78,20 +90,24 @@ trait Use {
     }
 }
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 impl Use for () {
     type AssocTy = ();
 
-     //~ ERROR `#[must_use]` has no effect
+     //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     fn get_four(&self) -> usize {
         4
     }
 }
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 trait Alias = Use;
 
- //~ ERROR `#[must_use]` has no effect
+ //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 macro_rules! cool_macro {
     () => {
         4
@@ -99,11 +115,13 @@ macro_rules! cool_macro {
 }
 
 fn main() {
-     //~ ERROR `#[must_use]` has no effect
+     //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     let x = || {};
     x();
 
-    let x =  //~ ERROR `#[must_use]` has no effect
+    let x =  //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     || {};
     x();
 
@@ -125,7 +143,8 @@ fn main() {
     let _ = ().get_four(); //~ ERROR that must be used
 
     match Some(4) {
-         //~ ERROR `#[must_use]` has no effect
+         //~ ERROR attribute cannot be used on
+        //~| WARN previously accepted
         Some(res) => res,
         None => 0,
     };
@@ -133,7 +152,9 @@ fn main() {
     struct PatternField {
         foo: i32,
     }
-    let s = PatternField {   foo: 123 }; //~ ERROR `#[must_use]` has no effect
-    let PatternField {  foo } = s; //~ ERROR `#[must_use]` has no effect
+    let s = PatternField {   foo: 123 }; //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
+    let PatternField {  foo } = s; //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     let _ = foo;
 }

--- a/tests/ui/lint/unused/unused_attributes-must_use.rs
+++ b/tests/ui/lint/unused/unused_attributes-must_use.rs
@@ -4,18 +4,23 @@
 #![deny(unused_attributes, unused_must_use)]
 #![feature(asm_experimental_arch, stmt_expr_attributes, trait_alias)]
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 extern crate std as std2;
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 mod test_mod {}
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 use std::arch::global_asm;
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 const CONST: usize = 4;
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 #[no_mangle]
 static STATIC: usize = 4;
 
@@ -32,7 +37,8 @@ union U {
     unit: (),
 }
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 impl U {
     #[must_use]
     fn method() -> i32 {
@@ -46,10 +52,12 @@ fn foo() -> i64 {
     4
 }
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 extern "Rust" {
     #[link_name = "STATIC"]
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     static FOREIGN_STATIC: usize;
 
     #[link_name = "foo"]
@@ -60,16 +68,20 @@ extern "Rust" {
 #[must_use] //~ ERROR unused attribute
 global_asm!("");
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 type UseMe = ();
 
-fn qux<#[must_use] T>(_: T) {} //~ ERROR `#[must_use]` has no effect
+fn qux<#[must_use] T>(_: T) {} //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 
 #[must_use]
 trait Use {
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     const ASSOC_CONST: usize = 4;
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     type AssocTy;
 
     #[must_use]
@@ -78,20 +90,24 @@ trait Use {
     }
 }
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 impl Use for () {
     type AssocTy = ();
 
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     fn get_four(&self) -> usize {
         4
     }
 }
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 trait Alias = Use;
 
-#[must_use] //~ ERROR `#[must_use]` has no effect
+#[must_use] //~ ERROR attribute cannot be used on
+//~| WARN previously accepted
 macro_rules! cool_macro {
     () => {
         4
@@ -99,11 +115,13 @@ macro_rules! cool_macro {
 }
 
 fn main() {
-    #[must_use] //~ ERROR `#[must_use]` has no effect
+    #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     let x = || {};
     x();
 
-    let x = #[must_use] //~ ERROR `#[must_use]` has no effect
+    let x = #[must_use] //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     || {};
     x();
 
@@ -125,7 +143,8 @@ fn main() {
     ().get_four(); //~ ERROR that must be used
 
     match Some(4) {
-        #[must_use] //~ ERROR `#[must_use]` has no effect
+        #[must_use] //~ ERROR attribute cannot be used on
+        //~| WARN previously accepted
         Some(res) => res,
         None => 0,
     };
@@ -133,7 +152,9 @@ fn main() {
     struct PatternField {
         foo: i32,
     }
-    let s = PatternField { #[must_use]  foo: 123 }; //~ ERROR `#[must_use]` has no effect
-    let PatternField { #[must_use] foo } = s; //~ ERROR `#[must_use]` has no effect
+    let s = PatternField { #[must_use]  foo: 123 }; //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
+    let PatternField { #[must_use] foo } = s; //~ ERROR attribute cannot be used on
+    //~| WARN previously accepted
     let _ = foo;
 }

--- a/tests/ui/lint/unused/unused_attributes-must_use.stderr
+++ b/tests/ui/lint/unused/unused_attributes-must_use.stderr
@@ -1,11 +1,11 @@
 error: unused attribute `must_use`
-  --> $DIR/unused_attributes-must_use.rs:60:1
+  --> $DIR/unused_attributes-must_use.rs:68:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
    |
 note: the built-in attribute `must_use` will be ignored, since it's applied to the macro invocation `global_asm`
-  --> $DIR/unused_attributes-must_use.rs:61:1
+  --> $DIR/unused_attributes-must_use.rs:69:1
    |
 LL | global_asm!("");
    | ^^^^^^^^^^
@@ -15,134 +15,197 @@ note: the lint level is defined here
 LL | #![deny(unused_attributes, unused_must_use)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: `#[must_use]` has no effect when applied to extern crates
+error: `#[must_use]` attribute cannot be used on extern crates
   --> $DIR/unused_attributes-must_use.rs:7:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to modules
-  --> $DIR/unused_attributes-must_use.rs:10:1
+error: `#[must_use]` attribute cannot be used on modules
+  --> $DIR/unused_attributes-must_use.rs:11:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to use statements
-  --> $DIR/unused_attributes-must_use.rs:13:1
+error: `#[must_use]` attribute cannot be used on use statements
+  --> $DIR/unused_attributes-must_use.rs:15:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to constants
-  --> $DIR/unused_attributes-must_use.rs:16:1
+error: `#[must_use]` attribute cannot be used on constants
+  --> $DIR/unused_attributes-must_use.rs:19:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to statics
-  --> $DIR/unused_attributes-must_use.rs:18:1
+error: `#[must_use]` attribute cannot be used on statics
+  --> $DIR/unused_attributes-must_use.rs:22:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to inherent impl blocks
-  --> $DIR/unused_attributes-must_use.rs:35:1
+error: `#[must_use]` attribute cannot be used on inherent impl blocks
+  --> $DIR/unused_attributes-must_use.rs:40:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to foreign modules
-  --> $DIR/unused_attributes-must_use.rs:49:1
+error: `#[must_use]` attribute cannot be used on foreign modules
+  --> $DIR/unused_attributes-must_use.rs:55:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to type aliases
-  --> $DIR/unused_attributes-must_use.rs:63:1
+error: `#[must_use]` attribute cannot be used on foreign statics
+  --> $DIR/unused_attributes-must_use.rs:59:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on type aliases
+  --> $DIR/unused_attributes-must_use.rs:71:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to type parameters
-  --> $DIR/unused_attributes-must_use.rs:66:8
+error: `#[must_use]` attribute cannot be used on function params
+  --> $DIR/unused_attributes-must_use.rs:75:8
    |
 LL | fn qux<#[must_use] T>(_: T) {}
    |        ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to trait impl blocks
-  --> $DIR/unused_attributes-must_use.rs:81:1
    |
-LL | #[must_use]
-   | ^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to trait aliases
-  --> $DIR/unused_attributes-must_use.rs:91:1
-   |
-LL | #[must_use]
-   | ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to macro defs
-  --> $DIR/unused_attributes-must_use.rs:94:1
-   |
-LL | #[must_use]
-   | ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to statements
-  --> $DIR/unused_attributes-must_use.rs:102:5
+error: `#[must_use]` attribute cannot be used on associated consts
+  --> $DIR/unused_attributes-must_use.rs:80:5
    |
 LL |     #[must_use]
    |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to closures
-  --> $DIR/unused_attributes-must_use.rs:106:13
+error: `#[must_use]` attribute cannot be used on associated types
+  --> $DIR/unused_attributes-must_use.rs:83:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on trait impl blocks
+  --> $DIR/unused_attributes-must_use.rs:93:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on trait methods in impl blocks
+  --> $DIR/unused_attributes-must_use.rs:98:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to data types, functions, unions, required trait methods, provided trait methods, inherent methods, foreign functions, traits
+
+error: `#[must_use]` attribute cannot be used on trait aliases
+  --> $DIR/unused_attributes-must_use.rs:105:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on macro defs
+  --> $DIR/unused_attributes-must_use.rs:109:1
+   |
+LL | #[must_use]
+   | ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on statements
+  --> $DIR/unused_attributes-must_use.rs:118:5
+   |
+LL |     #[must_use]
+   |     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
+
+error: `#[must_use]` attribute cannot be used on closures
+  --> $DIR/unused_attributes-must_use.rs:123:13
    |
 LL |     let x = #[must_use]
    |             ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to methods, data types, functions, unions, foreign functions, traits
 
-error: `#[must_use]` has no effect when applied to match arms
-  --> $DIR/unused_attributes-must_use.rs:128:9
+error: `#[must_use]` attribute cannot be used on match arms
+  --> $DIR/unused_attributes-must_use.rs:146:9
    |
 LL |         #[must_use]
    |         ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to struct fields
-  --> $DIR/unused_attributes-must_use.rs:136:28
+error: `#[must_use]` attribute cannot be used on struct fields
+  --> $DIR/unused_attributes-must_use.rs:155:28
    |
 LL |     let s = PatternField { #[must_use]  foo: 123 };
    |                            ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
-error: `#[must_use]` has no effect when applied to pattern fields
-  --> $DIR/unused_attributes-must_use.rs:137:24
+error: `#[must_use]` attribute cannot be used on pattern fields
+  --> $DIR/unused_attributes-must_use.rs:157:24
    |
 LL |     let PatternField { #[must_use] foo } = s;
    |                        ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to associated consts
-  --> $DIR/unused_attributes-must_use.rs:70:5
    |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to associated types
-  --> $DIR/unused_attributes-must_use.rs:72:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to provided trait methods
-  --> $DIR/unused_attributes-must_use.rs:85:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
-
-error: `#[must_use]` has no effect when applied to foreign statics
-  --> $DIR/unused_attributes-must_use.rs:52:5
-   |
-LL |     #[must_use]
-   |     ^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[must_use]` can be applied to functions, data types, unions, traits
 
 error: unused `X` that must be used
-  --> $DIR/unused_attributes-must_use.rs:110:5
+  --> $DIR/unused_attributes-must_use.rs:128:5
    |
 LL |     X;
    |     ^
@@ -158,7 +221,7 @@ LL |     let _ = X;
    |     +++++++
 
 error: unused `Y` that must be used
-  --> $DIR/unused_attributes-must_use.rs:111:5
+  --> $DIR/unused_attributes-must_use.rs:129:5
    |
 LL |     Y::Z;
    |     ^^^^
@@ -169,7 +232,7 @@ LL |     let _ = Y::Z;
    |     +++++++
 
 error: unused `U` that must be used
-  --> $DIR/unused_attributes-must_use.rs:112:5
+  --> $DIR/unused_attributes-must_use.rs:130:5
    |
 LL |     U { unit: () };
    |     ^^^^^^^^^^^^^^
@@ -180,7 +243,7 @@ LL |     let _ = U { unit: () };
    |     +++++++
 
 error: unused return value of `U::method` that must be used
-  --> $DIR/unused_attributes-must_use.rs:113:5
+  --> $DIR/unused_attributes-must_use.rs:131:5
    |
 LL |     U::method();
    |     ^^^^^^^^^^^
@@ -191,7 +254,7 @@ LL |     let _ = U::method();
    |     +++++++
 
 error: unused return value of `foo` that must be used
-  --> $DIR/unused_attributes-must_use.rs:114:5
+  --> $DIR/unused_attributes-must_use.rs:132:5
    |
 LL |     foo();
    |     ^^^^^
@@ -202,7 +265,7 @@ LL |     let _ = foo();
    |     +++++++
 
 error: unused return value of `foreign_foo` that must be used
-  --> $DIR/unused_attributes-must_use.rs:117:9
+  --> $DIR/unused_attributes-must_use.rs:135:9
    |
 LL |         foreign_foo();
    |         ^^^^^^^^^^^^^
@@ -213,7 +276,7 @@ LL |         let _ = foreign_foo();
    |         +++++++
 
 error: unused return value of `Use::get_four` that must be used
-  --> $DIR/unused_attributes-must_use.rs:125:5
+  --> $DIR/unused_attributes-must_use.rs:143:5
    |
 LL |     ().get_four();
    |     ^^^^^^^^^^^^^


### PR DESCRIPTION
This PR ports `must_use` to the new target checking logic 
This also adds a tool-only suggestion to remove attributes on invalid targets, as to not immediately undo the work of https://github.com/rust-lang/rust/pull/145274

r? @jdonszelmann 