### PR TITLE
bufreader::Buffer::backshift: don't move the uninit bytes

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -122,7 +122,7 @@ impl Buffer {
 
     /// Remove bytes that have already been read from the buffer.
     pub fn backshift(&mut self) {
-        self.buf.copy_within(self.pos.., 0);
+        self.buf.copy_within(self.pos..self.filled, 0);
         self.filled -= self.pos;
         self.pos = 0;
     }


### PR DESCRIPTION
previous code was perfectly sound because of MaybeUninit, but it did waste cycles on copying memory that is known to be uninitialized.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
