### PR TITLE
Unconditionally-const supertraits are considered not dyn compatible

### DIFF
--- a/tests/ui/traits/const-traits/const-supertraits-dyn-compat.rs
+++ b/tests/ui/traits/const-traits/const-supertraits-dyn-compat.rs
@@ -1,0 +1,18 @@
+#![feature(const_trait_impl)]
+
+const trait Super {}
+
+// Not ok
+const trait Unconditionally: const Super {}
+fn test() {
+    let _: &dyn Unconditionally;
+    //~^ ERROR the trait `Unconditionally` is not dyn compatible
+}
+
+// Okay
+const trait Conditionally: [const] Super {}
+fn test2() {
+    let _: &dyn Conditionally;
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/const-supertraits-dyn-compat.stderr
+++ b/tests/ui/traits/const-traits/const-supertraits-dyn-compat.stderr
@@ -1,0 +1,18 @@
+error[E0038]: the trait `Unconditionally` is not dyn compatible
+  --> $DIR/const-supertraits-dyn-compat.rs:8:17
+   |
+LL |     let _: &dyn Unconditionally;
+   |                 ^^^^^^^^^^^^^^^ `Unconditionally` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/const-supertraits-dyn-compat.rs:6:30
+   |
+LL | const trait Unconditionally: const Super {}
+   |             ---------------  ^^^^^^^^^^^ ...because it cannot have a `const` supertrait
+   |             |
+   |             this trait is not dyn compatible...
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.


### PR DESCRIPTION
Let's save some space in the design of const traits by making `dyn Trait` where `trait Trait: const Super` not dyn compatible.

Such a trait cannot satisfy `dyn Trait: Trait`; we could in the future make this dyn compatible but *NOT* implement `Trait`, but that's a bit weird and seems like it needs to be independently justified moving forward.

Fixes https://github.com/rust-lang/rust/issues/145198

r? fee1-dead