### PR TITLE
fix(compiler/rustc_target): set correct linker flags for `wasm32v1-none`

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
@@ -29,10 +29,11 @@ pub(crate) fn target() -> Target {
             // For now this target just never has an entry symbol no matter the output
             // type, so unconditionally pass this.
             "--no-entry",
-            // It is also necessary to explicitly set CPU since some changes
+            // It is also necessary to explicitly set CPU and features since some changes
             // were made to WebAssembly starting with LLVM 20.1.0:
             // https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-the-webassembly-backend
             "--mllvm=-mcpu=mvp",
+            "--mllvm=-mattr=+mutable-globals",
         ],
     );
     options.add_pre_link_args(
@@ -41,7 +42,7 @@ pub(crate) fn target() -> Target {
             // Make sure clang uses LLD as its linker and is configured appropriately
             // otherwise
             "--target=wasm32-unknown-unknown",
-            "-Wl,--no-entry,--mllvm=-mcpu=mvp",
+            "-Wl,--no-entry,--mllvm=-mcpu=mvp,--mllvm=-mattr=+mutable-globals",
         ],
     );
 

--- a/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
@@ -29,11 +29,10 @@ pub(crate) fn target() -> Target {
             // For now this target just never has an entry symbol no matter the output
             // type, so unconditionally pass this.
             "--no-entry",
-            // It is also necessary to explicitly set the features since some changes
+            // It is also necessary to explicitly set CPU since some changes
             // were made to WebAssembly starting with LLVM 20.1.0:
             // https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-the-webassembly-backend
-            "--features=+mutable-globals",
-            "--no-check-features",
+            "--mllvm=-mcpu=mvp",
         ],
     );
     options.add_pre_link_args(
@@ -42,7 +41,7 @@ pub(crate) fn target() -> Target {
             // Make sure clang uses LLD as its linker and is configured appropriately
             // otherwise
             "--target=wasm32-unknown-unknown",
-            "-Wl,--no-entry,--features=+mutable-globals,--no-check-features",
+            "-Wl,--no-entry,--mllvm=-mcpu=mvp",
         ],
     );
 

--- a/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
@@ -29,6 +29,11 @@ pub(crate) fn target() -> Target {
             // For now this target just never has an entry symbol no matter the output
             // type, so unconditionally pass this.
             "--no-entry",
+            // It is also necessary to explicitly set the features since some changes
+            // were made to WebAssembly starting with LLVM 20.1.0:
+            // https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-the-webassembly-backend
+            "--features=+mutable-globals",
+            "--no-check-features",
         ],
     );
     options.add_pre_link_args(
@@ -37,7 +42,7 @@ pub(crate) fn target() -> Target {
             // Make sure clang uses LLD as its linker and is configured appropriately
             // otherwise
             "--target=wasm32-unknown-unknown",
-            "-Wl,--no-entry",
+            "-Wl,--no-entry,--features=+mutable-globals,--no-check-features",
         ],
     );
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/145539)*
<!-- homu-ignore:end -->

Resolves rust-lang/rust#145491

r? @alexcrichton

https://github.com/llvm/llvm-project/blob/llvmorg-20.1.8/lld/wasm/Writer.cpp#L573-L691

https://releases.llvm.org/20.1.0/docs/ReleaseNotes.html#changes-to-the-webassembly-backend
