### PR TITLE
Pretty print the name of an future from calling async closure

### DIFF
--- a/tests/ui/async-await/async-closures/type-name.rs
+++ b/tests/ui/async-await/async-closures/type-name.rs
@@ -1,0 +1,18 @@
+//@ run-pass
+//@ edition: 2024
+
+fn once<F: FnOnce() -> T, T>(f: F) -> T {
+    f()
+}
+
+fn main() {
+    let closure = async || {};
+
+    // Name of future when called normally.
+    let name = std::any::type_name_of_val(&closure());
+    assert_eq!(name, "type_name::main::{{closure}}::{{closure}}");
+
+    // Name of future when closure is called via its FnOnce shim.
+    let name = std::any::type_name_of_val(&once(closure));
+    assert_eq!(name, "type_name::main::{{closure}}::{{closure}}::{{call_once}}");
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/145606 by introducing a way to customize the path rendering of async closures' futures in the pretty printer API.