### PR TITLE
UnsafePinned::raw_get: sync signature with get

### DIFF
--- a/library/core/src/pin/unsafe_pinned.rs
+++ b/library/core/src/pin/unsafe_pinned.rs
@@ -120,8 +120,8 @@ impl<T: ?Sized> UnsafePinned<T> {
     #[inline(always)]
     #[must_use]
     #[unstable(feature = "unsafe_pinned", issue = "125735")]
-    pub const fn raw_get(this: *const Self) -> *const T {
-        this as *const T
+    pub const fn raw_get(this: *const Self) -> *mut T {
+        this as *const T as *mut T
     }
 
     /// Gets a mutable pointer to the wrapped value.


### PR DESCRIPTION
This was forgotten in https://github.com/rust-lang/rust/pull/142162.

Tracking issue: https://github.com/rust-lang/rust/issues/125735.