### PR TITLE
Remove the std workspace patch for `compiler-builtins`

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -59,4 +59,3 @@ rustflags = ["-Cpanic=abort"]
 rustc-std-workspace-core = { path = 'rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'rustc-std-workspace-std' }
-compiler_builtins = { path = "compiler-builtins/compiler-builtins" }


### PR DESCRIPTION
All dependencies of `std` have dropped the crates.io dependency on `compiler-builtins`, so this patch is no longer needed.

Closes: RUST-142265