### PR TITLE
ci: add timeout to windows disk cleanup wait

### DIFF
--- a/src/ci/scripts/free-disk-space-windows-wait.py
+++ b/src/ci/scripts/free-disk-space-windows-wait.py
@@ -61,12 +61,27 @@ def read_pid_from_file() -> int:
         ) from e
 
 
-def main() -> int:
-    pid = read_pid_from_file()
+def wait_for_process(pid: int):
+    timeout_duration_seconds = 5 * 60
+    interval_seconds = 3
+    max_attempts = timeout_duration_seconds / interval_seconds
+    attempts = 0
 
     # Poll until process exits
     while is_process_running(pid):
-        time.sleep(3)
+        if attempts >= max_attempts:
+            print(
+                "::warning::Timeout expired while waiting for the disk cleanup process to finish."
+            )
+            break
+        time.sleep(interval_seconds)
+        attempts += 1
+
+
+def main() -> int:
+    pid = read_pid_from_file()
+
+    wait_for_process(pid)
 
     print_logs()
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Add timeout to the disk clean space operation introduced in https://github.com/rust-lang/rust/pull/145311

As reported in https://github.com/rust-lang/rust/pull/145311#issuecomment-3195687090 the wait can be stuck.
<!-- homu-ignore:end -->