### PR TITLE
Cut some needless muts in compiler

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -114,7 +114,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.arena.alloc(hir::LetStmt { hir_id, super_, ty, pat, init, els, span, source })
     }
 
-    fn lower_block_check_mode(&mut self, b: &BlockCheckMode) -> hir::BlockCheckMode {
+    fn lower_block_check_mode(&self, b: &BlockCheckMode) -> hir::BlockCheckMode {
         match *b {
             BlockCheckMode::Default => hir::BlockCheckMode::DefaultBlock,
             BlockCheckMode::Unsafe(u) => {

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -122,7 +122,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    fn lower_delegation_generics(&mut self, span: Span) -> &'hir hir::Generics<'hir> {
+    fn lower_delegation_generics(&self, span: Span) -> &'hir hir::Generics<'hir> {
         self.arena.alloc(hir::Generics {
             params: &[],
             predicates: &[],
@@ -179,7 +179,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_delegation_sig(
-        &mut self,
+        &self,
         sig_id: DefId,
         decl: &'hir hir::FnDecl<'hir>,
         span: Span,

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -424,7 +424,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    pub(crate) fn lower_lit(&mut self, token_lit: &token::Lit, span: Span) -> hir::Lit {
+    pub(crate) fn lower_lit(&self, token_lit: &token::Lit, span: Span) -> hir::Lit {
         let lit_kind = match LitKind::from_token_lit(*token_lit) {
             Ok(lit_kind) => lit_kind,
             Err(err) => {
@@ -435,7 +435,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         respan(self.lower_span(span), lit_kind)
     }
 
-    fn lower_unop(&mut self, u: UnOp) -> hir::UnOp {
+    fn lower_unop(&self, u: UnOp) -> hir::UnOp {
         match u {
             UnOp::Deref => hir::UnOp::Deref,
             UnOp::Not => hir::UnOp::Not,
@@ -443,11 +443,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    fn lower_binop(&mut self, b: BinOp) -> BinOp {
+    fn lower_binop(&self, b: BinOp) -> BinOp {
         Spanned { node: b.node, span: self.lower_span(b.span) }
     }
 
-    fn lower_assign_op(&mut self, a: AssignOp) -> AssignOp {
+    fn lower_assign_op(&self, a: AssignOp) -> AssignOp {
         Spanned { node: a.node, span: self.lower_span(a.span) }
     }
 
@@ -681,7 +681,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         hir::Arm { hir_id, pat, guard, body, span }
     }
 
-    fn lower_capture_clause(&mut self, capture_clause: CaptureBy) -> CaptureBy {
+    fn lower_capture_clause(&self, capture_clause: CaptureBy) -> CaptureBy {
         match capture_clause {
             CaptureBy::Ref => CaptureBy::Ref,
             CaptureBy::Use { use_kw } => CaptureBy::Use { use_kw: self.lower_span(use_kw) },
@@ -1103,7 +1103,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn closure_movability_for_fn(
-        &mut self,
+        &self,
         decl: &FnDecl,
         fn_decl_span: Span,
         coroutine_kind: Option<hir::CoroutineKind>,
@@ -1133,7 +1133,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_closure_binder<'c>(
-        &mut self,
+        &self,
         binder: &'c ClosureBinder,
     ) -> (hir::ClosureBinder, &'c [GenericParam]) {
         let (binder, params) = match binder {
@@ -1283,7 +1283,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     /// if they are not tuple structs.
     /// Type checking will take care of the full validation later.
     fn extract_tuple_struct_path<'a>(
-        &mut self,
+        &self,
         expr: &'a Expr,
     ) -> Option<(&'a Option<Box<QSelf>>, &'a Path)> {
         if let ExprKind::Path(qself, path) = &expr.kind {
@@ -1305,7 +1305,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     /// if they are not unit structs.
     /// Type checking will take care of the full validation later.
     fn extract_unit_struct_path<'a>(
-        &mut self,
+        &self,
         expr: &'a Expr,
     ) -> Option<(&'a Option<Box<QSelf>>, &'a Path)> {
         if let ExprKind::Path(qself, path) = &expr.kind {
@@ -1589,7 +1589,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         Some(Label { ident: self.lower_ident(label.ident) })
     }
 
-    fn lower_loop_destination(&mut self, destination: Option<(NodeId, Label)>) -> hir::Destination {
+    fn lower_loop_destination(&self, destination: Option<(NodeId, Label)>) -> hir::Destination {
         let target_id = match destination {
             Some((id, _)) => {
                 if let Some(loop_id) = self.resolver.get_label_res(id) {
@@ -1610,7 +1610,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         hir::Destination { label, target_id }
     }
 
-    fn lower_jump_destination(&mut self, id: NodeId, opt_label: Option<Label>) -> hir::Destination {
+    fn lower_jump_destination(&self, id: NodeId, opt_label: Option<Label>) -> hir::Destination {
         if self.is_in_loop_condition && opt_label.is_none() {
             hir::Destination {
                 label: None,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -685,7 +685,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_foreign_item_ref(&mut self, i: &ForeignItem) -> hir::ForeignItemId {
+    fn lower_foreign_item_ref(&self, i: &ForeignItem) -> hir::ForeignItemId {
         hir::ForeignItemId { owner_id: self.owner_id(i.id) }
     }
 
@@ -951,7 +951,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_trait_item_ref(&mut self, i: &AssocItem) -> hir::TraitItemId {
+    fn lower_trait_item_ref(&self, i: &AssocItem) -> hir::TraitItemId {
         hir::TraitItemId { owner_id: self.owner_id(i.id) }
     }
 
@@ -1135,7 +1135,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         self.arena.alloc(item)
     }
 
-    fn lower_impl_item_ref(&mut self, i: &AssocItem) -> hir::ImplItemId {
+    fn lower_impl_item_ref(&self, i: &AssocItem) -> hir::ImplItemId {
         hir::ImplItemId { owner_id: self.owner_id(i.id) }
     }
 
@@ -1582,7 +1582,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     pub(super) fn lower_fn_header(
-        &mut self,
+        &self,
         h: FnHeader,
         default_safety: hir::Safety,
         attrs: &[hir::Attribute],
@@ -1613,7 +1613,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    pub(super) fn lower_abi(&mut self, abi_str: StrLit) -> ExternAbi {
+    pub(super) fn lower_abi(&self, abi_str: StrLit) -> ExternAbi {
         let ast::StrLit { symbol_unescaped, span, .. } = abi_str;
         let extern_abi = symbol_unescaped.as_str().parse().unwrap_or_else(|_| {
             self.error_on_invalid_abi(abi_str);
@@ -1645,7 +1645,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         extern_abi
     }
 
-    pub(super) fn lower_extern(&mut self, ext: Extern) -> ExternAbi {
+    pub(super) fn lower_extern(&self, ext: Extern) -> ExternAbi {
         match ext {
             Extern::None => ExternAbi::Rust,
             Extern::Implicit(_) => ExternAbi::FALLBACK,
@@ -1670,7 +1670,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
     }
 
-    pub(super) fn lower_constness(&mut self, c: Const) -> hir::Constness {
+    pub(super) fn lower_constness(&self, c: Const) -> hir::Constness {
         match c {
             Const::Yes(_) => hir::Constness::Const,
             Const::No => hir::Constness::NotConst,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -732,7 +732,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn lower_res(&mut self, res: Res<NodeId>) -> Res {
+    fn lower_res(&self, res: Res<NodeId>) -> Res {
         let res: Result<Res, ()> = res.apply_id(|id| {
             let owner = self.current_hir_id_owner;
             let local_id = self.ident_and_label_to_local_id.get(&id).copied().ok_or(())?;
@@ -748,11 +748,11 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         res.unwrap_or(Res::Err)
     }
 
-    fn expect_full_res(&mut self, id: NodeId) -> Res<NodeId> {
+    fn expect_full_res(&self, id: NodeId) -> Res<NodeId> {
         self.resolver.get_partial_res(id).map_or(Res::Err, |pr| pr.expect_full_res())
     }
 
-    fn lower_import_res(&mut self, id: NodeId, span: Span) -> PerNS<Option<Res>> {
+    fn lower_import_res(&self, id: NodeId, span: Span) -> PerNS<Option<Res>> {
         let per_ns = self.resolver.get_import_res(id);
         let per_ns = per_ns.map(|res| res.map(|res| self.lower_res(res)));
         if per_ns.is_empty() {
@@ -1595,7 +1595,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         }))
     }
 
-    fn lower_fn_params_to_idents(&mut self, decl: &FnDecl) -> &'hir [Option<Ident>] {
+    fn lower_fn_params_to_idents(&self, decl: &FnDecl) -> &'hir [Option<Ident>] {
         self.arena.alloc_from_iter(decl.inputs.iter().map(|param| match param.pat.kind {
             PatKind::Missing => None,
             PatKind::Ident(_, ident, _) => Some(self.lower_ident(ident)),
@@ -2365,7 +2365,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         }))
     }
 
-    fn lower_unsafe_source(&mut self, u: UnsafeSource) -> hir::UnsafeSource {
+    fn lower_unsafe_source(&self, u: UnsafeSource) -> hir::UnsafeSource {
         match u {
             CompilerGenerated => hir::UnsafeSource::CompilerGenerated,
             UserProvided => hir::UnsafeSource::UserProvided,
@@ -2373,7 +2373,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_trait_bound_modifiers(
-        &mut self,
+        &self,
         modifiers: TraitBoundModifiers,
     ) -> hir::TraitBoundModifiers {
         let constness = match modifiers.constness {

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -331,13 +331,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         }
     }
 
-    fn pat_wild_with_node_id_of(&mut self, p: &Pat, hir_id: hir::HirId) -> &'hir hir::Pat<'hir> {
+    fn pat_wild_with_node_id_of(&self, p: &Pat, hir_id: hir::HirId) -> &'hir hir::Pat<'hir> {
         self.arena.alloc(self.pat_with_node_id_of(p, hir::PatKind::Wild, hir_id))
     }
 
     /// Construct a `Pat` with the `HirId` of `p.id` already lowered.
     fn pat_with_node_id_of(
-        &mut self,
+        &self,
         p: &Pat,
         kind: hir::PatKind<'hir>,
         hir_id: hir::HirId,
@@ -360,7 +360,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::PatKind::Wild
     }
 
-    fn lower_range_end(&mut self, e: &RangeEnd, has_end: bool) -> hir::RangeEnd {
+    fn lower_range_end(&self, e: &RangeEnd, has_end: bool) -> hir::RangeEnd {
         match *e {
             RangeEnd::Excluded if has_end => hir::RangeEnd::Excluded,
             // No end; so `X..` behaves like `RangeFrom`.

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -142,7 +142,7 @@ impl<'a> AstValidator<'a> {
     }
 
     fn check_type_alias_where_clause_location(
-        &mut self,
+        &self,
         ty_alias: &TyAlias,
     ) -> Result<(), errors::WhereClauseBeforeTypeAlias> {
         if ty_alias.ty.is_none() || !ty_alias.where_clauses.before.has_where_token {

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -90,7 +90,7 @@ fn parse_cfg_entry<S: Stage>(
 }
 
 fn parse_cfg_entry_version<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     list: &MetaItemListParser<'_>,
     meta_span: Span,
 ) -> Option<CfgEntry> {
@@ -119,7 +119,7 @@ fn parse_cfg_entry_version<S: Stage>(
 }
 
 fn parse_cfg_entry_target<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     list: &MetaItemListParser<'_>,
     meta_span: Span,
 ) -> Option<CfgEntry> {
@@ -169,7 +169,7 @@ fn parse_name_value<S: Stage>(
     name_span: Span,
     value: Option<&NameValueParser>,
     span: Span,
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
 ) -> Option<CfgEntry> {
     try_gate_cfg(name, span, cx.sess(), cx.features_option());
 

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -66,7 +66,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcBuiltinMacroParser {
 }
 
 fn parse_derive_like<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     args: &ArgParser<'_>,
     trait_name_mandatory: bool,
 ) -> Option<(Option<Symbol>, ThinVec<Symbol>)> {

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -67,7 +67,7 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
 }
 
 fn extract_value<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     key: Symbol,
     arg: &ArgParser<'_>,
     span: Span,
@@ -96,7 +96,7 @@ fn extract_value<S: Stage>(
 }
 
 fn parse_dialect<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     dialect: Option<(Symbol, Span)>,
     failed: &mut bool,
 ) -> Option<(MirDialect, Span)> {
@@ -118,7 +118,7 @@ fn parse_dialect<S: Stage>(
 }
 
 fn parse_phase<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     phase: Option<(Symbol, Span)>,
     failed: &mut bool,
 ) -> Option<(MirPhase, Span)> {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -1199,7 +1199,7 @@ pub(crate) const ALL_TARGETS: &'static [MaybeWarn] = &[
 /// `cx` is the context given to the attribute.
 /// `args` is the parser for the attribute arguments.
 pub(crate) fn parse_single_integer<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &AcceptContext<'_, '_, S>,
     args: &ArgParser<'_>,
 ) -> Option<u128> {
     let Some(list) = args.list() else {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3833,7 +3833,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         self.buffer_error(err);
     }
 
-    fn explain_deref_coercion(&mut self, loan: &BorrowData<'tcx>, err: &mut Diag<'_>) {
+    fn explain_deref_coercion(&self, loan: &BorrowData<'tcx>, err: &mut Diag<'_>) {
         let tcx = self.infcx.tcx;
         if let Some(Terminator { kind: TerminatorKind::Call { call_source, fn_span, .. }, .. }) =
             &self.body[loan.reserve_location.block].terminator

--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -15,7 +15,7 @@ pub(crate) fn find<'tcx>(
     region_vid: RegionVid,
     start_point: Location,
 ) -> Option<Cause> {
-    let mut uf = UseFinder { body, regioncx, tcx, region_vid, start_point };
+    let uf = UseFinder { body, regioncx, tcx, region_vid, start_point };
 
     uf.find()
 }
@@ -29,7 +29,7 @@ struct UseFinder<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> UseFinder<'a, 'tcx> {
-    fn find(&mut self) -> Option<Cause> {
+    fn find(&self) -> Option<Cause> {
         let mut queue = VecDeque::new();
         let mut visited = FxIndexSet::default();
 

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -293,7 +293,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         self.buffer_error(err);
     }
 
-    fn has_ambiguous_copy(&mut self, ty: Ty<'tcx>) -> bool {
+    fn has_ambiguous_copy(&self, ty: Ty<'tcx>) -> bool {
         let Some(copy_def_id) = self.infcx.tcx.lang_items().copy_trait() else { return false };
 
         // Avoid bogus move errors because of an incoherent `Copy` impl.
@@ -301,7 +301,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             && self.infcx.tcx.coherent_trait(copy_def_id).is_err()
     }
 
-    fn report_cannot_move_from_static(&mut self, place: Place<'tcx>, span: Span) -> Diag<'infcx> {
+    fn report_cannot_move_from_static(&self, place: Place<'tcx>, span: Span) -> Diag<'infcx> {
         let description = if place.projection.len() == 1 {
             format!("static item {}", self.describe_any_place(place.as_ref()))
         } else {

--- a/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
@@ -160,7 +160,7 @@ impl OutlivesSuggestionBuilder {
 
     /// Emit an intermediate note on the given `Diag` if the involved regions are suggestable.
     pub(crate) fn intermediate_suggestion(
-        &mut self,
+        &self,
         mbcx: &MirBorrowckCtxt<'_, '_, '_>,
         errci: &ErrorConstraintInfo<'_>,
         diag: &mut Diag<'_>,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2121,7 +2121,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
     /// An Err result includes a tag indicated why the search failed.
     /// Currently this can only occur if the place is built off of a
     /// static variable, as we do not track those in the MoveData.
-    fn move_path_closest_to(&mut self, place: PlaceRef<'tcx>) -> (PlaceRef<'tcx>, MovePathIndex) {
+    fn move_path_closest_to(&self, place: PlaceRef<'tcx>) -> (PlaceRef<'tcx>, MovePathIndex) {
         match self.move_data.rev_lookup.find(place) {
             LookupResult::Parent(Some(mpi)) | LookupResult::Exact(mpi) => {
                 (self.move_data.move_paths[mpi].place.as_ref(), mpi)
@@ -2130,7 +2130,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
         }
     }
 
-    fn move_path_for_place(&mut self, place: PlaceRef<'tcx>) -> Option<MovePathIndex> {
+    fn move_path_for_place(&self, place: PlaceRef<'tcx>) -> Option<MovePathIndex> {
         // If returns None, then there is no move path corresponding
         // to a direct owner of `place` (which means there is nothing
         // that borrowck tracks for its analysis).

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -77,7 +77,7 @@ pub(crate) fn replace_regions_in_mir<'tcx>(
 ///
 /// This may result in errors being reported.
 pub(crate) fn compute_regions<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'tcx>,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,

--- a/compiler/rustc_borrowck/src/renumber.rs
+++ b/compiler/rustc_borrowck/src/renumber.rs
@@ -61,7 +61,7 @@ struct RegionRenumberer<'a, 'tcx> {
 impl<'a, 'tcx> RegionRenumberer<'a, 'tcx> {
     /// Replaces all regions appearing in `value` with fresh inference
     /// variables.
-    fn renumber_regions<T, F>(&mut self, value: T, region_ctxt_fn: F) -> T
+    fn renumber_regions<T, F>(&self, value: T, region_ctxt_fn: F) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
         F: Fn() -> RegionCtxt,

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -70,11 +70,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         Ok(output)
     }
 
-    pub(super) fn instantiate_canonical<T>(
-        &mut self,
-        span: Span,
-        canonical: &Canonical<'tcx, T>,
-    ) -> T
+    pub(super) fn instantiate_canonical<T>(&self, span: Span, canonical: &Canonical<'tcx, T>) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2005,7 +2005,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn check_iscleanup(&mut self, block_data: &BasicBlockData<'tcx>) {
+    fn check_iscleanup(&self, block_data: &BasicBlockData<'tcx>) {
         let is_cleanup = block_data.is_cleanup;
         match block_data.terminator().kind {
             TerminatorKind::Goto { target } => {
@@ -2085,14 +2085,14 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
     }
 
-    fn assert_iscleanup(&mut self, ctxt: &dyn fmt::Debug, bb: BasicBlock, iscleanuppad: bool) {
+    fn assert_iscleanup(&self, ctxt: &dyn fmt::Debug, bb: BasicBlock, iscleanuppad: bool) {
         if self.body[bb].is_cleanup != iscleanuppad {
             span_mirbug!(self, ctxt, "cleanuppad mismatch: {:?} should be {:?}", bb, iscleanuppad);
         }
     }
 
     fn assert_iscleanup_unwind(
-        &mut self,
+        &self,
         ctxt: &dyn fmt::Debug,
         unwind: UnwindAction,
         is_cleanup: bool,

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -200,7 +200,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     }
 
     #[instrument(skip(self), level = "debug")]
-    fn instantiate_binder_with_existentials<T>(&mut self, binder: ty::Binder<'tcx, T>) -> T
+    fn instantiate_binder_with_existentials<T>(&self, binder: ty::Binder<'tcx, T>) -> T
     where
         T: ty::TypeFoldable<TyCtxt<'tcx>> + Copy,
     {
@@ -244,7 +244,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     }
 
     #[instrument(skip(self), level = "debug")]
-    fn next_existential_region_var(&mut self, name: Option<Symbol>) -> ty::Region<'tcx> {
+    fn next_existential_region_var(&self, name: Option<Symbol>) -> ty::Region<'tcx> {
         let origin = NllRegionVariableOrigin::Existential { name };
         self.type_checker.infcx.next_nll_region_var(origin, || RegionCtxt::Existential(name))
     }

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -83,7 +83,7 @@ mod llvm_enzyme {
     }
 
     pub(crate) fn from_ast(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &ExtCtxt<'_>,
         meta_item: &ThinVec<MetaItemInner>,
         has_ret: bool,
         mode: DiffMode,
@@ -203,7 +203,7 @@ mod llvm_enzyme {
     /// FIXME(ZuseZ4): Once autodiff is enabled by default, make this a doc comment which is checked
     /// in CI.
     pub(crate) fn expand_with_mode(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &ExtCtxt<'_>,
         expand_span: Span,
         meta_item: &ast::MetaItem,
         mut item: Annotatable,

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -70,7 +70,7 @@ fn has_cfg_or_cfg_attr(annotatable: &Annotatable) -> bool {
 }
 
 impl CfgEval<'_> {
-    fn configure<T: HasAttrs + HasTokens>(&mut self, node: T) -> Option<T> {
+    fn configure<T: HasAttrs + HasTokens>(&self, node: T) -> Option<T> {
         self.0.configure(node)
     }
 

--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -45,7 +45,7 @@ impl AttrProcMacro for ExpandEnsures {
 // our attribute infrastructure does not yet support mixing a token-tree annotation with an AST
 // annotated, we end up doing token tree manipulation.
 fn expand_contract_clause(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_>,
     attr_span: Span,
     annotated: TokenStream,
     inject: impl FnOnce(&mut TokenStream) -> Result<(), ErrorGuaranteed>,
@@ -123,7 +123,7 @@ fn expand_contract_clause(
 }
 
 fn expand_requires_tts(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_>,
     attr_span: Span,
     annotation: TokenStream,
     annotated: TokenStream,
@@ -149,7 +149,7 @@ fn expand_requires_tts(
 }
 
 fn expand_ensures_tts(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_>,
     attr_span: Span,
     annotation: TokenStream,
     annotated: TokenStream,

--- a/compiler/rustc_builtin_macros/src/iter.rs
+++ b/compiler/rustc_builtin_macros/src/iter.rs
@@ -19,11 +19,7 @@ pub(crate) fn expand<'cx>(
     ExpandResult::Ready(base::MacEager::expr(closure))
 }
 
-fn parse_closure<'a>(
-    cx: &mut ExtCtxt<'a>,
-    span: Span,
-    stream: TokenStream,
-) -> PResult<'a, Box<Expr>> {
+fn parse_closure<'a>(cx: &ExtCtxt<'a>, span: Span, stream: TokenStream) -> PResult<'a, Box<Expr>> {
     let mut closure_parser = cx.new_parser_from_tts(stream);
 
     let coroutine_kind = Some(CoroutineKind::Gen {

--- a/compiler/rustc_builtin_macros/src/util.rs
+++ b/compiler/rustc_builtin_macros/src/util.rs
@@ -204,7 +204,7 @@ pub(crate) fn get_single_str_spanned_from_tts(
 /// Interpreting `tts` as a comma-separated sequence of expressions,
 /// expect exactly one expression, or emit an error and return `Err`.
 pub(crate) fn get_single_expr_from_tts(
-    cx: &mut ExtCtxt<'_>,
+    cx: &ExtCtxt<'_>,
     span: Span,
     tts: TokenStream,
     name: &str,

--- a/compiler/rustc_codegen_ssa/src/back/command.rs
+++ b/compiler/rustc_codegen_ssa/src/back/command.rs
@@ -95,7 +95,7 @@ impl Command {
         self.env_remove.push(key.to_owned());
     }
 
-    pub(crate) fn output(&mut self) -> io::Result<Output> {
+    pub(crate) fn output(&self) -> io::Result<Output> {
         self.command().output()
     }
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
 
     fn llbb_characteristics<Bx: BuilderMethods<'a, 'tcx>>(
         &self,
-        fx: &mut FunctionCx<'a, 'tcx, Bx>,
+        fx: &FunctionCx<'a, 'tcx, Bx>,
         target: mir::BasicBlock,
     ) -> (bool, bool) {
         if let Some(ref cleanup_kinds) = fx.cleanup_kinds {
@@ -1503,7 +1503,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     fn codegen_argument(
-        &mut self,
+        &self,
         bx: &mut Bx,
         op: OperandRef<'tcx, Bx::Value>,
         llargs: &mut Vec<Bx::Value>,
@@ -1679,7 +1679,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     pub(super) fn get_caller_location(
-        &mut self,
+        &self,
         bx: &mut Bx,
         source_info: mir::SourceInfo,
     ) -> OperandRef<'tcx, Bx::Value> {

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -318,7 +318,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
 
     pub(crate) fn extract_field<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         &self,
-        fx: &mut FunctionCx<'a, 'tcx, Bx>,
+        fx: &FunctionCx<'a, 'tcx, Bx>,
         bx: &mut Bx,
         i: usize,
     ) -> Self {
@@ -928,7 +928,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandValue<V> {
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     fn maybe_codegen_consume_direct(
-        &mut self,
+        &self,
         bx: &mut Bx,
         place_ref: mir::PlaceRef<'tcx>,
     ) -> Option<OperandRef<'tcx, Bx::Value>> {

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -191,7 +191,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     /// See also [`Self::codegen_transmute_operand`] for cases that can be done
     /// without needing a pre-allocated place for the destination.
     fn codegen_transmute(
-        &mut self,
+        &self,
         bx: &mut Bx,
         src: OperandRef<'tcx, Bx::Value>,
         dst: PlaceRef<'tcx, Bx::Value>,
@@ -220,7 +220,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     /// This is supported for all cases where the `cast` type is SSA,
     /// but for non-ZSTs with [`abi::BackendRepr::Memory`] it ICEs.
     pub(crate) fn codegen_transmute_operand(
-        &mut self,
+        &self,
         bx: &mut Bx,
         operand: OperandRef<'tcx, Bx::Value>,
         cast: TyAndLayout<'tcx>,
@@ -782,7 +782,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     fn codegen_scalar_binop(
-        &mut self,
+        &self,
         bx: &mut Bx,
         op: mir::BinOp,
         lhs: Bx::Value,
@@ -935,7 +935,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     fn codegen_wide_ptr_binop(
-        &mut self,
+        &self,
         bx: &mut Bx,
         op: mir::BinOp,
         lhs_addr: Bx::Value,
@@ -977,7 +977,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     fn codegen_scalar_checked_binop(
-        &mut self,
+        &self,
         bx: &mut Bx,
         op: mir::BinOp,
         lhs: Bx::Value,

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -375,7 +375,7 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
 
     /// Returns whether there are const-conditions.
     fn revalidate_conditional_constness(
-        &mut self,
+        &self,
         callee: DefId,
         callee_args: ty::GenericArgsRef<'tcx>,
         call_span: Span,

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -229,7 +229,7 @@ impl<'tcx> CompileTimeInterpCx<'tcx> {
     /// compatible arguments, then evaluation should continue with that function.
     /// If this returns `None`, the function call has been handled and the function has returned.
     fn hook_special_const_fn(
-        &mut self,
+        &self,
         instance: ty::Instance<'tcx>,
         args: &[FnArg<'tcx>],
         _dest: &PlaceTy<'tcx>,
@@ -276,7 +276,7 @@ impl<'tcx> CompileTimeInterpCx<'tcx> {
     ///
     /// Note that this intrinsic is exposed on stable for comparison with null. In other words, any
     /// change to this function that affects comparison with null is insta-stable!
-    fn guaranteed_cmp(&mut self, a: Scalar, b: Scalar) -> InterpResult<'tcx, u8> {
+    fn guaranteed_cmp(&self, a: Scalar, b: Scalar) -> InterpResult<'tcx, u8> {
         interp_ok(match (a, b) {
             // Comparisons between integers are always known.
             (Scalar::Int(a), Scalar::Int(b)) => (a == b) as u8,

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -875,7 +875,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     pub(crate) fn compare_bytes_intrinsic(
-        &mut self,
+        &self,
         left: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
         right: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
         byte_count: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
@@ -893,7 +893,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     pub(crate) fn raw_eq_intrinsic(
-        &mut self,
+        &self,
         lhs: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
         rhs: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
     ) -> InterpResult<'tcx, Scalar<M::Provenance>> {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -291,7 +291,7 @@ struct ValidityVisitor<'rt, 'tcx, M: Machine<'tcx>> {
 }
 
 impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
-    fn aggregate_field_path_elem(&mut self, layout: TyAndLayout<'tcx>, field: usize) -> PathElem {
+    fn aggregate_field_path_elem(&self, layout: TyAndLayout<'tcx>, field: usize) -> PathElem {
         // First, check if we are projecting to a variant.
         match layout.variants {
             Variants::Multiple { tag_field, .. } => {
@@ -443,7 +443,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
     }
 
     fn check_wide_ptr_meta(
-        &mut self,
+        &self,
         meta: MemPlaceMeta<M::Provenance>,
         pointee: TyAndLayout<'tcx>,
     ) -> InterpResult<'tcx> {
@@ -801,7 +801,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
     }
 
     fn visit_scalar(
-        &mut self,
+        &self,
         scalar: Scalar<M::Provenance>,
         scalar_layout: ScalarAbi,
     ) -> InterpResult<'tcx> {

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -112,7 +112,7 @@ impl AnnotateSnippetEmitter {
     }
 
     fn emit_messages_default(
-        &mut self,
+        &self,
         level: &Level,
         messages: &[(DiagMessage, Style)],
         args: &FluentArgs<'_>,

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1333,7 +1333,7 @@ impl HumanEmitter {
             .collect::<Vec<_>>()
     }
 
-    fn get_multispan_max_line_num(&mut self, msp: &MultiSpan) -> usize {
+    fn get_multispan_max_line_num(&self, msp: &MultiSpan) -> usize {
         let Some(ref sm) = self.sm else {
             return 0;
         };
@@ -1364,7 +1364,7 @@ impl HumanEmitter {
         max
     }
 
-    fn get_max_line_num(&mut self, span: &MultiSpan, children: &[Subdiag]) -> usize {
+    fn get_max_line_num(&self, span: &MultiSpan, children: &[Subdiag]) -> usize {
         let primary = self.get_multispan_max_line_num(span);
         children
             .iter()

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2194,7 +2194,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
     }
 
     fn expand_cfg_true(
-        &mut self,
+        &self,
         node: &mut (impl HasAttrs + HasNodeId),
         attr: ast::Attribute,
         pos: usize,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -104,7 +104,7 @@ impl<'a> ParserAnyMacro<'a> {
 
     #[instrument(skip(cx, tts))]
     pub(crate) fn from_tts<'cx>(
-        cx: &'cx mut ExtCtxt<'a>,
+        cx: &'cx ExtCtxt<'a>,
         tts: TokenStream,
         site_span: Span,
         arm_span: Span,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2202,7 +2202,7 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
     /// Feature gates RFC 2056 -- trivial bounds, checking for global bounds that
     /// aren't true.
     #[instrument(level = "debug", skip(self))]
-    fn check_false_global_bounds(&mut self) {
+    fn check_false_global_bounds(&self) {
         let tcx = self.ocx.infcx.tcx;
         let mut span = tcx.def_span(self.body_def_id);
         let empty_env = ty::ParamEnv::empty();

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls_overlap.rs
@@ -16,7 +16,7 @@ pub(crate) fn crate_inherent_impls_overlap_check(
     tcx: TyCtxt<'_>,
     (): (),
 ) -> Result<(), ErrorGuaranteed> {
-    let mut inherent_overlap_checker = InherentOverlapChecker { tcx };
+    let inherent_overlap_checker = InherentOverlapChecker { tcx };
     let mut res = Ok(());
     for id in tcx.hir_free_items() {
         res = res.and(inherent_overlap_checker.check_item(id));
@@ -171,7 +171,7 @@ impl<'tcx> InherentOverlapChecker<'tcx> {
         }
     }
 
-    fn check_item(&mut self, id: hir::ItemId) -> Result<(), ErrorGuaranteed> {
+    fn check_item(&self, id: hir::ItemId) -> Result<(), ErrorGuaranteed> {
         let def_kind = self.tcx.def_kind(id.owner_id);
         if !matches!(def_kind, DefKind::Enum | DefKind::Struct | DefKind::Trait | DefKind::Union) {
             return Ok(());

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -160,11 +160,11 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
         });
     }
 
-    fn contravariant(&mut self, variance: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
+    fn contravariant(&self, variance: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
         self.xform(variance, self.contravariant)
     }
 
-    fn invariant(&mut self, variance: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
+    fn invariant(&self, variance: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
         self.xform(variance, self.invariant)
     }
 
@@ -177,7 +177,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
         }
     }
 
-    fn xform(&mut self, v1: VarianceTermPtr<'a>, v2: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
+    fn xform(&self, v1: VarianceTermPtr<'a>, v2: VarianceTermPtr<'a>) -> VarianceTermPtr<'a> {
         match (*v1, *v2) {
             (_, ConstantTerm(ty::Covariant)) => {
                 // Applying a "covariant" transform is always a no-op

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -70,7 +70,7 @@ pub(crate) enum DivergingBlockBehavior {
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
-    pub(in super::super) fn check_casts(&mut self) {
+    pub(in super::super) fn check_casts(&self) {
         // don't hold the borrow to deferred_cast_checks while checking to avoid borrow checker errors
         // when writing to `self.param_env`.
         let mut deferred_cast_checks = mem::take(&mut *self.deferred_cast_checks.borrow_mut());
@@ -666,7 +666,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_ty.peel_refs(),
                     callee_expr.unwrap().hir_id,
                     TraitsInScope,
-                    |mut ctxt| ctxt.probe_for_similar_candidate(),
+                    |ctxt| ctxt.probe_for_similar_candidate(),
                 )
                 && assoc.is_method()
             {

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -104,7 +104,7 @@ impl<'a, 'tcx> GatherLocalsVisitor<'a, 'tcx> {
         visitor.visit_pat(local.pat);
     }
 
-    fn assign(&mut self, span: Span, nid: HirId, ty_opt: Option<Ty<'tcx>>) -> Ty<'tcx> {
+    fn assign(&self, span: Span, nid: HirId, ty_opt: Option<Ty<'tcx>>) -> Ty<'tcx> {
         // We evaluate expressions twice occasionally in diagnostics for better
         // type information or because it needs type information out-of-order.
         // In order to not ICE and not lead to knock-on ambiguity errors, if we
@@ -133,7 +133,7 @@ impl<'a, 'tcx> GatherLocalsVisitor<'a, 'tcx> {
     /// Allocates a type for a declaration, which may have a type annotation. If it does have
     /// a type annotation, then the [`Ty`] stored will be the resolved type. This may be found
     /// again during type checking by querying [`FnCtxt::local_ty`] for the same hir_id.
-    fn declare(&mut self, decl: Declaration<'tcx>) {
+    fn declare(&self, decl: Declaration<'tcx>) {
         let local_ty = match decl.ty {
             Some(ref ty) => {
                 let o_ty = self.fcx.lower_ty(ty);

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -164,11 +164,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     ///////////////////////////////////////////////////////////////////////////
     // ADJUSTMENTS
 
-    fn adjust_self_ty(
-        &mut self,
-        unadjusted_self_ty: Ty<'tcx>,
-        pick: &probe::Pick<'tcx>,
-    ) -> Ty<'tcx> {
+    fn adjust_self_ty(&self, unadjusted_self_ty: Ty<'tcx>, pick: &probe::Pick<'tcx>) -> Ty<'tcx> {
         // Commit the autoderefs by calling `autoderef` again, but this
         // time writing the results into the various typeck results.
         let mut autoderef = self.autoderef(self.call_expr.span, unadjusted_self_ty);
@@ -384,7 +380,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     }
 
     fn instantiate_method_args(
-        &mut self,
+        &self,
         pick: &probe::Pick<'tcx>,
         seg: &hir::PathSegment<'tcx>,
         parent_args: GenericArgsRef<'tcx>,
@@ -525,7 +521,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     }
 
     fn unify_receivers(
-        &mut self,
+        &self,
         self_ty: Ty<'tcx>,
         method_self_ty: Ty<'tcx>,
         pick: &probe::Pick<'tcx>,
@@ -566,7 +562,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     // inference guessing, the predicates and method signature can't be normalized
     // until we unify the `Self` type.
     fn instantiate_method_sig(
-        &mut self,
+        &self,
         pick: &probe::Pick<'tcx>,
         all_args: GenericArgsRef<'tcx>,
     ) -> (ty::FnSig<'tcx>, ty::InstantiatedPredicates<'tcx>) {
@@ -590,7 +586,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     }
 
     fn add_obligations(
-        &mut self,
+        &self,
         sig: ty::FnSig<'tcx>,
         all_args: GenericArgsRef<'tcx>,
         method_predicates: ty::InstantiatedPredicates<'tcx>,
@@ -719,7 +715,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     }
 
     fn upcast(
-        &mut self,
+        &self,
         source_trait_ref: ty::PolyTraitRef<'tcx>,
         target_trait_def_id: DefId,
     ) -> ty::PolyTraitRef<'tcx> {

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -2171,7 +2171,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// edit distance based suggestions, we provide at most one such suggestion.
     #[instrument(level = "debug", skip(self))]
     pub(crate) fn probe_for_similar_candidate(
-        &mut self,
+        &self,
     ) -> Result<Option<ty::AssocItem>, MethodError<'tcx>> {
         debug!("probing for method names similar to {:?}", self.method_name);
 

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -197,12 +197,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     // into [T] but currently `Where` clause stops the normalization process for it,
     // here we compare types of expr and base in a code without `Where` clause they would be equal
     // if they are not we don't modify the expr, hence we bypass the ICE
-    fn is_builtin_index(
-        &mut self,
-        e: &hir::Expr<'_>,
-        base_ty: Ty<'tcx>,
-        index_ty: Ty<'tcx>,
-    ) -> bool {
+    fn is_builtin_index(&self, e: &hir::Expr<'_>, base_ty: Ty<'tcx>, index_ty: Ty<'tcx>) -> bool {
         if let Some(elem_ty) = base_ty.builtin_index()
             && let Some(exp_ty) = self.typeck_results.expr_ty_opt(e)
         {

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -182,7 +182,7 @@ struct DirtyCleanVisitor<'tcx> {
 
 impl<'tcx> DirtyCleanVisitor<'tcx> {
     /// Possibly "deserialize" the attribute into a clean/dirty assertion
-    fn assertion_maybe(&mut self, item_id: LocalDefId, attr: &Attribute) -> Option<Assertion> {
+    fn assertion_maybe(&self, item_id: LocalDefId, attr: &Attribute) -> Option<Assertion> {
         assert!(attr.has_name(sym::rustc_clean));
         if !check_config(self.tcx, attr) {
             // skip: not the correct `cfg=`
@@ -193,7 +193,7 @@ impl<'tcx> DirtyCleanVisitor<'tcx> {
     }
 
     /// Gets the "auto" assertion on pre-validated attr, along with the `except` labels.
-    fn assertion_auto(&mut self, item_id: LocalDefId, attr: &Attribute) -> Assertion {
+    fn assertion_auto(&self, item_id: LocalDefId, attr: &Attribute) -> Assertion {
         let (name, mut auto) = self.auto_labels(item_id, attr);
         let except = self.except(attr);
         let loaded_from_disk = self.loaded_from_disk(attr);
@@ -231,7 +231,7 @@ impl<'tcx> DirtyCleanVisitor<'tcx> {
 
     /// Return all DepNode labels that should be asserted for this item.
     /// index=0 is the "name" used for error messages
-    fn auto_labels(&mut self, item_id: LocalDefId, attr: &Attribute) -> (&'static str, Labels) {
+    fn auto_labels(&self, item_id: LocalDefId, attr: &Attribute) -> (&'static str, Labels) {
         let node = self.tcx.hir_node_by_def_id(item_id);
         let (name, labels) = match node {
             HirNode::Item(item) => {
@@ -434,7 +434,7 @@ struct FindAllAttrs<'tcx> {
 }
 
 impl<'tcx> FindAllAttrs<'tcx> {
-    fn is_active_attr(&mut self, attr: &Attribute) -> bool {
+    fn is_active_attr(&self, attr: &Attribute) -> bool {
         if attr.has_name(sym::rustc_clean) && check_config(self.tcx, attr) {
             return true;
         }

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -183,7 +183,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
 
     /// Returns a range of the type variables created during the snapshot.
     pub(crate) fn vars_since_snapshot(
-        &mut self,
+        &self,
         value_count: usize,
     ) -> (Range<TyVid>, Vec<TypeVariableOrigin>) {
         let range = TyVid::from_usize(value_count)..TyVid::from_usize(self.num_vars());

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1888,7 +1888,7 @@ impl KeywordIdents {
     }
 
     fn check_ident_token(
-        &mut self,
+        &self,
         cx: &EarlyContext<'_>,
         UnderMacro(under_macro): UnderMacro,
         ident: Ident,

--- a/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
+++ b/compiler/rustc_lint/src/macro_expr_fragment_specifier_2024_migration.rs
@@ -119,7 +119,7 @@ impl Expr2024 {
         }
     }
 
-    fn check_ident_token(&mut self, cx: &crate::EarlyContext<'_>, token: &Token) {
+    fn check_ident_token(&self, cx: &crate::EarlyContext<'_>, token: &Token) {
         debug!("check_ident_token: {:?}", token);
         let (sym, edition) = match token.kind {
             TokenKind::Ident(sym, _) => (sym, Edition::Edition2024),

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -630,7 +630,7 @@ impl<'a, V> LocalTableInContextMut<'a, V> {
         self.data.get_mut(&id.local_id)
     }
 
-    pub fn get(&mut self, id: HirId) -> Option<&V> {
+    pub fn get(&self, id: HirId) -> Option<&V> {
         validate_hir_id_for_typeck_results(self.hir_owner, id);
         self.data.get(&id.local_id)
     }

--- a/compiler/rustc_mir_build/src/builder/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
         Ok(())
     }
 
-    fn parse_let_statement(&mut self, stmt_id: StmtId) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
+    fn parse_let_statement(&self, stmt_id: StmtId) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
         let pattern = match &self.thir[stmt_id].kind {
             StmtKind::Let { pattern, .. } => pattern,
             StmtKind::Expr { expr, .. } => {
@@ -286,7 +286,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
         self.parse_var(pattern)
     }
 
-    fn parse_var(&mut self, mut pat: &Pat<'tcx>) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
+    fn parse_var(&self, mut pat: &Pat<'tcx>) -> PResult<(LocalVarId, Ty<'tcx>, Span)> {
         // Make sure we throw out any `AscribeUserType` we find
         loop {
             match &pat.kind {

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -602,7 +602,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// so we create a place starting from `PlaceBase::Upvar`, which will be resolved
     /// once all projections that allow us to identify a capture have been applied.
     fn lower_captured_upvar(
-        &mut self,
+        &self,
         block: BasicBlock,
         closure_def_id: LocalDefId,
         var_hir_id: LocalVarId,

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -776,7 +776,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     // Helper to get a `-1` value of the appropriate type
-    fn neg_1_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+    fn neg_1_literal(&self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         let typing_env = ty::TypingEnv::fully_monomorphized();
         let size = self.tcx.layout_of(typing_env.as_query_input(ty)).unwrap().size;
         let literal = Const::from_bits(self.tcx, size.unsigned_int_max(), typing_env, ty);
@@ -785,7 +785,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     // Helper to get the minimum value of the appropriate type
-    fn minval_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+    fn minval_literal(&self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         assert!(ty.is_signed());
         let typing_env = ty::TypingEnv::fully_monomorphized();
         let bits = self.tcx.layout_of(typing_env.as_query_input(ty)).unwrap().size.bits();

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1926,7 +1926,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// subcandidate. Any candidate that has been expanded this way should also be postprocessed
     /// at the end of [`Self::expand_and_match_or_candidates`].
     fn create_or_subcandidates(
-        &mut self,
+        &self,
         candidate: &mut Candidate<'tcx>,
         match_pair: MatchPairTree<'tcx>,
     ) {
@@ -2145,7 +2145,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// [`Switch`]: TestKind::Switch
     /// [`SwitchInt`]: TestKind::SwitchInt
     /// [`Range`]: TestKind::Range
-    fn pick_test(&mut self, candidates: &[&mut Candidate<'tcx>]) -> (Place<'tcx>, Test<'tcx>) {
+    fn pick_test(&self, candidates: &[&mut Candidate<'tcx>]) -> (Place<'tcx>, Test<'tcx>) {
         // Extract the match-pair from the highest priority candidate
         let match_pair = &candidates[0].match_pairs[0];
         let test = self.pick_test_for_match_pair(match_pair);
@@ -2197,7 +2197,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// - candidate 0 becomes `[z @ true]` since we know that `x` was `true`;
     /// - candidate 1 becomes `[y @ false]` since we know that `x` was `false`.
     fn sort_candidates<'b, 'c>(
-        &mut self,
+        &self,
         match_place: Place<'tcx>,
         test: &Test<'tcx>,
         mut candidates: &'b mut [&'c mut Candidate<'tcx>],

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -26,10 +26,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Identifies what test is needed to decide if `match_pair` is applicable.
     ///
     /// It is a bug to call this with a not-fully-simplified pattern.
-    pub(super) fn pick_test_for_match_pair(
-        &mut self,
-        match_pair: &MatchPairTree<'tcx>,
-    ) -> Test<'tcx> {
+    pub(super) fn pick_test_for_match_pair(&self, match_pair: &MatchPairTree<'tcx>) -> Test<'tcx> {
         let kind = match match_pair.test_case {
             TestCase::Variant { adt_def, variant_index: _ } => TestKind::Switch { adt_def },
 
@@ -512,7 +509,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// test does not apply to this candidate, but it might be we can get
     /// tighter match code if we do something a bit different.
     pub(super) fn sort_candidate(
-        &mut self,
+        &self,
         test_place: Place<'tcx>,
         test: &Test<'tcx>,
         candidate: &mut Candidate<'tcx>,

--- a/compiler/rustc_mir_build/src/builder/misc.rs
+++ b/compiler/rustc_mir_build/src/builder/misc.rs
@@ -24,14 +24,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     /// Convenience function for creating a literal operand, one
     /// without any user type annotation.
-    pub(crate) fn literal_operand(&mut self, span: Span, const_: Const<'tcx>) -> Operand<'tcx> {
+    pub(crate) fn literal_operand(&self, span: Span, const_: Const<'tcx>) -> Operand<'tcx> {
         let constant = Box::new(ConstOperand { span, user_ty: None, const_ });
         Operand::Constant(constant)
     }
 
     /// Returns a zero literal operand for the appropriate type, works for
     /// bool, char and integers.
-    pub(crate) fn zero_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
+    pub(crate) fn zero_literal(&self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         let literal = Const::from_bits(self.tcx, 0, ty::TypingEnv::fully_monomorphized(), ty);
 
         self.literal_operand(span, literal)

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -957,7 +957,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     };
 
                     fn local(
-                        cx: &mut ThirBuildCx<'_>,
+                        cx: &ThirBuildCx<'_>,
                         expr: &rustc_hir::Expr<'_>,
                     ) -> Option<hir::HirId> {
                         if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind
@@ -1102,7 +1102,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
     }
 
     fn user_args_applied_to_res(
-        &mut self,
+        &self,
         hir_id: hir::HirId,
         res: Res,
     ) -> Option<Box<ty::CanonicalUserType<'tcx>>> {
@@ -1137,7 +1137,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
     }
 
     fn method_callee(
-        &mut self,
+        &self,
         expr: &hir::Expr<'_>,
         span: Span,
         overloaded_callee: Option<Ty<'tcx>>,
@@ -1262,7 +1262,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         }
     }
 
-    fn convert_var(&mut self, var_hir_id: hir::HirId) -> ExprKind<'tcx> {
+    fn convert_var(&self, var_hir_id: hir::HirId) -> ExprKind<'tcx> {
         // We want upvars here not captures.
         // Captures will be handled in MIR.
         let is_upvar = self.is_upvar(var_hir_id);
@@ -1445,7 +1445,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         }
     }
 
-    fn is_upvar(&mut self, var_hir_id: hir::HirId) -> bool {
+    fn is_upvar(&self, var_hir_id: hir::HirId) -> bool {
         self.tcx
             .upvars_mentioned(self.body_owner)
             .is_some_and(|upvars| upvars.contains_key(&var_hir_id))

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -117,7 +117,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn pattern_from_hir(&mut self, p: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
+    fn pattern_from_hir(&self, p: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
         pat_from_hir(self.tcx, self.typing_env, self.typeck_results, p)
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -563,7 +563,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn check_let_chain(
-        &mut self,
+        &self,
         chain_refutabilities: Vec<Option<(Span, RefutableFlag)>>,
         whole_chain_span: Span,
     ) {

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         id: hir::HirId,
         span: Span,
     ) -> Box<Pat<'tcx>> {
-        let mut convert = ConstToPat::new(self, id, span, c);
+        let convert = ConstToPat::new(self, id, span, c);
 
         match c.kind() {
             ty::ConstKind::Unevaluated(uv) => convert.unevaluated_to_pat(uv, ty),
@@ -93,11 +93,7 @@ impl<'tcx> ConstToPat<'tcx> {
         Box::new(Pat { span: self.span, ty, kind: PatKind::Error(err.emit()) })
     }
 
-    fn unevaluated_to_pat(
-        &mut self,
-        uv: ty::UnevaluatedConst<'tcx>,
-        ty: Ty<'tcx>,
-    ) -> Box<Pat<'tcx>> {
+    fn unevaluated_to_pat(&self, uv: ty::UnevaluatedConst<'tcx>, ty: Ty<'tcx>) -> Box<Pat<'tcx>> {
         // It's not *technically* correct to be revealing opaque types here as borrowcheck has
         // not run yet. However, CTFE itself uses `TypingMode::PostAnalysis` unconditionally even
         // during typeck and not doing so has a lot of (undesirable) fallout (#101478, #119821).

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     }
 
     fn lower_pattern_range_endpoint(
-        &mut self,
+        &self,
         expr: Option<&'tcx hir::PatExpr<'tcx>>,
         // Out-parameters collecting extra data to be reapplied by the caller
         ascriptions: &mut Vec<Ascription<'tcx>>,
@@ -212,7 +212,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     }
 
     fn lower_pattern_range(
-        &mut self,
+        &self,
         lo_expr: Option<&'tcx hir::PatExpr<'tcx>>,
         hi_expr: Option<&'tcx hir::PatExpr<'tcx>>,
         end: RangeEnd,
@@ -456,7 +456,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     }
 
     fn lower_variant_or_leaf(
-        &mut self,
+        &self,
         res: Res,
         hir_id: hir::HirId,
         span: Span,
@@ -549,7 +549,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     /// it to `const_to_pat`. Any other path (like enum variants without fields)
     /// is converted to the corresponding pattern via `lower_variant_or_leaf`.
     #[instrument(skip(self), level = "debug")]
-    fn lower_path(&mut self, qpath: &hir::QPath<'_>, id: hir::HirId, span: Span) -> Box<Pat<'tcx>> {
+    fn lower_path(&self, qpath: &hir::QPath<'_>, id: hir::HirId, span: Span) -> Box<Pat<'tcx>> {
         let ty = self.typeck_results.node_type(id);
         let res = self.typeck_results.qpath_res(qpath, id);
 
@@ -598,7 +598,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
 
     /// Lowers an inline const block (e.g. `const { 1 + 1 }`) to a pattern.
     fn lower_inline_const(
-        &mut self,
+        &self,
         block: &'tcx hir::ConstBlock,
         id: hir::HirId,
         span: Span,
@@ -646,7 +646,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     /// - Inline const blocks (e.g. `const { 1 + 1 }`)
     /// - Literals, possibly negated (e.g. `-128u8`, `"hello"`)
     fn lower_pat_expr(
-        &mut self,
+        &self,
         expr: &'tcx hir::PatExpr<'tcx>,
         pat_ty: Option<Ty<'tcx>>,
     ) -> PatKind<'tcx> {

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -514,7 +514,7 @@ where
     }
 
     fn write_block_header_simple(
-        &mut self,
+        &self,
         w: &mut impl io::Write,
         block: BasicBlock,
     ) -> io::Result<()> {
@@ -546,7 +546,7 @@ where
     }
 
     fn write_block_header_with_state_columns(
-        &mut self,
+        &self,
         w: &mut impl io::Write,
         block: BasicBlock,
         state_column_names: &[&str],

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -179,7 +179,7 @@ fn build_poll_switch<'tcx>(
 }
 
 // Gather blocks, reachable through 'drop' targets of Yield and Drop terminators (chained)
-fn gather_dropline_blocks<'tcx>(body: &mut Body<'tcx>) -> DenseBitSet<BasicBlock> {
+fn gather_dropline_blocks<'tcx>(body: &Body<'tcx>) -> DenseBitSet<BasicBlock> {
     let mut dropline: DenseBitSet<BasicBlock> = DenseBitSet::new_empty(body.basic_blocks.len());
     for (bb, data) in traversal::reverse_postorder(body) {
         if dropline.contains(bb) {
@@ -223,7 +223,7 @@ pub(super) fn cleanup_async_drops<'tcx>(body: &mut Body<'tcx>) {
 
 pub(super) fn has_expandable_async_drops<'tcx>(
     tcx: TyCtxt<'tcx>,
-    body: &mut Body<'tcx>,
+    body: &Body<'tcx>,
     coroutine_ty: Ty<'tcx>,
 ) -> bool {
     for bb in START_BLOCK..body.basic_blocks.next_index() {

--- a/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
@@ -151,7 +151,7 @@ pub(crate) struct Hole {
 }
 
 impl Hole {
-    pub(crate) fn merge_if_overlapping_or_adjacent(&mut self, other: &mut Self) -> bool {
+    pub(crate) fn merge_if_overlapping_or_adjacent(&mut self, other: &Self) -> bool {
         if !self.span.overlaps_or_adjacent(other.span) {
             return false;
         }

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -269,7 +269,7 @@ impl<'a, 'tcx> ElaborateDropsCtxt<'a, 'tcx> {
         self.drop_flags[index].get_or_insert_with(|| patch.new_temp(self.tcx.types.bool, span));
     }
 
-    fn drop_flag(&mut self, index: MovePathIndex) -> Option<Place<'tcx>> {
+    fn drop_flag(&self, index: MovePathIndex) -> Option<Place<'tcx>> {
         self.drop_flags[index].map(Place::from)
     }
 

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1700,7 +1700,7 @@ impl<'tcx> VnState<'_, 'tcx> {
 
     /// If there is a local which is assigned `index`, and its assignment strictly dominates `loc`,
     /// return it. If you used this local, add it to `reused_locals` to remove storage statements.
-    fn try_as_local(&mut self, index: VnIndex, loc: Location) -> Option<Local> {
+    fn try_as_local(&self, index: VnIndex, loc: Location) -> Option<Local> {
         let other = self.rev_locals.get(index)?;
         other
             .iter()

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -360,7 +360,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
         bb: BasicBlock,
         lhs: PlaceIndex,
         rhs: ImmTy<'tcx>,
-        state: &mut State<ConditionSet<'a>>,
+        state: &State<ConditionSet<'a>>,
     ) {
         let register_opportunity = |c: Condition| {
             debug!(?bb, ?c.target, "register");
@@ -381,7 +381,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
         bb: BasicBlock,
         lhs: PlaceIndex,
         constant: OpTy<'tcx>,
-        state: &mut State<ConditionSet<'a>>,
+        state: &State<ConditionSet<'a>>,
     ) {
         self.map.for_each_projection_value(
             lhs,
@@ -642,7 +642,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
         discr: &Operand<'tcx>,
         targets: &SwitchTargets,
         target_bb: BasicBlock,
-        state: &mut State<ConditionSet<'a>>,
+        state: &State<ConditionSet<'a>>,
     ) {
         debug_assert_ne!(target_bb, START_BLOCK);
         debug_assert_eq!(self.body.basic_blocks.predecessors()[target_bb].len(), 1);

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -262,7 +262,7 @@ struct ReplacementVisitor<'tcx, 'll> {
 
 impl<'tcx> ReplacementVisitor<'tcx, '_> {
     #[instrument(level = "trace", skip(self))]
-    fn expand_var_debug_info(&mut self, var_debug_info: &mut Vec<VarDebugInfo<'tcx>>) {
+    fn expand_var_debug_info(&self, var_debug_info: &mut Vec<VarDebugInfo<'tcx>>) {
         var_debug_info.flat_map_in_place(|mut var_debug_info| {
             let place = match var_debug_info.value {
                 VarDebugInfoContents::Const(_) => return vec![var_debug_info],

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -660,7 +660,7 @@ impl<'a, 'tcx> MirUsedCollector<'a, 'tcx> {
     }
 
     /// Evaluates a *not yet monomorphized* constant.
-    fn eval_constant(&mut self, constant: &mir::ConstOperand<'tcx>) -> Option<mir::ConstValue> {
+    fn eval_constant(&self, constant: &mir::ConstOperand<'tcx>) -> Option<mir::ConstValue> {
         let const_ = self.monomorphize(constant.const_);
         // Evaluate the constant. This makes const eval failure a collection-time error (rather than
         // a codegen-time error). rustc stops after collection if there was an error, so this

--- a/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
@@ -121,7 +121,7 @@ impl<'tcx> MoveCheckVisitor<'tcx> {
     }
 
     fn operand_size_if_too_large(
-        &mut self,
+        &self,
         limit: Limit,
         operand: &mir::Operand<'tcx>,
     ) -> Option<Size> {

--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -287,7 +287,7 @@ where
         ControlFlow::Continue(())
     }
 
-    fn found_uncovered_ty_param(&mut self, ty: I::Ty) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
+    fn found_uncovered_ty_param(&self, ty: I::Ty) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
         if self.search_first_local_ty {
             return ControlFlow::Continue(());
         }
@@ -295,7 +295,7 @@ where
         ControlFlow::Break(OrphanCheckEarlyExit::UncoveredTyParam(ty))
     }
 
-    fn def_id_is_local(&mut self, def_id: I::DefId) -> bool {
+    fn def_id_is_local(&self, def_id: I::DefId) -> bool {
         match self.in_crate {
             InCrate::Local { .. } => def_id.is_local(),
             InCrate::Remote => false,

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -895,7 +895,7 @@ where
     ///
     /// This is only necessary for `feature(specialization)` and seems quite ugly.
     pub(super) fn filter_specialized_impls(
-        &mut self,
+        &self,
         allow_inference_constraints: AllowInferenceConstraints,
         candidates: &mut Vec<Candidate<I>>,
     ) {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
@@ -273,7 +273,7 @@ where
     /// - we apply the `external_constraints` returned by the query, returning
     ///   the `normalization_nested_goals`
     pub(super) fn instantiate_and_apply_query_response(
-        &mut self,
+        &self,
         param_env: I::ParamEnv,
         original_values: &[I::GenericArg],
         response: CanonicalResponse<I>,
@@ -425,10 +425,7 @@ where
         }
     }
 
-    fn register_region_constraints(
-        &mut self,
-        outlives: &[ty::OutlivesPredicate<I, I::GenericArg>],
-    ) {
+    fn register_region_constraints(&self, outlives: &[ty::OutlivesPredicate<I, I::GenericArg>]) {
         for &ty::OutlivesPredicate(lhs, rhs) in outlives {
             match lhs.kind() {
                 ty::GenericArgKind::Lifetime(lhs) => self.register_region_outlives(lhs, rhs),
@@ -438,7 +435,7 @@ where
         }
     }
 
-    fn register_new_opaque_types(&mut self, opaque_types: &[(ty::OpaqueTypeKey<I>, I::Ty)]) {
+    fn register_new_opaque_types(&self, opaque_types: &[(ty::OpaqueTypeKey<I>, I::Ty)]) {
         for &(key, ty) in opaque_types {
             let prev = self.delegate.register_hidden_type_in_storage(key, ty, self.origin_span);
             // We eagerly resolve inference variables when computing the query response.

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1132,7 +1132,7 @@ where
     }
 
     pub(super) fn register_hidden_type_in_storage(
-        &mut self,
+        &self,
         opaque_type_key: ty::OpaqueTypeKey<I>,
         hidden_ty: I::Ty,
     ) -> Option<I::Ty> {
@@ -1160,7 +1160,7 @@ where
     // Do something for each opaque/hidden pair defined with `def_id` in the
     // current inference context.
     pub(super) fn probe_existing_opaque_ty(
-        &mut self,
+        &self,
         key: ty::OpaqueTypeKey<I>,
     ) -> Option<(ty::OpaqueTypeKey<I>, I::Ty)> {
         // We shouldn't have any duplicate entries when using
@@ -1192,7 +1192,7 @@ where
     }
 
     pub(super) fn is_transmutable(
-        &mut self,
+        &self,
         dst: I::Ty,
         src: I::Ty,
         assume: I::Const,

--- a/compiler/rustc_next_trait_solver/src/solve/inspect/build.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/inspect/build.rs
@@ -239,7 +239,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> ProofTreeBuilder<D> {
     }
 
     pub(in crate::solve) fn new_goal_evaluation(
-        &mut self,
+        &self,
         uncanonicalized_goal: Goal<I, I::Predicate>,
         orig_values: &[I::GenericArg],
         kind: GoalEvaluationKind,
@@ -280,7 +280,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> ProofTreeBuilder<D> {
     }
 
     pub(crate) fn new_goal_evaluation_step(
-        &mut self,
+        &self,
         var_values: ty::CanonicalVarValues<I>,
     ) -> ProofTreeBuilder<D> {
         self.nested(|| WipCanonicalGoalEvaluationStep {

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -252,7 +252,7 @@ where
     /// In this case we tend to flounder and return ambiguity by calling `[EvalCtxt::flounder]`.
     #[instrument(level = "trace", skip(self), ret)]
     fn try_merge_candidates(
-        &mut self,
+        &self,
         candidates: &[Candidate<I>],
     ) -> Option<(CanonicalResponse<I>, MergeCandidateInfo)> {
         if candidates.is_empty() {
@@ -275,7 +275,7 @@ where
         None
     }
 
-    fn bail_with_ambiguity(&mut self, candidates: &[Candidate<I>]) -> CanonicalResponse<I> {
+    fn bail_with_ambiguity(&self, candidates: &[Candidate<I>]) -> CanonicalResponse<I> {
         debug_assert!(candidates.len() > 1);
         let maybe_cause =
             candidates.iter().fold(MaybeCause::Ambiguity, |maybe_cause, candidates| {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1315,7 +1315,7 @@ where
     /// Importantly, we also only prefer the builtin impls for trait goals, and not during
     /// normalization. This means the only case where this special-case results in exploitable
     /// unsoundness should be lifetime dependent user-written impls.
-    pub(super) fn unsound_prefer_builtin_dyn_impl(&mut self, candidates: &mut Vec<Candidate<I>>) {
+    pub(super) fn unsound_prefer_builtin_dyn_impl(&self, candidates: &mut Vec<Candidate<I>>) {
         match self.typing_mode() {
             TypingMode::Coherence => return,
             TypingMode::Analysis { .. }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -478,7 +478,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
         }
     }
 
-    fn lint_doc_comment_unicode_text_flow(&mut self, start: BytePos, content: &str) {
+    fn lint_doc_comment_unicode_text_flow(&self, start: BytePos, content: &str) {
         if contains_text_flow_control_chars(content) {
             self.report_text_direction_codepoint(
                 content,
@@ -491,7 +491,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
     }
 
     fn lint_literal_unicode_text_flow(
-        &mut self,
+        &self,
         text: Symbol,
         lit_kind: token::LitKind,
         span: Span,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -444,7 +444,7 @@ impl<'a> Parser<'a> {
     ///
     /// Returns the number of characters (bytes) composing the invalid portion
     /// of the identifier and the valid portion of the identifier.
-    pub(super) fn is_lit_bad_ident(&mut self) -> Option<(usize, Symbol)> {
+    pub(super) fn is_lit_bad_ident(&self) -> Option<(usize, Symbol)> {
         // ensure that the integer literal is followed by a *invalid*
         // suffix: this is how we know that it is a identifier with an
         // invalid beginning.
@@ -766,7 +766,7 @@ impl<'a> Parser<'a> {
     ///
     /// Given that not all parser diagnostics flow through `expected_one_of_not_found`, this
     /// label may need added to other diagnostics emission paths as needed.
-    pub(super) fn label_expected_raw_ref(&mut self, err: &mut Diag<'_>) {
+    pub(super) fn label_expected_raw_ref(&self, err: &mut Diag<'_>) {
         if self.prev_token.is_keyword(kw::Raw)
             && self.expected_token_types.contains(TokenType::KwMut)
             && self.expected_token_types.contains(TokenType::KwConst)
@@ -1585,7 +1585,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn maybe_report_ambiguous_plus(&mut self, impl_dyn_multi: bool, ty: &Ty) {
+    pub(super) fn maybe_report_ambiguous_plus(&self, impl_dyn_multi: bool, ty: &Ty) {
         if impl_dyn_multi {
             self.dcx().emit_err(AmbiguousPlus {
                 span: ty.span,
@@ -1689,7 +1689,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn recover_from_prefix_increment(
-        &mut self,
+        &self,
         operand_expr: Box<Expr>,
         op_span: Span,
         start_stmt: bool,
@@ -1700,7 +1700,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn recover_from_postfix_increment(
-        &mut self,
+        &self,
         operand_expr: Box<Expr>,
         op_span: Span,
         start_stmt: bool,
@@ -1714,7 +1714,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn recover_from_postfix_decrement(
-        &mut self,
+        &self,
         operand_expr: Box<Expr>,
         op_span: Span,
         start_stmt: bool,
@@ -1728,7 +1728,7 @@ impl<'a> Parser<'a> {
     }
 
     fn recover_from_inc_dec(
-        &mut self,
+        &self,
         base: Box<Expr>,
         kind: IncDecRecovery,
         op_span: Span,
@@ -1777,7 +1777,7 @@ impl<'a> Parser<'a> {
     }
 
     fn prefix_inc_dec_suggest(
-        &mut self,
+        &self,
         base_src: String,
         kind: IncDecRecovery,
         (pre_span, post_span): (Span, Span),
@@ -1793,7 +1793,7 @@ impl<'a> Parser<'a> {
     }
 
     fn postfix_inc_dec_suggest(
-        &mut self,
+        &self,
         base_src: String,
         kind: IncDecRecovery,
         (pre_span, post_span): (Span, Span),
@@ -1810,7 +1810,7 @@ impl<'a> Parser<'a> {
     }
 
     fn inc_dec_standalone_suggest(
-        &mut self,
+        &self,
         kind: IncDecRecovery,
         (pre_span, post_span): (Span, Span),
     ) -> MultiSugg {
@@ -1899,7 +1899,7 @@ impl<'a> Parser<'a> {
 
     /// Creates a `Diag` for an unexpected token `t` and tries to recover if it is a
     /// closing delimiter.
-    pub(super) fn unexpected_try_recover(&mut self, t: &TokenKind) -> PResult<'a, Recovered> {
+    pub(super) fn unexpected_try_recover(&self, t: &TokenKind) -> PResult<'a, Recovered> {
         let token_str = pprust::token_kind_to_string(t);
         let this_token_str = super::token_descr(&self.token);
         let (prev_sp, sp) = match (&self.token.kind, self.subparser_name) {
@@ -2377,7 +2377,7 @@ impl<'a> Parser<'a> {
         Ok((pat, ty))
     }
 
-    pub(super) fn recover_bad_self_param(&mut self, mut param: Param) -> PResult<'a, Param> {
+    pub(super) fn recover_bad_self_param(&self, mut param: Param) -> PResult<'a, Param> {
         let span = param.pat.span;
         let guar = self.dcx().emit_err(SelfParamNotFirst { span });
         param.ty.kind = TyKind::Err(guar);
@@ -2971,7 +2971,7 @@ impl<'a> Parser<'a> {
         Err(err)
     }
 
-    pub(crate) fn maybe_recover_bounds_doubled_colon(&mut self, ty: &Ty) -> PResult<'a, ()> {
+    pub(crate) fn maybe_recover_bounds_doubled_colon(&self, ty: &Ty) -> PResult<'a, ()> {
         let TyKind::Path(qself, path) = &ty.kind else { return Ok(()) };
         let qself_position = qself.as_ref().map(|qself| qself.position);
         for (i, segments) in path.segments.windows(2).enumerate() {
@@ -3016,7 +3016,7 @@ impl<'a> Parser<'a> {
     /// * `>>>>>>>`
     ///
     pub(super) fn is_vcs_conflict_marker(
-        &mut self,
+        &self,
         long_kind: &TokenKind,
         short_kind: &TokenKind,
     ) -> bool {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -307,7 +307,7 @@ impl<'a> Parser<'a> {
         Ok((lhs, parsed_something))
     }
 
-    fn should_continue_as_assoc_expr(&mut self, lhs: &Expr) -> bool {
+    fn should_continue_as_assoc_expr(&self, lhs: &Expr) -> bool {
         match (self.expr_is_complete(lhs), AssocOp::from_token(&self.token)) {
             // Semi-statement forms are odd:
             // See https://github.com/rust-lang/rust/issues/29071
@@ -2281,7 +2281,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn is_array_like_block(&mut self) -> bool {
+    fn is_array_like_block(&self) -> bool {
         self.token.kind == TokenKind::OpenBrace
             && self
                 .look_ahead(1, |t| matches!(t.kind, TokenKind::Ident(..) | TokenKind::Literal(_)))
@@ -2893,7 +2893,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn error_on_extra_if(&mut self, cond: &Box<Expr>) -> PResult<'a, ()> {
+    fn error_on_extra_if(&self, cond: &Box<Expr>) -> PResult<'a, ()> {
         if let ExprKind::Binary(Spanned { span: binop_span, node: binop }, _, right) = &cond.kind
             && let BinOpKind::And = binop
             && let ExprKind::If(cond, ..) = &right.kind
@@ -3864,7 +3864,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Converts an ident into 'label and emits an "expected a label, found an identifier" error.
-    fn recover_ident_into_label(&mut self, ident: Ident) -> Label {
+    fn recover_ident_into_label(&self, ident: Ident) -> Label {
         // Convert `label` -> `'label`,
         // so that nameres doesn't complain about non-existing label
         let label = format!("'{}", ident.name);

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -378,7 +378,7 @@ impl<'a> Parser<'a> {
         || matches!(self.is_macro_rules_item(), IsMacroRulesItem::Yes{..}) // no: `macro_rules::b`, yes: `macro_rules! mac`
     }
 
-    fn is_reuse_path_item(&mut self) -> bool {
+    fn is_reuse_path_item(&self) -> bool {
         // no: `reuse ::path` for compatibility reasons with macro invocations
         self.token.is_keyword(kw::Reuse)
             && self.look_ahead(1, |t| t.is_path_start() && *t != token::PathSep)
@@ -471,7 +471,7 @@ impl<'a> Parser<'a> {
         if let Some(err) = err { Err(self.dcx().create_err(err)) } else { Ok(()) }
     }
 
-    fn parse_item_builtin(&mut self) -> PResult<'a, Option<ItemKind>> {
+    fn parse_item_builtin(&self) -> PResult<'a, Option<ItemKind>> {
         // To be expanded
         Ok(None)
     }
@@ -507,7 +507,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Recover if we parsed attributes and expected an item but there was none.
-    fn recover_attrs_no_item(&mut self, attrs: &[Attribute]) -> PResult<'a, ()> {
+    fn recover_attrs_no_item(&self, attrs: &[Attribute]) -> PResult<'a, ()> {
         let ([start @ end] | [start, .., end]) = attrs else {
             return Ok(());
         };
@@ -1545,7 +1545,7 @@ impl<'a> Parser<'a> {
     /// We were supposed to parse `":" $ty` but the `:` or the type was missing.
     /// This means that the type is missing.
     fn recover_missing_global_item_type(
-        &mut self,
+        &self,
         colon_present: bool,
         m: Option<Mutability>,
     ) -> Box<Ty> {

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -502,7 +502,7 @@ impl<'a> Parser<'a> {
 
     /// Called by [`Parser::parse_stmt_without_recovery`], used to add statement-aware subdiagnostics to the errors stashed
     /// by [`Parser::maybe_recover_trailing_expr`].
-    pub(super) fn maybe_augment_stashed_expr_in_pats_with_suggestions(&mut self, stmt: &Stmt) {
+    pub(super) fn maybe_augment_stashed_expr_in_pats_with_suggestions(&self, stmt: &Stmt) {
         if self.dcx().has_errors().is_none() {
             // No need to walk the statement if there's no stashed errors.
             return;
@@ -1145,7 +1145,7 @@ impl<'a> Parser<'a> {
     }
 
     fn fatal_unexpected_non_pat(
-        &mut self,
+        &self,
         err: Diag<'a>,
         expected: Option<Expected>,
     ) -> PResult<'a, Box<Pat>> {

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -783,7 +783,7 @@ impl<'a> Parser<'a> {
         Ok(self.mk_block(stmts, s, lo.to(self.prev_token.span)))
     }
 
-    fn recover_missing_dot(&mut self, err: &mut Diag<'_>) {
+    fn recover_missing_dot(&self, err: &mut Diag<'_>) {
         let Some((ident, _)) = self.token.ident() else {
             return;
         };

--- a/compiler/rustc_passes/src/check_export.rs
+++ b/compiler/rustc_passes/src/check_export.rs
@@ -227,7 +227,7 @@ impl<'tcx, 'a> ExportableItemsChecker<'tcx, 'a> {
         }
     }
 
-    fn check_ty(&mut self) {
+    fn check_ty(&self) {
         let ty = self.tcx.type_of(self.item_id).skip_binder();
         if let ty::Adt(adt_def, _) = ty.kind() {
             if !adt_def.repr().inhibit_struct_field_reordering() {

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -188,7 +188,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
         }
     }
 
-    fn check_for_self_assign(&mut self, assign: &'tcx hir::Expr<'tcx>) {
+    fn check_for_self_assign(&self, assign: &'tcx hir::Expr<'tcx>) {
         fn check_for_self_assign_helper<'tcx>(
             typeck_results: &'tcx ty::TypeckResults<'tcx>,
             lhs: &'tcx hir::Expr<'tcx>,
@@ -478,7 +478,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
     /// `local_def_id` points to an impl or an impl item,
     /// both impl and impl item that may be passed to this function are of a trait,
     /// and added into the unsolved_items during `create_and_seed_worklist`
-    fn check_impl_or_impl_item_live(&mut self, local_def_id: LocalDefId) -> bool {
+    fn check_impl_or_impl_item_live(&self, local_def_id: LocalDefId) -> bool {
         let (impl_block_id, trait_def_id) = match self.tcx.def_kind(local_def_id) {
             // assoc impl items of traits are live if the corresponding trait items are live
             DefKind::AssocConst | DefKind::AssocTy | DefKind::AssocFn => (
@@ -888,7 +888,7 @@ enum ReportOn {
 }
 
 impl<'tcx> DeadVisitor<'tcx> {
-    fn should_warn_about_field(&mut self, field: &ty::FieldDef) -> ShouldWarnAboutField {
+    fn should_warn_about_field(&self, field: &ty::FieldDef) -> ShouldWarnAboutField {
         if self.live_symbols.contains(&field.did.expect_local()) {
             return ShouldWarnAboutField::No;
         }
@@ -1096,7 +1096,7 @@ impl<'tcx> DeadVisitor<'tcx> {
         }
     }
 
-    fn warn_dead_code(&mut self, id: LocalDefId, participle: &str) {
+    fn warn_dead_code(&self, id: LocalDefId, participle: &str) {
         let item = DeadItem {
             def_id: id,
             name: self.tcx.item_name(id.to_def_id()),
@@ -1105,7 +1105,7 @@ impl<'tcx> DeadVisitor<'tcx> {
         self.lint_at_single_level(&[&item], participle, None, ReportOn::NamedField);
     }
 
-    fn check_definition(&mut self, def_id: LocalDefId) {
+    fn check_definition(&self, def_id: LocalDefId) {
         if self.is_live_code(def_id) {
             return;
         }
@@ -1140,7 +1140,7 @@ impl<'tcx> DeadVisitor<'tcx> {
 
 fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
     let (live_symbols, ignored_derived_traits) = tcx.live_symbols_and_ignored_derived_traits(());
-    let mut visitor = DeadVisitor { tcx, live_symbols, ignored_derived_traits };
+    let visitor = DeadVisitor { tcx, live_symbols, ignored_derived_traits };
 
     let module_items = tcx.hir_module_items(module);
 

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1312,7 +1312,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         ln
     }
 
-    fn check_is_ty_uninhabited(&mut self, expr: &Expr<'_>, succ: LiveNode) -> LiveNode {
+    fn check_is_ty_uninhabited(&self, expr: &Expr<'_>, succ: LiveNode) -> LiveNode {
         let ty = self.typeck_results.expr_ty(expr);
         let m = self.ir.tcx.parent_module(expr.hir_id).to_def_id();
         if ty.is_inhabited_from(self.ir.tcx, m, self.typing_env) {
@@ -1331,7 +1331,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     }
 
     fn warn_about_unreachable<'desc>(
-        &mut self,
+        &self,
         orig_span: Span,
         orig_ty: Ty<'tcx>,
         expr_span: Span,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -933,7 +933,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
 
     // Checks that a field in a struct constructor (expression or pattern) is accessible.
     fn check_field(
-        &mut self,
+        &self,
         hir_id: hir::HirId,    // ID of the field use
         use_ctxt: Span,        // syntax context of the field name at the use site
         def: ty::AdtDef<'tcx>, // definition of the struct or enum
@@ -951,7 +951,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
 
     // Checks that a field in a struct constructor (expression or pattern) is accessible.
     fn emit_unreachable_field_error(
-        &mut self,
+        &self,
         fields: Vec<(Symbol, Span, bool /* field is present */)>,
         def: ty::AdtDef<'tcx>, // definition of the struct or enum
         update_syntax: Option<Span>,
@@ -1014,7 +1014,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
     }
 
     fn check_expanded_fields(
-        &mut self,
+        &self,
         adt: ty::AdtDef<'tcx>,
         variant: &'tcx ty::VariantDef,
         fields: &[hir::ExprField<'tcx>],
@@ -1154,7 +1154,7 @@ impl<'tcx> TypePrivacyVisitor<'tcx> {
         result.is_break()
     }
 
-    fn check_def_id(&mut self, def_id: DefId, kind: &str, descr: &dyn fmt::Display) -> bool {
+    fn check_def_id(&self, def_id: DefId, kind: &str, descr: &dyn fmt::Display) -> bool {
         let is_error = !self.item_is_accessible(def_id);
         if is_error {
             self.tcx.dcx().emit_err(ItemIsPrivate { span: self.span, kind, descr: descr.into() });
@@ -1415,7 +1415,7 @@ impl SearchInterfaceForPrivateItemsVisitor<'_> {
         self
     }
 
-    fn check_def_id(&mut self, def_id: DefId, kind: &str, descr: &dyn fmt::Display) -> bool {
+    fn check_def_id(&self, def_id: DefId, kind: &str, descr: &dyn fmt::Display) -> bool {
         if self.leaks_private_dep(def_id) {
             self.tcx.emit_node_span_lint(
                 lint::builtin::EXPORTED_PRIVATE_DEPENDENCIES,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -539,7 +539,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// This takes the error provided, combines it with the span and any additional spans inside the
     /// error and emits it.
     pub(crate) fn report_error(
-        &mut self,
+        &self,
         span: Span,
         resolution_error: ResolutionError<'ra>,
     ) -> ErrorGuaranteed {
@@ -547,7 +547,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     pub(crate) fn into_struct_error(
-        &mut self,
+        &self,
         span: Span,
         resolution_error: ResolutionError<'ra>,
     ) -> Diag<'_> {
@@ -985,7 +985,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     pub(crate) fn report_vis_error(
-        &mut self,
+        &self,
         vis_resolution_error: VisResolutionError<'_>,
     ) -> ErrorGuaranteed {
         match vis_resolution_error {
@@ -1380,7 +1380,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// N.B., the method does not look into imports, but this is not a problem,
     /// since we report the definitions (thus, the de-aliased imports).
     pub(crate) fn lookup_import_candidates<FilterFn>(
-        &mut self,
+        &self,
         lookup_ident: Ident,
         namespace: Namespace,
         parent_scope: &ParentScope<'ra>,
@@ -1952,7 +1952,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         self.field_idents(def_id)?.iter().map(|&f| f.span).reduce(Span::to) // None for `struct Foo()`
     }
 
-    fn report_privacy_error(&mut self, privacy_error: &PrivacyError<'ra>) {
+    fn report_privacy_error(&self, privacy_error: &PrivacyError<'ra>) {
         let PrivacyError {
             ident,
             binding,
@@ -2738,7 +2738,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ///            at the root of the crate instead of the module where it is defined
     /// ```
     pub(crate) fn check_for_module_export_macro(
-        &mut self,
+        &self,
         import: Import<'ra>,
         module: ModuleOrUniformRoot<'ra>,
         ident: Ident,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1132,7 +1132,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     /// Validate a local resolution (from ribs).
     #[instrument(level = "debug", skip(self, all_ribs))]
     fn validate_res_from_ribs(
-        &mut self,
+        &self,
         rib_index: usize,
         rib_ident: Ident,
         mut res: Res,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3948,7 +3948,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
     }
 
     fn fresh_binding(
-        &mut self,
+        &self,
         ident: Ident,
         pat_id: NodeId,
         pat_src: PatternSource,
@@ -4409,7 +4409,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
     /// A wrapper around [`Resolver::report_error`].
     ///
     /// This doesn't emit errors for function bodies if this is rustdoc.
-    fn report_error(&mut self, span: Span, resolution_error: ResolutionError<'ra>) {
+    fn report_error(&self, span: Span, resolution_error: ResolutionError<'ra>) {
         if self.should_report_errs() {
             self.r.report_error(span, resolution_error);
         }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -374,7 +374,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     /// We need a separate function here because we won't suggest for a path with single segment
     /// and we won't change `SourcePath` api `is_expected` to match `Type` with `DefKind::Mod`
     pub(crate) fn smart_resolve_partial_mod_path_errors(
-        &mut self,
+        &self,
         prefix_path: &[Segment],
         following_seg: Option<&Segment>,
     ) -> Vec<ImportSuggestion> {
@@ -2141,7 +2141,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     }
 
     fn suggest_alternative_construction_methods(
-        &mut self,
+        &self,
         def_id: DefId,
         err: &mut Diag<'_>,
         path_span: Span,
@@ -2288,7 +2288,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     /// Given the target `ident` and `kind`, search for the similarly named associated item
     /// in `self.current_trait_ref`.
     pub(crate) fn find_similarly_named_assoc_item(
-        &mut self,
+        &self,
         ident: Symbol,
         kind: &AssocItemKind,
     ) -> Option<Symbol> {

--- a/compiler/rustc_symbol_mangling/src/test.rs
+++ b/compiler/rustc_symbol_mangling/src/test.rs
@@ -23,7 +23,7 @@ pub fn report_symbol_names(tcx: TyCtxt<'_>) {
     }
 
     tcx.dep_graph.with_ignore(|| {
-        let mut symbol_names = SymbolNamesTest { tcx };
+        let symbol_names = SymbolNamesTest { tcx };
         let crate_items = tcx.hir_crate_items(());
 
         for id in crate_items.free_items() {
@@ -49,7 +49,7 @@ struct SymbolNamesTest<'tcx> {
 }
 
 impl SymbolNamesTest<'_> {
-    fn process_attrs(&mut self, def_id: LocalDefId) {
+    fn process_attrs(&self, def_id: LocalDefId) {
         let tcx = self.tcx;
         // The formatting of `tag({})` is chosen so that tests can elect
         // to test the entirety of the string, if they choose, or else just

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -160,7 +160,7 @@ struct ClosureEraser<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ClosureEraser<'a, 'tcx> {
-    fn new_infer(&mut self) -> Ty<'tcx> {
+    fn new_infer(&self) -> Ty<'tcx> {
         self.infcx.next_ty_var(DUMMY_SP)
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2477,7 +2477,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
     pub(super) fn is_recursive_obligation(
         &self,
-        obligated_types: &mut Vec<Ty<'tcx>>,
+        obligated_types: &Vec<Ty<'tcx>>,
         cause_code: &ObligationCauseCode<'tcx>,
     ) -> bool {
         if let ObligationCauseCode::BuiltinDerived(data) = cause_code {

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -299,7 +299,7 @@ fn evaluate_host_effect_from_item_bounds<'tcx>(
 }
 
 fn evaluate_host_effect_from_builtin_impls<'tcx>(
-    selcx: &mut SelectionContext<'_, 'tcx>,
+    selcx: &SelectionContext<'_, 'tcx>,
     obligation: &HostEffectObligation<'tcx>,
 ) -> Result<ThinVec<PredicateObligation<'tcx>>, EvaluationFailure> {
     match selcx.tcx().as_lang_item(obligation.predicate.def_id()) {
@@ -313,7 +313,7 @@ fn evaluate_host_effect_from_builtin_impls<'tcx>(
 
 // NOTE: Keep this in sync with `const_conditions_for_destruct` in the new solver.
 fn evaluate_host_effect_for_destruct_goal<'tcx>(
-    selcx: &mut SelectionContext<'_, 'tcx>,
+    selcx: &SelectionContext<'_, 'tcx>,
     obligation: &HostEffectObligation<'tcx>,
 ) -> Result<ThinVec<PredicateObligation<'tcx>>, EvaluationFailure> {
     let tcx = selcx.tcx();
@@ -404,7 +404,7 @@ fn evaluate_host_effect_for_destruct_goal<'tcx>(
 
 // NOTE: Keep this in sync with `extract_fn_def_from_const_callable` in the new solver.
 fn evaluate_host_effect_for_fn_goal<'tcx>(
-    selcx: &mut SelectionContext<'_, 'tcx>,
+    selcx: &SelectionContext<'_, 'tcx>,
     obligation: &HostEffectObligation<'tcx>,
 ) -> Result<ThinVec<PredicateObligation<'tcx>>, EvaluationFailure> {
     let tcx = selcx.tcx();

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -2134,7 +2134,7 @@ impl<'cx, 'tcx> ProjectionCacheKeyExt<'cx, 'tcx> for ProjectionCacheKey<'tcx> {
 }
 
 fn get_associated_const_value<'tcx>(
-    selcx: &mut SelectionContext<'_, 'tcx>,
+    selcx: &SelectionContext<'_, 'tcx>,
     alias_ct: ty::Const<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
 ) -> ty::Const<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -220,7 +220,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     fn confirm_param_candidate(
-        &mut self,
+        &self,
         obligation: &PolyTraitObligation<'tcx>,
         param: ty::PolyTraitRef<'tcx>,
     ) -> PredicateObligations<'tcx> {
@@ -300,7 +300,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     fn confirm_transmutability_candidate(
-        &mut self,
+        &self,
         obligation: &PolyTraitObligation<'tcx>,
     ) -> Result<PredicateObligations<'tcx>, SelectionError<'tcx>> {
         use rustc_transmute::{Answer, Assume, Condition};
@@ -1243,7 +1243,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     fn confirm_bikeshed_guaranteed_no_drop_candidate(
-        &mut self,
+        &self,
         obligation: &PolyTraitObligation<'tcx>,
     ) -> ImplSource<'tcx, PredicateObligation<'tcx>> {
         let mut obligations = thin_vec![];

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1136,7 +1136,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     /// fresh regions with the same index, they refer to the same
     /// unbound type variable.
     fn check_evaluation_cycle(
-        &mut self,
+        &self,
         stack: &TraitObligationStack<'_, 'tcx>,
     ) -> Option<EvaluationResult> {
         if let Some(cycle_depth) = stack
@@ -1238,7 +1238,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     /// - it also appears in the backtrace at some position `X`,
     /// - all the predicates at positions `X..` between `X` and the top are
     ///   also coinductive traits.
-    pub(crate) fn coinductive_match<I>(&mut self, mut cycle: I) -> bool
+    pub(crate) fn coinductive_match<I>(&self, mut cycle: I) -> bool
     where
         I: Iterator<Item = ty::Predicate<'tcx>>,
     {
@@ -1319,7 +1319,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     fn insert_evaluation_cache(
-        &mut self,
+        &self,
         param_env: ty::ParamEnv<'tcx>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
         dep_node: DepNodeIndex,
@@ -1399,7 +1399,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     /// goal and a negative impl for a positive goal
     #[instrument(level = "debug", skip(self, candidates))]
     fn filter_impls(
-        &mut self,
+        &self,
         candidates: Vec<SelectionCandidate<'tcx>>,
         obligation: &PolyTraitObligation<'tcx>,
     ) -> Vec<SelectionCandidate<'tcx>> {
@@ -1455,7 +1455,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         Ok(Some(candidate))
     }
 
-    fn is_knowable<'o>(&mut self, stack: &TraitObligationStack<'o, 'tcx>) -> Result<(), Conflict> {
+    fn is_knowable<'o>(&self, stack: &TraitObligationStack<'o, 'tcx>) -> Result<(), Conflict> {
         let obligation = &stack.obligation;
         match self.infcx.typing_mode() {
             TypingMode::Coherence => {}
@@ -1526,7 +1526,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     fn check_candidate_cache(
-        &mut self,
+        &self,
         param_env: ty::ParamEnv<'tcx>,
         cache_fresh_trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> Option<SelectionResult<'tcx, SelectionCandidate<'tcx>>> {
@@ -1579,7 +1579,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
     #[instrument(skip(self, param_env, cache_fresh_trait_pred, dep_node), level = "debug")]
     fn insert_candidate_cache(
-        &mut self,
+        &self,
         param_env: ty::ParamEnv<'tcx>,
         cache_fresh_trait_pred: ty::PolyTraitPredicate<'tcx>,
         dep_node: DepNodeIndex,
@@ -2098,7 +2098,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
 impl<'tcx> SelectionContext<'_, 'tcx> {
     fn sizedness_conditions(
-        &mut self,
+        &self,
         self_ty: Ty<'tcx>,
         sizedness: SizedTraitKind,
     ) -> ty::Binder<'tcx, Vec<Ty<'tcx>>> {
@@ -2154,7 +2154,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         }
     }
 
-    fn copy_clone_conditions(&mut self, self_ty: Ty<'tcx>) -> ty::Binder<'tcx, Vec<Ty<'tcx>>> {
+    fn copy_clone_conditions(&self, self_ty: Ty<'tcx>) -> ty::Binder<'tcx, Vec<Ty<'tcx>>> {
         match *self_ty.kind() {
             ty::FnDef(..) | ty::FnPtr(..) | ty::Error(_) => ty::Binder::dummy(vec![]),
 
@@ -2241,7 +2241,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         }
     }
 
-    fn coroutine_is_gen(&mut self, self_ty: Ty<'tcx>) -> bool {
+    fn coroutine_is_gen(&self, self_ty: Ty<'tcx>) -> bool {
         matches!(*self_ty.kind(), ty::Coroutine(did, ..)
             if self.tcx().coroutine_is_gen(did))
     }
@@ -2696,7 +2696,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
     /// `obligation`. If successful, return any predicates that
     /// result from the normalization.
     fn match_where_clause_trait_ref(
-        &mut self,
+        &self,
         obligation: &PolyTraitObligation<'tcx>,
         where_clause_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<PredicateObligations<'tcx>, ()> {
@@ -2707,7 +2707,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
     /// obligation is satisfied.
     #[instrument(skip(self), level = "debug")]
     fn match_poly_trait_ref(
-        &mut self,
+        &self,
         obligation: &PolyTraitObligation<'tcx>,
         poly_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<PredicateObligations<'tcx>, ()> {
@@ -2757,7 +2757,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
     #[instrument(skip(self), level = "debug")]
     fn closure_trait_ref_unnormalized(
-        &mut self,
+        &self,
         self_ty: Ty<'tcx>,
         fn_trait_def_id: DefId,
     ) -> ty::PolyTraitRef<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -564,7 +564,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     fn nominal_obligations(
-        &mut self,
+        &self,
         def_id: DefId,
         args: GenericArgsRef<'tcx>,
     ) -> PredicateObligations<'tcx> {

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -369,7 +369,7 @@ impl<'a, 'tcx> IsThirPolymorphic<'a, 'tcx> {
             | thir::ExprKind::Yield { .. } => false,
         }
     }
-    fn pat_is_poly(&mut self, pat: &thir::Pat<'tcx>) -> bool {
+    fn pat_is_poly(&self, pat: &thir::Pat<'tcx>) -> bool {
         if pat.ty.has_non_region_param() {
             return true;
         }

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -1192,7 +1192,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
 
     /// Whether we've reached a fixpoint when evaluating a cycle head.
     fn reached_fixpoint(
-        &mut self,
+        &self,
         cx: X,
         stack_entry: &StackEntry<X>,
         usages: HeadUsages,
@@ -1336,7 +1336,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
     /// results. See the comment of `StackEntry::nested_goals` for
     /// more details.
     fn insert_global_cache(
-        &mut self,
+        &self,
         cx: X,
         input: X::Input,
         evaluation_result: EvaluationResult<X>,


### PR DESCRIPTION
Hello. This PR cuts most of the unnecessary `&mut` references from the compiler, changing them to plain `&` references instead. There are also a few resulting `mut` variable flags cut as well.

Should cause no change in behavior. Possibly will make something along the way a little faster?

`x check` and `x clippy` passed locally.