### PR TITLE
Add some conversion trait impls

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -689,6 +689,30 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Cell<U>> for Cell<T> {}
 
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>; N] {
+        self.as_array_of_cells()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>] {
+        &*self.as_array_of_cells()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T> AsRef<[Cell<T>]> for Cell<[T]> {
+    #[inline]
+    fn as_ref(&self) -> &[Cell<T>] {
+        self.as_slice_of_cells()
+    }
+}
+
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
     ///

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1532,6 +1532,56 @@ impl<T, const N: usize> MaybeUninit<[T; N]> {
     }
 }
 
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> From<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn from(arr: [MaybeUninit<T>; N]) -> Self {
+        arr.transpose()
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[MaybeUninit<T>; N] {
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        unsafe { &*ptr::from_ref(self).cast() }
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_ref(&self) -> &[MaybeUninit<T>] {
+        &*AsRef::<[MaybeUninit<T>; N]>::as_ref(self)
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsMut<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [MaybeUninit<T>; N] {
+        // SAFETY: T and MaybeUninit<T> have the same layout
+        unsafe { &mut *ptr::from_mut(self).cast() }
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsMut<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut *AsMut::<[MaybeUninit<T>; N]>::as_mut(self)
+    }
+}
+
+#[stable(feature = "more_conversion_trait_impls", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> From<MaybeUninit<[T; N]>> for [MaybeUninit<T>; N] {
+    #[inline]
+    fn from(arr: MaybeUninit<[T; N]>) -> Self {
+        arr.transpose()
+    }
+}
+
 impl<T, const N: usize> [MaybeUninit<T>; N] {
     /// Transposes a `[MaybeUninit<T>; N]` into a `MaybeUninit<[T; N]>`.
     ///

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -13,7 +13,7 @@ LL |     let _: &[i8] = data.into();
              `[T; 6]` implements `From<(T, T, T, T, T, T)>`
              `[T; 7]` implements `From<(T, T, T, T, T, T, T)>`
              `[T; 8]` implements `From<(T, T, T, T, T, T, T, T)>`
-           and 6 others
+           and 7 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
- `impl<T, const N: usize> From<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]>` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]>` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]>` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> AsMut<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]>` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> AsMut<[MaybeUninit<T>]> for MaybeUninit<[T; N]>` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> From<MaybeUninit<[T; N]>> for [MaybeUninit<T>; N]` (cc https://github.com/rust-lang/rust/issues/96097)
- `impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]>` (equivalent of `as_array_of_cells`, cc https://github.com/rust-lang/rust/issues/88248)
- `impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]>`
- `impl<T> AsRef<[Cell<T>]> for Cell<[T]>` (equivalent of `as_slice_of_cells`)

@rustbot label T-libs-api needs-fcp -T-libs

I’ve tried to only add impls that are unlikely to cause single-applicable-impl inference breakage.