### PR TITLE
rustdoc-search: adjust packing heuristics to save more space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5228,9 +5228,9 @@ dependencies = [
 
 [[package]]
 name = "stringdex"
-version = "0.0.1-alpha4"
+version = "0.0.1-alpha6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2841fd43df5b1ff1b042e167068a1fe9b163dc93041eae56ab2296859013a9a0"
+checksum = "202353c896804b8818f38f099422384afa2c592bd4532253d245bad16e2bb5b0"
 dependencies = [
  "stacker",
 ]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-json-types = { path = "../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.8.1"
-stringdex = { version = "0.0.1-alpha4" }
+stringdex = { version = "0.0.1-alpha6" }
 tempfile = "3"
 threadpool = "1.8.1"
 tracing = "0.1"


### PR DESCRIPTION
This upgrade causes stringdex to use fewer, larger files with the suffix-only children included more often. This is particularly aimed at reducing the number of files required by many-assoc-items.

The cost of this change is that the browser has to download more data that it isn't using while walking the search tree, because branches of the search tree that it isn't using are in the files it downloads. When I tested against the wordnet dictionary, a search for "indexing" required 12MiB of transfer, where it used to require 8MiB.

https://github.com/rust-lang/rust/pull/144476#issuecomment-3201429325