### PR TITLE
Add -Awarnings on tests for ignoring warning from xcrun

### DIFF
--- a/tests/ui/symbol-names/verbose.rs
+++ b/tests/ui/symbol-names/verbose.rs
@@ -2,9 +2,10 @@
 // affected produced symbols making it impossible to link between crates
 // with a different value of the flag (for symbols involving generic
 // arguments equal to defaults of their respective parameters).
+// Add -Awarnings to ignore unexpected warnings on StdErr, especially from external tools.
 //
 //@ build-pass
-//@ compile-flags: -Zverbose-internals
+//@ compile-flags: -Zverbose-internals -Awarnings
 
 pub fn error(msg: String) -> Box<dyn std::error::Error> {
   msg.into()

--- a/tests/ui/type/issue-94187-verbose-type-name.rs
+++ b/tests/ui/type/issue-94187-verbose-type-name.rs
@@ -1,8 +1,9 @@
 // Ensure the output of `std::any::type_name` does not change based on `-Zverbose-internals`
+// Add -Awarnings to ignore unexpected warnings on StdErr, especially from external tools.
 //@ run-pass
 //@ edition: 2018
 //@ revisions: normal verbose
-//@ [verbose]compile-flags:-Zverbose-internals --verbose
+//@ [verbose]compile-flags:-Zverbose-internals --verbose -Awarnings
 
 use std::any::type_name;
 


### PR DESCRIPTION
## Context
close rust-lang/rust#145543 
Those two tests fail on MacOS because xcrun puts a warning on StdErr.
The warning is only shown when we put -Zverbose-internals flag to the compiler.

## Change
I added -Awarnings to those two tests to ignore the warning, because
1. verbose output from 3rd party tools like xcrun are sometimes useful for debugging
2. the warning doesn't ask us to take any actions (it looks just info-level log, I'm not sure why xcrun decided to output the message as warning), so we can safely ignore it I think
