### PR TITLE
stdlib: Replace typedef -> type alias in doc comment

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -18,7 +18,7 @@ use crate::{error, fmt, result, sys};
 /// This type is broadly used across [`std::io`] for any operation which may
 /// produce an error.
 ///
-/// This typedef is generally used to avoid writing out [`io::Error`] directly and
+/// This type alias is generally used to avoid writing out [`io::Error`] directly and
 /// is otherwise a direct mapping to [`Result`].
 ///
 /// While usual Rust style is to import types directly, aliases of [`Result`]


### PR DESCRIPTION
'typedef' is jargon from C and C++.

Since the Rust reference uses the term [type alias](https://doc.rust-lang.org/reference/items/type-aliases.html),
this patch changes the doc comment in io/error.rs
to also use 'type alias'.