### PR TITLE
Prevent downstream `impl DerefMut for Pin<LocalType>`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -309,6 +309,7 @@ symbols! {
         PathBuf,
         Pending,
         PinCoerceUnsized,
+        PinDerefMutHelper,
         Pointer,
         Poll,
         ProcMacro,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3476,6 +3476,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // can do about it. As far as they are concerned, `?` is compiler magic.
                     return;
                 }
+                if tcx.is_diagnostic_item(sym::PinDerefMutHelper, parent_def_id) {
+                    let parent_predicate =
+                        self.resolve_vars_if_possible(data.derived.parent_trait_pred);
+
+                    // Skip PinDerefMutHelper in suggestions, but still show downstream suggestions.
+                    ensure_sufficient_stack(|| {
+                        self.note_obligation_cause_code(
+                            body_id,
+                            err,
+                            parent_predicate,
+                            param_env,
+                            &data.derived.parent_code,
+                            obligated_types,
+                            seen_requirements,
+                        )
+                    });
+                    return;
+                }
                 let self_ty_str =
                     tcx.short_string(parent_trait_pred.skip_binder().self_ty(), err.long_ty_path());
                 let trait_name = tcx.short_string(

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1755,13 +1755,21 @@ where
     }
 }
 
+/// The `Target` type is restricted to `Unpin` types as it's not safe to obtain a mutable reference
+/// to a pinned value.
+///
+/// For soundness reasons, implementations of `DerefMut` for `Pin<T>` are rejected even when `T` is
+/// a local type not covered by this impl block. (Since `Pin` is [fundamental], such implementations
+/// would normally be possible.)
+///
+/// [fundamental]: ../../reference/items/implementations.html#r-items.impl.trait.fundamental
 #[stable(feature = "pin", since = "1.33.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 #[cfg(doc)]
 impl<Ptr> const DerefMut for Pin<Ptr>
 where
     Ptr: [const] DerefMut,
