### PR TITLE
ignore frontmatters in `TokenStream::new`

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -49,6 +49,7 @@ pub(crate) fn lex_token_trees<'psess, 'src>(
     mut src: &'src str,
     mut start_pos: BytePos,
     override_span: Option<Span>,
+    frontmatter_allowed: FrontmatterAllowed,
 ) -> Result<TokenStream, Vec<Diag<'psess>>> {
     // Skip `#!`, if present.
     if let Some(shebang_len) = rustc_lexer::strip_shebang(src) {
@@ -56,7 +57,7 @@ pub(crate) fn lex_token_trees<'psess, 'src>(
         start_pos = start_pos + BytePos::from_usize(shebang_len);
     }
 
-    let cursor = Cursor::new(src, FrontmatterAllowed::Yes);
+    let cursor = Cursor::new(src, frontmatter_allowed);
     let mut lexer = Lexer {
         psess,
         start_pos,

--- a/tests/ui/frontmatter/auxiliary/makro.rs
+++ b/tests/ui/frontmatter/auxiliary/makro.rs
@@ -3,6 +3,6 @@ use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn check(_: TokenStream) -> TokenStream {
-    assert!("---\n---".parse::<TokenStream>().unwrap().is_empty());
+    assert_eq!(6, "---\n---".parse::<TokenStream>().unwrap().into_iter().count());
     Default::default()
 }

--- a/tests/ui/frontmatter/proc-macro-observer.rs
+++ b/tests/ui/frontmatter/proc-macro-observer.rs
@@ -2,11 +2,10 @@
 //@ proc-macro: makro.rs
 //@ edition: 2021
 
-#![feature(frontmatter)]
-
 makro::check!();
 
-// checks that a proc-macro cannot observe frontmatter tokens.
+// checks that a proc-macro doesn't know or parse frontmatters at all and instead treats
+// it as normal Rust code.
 // see auxiliary/makro.rs for how it is tested.
 
 fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#145520 for now, we'd likely want to figure the stripping part later, so I noted it down on the list on the tracking issue.

cc @fmease 