### PR TITLE
Allow stability attributes on extern crates

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -54,6 +54,7 @@ const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
     Allow(Target::Static),
     Allow(Target::ForeignFn),
     Allow(Target::ForeignStatic),
+    Allow(Target::ExternCrate),
 ]);
 
 #[derive(Default)]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145497

r? @jdonszelmann 