### PR TITLE
Fix doc of `std::os::windows::io::BorrowedSocket::borrow_raw`

### DIFF
--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -54,7 +54,7 @@ impl BorrowedSocket<'_> {
     ///
     /// # Safety
     ///
-    /// The resource pointed to by `raw` must remain open for the duration of
+    /// The resource pointed to by `socket` must remain open for the duration of
     /// the returned `BorrowedSocket`, and it must not have the value
     /// `INVALID_SOCKET`.
     #[inline]


### PR DESCRIPTION
A small oversight in 0cb69dec57f I noticed while reading.
