### PR TITLE
Reimplement DestinationPropagation according to live ranges.

### DIFF
--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -146,8 +146,11 @@ impl<I: Idx> IntervalSet<I> {
         let point = point.index() as u32;
 
         if let Some((first_start, _)) = self.map.first_mut() {
-            assert!(point < *first_start);
-            if point + 1 == *first_start {
+            assert!(point <= *first_start);
+            if point == *first_start {
+                // The point is already present in the set.
+            } else if point + 1 == *first_start {
+                // Just extend the first range.
                 *first_start = point;
             } else {
                 self.map.insert(0, (point, point));

--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -219,6 +219,32 @@ impl<I: Idx> IntervalSet<I> {
         })
     }
 
+    pub fn disjoint(&self, other: &IntervalSet<I>) -> bool
+    where
+        I: Step,
+    {
+        let helper = move || {
+            let mut self_iter = self.iter_intervals();
+            let mut other_iter = other.iter_intervals();
+
+            let mut self_current = self_iter.next()?;
+            let mut other_current = other_iter.next()?;
+
+            loop {
+                if self_current.end <= other_current.start {
+                    self_current = self_iter.next()?;
+                    continue;
+                }
+                if other_current.end <= self_current.start {
+                    other_current = other_iter.next()?;
+                    continue;
+                }
+                return Some(false);
+            }
+        };
+        helper().unwrap_or(true)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }

--- a/compiler/rustc_mir_dataflow/src/impls/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/mod.rs
@@ -9,7 +9,8 @@ pub use self::initialized::{
     MaybeUninitializedPlaces, MaybeUninitializedPlacesDomain,
 };
 pub use self::liveness::{
-    MaybeLiveLocals, MaybeTransitiveLiveLocals, TransferFunction as LivenessTransferFunction,
+    DefUse, MaybeLiveLocals, MaybeTransitiveLiveLocals,
+    TransferFunction as LivenessTransferFunction,
 };
 pub use self::storage_liveness::{
     MaybeRequiresStorage, MaybeStorageDead, MaybeStorageLive, always_storage_live_locals,

--- a/compiler/rustc_mir_dataflow/src/points.rs
+++ b/compiler/rustc_mir_dataflow/src/points.rs
@@ -1,9 +1,5 @@
-use rustc_index::bit_set::DenseBitSet;
-use rustc_index::interval::SparseIntervalMatrix;
 use rustc_index::{Idx, IndexVec};
-use rustc_middle::mir::{self, BasicBlock, Body, Location};
-
-use crate::framework::{Analysis, Direction, Results, ResultsVisitor, visit_results};
+use rustc_middle::mir::{BasicBlock, Body, Location};
 
 /// Maps between a `Location` and a `PointIndex` (and vice versa).
 pub struct DenseLocationMap {
@@ -92,78 +88,4 @@ rustc_index::newtype_index! {
     #[orderable]
     #[debug_format = "PointIndex({})"]
     pub struct PointIndex {}
-}
-
-/// Add points depending on the result of the given dataflow analysis.
-pub fn save_as_intervals<'tcx, N, A>(
-    elements: &DenseLocationMap,
-    body: &mir::Body<'tcx>,
-    mut analysis: A,
-    results: Results<A::Domain>,
-) -> SparseIntervalMatrix<N, PointIndex>
-where
-    N: Idx,
-    A: Analysis<'tcx, Domain = DenseBitSet<N>>,
-{
-    let mut values = SparseIntervalMatrix::new(elements.num_points());
-    let reachable_blocks = mir::traversal::reachable_as_bitset(body);
-    if A::Direction::IS_BACKWARD {
-        // Iterate blocks in decreasing order, to visit locations in decreasing order. This
-        // allows to use the more efficient `prepend` method to interval sets.
-        let callback = |state: &DenseBitSet<N>, location| {
-            let point = elements.point_from_location(location);
-            // Use internal iterator manually as it is much more efficient.
-            state.iter().for_each(|node| values.prepend(node, point));
-        };
-        let mut visitor = Visitor { callback };
-        visit_results(
-            body,
-            // Note the `.rev()`.
-            body.basic_blocks.indices().filter(|&bb| reachable_blocks.contains(bb)).rev(),
-            &mut analysis,
-            &results,
-            &mut visitor,
-        );
-    } else {
-        // Iterate blocks in increasing order, to visit locations in increasing order. This
-        // allows to use the more efficient `append` method to interval sets.
-        let callback = |state: &DenseBitSet<N>, location| {
-            let point = elements.point_from_location(location);
-            // Use internal iterator manually as it is much more efficient.
-            state.iter().for_each(|node| values.append(node, point));
-        };
-        let mut visitor = Visitor { callback };
-        visit_results(body, reachable_blocks.iter(), &mut analysis, &results, &mut visitor);
-    }
-    values
-}
-
-struct Visitor<F> {
-    callback: F,
-}
-
-impl<'tcx, A, F> ResultsVisitor<'tcx, A> for Visitor<F>
-where
-    A: Analysis<'tcx>,
-    F: FnMut(&A::Domain, Location),
-{
-    fn visit_after_primary_statement_effect<'mir>(
-        &mut self,
-        _analysis: &mut A,
-        state: &A::Domain,
-        _statement: &'mir mir::Statement<'tcx>,
-        location: Location,
-    ) {
-        (self.callback)(state, location);
-    }
-
-    fn visit_after_primary_terminator_effect<'mir>(
-        &mut self,
-        _analysis: &mut A,
-        state: &A::Domain,
-        _terminator: &'mir mir::Terminator<'tcx>,
-        location: Location,
-    ) {
-        (self.callback)(state, location);
-    }
 }

--- a/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-abort.diff
@@ -9,15 +9,15 @@
       let mut _6: i32;
       scope 1 {
 -         debug x => _1;
-+         debug x => _6;
++         debug x => _4;
           let _2: i32;
           scope 2 {
 -             debug y => _2;
-+             debug y => _6;
++             debug y => _4;
               let _3: i32;
               scope 3 {
 -                 debug z => _3;
-+                 debug z => _6;
++                 debug z => _4;
               }
           }
       }
@@ -26,7 +26,7 @@
 -         StorageLive(_1);
 -         _1 = val() -> [return: bb1, unwind unreachable];
 +         nop;
-+         _6 = val() -> [return: bb1, unwind unreachable];
++         _4 = val() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
@@ -47,16 +47,14 @@
 +         nop;
 +         nop;
           StorageLive(_5);
--         StorageLive(_6);
+          StorageLive(_6);
 -         _6 = copy _1;
-+         nop;
-+         nop;
++         _6 = copy _4;
           _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind unreachable];
       }
   
       bb2: {
--         StorageDead(_6);
-+         nop;
+          StorageDead(_6);
           StorageDead(_5);
           _0 = const ();
 -         StorageDead(_3);

--- a/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-abort.diff
@@ -8,25 +8,23 @@
       let _5: ();
       let mut _6: i32;
       scope 1 {
--         debug x => _1;
-+         debug x => _4;
+          debug x => _1;
           let _2: i32;
           scope 2 {
 -             debug y => _2;
-+             debug y => _4;
++             debug y => _1;
               let _3: i32;
               scope 3 {
 -                 debug z => _3;
-+                 debug z => _4;
++                 debug z => _1;
               }
           }
       }
   
       bb0: {
 -         StorageLive(_1);
--         _1 = val() -> [return: bb1, unwind unreachable];
 +         nop;
-+         _4 = val() -> [return: bb1, unwind unreachable];
+          _1 = val() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
@@ -47,14 +45,17 @@
 +         nop;
 +         nop;
           StorageLive(_5);
-          StorageLive(_6);
+-         StorageLive(_6);
 -         _6 = copy _1;
-+         _6 = copy _4;
-          _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind unreachable];
+-         _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind unreachable];
++         nop;
++         nop;
++         _5 = std::mem::drop::<i32>(move _1) -> [return: bb2, unwind unreachable];
       }
   
       bb2: {
-          StorageDead(_6);
+-         StorageDead(_6);
++         nop;
           StorageDead(_5);
           _0 = const ();
 -         StorageDead(_3);

--- a/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
@@ -8,25 +8,23 @@
       let _5: ();
       let mut _6: i32;
       scope 1 {
--         debug x => _1;
-+         debug x => _4;
+          debug x => _1;
           let _2: i32;
           scope 2 {
 -             debug y => _2;
-+             debug y => _4;
++             debug y => _1;
               let _3: i32;
               scope 3 {
 -                 debug z => _3;
-+                 debug z => _4;
++                 debug z => _1;
               }
           }
       }
   
       bb0: {
 -         StorageLive(_1);
--         _1 = val() -> [return: bb1, unwind continue];
 +         nop;
-+         _4 = val() -> [return: bb1, unwind continue];
+          _1 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -47,14 +45,17 @@
 +         nop;
 +         nop;
           StorageLive(_5);
-          StorageLive(_6);
+-         StorageLive(_6);
 -         _6 = copy _1;
-+         _6 = copy _4;
-          _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind continue];
+-         _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind continue];
++         nop;
++         nop;
++         _5 = std::mem::drop::<i32>(move _1) -> [return: bb2, unwind continue];
       }
   
       bb2: {
-          StorageDead(_6);
+-         StorageDead(_6);
++         nop;
           StorageDead(_5);
           _0 = const ();
 -         StorageDead(_3);

--- a/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/cycle.main.DestinationPropagation.panic-unwind.diff
@@ -9,15 +9,15 @@
       let mut _6: i32;
       scope 1 {
 -         debug x => _1;
-+         debug x => _6;
++         debug x => _4;
           let _2: i32;
           scope 2 {
 -             debug y => _2;
-+             debug y => _6;
++             debug y => _4;
               let _3: i32;
               scope 3 {
 -                 debug z => _3;
-+                 debug z => _6;
++                 debug z => _4;
               }
           }
       }
@@ -26,7 +26,7 @@
 -         StorageLive(_1);
 -         _1 = val() -> [return: bb1, unwind continue];
 +         nop;
-+         _6 = val() -> [return: bb1, unwind continue];
++         _4 = val() -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -47,16 +47,14 @@
 +         nop;
 +         nop;
           StorageLive(_5);
--         StorageLive(_6);
+          StorageLive(_6);
 -         _6 = copy _1;
-+         nop;
-+         nop;
++         _6 = copy _4;
           _5 = std::mem::drop::<i32>(move _6) -> [return: bb2, unwind continue];
       }
   
       bb2: {
--         StorageDead(_6);
-+         nop;
+          StorageDead(_6);
           StorageDead(_5);
           _0 = const ();
 -         StorageDead(_3);

--- a/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-abort.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-abort.mir
@@ -7,16 +7,16 @@ fn f(_1: usize) -> usize {
     let mut _3: usize;
     let mut _4: usize;
     scope 1 {
-        debug b => _3;
+        debug b => _2;
     }
 
     bb0: {
         nop;
-        _3 = copy _1;
+        _2 = copy _1;
         _1 = const 5_usize;
         nop;
         nop;
-        _1 = move _3;
+        _1 = move _2;
         nop;
         nop;
         nop;

--- a/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-unwind.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_79191.f.DestinationPropagation.after.panic-unwind.mir
@@ -7,16 +7,16 @@ fn f(_1: usize) -> usize {
     let mut _3: usize;
     let mut _4: usize;
     scope 1 {
-        debug b => _3;
+        debug b => _2;
     }
 
     bb0: {
         nop;
-        _3 = copy _1;
+        _2 = copy _1;
         _1 = const 5_usize;
         nop;
         nop;
-        _1 = move _3;
+        _1 = move _2;
         nop;
         nop;
         nop;

--- a/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-abort.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-abort.mir
@@ -7,16 +7,16 @@ fn f(_1: usize) -> usize {
     let mut _3: usize;
     let mut _4: usize;
     scope 1 {
-        debug b => _3;
+        debug b => _2;
     }
 
     bb0: {
         nop;
-        _3 = copy _1;
+        _2 = copy _1;
         _1 = const 5_usize;
         nop;
         nop;
-        _1 = move _3;
+        _1 = move _2;
         nop;
         nop;
         nop;

--- a/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-unwind.mir
+++ b/tests/mir-opt/dest-prop/dead_stores_better.f.DestinationPropagation.after.panic-unwind.mir
@@ -7,16 +7,16 @@ fn f(_1: usize) -> usize {
     let mut _3: usize;
     let mut _4: usize;
     scope 1 {
-        debug b => _3;
+        debug b => _2;
     }
 
     bb0: {
         nop;
-        _3 = copy _1;
+        _2 = copy _1;
         _1 = const 5_usize;
         nop;
         nop;
-        _1 = move _3;
+        _1 = move _2;
         nop;
         nop;
         nop;

--- a/tests/mir-opt/nrvo_miscompile_111005.rs
+++ b/tests/mir-opt/nrvo_miscompile_111005.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // This is a miscompilation, #111005 to track
 
 //@ test-mir-pass: RenameReturnPlace
@@ -10,6 +9,11 @@ use core::intrinsics::mir::*;
 // EMIT_MIR nrvo_miscompile_111005.wrong.RenameReturnPlace.diff
 #[custom_mir(dialect = "runtime", phase = "initial")]
 pub fn wrong(arg: char) -> char {
+    // CHECK-LABEL: fn wrong(
+    // CHECK: _0 = copy _1;
+    // FIXME: This is wrong:
+    // CHECK-NEXT: _0 = const 'b';
+    // CHECK-NEXT: return;
     mir! {
         {
             let temp = arg;

--- a/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
@@ -6,8 +6,8 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
     scope 1 (inlined <Enum1 as Clone>::clone) {
         debug self => _1;
         let mut _2: isize;
-        let mut _3: &AllCopy;
-        let mut _4: &NestCopy;
+        let _3: &AllCopy;
+        let _4: &NestCopy;
         scope 2 {
             debug __self_0 => _3;
             scope 6 (inlined <AllCopy as Clone>::clone) {


### PR DESCRIPTION
This PR reimplements DestinationPropagation as a problem of merging live-ranges of locals. We merge locals that have disjoint live-ranges. This allows merging several locals in the same round by updating live range information.

Live ranges are mainly computed using the `MaybeLiveLocals` analysis. The subtlety is that we split each statement and terminator in 2 positions. The first position is the regular statement. The second position is a shadow, which is always more live. It encodes partial writes and dead writes as a local being live for half a statement. This half statement ensures that writes conflict with another local's writes and regular liveness.

r? @Amanieu 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
