### PR TITLE
docs(style): Specify the frontmatter style

### DIFF
--- a/src/doc/style-guide/src/nightly.md
+++ b/src/doc/style-guide/src/nightly.md
@@ -5,3 +5,29 @@ This chapter documents style and formatting for nightly-only syntax. The rest of
 Style and formatting for nightly-only syntax should be removed from this chapter and integrated into the appropriate sections of the style guide at the time of stabilization.
 
 There is no guarantee of the stability of this chapter in contrast to the rest of the style guide. Refer to the style team policy for nightly formatting procedure regarding breaking changes to this chapter.
+
+### Frontmatter
+
+*Location: Placed before comments and attributes in the [root](index.html).*
+
+*Tracking issue: [#136889](https://github.com/rust-lang/rust/issues/136889)*
+
+*Feature gate: `frontmatter`*
+
+There should be no blank lines between the frontmatter and either the start of the file or a shebang.
+There can be zero or one line between the frontmatter and any following content.
+
+The frontmatter fences should use the minimum number of dashes necessary for the contained content (one more than the longest series of initial dashes in the
+content, with a minimum of 3 to be recognized as frontmatter delimiters).
+If an infostring is present after the opening fence, there should be one space separating them.
+The frontmatter fence lines should not have trailing whitespace.
+
+```rust
+#!/usr/bin/env cargo
+--- cargo
+[dependencies]
+regex = "1"
+---
+
+fn main() {}
+```


### PR DESCRIPTION
Taken from [a style team discussion](https://github.com/rust-lang/style-team/issues/212#issuecomment-3185911143).

Assumptions on my part:
- I specify that frontmatter fences should not have trailing whitespace
- We aren't specifying when to include the infostring (one idea being if there is no shebang)
- Keep it simple and have a single example instead of showing allowed several variations

Tracking issue: rust-lang/rust#136889

Closes rust-lang/style-team#212