### PR TITLE
Do not consider a `T: !Sized` candidate to satisfy a `T: !MetaSized` obligation.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -9,8 +9,8 @@ pub use rustc_infer::traits::util::*;
 use rustc_middle::bug;
 use rustc_middle::ty::fast_reject::DeepRejectCtxt;
 use rustc_middle::ty::{
-    self, PolyTraitPredicate, SizedTraitKind, TraitPredicate, TraitRef, Ty, TyCtxt, TypeFoldable,
-    TypeFolder, TypeSuperFoldable, TypeVisitableExt,
+    self, PolyTraitPredicate, PredicatePolarity, SizedTraitKind, TraitPredicate, TraitRef, Ty,
+    TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
 pub use rustc_next_trait_solver::placeholder::BoundVarReplacer;
 use rustc_span::Span;
@@ -427,7 +427,9 @@ pub(crate) fn lazily_elaborate_sizedness_candidate<'tcx>(
         return candidate;
     }
 
-    if obligation.predicate.polarity() != candidate.polarity() {
+    if obligation.predicate.polarity() != PredicatePolarity::Positive
+        || candidate.polarity() != PredicatePolarity::Positive
+    {
         return candidate;
     }
 

--- a/tests/ui/traits/negative-bounds/negative-metasized.current.stderr
+++ b/tests/ui/traits/negative-bounds/negative-metasized.current.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `T: !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:12:11
+   |
+LL |     foo::<T>();
+   |           ^ the trait bound `T: !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `(): !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:17:11
+   |
+LL |     foo::<()>();
+   |           ^^ the trait bound `(): !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `str: !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:19:11
+   |
+LL |     foo::<str>();
+   |           ^^^ the trait bound `str: !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/negative-bounds/negative-metasized.next.stderr
+++ b/tests/ui/traits/negative-bounds/negative-metasized.next.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `T: !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:12:11
+   |
+LL |     foo::<T>();
+   |           ^ the trait bound `T: !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `(): !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:17:11
+   |
+LL |     foo::<()>();
+   |           ^^ the trait bound `(): !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error[E0277]: the trait bound `str: !MetaSized` is not satisfied
+  --> $DIR/negative-metasized.rs:19:11
+   |
+LL |     foo::<str>();
+   |           ^^^ the trait bound `str: !MetaSized` is not satisfied
+   |
+note: required by a bound in `foo`
+  --> $DIR/negative-metasized.rs:9:11
+   |
+LL | fn foo<T: !MetaSized>() {}
+   |           ^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/negative-bounds/negative-metasized.rs
+++ b/tests/ui/traits/negative-bounds/negative-metasized.rs
@@ -1,0 +1,21 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+#![feature(negative_bounds)]
+#![feature(sized_hierarchy)]
+
+use std::marker::MetaSized;
+
+fn foo<T: !MetaSized>() {}
+
+fn bar<T: !Sized + MetaSized>() {
+    foo::<T>();
+    //~^ ERROR the trait bound `T: !MetaSized` is not satisfied
+}
+
+fn main() {
+    foo::<()>();
+    //~^ ERROR the trait bound `(): !MetaSized` is not satisfied
+    foo::<str>();
+    //~^ ERROR the trait bound `str: !MetaSized` is not satisfied
+}


### PR DESCRIPTION
This example should fail to compile (and does under this PR, with the old and new solvers), but currently compiles successfully ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=6e0e5d0ae0cdf0571dea97938fb4a86d)), because (IIUC) the old solver's `lazily_elaborate_sizedness_candidate`/callers and the new solver's `TraitPredicate::fast_reject_assumption`/`match_assumption` consider a `T: _ Sized` candidate to satisfy a `T: _ MetaSized` obligation, for either polarity `_`, when that should only hold for positive polarity.

```rs
#![feature(negative_bounds)]
#![feature(sized_hierarchy)]

use std::marker::MetaSized;

fn foo<T: !MetaSized>() {}

fn bar<T: !Sized + MetaSized>() {
    foo::<T>();
    //~^ ERROR the trait bound `T: !MetaSized` is not satisfied // error under this PR
}
```

Only observable with the internal-only `feature(negative_bounds)`, so might just be "wontfix".

This example is added as a test in this PR (as well as testing that `foo<()>` and `foo<str>` are disallowed for `fn foo<T: !MetaSized`).

cc @davidtwco for `feature(sized_hierarchy)`

Maybe similar to 91c53c9 from <https://github.com/rust-lang/rust/pull/143307>




<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
