### PR TITLE
Opportunistically split `!=` to successfully parse never type

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -774,24 +774,29 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Eats `+` possibly breaking tokens like `+=` in process.
+    /// Eats `+` possibly breaking tokens like `+=` in the process.
     fn eat_plus(&mut self) -> bool {
         self.break_and_eat(exp!(Plus))
     }
 
-    /// Eats `&` possibly breaking tokens like `&&` in process.
+    /// Eats `!` possibly breaking tokens like `!=` in the process.
+    fn eat_bang(&mut self) -> bool {
+        self.break_and_eat(exp!(Bang))
+    }
+
+    /// Eats `&` possibly breaking tokens like `&&` in the process.
     /// Signals an error if `&` is not eaten.
     fn expect_and(&mut self) -> PResult<'a, ()> {
         if self.break_and_eat(exp!(And)) { Ok(()) } else { self.unexpected() }
     }
 
-    /// Eats `|` possibly breaking tokens like `||` in process.
+    /// Eats `|` possibly breaking tokens like `||` in the process.
     /// Signals an error if `|` was not eaten.
     fn expect_or(&mut self) -> PResult<'a, ()> {
         if self.break_and_eat(exp!(Or)) { Ok(()) } else { self.unexpected() }
     }
 
-    /// Eats `<` possibly breaking tokens like `<<` in process.
+    /// Eats `<` possibly breaking tokens like `<<` in the process.
     fn eat_lt(&mut self) -> bool {
         let ate = self.break_and_eat(exp!(Lt));
         if ate {
@@ -802,13 +807,13 @@ impl<'a> Parser<'a> {
         ate
     }
 
-    /// Eats `<` possibly breaking tokens like `<<` in process.
+    /// Eats `<` possibly breaking tokens like `<<` in the process.
     /// Signals an error if `<` was not eaten.
     fn expect_lt(&mut self) -> PResult<'a, ()> {
         if self.eat_lt() { Ok(()) } else { self.unexpected() }
     }
 
-    /// Eats `>` possibly breaking tokens like `>>` in process.
+    /// Eats `>` possibly breaking tokens like `>>` in the process.
     /// Signals an error if `>` was not eaten.
     fn expect_gt(&mut self) -> PResult<'a, ()> {
         if self.break_and_eat(exp!(Gt)) {

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -758,7 +758,9 @@ impl<'a> Parser<'a> {
         } else if let Some(form) = self.parse_range_end() {
             self.parse_pat_range_to(form)? // `..=X`, `...X`, or `..X`.
         } else if self.eat(exp!(Bang)) {
-            // Parse `!`
+            // Ideally we'd use `eat_bang` here to allow us to parse `!=>` as `! =>`. However,
+            // `break_and_eat` doesn't "reglue" the split-off `=` with any following `>` (since
+            // that would likely be super fragile and complex).
             self.psess.gated_spans.gate(sym::never_patterns, self.prev_token.span);
             PatKind::Never
         } else if self.eat_keyword(exp!(Underscore)) {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -280,12 +280,12 @@ impl<'a> Parser<'a> {
             return Ok(ty);
         }
 
-        let lo = self.token.span;
         let mut impl_dyn_multi = false;
+        let mut lo = self.token.span;
         let kind = if self.check(exp!(OpenParen)) {
             self.parse_ty_tuple_or_parens(lo, allow_plus)?
-        } else if self.eat(exp!(Bang)) {
-            // Never type `!`
+        } else if self.eat_bang() {
+            lo = self.prev_token.span;
             TyKind::Never
         } else if self.eat(exp!(Star)) {
             self.parse_ty_ptr()?

--- a/tests/ui/parser/token-splitting.rs
+++ b/tests/ui/parser/token-splitting.rs
@@ -1,0 +1,35 @@
+// Check some places in which we want to split multi-character punctuation.
+//@ edition: 2015
+//@ check-pass
+#![feature(never_type)] // only used inside `bang_eq_never_ty`!
+#![expect(bare_trait_objects)]
+
+use std::fmt::Debug;
+
+fn plus_eq_bound() {
+    // issue: <https://github.com/rust-lang/rust/issues/47856>
+    struct W<T: Clone + = ()> { t: T }
+    struct S<T: Clone += ()> { t: T }
+
+    // Bare & `dyn`-prefixed trait object types take different paths in the parser.
+    // Therefore, test both branches.
+
+    let _: Debug + = *(&() as &dyn Debug);
+    let _: Debug += *(&() as &dyn Debug);
+
+    let _: dyn Debug + = *(&() as &dyn Debug);
+    let _: dyn Debug += *(&() as &dyn Debug);
+
+    #[cfg(false)] fn w() where Trait + = () {}
+    #[cfg(false)] fn s() where Trait += () {}
+}
+
+fn bang_eq_never_ty(x: !) {
+    let _: ! = x;
+    let _: != x;
+
+    #[cfg(false)] struct W<const X: ! = { loop {} }>;
+    #[cfg(false)] struct S<const X: != { loop {} }>;
+}
+
+fn main() {}

--- a/tests/ui/parser/trait-plusequal-splitting.rs
+++ b/tests/ui/parser/trait-plusequal-splitting.rs
@@ -1,8 +1,0 @@
-// Fixes issue where `+` in generics weren't parsed if they were part of a `+=`.
-
-//@ check-pass
-
-struct Whitespace<T: Clone + = ()> { t: T }
-struct TokenSplit<T: Clone +=  ()> { t: T }
-
-fn main() {}


### PR DESCRIPTION
Accept code like `let _: != loop {};` or `let _: fn() -> != || loop {};` (previously: syntax error). Similar to sth. like https://github.com/rust-lang/rust/pull/51068.

There's no inherent need to update `can_begin_type` from what I can tell, since macro matcher `$ty:ty =` already accepts `!=` (**edit**: this is not true actually, my bad, I don't know what snippet I tested to come to that conclusion) and since no other current direct/transitive callers would 'benefit' from doing that either, so I didn't do it. It's a conservative choice to avoid odd consequences (concrete example: it would widen the *follow set* of `:vis` to include `!=`).