### PR TITLE
Forbid `static async` closures

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -223,6 +223,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         binder,
                         *capture_clause,
                         e.id,
+                        *movability,
                         expr_hir_id,
                         *coroutine_kind,
                         fn_decl,
@@ -1152,6 +1153,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         binder: &ClosureBinder,
         capture_clause: CaptureBy,
         closure_id: NodeId,
+        movability: Movability,
         closure_hir_id: HirId,
         coroutine_kind: CoroutineKind,
         decl: &FnDecl,
@@ -1159,6 +1161,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         fn_decl_span: Span,
         fn_arg_span: Span,
     ) -> hir::ExprKind<'hir> {
+        if movability == Movability::Static {
+            self.dcx().emit_err(ClosureCannotBeStatic { fn_decl_span });
+        }
         let closure_def_id = self.local_def_id(closure_id);
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);
 

--- a/tests/ui/unpretty/exhaustive.hir.stderr
+++ b/tests/ui/unpretty/exhaustive.hir.stderr
@@ -10,6 +10,18 @@ error[E0697]: closures cannot be static
 LL |         static move || value;
    |         ^^^^^^^^^^^^^^
 
+error[E0697]: closures cannot be static
+  --> $DIR/exhaustive.rs:211:10
+   |
+LL |         (static async || value);
+   |          ^^^^^^^^^^^^^^^
+
+error[E0697]: closures cannot be static
+  --> $DIR/exhaustive.rs:212:10
+   |
+LL |         (static async move || value);
+   |          ^^^^^^^^^^^^^^^^^^^^
+
 error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/exhaustive.rs:239:13
    |
@@ -166,7 +178,7 @@ LL |         let _: impl for<'a> Send;
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 20 previous errors
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0214, E0562, E0697, E0703, E0728.
 For more information about an error, try `rustc --explain E0214`.

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -215,8 +215,16 @@ mod expressions {
         move || |mut _task_context: ResumeTy| { { let _t = value; _t } };
         || value;
         move || value;
-        || |mut _task_context: ResumeTy| { { let _t = value; _t } };
-        move || |mut _task_context: ResumeTy| { { let _t = value; _t } };
+        ||
+            |mut _task_context: ResumeTy|
+                {
+                    { let _t = value; _t }
+                };
+        move ||
+            |mut _task_context: ResumeTy|
+                {
+                    { let _t = value; _t }
+                };
         || -> u8 { value };
         1 + (|| { });
     }

--- a/tests/ui/unpretty/exhaustive.rs
+++ b/tests/ui/unpretty/exhaustive.rs
@@ -206,10 +206,10 @@ mod expressions {
         move || value;
         async || value;
         async move || value;
-        static || value;            //[hir]~ ERROR closures cannot be static
-        static move || value;       //[hir]~ ERROR closures cannot be static
-        (static async || value);
-        (static async move || value);
+        static || value;              //[hir]~ ERROR closures cannot be static
+        static move || value;         //[hir]~ ERROR closures cannot be static
+        (static async || value);      //[hir]~ ERROR closures cannot be static
+        (static async move || value); //[hir]~ ERROR closures cannot be static
         || -> u8 { value };
         1 + || {};
     }


### PR DESCRIPTION
Discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/static.20async.20closures/near/535117206).

This is technically a breaking change, but @compiler-errors says it's a bug that was never meant to be stable.

The only instance of `static async` in Rust code that I've found on GitHub that wasn't a javascript snippet in JS analyzers/generators is a rust-analyzer test.