### PR TITLE
Reorder `lto` options from most to least optimizing

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -375,12 +375,12 @@ linking time. It takes one of the following values:
 
 * `y`, `yes`, `on`, `true`, `fat`, or no value: perform "fat" LTO which attempts to
   perform optimizations across all crates within the dependency graph.
-* `n`, `no`, `off`, `false`: disables LTO.
 * `thin`: perform ["thin"
   LTO](http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html).
   This is similar to "fat", but takes substantially less time to run while
   still achieving performance gains similar to "fat".
   For larger projects like the Rust compiler, ThinLTO can even result in better performance than fat LTO.
+* `n`, `no`, `off`, `false`: disables LTO.
 
 If `-C lto` is not specified, then the compiler will attempt to perform "thin
 local LTO" which performs "thin" LTO on the local crate only across its


### PR DESCRIPTION
This is a follow up to https://github.com/rust-lang/cargo/pull/15841.

@weihanglo pointed out the original order of the `lto` options in the Cargo book was consistent with https://doc.rust-lang.org/rustc/codegen-options/index.html?highlight=lto#lto.

The options in the Cargo book have since been reordered. This PR keeps the two references consistent.