### PR TITLE
Remove the `From` derive macro from prelude

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -226,6 +226,13 @@ pub mod assert_matches {
     pub use crate::macros::{assert_matches, debug_assert_matches};
 }
 
+#[unstable(feature = "derive_from", issue = "144889")]
+/// Unstable module containing the unstable `From` derive macro.
+pub mod from {
+    #[unstable(feature = "derive_from", issue = "144889")]
+    pub use crate::macros::builtin::From;
+}
+
 // We don't export this through #[macro_export] for now, to avoid breakage.
 #[unstable(feature = "autodiff", issue = "124509")]
 /// Unstable module containing the unstable `autodiff` macro.

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -117,10 +117,3 @@ pub use crate::macros::builtin::deref;
     reason = "`type_alias_impl_trait` has open design concerns"
 )]
 pub use crate::macros::builtin::define_opaque;
-
-#[unstable(
-    feature = "derive_from",
-    issue = "144889",
-    reason = "`derive(From)` is unstable"
-)]
-pub use crate::macros::builtin::From;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -737,6 +737,14 @@ pub use core::{
     unreachable, write, writeln,
 };
 
+// Re-export unstable derive macro defined through core.
+#[unstable(feature = "derive_from", issue = "144889")]
+/// Unstable module containing the unstable `From` derive macro.
+pub mod from {
+    #[unstable(feature = "derive_from", issue = "144889")]
+    pub use core::from::From;
+}
+
 // Include a number of private modules that exist solely to provide
 // the rustdoc documentation for primitive types. Using `include!`
 // because rustdoc only looks for these modules at the crate level.

--- a/tests/ui/deriving/deriving-all-codegen.rs
+++ b/tests/ui/deriving/deriving-all-codegen.rs
@@ -18,6 +18,8 @@
 #![allow(deprecated)]
 #![feature(derive_from)]
 
+use std::from::From;
+
 // Empty struct.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct Empty;
@@ -51,7 +53,14 @@ struct SingleField {
 // `clone` implemention that just does `*self`.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct Big {
-    b1: u32, b2: u32, b3: u32, b4: u32, b5: u32, b6: u32, b7: u32, b8: u32,
+    b1: u32,
+    b2: u32,
+    b3: u32,
+    b4: u32,
+    b5: u32,
+    b6: u32,
+    b7: u32,
+    b8: u32,
 }
 
 // It is more efficient to compare scalar types before non-scalar types.
@@ -126,7 +135,7 @@ enum Enum0 {}
 // A single-variant enum.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 enum Enum1 {
-    Single { x: u32 }
+    Single { x: u32 },
 }
 
 // A C-like, fieldless enum with a single variant.
@@ -152,7 +161,10 @@ enum Mixed {
     P,
     Q,
     R(u32),
-    S { d1: Option<u32>, d2: Option<i32> },
+    S {
+        d1: Option<u32>,
+        d2: Option<i32>,
+    },
 }
 
 // When comparing enum variant it is more efficient to compare scalar types before non-scalar types.

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -23,6 +23,8 @@ extern crate std;
 #[prelude_import]
 use std::prelude::rust_2021::*;
 
+use std::from::From;
+
 // Empty struct.
 struct Empty;
 #[automatically_derived]

--- a/tests/ui/deriving/deriving-from-wrong-target.rs
+++ b/tests/ui/deriving/deriving-from-wrong-target.rs
@@ -1,8 +1,9 @@
-//@ edition: 2021
 //@ check-fail
 
 #![feature(derive_from)]
 #![allow(dead_code)]
+
+use std::from::From;
 
 #[derive(From)]
 //~^ ERROR `#[derive(From)]` used on a struct with no fields

--- a/tests/ui/deriving/deriving-from-wrong-target.stderr
+++ b/tests/ui/deriving/deriving-from-wrong-target.stderr
@@ -1,5 +1,5 @@
 error: `#[derive(From)]` used on a struct with no fields
-  --> $DIR/deriving-from-wrong-target.rs:7:10
+  --> $DIR/deriving-from-wrong-target.rs:8:10
    |
 LL | #[derive(From)]
    |          ^^^^
@@ -10,7 +10,7 @@ LL | struct S1;
    = note: `#[derive(From)]` can only be used on structs with exactly one field
 
 error: `#[derive(From)]` used on a struct with no fields
-  --> $DIR/deriving-from-wrong-target.rs:11:10
+  --> $DIR/deriving-from-wrong-target.rs:12:10
    |
 LL | #[derive(From)]
    |          ^^^^
@@ -21,7 +21,7 @@ LL | struct S2 {}
    = note: `#[derive(From)]` can only be used on structs with exactly one field
 
 error: `#[derive(From)]` used on a struct with multiple fields