-    Ptr::Target: Unpin,
+    <Ptr as Deref>::Target: Unpin,
 {
     fn deref_mut(&mut self) -> &mut Ptr::Target {
         Pin::get_mut(Pin::as_mut(self))

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -63,9 +63,9 @@
 +                             let mut _44: &mut std::future::Ready<()>;
 +                             let mut _45: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 let mut _46: *mut std::pin::helper::Pin<&mut std::future::Ready<()>>;
++                                 let mut _46: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
 +                                 let mut _47: *mut std::pin::Pin<&mut std::future::Ready<()>>;
-+                                 scope 15 (inlined <pin::helper::Pin<&mut std::future::Ready<()>> as pin::helper::DerefMut>::deref_mut) {
++                                 scope 15 (inlined <pin::helper::PinHelper<&mut std::future::Ready<()>> as pin::helper::PinDerefMutHelper>::deref_mut) {
 +                                     let mut _48: &mut &mut std::future::Ready<()>;
 +                                     scope 16 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
@@ -221,7 +221,7 @@
 +         StorageLive(_42);
 +         StorageLive(_47);
 +         _47 = &raw mut _19;
-+         _46 = copy _47 as *mut std::pin::helper::Pin<&mut std::future::Ready<()>> (PtrToPtr);
++         _46 = copy _47 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_47);
 +         _44 = copy ((*_46).0: &mut std::future::Ready<()>);
 +         StorageLive(_49);

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -63,27 +63,25 @@
 +                             let mut _44: &mut std::future::Ready<()>;
 +                             let mut _45: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 scope 15 (inlined Pin::<&mut std::future::Ready<()>>::as_mut) {
-+                                     let mut _46: &mut &mut std::future::Ready<()>;
-+                                     scope 16 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
-+                                     }
-+                                     scope 18 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
-+                                     }
-+                                 }
-+                                 scope 17 (inlined Pin::<&mut std::future::Ready<()>>::get_mut) {
-+                                 }
-+                             }
-+                             scope 19 (inlined Option::<()>::take) {
-+                                 let mut _47: std::option::Option<()>;
-+                                 scope 20 (inlined std::mem::replace::<Option<()>>) {
-+                                     scope 21 {
++                                 let mut _46: *mut std::pin::helper::Pin<&mut std::future::Ready<()>>;
++                                 let mut _47: *mut std::pin::Pin<&mut std::future::Ready<()>>;
++                                 scope 15 (inlined <pin::helper::Pin<&mut std::future::Ready<()>> as pin::helper::DerefMut>::deref_mut) {
++                                     let mut _48: &mut &mut std::future::Ready<()>;
++                                     scope 16 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
 +                                 }
 +                             }
-+                             scope 22 (inlined #[track_caller] Option::<()>::expect) {
-+                                 let mut _48: isize;
-+                                 let mut _49: !;
-+                                 scope 23 {
++                             scope 17 (inlined Option::<()>::take) {
++                                 let mut _49: std::option::Option<()>;
++                                 scope 18 (inlined std::mem::replace::<Option<()>>) {
++                                     scope 19 {
++                                     }
++                                 }
++                             }
++                             scope 20 (inlined #[track_caller] Option::<()>::expect) {
++                                 let mut _50: isize;
++                                 let mut _51: !;
++                                 scope 21 {
 +                                 }
 +                             }
 +                         }
@@ -217,18 +215,23 @@
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
 +         StorageLive(_44);
-+         StorageLive(_49);
++         StorageLive(_46);
++         StorageLive(_51);
 +         StorageLive(_41);
 +         StorageLive(_42);
-+         _44 = copy (_19.0: &mut std::future::Ready<()>);
 +         StorageLive(_47);
-+         _47 = Option::<()>::None;
-+         _42 = copy ((*_44).0: std::option::Option<()>);
-+         ((*_44).0: std::option::Option<()>) = copy _47;
++         _47 = &raw mut _19;
++         _46 = copy _47 as *mut std::pin::helper::Pin<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_47);
-+         StorageLive(_48);
-+         _48 = discriminant(_42);
-+         switchInt(move _48) -> [0: bb11, 1: bb12, otherwise: bb5];
++         _44 = copy ((*_46).0: &mut std::future::Ready<()>);
++         StorageLive(_49);
++         _49 = Option::<()>::None;
++         _42 = copy ((*_44).0: std::option::Option<()>);
++         ((*_44).0: std::option::Option<()>) = copy _49;
++         StorageDead(_49);
++         StorageLive(_50);
++         _50 = discriminant(_42);
++         switchInt(move _50) -> [0: bb11, 1: bb12, otherwise: bb5];
       }
 + 
 +     bb5: {
@@ -291,16 +294,17 @@
 +     }
 + 
 +     bb11: {
-+         _49 = option::expect_failed(const "`Ready` polled after completion") -> unwind unreachable;
++         _51 = option::expect_failed(const "`Ready` polled after completion") -> unwind unreachable;
 +     }
 + 
 +     bb12: {
 +         _41 = move ((_42 as Some).0: ());
-+         StorageDead(_48);
++         StorageDead(_50);
 +         StorageDead(_42);
 +         _18 = Poll::<()>::Ready(move _41);
 +         StorageDead(_41);
-+         StorageDead(_49);
++         StorageDead(_51);
++         StorageDead(_46);
 +         StorageDead(_44);
 +         StorageDead(_22);
 +         StorageDead(_19);

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -65,27 +65,25 @@
 +                             let mut _46: &mut std::future::Ready<()>;
 +                             let mut _47: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 scope 15 (inlined Pin::<&mut std::future::Ready<()>>::as_mut) {
-+                                     let mut _48: &mut &mut std::future::Ready<()>;
-+                                     scope 16 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
-+                                     }
-+                                     scope 18 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
-+                                     }
-+                                 }
-+                                 scope 17 (inlined Pin::<&mut std::future::Ready<()>>::get_mut) {
-+                                 }
-+                             }
-+                             scope 19 (inlined Option::<()>::take) {
-+                                 let mut _49: std::option::Option<()>;
-+                                 scope 20 (inlined std::mem::replace::<Option<()>>) {
-+                                     scope 21 {
++                                 let mut _48: *mut std::pin::helper::Pin<&mut std::future::Ready<()>>;
++                                 let mut _49: *mut std::pin::Pin<&mut std::future::Ready<()>>;
++                                 scope 15 (inlined <pin::helper::Pin<&mut std::future::Ready<()>> as pin::helper::DerefMut>::deref_mut) {
++                                     let mut _50: &mut &mut std::future::Ready<()>;
++                                     scope 16 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
 +                                 }
 +                             }
-+                             scope 22 (inlined #[track_caller] Option::<()>::expect) {
-+                                 let mut _50: isize;
-+                                 let mut _51: !;
-+                                 scope 23 {
++                             scope 17 (inlined Option::<()>::take) {
++                                 let mut _51: std::option::Option<()>;
++                                 scope 18 (inlined std::mem::replace::<Option<()>>) {
++                                     scope 19 {
++                                     }
++                                 }
++                             }
++                             scope 20 (inlined #[track_caller] Option::<()>::expect) {
++                                 let mut _52: isize;
++                                 let mut _53: !;
++                                 scope 21 {
 +                                 }
 +                             }
 +                         }
@@ -234,18 +232,23 @@
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
 +         StorageLive(_46);
-+         StorageLive(_51);
++         StorageLive(_48);
++         StorageLive(_53);
 +         StorageLive(_43);
 +         StorageLive(_44);
-+         _46 = copy (_19.0: &mut std::future::Ready<()>);
 +         StorageLive(_49);
-+         _49 = Option::<()>::None;
-+         _44 = copy ((*_46).0: std::option::Option<()>);
-+         ((*_46).0: std::option::Option<()>) = copy _49;
++         _49 = &raw mut _19;
++         _48 = copy _49 as *mut std::pin::helper::Pin<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_49);
-+         StorageLive(_50);
-+         _50 = discriminant(_44);
-+         switchInt(move _50) -> [0: bb16, 1: bb17, otherwise: bb7];
++         _46 = copy ((*_48).0: &mut std::future::Ready<()>);
++         StorageLive(_51);
++         _51 = Option::<()>::None;
++         _44 = copy ((*_46).0: std::option::Option<()>);
++         ((*_46).0: std::option::Option<()>) = copy _51;
++         StorageDead(_51);
++         StorageLive(_52);
++         _52 = discriminant(_44);
++         switchInt(move _52) -> [0: bb16, 1: bb17, otherwise: bb7];
       }
   
 -     bb6 (cleanup): {
@@ -332,16 +335,17 @@
 +     }
 + 
 +     bb16: {
-+         _51 = option::expect_failed(const "`Ready` polled after completion") -> bb11;
++         _53 = option::expect_failed(const "`Ready` polled after completion") -> bb11;
 +     }
 + 
 +     bb17: {
 +         _43 = move ((_44 as Some).0: ());
-+         StorageDead(_50);
++         StorageDead(_52);
 +         StorageDead(_44);
 +         _18 = Poll::<()>::Ready(move _43);
 +         StorageDead(_43);
-+         StorageDead(_51);
++         StorageDead(_53);
++         StorageDead(_48);
 +         StorageDead(_46);
 +         StorageDead(_22);
 +         StorageDead(_19);

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -65,9 +65,9 @@
 +                             let mut _46: &mut std::future::Ready<()>;
 +                             let mut _47: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 let mut _48: *mut std::pin::helper::Pin<&mut std::future::Ready<()>>;
++                                 let mut _48: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
 +                                 let mut _49: *mut std::pin::Pin<&mut std::future::Ready<()>>;
-+                                 scope 15 (inlined <pin::helper::Pin<&mut std::future::Ready<()>> as pin::helper::DerefMut>::deref_mut) {
++                                 scope 15 (inlined <pin::helper::PinHelper<&mut std::future::Ready<()>> as pin::helper::PinDerefMutHelper>::deref_mut) {
 +                                     let mut _50: &mut &mut std::future::Ready<()>;
 +                                     scope 16 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
@@ -238,7 +238,7 @@
 +         StorageLive(_44);
 +         StorageLive(_49);
 +         _49 = &raw mut _19;
-+         _48 = copy _49 as *mut std::pin::helper::Pin<&mut std::future::Ready<()>> (PtrToPtr);
++         _48 = copy _49 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_49);
 +         _46 = copy ((*_48).0: &mut std::future::Ready<()>);
 +         StorageLive(_51);

--- a/tests/ui/deref/pin-impl-deref.rs
+++ b/tests/ui/deref/pin-impl-deref.rs
@@ -22,7 +22,7 @@ impl MyPinType {
 fn impl_deref_mut(_: impl DerefMut) {}
 fn unpin_impl_ref(r_unpin: Pin<&MyUnpinType>) {
     impl_deref_mut(r_unpin)
-    //~^ ERROR: the trait bound `Pin<&MyUnpinType>: DerefMut` is not satisfied
+    //~^ ERROR: the trait bound `&MyUnpinType: DerefMut` is not satisfied
 }
 fn unpin_impl_mut(r_unpin: Pin<&mut MyUnpinType>) {
     impl_deref_mut(r_unpin)
@@ -30,7 +30,7 @@ fn unpin_impl_mut(r_unpin: Pin<&mut MyUnpinType>) {
 fn pin_impl_ref(r_pin: Pin<&MyPinType>) {
     impl_deref_mut(r_pin)
     //~^ ERROR: `PhantomPinned` cannot be unpinned
-    //~| ERROR: the trait bound `Pin<&MyPinType>: DerefMut` is not satisfied
+    //~| ERROR: the trait bound `&MyPinType: DerefMut` is not satisfied
 }
 fn pin_impl_mut(r_pin: Pin<&mut MyPinType>) {
     impl_deref_mut(r_pin)

--- a/tests/ui/deref/pin-impl-deref.stderr
+++ b/tests/ui/deref/pin-impl-deref.stderr
@@ -1,40 +1,36 @@
-error[E0277]: the trait bound `Pin<&MyUnpinType>: DerefMut` is not satisfied
+error[E0277]: the trait bound `&MyUnpinType: DerefMut` is not satisfied
   --> $DIR/pin-impl-deref.rs:24:20
    |
 LL |     impl_deref_mut(r_unpin)
-   |     -------------- ^^^^^^^ the trait `DerefMut` is not implemented for `Pin<&MyUnpinType>`
+   |     -------------- ^^^^^^^ the trait `DerefMut` is not implemented for `&MyUnpinType`
    |     |
    |     required by a bound introduced by this call
    |
+   = note: `DerefMut` is implemented for `&mut MyUnpinType`, but not for `&MyUnpinType`
+   = note: required for `pin::helper::Pin<&MyUnpinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyUnpinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
    |
 LL | fn impl_deref_mut(_: impl DerefMut) {}
    |                           ^^^^^^^^ required by this bound in `impl_deref_mut`
-help: consider mutably borrowing here
-   |
-LL |     impl_deref_mut(&mut r_unpin)
-   |                    ++++
 
-error[E0277]: the trait bound `Pin<&MyPinType>: DerefMut` is not satisfied
+error[E0277]: the trait bound `&MyPinType: DerefMut` is not satisfied
   --> $DIR/pin-impl-deref.rs:31:20
    |
 LL |     impl_deref_mut(r_pin)
-   |     -------------- ^^^^^ the trait `DerefMut` is not implemented for `Pin<&MyPinType>`
+   |     -------------- ^^^^^ the trait `DerefMut` is not implemented for `&MyPinType`
    |     |
    |     required by a bound introduced by this call
    |
+   = note: `DerefMut` is implemented for `&mut MyPinType`, but not for `&MyPinType`
+   = note: required for `pin::helper::Pin<&MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
    |
 LL | fn impl_deref_mut(_: impl DerefMut) {}
    |                           ^^^^^^^^ required by this bound in `impl_deref_mut`
-help: consider mutably borrowing here
-   |
-LL |     impl_deref_mut(&mut r_pin)
-   |                    ++++
 
 error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/pin-impl-deref.rs:31:20
@@ -51,6 +47,7 @@ note: required because it appears within the type `MyPinType`
    |
 LL | struct MyPinType(core::marker::PhantomPinned);
    |        ^^^^^^^^^
+   = note: required for `pin::helper::Pin<&MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
@@ -73,6 +70,7 @@ note: required because it appears within the type `MyPinType`
    |
 LL | struct MyPinType(core::marker::PhantomPinned);
    |        ^^^^^^^^^
+   = note: required for `pin::helper::Pin<&mut MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&mut MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27

--- a/tests/ui/deref/pin-impl-deref.stderr
+++ b/tests/ui/deref/pin-impl-deref.stderr
@@ -7,7 +7,6 @@ LL |     impl_deref_mut(r_unpin)
    |     required by a bound introduced by this call
    |
    = note: `DerefMut` is implemented for `&mut MyUnpinType`, but not for `&MyUnpinType`
-   = note: required for `pin::helper::Pin<&MyUnpinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyUnpinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
@@ -24,7 +23,6 @@ LL |     impl_deref_mut(r_pin)
    |     required by a bound introduced by this call
    |
    = note: `DerefMut` is implemented for `&mut MyPinType`, but not for `&MyPinType`
-   = note: required for `pin::helper::Pin<&MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
@@ -47,7 +45,6 @@ note: required because it appears within the type `MyPinType`
    |
 LL | struct MyPinType(core::marker::PhantomPinned);
    |        ^^^^^^^^^
-   = note: required for `pin::helper::Pin<&MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27
@@ -70,7 +67,6 @@ note: required because it appears within the type `MyPinType`
    |
 LL | struct MyPinType(core::marker::PhantomPinned);
    |        ^^^^^^^^^
-   = note: required for `pin::helper::Pin<&mut MyPinType>` to implement `pin::helper::DerefMut`
    = note: required for `Pin<&mut MyPinType>` to implement `DerefMut`
 note: required by a bound in `impl_deref_mut`
   --> $DIR/pin-impl-deref.rs:22:27

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.rs
@@ -1,5 +1,4 @@
-//@ check-pass
-//@ known-bug: #85099
+//@ check-fail
 
 // Should fail. Can coerce `Pin<T>` into `Pin<U>` where
 // `T: Deref<Target: Unpin>` and `U: Deref<Target: !Unpin>`, using the
@@ -43,6 +42,7 @@ impl<'a, Fut: Future<Output = ()>> SomeTrait<'a, Fut> for Fut {
 }
 
 impl<'b, 'a, Fut> DerefMut for Pin<&'b dyn SomeTrait<'a, Fut>> {
+//~^ ERROR: conflicting implementations of trait `DerefMut`
     fn deref_mut<'c>(
         self: &'c mut Pin<&'b dyn SomeTrait<'a, Fut>>,
     ) -> &'c mut (dyn SomeTrait<'a, Fut> + 'b) {

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `DerefMut` for type `Pin<&dyn SomeTrait<'_, _>>`
+  --> $DIR/pin-unsound-issue-85099-derefmut.rs:44:1
+   |
+LL | impl<'b, 'a, Fut> DerefMut for Pin<&'b dyn SomeTrait<'a, Fut>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<Ptr> DerefMut for Pin<Ptr>
+             where <pin::helper::Pin<Ptr> as pin::helper::DerefMut>::Target == <Pin<Ptr> as Deref>::Target, Ptr: Deref, pin::helper::Pin<Ptr>: pin::helper::DerefMut, pin::helper::Pin<Ptr>: ?Sized;
+   = note: upstream crates may add a new impl of trait `std::pin::helper::DerefMut` for type `std::pin::helper::Pin<&dyn SomeTrait<'_, _>>` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
+++ b/tests/ui/typeck/pin-unsound-issue-85099-derefmut.stderr
@@ -6,8 +6,8 @@ LL | impl<'b, 'a, Fut> DerefMut for Pin<&'b dyn SomeTrait<'a, Fut>> {
    |
    = note: conflicting implementation in crate `core`:
            - impl<Ptr> DerefMut for Pin<Ptr>
-             where <pin::helper::Pin<Ptr> as pin::helper::DerefMut>::Target == <Pin<Ptr> as Deref>::Target, Ptr: Deref, pin::helper::Pin<Ptr>: pin::helper::DerefMut, pin::helper::Pin<Ptr>: ?Sized;
-   = note: upstream crates may add a new impl of trait `std::pin::helper::DerefMut` for type `std::pin::helper::Pin<&dyn SomeTrait<'_, _>>` in future versions
+             where <pin::helper::PinHelper<Ptr> as pin::helper::PinDerefMutHelper>::Target == <Pin<Ptr> as Deref>::Target, Ptr: Deref, pin::helper::PinHelper<Ptr>: pin::helper::PinDerefMutHelper, pin::helper::PinHelper<Ptr>: ?Sized;
+   = note: upstream crates may add a new impl of trait `std::pin::helper::PinDerefMutHelper` for type `std::pin::helper::PinHelper<&dyn SomeTrait<'_, _>>` in future versions
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
The safety requirements for [`PinCoerceUnsized`](https://doc.rust-lang.org/stable/std/pin/trait.PinCoerceUnsized.html) are essentially that the type does not have a malicious `Deref` or `DerefMut` impl. However, the `Pin` type is fundamental, so the end-user can provide their own implementation of `DerefMut` for `Pin<&SomeLocalType>`, so it's possible for `Pin` to have a malicious `DerefMut` impl. This unsoundness is known as rust-lang/rust#85099.

Unfortunately, this means that the implementation of `PinCoerceUnsized` for `Pin` is currently unsound. To fix that, modify the impl so that it becomes impossible for downstream crates to provide their own implementation of `DerefMut` for `Pin` by abusing a hidden struct that is not fundamental.

This PR is a breaking change, but it fixes rust-lang/rust#85099. The PR supersedes rust-lang/rust#144896.

r? lcnr