### PR TITLE
`std_detect`: Use `rustc-std-workspace-*` to pull in `compiler-builtins`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 name = "std_detect"
 version = "0.1.5"
 dependencies = [
- "alloc",
- "core",
  "libc",
+ "rustc-std-workspace-alloc",
+ "rustc-std-workspace-core",
 ]
 
 [[package]]

--- a/library/std_detect/Cargo.toml
+++ b/library/std_detect/Cargo.toml
@@ -21,8 +21,8 @@ is-it-maintained-open-issues = { repository = "rust-lang/stdarch" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-core = { path = "../core" }
-alloc = { path = "../alloc" }
+core = { version = "1.0.0", package = 'rustc-std-workspace-core' }
+alloc = { version = "1.0.0", package = 'rustc-std-workspace-alloc' }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.0", optional = true, default-features = false }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/145489 changed `std_detect` to no
longer depend on `cfg-if`, which meant it no longer indirectly pulled in
`rustc-std-workspace-core` via `cfg-if`. That caused it to no longer
depend on `compiler-builtins`.

Change `std_detect` to use `rustc-std-workspace-core` and
`rustc-std-workspace-alloc`, to integrate with the rustc workspace. This
also pulls in `compiler-builtins` via `rustc-std-workspace-core`.

Closes: https://github.com/rust-lang/rust/issues/145594