-  --> $DIR/deriving-from-wrong-target.rs:15:10
+  --> $DIR/deriving-from-wrong-target.rs:16:10
    |
 LL | #[derive(From)]
    |          ^^^^
@@ -32,7 +32,7 @@ LL | struct S3(u32, bool);
    = note: `#[derive(From)]` can only be used on structs with exactly one field
 
 error: `#[derive(From)]` used on a struct with multiple fields
-  --> $DIR/deriving-from-wrong-target.rs:19:10
+  --> $DIR/deriving-from-wrong-target.rs:20:10
    |
 LL | #[derive(From)]
    |          ^^^^
@@ -43,7 +43,7 @@ LL | struct S4 {
    = note: `#[derive(From)]` can only be used on structs with exactly one field
 
 error: `#[derive(From)]` used on an enum
-  --> $DIR/deriving-from-wrong-target.rs:26:10
+  --> $DIR/deriving-from-wrong-target.rs:27:10
    |
 LL | #[derive(From)]
    |          ^^^^
@@ -54,7 +54,7 @@ LL | enum E1 {}
    = note: `#[derive(From)]` can only be used on structs with exactly one field
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/deriving-from-wrong-target.rs:30:10
+  --> $DIR/deriving-from-wrong-target.rs:31:10
    |
 LL | #[derive(From)]
    |          ^^^^ doesn't have a size known at compile-time
@@ -71,7 +71,7 @@ LL + struct SUnsizedField<T> {
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/deriving-from-wrong-target.rs:30:10
+  --> $DIR/deriving-from-wrong-target.rs:31:10
    |
 LL | #[derive(From)]
    |          ^^^^ doesn't have a size known at compile-time
@@ -80,7 +80,7 @@ LL | struct SUnsizedField<T: ?Sized> {
    |                      - this type parameter needs to be `Sized`
    |
 note: required because it appears within the type `SUnsizedField<T>`
-  --> $DIR/deriving-from-wrong-target.rs:33:8
+  --> $DIR/deriving-from-wrong-target.rs:34:8
    |
 LL | struct SUnsizedField<T: ?Sized> {
    |        ^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL + struct SUnsizedField<T> {
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/deriving-from-wrong-target.rs:34:11
+  --> $DIR/deriving-from-wrong-target.rs:35:11
    |
 LL | struct SUnsizedField<T: ?Sized> {
    |                      - this type parameter needs to be `Sized`

--- a/tests/ui/deriving/deriving-from.rs
+++ b/tests/ui/deriving/deriving-from.rs
@@ -3,6 +3,8 @@
 
 #![feature(derive_from)]
 
+use core::from::From;
+
 #[derive(From)]
 struct TupleSimple(u32);
 

--- a/tests/ui/feature-gates/feature-gate-derive-from.rs
+++ b/tests/ui/feature-gates/feature-gate-derive-from.rs
@@ -1,4 +1,4 @@
-//@ edition: 2021
+use std::from::From; //~ ERROR use of unstable library feature `derive_from
 
 #[derive(From)] //~ ERROR use of unstable library feature `derive_from`
 struct Foo(u32);

--- a/tests/ui/feature-gates/feature-gate-derive-from.stderr
+++ b/tests/ui/feature-gates/feature-gate-derive-from.stderr
@@ -8,6 +8,16 @@ LL | #[derive(From)]
    = help: add `#![feature(derive_from)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: use of unstable library feature `derive_from`
+  --> $DIR/feature-gate-derive-from.rs:1:5
+   |
+LL | use std::from::From;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #144889 <https://github.com/rust-lang/rust/issues/144889> for more information
+   = help: add `#![feature(derive_from)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
The new `#[derive(From)]` functionality (implemented in https://github.com/rust-lang/rust/pull/144922) caused name resolution ambiguity issues (https://github.com/rust-lang/rust/issues/145524). The reproducer looks e.g. like this:

```rust
mod foo {
    pub use derive_more::From;
}

use foo::*;

#[derive(From)] // ERROR: `From` is ambiguous
struct S(u32);
```

It's pretty unfortunate that it works like this, but I guess that there's not much to be done here, and we'll have to wait for the next edition to put the `From` macro into the prelude. That will probably require https://github.com/rust-lang/rust/pull/139493 to land.

I created a new module in core (and re-exported it in std) called `from`, where I re-exported the `From` macro. I *think* that since this is a new module, it should not have the same backwards incompatibility issue.

Happy to hear suggestions about the naming - maybe it would make sense as `core::macros::from::From`? But we already had a precedent in the `core::assert_matches` module, so I just followed suit.

Fixes: https://github.com/rust-lang/rust/issues/145524

r? @petrochenkov